### PR TITLE
Disable clang-format on PR Actions

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -48,6 +48,9 @@ jobs:
         '[[ ${{ matrix.mode }} != "release" ]] || ./ci.sh test'
 
   format:
+    # TODO(deymo): Currently disabled because the git structure where the PR
+    # runs is different.
+    if: false
     runs-on: [ubuntu-latest]
     steps:
     - name: Install build deps


### PR DESCRIPTION
The pull request workflow runs on a merge request which confuses our ci.sh lint on what to run the linter on.