### PR TITLE
SIMDify upsampling

### DIFF
--- a/lib/jxl/dec_group.cc
+++ b/lib/jxl/dec_group.cc
@@ -810,7 +810,8 @@ Status DecodeGroup(BitReader* JXL_RESTRICT* JXL_RESTRICT readers,
         dst_rect,
         static_cast<ssize_t>(src_rect.y0()) -
             static_cast<ssize_t>(copy_rect.y0()),
-        dec_state->shared->frame_dim.ysize_blocks);
+        dec_state->shared->frame_dim.ysize_blocks,
+        dec_state->upsampler_storage[thread].get());
     draw = kOnlyImageFeatures;
   }
 

--- a/lib/jxl/dec_reconstruct.cc
+++ b/lib/jxl/dec_reconstruct.cc
@@ -661,7 +661,7 @@ Status FinalizeImageRect(
           &output_image->extra_channels()[ec], upsampled_frame_rect,
           static_cast<ssize_t>(ec_image_rect.y0()) -
               static_cast<ssize_t>(extra_channels[ec].second.y0()),
-          ecys);
+          ecys, dec_state->upsampler_storage[thread].get());
       extra_channels_for_patches.emplace_back(
           &output_image->extra_channels()[ec], upsampled_frame_rect);
     }
@@ -824,7 +824,7 @@ Status FinalizeImageRect(
           upsampled_frame_rect_for_storage.Lines(upsampled_available_y, num_ys),
           static_cast<ssize_t>(frame_rect.y0()) -
               static_cast<ssize_t>(rect_for_upsampling.y0()),
-          frame_dim.ysize_padded);
+          frame_dim.ysize_padded, dec_state->upsampler_storage[thread].get());
       if (late_ec_upsample) {
         for (size_t ec = 0; ec < extra_channels.size(); ec++) {
           color_upsampler->UpsampleRect(
@@ -834,7 +834,7 @@ Status FinalizeImageRect(
               upsampled_frame_rect.Lines(upsampled_available_y, num_ys),
               static_cast<ssize_t>(frame_rect.y0()) -
                   static_cast<ssize_t>(extra_channels[ec].second.y0()),
-              frame_dim.ysize);
+              frame_dim.ysize, dec_state->upsampler_storage[thread].get());
         }
       }
       available_y = upsampled_available_y;

--- a/lib/jxl/dec_upsample.cc
+++ b/lib/jxl/dec_upsample.cc
@@ -5,117 +5,349 @@
 
 #include "lib/jxl/dec_upsample.h"
 
+#undef HWY_TARGET_INCLUDE
+#define HWY_TARGET_INCLUDE "lib/jxl/dec_upsample.cc"
+#include <hwy/foreach_target.h>
+#include <hwy/highway.h>
+
+#include "lib/jxl/base/profiler.h"
 #include "lib/jxl/image_ops.h"
 
+HWY_BEFORE_NAMESPACE();
 namespace jxl {
+namespace HWY_NAMESPACE {
 namespace {
 
-template <size_t N>
-void InitKernel(const float* weights, float kernel[4][4][5][5]) {
-  static_assert(N == 1 || N == 2 || N == 4,
-                "Upsampling kernel init only implemented for N = 1,2,4");
-  for (size_t i = 0; i < 5 * N; i++) {
-    for (size_t j = 0; j < 5 * N; j++) {
+void InitKernel(const float* weights, CacheAlignedUniquePtr* kernel_storage,
+                size_t N, size_t x_repeat) {
+  const size_t NX = N * x_repeat;
+  const size_t N2 = N / 2;
+  HWY_FULL(float) df;
+  const size_t V = Lanes(df);
+  const size_t num_kernels = N * NX;
+
+  constexpr const size_t M = 2 * Upsampler::filter_radius() + 1;
+  const size_t MX = M + x_repeat - 1;
+  const size_t num_coeffs = M * MX;
+
+  // Pad kernel slices to vector size.
+  const size_t stride = RoundUpTo(num_kernels, V);
+  *kernel_storage = AllocateArray(stride * sizeof(float) * num_coeffs);
+  float* kernels = reinterpret_cast<float*>(kernel_storage->get());
+  memset(kernels, 0, stride * sizeof(float) * num_coeffs);
+
+  for (size_t offset = 0; offset < num_coeffs; ++offset) {
+    size_t iy = offset / MX;
+    size_t ix = offset % MX;
+    for (size_t kernel = 0; kernel < num_kernels; ++kernel) {
+      size_t ky = kernel / NX;
+      size_t kx_ = kernel % NX;
+      size_t kx = kx_ % N;
+      size_t shift = kx_ / N;
+      if ((ix < shift) || (ix - shift >= M)) continue;  // 0 weight from memset.
+      // Only weights for top-left 1 / 4 of kernels are specified; other 3 / 4
+      // kernels are produced by vertical and horizontal mirroring.
+      size_t j = (ky < N2) ? (iy + M * ky) : ((M - 1 - iy) + M * (N - 1 - ky));
+      size_t i = (kx < N2) ? (ix - shift + M * kx)
+                           : ((M - 1 - (ix - shift)) + M * (N - 1 - kx));
+      // (y, x) = sorted(i, j)
+      // the matrix built of kernel matrices as blocks is symmetric.
       size_t y = std::min(i, j);
       size_t x = std::max(i, j);
-      kernel[j / 5][i / 5][j % 5][i % 5] =
-          weights[5 * N * y - y * (y - 1) / 2 + x - y];
+      // Take the weight from "triangle" coordinates.
+      float weight = weights[M * N2 * y - y * (y - 1) / 2 + x - y];
+      kernels[offset * stride + kernel] = weight;
     }
   }
 }
 
-template <size_t N>
-float Kernel(size_t x, size_t y, size_t ix, size_t iy,
-             const float kernel[4][4][5][5]) {
-  if (N == 2) {
-    return kernel[0][0][y % 2 ? 4 - iy : iy][x % 2 ? 4 - ix : ix];
-  }
-  if (N == 4) {
-    return kernel[y % 4 < 2 ? y % 2 : 1 - y % 2][x % 4 < 2 ? x % 2 : 1 - x % 2]
-                 [y % 4 < 2 ? iy : 4 - iy][x % 4 < 2 ? ix : 4 - ix];
-  }
-  if (N == 8) {
-    return kernel[y % 8 < 4 ? y % 4 : 3 - y % 4][x % 8 < 4 ? x % 4 : 3 - x % 4]
-                 [y % 8 < 4 ? iy : 4 - iy][x % 8 < 4 ? ix : 4 - ix];
-  }
-  JXL_ABORT("Invalid upsample");
-}
-
-template <int N>
+template <size_t N, size_t x_repeat>
 void Upsample(const ImageF& src, const Rect& src_rect, ImageF* dst,
-              const Rect& dst_rect, const float kernel[4][4][5][5],
-              ssize_t image_y_offset, size_t image_ysize) {
-  JXL_DASSERT(src_rect.x0() >= 2);
-  JXL_DASSERT(src_rect.x0() + src_rect.xsize() + 2 <= src.xsize());
-  for (size_t y = 0; y < dst_rect.ysize(); y++) {
-    float* dst_row = dst_rect.Row(dst, y);
-    const float* src_rows[5];
-    for (int iy = -2; iy <= 2; iy++) {
-      ssize_t image_y =
-          static_cast<ssize_t>(y / N + src_rect.y0() + iy) + image_y_offset;
-      src_rows[iy + 2] = src.Row(Mirror(image_y, image_ysize) - image_y_offset);
+              const Rect& dst_rect, const float* kernels,
+              ssize_t image_y_offset, size_t image_ysize, float* arena) {
+  constexpr const size_t M = 2 * Upsampler::filter_radius() + 1;
+  constexpr const size_t M2 = M / 2;
+  JXL_DASSERT(src_rect.x0() >= M2);
+  JXL_DASSERT(src_rect.x0() + src_rect.xsize() + M2 <= src.xsize());
+  JXL_ASSERT(DivCeil(dst_rect.xsize(), N) <= src_rect.xsize());
+  // TODO(eustas): add proper (src|dst) ysize check that accounts for mirroring.
+
+  constexpr const size_t MX = M + x_repeat - 1;
+  constexpr const size_t num_coeffs = M * MX;
+
+  constexpr const size_t NX = N * x_repeat;
+
+  HWY_FULL(float) df;
+  const size_t V = Lanes(df);
+  const size_t num_kernels = N * NX;
+  const size_t stride = RoundUpTo(num_kernels, V);
+
+  const size_t rsx = DivCeil(dst_rect.xsize(), N);
+  const size_t dsx = rsx + 2 * M2;
+  // Round-down to complete vectors.
+  const size_t dsx_v = V * (dsx / V);
+
+  float* JXL_RESTRICT in = arena;
+  arena += RoundUpTo(num_coeffs, V);
+  float* JXL_RESTRICT out = arena;
+  arena += stride;
+  float* JXL_RESTRICT raw_min_row = arena;
+  arena += RoundUpTo(dsx + V, V);
+  float* JXL_RESTRICT raw_max_row = arena;
+  arena += RoundUpTo(dsx + V, V);
+  float* JXL_RESTRICT min_row = arena;
+  arena += RoundUpTo(rsx * N + V, V);
+  float* JXL_RESTRICT max_row = arena;
+  arena += RoundUpTo(rsx * N + V, V);
+
+  memset(raw_min_row + dsx_v, 0, sizeof(float) * (V + dsx - dsx_v));
+  memset(raw_max_row + dsx_v, 0, sizeof(float) * (V + dsx - dsx_v));
+  memset(min_row + dst_rect.xsize(), 0, sizeof(float) * V);
+  memset(max_row + dst_rect.xsize(), 0, sizeof(float) * V);
+
+  // For min/max reduction.
+  const size_t span_tail_len = M % V;
+  const bool has_span_tail = (span_tail_len != 0);
+  JXL_ASSERT(has_span_tail || V <= M);
+  const size_t span_start = has_span_tail ? 0 : V;
+  const size_t span_tail_start = M - span_tail_len;
+  const auto span_tail_mask = Iota(df, 0) < Set(df, span_tail_len);
+
+  // sx and sy correspond to offset in source image.
+  // x and y correspond to top-left pixel offset in upsampled output image.
+  for (size_t y = 0; y < dst_rect.ysize(); y += N) {
+    const float* src_rows[M];
+    const size_t sy = y / N;
+    const ssize_t top = static_cast<ssize_t>(sy + src_rect.y0() - M2);
+    for (size_t iy = 0; iy < M; iy++) {
+      const ssize_t image_y = top + iy + image_y_offset;
+      src_rows[iy] = src.Row(Mirror(image_y, image_ysize) - image_y_offset);
     }
-    for (size_t x = 0; x < dst_rect.xsize(); x++) {
-      size_t xbase = x / N + src_rect.x0() - 2;
-      float result = 0;
-      float min = src_rows[0][xbase];
-      float max = src_rows[0][xbase];
-      for (size_t iy = 0; iy < 5; iy++) {
-        for (size_t ix = 0; ix < 5; ix++) {
-          float v = src_rows[iy][xbase + ix];
-          result += Kernel<N>(x, y, ix, iy, kernel) * v;
-          min = std::min(v, min);
-          max = std::max(v, max);
+    const size_t sx0 = src_rect.x0() - M2;
+    for (size_t sx = 0; sx < dsx_v; sx += V) {
+      static_assert(M == 5, "Filter diameter is expected to be 5");
+      const auto r0 = LoadU(df, src_rows[0] + sx0 + sx);
+      const auto r1 = LoadU(df, src_rows[1] + sx0 + sx);
+      const auto r2 = LoadU(df, src_rows[2] + sx0 + sx);
+      const auto r3 = LoadU(df, src_rows[3] + sx0 + sx);
+      const auto r4 = LoadU(df, src_rows[4] + sx0 + sx);
+      const auto min0 = Min(r0, r1);
+      const auto max0 = Max(r0, r1);
+      const auto min1 = Min(r2, r3);
+      const auto max1 = Max(r2, r3);
+      const auto min2 = Min(min0, r4);
+      const auto max2 = Max(max0, r4);
+      Store(Min(min1, min2), df, raw_min_row + sx);
+      Store(Max(max1, max2), df, raw_max_row + sx);
+    }
+    for (size_t sx = dsx_v; sx < dsx; sx++) {
+      static_assert(M == 5, "Filter diameter is expected to be 5");
+      const auto r0 = src_rows[0][sx0 + sx];
+      const auto r1 = src_rows[1][sx0 + sx];
+      const auto r2 = src_rows[2][sx0 + sx];
+      const auto r3 = src_rows[3][sx0 + sx];
+      const auto r4 = src_rows[4][sx0 + sx];
+      const auto min0 = std::min(r0, r1);
+      const auto max0 = std::max(r0, r1);
+      const auto min1 = std::min(r2, r3);
+      const auto max1 = std::max(r2, r3);
+      const auto min2 = std::min(min0, r4);
+      const auto max2 = std::max(max0, r4);
+      raw_min_row[sx] = std::min(min1, min2);
+      raw_max_row[sx] = std::max(max1, max2);
+    }
+
+    for (size_t sx = 0; sx < rsx; sx++) {
+      decltype(Zero(df)) min, max;
+      if (has_span_tail) {
+        auto dummy = Set(df, raw_min_row[sx]);
+        min = IfThenElse(span_tail_mask,
+                         LoadU(df, raw_min_row + sx + span_tail_start), dummy);
+        max = IfThenElse(span_tail_mask,
+                         LoadU(df, raw_max_row + sx + span_tail_start), dummy);
+      } else {
+        min = LoadU(df, raw_min_row + sx);
+        max = LoadU(df, raw_max_row + sx);
+      }
+      for (size_t fx = span_start; fx < span_tail_start; fx += V) {
+        min = Min(LoadU(df, raw_min_row + sx + fx), min);
+        max = Max(LoadU(df, raw_max_row + sx + fx), max);
+      }
+      min = MinOfLanes(min);
+      max = MaxOfLanes(max);
+      for (size_t lx = 0; lx < N; lx += V) {
+        StoreU(min, df, min_row + N * sx + lx);
+        StoreU(max, df, max_row + N * sx + lx);
+      }
+    }
+
+    for (size_t x = 0; x < dst_rect.xsize(); x += NX) {
+      const size_t sx = x / N;
+      const size_t xbase = sx + sx0;
+      // Copy input pixels for "linearization".
+      for (size_t iy = 0; iy < M; iy++) {
+        memcpy(in + MX * iy, src_rows[iy] + xbase, MX * sizeof(float));
+      }
+      constexpr size_t U = 4;  // Unroll factor.
+      constexpr size_t tail = num_coeffs & ~(U - 1);
+      constexpr size_t tail_length = num_coeffs - tail;
+      for (size_t kernel_idx = 0; kernel_idx < num_kernels; kernel_idx += V) {
+        const float* JXL_RESTRICT kernel_base = kernels + kernel_idx;
+        decltype(Zero(df)) results[U];
+        for (size_t i = 0; i < U; i++) {
+          results[i] = Set(df, in[i]) * Load(df, kernel_base + i * stride);
+        }
+        for (size_t i = U; i < tail; i += U) {
+          for (size_t j = 0; j < U; ++j) {
+            results[j] =
+                MulAdd(Set(df, in[i + j]),
+                       Load(df, kernel_base + (i + j) * stride), results[j]);
+          }
+        }
+        for (size_t i = 0; i < tail_length; ++i) {
+          results[i] =
+              MulAdd(Set(df, in[tail + i]),
+                     Load(df, kernel_base + (tail + i) * stride), results[i]);
+        }
+        auto result = results[0];
+        for (size_t i = 1; i < U; ++i) result += results[i];
+        Store(result, df, out + kernel_idx);
+      }
+      const size_t oy_max = std::min<size_t>(dst_rect.ysize(), y + N);
+      const size_t ox_max = std::min<size_t>(dst_rect.xsize(), x + NX);
+      const size_t copy_len = ox_max - x;
+      float* pixels = out;
+      // TODO(eustas): add graceful tail processing.
+      for (size_t oy = sy * N; oy < oy_max; ++oy, pixels += NX) {
+        for (size_t dx = 0; dx < copy_len; dx += V) {
+          auto result = LoadU(df, pixels + dx);
+          auto min = LoadU(df, min_row + x + dx);
+          auto max = LoadU(df, max_row + x + dx);
+          StoreU(Clamp(result, min, max), df, dst_rect.Row(dst, oy) + x + dx);
         }
       }
-      // Avoid overshooting.
-      dst_row[x] = std::min(std::max(result, min), max);
     }
   }
 }
+
 }  // namespace
 
-void Upsampler::Init(size_t upsampling, const CustomTransformData& data) {
-  upsampling_ = upsampling;
-  if (upsampling_ == 1) return;
-  if (upsampling_ == 2) {
-    InitKernel<1>(data.upsampling2_weights, kernel_);
-  } else if (upsampling_ == 4) {
-    InitKernel<2>(data.upsampling4_weights, kernel_);
-  } else if (upsampling_ == 8) {
-    InitKernel<4>(data.upsampling8_weights, kernel_);
-  } else {
-    JXL_ABORT("Invalid upsample");
-  }
-}
-
-void Upsampler::UpsampleRect(const ImageF& src, const Rect& src_rect,
-                             ImageF* dst, const Rect& dst_rect,
-                             ssize_t image_y_offset, size_t image_ysize) const {
-  if (upsampling_ == 1) return;
-  JXL_ASSERT(DivCeil(dst_rect.xsize(), upsampling_) <= src_rect.xsize());
-  // TODO(eustas): add proper (src|dst) ysize check that accounts for mirroring.
-  if (upsampling_ == 2) {
-    Upsample<2>(src, src_rect, dst, dst_rect, kernel_, image_y_offset,
-                image_ysize);
-  } else if (upsampling_ == 4) {
-    Upsample<4>(src, src_rect, dst, dst_rect, kernel_, image_y_offset,
-                image_ysize);
-  } else if (upsampling_ == 8) {
-    Upsample<8>(src, src_rect, dst, dst_rect, kernel_, image_y_offset,
-                image_ysize);
+void UpsampleRect(size_t upsampling, const float* kernels, const ImageF& src,
+                  const Rect& src_rect, ImageF* dst, const Rect& dst_rect,
+                  ssize_t image_y_offset, size_t image_ysize, float* arena,
+                  size_t x_repeat) {
+  if (upsampling == 1) return;
+  if (upsampling == 2) {
+    if (x_repeat == 1) {
+      Upsample</*N=*/2, /*x_repeat=*/1>(src, src_rect, dst, dst_rect, kernels,
+                                        image_y_offset, image_ysize, arena);
+    } else if (x_repeat == 2) {
+      Upsample</*N=*/2, /*x_repeat=*/2>(src, src_rect, dst, dst_rect, kernels,
+                                        image_y_offset, image_ysize, arena);
+    } else if (x_repeat == 4) {
+      Upsample</*N=*/2, /*x_repeat=*/4>(src, src_rect, dst, dst_rect, kernels,
+                                        image_y_offset, image_ysize, arena);
+    } else {
+      JXL_ABORT("Not implemented");
+    }
+  } else if (upsampling == 4) {
+    JXL_ASSERT(x_repeat == 1);
+    Upsample</*N=*/4, /*x_repeat=*/1>(src, src_rect, dst, dst_rect, kernels,
+                                      image_y_offset, image_ysize, arena);
+  } else if (upsampling == 8) {
+    JXL_ASSERT(x_repeat == 1);
+    Upsample</*N=*/8, /*x_repeat=*/1>(src, src_rect, dst, dst_rect, kernels,
+                                      image_y_offset, image_ysize, arena);
   } else {
     JXL_ABORT("Not implemented");
   }
 }
 
+size_t NumLanes() {
+  HWY_FULL(float) df;
+  return Lanes(df);
+}
+
+void Init(size_t upsampling, CacheAlignedUniquePtr* kernel_storage,
+          const CustomTransformData& data, size_t x_repeat) {
+  if ((upsampling & (upsampling - 1)) != 0 ||
+      upsampling > Upsampler::max_upsampling()) {
+    JXL_ABORT("Invalid upsample");
+  }
+  if ((x_repeat & (x_repeat - 1)) != 0 ||
+      x_repeat > Upsampler::max_x_repeat()) {
+    JXL_ABORT("Invalid x_repeat");
+  }
+
+  // No-op upsampling.
+  if (upsampling == 1) return;
+  const float* weights = (upsampling == 2)
+                             ? data.upsampling2_weights
+                             : (upsampling == 4) ? data.upsampling4_weights
+                                                 : data.upsampling8_weights;
+  InitKernel(weights, kernel_storage, upsampling, x_repeat);
+}
+
+// NOLINTNEXTLINE(google-readability-namespace-comments)
+}  // namespace HWY_NAMESPACE
+}  // namespace jxl
+HWY_AFTER_NAMESPACE();
+
+#if HWY_ONCE
+namespace jxl {
+
+namespace {
+HWY_EXPORT(NumLanes);
+HWY_EXPORT(Init);
+HWY_EXPORT(UpsampleRect);
+}  // namespace
+
+void Upsampler::Init(size_t upsampling, const CustomTransformData& data) {
+  upsampling_ = upsampling;
+  size_t V = HWY_DYNAMIC_DISPATCH(NumLanes)();
+  x_repeat_ = 1;
+  if (upsampling_ == 2) {
+    // 2 * 2 = 4 kernels; repeat cell, if there is more lanes available
+    if (V >= 8) x_repeat_ = 2;
+    if (V >= 16) x_repeat_ = 4;
+  }
+  HWY_DYNAMIC_DISPATCH(Init)(upsampling, &kernel_storage_, data, x_repeat_);
+}
+
+size_t Upsampler::GetArenaSize(size_t max_dst_xsize) {
+  size_t V = HWY_DYNAMIC_DISPATCH(NumLanes)();
+  constexpr const size_t M2 = Upsampler::filter_radius();
+  constexpr const size_t M = 2 * M2 + 1;
+  constexpr size_t X = max_x_repeat();
+  constexpr const size_t MX = M + X - 1;
+  constexpr const size_t N = max_upsampling();
+  // TODO(eustas): raw_(min|max)_row and (min|max)_row could overlap almost
+  // completely.
+  return RoundUpTo(N * N * X, V) + RoundUpTo(M * MX, V) +
+         2 * RoundUpTo(DivCeil(max_dst_xsize, 8) * 4 + 2 * M2 + V, V) +
+         2 * RoundUpTo(max_dst_xsize + V, V);
+}
+
+void Upsampler::UpsampleRect(const ImageF& src, const Rect& src_rect,
+                             ImageF* dst, const Rect& dst_rect,
+                             ssize_t image_y_offset, size_t image_ysize,
+                             float* arena) const {
+  JXL_CHECK(arena);
+  HWY_DYNAMIC_DISPATCH(UpsampleRect)
+  (upsampling_, reinterpret_cast<float*>(kernel_storage_.get()), src, src_rect,
+   dst, dst_rect, image_y_offset, image_ysize, arena, x_repeat_);
+}
+
 void Upsampler::UpsampleRect(const Image3F& src, const Rect& src_rect,
                              Image3F* dst, const Rect& dst_rect,
-                             ssize_t image_y_offset, size_t image_ysize) const {
+                             ssize_t image_y_offset, size_t image_ysize,
+                             float* arena) const {
+  PROFILER_FUNC;
   for (size_t c = 0; c < 3; c++) {
     UpsampleRect(src.Plane(c), src_rect, &dst->Plane(c), dst_rect,
-                 image_y_offset, image_ysize);
+                 image_y_offset, image_ysize, arena);
   }
 }
 
 }  // namespace jxl
+#endif  // HWY_ONCE

--- a/lib/jxl/dec_upsample.h
+++ b/lib/jxl/dec_upsample.h
@@ -14,6 +14,26 @@ namespace jxl {
 struct Upsampler {
   void Init(size_t upsampling, const CustomTransformData& data);
 
+  // Only 1x, 2x, 4x and 8x upsampling is supported.
+  static constexpr size_t max_upsampling() { return 8; }
+
+  // To produce N x N upsampled pixels the [-2..2]x[-2..2] neighborhood of
+  // input pixel is taken and dot-multiplied with N x N corresponding "kernels".
+  // Thus the "kernel" is a 5 x 5 matrix of weights.
+  static constexpr size_t filter_radius() { return 2; }
+
+  // Calculate multiple upsampled cells at the same time.
+  // Kernels are transposed - several kernels are multiplied by input
+  // at the same time.  In case of 2x upsampling there are only 4 kernels.
+  // If current target supports SIMD vectors longer than 4 floats, to reduce
+  // the wasted multiplications we increase the effective kernel count.
+  static constexpr size_t max_x_repeat() { return 4; }
+
+  // Get the size of "arena" required for UpsampleRect;
+  // "arena" should be an aligned piece of memory with at least `GetArenaSize()`
+  // float values accessible.
+  static size_t GetArenaSize(size_t max_dst_xsize);
+
   // The caller must guarantee that `src:src_rect` has two pixels of padding
   // available on each side of the x dimension. `image_ysize` is the total
   // height of the frame that the source area belongs to (not the buffer);
@@ -21,14 +41,15 @@ struct Upsampler {
   // y value in the full frame.
   void UpsampleRect(const Image3F& src, const Rect& src_rect, Image3F* dst,
                     const Rect& dst_rect, ssize_t image_y_offset,
-                    size_t image_ysize) const;
+                    size_t image_ysize, float* arena) const;
   void UpsampleRect(const ImageF& src, const Rect& src_rect, ImageF* dst,
                     const Rect& dst_rect, ssize_t image_y_offset,
-                    size_t image_ysize) const;
+                    size_t image_ysize, float* arena) const;
 
  private:
   size_t upsampling_ = 1;
-  float kernel_[4][4][5][5];
+  size_t x_repeat_ = 1;
+  CacheAlignedUniquePtr kernel_storage_ = {nullptr};
 };
 
 }  // namespace jxl


### PR DESCRIPTION
```
+------------+--------+--------+--------+
| cycles     |   2x   |   4x   |   8x   |
+------------+--------+--------+--------+
| Baseline   | 249948 | 377275 | 523975 |
+------------+--------+--------+--------+
| Scalar (1) | 111383 | 162607 | 299005 |
+------------+--------+--------+--------+
| SSE4 (4)   |  48596 |  47257 |  72677 |
+------------+--------+--------+--------+
| AVX2 (8)   |  38341 |  39268 |  45655 |
+------------+--------+--------+--------+
| AVX3 (16)  |  36736 |  44514 |  41769 |
+------------+--------+--------+--------+
```

BEFORE

```
Compr                            Input    Compr            Compr       Compr  Decomp  Butteraugli
Method                          Pixels     Size              BPP   #    MP/s    MP/s     Distance    Error p norm           BPP*pnorm   Errors
----------------------------------------------------------------------------------------------------------------------------------------------
jxl:fast:d1:resampling=2     136323072  8731417    0.51239555400   1  32.522   2.398  13.27280712   2.98966850267  1.5318928486911312        0
jxl:fast:d1:resampling=4     136323072  2494249    0.14637281648   1  58.210   3.667  54.28284454  11.65082575442  1.7053641800059982        0
jxl:fast:d1:resampling=8     136323072   656189    0.03850787635   1  71.192   5.017 113.40100098  27.19273331255  1.0471344119728105        0
Aggregate:                   136323072  2426710    0.14240933233 ---  51.271   3.533  43.39244180   9.82073974612  1.3985649902105746        0
```

AFTER
```
Compr                            Input    Compr            Compr       Compr  Decomp  Butteraugli
Method                          Pixels     Size              BPP   #    MP/s    MP/s     Distance    Error p norm           BPP*pnorm   Errors
----------------------------------------------------------------------------------------------------------------------------------------------
jxl:fast:d1:resampling=2     136323072  8731417    0.51239555400   1  30.802  20.693  13.27280331   2.98966850189  1.5318928482907228        0
jxl:fast:d1:resampling=4     136323072  2494249    0.14637281648   1  54.076  32.372  54.28282928  11.65082574146  1.7053641781087603        0
jxl:fast:d1:resampling=8     136323072   656189    0.03850787635   1  67.589  50.065 113.40100098  27.19273316916  1.0471344064509187        0
Aggregate:                   136323072  2426710    0.14240933233 ---  48.286  32.248  43.39243358   9.82073972436  1.3985649871117138        0
```