### PR TITLE
Limit tree size for DC tiles

### DIFF
--- a/lib/jxl/modular/encoding/encoding.cc
+++ b/lib/jxl/modular/encoding/encoding.cc
@@ -430,8 +430,25 @@ Status ModularDecode(BitReader *br, Image &image, GroupHeader &header,
   const ANSCode *code = &code_storage;
   const std::vector<uint8_t> *context_map = &context_map_storage;
   if (!header.use_global_tree) {
-    size_t tree_size_limit = 1024 + image.w * image.h * nb_channels;
-    JXL_RETURN_IF_ERROR(DecodeTree(br, &tree_storage, tree_size_limit));
+    size_t max_tree_size = 1024;
+    for (size_t i = 0; i < nb_channels; i++) {
+      Channel &channel = image.channel[i];
+      if (!channel.w || !channel.h) {
+        continue;  // skip empty channels
+      }
+      if (i >= image.nb_meta_channels && (channel.w > options->max_chan_size ||
+                                          channel.h > options->max_chan_size)) {
+        break;
+      }
+      size_t pixels = channel.w * channel.h;
+      if (pixels / channel.w != channel.h) {
+        return JXL_FAILURE("Tree size overflow");
+      }
+      max_tree_size += pixels;
+      if (max_tree_size < pixels) return JXL_FAILURE("Tree size overflow");
+    }
+
+    JXL_RETURN_IF_ERROR(DecodeTree(br, &tree_storage, max_tree_size));
     JXL_RETURN_IF_ERROR(DecodeHistograms(br, (tree_storage.size() + 1) / 2,
                                          &code_storage, &context_map_storage));
   } else {


### PR DESCRIPTION
Image "size" for DC tile is 2048x2048. If there is e.g. 13 channels,
then tree is allowed to grow to 50M nodes. But when tree reaches 32M nodes,
for resizing it would temporarlily require ~4GiB...