### PR TITLE
Fuzz: accessing undefined values

### DIFF
--- a/lib/jxl/dec_modular.cc
+++ b/lib/jxl/dec_modular.cc
@@ -207,6 +207,7 @@ Status ModularFrameDecoder::DecodeGlobalInfo(BitReader* reader,
 
   ModularOptions options;
   options.max_chan_size = frame_dim.group_dim;
+  options.group_dim = frame_dim.group_dim;
   Status dec_status = ModularGenericDecompress(
       reader, gi, &global_header, ModularStreamId::Global().ID(frame_dim),
       &options,

--- a/lib/jxl/enc_modular.cc
+++ b/lib/jxl/enc_modular.cc
@@ -425,6 +425,7 @@ ModularFrameEncoder::ModularFrameEncoder(const FrameHeader& frame_header,
   }
   tree_splits.push_back(num_streams);
   cparams.options.max_chan_size = frame_dim.group_dim;
+  cparams.options.group_dim = frame_dim.group_dim;
 
   // TODO(veluca): figure out how to use different predictor sets per channel.
   stream_options.resize(num_streams, cparams.options);
@@ -862,6 +863,8 @@ Status ModularFrameEncoder::ComputeEncodingData(
     }
     multiplier_info.resize(new_num);
   }
+
+  JXL_RETURN_IF_ERROR(ValidateChannelDimensions(gi, stream_options[0]));
 
   return PrepareEncoding(pool, enc_state->shared.frame_dim,
                          enc_state->heuristics.get(), aux_out);

--- a/lib/jxl/modular/encoding/encoding.cc
+++ b/lib/jxl/modular/encoding/encoding.cc
@@ -358,6 +358,30 @@ Status DecodeModularChannelMAANS(BitReader *br, ANSSymbolReader *reader,
 
 GroupHeader::GroupHeader() { Bundle::Init(this); }
 
+Status ValidateChannelDimensions(const Image &image,
+                                 const ModularOptions &options) {
+  size_t nb_channels = image.channel.size();
+  for (bool is_dc : {true, false}) {
+    size_t group_dim = options.group_dim * (is_dc ? kBlockDim : 1);
+    size_t c = image.nb_meta_channels;
+    for (; c < nb_channels; c++) {
+      const Channel &ch = image.channel[c];
+      if (ch.w > options.group_dim || ch.h > options.group_dim) break;
+    }
+    for (; c < nb_channels; c++) {
+      const Channel &ch = image.channel[c];
+      if (ch.w == 0 || ch.h == 0) continue;  // skip empty
+      bool is_dc_channel = std::min(ch.hshift, ch.vshift) >= 3;
+      if (is_dc_channel != is_dc) continue;
+      size_t tile_dim = group_dim >> std::max(ch.hshift, ch.vshift);
+      if (tile_dim == 0) {
+        return JXL_FAILURE("Inconsistent transforms");
+      }
+    }
+  }
+  return true;
+}
+
 Status ModularDecode(BitReader *br, Image &image, GroupHeader &header,
                      size_t group_id, ModularOptions *options,
                      const Tree *global_tree, const ANSCode *global_code,
@@ -377,6 +401,10 @@ Status ModularDecode(BitReader *br, Image &image, GroupHeader &header,
   }
   if (image.error) {
     return JXL_FAILURE("Corrupt file. Aborting.");
+  }
+  if (br->AllReadsWithinBounds()) {
+    // Only check if the transforms list is complete.
+    JXL_RETURN_IF_ERROR(ValidateChannelDimensions(image, *options));
   }
 
   size_t nb_channels = image.channel.size();

--- a/lib/jxl/modular/encoding/encoding.h
+++ b/lib/jxl/modular/encoding/encoding.h
@@ -123,6 +123,9 @@ bool TreeToLookupTable(const FlatTree &tree,
 }
 // TODO(veluca): make cleaner interfaces.
 
+Status ValidateChannelDimensions(const Image &image,
+                                 const ModularOptions &options);
+
 // undo_transforms == N > 0: undo all transforms except the first N
 //                           (e.g. to represent YCbCr420 losslessly)
 // undo_transforms == 0: undo all transforms

--- a/lib/jxl/modular/options.h
+++ b/lib/jxl/modular/options.h
@@ -115,6 +115,9 @@ struct ModularOptions {
   // dimension bigger than max_chan_size.
   size_t max_chan_size = 0xFFFFFF;
 
+  // Used during decoding for validation of transforms (sqeeezing) scheme.
+  size_t group_dim = 0x1FFFFFFF;
+
   /// Encode options:
   // Fraction of pixels to look at to learn a MA tree
   // Number of iterations to do to learn a MA tree


### PR DESCRIPTION
If group_rect gets squeezed to 0, it causes the situation when non-empty channel
is not decoded.

Validate channel configuration after MetaApply.