### PR TITLE
Add AppVeyor configuration file

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,38 @@
+image: Visual Studio 2019
+configuration: Release
+clone_depth: 1
+
+environment:
+  VCPKG: C:/Tools/vcpkg
+  matrix:
+  - arch: x64
+  - arch: ARM64
+
+matrix:
+  allow_failures:
+    - arch: ARM64
+
+cache:
+- c:\tools\vcpkg\installed\
+- c:\Users\appveyor\AppData\Local\vcpkg\
+
+install:
+  - git submodule update --init --recursive
+  - vcpkg install gtest:%arch%-windows
+  - vcpkg install giflib:%arch%-windows
+  - vcpkg install libjpeg-turbo:%arch%-windows
+  - vcpkg install libpng:%arch%-windows
+  - vcpkg install zlib:%arch%-windows
+
+
+before_build:
+  - mkdir build
+  - cd build
+  - cmake .. -A %arch% -DBUILD_TESTING=OFF -DJPEGXL_STATIC=ON
+
+build:
+  project: build/JPEGXL.sln
+  verbosity: minimal
+
+artifacts:
+  - path: build\*\Release\*.exe


### PR DESCRIPTION
Add an AppVeyor configuration file that builds libjxl statically for Windows x64 and Arm64 using CMake and MSVC.

Arm64 builds are allowed to fail now due to dependencies not compiling correctly.

An example build can be [found here](https://ci.appveyor.com/project/EwoutH/libjxl/builds/39328673).

AppVeyor can be enabled via the [GitHub Marketplace](https://github.com/marketplace/appveyor).