### PR TITLE
Allow alternative to linear srgb when xyb with ICC

### DIFF
--- a/lib/jxl/color_encoding_internal.cc
+++ b/lib/jxl/color_encoding_internal.cc
@@ -665,6 +665,42 @@ void ConvertInternalToExternalColorEncoding(const ColorEncoding& internal,
       static_cast<JxlRenderingIntent>(internal.rendering_intent);
 }
 
+Status ConvertExternalToInternalColorEncoding(const JxlColorEncoding& external,
+                                              ColorEncoding* internal) {
+  internal->SetColorSpace(static_cast<ColorSpace>(external.color_space));
+
+  CIExy wp;
+  wp.x = external.white_point_xy[0];
+  wp.y = external.white_point_xy[1];
+  JXL_RETURN_IF_ERROR(internal->SetWhitePoint(wp));
+
+  if (external.color_space == JXL_COLOR_SPACE_RGB ||
+      external.color_space == JXL_COLOR_SPACE_UNKNOWN) {
+    internal->primaries = static_cast<Primaries>(external.primaries);
+    PrimariesCIExy primaries;
+    primaries.r.x = external.primaries_red_xy[0];
+    primaries.r.y = external.primaries_red_xy[1];
+    primaries.g.x = external.primaries_green_xy[0];
+    primaries.g.y = external.primaries_green_xy[1];
+    primaries.b.x = external.primaries_blue_xy[0];
+    primaries.b.y = external.primaries_blue_xy[1];
+    JXL_RETURN_IF_ERROR(internal->SetPrimaries(primaries));
+  }
+  CustomTransferFunction tf;
+  if (external.transfer_function == JXL_TRANSFER_FUNCTION_GAMMA) {
+    JXL_RETURN_IF_ERROR(tf.SetGamma(external.gamma));
+  } else {
+    tf.SetTransferFunction(
+        static_cast<TransferFunction>(external.transfer_function));
+  }
+  internal->tf = tf;
+
+  internal->rendering_intent =
+      static_cast<RenderingIntent>(external.rendering_intent);
+
+  return true;
+}
+
 /* Chromatic adaptation matrices*/
 static float kBradford[9] = {
     0.8951f, 0.2664f, -0.1614f, -0.7502f, 1.7135f,

--- a/lib/jxl/color_encoding_internal.h
+++ b/lib/jxl/color_encoding_internal.h
@@ -450,6 +450,9 @@ static inline std::ostream& operator<<(std::ostream& os,
 void ConvertInternalToExternalColorEncoding(const jxl::ColorEncoding& internal,
                                             JxlColorEncoding* external);
 
+Status ConvertExternalToInternalColorEncoding(const JxlColorEncoding& external,
+                                              jxl::ColorEncoding* internal);
+
 Status PrimariesToXYZD50(float rx, float ry, float gx, float gy, float bx,
                          float by, float wx, float wy, float matrix[9]);
 Status AdaptToXYZD50(float wx, float wy, float matrix[9]);

--- a/lib/jxl/dec_file.cc
+++ b/lib/jxl/dec_file.cc
@@ -64,7 +64,9 @@ Status DecodePreview(const DecompressParams& dparams,
 
   // Else: default or kOn => decode preview.
   PassesDecoderState dec_state;
-  JXL_RETURN_IF_ERROR(dec_state.output_encoding_info.Set(metadata.m));
+  JXL_RETURN_IF_ERROR(dec_state.output_encoding_info.Set(
+      metadata.m,
+      ColorEncoding::LinearSRGB(metadata.m.color_encoding.IsGray())));
   JXL_RETURN_IF_ERROR(DecodeFrame(dparams, &dec_state, pool, reader, preview,
                                   metadata, constraints,
                                   /*is_preview=*/true));
@@ -134,7 +136,9 @@ Status DecodeFile(const DecompressParams& dparams,
     }
 
     PassesDecoderState dec_state;
-    JXL_RETURN_IF_ERROR(dec_state.output_encoding_info.Set(io->metadata.m));
+    JXL_RETURN_IF_ERROR(dec_state.output_encoding_info.Set(
+        io->metadata.m,
+        ColorEncoding::LinearSRGB(io->metadata.m.color_encoding.IsGray())));
 
     io->frames.clear();
     Status dec_ok(false);

--- a/lib/jxl/dec_xyb.cc
+++ b/lib/jxl/dec_xyb.cc
@@ -331,14 +331,15 @@ void OpsinParams::Init(float intensity_target) {
   }
 }
 
-Status OutputEncodingInfo::Set(const ImageMetadata& metadata) {
+Status OutputEncodingInfo::Set(const ImageMetadata& metadata,
+                               const ColorEncoding& default_enc) {
   const auto& im = metadata.transform_data.opsin_inverse_matrix;
   float inverse_matrix[9];
   memcpy(inverse_matrix, im.inverse_matrix, sizeof(inverse_matrix));
   float intensity_target = metadata.IntensityTarget();
   if (metadata.xyb_encoded) {
     const auto& orig_color_encoding = metadata.color_encoding;
-    color_encoding = ColorEncoding::LinearSRGB(orig_color_encoding.IsGray());
+    color_encoding = default_enc;
     // Figure out if we can output to this color encoding.
     do {
       if (!orig_color_encoding.HaveFields()) break;

--- a/lib/jxl/dec_xyb.h
+++ b/lib/jxl/dec_xyb.h
@@ -35,7 +35,10 @@ struct OutputEncodingInfo {
   // Contains an opsin matrix that converts to the primaries of the output
   // encoding.
   OpsinParams opsin_params;
-  Status Set(const ImageMetadata& metadata);
+  // default_enc is used for xyb encoded image with ICC profile, in other
+  // cases it has no effect. Use linear sRGB or grayscale if ICC profile is
+  // not matched (not parsed or no matching ColorEncoding exists)
+  Status Set(const ImageMetadata& metadata, const ColorEncoding& default_enc);
   bool all_default_opsin = true;
   bool color_encoding_is_original = false;
 };

--- a/lib/jxl/enc_adaptive_quantization.cc
+++ b/lib/jxl/enc_adaptive_quantization.cc
@@ -964,7 +964,10 @@ ImageBundle RoundtripImage(const Image3F& opsin, PassesEncoderState* enc_state,
   PROFILER_ZONE("enc roundtrip");
   std::unique_ptr<PassesDecoderState> dec_state =
       jxl::make_unique<PassesDecoderState>();
-  JXL_CHECK(dec_state->output_encoding_info.Set(enc_state->shared.metadata->m));
+  JXL_CHECK(dec_state->output_encoding_info.Set(
+      enc_state->shared.metadata->m,
+      ColorEncoding::LinearSRGB(
+          enc_state->shared.metadata->m.color_encoding.IsGray())));
   dec_state->shared = &enc_state->shared;
   JXL_ASSERT(opsin.ysize() % kBlockDim == 0);
 

--- a/lib/jxl/enc_cache.cc
+++ b/lib/jxl/enc_cache.cc
@@ -144,7 +144,9 @@ void InitializePassesEncoder(const Image3F& opsin, ThreadPool* pool,
     ImageBundle decoded(&shared.metadata->m);
     std::unique_ptr<PassesDecoderState> dec_state =
         jxl::make_unique<PassesDecoderState>();
-    JXL_CHECK(dec_state->output_encoding_info.Set(shared.metadata->m));
+    JXL_CHECK(dec_state->output_encoding_info.Set(
+        shared.metadata->m,
+        ColorEncoding::LinearSRGB(shared.metadata->m.color_encoding.IsGray())));
     JXL_CHECK(DecodeFrame({}, dec_state.get(), pool, &br, &decoded,
                           *shared.metadata, /*constraints=*/nullptr));
     // TODO(lode): shared.frame_header.dc_level should be equal to

--- a/lib/jxl/enc_patch_dictionary.cc
+++ b/lib/jxl/enc_patch_dictionary.cc
@@ -812,7 +812,10 @@ void FindBestPatchDictionary(const Image3F& opsin,
     BitReader br(encoded);
     ImageBundle decoded(&state->shared.metadata->m);
     PassesDecoderState dec_state;
-    JXL_CHECK(dec_state.output_encoding_info.Set(state->shared.metadata->m));
+    JXL_CHECK(dec_state.output_encoding_info.Set(
+        state->shared.metadata->m,
+        ColorEncoding::LinearSRGB(
+            state->shared.metadata->m.color_encoding.IsGray())));
     JXL_CHECK(DecodeFrame({}, &dec_state, pool, &br, &decoded,
                           *state->shared.metadata, /*constraints=*/nullptr));
     JXL_CHECK(br.Close());

--- a/lib/jxl/encode.cc
+++ b/lib/jxl/encode.cc
@@ -32,42 +32,6 @@
 
 namespace jxl {
 
-Status ConvertExternalToInternalColorEncoding(const JxlColorEncoding& external,
-                                              ColorEncoding* internal) {
-  internal->SetColorSpace(static_cast<ColorSpace>(external.color_space));
-
-  CIExy wp;
-  wp.x = external.white_point_xy[0];
-  wp.y = external.white_point_xy[1];
-  JXL_RETURN_IF_ERROR(internal->SetWhitePoint(wp));
-
-  if (external.color_space == JXL_COLOR_SPACE_RGB ||
-      external.color_space == JXL_COLOR_SPACE_UNKNOWN) {
-    internal->primaries = static_cast<Primaries>(external.primaries);
-    PrimariesCIExy primaries;
-    primaries.r.x = external.primaries_red_xy[0];
-    primaries.r.y = external.primaries_red_xy[1];
-    primaries.g.x = external.primaries_green_xy[0];
-    primaries.g.y = external.primaries_green_xy[1];
-    primaries.b.x = external.primaries_blue_xy[0];
-    primaries.b.y = external.primaries_blue_xy[1];
-    JXL_RETURN_IF_ERROR(internal->SetPrimaries(primaries));
-  }
-  CustomTransferFunction tf;
-  if (external.transfer_function == JXL_TRANSFER_FUNCTION_GAMMA) {
-    JXL_RETURN_IF_ERROR(tf.SetGamma(external.gamma));
-  } else {
-    tf.SetTransferFunction(
-        static_cast<TransferFunction>(external.transfer_function));
-  }
-  internal->tf = tf;
-
-  internal->rendering_intent =
-      static_cast<RenderingIntent>(external.rendering_intent);
-
-  return true;
-}
-
 }  // namespace jxl
 
 uint32_t JxlEncoderVersion(void) {

--- a/lib/jxl/encode_internal.h
+++ b/lib/jxl/encode_internal.h
@@ -31,9 +31,6 @@ typedef struct JxlEncoderQueuedFrame {
   jxl::ImageBundle frame;
 } JxlEncoderQueuedFrame;
 
-Status ConvertExternalToInternalColorEncoding(const JxlColorEncoding& external,
-                                              jxl::ColorEncoding* internal);
-
 typedef std::array<uint8_t, 4> BoxType;
 
 // Utility function that makes a BoxType from a null terminated string literal.


### PR DESCRIPTION
For decoding a XYB-encoded image with ICC profile as original color
profile, allow configuring the decoder to decode to a color encoding of
your choosing, rather than the decoder always converting xyb to srgb.

Reason for this: the decoder is able to convert xyb to all supported
color encoding values (srgb, pq, hlg, linear, p3, ...). It does this
when it knows the color encoding, but not when an ICC profile is used
(since the libjxl decoder does not have color management system to parse
it, nor would all icc profiles be representable as a jxl color encoding)

If the decoder does not know the color encoding, it default to linear
srgb.

However, if you have a system, like the chrome browser, that can
determine form the ICC profile what the color encoding is, then it is
better to be able to let the decoder convert the xyb immediately to
that, to avoid needing two passes over the data.

Therefore this option is added to the API and implemented in the
decoder.