### PR TITLE
Share LCMS transform across threads

### DIFF
--- a/lib/jxl/enc_color_management.cc
+++ b/lib/jxl/enc_color_management.cc
@@ -201,9 +201,7 @@ void DoColorSpaceTransform(ColorSpaceTransform* t, const size_t thread,
         &t->skcms_icc_->profile_src_, buf_dst, skcms_PixelFormat_RGB_fff,
         skcms_AlphaFormat_Opaque, &t->skcms_icc_->profile_dst_, t->xsize_));
 #else   // JPEGXL_ENABLE_SKCMS
-    JXL_DASSERT(thread < t->transforms_.size());
-    cmsHTRANSFORM xform = t->transforms_[thread];
-    cmsDoTransform(xform, xform_src, buf_dst,
+    cmsDoTransform(t->lcms_transform_, xform_src, buf_dst,
                    static_cast<cmsUInt32Number>(t->xsize_));
 #endif  // JPEGXL_ENABLE_SKCMS
   }
@@ -735,9 +733,7 @@ void ColorEncoding::DecideIfWantICC() {
 ColorSpaceTransform::~ColorSpaceTransform() {
 #if !JPEGXL_ENABLE_SKCMS
   std::lock_guard<std::mutex> guard(LcmsMutex());
-  for (void* p : transforms_) {
-    TransformDeleter()(p);
-  }
+  TransformDeleter()(lcms_transform_);
 #endif
 }
 
@@ -856,19 +852,16 @@ Status ColorSpaceTransform::Init(const ColorEncoding& c_src,
   // Type includes color space (XYZ vs RGB), so can be different.
   const uint32_t type_src = Type32(c_src);
   const uint32_t type_dst = Type32(c_dst);
-  transforms_.clear();
-  for (size_t i = 0; i < num_threads; ++i) {
-    const uint32_t intent = static_cast<uint32_t>(c_dst.rendering_intent);
-    const uint32_t flags =
-        cmsFLAGS_BLACKPOINTCOMPENSATION | cmsFLAGS_HIGHRESPRECALC;
-    // NOTE: we're using the current thread's context and assuming all state
-    // modified by cmsDoTransform resides in the transform, not the context.
-    transforms_.emplace_back(cmsCreateTransformTHR(context, profile_src.get(),
-                                                   type_src, profile_dst.get(),
-                                                   type_dst, intent, flags));
-    if (transforms_.back() == nullptr) {
-      return JXL_FAILURE("Failed to create transform");
-    }
+  const uint32_t intent = static_cast<uint32_t>(c_dst.rendering_intent);
+  // Use cmsFLAGS_NOCACHE to disable the 1-pixel cache and make calling
+  // cmsDoTransform() thread-safe.
+  const uint32_t flags = cmsFLAGS_NOCACHE | cmsFLAGS_BLACKPOINTCOMPENSATION |
+                         cmsFLAGS_HIGHRESPRECALC;
+  lcms_transform_ =
+      cmsCreateTransformTHR(context, profile_src.get(), type_src,
+                            profile_dst.get(), type_dst, intent, flags);
+  if (lcms_transform_ == nullptr) {
+    return JXL_FAILURE("Failed to create transform");
   }
 #endif  // !JPEGXL_ENABLE_SKCMS
 

--- a/lib/jxl/enc_color_management.h
+++ b/lib/jxl/enc_color_management.h
@@ -47,8 +47,7 @@ class ColorSpaceTransform {
   struct SkcmsICC;
   std::unique_ptr<SkcmsICC> skcms_icc_;
 #else
-  // One per thread - cannot share because of caching.
-  std::vector<void*> transforms_;
+  void* lcms_transform_;
 #endif
 
   ImageF buf_src_;


### PR DESCRIPTION
`cmsFLAGS_NOCACHE` disables the 1-pixel cache and makes calling `cmsDoTransform()` thread-safe. So instead of creating an LCMS transform for each thread, one can pass this flag and share a single transform across all threads.

I made an attempt to benchmark this, but the benefits (in terms of performance) are minimal, and I'm not sure whether it can be properly measured. Therefore, this should be considered as a general improvement.

<details>
  <summary>Benchmark results</summary>

Benchmarked with a [photo of Wat Arun](https://commons.wikimedia.org/wiki/File:The_sculptures_of_two_mythical_giant_demons,_Thotsakan_and_Sahatsadecha,_guarding_the_eastern_gate_of_the_main_chapel_of_Wat_Arun,_Bangkok.jpg) (JPEG, 7360x4912, 29MB) containing the common sRGB IEC61966-2.1 profile.

Run with:
```bash
$ SKIP_TEST=1 ./ci.sh release -DJPEGXL_ENABLE_SKCMS=OFF
$ build/tools/benchmark_xl --input "~/wat-arun.jpg" --codec jxl:fast:d1
```

Before:
```
Compr               Input    Compr            Compr       Compr  Decomp  Butteraugli                                             
Method             Pixels     Size              BPP   #    MP/s    MP/s     Distance    Error p norm           BPP*pnorm   Errors
---------------------------------------------------------------------------------------------------------------------------------
jxl:fast:d1      36152320  6101574    1.35019251877   1  45.831  36.947   1.68089497   0.58562449946  0.7907058179756201        0
Aggregate:       36152320  6101574    1.35019251877 ---  45.831  36.947   1.68089497   0.58562449946  0.7907058179756201        0
```


After:
```
Compr               Input    Compr            Compr       Compr  Decomp  Butteraugli                                             
Method             Pixels     Size              BPP   #    MP/s    MP/s     Distance    Error p norm           BPP*pnorm   Errors
---------------------------------------------------------------------------------------------------------------------------------
jxl:fast:d1      36152320  6101574    1.35019251877   1  45.905  37.082   1.68089497   0.58562449946  0.7907058179756201        0
Aggregate:       36152320  6101574    1.35019251877 ---  45.905  37.082   1.68089497   0.58562449946  0.7907058179756201        0
```

</details>