### PR TITLE
add (still-only) y4m input support

### DIFF
--- a/lib/extras/codec_pnm.cc
+++ b/lib/extras/codec_pnm.cc
@@ -35,6 +35,7 @@ struct HeaderPNM {
   size_t ysize;
   bool is_bit;   // PBM
   bool is_gray;  // PGM
+  int is_yuv;    // Y4M: where 1 = 444, 2 = 422, 3 = 420
   size_t bits_per_sample;
   bool floating_point;
   bool big_endian;
@@ -48,11 +49,13 @@ class Parser {
   // Sets "pos" to the first non-header byte/pixel on success.
   Status ParseHeader(HeaderPNM* header, const uint8_t** pos) {
     // codec.cc ensures we have at least two bytes => no range check here.
+    if (pos_[0] == 'Y' && pos_[1] == 'U') return ParseHeaderY4M(header, pos);
     if (pos_[0] != 'P') return false;
     const uint8_t type = pos_[1];
     pos_ += 2;
 
     header->is_bit = false;
+    header->is_yuv = 0;
 
     switch (type) {
       case '4':
@@ -68,6 +71,8 @@ class Parser {
       case '6':
         header->is_gray = false;
         return ParseHeaderPNM(header, pos);
+
+        // TODO(jon): P7 (PAM)
 
       case 'F':
         header->is_gray = false;
@@ -176,6 +181,80 @@ class Parser {
     while (pos_ < end_ && IsWhitespace(*pos_)) {
       ++pos_;
     }
+    return true;
+  }
+
+  // TODO(jon): support multi-frame y4m
+  Status ParseHeaderY4M(HeaderPNM* header, const uint8_t** pos) {
+    if (strncmp("YUV4MPEG2", (const char*)pos_, 9) != 0) return false;
+    pos_ += 9;
+    header->is_gray = false;
+    header->is_yuv = 3;
+    // TODO(jon): check if 4:2:0 is indeed the default
+    header->bits_per_sample = 8;
+    // TODO(jon): check if there's a y4m convention for higher bit depths
+    while (pos_ < end_) {
+      if (pos_[0] == 0x0A) {
+        pos_++;
+        break;
+      }
+      if (pos_[0] == ' ') {
+        uint8_t field = pos_[1];
+        pos_ += 2;
+        switch (field) {
+          case 'W':
+            JXL_RETURN_IF_ERROR(ParseUnsigned(&header->xsize));
+            break;
+          case 'H':
+            JXL_RETURN_IF_ERROR(ParseUnsigned(&header->ysize));
+            break;
+          case 'I':
+            if (pos_[0] != 'p') {
+              return JXL_FAILURE(
+                  "Y4M: only progressive (no frame interlacing) allowed");
+            }
+            pos_++;
+            break;
+          case 'C':
+            if (pos_[0] != '4') return JXL_FAILURE("Y4M: invalid C param");
+            if (pos_[1] == '4') {
+              header->is_yuv = 1;  // 444
+            } else if (pos_[1] == '2') {
+              if (pos_[2] == '2') {
+                header->is_yuv = 2;  // 422
+              } else if (pos_[2] == '0') {
+                header->is_yuv = 3;  // 420
+              } else {
+                return JXL_FAILURE("Y4M: invalid C param");
+              }
+            } else {
+              return JXL_FAILURE("Y4M: invalid C param");
+            }
+            [[fallthrough]];
+            // no break: fallthrough because this field can have values like
+            // "C420jpeg" (we are ignoring the chroma sample location and treat
+            // everything like C420jpeg)
+          case 'F':  // Framerate in fps as numerator:denominator
+                     // TODO(jon): actually read this and set corresponding jxl
+                     // metadata
+          case 'A':  // Pixel aspect ratio (ignoring it, could perhaps adjust
+                     // intrinsic dimensions based on this?)
+          case 'X':  // Comment, ignore
+            // ignore the field value and go to next one
+            while (pos_[0] != ' ' && pos_[0] != 0x0A) pos_++;
+            break;
+          default:
+            return JXL_FAILURE("Y4M: parse error");
+        }
+      }
+    }
+    if (strncmp("FRAME", (const char*)pos_, 5) != 0)
+      return JXL_FAILURE("Y4M: expected FRAME");
+    pos_ += 5;
+    while (pos_[0] != 0x0A && pos_ < end_) pos_++;
+    if (pos_[0] != 0x0A) return JXL_FAILURE("Y4M: parse error");
+    pos_++;
+    *pos = pos_;
     return true;
   }
 
@@ -342,14 +421,52 @@ Status DecodeImagePNM(const Span<const uint8_t> bytes, ThreadPool* pool,
   io->metadata.m.SetAlphaBits(0);
   io->dec_pixels = header.xsize * header.ysize;
 
-  const bool flipped_y = header.bits_per_sample == 32;  // PFMs are flipped
-  const Span<const uint8_t> span(pos, bytes.data() + bytes.size() - pos);
-  JXL_RETURN_IF_ERROR(ConvertFromExternal(
-      span, header.xsize, header.ysize, io->metadata.m.color_encoding,
-      /*has_alpha=*/false, /*alpha_is_premultiplied=*/false,
-      io->metadata.m.bit_depth.bits_per_sample,
-      header.big_endian ? JXL_BIG_ENDIAN : JXL_LITTLE_ENDIAN, flipped_y, pool,
-      &io->Main()));
+  if (header.is_yuv > 0) {
+    Image3F yuvdata(header.xsize, header.ysize);
+    ImageBundle bundle(&io->metadata.m);
+    const int hshift[3][3] = {{0, 0, 0}, {0, 1, 1}, {0, 1, 1}};
+    const int vshift[3][3] = {{0, 0, 0}, {0, 0, 0}, {0, 1, 1}};
+
+    for (size_t c = 0; c < 3; c++) {
+      for (size_t y = 0; y < header.ysize >> vshift[header.is_yuv - 1][c];
+           ++y) {
+        float* const JXL_RESTRICT row =
+            yuvdata.PlaneRow((c == 2 ? 2 : 1 - c), y);
+        if (pos + (header.xsize >> hshift[header.is_yuv - 1][c]) >
+            bytes.data() + bytes.size())
+          return JXL_FAILURE("Not enough image data");
+        for (size_t x = 0; x < header.xsize >> hshift[header.is_yuv - 1][c];
+             ++x) {
+          row[x] = (1.f / 255.f) * ((*pos++) - 127.f);
+        }
+      }
+    }
+    bundle.SetFromImage(std::move(yuvdata), io->metadata.m.color_encoding);
+    bundle.color_transform = ColorTransform::kYCbCr;
+
+    YCbCrChromaSubsampling subsampling;
+    uint8_t cssh[3] = {
+        2, static_cast<uint8_t>(hshift[header.is_yuv - 1][1] ? 1 : 2),
+        static_cast<uint8_t>(hshift[header.is_yuv - 1][2] ? 1 : 2)};
+    uint8_t cssv[3] = {
+        2, static_cast<uint8_t>(vshift[header.is_yuv - 1][1] ? 1 : 2),
+        static_cast<uint8_t>(vshift[header.is_yuv - 1][2] ? 1 : 2)};
+
+    JXL_RETURN_IF_ERROR(subsampling.Set(cssh, cssv));
+
+    bundle.chroma_subsampling = subsampling;
+
+    io->Main() = std::move(bundle);
+  } else {
+    const bool flipped_y = header.bits_per_sample == 32;  // PFMs are flipped
+    const Span<const uint8_t> span(pos, bytes.data() + bytes.size() - pos);
+    JXL_RETURN_IF_ERROR(ConvertFromExternal(
+        span, header.xsize, header.ysize, io->metadata.m.color_encoding,
+        /*has_alpha=*/false, /*alpha_is_premultiplied=*/false,
+        io->metadata.m.bit_depth.bits_per_sample,
+        header.big_endian ? JXL_BIG_ENDIAN : JXL_LITTLE_ENDIAN, flipped_y, pool,
+        &io->Main()));
+  }
   if (!header.floating_point) {
     io->metadata.m.bit_depth.bits_per_sample = io->Main().DetectRealBitdepth();
   }


### PR DESCRIPTION
Adds decode support for `.y4m` (see https://wiki.multimedia.cx/index.php/YUV4MPEG2) which is convenient for source material that happens to be YCbCr 4:4:4, 4:2:2 or 4:2:0. Such images can be created using e.g. `ffmpeg -i input.png -pix_fmt yuv420p input.y4m`.

Only single-frame input works for now.

I used this to test lossless encoding of subsampled ycbcr and it works.

Trying vardct with this kind of input doesn't work (I suppose we could upsample and convert to RGB in that case).

There's no encode support for `.y4m` yet; that would involve having a way to skip the upsampling and color conversion, so the data stays in the original yuv4xx format.

If multi-frame and .y4m write support would later be added, it would be useful for lossless archival of uncompressed video in a way that also happens to be a valid jxl animation.