### PR TITLE
simpler cjxl banner, also one for djxl

### DIFF
--- a/tools/benchmark/benchmark_xl.cc
+++ b/tools/benchmark/benchmark_xl.cc
@@ -1077,7 +1077,7 @@ class Benchmark {
 };
 
 int BenchmarkMain(int argc, const char** argv) {
-  fprintf(stderr, "benchmark_xl [%s]\n",
+  fprintf(stderr, "benchmark_xl %s\n",
           jpegxl::tools::CodecConfigString(JxlDecoderVersion()).c_str());
 
   JXL_CHECK(Args()->AddCommandLineOptions());

--- a/tools/cjxl_main.cc
+++ b/tools/cjxl_main.cc
@@ -28,15 +28,14 @@ int CompressJpegXlMain(int argc, const char* argv[]) {
   }
 
   if (args.version) {
-    fprintf(stdout, "cjxl [%s]\n",
+    fprintf(stdout, "cjxl %s\n",
             CodecConfigString(JxlEncoderVersion()).c_str());
     fprintf(stdout, "Copyright (c) the JPEG XL Project\n");
     return 0;
   }
 
   if (!args.quiet) {
-    fprintf(stderr, "  J P E G   \\/ |\n");
-    fprintf(stderr, "            /\\ |_   e n c o d e r    [%s]\n\n",
+    fprintf(stderr, "JPEG XL encoder %s\n",
             CodecConfigString(JxlEncoderVersion()).c_str());
   }
 

--- a/tools/codec_config.cc
+++ b/tools/codec_config.cc
@@ -38,7 +38,7 @@ std::string CodecConfigString(uint32_t lib_version) {
 #endif
 
   bool saw_target = false;
-  config += "| SIMD supported: ";
+  config += "[";
   for (const uint32_t target : hwy::SupportedAndGeneratedTargets()) {
     config += hwy::TargetName(target);
     config += ',';
@@ -47,6 +47,7 @@ std::string CodecConfigString(uint32_t lib_version) {
   JXL_ASSERT(saw_target);
   (void)saw_target;
   config.resize(config.size() - 1);  // remove trailing comma
+  config += "]";
 
   return config;
 }

--- a/tools/djxl.cc
+++ b/tools/djxl.cc
@@ -312,7 +312,6 @@ jxl::Status WriteJxlOutput(const DecompressArgs& args, const char* file_out,
       }
     }
   }
-  if (!args.quiet) fprintf(stderr, "Done.\n");
   return true;
 }
 

--- a/tools/djxl_main.cc
+++ b/tools/djxl_main.cc
@@ -45,10 +45,14 @@ int DecompressMain(int argc, const char* argv[]) {
   }
 
   if (args.version) {
-    fprintf(stdout, "djxl [%s]\n",
+    fprintf(stdout, "djxl %s\n",
             CodecConfigString(JxlDecoderVersion()).c_str());
     fprintf(stdout, "Copyright (c) the JPEG XL Project\n");
     return 0;
+  }
+  if (!args.quiet) {
+    fprintf(stderr, "JPEG XL decoder %s\n",
+            CodecConfigString(JxlDecoderVersion()).c_str());
   }
 
   if (cmdline.HelpFlagPassed()) {
@@ -65,8 +69,7 @@ int DecompressMain(int argc, const char* argv[]) {
   jxl::PaddedBytes compressed;
   if (!jxl::ReadFile(args.file_in, &compressed)) return 1;
   if (!args.quiet) {
-    fprintf(stderr, "Read %zu compressed bytes [%s]\n", compressed.size(),
-            CodecConfigString(JxlDecoderVersion()).c_str());
+    fprintf(stderr, "Read %zu compressed bytes.\n", compressed.size());
   }
 
   // If the file uses the box format container, unpack the boxes into


### PR DESCRIPTION
Addresses https://gitlab.com/wg1/jpeg-xl/-/issues/183

Simplifies the cjxl banner (ascii art is fun, but not very good for a11y etc), and adds a banner to djxl and benchmark_xl so the version number can be seen in all tools, not only the encoder.