### PR TITLE
 Fuzz: fix heap-buffer-overflow in codec_psd

### DIFF
--- a/lib/extras/codec_psd.cc
+++ b/lib/extras/codec_psd.cc
@@ -527,9 +527,11 @@ Status DecodeImagePSD(const Span<const uint8_t> bytes, ThreadPool* pool,
       JXL_DEBUG_V(PSD_VERBOSITY, "At position %i (%zu)",
                   (int)(pos - bytes.data()), (size_t)pos);
       ImageBundle& layer = io->frames[il++];
-      JXL_RETURN_IF_ERROR(decode_layer(pos, maxpos, layer, layer_chan_id[l],
-                                       invert, layer.xsize(), layer.ysize(),
-                                       version, colormodel, true, bitdepth));
+      std::vector<int>& chan_id = layer_chan_id[l];
+      if (chan_id.size() > invert.size()) invert.resize(chan_id.size(), false);
+      JXL_RETURN_IF_ERROR(decode_layer(pos, maxpos, layer, chan_id, invert,
+                                       layer.xsize(), layer.ysize(), version,
+                                       colormodel, true, bitdepth));
     }
   } else
     return JXL_FAILURE("PSD: no layer data found");


### PR DESCRIPTION
decode_layer assumes that chan_id.size() == invert.size().
On one callsite (where invert is actually used) this is true.
On the other callsite invert is just an "all-false" stub, but
its size is set to be `real_nb_channels` which might be not enough.