### PR TITLE
Revert "Install JDK into docker image (for testing JNI wrapper). (#27)"

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -31,7 +31,7 @@ variables:
 # A template for running in the generic cloud builders. These are tagged with
 # "linux" and run on shared VMs.
 .linux_host_template: &linux_host_template
-  image: &jpegxl-builder gcr.io/jpegxl/jpegxl-builder@sha256:ae3b4dcf32eef31a441da2c63f10a4404dd45dcb96edbb033299050eac8650ef
+  image: &jpegxl-builder gcr.io/jpegxl/jpegxl-builder@sha256:e8192a8b641f6b85ff423c3fdc4cb69ffa8ad04e05f9c4c92021ebe4c633deef
   tags:
     - linux
   # By default all the workflows run on master and on request. This can be

--- a/docker/scripts/jpegxl_builder.sh
+++ b/docker/scripts/jpegxl_builder.sh
@@ -168,11 +168,6 @@ install_pkgs() {
     parallel
     pkg-config
 
-    # For compiling / testing JNI wrapper. JDK8 is almost 2x smaller than JDK11
-    # openjdk-8-jdk-headless would be 50MB smaller, unfortunately, CMake
-    # does mistakenly thinks it does not contain JNI feature.
-    openjdk-8-jdk
-
     # These are used by the ./ci.sh lint in the native builder.
     clang-format-7
     clang-format-8
@@ -435,9 +430,6 @@ main() {
   install_pkgs
   install_binutils
   apt clean
-
-  # Remove prebuilt Java classes cache.
-  rm /usr/lib/jvm/java-8-openjdk-amd64/jre/lib/amd64/server/classes.jsa
 
   # Manually extract packages for the target arch that can't install it directly
   # at the same time as the native ones.


### PR DESCRIPTION
This reverts commit 22ab730343a5ff0ed041359cee972f94e94e9a52.

It seems that EMCC uses improper closure-compiler version.