### PR TITLE
Use disabled-targets instead of build-only-scalar

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -225,7 +225,7 @@ build:x86_64:clang:scalar:
   <<: *linux_host_build_template
   stage: build
   script:
-    - SKIP_TEST=1 PACK_TEST=1 CMAKE_CXX_FLAGS="-DHWY_COMPILE_ONLY_SCALAR" ./ci.sh release
+    - SKIP_TEST=1 PACK_TEST=1 CMAKE_CXX_FLAGS="-DHWY_DISABLED_TARGETS=~HWY_SCALAR" ./ci.sh release
 
 test:x86_64:clang:scalar:
   <<: *linux_host_template


### PR DESCRIPTION
This allows deprecating the (potentially disruptive) build-only-scalar
option, which may conflict with the desired build policy for tests.