### PR TITLE
inverse palette bugfix: preserve hshift/vshift

### DIFF
--- a/lib/jxl/modular/transform/palette.h
+++ b/lib/jxl/modular/transform/palette.h
@@ -218,7 +218,9 @@ static Status InvPalette(Image &input, uint32_t begin_c, uint32_t nb_colors,
   // JXL_DASSERT(input.channel[c0].maxval == palette.w-1);
   if (nb < 1) return JXL_FAILURE("Corrupted transforms");
   for (int i = 1; i < nb; i++) {
-    input.channel.insert(input.channel.begin() + c0 + 1, Channel(w, h));
+    input.channel.insert(
+        input.channel.begin() + c0 + 1,
+        Channel(w, h, input.channel[c0].hshift, input.channel[c0].vshift));
   }
   const Channel &palette = input.channel[0];
   const pixel_type *JXL_RESTRICT p_palette = input.channel[0].Row(0);


### PR DESCRIPTION
Fixes https://github.com/libjxl/libjxl/issues/29

Inverse palette of multiple channels resetted hshift/vshift of the non-first restored channel to zero, which is incorrect.
In weird combinations with Squeeze, this can lead to negative shift values.

This does (probably) not happen in any bitstream created by cjxl.