### PR TITLE
Install JDK into docker image (for testing JNI wrapper).

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -22,7 +22,7 @@ variables:
 # A template for running in the generic cloud builders. These are tagged with
 # "linux" and run on shared VMs.
 .linux_host_template: &linux_host_template
-  image: &jpegxl-builder gcr.io/jpegxl/jpegxl-builder@sha256:e8192a8b641f6b85ff423c3fdc4cb69ffa8ad04e05f9c4c92021ebe4c633deef
+  image: &jpegxl-builder gcr.io/jpegxl/jpegxl-builder@sha256:439a05c41f86a82067042fca16d5c9c7cc5836a8a5d8dba7fa0383f3c1e603c2
   tags:
     - linux
   # By default all the workflows run on master and on request. This can be

--- a/docker/scripts/emsdk_install.sh
+++ b/docker/scripts/emsdk_install.sh
@@ -4,10 +4,10 @@
 # Use of this source code is governed by a BSD-style
 # license that can be found in the LICENSE file.
 
-EMSDK_URL="https://github.com/emscripten-core/emsdk/archive/master.tar.gz"
+EMSDK_URL="https://github.com/emscripten-core/emsdk/archive/main.tar.gz"
 EMSDK_DIR="/opt/emsdk"
 
-EMSDK_RELEASE="2.0.4"
+EMSDK_RELEASE="2.0.23"
 
 set -eu -x
 

--- a/docker/scripts/jpegxl_builder.sh
+++ b/docker/scripts/jpegxl_builder.sh
@@ -57,7 +57,7 @@ BENCHMARK_FLAGS="-DCMAKE_BUILD_TYPE=Release -DBENCHMARK_ENABLE_TESTING=OFF \
   -DCMAKE_POSITION_INDEPENDENT_CODE=ON"
 
 # V8
-V8_VERSION="8.7.230"
+V8_VERSION="9.3.22"
 
 # Temporary files cleanup hooks.
 CLEANUP_FILES=()
@@ -167,6 +167,11 @@ install_pkgs() {
     ninja-build
     parallel
     pkg-config
+
+    # For compiling / testing JNI wrapper. JDK8 is almost 2x smaller than JDK11
+    # openjdk-8-jdk-headless would be 50MB smaller, unfortunately, CMake
+    # does mistakenly thinks it does not contain JNI feature.
+    openjdk-8-jdk
 
     # These are used by the ./ci.sh lint in the native builder.
     clang-format-7
@@ -399,6 +404,10 @@ install_from_source() {
       exit 1
     fi
 
+    # CMake mistakenly uses ".so" libraries and EMCC fails to link properly.
+    if [[ "${target}" == wasm* ]]; then
+      rm -f "${prefix}/lib"/*.so*
+    fi
   done
 }
 
@@ -430,6 +439,9 @@ main() {
   install_pkgs
   install_binutils
   apt clean
+
+  # Remove prebuilt Java classes cache.
+  rm /usr/lib/jvm/java-8-openjdk-amd64/jre/lib/amd64/server/classes.jsa
 
   # Manually extract packages for the target arch that can't install it directly
   # at the same time as the native ones.
@@ -492,7 +504,7 @@ main() {
 
   install_from_source BENCHMARK "${LIST_TARGETS[@]}" "${LIST_MINGW_TARGETS[@]}"
 
-  # Install v8. v8 has better WASM SIMD support than NodeJS 14.
+  # Install v8. v8 has better WASM SIMD support than NodeJS 14 (LTS).
   # First we need the installer to install v8.
   npm install jsvu -g
   # install specific version;


### PR DESCRIPTION
Do not land until HWY is updated past 376176136.