### PR TITLE
Update build command in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ export CC=clang-7 CXX=clang++-7
 ### Building
 
 ```bash
-cd jpeg-xl
+cd libjxl
 mkdir build
 cd build
 cmake -DCMAKE_BUILD_TYPE=Release -DBUILD_TESTING=OFF ..


### PR DESCRIPTION
After updating repo link in PR #41 the repo name changed too, so `cd jpeg-xl` doesn't work anymore if one wanted to use that link.