### PR TITLE
fix: unused CPU_[ZERO|SET] on HaikuOS

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -18,3 +18,4 @@ Google LLC <*@google.com>
 # Individuals:
 Jon Sneyers <jon@cloudinary.com>
 Pieter Wuille
+Marcin Konicki <ahwayakchih@gmail.com>

--- a/tools/cpu/os_specific.cc
+++ b/tools/cpu/os_specific.cc
@@ -250,7 +250,7 @@ Status PinThreadToCPU(const int cpu) {
 #ifdef JXL_DISABLE_PINNING
   return false;
 #else
-#if JXL_OS_WIN || JXL_OS_LINUX || JXL_OS_FREEBSD || JXL_OS_MAC
+#if JXL_OS_WIN || JXL_OS_LINUX || JXL_OS_FREEBSD || JXL_OS_MAC || JXL_OS_HAIKU
   ThreadAffinity affinity;
   CPU_ZERO(&affinity.set);
   CPU_SET(cpu, &affinity.set);


### PR DESCRIPTION
Building was failing because `CPU_ZERO` and `CPU_SET` in `os_specific.cc` were unused on HaikuOS.

This change makes HaikuOS follow example of MacOS: call them even though in the end thread will not be pinned anyway.

HaikuOS build could use `JXL_DISABLE_PINNING`, but then it would have to add some defines to exclude declaring `CPU_SET` and `CPU_ZERO`, which would lessen code readability for everyone.