### PR TITLE
New GitHub workflow to build and test several modes.

### DIFF
--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -1,0 +1,88 @@
+# Copyright (c) the JPEG XL Project Authors. All rights reserved.
+#
+# Use of this source code is governed by a BSD-style
+# license that can be found in the LICENSE file.
+
+# Workflow for building and running tests.
+
+name: Build/Test
+on:
+  push:
+    branches:
+      - main
+      - v*.*.x
+  pull_request:
+    types: [opened, reopened, labeled, synchronize]
+
+jobs:
+  ubuntu_build:
+    name: Ubuntu Build ${{ matrix.name }}
+    runs-on: [ubuntu-latest]
+    strategy:
+      matrix:
+        # We have one job per "name" in the matrix. Attributes are set on the
+        # specific job names.
+        name: [release, debug, asan, msan, scalar]
+        include:
+          - name: release
+            test_in_pr: true
+          - name: debug
+          # Build scalar-only hwy instructions.
+          - name: scalar
+            mode: release
+            cxxflags: -DHWY_DISABLED_TARGETS=~HWY_SCALAR
+          # Disabling optional features to speed up msan build a little bit.
+          - name: msan
+            cmake_args: >-
+              -DJPEGXL_ENABLE_DEVTOOLS=OFF -DJPEGXL_ENABLE_PLUGINS=OFF
+              -DJPEGXL_ENABLE_VIEWERS=OFF
+
+    steps:
+    - name: Install build deps
+      run: |
+        sudo apt update
+        sudo apt install -y \
+          clang-7 \
+          cmake \
+          doxygen \
+          libbrotli-dev \
+          libgif-dev \
+          libgtest-dev \
+          libjpeg-dev \
+          libopenexr-dev \
+          libpng-dev \
+          libwebp-dev \
+          ninja-build \
+          pkg-config \
+        #
+        echo "CC=clang-7" >> $GITHUB_ENV
+        echo "CXX=clang++-7" >> $GITHUB_ENV
+    - name: Checkout the source
+      uses: actions/checkout@v2
+      with:
+        submodules: true
+    - name: Build
+      run: |
+        mode="${{ matrix.mode }}"
+        [[ -n "${mode}" ]] || mode="${{ matrix.name }}"
+        ./ci.sh ${mode} -DJPEGXL_FORCE_SYSTEM_BROTLI=ON ${{ matrix.cmake_args }}
+      env:
+        SKIP_TEST: 1
+        CMAKE_CXX_FLAGS: ${{ matrix.cxxflags }}
+    - name: Build stats ${{ matrix.name }}
+      if: matrix.mode == 'release' || matrix.name == 'release'
+      run: |
+        tools/build_stats.py --save build/stats.json \
+          cjxl djxl libjxl.so libjxl_dec.so
+    # Run the tests on push and when requested in pull_request.
+    - name: Test ${{ matrix.mode }}
+      if: |
+        github.event_name == 'push' ||
+        (github.event_name == 'pull_request' && (
+         matrix.test_in_pr ||
+         contains(github.event.pull_request.labels.*.names, 'CI:full')))
+      run: |
+        if [[ "${{ matrix.name }}" == "debug" ]]; then
+          export TEST_STACK_LIMIT=1024
+        fi
+        ./ci.sh test

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -1,50 +1,16 @@
-# Workflow to run on pull-requests
+# Copyright (c) the JPEG XL Project Authors. All rights reserved.
+#
+# Use of this source code is governed by a BSD-style
+# license that can be found in the LICENSE file.
+
+# Workflow to run pull-requests specific checks.
 
 name: PR
 on:
   pull_request:
-    types: [opened, reopened, labeled, unlabeled, synchronize]
+    types: [opened, reopened, synchronize]
 
 jobs:
-  build:
-    runs-on: [ubuntu-latest]
-    strategy:
-      matrix:
-        mode: [release, debug]
-    steps:
-    - name: Install build deps
-      run: |
-        sudo apt update
-        sudo apt install -y \
-          clang-7 \
-          cmake \
-          doxygen \
-          libbrotli-dev \
-          libgif-dev \
-          libgtest-dev \
-          libjpeg-dev \
-          libopenexr-dev \
-          libpng-dev \
-          libwebp-dev \
-          ninja-build \
-          pkg-config \
-        #
-        echo "CC=clang-7" >> $GITHUB_ENV
-        echo "CXX=clang++-7" >> $GITHUB_ENV
-    - name: Checkout the source
-      uses: actions/checkout@v2
-      with:
-        submodules: true
-    - name: Build ${{ matrix.mode }}
-      run:
-        ./ci.sh ${{ matrix.mode }} -DJPEGXL_FORCE_SYSTEM_BROTLI=ON
-      env:
-        SKIP_TEST: 1
-    # Run the tests only on release mode.
-    - name: Test ${{ matrix.mode }}
-      run:
-        '[[ ${{ matrix.mode }} != "release" ]] || ./ci.sh test'
-
   # Checks that the AUTHORS files is updated with new contributors.
   authors:
     runs-on: [ubuntu-latest]

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,16 +1,7 @@
-# Copyright (c) the JPEG XL Project
+# Copyright (c) the JPEG XL Project Authors. All rights reserved.
 #
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#      http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# Use of this source code is governed by a BSD-style
+# license that can be found in the LICENSE file.
 
 # We define only two stages for development. The "build" stage only compiles the
 # code and doesn't run any target code. The "test" stage runs the code compiled

--- a/bash_test.sh
+++ b/bash_test.sh
@@ -65,7 +65,7 @@ test_copyright() {
   local f
   for f in $(
       git ls-files | grep -E \
-      '(Dockerfile.*|\.c|\.cc|\.cpp|\.gni|\.h|\.java|\.sh|\.m|\.py|\.ui)$'); do
+      '(Dockerfile.*|\.c|\.cc|\.cpp|\.gni|\.h|\.java|\.sh|\.m|\.py|\.ui|\.yml)$'); do
     if [[ "${f#third_party/}" == "$f" ]]; then
       # $f is not in third_party/
       if ! head -n 10 "$f" |


### PR DESCRIPTION
This new build_test.yml workflow builds and tests for release, debug,
asan, msan and release with scalar-only modes in the the main and
release branches.

This patch now also builds all these targets but only tests release in
the pull request, unless it is labeled with "CI:full" label which will
cause it to test all the modes as well.