### PR TITLE
docs: add `giflib_devel` as dependency on HaikuOS

### DIFF
--- a/README.Haiku.md
+++ b/README.Haiku.md
@@ -10,7 +10,7 @@ instructions see "[README](README.md)" and
 ## Dependencies
 
 ```shell
-pkgman install llvm9_clang ninja cmake doxygen libjpeg_turbo_devel
+pkgman install llvm9_clang ninja cmake doxygen libjpeg_turbo_devel giflib_devel
 ```
 
 ## Building


### PR DESCRIPTION
This adds `giflib_devel` (same as libgif on Linux) to list of dependencies to install on HaikuOS.

It's not strictly necessary for libjxl to work, but `RoundtripAnimationPatches` test fails without it.