### PR TITLE
Use a sentinel value instead of 0 for memory sanitizer.

### DIFF
--- a/lib/jxl/common.h
+++ b/lib/jxl/common.h
@@ -25,6 +25,12 @@
 namespace jxl {
 // Some enums and typedefs used by more than one header file.
 
+#ifdef MEMORY_SANITIZER
+// Chosen so that kSanitizerSentinel is four copies of kSanitizerSentinelByte.
+constexpr uint8_t kSanitizerSentinelByte = 0x48;
+constexpr float kSanitizerSentinel = 205089.125f;
+#endif
+
 constexpr size_t kBitsPerByte = 8;  // more clear than CHAR_BIT
 
 constexpr inline size_t RoundUpBitsToByteMultiple(size_t bits) {

--- a/lib/jxl/dec_cache.h
+++ b/lib/jxl/dec_cache.h
@@ -186,7 +186,7 @@ struct PassesDecoderState {
                               kGroupDim + 2 * kGroupDataYBorder);
 #if MEMORY_SANITIZER
       // Avoid errors due to loading vectors on the outermost padding.
-      ZeroFillImage(&group_data.back());
+      FillImage(kSanitizerSentinel, &group_data.back());
 #endif
     }
     if (rgb_output || pixel_callback) {
@@ -317,7 +317,7 @@ struct PassesDecoderState {
     }
 #if MEMORY_SANITIZER
     // Avoid errors due to loading vectors on the outermost padding.
-    ZeroFillImage(&decoded);
+    FillImage(kSanitizerSentinel, &decoded);
 #endif
   }
 

--- a/lib/jxl/dec_frame.cc
+++ b/lib/jxl/dec_frame.cc
@@ -442,7 +442,7 @@ void FrameDecoder::AllocateOutput() {
            y++) {
         for (size_t x = DivCeil(frame_dim_.xsize_upsampled, ecups);
              x < DivCeil(frame_dim_.xsize_upsampled_padded, ecups); x++) {
-          dec_state_->extra_channels.back().Row(y)[x] = 0;
+          dec_state_->extra_channels.back().Row(y)[x] = kSanitizerSentinel;
         }
       }
 #endif

--- a/lib/jxl/dec_reconstruct.cc
+++ b/lib/jxl/dec_reconstruct.cc
@@ -147,9 +147,10 @@ Status UndoXYBInPlace(Image3F* idct, const Rect& rect,
       for (size_t x = 0; x < rect.xsize(); x += Lanes(d)) {
 #if MEMORY_SANITIZER
         const auto mask = Iota(d, x) < Set(d, rect.xsize());
-        const auto in_opsin_x = IfThenElseZero(mask, Load(d, row0 + x));
-        const auto in_opsin_y = IfThenElseZero(mask, Load(d, row1 + x));
-        const auto in_opsin_b = IfThenElseZero(mask, Load(d, row2 + x));
+        const auto sentinel = Set(d, kSanitizerSentinel);
+        const auto in_opsin_x = IfThenElse(mask, Load(d, row0 + x), sentinel);
+        const auto in_opsin_y = IfThenElse(mask, Load(d, row1 + x), sentinel);
+        const auto in_opsin_b = IfThenElse(mask, Load(d, row2 + x), sentinel);
 #else
         const auto in_opsin_x = Load(d, row0 + x);
         const auto in_opsin_y = Load(d, row1 + x);

--- a/lib/jxl/filters.h
+++ b/lib/jxl/filters.h
@@ -168,9 +168,9 @@ class FilterPipeline {
     for (size_t c = 0; c < 3; c++) {
       for (size_t y = 0; y < storage.ysize(); y++) {
         float* row = storage.PlaneRow(c, y);
-        memset(row, 0x77, sizeof(float) * kMaxFilterPadding);
-        memset(row + storage.xsize() - kMaxFilterPadding, 0x77,
-               sizeof(float) * kMaxFilterPadding);
+        std::fill(row, row + kMaxFilterPadding, kSanitizerSentinel);
+        std::fill(row + storage.xsize() - kMaxFilterPadding,
+                  row + storage.xsize(), kSanitizerSentinel);
       }
     }
 #endif  // MEMORY_SANITIZER

--- a/lib/jxl/image.cc
+++ b/lib/jxl/image.cc
@@ -114,9 +114,10 @@ void PlaneBase::InitializePadding(const size_t sizeof_t, Padding padding) {
     // There's a bug in msan in clang-6 when handling AVX2 operations. This
     // workaround allows tests to pass on msan, although it is slower and
     // prevents msan warnings from uninitialized images.
-    memset(row, 0, initialize_size);
+    std::fill(row, kSanitizerSentinelByte, initialize_size);
 #else
-    memset(row + valid_size, 0, initialize_size - valid_size);
+    memset(row + valid_size, kSanitizerSentinelByte,
+           initialize_size - valid_size);
 #endif  // clang6
   }
 #endif  // MEMORY_SANITIZER


### PR DESCRIPTION
This should make it more evident when actually using "uninitialized"
padding memory in sanitizer builds.