### PR TITLE
Only make `jpeg_transcode` set `butteraugli_distance` to 0 after it itself receives its correct value

### DIFF
--- a/tools/cjxl.cc
+++ b/tools/cjxl.cc
@@ -552,7 +552,6 @@ jxl::Status CompressArgs::ValidateArgs(const CommandLineParser& cmdline) {
   bool got_intensity_target =
       cmdline.GetOption(opt_intensity_target_id)->matched();
 
-  if (jpeg_transcode) params.butteraugli_distance = 0;
   if (got_quality) {
     default_settings = false;
     if (quality < 100) jpeg_transcode = false;
@@ -729,6 +728,7 @@ jxl::Status LoadAll(CompressArgs& args, jxl::ThreadPoolInternal* pool,
     return false;
   }
   if (input_codec != jxl::Codec::kJPG) args.jpeg_transcode = false;
+  if (args.jpeg_transcode) args.params.butteraugli_distance = 0;
 
   if (input_codec == jxl::Codec::kGIF && args.default_settings) {
     args.params.modular_mode = true;


### PR DESCRIPTION
This fixes a recent breakage in the handling of `--distance`.