### PR TITLE
Progressive steps

### DIFF
--- a/lib/jxl/enc_file.cc
+++ b/lib/jxl/enc_file.cc
@@ -58,8 +58,6 @@ PassDefinition progressive_passes_dc_lf_salient_ac_other_ac[] = {
      /*suitable_for_downsampling_of_at_least=*/0}};
 
 PassDefinition progressive_passes_dc_quant_ac_full_ac[] = {
-    {/*num_coefficients=*/8, /*shift=*/2, /*salient_only=*/false,
-     /*suitable_for_downsampling_of_at_least=*/4},
     {/*num_coefficients=*/8, /*shift=*/1, /*salient_only=*/false,
      /*suitable_for_downsampling_of_at_least=*/2},
     {/*num_coefficients=*/8, /*shift=*/0, /*salient_only=*/false,

--- a/tools/cjxl.cc
+++ b/tools/cjxl.cc
@@ -339,7 +339,8 @@ void CompressArgs::AddCommandLineOptions(CommandLineParser* cmdline) {
   cmdline->AddOptionValue(
       's', "speed", "ANIMAL",
       "Deprecated synonym for --effort. Valid values are:\n"
-      "    lightning (1), thunder, falcon, cheetah, hare, wombat, squirrel, kitten, tortoise (9)\n"
+      "    lightning (1), thunder, falcon, cheetah, hare, wombat, squirrel, "
+      "kitten, tortoise (9)\n"
       "    Default: squirrel. Values are in order from faster to slower.\n",
       &params.speed_tier, &ParseSpeedTier, 2);
 
@@ -578,7 +579,6 @@ jxl::Status CompressArgs::ValidateArgs(const CommandLineParser& cmdline) {
 
   if (progressive) {
     params.qprogressive_mode = true;
-    params.progressive_dc = 1;
     params.responsive = 1;
     default_settings = false;
   }


### PR DESCRIPTION
Disable progressive_dc with -p, and remove a 4x downsampled pass that
can look worse than just upsampling DC.
