### PR TITLE
set modular_16_bit_buffer_sufficient header field

### DIFF
--- a/lib/jxl/image_metadata.cc
+++ b/lib/jxl/image_metadata.cc
@@ -409,5 +409,6 @@ void ImageMetadata::SetAlphaBits(uint32_t bits, bool alpha_is_premultiplied) {
     }
   }
   num_extra_channels = extra_channel_info.size();
+  if (bits > 12) modular_16_bit_buffer_sufficient = false;
 }
 }  // namespace jxl

--- a/lib/jxl/image_metadata.h
+++ b/lib/jxl/image_metadata.h
@@ -218,6 +218,12 @@ struct ImageMetadata : public Fields {
     bit_depth.bits_per_sample = bits;
     bit_depth.exponent_bits_per_sample = 0;
     bit_depth.floating_point_sample = false;
+    // RCT / Squeeze may add one bit each, and this is about int16_t,
+    // so uint13 should still be OK but limiting it to 12 seems safer.
+    // TODO(jon): figure out a better way to set this header field.
+    // (in particular, if modular mode is not used it doesn't matter,
+    // and if transforms are restricted, up to 15-bit could be done)
+    if (bits > 12) modular_16_bit_buffer_sufficient = false;
   }
   // Sets the original bit depth fields to indicate single precision floating
   // point.
@@ -226,12 +232,14 @@ struct ImageMetadata : public Fields {
     bit_depth.bits_per_sample = 32;
     bit_depth.exponent_bits_per_sample = 8;
     bit_depth.floating_point_sample = true;
+    modular_16_bit_buffer_sufficient = false;
   }
 
   void SetFloat16Samples() {
     bit_depth.bits_per_sample = 16;
     bit_depth.exponent_bits_per_sample = 5;
     bit_depth.floating_point_sample = true;
+    modular_16_bit_buffer_sufficient = false;
   }
 
   void SetIntensityTarget(float intensity_target) {


### PR DESCRIPTION
This header field wasn't actually set by the encoder.

For now, set it conservatively: if the RGB or A has a bit depth that is > 12, set the field to false.

Note that this may set it to false unnecessarily (e.g. if everything is VarDCT, the bit depth doesn't really matter; also 15-bit modular could be fine if no Squeeze or RCT is done and there are no out-of-range values), but that's better than nothing.

For now misses the cases where extra channels are manually added and have a higher bit depth than the main image (but I don't think there's any way that can happen at the moment in cjxl or in the encode api).
