### PR TITLE
don't do lossy palette when also doing lossy

### DIFF
--- a/lib/jxl/enc_modular.cc
+++ b/lib/jxl/enc_modular.cc
@@ -567,6 +567,7 @@ Status ModularFrameEncoder::ComputeEncodingData(
     }
     cparams.channel_colors_percent = 0;
     cparams.palette_colors = 0;
+    cparams.lossy_palette = false;
   }
 
   // if few colors, do all-channel palette before trying channel palette


### PR DESCRIPTION
Fixes https://github.com/libjxl/libjxl/issues/75

It doesn't make sense to do lossy palette in combination with other lossy modular encode methods.