### PR TITLE
Add --premultiply option to cjxl

### DIFF
--- a/lib/jxl/codec_in_out.h
+++ b/lib/jxl/codec_in_out.h
@@ -183,6 +183,19 @@ class CodecInOut {
     }
     return true;
   }
+  // Calls PremultiplyAlpha for each ImageBundle (preview/frames).
+  void PremultiplyAlpha() {
+    ExtraChannelInfo* eci = metadata.m.Find(ExtraChannel::kAlpha);
+    if (eci == nullptr || eci->alpha_associated) return;  // nothing to do
+    if (metadata.m.have_preview) {
+      preview_frame.PremultiplyAlpha();
+    }
+    for (ImageBundle& ib : frames) {
+      ib.PremultiplyAlpha();
+    }
+    eci->alpha_associated = true;
+    return;
+  }
 
   // -- DECODER INPUT:
 

--- a/lib/jxl/image_bundle.cc
+++ b/lib/jxl/image_bundle.cc
@@ -112,6 +112,32 @@ void ImageBundle::SetAlpha(ImageF&& alpha, bool alpha_is_premultiplied) {
   // num_extra_channels is automatically set in visitor
   VerifySizes();
 }
+void ImageBundle::PremultiplyAlpha() {
+  if (!HasAlpha()) return;
+  if (!HasColor()) return;
+  const ExtraChannelInfo* eci = metadata_->Find(ExtraChannel::kAlpha);
+  if (eci->alpha_associated) return;  // already premultiplied
+  JXL_CHECK(color_.ysize() == alpha()->ysize());
+  JXL_CHECK(color_.xsize() == alpha()->xsize());
+  for (size_t y = 0; y < color_.ysize(); y++) {
+    ::jxl::PremultiplyAlpha(color_.PlaneRow(0, y), color_.PlaneRow(1, y),
+                            color_.PlaneRow(2, y), alpha()->Row(y),
+                            color_.xsize());
+  }
+}
+void ImageBundle::UnpremultiplyAlpha() {
+  if (!HasAlpha()) return;
+  if (!HasColor()) return;
+  const ExtraChannelInfo* eci = metadata_->Find(ExtraChannel::kAlpha);
+  if (!eci->alpha_associated) return;  // already unpremultiplied
+  JXL_CHECK(color_.ysize() == alpha()->ysize());
+  JXL_CHECK(color_.xsize() == alpha()->xsize());
+  for (size_t y = 0; y < color_.ysize(); y++) {
+    ::jxl::UnpremultiplyAlpha(color_.PlaneRow(0, y), color_.PlaneRow(1, y),
+                              color_.PlaneRow(2, y), alpha()->Row(y),
+                              color_.xsize());
+  }
+}
 
 void ImageBundle::SetExtraChannels(std::vector<ImageF>&& extra_channels) {
   for (const ImageF& plane : extra_channels) {

--- a/lib/jxl/image_bundle.h
+++ b/lib/jxl/image_bundle.h
@@ -172,6 +172,10 @@ class ImageBundle {
     const ExtraChannelInfo* eci = metadata_->Find(ExtraChannel::kAlpha);
     return (eci == nullptr) ? false : eci->alpha_associated;
   }
+  // Premultiply alpha (if it isn't already premultiplied)
+  void PremultiplyAlpha();
+  // Unpremultiply alpha (if it isn't already non-premultiplied)
+  void UnpremultiplyAlpha();
   const ImageF& alpha() const;
   ImageF* alpha();
 

--- a/tools/cjxl.cc
+++ b/tools/cjxl.cc
@@ -353,6 +353,10 @@ void CompressArgs::AddCommandLineOptions(CommandLineParser* cmdline) {
                          "Enable progressive/responsive decoding.",
                          &progressive, &SetBooleanTrue);
 
+  cmdline->AddOptionFlag('\0', "premultiply",
+                         "Force premultiplied (associated) alpha.",
+                         &force_premultiplied, &SetBooleanTrue, 1);
+
   cmdline->AddOptionFlag('\0', "middleout",
                          "Put center groups first in the compressed file.",
                          &params.middleout, &SetBooleanTrue, 1);
@@ -749,6 +753,9 @@ jxl::Status LoadAll(CompressArgs& args, jxl::ThreadPoolInternal* pool,
     } else {
       io->metadata.m.SetUintSamples(args.override_bitdepth);
     }
+  }
+  if (args.force_premultiplied) {
+    io->PremultiplyAlpha();
   }
 
   jxl::ImageF saliency_map;

--- a/tools/cjxl.h
+++ b/tools/cjxl.h
@@ -73,6 +73,7 @@ struct CompressArgs {
                             // or to VarDCT otherwise.
   bool progressive = false;
   bool default_settings = true;
+  bool force_premultiplied = false;
 
   // Will get passed on to AuxOut.
   jxl::InspectorImage3F inspector_image3f;


### PR DESCRIPTION
Addresses one of the two feature requests in https://github.com/libjxl/libjxl/issues/76 :
Adds an option `--premultiply` to cjxl which will store the image in a premultiplied-alpha way (converting non-premultiplied to premultiplied).

Note: until https://github.com/libjxl/libjxl/issues/81 is resolved, this option will cause image to be rendered incorrectly.