### PR TITLE
do unpremultiply if needed in ConvertToExternal

### DIFF
--- a/lib/jxl/dec_frame.h
+++ b/lib/jxl/dec_frame.h
@@ -191,9 +191,10 @@ class FrameDecoder {
   }
 
   // If the image has default exif orientation and no blending,
-  // the current frame cannot be referenced by future frames, and
-  // there are no spot colors to be rendered, then low memory options
-  // (uint8 output buffer or float pixel callback) can be used.
+  // the current frame cannot be referenced by future frames,
+  // there are no spot colors to be rendered, and alpha is not
+  // premultiplied, then low memory options can be used
+  // (uint8 output buffer or float pixel callback).
   // TODO(veluca): reduce this set of restrictions.
   bool CanDoLowMemoryPath() const {
     if (decoded_->metadata()->GetOrientation() != Orientation::kIdentity) {
@@ -205,6 +206,7 @@ class FrameDecoder {
         decoded_->metadata()->Find(ExtraChannel::kSpotColor)) {
       return false;
     }
+    if (decoded_->AlphaIsPremultiplied()) return false;
     return true;
   }
 


### PR DESCRIPTION
Partially fixes https://github.com/libjxl/libjxl/issues/81

In the cases where ConvertToExternal is called to get an RGBA buffer, it will now always be unassociated alpha (which is what most applications will expect, including e.g. the png encoder in djxl).

If there is a need to also have the option of not doing the unpremultiply and getting the original, premultiplied values, this can be added later; for now it is important to get things right in decoders/viewers that are not looking at the premultiplied field and assuming things to be non-premultiplied.

This doesn't yet fix code paths that do not involve ConvertToExternal.