### PR TITLE
Fix benchmark on image with exif orientation

### DIFF
--- a/tools/benchmark/benchmark_codec_jxl.cc
+++ b/tools/benchmark/benchmark_codec_jxl.cc
@@ -294,6 +294,12 @@ class JxlCodec : public ImageCodec {
       PaddedBytes icc_profile;
       auto runner = JxlThreadParallelRunnerMake(nullptr, pool->NumThreads());
       auto dec = JxlDecoderMake(nullptr);
+      // By default, the decoder will undo exif orientation, giving an image
+      // with identity exif rotation as result. However, the benchmark does
+      // not undo exif orientation of the originals, and compares against the
+      // originals, so we must set the option to keep the original orientation
+      // instead.
+      JxlDecoderSetKeepOrientation(dec.get(), JXL_TRUE);
       JXL_RETURN_IF_ERROR(
           JXL_DEC_SUCCESS ==
           JxlDecoderSubscribeEvents(dec.get(), JXL_DEC_BASIC_INFO |


### PR DESCRIPTION
When running benchmark_xl on JPEG with exif orientation, or a PNG with
exif orientation in a text chunk identified as exif, the benchmark
compared the images with the mismatching orientation