### PR TITLE
Remove unused JxlInverseOpsinMatrix

### DIFF
--- a/lib/include/jxl/color_encoding.h
+++ b/lib/include/jxl/color_encoding.h
@@ -138,25 +138,6 @@ typedef struct {
   JxlRenderingIntent rendering_intent;
 } JxlColorEncoding;
 
-/** Color transform used for the XYB encoding. This affects how the internal
- * XYB color format is converted, and is not needed unless XYB color is used.
- */
-typedef struct {
-  /** Inverse opsin matrix.
-   */
-  float opsin_inv_matrix[3][3];
-
-  /** Opsin bias for opsin matrix. This affects how the internal XYB color
-   * format is converted, and is not needed unless XYB color is used.
-   */
-  float opsin_biases[3];
-
-  /** Quantization bias for opsin matrix. This affects how the internal XYB
-   * color format is converted, and is not needed unless XYB color is used.
-   */
-  float quant_biases[3];
-} JxlInverseOpsinMatrix;
-
 #if defined(__cplusplus) || defined(c_plusplus)
 }
 #endif

--- a/lib/jxl/decode.cc
+++ b/lib/jxl/decode.cc
@@ -1887,21 +1887,6 @@ JxlDecoderStatus JxlDecoderGetColorAsICCProfile(const JxlDecoder* dec,
   return JXL_DEC_SUCCESS;
 }
 
-JxlDecoderStatus JxlDecoderGetInverseOpsinMatrix(
-    const JxlDecoder* dec, JxlInverseOpsinMatrix* matrix) {
-  memcpy(matrix->opsin_inv_matrix,
-         dec->metadata.transform_data.opsin_inverse_matrix.inverse_matrix,
-         sizeof(matrix->opsin_inv_matrix));
-  memcpy(matrix->opsin_biases,
-         dec->metadata.transform_data.opsin_inverse_matrix.opsin_biases,
-         sizeof(matrix->opsin_biases));
-  memcpy(matrix->quant_biases,
-         dec->metadata.transform_data.opsin_inverse_matrix.quant_biases,
-         sizeof(matrix->quant_biases));
-
-  return JXL_DEC_SUCCESS;
-}
-
 namespace {
 // Returns the amount of bits needed for getting memory buffer size, and does
 // all error checking required for size checking and format validity.


### PR DESCRIPTION
The function JxlDecoderGetInverseOpsinMatrix was defined but not
available in decode.h. It is not currently needed since the library
doesn't support outputting the internal xyb color values, and could be
restored (and added to the header) if such feature is added.