### PR TITLE
Refactor decoding Jxl to JPEG out of decode.cc

### DIFF
--- a/lib/jxl.cmake
+++ b/lib/jxl.cmake
@@ -100,6 +100,8 @@ set(JPEGXL_INTERNAL_SOURCES_DEC
   jxl/dec_xyb.cc
   jxl/dec_xyb.h
   jxl/decode.cc
+  jxl/decode_to_jpeg.cc
+  jxl/decode_to_jpeg.h
   jxl/enc_bit_writer.cc
   jxl/enc_bit_writer.h
   jxl/entropy_coder.cc

--- a/lib/jxl/decode.cc
+++ b/lib/jxl/decode.cc
@@ -12,12 +12,11 @@
 #include "lib/jxl/dec_frame.h"
 #include "lib/jxl/dec_modular.h"
 #include "lib/jxl/dec_reconstruct.h"
+#include "lib/jxl/decode_to_jpeg.h"
 #include "lib/jxl/fields.h"
 #include "lib/jxl/headers.h"
 #include "lib/jxl/icc_codec.h"
 #include "lib/jxl/image_bundle.h"
-#include "lib/jxl/jpeg/dec_jpeg_data.h"
-#include "lib/jxl/jpeg/dec_jpeg_data_writer.h"
 #include "lib/jxl/loop_filter.h"
 #include "lib/jxl/memory_manager_internal.h"
 #include "lib/jxl/toc.h"
@@ -150,6 +149,8 @@ JxlSignature JxlSignatureCheck(const uint8_t* buf, size_t len) {
   size_t pos = 0;
   return ReadSignature(buf, len, &pos);
 }
+
+namespace {
 
 size_t BitsPerChannel(JxlDataType data_type) {
   switch (data_type) {
@@ -286,6 +287,8 @@ struct Sections {
   std::vector<char> section_received;
 };
 
+}  // namespace
+
 // NOLINTNEXTLINE(clang-analyzer-optin.performance.Padding)
 struct JxlDecoderStruct {
   JxlDecoderStruct() = default;
@@ -404,23 +407,7 @@ struct JxlDecoderStruct {
   // strategy to prevent some memory usage.
   std::vector<uint8_t> codestream;
 
-  // Content of the most recently parsed JPEG reconstruction box is stored here.
-  std::vector<uint8_t> jpeg_reconstruction_buffer;
-  // Decoded content of the most recently parsed JPEG reconstruction box is
-  // stored here.
-  std::unique_ptr<jxl::jpeg::JPEGData> jpeg_reconstruction_data;
-  // True if the decoder is currently reading bytes inside a JPEG reconstruction
-  // box.
-  bool inside_jpeg_reconstruction_box = false;
-  // True if the JPEG reconstruction box had undefined size (all remaining
-  // bytes).
-  bool jpeg_reconstruction_box_until_eof = false;
-  // Size of most recently parsed JPEG reconstruction box contents.
-  size_t jpeg_reconstruction_size = 0;
-  // Next bytes to write JPEG reconstruction to.
-  uint8_t* next_jpeg_reconstruction_out = nullptr;
-  // Available bytes to write JPEG reconstruction to.
-  size_t avail_jpeg_reconstruction_size = 0;
+  jxl::JxlToJpegDecoder jpeg_decoder;
 
   // Position in the actual codestream, which codestream.begin() points to.
   // Non-zero once earlier parts of the codestream vector have been erased.
@@ -1025,17 +1012,10 @@ JxlDecoderStatus JxlDecoderProcessInternal(JxlDecoder* dec, const uint8_t* in,
       dec->frame_dec.reset(new FrameDecoder(
           dec->passes_state.get(), dec->metadata, dec->thread_pool.get()));
 
-      if (dec->next_jpeg_reconstruction_out != nullptr &&
-          dec->jpeg_reconstruction_data != nullptr) {
-        // If JPEG reconstruction is wanted and possible, set the jpeg_data of
-        // the ImageBundle.
-        if (!jxl::jpeg::SetJPEGDataFromICC(
-                dec->ib->metadata()->color_encoding.ICC(),
-                dec->jpeg_reconstruction_data.get())) {
-          return JXL_DEC_ERROR;
-        }
-        dec->ib->jpeg_data = std::move(dec->jpeg_reconstruction_data);
-      }
+      // If JPEG reconstruction is wanted and possible, set the jpeg_data of
+      // the ImageBundle.
+      if (!dec->jpeg_decoder.SetImageBundleJpegData(dec->ib.get()))
+        return JXL_DEC_ERROR;
 
       jxl::Status status = dec->frame_dec->InitFrame(
           reader.get(), dec->ib.get(), /*is_preview=*/false,
@@ -1071,7 +1051,7 @@ JxlDecoderStatus JxlDecoderProcessInternal(JxlDecoder* dec, const uint8_t* in,
         dec->frame_stage == FrameStage::kDC) {
       if (dec->events_wanted & JXL_DEC_FULL_IMAGE) {
         if (!dec->image_out_buffer_set &&
-            (dec->next_jpeg_reconstruction_out == nullptr ||
+            (!dec->jpeg_decoder.IsOutputSet() ||
              dec->ib->jpeg_data == nullptr) &&
             dec->is_last_of_still) {
           // TODO(lode): remove the dec->is_last_of_still condition if the
@@ -1218,29 +1198,10 @@ JxlDecoderStatus JxlDecoderProcessInternal(JxlDecoder* dec, const uint8_t* in,
 
         // If no output buffer was set, we merely return the JXL_DEC_FULL_IMAGE
         // status without outputting pixels.
-        if (dec->next_jpeg_reconstruction_out != nullptr &&
-            dec->ib->jpeg_data != nullptr) {
-          // Copy JPEG bytestream if desired.
-          uint8_t* tmp_next_out = dec->next_jpeg_reconstruction_out;
-          size_t tmp_avail_size = dec->avail_jpeg_reconstruction_size;
-          auto write = [&tmp_next_out, &tmp_avail_size](const uint8_t* buf,
-                                                        size_t len) {
-            size_t to_write = std::min<size_t>(tmp_avail_size, len);
-            memcpy(tmp_next_out, buf, to_write);
-            tmp_next_out += to_write;
-            tmp_avail_size -= to_write;
-            return to_write;
-          };
-          Status write_result =
-              jxl::jpeg::WriteJpeg(*(dec->ib->jpeg_data.get()), write);
-          if (!write_result) {
-            if (tmp_avail_size == 0) {
-              return JXL_DEC_JPEG_NEED_MORE_OUTPUT;
-            }
-            return JXL_DEC_ERROR;
-          }
-          dec->next_jpeg_reconstruction_out = tmp_next_out;
-          dec->avail_jpeg_reconstruction_size = tmp_avail_size;
+        if (dec->jpeg_decoder.IsOutputSet() && dec->ib->jpeg_data != nullptr) {
+          JxlDecoderStatus status =
+              dec->jpeg_decoder.WriteOutput(*dec->ib->jpeg_data);
+          if (status != JXL_DEC_SUCCESS) return status;
         } else if (return_full_image && dec->image_out_buffer_set) {
           if (!dec->frame_dec->HasRGBBuffer()) {
             // Copy pixels if desired.
@@ -1291,97 +1252,11 @@ size_t JxlDecoderReleaseInput(JxlDecoder* dec) {
 
 JxlDecoderStatus JxlDecoderSetJPEGBuffer(JxlDecoder* dec, uint8_t* data,
                                          size_t size) {
-  if (dec->next_jpeg_reconstruction_out) return JXL_DEC_ERROR;
-
-  dec->next_jpeg_reconstruction_out = data;
-  dec->avail_jpeg_reconstruction_size = size;
-  return JXL_DEC_SUCCESS;
+  return dec->jpeg_decoder.SetOutputBuffer(data, size);
 }
 
 size_t JxlDecoderReleaseJPEGBuffer(JxlDecoder* dec) {
-  size_t result = dec->avail_jpeg_reconstruction_size;
-  dec->next_jpeg_reconstruction_out = nullptr;
-  dec->avail_jpeg_reconstruction_size = 0;
-  return result;
-}
-
-// Consumes data from next_in/avail_in to reconstruct JPEG data.
-// Uses dec->jpeg_reconstruction_size, dec->inside_jpeg_reconstruction_box, and
-// dec->jpeg_reconstruction_box_until_eof to calculate how much to consume.
-// Potentially stores unparsed data in dec->jpeg_reconstruction_buffer.
-// Potentially populates dec->jpeg_reconstruction_data.
-// Potentially updates dec->inside_reconstruction_box.
-JxlDecoderStatus JxlDecoderProcessJPEGReconstruction(JxlDecoder* dec,
-                                                     const uint8_t** next_in,
-                                                     size_t* avail_in) {
-  if (!dec->inside_jpeg_reconstruction_box) {
-    JXL_ABORT(
-        "processing of JPEG reconstruction data outside JPEG reconstruction "
-        "box");
-  }
-  jxl::Span<const uint8_t> to_decode;
-  if (dec->jpeg_reconstruction_box_until_eof) {
-    // Until EOF means consume all data.
-    to_decode = jxl::Span<const uint8_t>(*next_in, *avail_in);
-    *next_in += *avail_in;
-    *avail_in = 0;
-  } else {
-    // Defined size means consume min(available, needed).
-    size_t avail_recon_in =
-        std::min<size_t>(*avail_in, dec->jpeg_reconstruction_size -
-                                        dec->jpeg_reconstruction_buffer.size());
-    to_decode = jxl::Span<const uint8_t>(*next_in, avail_recon_in);
-    *next_in += avail_recon_in;
-    *avail_in -= avail_recon_in;
-  }
-  bool old_data_exists = !dec->jpeg_reconstruction_buffer.empty();
-  if (old_data_exists) {
-    // Append incoming data to buffer if we already had data in the buffer.
-    dec->jpeg_reconstruction_buffer.insert(
-        dec->jpeg_reconstruction_buffer.end(), to_decode.data(),
-        to_decode.data() + to_decode.size());
-    to_decode =
-        jxl::Span<const uint8_t>(dec->jpeg_reconstruction_buffer.data(),
-                                 dec->jpeg_reconstruction_buffer.size());
-  }
-  if (!dec->jpeg_reconstruction_box_until_eof &&
-      to_decode.size() > dec->jpeg_reconstruction_size) {
-    JXL_ABORT("JPEG reconstruction data to decode larger than expected");
-  }
-  if (dec->jpeg_reconstruction_box_until_eof ||
-      to_decode.size() == dec->jpeg_reconstruction_size) {
-    // If undefined size, or the right size, try to decode.
-    dec->jpeg_reconstruction_data = jxl::make_unique<jxl::jpeg::JPEGData>();
-    const auto status = jxl::jpeg::DecodeJPEGData(
-        to_decode, dec->jpeg_reconstruction_data.get());
-    if (status.IsFatalError()) return JXL_DEC_ERROR;
-    if (status) {
-      // Successful decoding, emit event after updating state to track that we
-      // are no longer parsing JPEG reconstruction data.
-      dec->inside_jpeg_reconstruction_box = false;
-      return JXL_DEC_JPEG_RECONSTRUCTION;
-    }
-    if (dec->jpeg_reconstruction_box_until_eof) {
-      // Unsuccessful decoding and undefined size, assume incomplete data. Copy
-      // the data if we haven't already.
-      if (!old_data_exists) {
-        dec->jpeg_reconstruction_buffer.insert(
-            dec->jpeg_reconstruction_buffer.end(), to_decode.data(),
-            to_decode.data() + to_decode.size());
-      }
-    } else {
-      // Unsuccessful decoding of correct amount of data, assume error.
-      return JXL_DEC_ERROR;
-    }
-  } else {
-    // Not enough data, copy the data if we haven't already.
-    if (!old_data_exists) {
-      dec->jpeg_reconstruction_buffer.insert(
-          dec->jpeg_reconstruction_buffer.end(), to_decode.data(),
-          to_decode.data() + to_decode.size());
-    }
-  }
-  return JXL_DEC_NEED_MORE_INPUT;
+  return dec->jpeg_decoder.ReleaseOutputBuffer();
 }
 
 JxlDecoderStatus JxlDecoderProcessInput(JxlDecoder* dec) {
@@ -1456,10 +1331,10 @@ JxlDecoderStatus JxlDecoderProcessInput(JxlDecoder* dec) {
       *avail_in -= csize;
     }
 
-    if (dec->inside_jpeg_reconstruction_box) {
+    if (dec->jpeg_decoder.IsParsingBox()) {
       // We are inside a JPEG reconstruction box.
       JxlDecoderStatus recon_result =
-          JxlDecoderProcessJPEGReconstruction(dec, next_in, avail_in);
+          dec->jpeg_decoder.Process(next_in, avail_in);
       if (recon_result == JXL_DEC_JPEG_RECONSTRUCTION) {
         // If successful JPEG reconstruction, return the success if the user
         // cares about it, otherwise continue.
@@ -1603,21 +1478,14 @@ JxlDecoderStatus JxlDecoderProcessInput(JxlDecoder* dec) {
           }
         } else if ((dec->orig_events_wanted & JXL_DEC_JPEG_RECONSTRUCTION) &&
                    strcmp(type, "jbrd") == 0) {
-          // This is a JPEG reconstruction metadata box.
-          // A new box implies that we clear the buffer.
-          dec->jpeg_reconstruction_buffer.clear();
-          dec->inside_jpeg_reconstruction_box = true;
-          if (box_size == 0) {
-            dec->jpeg_reconstruction_box_until_eof = true;
-          } else {
-            dec->jpeg_reconstruction_size = contents_size;
-          }
+          // This is a new JPEG reconstruction metadata box.
+          dec->jpeg_decoder.StartBox(box_size, contents_size);
           dec->file_pos += pos;
           *next_in += pos;
           *avail_in -= pos;
-          JxlDecoderStatus recon_result =
-              JxlDecoderProcessJPEGReconstruction(dec, next_in, avail_in);
           pos = 0;
+          JxlDecoderStatus recon_result =
+              dec->jpeg_decoder.Process(next_in, avail_in);
           if (recon_result == JXL_DEC_JPEG_RECONSTRUCTION) {
             // If successful JPEG reconstruction, return the success if the user
             // cares about it, otherwise continue.
@@ -1903,6 +1771,7 @@ JxlDecoderStatus JxlDecoderGetColorAsICCProfile(const JxlDecoder* dec,
 }
 
 namespace {
+
 // Returns the amount of bits needed for getting memory buffer size, and does
 // all error checking required for size checking and format validity.
 JxlDecoderStatus PrepareSizeCheck(const JxlDecoder* dec,

--- a/lib/jxl/decode_to_jpeg.cc
+++ b/lib/jxl/decode_to_jpeg.cc
@@ -1,0 +1,73 @@
+// Copyright (c) the JPEG XL Project Authors. All rights reserved.
+//
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+#include "lib/jxl/decode_to_jpeg.h"
+
+namespace jxl {
+
+JxlDecoderStatus JxlToJpegDecoder::Process(const uint8_t** next_in,
+                                           size_t* avail_in) {
+  if (!inside_box_) {
+    JXL_ABORT(
+        "processing of JPEG reconstruction data outside JPEG reconstruction "
+        "box");
+  }
+  Span<const uint8_t> to_decode;
+  if (box_until_eof_) {
+    // Until EOF means consume all data.
+    to_decode = Span<const uint8_t>(*next_in, *avail_in);
+    *next_in += *avail_in;
+    *avail_in = 0;
+  } else {
+    // Defined size means consume min(available, needed).
+    size_t avail_recon_in =
+        std::min<size_t>(*avail_in, box_size_ - buffer_.size());
+    to_decode = Span<const uint8_t>(*next_in, avail_recon_in);
+    *next_in += avail_recon_in;
+    *avail_in -= avail_recon_in;
+  }
+  bool old_data_exists = !buffer_.empty();
+  if (old_data_exists) {
+    // Append incoming data to buffer if we already had data in the buffer.
+    buffer_.insert(buffer_.end(), to_decode.data(),
+                   to_decode.data() + to_decode.size());
+    to_decode = Span<const uint8_t>(buffer_.data(), buffer_.size());
+  }
+  if (!box_until_eof_ && to_decode.size() > box_size_) {
+    JXL_ABORT("JPEG reconstruction data to decode larger than expected");
+  }
+  if (box_until_eof_ || to_decode.size() == box_size_) {
+    // If undefined size, or the right size, try to decode.
+    jpeg_data_ = make_unique<jpeg::JPEGData>();
+    const auto status = jpeg::DecodeJPEGData(to_decode, jpeg_data_.get());
+    if (status.IsFatalError()) return JXL_DEC_ERROR;
+    if (status) {
+      // Successful decoding, emit event after updating state to track that we
+      // are no longer parsing JPEG reconstruction data.
+      inside_box_ = false;
+      return JXL_DEC_JPEG_RECONSTRUCTION;
+    }
+    if (box_until_eof_) {
+      // Unsuccessful decoding and undefined size, assume incomplete data. Copy
+      // the data if we haven't already.
+      if (!old_data_exists) {
+        buffer_.insert(buffer_.end(), to_decode.data(),
+                       to_decode.data() + to_decode.size());
+      }
+    } else {
+      // Unsuccessful decoding of correct amount of data, assume error.
+      return JXL_DEC_ERROR;
+    }
+  } else {
+    // Not enough data, copy the data if we haven't already.
+    if (!old_data_exists) {
+      buffer_.insert(buffer_.end(), to_decode.data(),
+                     to_decode.data() + to_decode.size());
+    }
+  }
+  return JXL_DEC_NEED_MORE_INPUT;
+}
+
+}  // namespace jxl

--- a/lib/jxl/decode_to_jpeg.h
+++ b/lib/jxl/decode_to_jpeg.h
@@ -1,0 +1,137 @@
+// Copyright (c) the JPEG XL Project Authors. All rights reserved.
+//
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+#ifndef LIB_JXL_DECODE_TO_JPEG_H_
+#define LIB_JXL_DECODE_TO_JPEG_H_
+
+// JPEG XL to JPEG bytes decoder logic. The JxlToJpegDecoder class keeps track
+// of the decoder state needed to parse the JPEG reconstruction box and provide
+// the reconstructed JPEG to the output buffer.
+
+#include <stdint.h>
+#include <stdlib.h>
+
+#include <memory>
+#include <vector>
+
+#include "jxl/decode.h"
+#include "lib/jxl/base/status.h"
+#include "lib/jxl/image_bundle.h"
+#include "lib/jxl/jpeg/dec_jpeg_data.h"
+#include "lib/jxl/jpeg/dec_jpeg_data_writer.h"
+
+namespace jxl {
+
+class JxlToJpegDecoder {
+ public:
+  // Returns whether an output buffer is set.
+  bool IsOutputSet() const { return next_out_ != nullptr; }
+
+  // Returns whether the decoder is parsing a boxa JPEG box was parsed.
+  bool IsParsingBox() const { return inside_box_; }
+
+  const jpeg::JPEGData* JpegData() const { return jpeg_data_.get(); }
+
+  // Return the parsed jpeg::JPEGData object and removes it from the
+  // JxlToJpegDecoder.
+  jpeg::JPEGData* ReleaseJpegData() { return jpeg_data_.release(); }
+
+  // Sets the output buffer used when producing JPEG output.
+  JxlDecoderStatus SetOutputBuffer(uint8_t* data, size_t size) {
+    if (next_out_) return JXL_DEC_ERROR;
+    next_out_ = data;
+    avail_size_ = size;
+    return JXL_DEC_SUCCESS;
+  }
+
+  // Releases the buffer set with SetOutputBuffer().
+  size_t ReleaseOutputBuffer() {
+    size_t result = avail_size_;
+    next_out_ = nullptr;
+    avail_size_ = 0;
+    return result;
+  }
+
+  void StartBox(uint64_t box_size, size_t contents_size) {
+    // A new box implies that we clear the buffer.
+    buffer_.clear();
+    inside_box_ = true;
+    if (box_size == 0) {
+      box_until_eof_ = true;
+    } else {
+      box_size_ = contents_size;
+    }
+  }
+
+  // Consumes data from next_in/avail_in to reconstruct JPEG data.
+  // Uses box_size_, inside_box_ and box_until_eof_ to calculate how much to
+  // consume. Potentially stores unparsed data in buffer_.
+  // Potentially populates jpeg_data_. Potentially updates inside_box_.
+  JxlDecoderStatus Process(const uint8_t** next_in, size_t* avail_in);
+
+  // Sets the JpegData of the ImageBundle passed if there is anything to set.
+  // Releases the JpegData from this decoder if set.
+  Status SetImageBundleJpegData(ImageBundle* ib) {
+    if (IsOutputSet() && jpeg_data_ != nullptr) {
+      if (!jpeg::SetJPEGDataFromICC(ib->metadata()->color_encoding.ICC(),
+                                    jpeg_data_.get())) {
+        return false;
+      }
+      ib->jpeg_data.reset(jpeg_data_.release());
+    }
+    return true;
+  }
+
+  JxlDecoderStatus WriteOutput(const jpeg::JPEGData& jpeg_data) {
+    // Copy JPEG bytestream if desired.
+    uint8_t* tmp_next_out = next_out_;
+    size_t tmp_avail_size = avail_size_;
+    auto write = [&tmp_next_out, &tmp_avail_size](const uint8_t* buf,
+                                                  size_t len) {
+      size_t to_write = std::min<size_t>(tmp_avail_size, len);
+      memcpy(tmp_next_out, buf, to_write);
+      tmp_next_out += to_write;
+      tmp_avail_size -= to_write;
+      return to_write;
+    };
+    Status write_result = jpeg::WriteJpeg(jpeg_data, write);
+    if (!write_result) {
+      if (tmp_avail_size == 0) {
+        return JXL_DEC_JPEG_NEED_MORE_OUTPUT;
+      }
+      return JXL_DEC_ERROR;
+    }
+    next_out_ = tmp_next_out;
+    avail_size_ = tmp_avail_size;
+    return JXL_DEC_SUCCESS;
+  }
+
+ private:
+  // Content of the most recently parsed JPEG reconstruction box if any.
+  std::vector<uint8_t> buffer_;
+
+  // Decoded content of the most recently parsed JPEG reconstruction box is
+  // stored here.
+  std::unique_ptr<jpeg::JPEGData> jpeg_data_;
+
+  // True if the decoder is currently reading bytes inside a JPEG reconstruction
+  // box.
+  bool inside_box_ = false;
+
+  // True if the JPEG reconstruction box had undefined size (all remaining
+  // bytes).
+  bool box_until_eof_ = false;
+  // Size of most recently parsed JPEG reconstruction box contents.
+  size_t box_size_ = 0;
+
+  // Next bytes to write JPEG reconstruction to.
+  uint8_t* next_out_ = nullptr;
+  // Available bytes to write JPEG reconstruction to.
+  size_t avail_size_ = 0;
+};
+
+}  // namespace jxl
+
+#endif  // LIB_JXL_DECODE_TO_JPEG_H_

--- a/lib/lib.gni
+++ b/lib/lib.gni
@@ -103,6 +103,8 @@ libjxl_dec_sources = [
     "jxl/dec_xyb.cc",
     "jxl/dec_xyb.h",
     "jxl/decode.cc",
+    "jxl/decode_to_jpeg.cc",
+    "jxl/decode_to_jpeg.h",
     "jxl/enc_bit_writer.cc",
     "jxl/enc_bit_writer.h",
     "jxl/entropy_coder.cc",


### PR DESCRIPTION
This patch groups most of the JPEG reconstruction decoder logic out of
the JxlDecoder to a new class JxlToJpegDecoder that is included in the
JxlDecoder struct. This clears a little bit the JxlDecoder but more
importantly makes it easier to remove the dependency on jxl::jpeg::
functions with a flag at build time which will be added later.