### PR TITLE
fix check in MaybeSetFloatCallback, factor out duplicate code

### DIFF
--- a/lib/jxl/dec_frame.h
+++ b/lib/jxl/dec_frame.h
@@ -122,26 +122,11 @@ class FrameDecoder {
     return frame_header_.encoding == FrameEncoding::kVarDCT && finalized_dc_;
   }
 
-  // If the image has default exif orientation and no
-  // blending, the current frame cannot be referenced by future frames, sets the
-  // buffer to which uint8 sRGB pixels will be decoded to.
-  // TODO(veluca): reduce this set of restrictions.
+  // Sets the buffer to which uint8 sRGB pixels will be decoded.
   // If an output callback is set, this function *must not* be called.
   void MaybeSetRGB8OutputBuffer(uint8_t* rgb_output, size_t stride,
                                 bool is_rgba) const {
-    if (decoded_->metadata()->GetOrientation() != Orientation::kIdentity) {
-      return;
-    }
-    if (ImageBlender::NeedsBlending(dec_state_)) {
-      return;
-    }
-    if (frame_header_.CanBeReferenced()) {
-      return;
-    }
-    if (render_spotcolors_ &&
-        decoded_->metadata()->Find(ExtraChannel::kSpotColor)) {
-      return;
-    }
+    if (!CanDoLowMemoryPath()) return;
     dec_state_->rgb_output = rgb_output;
     dec_state_->rgb_output_is_rgba = is_rgba;
     dec_state_->rgb_stride = stride;
@@ -162,20 +147,7 @@ class FrameDecoder {
       const std::function<void(const float* pixels, size_t x, size_t y,
                                size_t num_pixels)>& cb,
       bool is_rgba) const {
-    if (decoded_->metadata()->GetOrientation() != Orientation::kIdentity) {
-      return;
-    }
-    if (frame_header_.blending_info.mode != BlendMode::kReplace ||
-        frame_header_.custom_size_or_origin) {
-      return;
-    }
-    if (frame_header_.CanBeReferenced()) {
-      return;
-    }
-    if (render_spotcolors_ &&
-        decoded_->metadata()->Find(ExtraChannel::kSpotColor)) {
-      return;
-    }
+    if (!CanDoLowMemoryPath()) return;
     dec_state_->pixel_callback = cb;
     dec_state_->rgb_output_is_rgba = is_rgba;
     JXL_ASSERT(dec_state_->rgb_output == nullptr);
@@ -216,6 +188,24 @@ class FrameDecoder {
   size_t GetStorageLocation(size_t thread, size_t task) {
     if (use_task_id_) return task;
     return thread;
+  }
+
+  // If the image has default exif orientation and no blending,
+  // the current frame cannot be referenced by future frames, and
+  // there are no spot colors to be rendered, then low memory options
+  // (uint8 output buffer or float pixel callback) can be used.
+  // TODO(veluca): reduce this set of restrictions.
+  bool CanDoLowMemoryPath() const {
+    if (decoded_->metadata()->GetOrientation() != Orientation::kIdentity) {
+      return false;
+    }
+    if (ImageBlender::NeedsBlending(dec_state_)) return false;
+    if (frame_header_.CanBeReferenced()) return false;
+    if (render_spotcolors_ &&
+        decoded_->metadata()->Find(ExtraChannel::kSpotColor)) {
+      return false;
+    }
+    return true;
   }
 
   PassesDecoderState* dec_state_;


### PR DESCRIPTION
Blending check in MaybeSetFloatCallback was not quite correct, possibly causing segfaults.

Since the conditions are / should be the same between the two MaybeSet* functions, better to factor them out and avoid the duplication.