### PR TITLE
Header only: rewinding API

### DIFF
--- a/lib/include/jxl/decode.h
+++ b/lib/include/jxl/decode.h
@@ -236,6 +236,35 @@ typedef enum {
   JXL_DEC_JPEG_RECONSTRUCTION = 0x2000,
 } JxlDecoderStatus;
 
+/** Rewinds decoder to the beginning. The same input must be given again from
+ * the beginning of the file and the decoder will emit events from the beginning
+ * again. When rewinding (as opposed to JxlDecoderReset), the decoder keeps
+ * state about the image, which it can use to skip to a requested frame more
+ * efficiently with JxlDecoderSkipFrames. After rewind,
+ * JxlDecoderSubscribeEvents can be used again, and it is feasible to leave out
+ * events that were already handled before, such as JXL_DEC_BASIC_INFO and
+ * JXL_DEC_COLOR_ENCODING, since they will provide the same information as
+ * before.
+ * @param dec decoder object
+ */
+JXL_EXPORT void JxlDecoderRewind(const JxlDecoder* dec);
+
+/** Makes the decoder skip the next `amount` frames. If this is used after
+ * JxlDecoderRewind to skip frames that were already decoded before, the decoder
+ * is able to skip more efficiently, as it can skip decoding earlier frames that
+ * it knows later frames don't depend on. A frame here is defined as a frame
+ * that without skipping emits events such as JXL_DEC_FRAME and JXL_FULL_IMAGE,
+ * frames that are internal to the file format but are not rendered as part of
+ * an animation, or are not the final still frame of a still image, are not
+ * counted. If the decoder is already processing a frame (could have emitted
+ * JXL_DEC_FRAME but not yet JXL_DEC_FULL_IMAGE), it starts skipping from the
+ * next frame. If the amount is larger than the amount of frames remaining in
+ * the image, all remaining frames are skipped.
+ * @param dec decoder object
+ * @param amount the amount of frames to skip
+ */
+JXL_EXPORT void JxlDecoderSkipFrames(const JxlDecoder* dec, size_t amount);
+
 /**
  * Get the default pixel format for this decoder.
  *


### PR DESCRIPTION
Add proposed API for rewinding the decoder with the purpose of
efficiently skipping to a frame

The goal of this is as follows: if you are rendering a looping animated JXL
image, but do not keep all frames in memory, and need to render an
arbitrary frame in the animation again (which may be beyond the start,
and may be at any point in time, e.g. due to not rendering frames when
not looking at the animation), how can we decode that frame as
efficiently as possible again, given the encoded jxl input data:

Decoding every frame from the beginning is very inefficient if you only
need to display frame N, and the SkipFrames function helps with that.

Even then it may be doing too much work though, since a decoder reset to
the beginning doesn't know which patches / to-be-blended frames affect
the frame you are skipping to.

The rewind function allows the decoder to begin from the beginning and
keep state to remember which frames depend on which, to make that
scenario more efficient as well.