### PR TITLE
Split fuzzer builds to "asanfuzz" and "msanfuzz".

### DIFF
--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -245,9 +245,13 @@ if(${JPEGXL_ENABLE_FUZZERS})
   foreach(BINARY IN LISTS FUZZER_BINARIES)
     add_executable("${BINARY}" "${BINARY}.cc")
     target_include_directories("${BINARY}" PRIVATE "${CMAKE_SOURCE_DIR}")
-    target_link_libraries("${BINARY}" jxl-static jxl_extras-static jxl_threads-static jxl_tool)
-    target_compile_options("${BINARY}" PRIVATE "-fsanitize=fuzzer-no-link")
-    target_link_libraries("${BINARY}" -fsanitize=fuzzer)
+    target_link_libraries("${BINARY}"
+        jxl-static
+        jxl_extras-static
+        jxl_threads-static
+        jxl_tool
+        ${JPEGXL_FUZZER_LINK_FLAGS}
+    )
   endforeach()
 endif()  # JPEGXL_ENABLE_FUZZERS
 


### PR DESCRIPTION
The new ci.sh commands "asanfuzz" and "msanfuzz" are like "asan" and
"msan" but building all the code with -fsanitize=fuzzer-no-link.

This also allows to use a different set of flags when building the
fuzzers since the new JPEGXL_FUZZER_LINK_FLAGS cmake variable can be
changed to something else to use a different fuzzer driver.

Manually tested asanfuzz and msanfuzz.