### PR TITLE
add cjxl option --keep_invisible

### DIFF
--- a/lib/jxl/enc_cache.cc
+++ b/lib/jxl/enc_cache.cc
@@ -90,7 +90,7 @@ void InitializePassesEncoder(const Image3F& opsin, ThreadPool* pool,
     JXL_ASSERT(cparams.progressive_dc > 0);
     cparams.progressive_dc--;
     // The DC frame will have alpha=0. Don't erase its contents.
-    cparams.keep_invisible = true;
+    cparams.keep_invisible = Override::kOn;
     // No EPF or Gaborish in DC frames.
     cparams.epf = 0;
     cparams.gaborish = Override::kOff;

--- a/lib/jxl/enc_params.h
+++ b/lib/jxl/enc_params.h
@@ -168,8 +168,9 @@ struct CompressParams {
 
   int progressive_dc = -1;
 
-  // Ensure invisible pixels are not set to 0.
-  bool keep_invisible = false;
+  // If on: preserve color of invisible pixels (if off: don't care)
+  // Default: on for lossless, off for lossy
+  Override keep_invisible = Override::kDefault;
 
   // Progressive-mode saliency.
   //

--- a/tools/cjxl.cc
+++ b/tools/cjxl.cc
@@ -356,6 +356,10 @@ void CompressArgs::AddCommandLineOptions(CommandLineParser* cmdline) {
   cmdline->AddOptionFlag('\0', "premultiply",
                          "Force premultiplied (associated) alpha.",
                          &force_premultiplied, &SetBooleanTrue, 1);
+  cmdline->AddOptionValue('\0', "keep_invisible", "0|1",
+                          "force disable/enable preserving color of invisible "
+                          "pixels (default: 1 if lossless, 0 if lossy).",
+                          &params.keep_invisible, &ParseOverride, 1);
 
   cmdline->AddOptionFlag('\0', "middleout",
                          "Put center groups first in the compressed file.",
@@ -472,7 +476,7 @@ void CompressArgs::AddCommandLineOptions(CommandLineParser* cmdline) {
        "2-37=RCT (default: try several, depending on speed)"),
       &params.colorspace, &ParseSigned, 1);
 
-  m_group_size_id = cmdline->AddOptionValue(
+  opt_m_group_size_id = cmdline->AddOptionValue(
       'g', "group-size", "K",
       ("[modular encoding] set group size to 128 << K "
        "(default: 1 or 2)"),
@@ -689,7 +693,7 @@ jxl::Status CompressArgs::ValidateArgs(const CommandLineParser& cmdline) {
 jxl::Status CompressArgs::ValidateArgsAfterLoad(
     const CommandLineParser& cmdline, const jxl::CodecInOut& io) {
   if (!ValidateArgs(cmdline)) return false;
-  bool got_m_group_size = cmdline.GetOption(m_group_size_id)->matched();
+  bool got_m_group_size = cmdline.GetOption(opt_m_group_size_id)->matched();
   if (params.modular_mode && !got_m_group_size) {
     // Default modular group size: set to 512 if 256 would be silly
     const size_t kThinImageThr = 256 + 64;

--- a/tools/cjxl.h
+++ b/tools/cjxl.h
@@ -87,7 +87,7 @@ struct CompressArgs {
   CommandLineParser::OptionId opt_near_lossless_id = -1;
   CommandLineParser::OptionId opt_intensity_target_id = -1;
   CommandLineParser::OptionId opt_color_id = -1;
-  CommandLineParser::OptionId m_group_size_id = -1;
+  CommandLineParser::OptionId opt_m_group_size_id = -1;
 };
 
 jxl::Status LoadAll(CompressArgs& args, jxl::ThreadPoolInternal* pool,


### PR DESCRIPTION
Allows preserving the color of invisible pixels in lossy mode (`--keep_invisible=1`) or forgetting the color of invisible pixels in lossless mode (`--keep_invisible=0`). For now just sets invisible pixels to black in lossless mode (probably something better is possible, but the smearing we're doing in lossy mode is not it).