### PR TITLE
Add instructions to revert unintended submodule changes.

### DIFF
--- a/bash_test.sh
+++ b/bash_test.sh
@@ -173,6 +173,15 @@ test_deps_version() {
       cat >&2 <<EOF
 deps.sh: SHA for project ${line} is at ${deps_sha} but the git submodule is at
 ${git_sha}. Please update deps.sh
+
+If you did not intend to change the submodule's SHA value, it is possible that
+you accidentally included this change in your commit after a rebase or checkout
+without running "git submodule --init". To revert the submodule change run from
+the top checkout directory:
+
+  git -C ${line} checkout ${deps_sha}
+  git commit --amend ${line}
+
 EOF
       return 1
     fi


### PR DESCRIPTION
When bash_test fails in the test_deps_version() print instructions on
how to revert the change if it was unintended.