### PR TITLE
Silence deprecation warnings when building with gcc

### DIFF
--- a/lib/jxl.cmake
+++ b/lib/jxl.cmake
@@ -301,6 +301,10 @@ set(JPEGXL_DEC_INTERNAL_LIBS
   hwy
 )
 
+set_source_files_properties(jxl/decode.cc PROPERTIES
+  COMPILE_FLAGS -Wno-deprecated-declarations
+)
+
 if(JPEGXL_ENABLE_PROFILER)
 list(APPEND JPEGXL_DEC_INTERNAL_LIBS jxl_profiler)
 endif()

--- a/lib/jxl_tests.cmake
+++ b/lib/jxl_tests.cmake
@@ -85,7 +85,7 @@ set(TESTLIB_FILES
 
 # Still tests the deprecated DC functions.
 set_source_files_properties(jxl/decode_test.cc PROPERTIES
-    COMPILE_FLAGS -Wno-deprecated
+  COMPILE_FLAGS "-Wno-deprecated -Wno-deprecated-declarations"
 )
 
 find_package(GTest)

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -262,7 +262,7 @@ endif()  # JPEGXL_ENABLE_FUZZERS
 
 # Still tests the deprecated DC functions.
 set_source_files_properties(djxl_fuzzer.cc PROPERTIES
-    COMPILE_FLAGS -Wno-deprecated
+    COMPILE_FLAGS "-Wno-deprecated -Wno-deprecated-declarations"
 )
 
 # For coverage we want a lightweight alternative for regular fuzzers.


### PR DESCRIPTION
This fixes the post-submit checks for the v0.4.x branch.