### PR TITLE
Fuzz: Initialize "0-symbol" Huffman tables.

### DIFF
--- a/lib/jxl/dec_ans.cc
+++ b/lib/jxl/dec_ans.cc
@@ -213,6 +213,7 @@ Status DecodeANSCodes(const size_t num_histograms,
         }
       } else {
         // 0-bit codes does not requre extension tables.
+        result->huffman_data[c].table_.clear();
         result->huffman_data[c].table_.resize(1u << kHuffmanTableBits);
       }
       for (const auto& h : result->huffman_data[c].table_) {


### PR DESCRIPTION
Otherwise general ReadSymbol could read outside of vector
(and what worse, return wrong values).