### PR TITLE
Run CIFuzz continuous integration on PRs.

### DIFF
--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -1,0 +1,52 @@
+# Copyright (c) the JPEG XL Project Authors. All rights reserved.
+#
+# Use of this source code is governed by a BSD-style
+# license that can be found in the LICENSE file.
+
+# CI on pull-requests to run the fuzzer from oss-fuzz. See:
+#
+#   https://google.github.io/oss-fuzz/getting-started/continuous-integration/
+
+name: CIFuzz
+on:
+  pull_request:
+    types: [opened, reopened, synchronize]
+    paths:
+      - '**.c'
+      - '**.cc'
+      - '**.cmake'
+      - '**.h'
+      - '**CMakeLists.txt'
+      - .github/workflows/fuzz.yml
+
+jobs:
+  fuzzing:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout source
+      uses: actions/checkout@v2
+      id: checkout
+      with:
+        # The build_fuzzers action checks out the code to the storage/libjxl
+        # directory already, but doesn't check out the submodules. This step
+        # is a workaround for checking out the submodules.
+        path: storage/libjxl
+        submodules: true
+    - name: Build Fuzzers
+      id: build
+      uses: google/oss-fuzz/infra/cifuzz/actions/build_fuzzers@master
+      with:
+        oss-fuzz-project-name: 'libjxl'
+        language: c++
+    - name: Run Fuzzers
+      uses: google/oss-fuzz/infra/cifuzz/actions/run_fuzzers@master
+      with:
+        oss-fuzz-project-name: 'libjxl'
+        language: c++
+        fuzz-seconds: 600
+    - name: Upload Crash
+      uses: actions/upload-artifact@v1
+      if: failure() && steps.build.outcome == 'success'
+      with:
+        name: artifacts
+        path: ./out/artifacts


### PR DESCRIPTION
oss-fuzz provides a GitHub CI integration that would run the fuzzer on a
given pull request for a period of time. The minimum recommended time is
600 seconds, which is the value included in this commit.

See the following link for details:

  https://google.github.io/oss-fuzz/getting-started/continuous-integration/