### PR TITLE
don't use ClampToRange in modular

### DIFF
--- a/lib/jxl/common.h
+++ b/lib/jxl/common.h
@@ -167,22 +167,6 @@ JXL_INLINE T Clamp1(T val, T low, T hi) {
   return val < low ? low : val > hi ? hi : val;
 }
 
-template <typename T>
-JXL_INLINE T ClampToRange(int64_t val) {
-  return Clamp1<int64_t>(val, std::numeric_limits<T>::min(),
-                         std::numeric_limits<T>::max());
-}
-
-template <typename T>
-JXL_INLINE T SaturatingMul(int64_t a, int64_t b) {
-  return ClampToRange<T>(a * b);
-}
-
-template <typename T>
-JXL_INLINE T SaturatingAdd(int64_t a, int64_t b) {
-  return ClampToRange<T>(a + b);
-}
-
 // Encodes non-negative (X) into (2 * X), negative (-X) into (2 * X - 1)
 constexpr uint32_t PackSigned(int32_t value) {
   return (static_cast<uint32_t>(value) << 1) ^

--- a/lib/jxl/modular/encoding/context_predict.h
+++ b/lib/jxl/modular/encoding/context_predict.h
@@ -182,7 +182,7 @@ struct State {
     size_t cur_row = y & 1 ? 0 : (xsize + 2);
     size_t prev_row = y & 1 ? (xsize + 2) : 0;
     val = AddBits(val);
-    error[cur_row + x] = ClampToRange<pixel_type>(pred - val);
+    error[cur_row + x] = pred - val;
     for (size_t i = 0; i < kNumPredictors; i++) {
       pixel_type_w err =
           (std::abs(prediction[i] - val) + kPredictionRound) >> kPredExtraBits;

--- a/lib/jxl/modular/transform/squeeze.h
+++ b/lib/jxl/modular/transform/squeeze.h
@@ -111,8 +111,8 @@ void InvHSqueeze(Image &input, int c, int rc, ThreadPool *pool) {
         pixel_type_w A =
             ((avg * 2) + diff + (diff > 0 ? -(diff & 1) : (diff & 1))) >> 1;
         pixel_type_w B = A - diff;
-        p_out[0] = ClampToRange<pixel_type>(A);
-        p_out[1] = ClampToRange<pixel_type>(B);
+        p_out[0] = A;
+        p_out[1] = B;
 
         for (size_t x = 1; x < chin_residual.w; x++) {
           pixel_type_w diff_minus_tendency = p_residual[x];
@@ -123,9 +123,9 @@ void InvHSqueeze(Image &input, int c, int rc, ThreadPool *pool) {
           pixel_type_w diff = diff_minus_tendency + tendency;
           pixel_type_w A =
               ((avg * 2) + diff + (diff > 0 ? -(diff & 1) : (diff & 1))) >> 1;
-          p_out[x << 1] = ClampToRange<pixel_type>(A);
+          p_out[x << 1] = A;
           pixel_type_w B = A - diff;
-          p_out[(x << 1) + 1] = ClampToRange<pixel_type>(B);
+          p_out[(x << 1) + 1] = B;
         }
         if (chout.w & 1) p_out[chout.w - 1] = p_avg[chin.w - 1];
       },
@@ -227,11 +227,11 @@ void InvVSqueeze(Image &input, int c, int rc, ThreadPool *pool) {
             pixel_type_w out =
                 ((avg * 2) + diff + (diff > 0 ? -(diff & 1) : (diff & 1))) >> 1;
 
-            p_out[x] = ClampToRange<pixel_type>(out);
+            p_out[x] = out;
             // If the chin_residual.h == chin.h, the output has an even number
             // of rows so the next line is fine. Otherwise, this loop won't
             // write to the last output row which is handled separately.
-            p_out[x + onerow_out] = ClampToRange<pixel_type>(p_out[x] - diff);
+            p_out[x + onerow_out] = p_out[x] - diff;
           }
         }
       },

--- a/lib/jxl/modular/transform/subtractgreen.h
+++ b/lib/jxl/modular/transform/subtractgreen.h
@@ -12,6 +12,10 @@
 
 namespace jxl {
 
+pixel_type PixelAdd(pixel_type a, pixel_type b) {
+  return static_cast<pixel_type>(static_cast<uint32_t>(a) +
+                                 static_cast<uint32_t>(b));
+}
 template <int transform_type>
 void InvSubtractGreenRow(const pixel_type* in0, const pixel_type* in1,
                          const pixel_type* in2, pixel_type* out0,
@@ -22,29 +26,29 @@ void InvSubtractGreenRow(const pixel_type* in0, const pixel_type* in1,
   int third = transform_type & 1;
   for (size_t x = 0; x < w; x++) {
     if (transform_type == 6) {
-      pixel_type_w Y = in0[x];
-      pixel_type_w Co = in1[x];
-      pixel_type_w Cg = in2[x];
-      pixel_type_w tmp = Y - (Cg >> 1);
-      pixel_type_w G = Cg + tmp;
-      pixel_type_w B = tmp - (Co >> 1);
-      pixel_type_w R = B + Co;
-      out0[x] = ClampToRange<pixel_type>(R);
-      out1[x] = ClampToRange<pixel_type>(G);
-      out2[x] = ClampToRange<pixel_type>(B);
+      pixel_type Y = in0[x];
+      pixel_type Co = in1[x];
+      pixel_type Cg = in2[x];
+      pixel_type tmp = PixelAdd(Y, -(Cg >> 1));
+      pixel_type G = PixelAdd(Cg, tmp);
+      pixel_type B = PixelAdd(tmp, -(Co >> 1));
+      pixel_type R = PixelAdd(B, Co);
+      out0[x] = R;
+      out1[x] = G;
+      out2[x] = B;
     } else {
-      pixel_type_w First = in0[x];
-      pixel_type_w Second = in1[x];
-      pixel_type_w Third = in2[x];
-      if (third) Third = Third + First;
+      pixel_type First = in0[x];
+      pixel_type Second = in1[x];
+      pixel_type Third = in2[x];
+      if (third) Third = PixelAdd(Third, First);
       if (second == 1) {
-        Second = Second + First;
+        Second = PixelAdd(Second, First);
       } else if (second == 2) {
-        Second = Second + ((First + Third) >> 1);
+        Second = PixelAdd(Second, (PixelAdd(First, Third) >> 1));
       }
-      out0[x] = ClampToRange<pixel_type>(First);
-      out1[x] = ClampToRange<pixel_type>(Second);
-      out2[x] = ClampToRange<pixel_type>(Third);
+      out0[x] = First;
+      out1[x] = Second;
+      out2[x] = Third;
     }
   }
 }


### PR DESCRIPTION
Don't do unnecessary clamping and use of wider types in modular transforms and in the weighted predictor.

Small speedup of 1-4%, for example:

Modular falcon:
before: 4064 x 2704, geomean: 24.53 MP/s [21.31, 24.99], 30 reps, 4 threads.
after: 4064 x 2704, geomean: 24.77 MP/s [21.54, 25.62], 30 reps, 4 threads.

Modular default speed:
before: 4064 x 2704, geomean: 14.51 MP/s [13.62, 14.76], 30 reps, 4 threads.
after: 4064 x 2704, geomean: 14.61 MP/s [13.73, 14.99], 30 reps, 4 threads.

Modular default speed -Q 80:
before: 4064 x 2704, geomean: 17.86 MP/s [15.21, 18.50], 30 reps, 4 threads.
after: 4064 x 2704, geomean: 18.13 MP/s [14.79, 18.53], 30 reps, 4 threads.

Modular thunder:
before: 4064 x 2704, geomean: 49.24 MP/s [40.27, 51.04], 30 reps, 4 threads.
after: 4064 x 2704, geomean: 51.29 MP/s [42.49, 53.30], 30 reps, 4 threads.
