### PR TITLE
check earlier and better if RCT operates on valid channels

### DIFF
--- a/lib/jxl/modular/transform/palette.h
+++ b/lib/jxl/modular/transform/palette.h
@@ -378,29 +378,9 @@ static Status InvPalette(Image &input, uint32_t begin_c, uint32_t nb_colors,
   return num_errors.load(std::memory_order_relaxed) == 0;
 }
 
-static Status CheckPaletteParams(const Image &image, uint32_t begin_c,
-                                 uint32_t end_c) {
-  uint32_t c1 = begin_c;
-  uint32_t c2 = end_c;
-  // The range is including c1 and c2, so c2 may not be num_channels.
-  if (c1 > image.channel.size() || c2 >= image.channel.size() || c2 < c1) {
-    return JXL_FAILURE("Invalid channel range");
-  }
-  const auto &ch1 = image.channel[begin_c];
-  for (size_t c = begin_c + 1; c <= end_c; c++) {
-    const auto &ch2 = image.channel[c];
-    if (ch1.w != ch2.w || ch1.h != ch2.h || ch1.hshift != ch2.hshift ||
-        ch1.vshift != ch2.vshift) {
-      return false;
-    }
-  }
-
-  return true;
-}
-
 static Status MetaPalette(Image &input, uint32_t begin_c, uint32_t end_c,
                           uint32_t nb_colors, uint32_t nb_deltas, bool lossy) {
-  JXL_RETURN_IF_ERROR(CheckPaletteParams(input, begin_c, end_c));
+  JXL_RETURN_IF_ERROR(CheckEqualChannels(input, begin_c, end_c));
 
   size_t nb = end_c - begin_c + 1;
   input.nb_meta_channels++;
@@ -420,7 +400,7 @@ static Status FwdPalette(Image &input, uint32_t begin_c, uint32_t end_c,
                          uint32_t &nb_colors, bool ordered, bool lossy,
                          Predictor &predictor,
                          const weighted::Header &wp_header) {
-  JXL_QUIET_RETURN_IF_ERROR(CheckPaletteParams(input, begin_c, end_c));
+  JXL_QUIET_RETURN_IF_ERROR(CheckEqualChannels(input, begin_c, end_c));
   uint32_t nb = end_c - begin_c + 1;
   if (nb < 1 || input.nb_channels < nb) {
     return JXL_FAILURE("Corrupted transforms");

--- a/lib/jxl/modular/transform/subtractgreen.h
+++ b/lib/jxl/modular/transform/subtractgreen.h
@@ -50,23 +50,11 @@ void InvSubtractGreenRow(const pixel_type* in0, const pixel_type* in1,
 }
 
 Status InvSubtractGreen(Image& input, size_t begin_c, size_t rct_type) {
+  JXL_RETURN_IF_ERROR(CheckEqualChannels(input, begin_c, begin_c + 2));
   size_t m = begin_c;
-  if (input.nb_channels + input.nb_meta_channels < begin_c + 3) {
-    return JXL_FAILURE(
-        "Invalid number of channels to apply inverse subtract_green.");
-  }
   Channel& c0 = input.channel[m + 0];
-  Channel& c1 = input.channel[m + 1];
-  Channel& c2 = input.channel[m + 2];
   size_t w = c0.w;
   size_t h = c0.h;
-  if (c0.plane.xsize() < w || c0.plane.ysize() < h || c1.plane.xsize() < w ||
-      c1.plane.ysize() < h || c2.plane.xsize() < w || c2.plane.ysize() < h ||
-      c1.w != w || c1.h != h || c2.w != w || c2.h != h) {
-    return JXL_FAILURE(
-        "Invalid channel dimensions to apply inverse subtract_green (maybe "
-        "chroma is subsampled?).");
-  }
   if (rct_type == 0) {  // noop
     return true;
   }
@@ -111,9 +99,7 @@ Status InvSubtractGreen(Image& input, size_t begin_c, size_t rct_type) {
 }
 
 Status FwdSubtractGreen(Image& input, size_t begin_c, size_t rct_type) {
-  if (input.nb_channels + input.nb_meta_channels < begin_c + 3) {
-    return false;
-  }
+  JXL_RETURN_IF_ERROR(CheckEqualChannels(input, begin_c, begin_c + 2));
   if (rct_type == 0) {  // noop
     return false;
   }

--- a/lib/jxl/modular/transform/transform.cc
+++ b/lib/jxl/modular/transform/transform.cc
@@ -94,4 +94,19 @@ Status Transform::MetaApply(Image &input) {
   }
 }
 
+Status CheckEqualChannels(const Image &image, uint32_t c1, uint32_t c2) {
+  if (c1 > image.channel.size() || c2 >= image.channel.size() || c2 < c1) {
+    return JXL_FAILURE("Invalid channel range");
+  }
+  const auto &ch1 = image.channel[c1];
+  for (size_t c = c1 + 1; c <= c2; c++) {
+    const auto &ch2 = image.channel[c];
+    if (ch1.w != ch2.w || ch1.h != ch2.h || ch1.hshift != ch2.hshift ||
+        ch1.vshift != ch2.vshift) {
+      return false;
+    }
+  }
+  return true;
+}
+
 }  // namespace jxl

--- a/lib/jxl/modular/transform/transform.h
+++ b/lib/jxl/modular/transform/transform.h
@@ -148,6 +148,8 @@ class Transform : public Fields {
   Status MetaApply(Image &input);
 };
 
+Status CheckEqualChannels(const Image &image, uint32_t c1, uint32_t c2);
+
 }  // namespace jxl
 
 #endif  // LIB_JXL_MODULAR_TRANSFORM_TRANSFORM_H_


### PR DESCRIPTION
RCT could be applied to channels of different hshift/vshift. If they have different dimensions, this got caught when trying to undo the RCT (which is rather late), but if they have the same dimensions (which can happen in weird/fuzzer cases), it was caught nowhere. When doing a permute-only RCT, that would lead to hshift/vshift values becoming invalid, and in combination with Squeeze it could lead to negative hshift/vshift.

This cleans up the checking a bit, doing the same check as in Palette also as a "Meta-RCT" check.