### PR TITLE
Fix for https://github.com/libjxl/libjxl/issues/150

### DIFF
--- a/lib/jxl/enc_file.cc
+++ b/lib/jxl/enc_file.cc
@@ -185,11 +185,17 @@ Status WriteHeaders(CodecMetadata* metadata, BitWriter* writer,
   return true;
 }
 
-Status EncodeFile(const CompressParams& cparams, const CodecInOut* io,
+Status EncodeFile(const CompressParams& cparams_orig, const CodecInOut* io,
                   PassesEncoderState* passes_enc_state, PaddedBytes* compressed,
                   AuxOut* aux_out, ThreadPool* pool) {
   io->CheckMetadata();
   BitWriter writer;
+
+  CompressParams cparams = cparams_orig;
+  if (io->Main().color_transform != ColorTransform::kNone) {
+    // Set the color transform to YCbCr or XYB if the original image is such.
+    cparams.color_transform = io->Main().color_transform;
+  }
 
   std::unique_ptr<CodecMetadata> metadata = jxl::make_unique<CodecMetadata>();
   JXL_RETURN_IF_ERROR(PrepareCodecMetadataFromIO(cparams, io, metadata.get()));

--- a/lib/jxl/enc_frame.cc
+++ b/lib/jxl/enc_frame.cc
@@ -1016,9 +1016,6 @@ Status EncodeFrame(const CompressParams& cparams_orig,
   passes_enc_state->special_frames.clear();
 
   CompressParams cparams = cparams_orig;
-  if (ib.color_transform != ColorTransform::kNone) {
-    cparams.color_transform = ib.color_transform;
-  }
 
   if (cparams.progressive_dc < 0) {
     if (cparams.progressive_dc != -1) {


### PR DESCRIPTION
Overriding the color transform in enc_frame can an xyb_encoded <->
xyb mismatch assert to fail.

However, overriding color transform is still necessary to encode other
images correctly with correct color, such as y4m. Do this earlier, in
enc_file, now.
