### PR TITLE
Add missing header includes.

### DIFF
--- a/lib/jxl/modular/transform/palette.h
+++ b/lib/jxl/modular/transform/palette.h
@@ -14,6 +14,7 @@
 #include "lib/jxl/common.h"
 #include "lib/jxl/modular/encoding/context_predict.h"
 #include "lib/jxl/modular/modular_image.h"
+#include "lib/jxl/modular/transform/transform.h"  // CheckEqualChannels
 
 namespace jxl {
 

--- a/lib/jxl/modular/transform/subtractgreen.h
+++ b/lib/jxl/modular/transform/subtractgreen.h
@@ -9,6 +9,7 @@
 #include "lib/jxl/base/status.h"
 #include "lib/jxl/common.h"
 #include "lib/jxl/modular/modular_image.h"
+#include "lib/jxl/modular/transform/transform.h"  // CheckEqualChannels
 
 namespace jxl {
 


### PR DESCRIPTION
This allows to compile headers as standalone units.