### PR TITLE
Add F16 support to JNI wrapper.

### DIFF
--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -343,6 +343,7 @@ if ("${JNI_FOUND}" AND "${Java_FOUND}")
     jni/org/jpeg/jpegxl/wrapper/Decoder.java
     jni/org/jpeg/jpegxl/wrapper/DecoderJni.java
     jni/org/jpeg/jpegxl/wrapper/ImageData.java
+    jni/org/jpeg/jpegxl/wrapper/PixelFormat.java
   )
   get_target_property(JXL_JNI_WRAPPER_JAR jxl_jni_wrapper JAR_FILE)
 

--- a/tools/jni/org/jpeg/jpegxl/wrapper/Decoder.java
+++ b/tools/jni/org/jpeg/jpegxl/wrapper/Decoder.java
@@ -14,15 +14,19 @@ public class Decoder {
   private Decoder() {}
 
   /** One-shot decoding. */
-  public static ImageData decode(Buffer data) {
-    DecoderJni.BasicInfo basicInfo = DecoderJni.getBasicInfo(data);
+  public static ImageData decode(Buffer data, PixelFormat pixelFormat) {
+    DecoderJni.BasicInfo basicInfo = DecoderJni.getBasicInfo(data, pixelFormat);
     if (basicInfo.width < 0 || basicInfo.height < 0 || basicInfo.pixelsSize < 0
         || basicInfo.iccSize < 0) {
       throw new IllegalStateException("JNI has returned negative size");
     }
     Buffer pixels = ByteBuffer.allocateDirect(basicInfo.pixelsSize);
     Buffer icc = ByteBuffer.allocateDirect(basicInfo.iccSize);
-    DecoderJni.getPixels(data, pixels, icc);
+    DecoderJni.getPixels(data, pixels, icc, pixelFormat);
     return new ImageData(basicInfo.width, basicInfo.height, pixels, icc);
+  }
+
+  public static ImageData decode(Buffer data) {
+    return decode(data, PixelFormat.RGBA_8888);
   }
 }

--- a/tools/jni/org/jpeg/jpegxl/wrapper/DecoderJni.java
+++ b/tools/jni/org/jpeg/jpegxl/wrapper/DecoderJni.java
@@ -39,17 +39,18 @@ class DecoderJni {
   }
 
   /** One-shot decoding. */
-  static BasicInfo getBasicInfo(Buffer data) {
+  static BasicInfo getBasicInfo(Buffer data, PixelFormat pixelFormat) {
     if (!data.isDirect()) {
       throw new IllegalArgumentException("data must be direct buffer");
     }
     int[] context = new int[5];
+    context[0] = pixelFormat.ordinal();
     nativeGetBasicInfo(context, data);
     return new BasicInfo(context);
   }
 
   /** One-shot decoding. */
-  static void getPixels(Buffer data, Buffer pixels, Buffer icc) {
+  static void getPixels(Buffer data, Buffer pixels, Buffer icc, PixelFormat pixelFormat) {
     if (!data.isDirect()) {
       throw new IllegalArgumentException("data must be direct buffer");
     }
@@ -60,6 +61,7 @@ class DecoderJni {
       throw new IllegalArgumentException("icc must be direct buffer");
     }
     int[] context = new int[1];
+    context[0] = pixelFormat.ordinal();
     nativeGetPixels(context, data, pixels, icc);
     checkStatusCode(context[0]);
   }

--- a/tools/jni/org/jpeg/jpegxl/wrapper/DecoderTest.java
+++ b/tools/jni/org/jpeg/jpegxl/wrapper/DecoderTest.java
@@ -24,19 +24,45 @@ public class DecoderTest {
     }
   }
 
-  // Simple executable to avoid extra dependencies.
-  public static void main(String[] args) {
+  static ByteBuffer makeSimpleImage() {
     byte[] jxl = Base64.getDecoder().decode("/wr6H0GRCAYBAGAASzgkunkeVbaSBu95EXDn0e7ABz2ShAMA");
     ByteBuffer jxlData = ByteBuffer.allocateDirect(jxl.length);
     jxlData.put(jxl);
-    ImageData imageData = Decoder.decode(jxlData);
-    if (imageData.width != 1024)
+    return jxlData;
+  }
+
+  static void checkSimpleImageData(ImageData imageData) {
+    if (imageData.width != 1024) {
       throw new IllegalStateException("invalid width");
-    if (imageData.height != 1024)
+    }
+    if (imageData.height != 1024) {
       throw new IllegalStateException("invalid height");
+    }
     int iccSize = imageData.icc.capacity();
     // Do not expect ICC profile to be some exact size; currently it is 732
-    if (iccSize < 300 || iccSize > 1000)
+    if (iccSize < 300 || iccSize > 1000) {
       throw new IllegalStateException("unexpected ICC profile size");
+    }
+  }
+
+  static void testRgba() {
+    ImageData imageData = Decoder.decode(makeSimpleImage());
+    checkSimpleImageData(imageData);
+    if (imageData.pixels.limit() != 1024 * 1024 * 4) {
+      throw new IllegalStateException("Expected 4 bytes per pixels (RGBA_8888)");
+    }
+  }
+
+  static void testRgbaF16() {
+    ImageData imageData = Decoder.decode(makeSimpleImage(), PixelFormat.RGBA_F16);
+    checkSimpleImageData(imageData);
+    if (imageData.pixels.limit() != 1024 * 1024 * 8) {
+      throw new IllegalStateException("Expected 8 bytes per pixels (RGBA_F16)");
+    }
+  }
+  // Simple executable to avoid extra dependencies.
+  public static void main(String[] args) {
+    testRgba();
+    testRgbaF16();
   }
 }

--- a/tools/jni/org/jpeg/jpegxl/wrapper/ImageData.java
+++ b/tools/jni/org/jpeg/jpegxl/wrapper/ImageData.java
@@ -13,11 +13,17 @@ public class ImageData {
   final int height;
   final Buffer pixels;
   final Buffer icc;
+  final PixelFormat pixelFormat;
 
-  ImageData(int width, int height, Buffer pixels, Buffer icc) {
+  ImageData(int width, int height, Buffer pixels, Buffer icc, PixelFormat pixelFormat) {
     this.width = width;
     this.height = height;
     this.pixels = pixels;
     this.icc = icc;
+    this.pixelFormat = pixelFormat;
+  }
+
+  ImageData(int width, int height, Buffer pixels, Buffer icc) {
+    this(width, height, pixels, icc, PixelFormat.RGBA_F16);
   }
 }

--- a/tools/jni/org/jpeg/jpegxl/wrapper/PixelFormat.java
+++ b/tools/jni/org/jpeg/jpegxl/wrapper/PixelFormat.java
@@ -1,0 +1,11 @@
+// Copyright (c) the JPEG XL Project Authors. All rights reserved.
+//
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package org.jpeg.jpegxl.wrapper;
+
+public enum PixelFormat {
+  RGBA_8888, // 0
+  RGBA_F16 // 1
+}

--- a/tools/jni/org/jpeg/jpegxl/wrapper/decoder_jni.h
+++ b/tools/jni/org/jpeg/jpegxl/wrapper/decoder_jni.h
@@ -15,7 +15,8 @@ extern "C" {
 /**
  * Get basic image information (size, etc.)
  *
- * @param ctx {out_status, out_width, out_height, pixels_size, icc_size} tuple
+ * @param ctx {in_pixel_format_out_status, out_width, out_height, pixels_size,
+ *             icc_size} tuple
  * @param data [in] Buffer with encoded JXL stream
  */
 JNIEXPORT void JNICALL
@@ -27,7 +28,7 @@ Java_org_jpeg_jpegxl_wrapper_DecoderJni_nativeGetBasicInfo(JNIEnv* env,
 /**
  * Get image pixel data.
  *
- * @param ctx {out_status} tuple
+ * @param ctx {in_pixel_format_out_status} tuple
  * @param data [in] Buffer with encoded JXL stream
  * @param pixels [out] Buffer to place pixels to
  */


### PR DESCRIPTION
Both RGBA_8888 and RGBA_F16 are tested in test_jxl_jni_wrapper unit test.