### PR TITLE
some minor code cleanup in modular decode

### DIFF
--- a/lib/jxl/modular/encoding/encoding.h
+++ b/lib/jxl/modular/encoding/encoding.h
@@ -11,10 +11,6 @@
 
 #include <vector>
 
-#include "lib/jxl/aux_out_fwd.h"
-#include "lib/jxl/base/compiler_specific.h"
-#include "lib/jxl/base/padded_bytes.h"
-#include "lib/jxl/base/span.h"
 #include "lib/jxl/dec_ans.h"
 #include "lib/jxl/image.h"
 #include "lib/jxl/modular/encoding/context_predict.h"


### PR DESCRIPTION
Get rid of unnecessary includes (I think most of those are for things that are now in enc_encoding.cc), some other minor cleanups.