### PR TITLE
Replace <cinttypes> macros with casts

### DIFF
--- a/lib/jxl/blending.cc
+++ b/lib/jxl/blending.cc
@@ -5,8 +5,6 @@
 
 #include "lib/jxl/blending.h"
 
-#include <cinttypes>
-
 #include "lib/jxl/alpha.h"
 #include "lib/jxl/image_ops.h"
 
@@ -133,12 +131,11 @@ Status ImageBlender::PrepareBlending(PassesDecoderState* dec_state,
             src.extra_channels()[i].ysize() < image_ysize ||
             src.origin.x0 != 0 || src.origin.y0 != 0) {
           return JXL_FAILURE(
-              "Invalid size %zux%zu or origin +%" PRIi32 "+%" PRIi32
-              " for extra channel %zu of reference frame %" PRIu32
-              ", expected at least %zux%zu+0+0",
+              "Invalid size %zux%zu or origin %+d%+d for extra channel %zu of "
+              "reference frame %zu, expected at least %zux%zu+0+0",
               src.extra_channels()[i].xsize(), src.extra_channels()[i].ysize(),
-              src.origin.x0, src.origin.y0, i, eci.source, image_xsize,
-              image_ysize);
+              static_cast<int>(src.origin.x0), static_cast<int>(src.origin.y0),
+              i, static_cast<size_t>(eci.source), image_xsize, image_ysize);
         }
         CopyImageTo(Rect(dest_->extra_channels()[i]), src.extra_channels()[i],
                     &dest_->extra_channels()[i]);

--- a/lib/jxl/frame_header.cc
+++ b/lib/jxl/frame_header.cc
@@ -5,8 +5,6 @@
 
 #include "lib/jxl/frame_header.h"
 
-#include <cinttypes>
-
 #include "lib/jxl/aux_out.h"
 #include "lib/jxl/base/status.h"
 #include "lib/jxl/fields.h"
@@ -354,10 +352,11 @@ Status FrameHeader::VisitFields(Visitor* JXL_RESTRICT visitor) {
            frame_size.ysize < nonserialized_metadata->ysize() ||
            frame_origin.x0 != 0 || frame_origin.y0 != 0)) {
         return JXL_FAILURE(
-            "non-patch reference frame with invalid crop: %" PRIu32 "x%" PRIu32
-            "+%" PRIi32 "+%" PRIi32,
-            frame_size.xsize, frame_size.ysize, frame_origin.x0,
-            frame_origin.y0);
+            "non-patch reference frame with invalid crop: %zux%zu%+d%+d",
+            static_cast<size_t>(frame_size.xsize),
+            static_cast<size_t>(frame_size.ysize),
+            static_cast<int>(frame_origin.x0),
+            static_cast<int>(frame_origin.y0));
       }
     }
   } else {


### PR DESCRIPTION
The latter appear to be more widely supported.