### PR TITLE
fix *san complaining about 1 << 32

### DIFF
--- a/lib/jxl/enc_modular.cc
+++ b/lib/jxl/enc_modular.cc
@@ -479,7 +479,7 @@ Status ModularFrameEncoder::ComputeEncodingData(
     static const float enc_factors[3] = {32768.0f, 2048.0f, 2048.0f};
     DequantMatricesSetCustomDC(&enc_state->shared.matrices, enc_factors);
   }
-  pixel_type maxval = (1u << gi.bitdepth) - 1;
+  pixel_type maxval = gi.bitdepth < 32 ? (1u << gi.bitdepth) - 1 : 0;
   if (do_color) {
     for (; c < 3; c++) {
       if (metadata.color_encoding.IsGray() &&


### PR DESCRIPTION
Asan/msan tests fail because `1u << 32` has a too large shift. This only happens iff the result is not used anyway, but let's keep asan/msan happy.