### PR TITLE
Reversing the decision tree

### DIFF
--- a/lib/jxl/decode_test.cc
+++ b/lib/jxl/decode_test.cc
@@ -1682,7 +1682,7 @@ TEST(DecodeTest, PixelTestWithICCProfileLossy) {
 
   jxl::ButteraugliParams ba;
   EXPECT_LE(ButteraugliDistance(io0, io1, ba, /*distmap=*/nullptr, nullptr),
-            2.0f);
+            2.4f);
 
   JxlDecoderDestroy(dec);
 }
@@ -1744,7 +1744,7 @@ TEST(DecodeTest, PixelTestOpaqueSrgbLossy) {
 
     jxl::ButteraugliParams ba;
     EXPECT_LE(ButteraugliDistance(io0, io1, ba, /*distmap=*/nullptr, nullptr),
-              2.0f);
+              2.4f);
 
     JxlDecoderDestroy(dec);
   }
@@ -1807,7 +1807,7 @@ TEST(DecodeTest, PixelTestOpaqueSrgbLossyNoise) {
 
     jxl::ButteraugliParams ba;
     EXPECT_LE(ButteraugliDistance(io0, io1, ba, /*distmap=*/nullptr, nullptr),
-              2.0f);
+              2.4f);
 
     JxlDecoderDestroy(dec);
   }


### PR DESCRIPTION
look first for best 8x8 transforms, then combine them until one cannot

this leads to much less ringing and much more agreeable low bpp
performance

About 1.5-1.7 % improvement in d1-d0.8, 3-3.5 % in d3-d8, images look
better

Before:

```
Compr                 Input    Compr            Compr       Compr  Decomp  Butteraugli
Method               Pixels     Size              BPP   #    MP/s    MP/s     Distance    Error p norm   PSNR   QABPP     DCT2     DCT4   DCT4X8      AFV     DCT8  DCT8X16  DCT8X32    DCT16 DCT16X32    DCT32           BPP*pnorm   Errors
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
jxl:d0.8:epf0      17448577  3882970    1.78030334508   1   2.463  13.888   1.78702760   0.53532604362  41.74   2.169 0.000586 0.000234 0.058668 0.028092 0.150227 0.188963 0.000000 0.238400 0.052994 0.289325  0.9530427461578836        0
jxl:d1:epf1        17448577  3390345    1.55443965431   1   3.661  21.472   1.92427385   0.61798232243  40.64   2.182 0.000704 0.000234 0.054758 0.027531 0.143547 0.203723 0.000000 0.222320 0.058569 0.296191  0.9606162276488913        0
jxl:d2:epf3        17448577  2211623    1.01400727406   1   3.656  17.309   3.33052874   0.96634995600  37.43   2.306 0.000821 0.000234 0.045867 0.026277 0.134763 0.241517 0.000000 0.167594 0.085007 0.305581  0.9798858846749036        0
jxl:d3:epf0        17448577  1659494    0.76086158774   1   2.628  24.616   4.26731873   1.28979124040  35.23   2.307 0.001408 0.000234 0.040508 0.024509 0.131806 0.246212 0.000000 0.141244 0.103171 0.318786  0.9813526110223445        0
jxl:d4:epf3        17448577  1379671    0.63256550950   1   3.433  15.581   5.55589771   1.57312789681  34.11   2.524 0.001995 0.000234 0.037192 0.024024 0.122042 0.244378 0.000000 0.130900 0.120924 0.326239  0.9951064495489939        0
jxl:d8:epf1        17448577   797336    0.36557067089   1   3.467  24.867  10.19216442   2.59725100656  30.86   2.517 0.006925 0.000234 0.021934 0.016744 0.099738 0.233397 0.000000 0.112165 0.136182 0.380642  0.9494787929423127        0
jxl:d16:epf3       17448577   447915    0.20536459793   1   2.744  13.994  20.44609451   4.65698285309  28.49   2.771 0.104579 0.018545 0.004009 0.004959 0.028316 0.164711 0.000000 0.084640 0.176764 0.421722  0.9563794111769300        0
jxl:d24:epf3       17448577   337423    0.15470510862   1   3.775  14.587  22.80272484   6.08515321171  27.24   2.777 0.176881 0.050001 0.001173 0.002123 0.011341 0.111248 0.000000 0.072977 0.188237 0.394316  0.9414042885690688        0
jxl:d32:epf3       17448577   275293    0.12621911804   1   3.851  14.683  32.96412277   7.37702894473  26.45   2.838 0.193196 0.087560 0.000403 0.000939 0.004522 0.071487 0.000000 0.062163 0.181694 0.406346  0.9311220871625333        0
Aggregate:         17448577  1092188    0.50075745781 ---   3.256  17.418   7.04102991   1.91856265434  33.15   2.476 0.006595 0.001336 0.012803 0.010789 0.057407 0.177060 0.000000 0.124280 0.111714 0.345444  0.9607345574421874        0
```

After:

```
Compr                 Input    Compr            Compr       Compr  Decomp  Butteraugli
Method               Pixels     Size              BPP   #    MP/s    MP/s     Distance    Error p norm   PSNR   QABPP     DCT2     DCT4   DCT4X8      AFV     DCT8  DCT8X16  DCT8X32    DCT16 DCT16X32    DCT32           BPP*pnorm   Errors
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
jxl:d0.8:epf0      17448577  3839018    1.76015178774   1   2.186  13.917   1.82268906   0.53243755115  41.66   2.143 0.000469 0.000234 0.064522 0.033972 0.100244 0.187870 0.000000 0.246513 0.065347 0.308222  0.9371709075114463        0
jxl:d1:epf1        17448577  3358650    1.53990781025   1   3.051  21.344   1.91374373   0.61429703499  40.61   2.162 0.000586 0.000234 0.062152 0.033759 0.097783 0.199835 0.000000 0.226985 0.073505 0.312682  0.9459608019921065        0
jxl:d2:epf3        17448577  2193579    1.00573427850   1   3.090  17.292   3.44436002   0.95646373904  37.46   2.262 0.000939 0.000234 0.053349 0.033594 0.090443 0.233316 0.000000 0.170074 0.111328 0.314267  0.9619483684985939        0
jxl:d3:epf0        17448577  1644345    0.75391592105   1   2.331  24.508   4.63104630   1.27172922181  35.29   2.247 0.001760 0.000234 0.042170 0.030124 0.081985 0.243894 0.000000 0.148785 0.131605 0.327119  0.9587769075929928        0
jxl:d4:epf3        17448577  1365861    0.62623376107   1   2.969  15.609   6.93971729   1.55148313567  34.16   2.433 0.002817 0.000234 0.036330 0.028760 0.072910 0.241187 0.000000 0.140114 0.151998 0.333340  0.9715911192830359        0
jxl:d8:epf1        17448577   790541    0.36245523059   1   2.988  24.655   9.19697952   2.52667172032  30.91   2.408 0.009742 0.000234 0.017576 0.018214 0.055147 0.218322 0.000000 0.123785 0.185714 0.378881  0.9158053810144500        0
jxl:d16:epf3       17448577   449343    0.20601932180   1   2.423  13.954  21.47150230   4.61578107052  28.54   2.754 0.120777 0.021362 0.003579 0.005604 0.020056 0.126646 0.000000 0.094309 0.215732 0.400126  0.9509400857485670        0
jxl:d24:epf3       17448577   338680    0.15528143069   1   3.078  14.421  22.44577408   6.02338281245  27.28   2.728 0.198948 0.053522 0.001305 0.002736 0.009852 0.081112 0.000000 0.078229 0.210039 0.372543  0.9353195006879738        0
jxl:d32:epf3       17448577   275854    0.12647633099   1   3.134  14.407  26.11194992   7.30797489073  26.48   2.762 0.218666 0.093898 0.000484 0.001239 0.004816 0.053955 0.000000 0.060594 0.196307 0.378353  0.9242858511645232        0
Aggregate:         17448577  1086400    0.49810378720 ---   2.781  17.323   7.07983341   1.89616680255  33.18   2.422 0.007389 0.001378 0.013302 0.013125 0.040263 0.158280 0.000000 0.130501 0.137589 0.345730  0.9444878655225486        0
```

Compression is significantly slower, and fast modes may need a new
approach.