### PR TITLE
compute_minmax is encode-only, real_nb_channels is not needed

### DIFF
--- a/lib/jxl/dec_modular.cc
+++ b/lib/jxl/dec_modular.cc
@@ -258,7 +258,6 @@ Status ModularFrameDecoder::DecodeGroup(const Rect& rect, BitReader* reader,
     gi.channel.emplace_back(std::move(gc));
   }
   gi.nb_channels = gi.channel.size();
-  gi.real_nb_channels = gi.nb_channels;
   if (zerofill) {
     int gic = 0;
     for (c = beginc; c < full_image.channel.size(); c++) {

--- a/lib/jxl/modular/encoding/enc_encoding.cc
+++ b/lib/jxl/modular/encoding/enc_encoding.cc
@@ -540,7 +540,7 @@ Status ModularGenericCompress(Image &image, const ModularOptions &opts,
     JXL_DEBUG_V(
         4,
         "Modular-encoded a %zux%zu bitdepth=%i nbchans=%zu image in %zu bytes",
-        image.w, image.h, image.bitdepth, image.real_nb_channels, bits / 8);
+        image.w, image.h, image.bitdepth, image.nb_channels, bits / 8);
   }
   (void)bits;
   return true;

--- a/lib/jxl/modular/encoding/encoding.cc
+++ b/lib/jxl/modular/encoding/encoding.cc
@@ -510,7 +510,7 @@ Status ModularGenericDecompress(BitReader *br, Image &image,
   if (image.error) return JXL_FAILURE("Corrupt file. Aborting.");
   size_t bit_pos = br->TotalBitsConsumed();
   JXL_DEBUG_V(4, "Modular-decoded a %zux%zu nbchans=%zu image from %zu bytes",
-              image.w, image.h, image.real_nb_channels,
+              image.w, image.h, image.nb_channels,
               (br->TotalBitsConsumed() - bit_pos) / 8);
   (void)bit_pos;
 #ifdef JXL_ENABLE_ASSERT

--- a/lib/jxl/modular/modular_image.cc
+++ b/lib/jxl/modular/modular_image.cc
@@ -11,21 +11,6 @@
 
 namespace jxl {
 
-void Channel::compute_minmax(pixel_type *min, pixel_type *max) const {
-  pixel_type realmin = std::numeric_limits<pixel_type>::max();
-  pixel_type realmax = std::numeric_limits<pixel_type>::min();
-  for (size_t y = 0; y < h; y++) {
-    const pixel_type *JXL_RESTRICT p = plane.Row(y);
-    for (size_t x = 0; x < w; x++) {
-      if (p[x] < realmin) realmin = p[x];
-      if (p[x] > realmax) realmax = p[x];
-    }
-  }
-
-  if (min) *min = realmin;
-  if (max) *max = realmax;
-}
-
 void Image::undo_transforms(const weighted::Header &wp_header, int keep,
                             jxl::ThreadPool *pool) {
   if (keep == -2) return;
@@ -61,28 +46,24 @@ Image::Image(size_t iw, size_t ih, int bd, int nb_chans)
       h(ih),
       bitdepth(bd),
       nb_channels(nb_chans),
-      real_nb_channels(nb_chans),
       nb_meta_channels(0),
       error(false) {
   for (int i = 0; i < nb_chans; i++) channel.emplace_back(Channel(iw, ih));
 }
+
 Image::Image()
     : w(0),
       h(0),
       bitdepth(8),
       nb_channels(0),
-      real_nb_channels(0),
       nb_meta_channels(0),
       error(true) {}
-
-Image::~Image() = default;
 
 Image &Image::operator=(Image &&other) noexcept {
   w = other.w;
   h = other.h;
   bitdepth = other.bitdepth;
   nb_channels = other.nb_channels;
-  real_nb_channels = other.real_nb_channels;
   nb_meta_channels = other.nb_meta_channels;
   error = other.error;
   channel = std::move(other.channel);

--- a/lib/jxl/modular/modular_image.h
+++ b/lib/jxl/modular/modular_image.h
@@ -92,7 +92,6 @@ class Channel {
   JXL_INLINE const pixel_type* Row(const size_t y) const {
     return plane.Row(y);
   }
-  void compute_minmax(pixel_type* min, pixel_type* max) const;
 };
 
 class Transform;
@@ -112,8 +111,6 @@ class Image {
   size_t nb_channels;  // actual number of distinct channels (after undoing all
                        // transforms except Palette; can be different from
                        // channel.size())
-  size_t real_nb_channels;  // real number of channels (after undoing all
-                            // transforms)
   size_t nb_meta_channels;  // first few channels might contain things like
                             // palettes or compaction data that are not yet real
                             // image data
@@ -122,7 +119,6 @@ class Image {
   Image(size_t iw, size_t ih, int bitdepth, int nb_chans);
 
   Image();
-  ~Image();
 
   Image(const Image& other) = delete;
   Image& operator=(const Image& other) = delete;

--- a/lib/jxl/modular/transform/enc_palette.cc
+++ b/lib/jxl/modular/transform/enc_palette.cc
@@ -13,8 +13,8 @@
 #include "lib/jxl/common.h"
 #include "lib/jxl/modular/encoding/context_predict.h"
 #include "lib/jxl/modular/modular_image.h"
+#include "lib/jxl/modular/transform/enc_transform.h"
 #include "lib/jxl/modular/transform/palette.h"
-#include "lib/jxl/modular/transform/transform.h"  // CheckEqualChannels
 
 namespace jxl {
 
@@ -112,7 +112,7 @@ Status FwdPalette(Image &input, uint32_t begin_c, uint32_t end_c,
     if (nb_colors == 0) return false;
     std::vector<pixel_type> lookup;
     int minval, maxval;
-    input.channel[begin_c].compute_minmax(&minval, &maxval);
+    compute_minmax(input.channel[begin_c], &minval, &maxval);
     int lookup_table_size = maxval - minval + 1;
     if (lookup_table_size > palette_internal::kMaxPaletteLookupTableSize) {
       return false;  // too large lookup table

--- a/lib/jxl/modular/transform/enc_transform.cc
+++ b/lib/jxl/modular/transform/enc_transform.cc
@@ -28,4 +28,19 @@ Status TransformForward(Transform &t, Image &input,
   }
 }
 
+void compute_minmax(const Channel &ch, pixel_type *min, pixel_type *max) {
+  pixel_type realmin = std::numeric_limits<pixel_type>::max();
+  pixel_type realmax = std::numeric_limits<pixel_type>::min();
+  for (size_t y = 0; y < ch.h; y++) {
+    const pixel_type *JXL_RESTRICT p = ch.Row(y);
+    for (size_t x = 0; x < ch.w; x++) {
+      if (p[x] < realmin) realmin = p[x];
+      if (p[x] > realmax) realmax = p[x];
+    }
+  }
+
+  if (min) *min = realmin;
+  if (max) *max = realmax;
+}
+
 }  // namespace jxl

--- a/lib/jxl/modular/transform/enc_transform.h
+++ b/lib/jxl/modular/transform/enc_transform.h
@@ -15,6 +15,8 @@ namespace jxl {
 Status TransformForward(Transform &t, Image &input,
                         const weighted::Header &wp_header, ThreadPool *pool);
 
+void compute_minmax(const Channel &ch, pixel_type *min, pixel_type *max);
+
 }  // namespace jxl
 
 #endif  // LIB_JXL_MODULAR_TRANSFORM_ENC_TRANSFORM_H_


### PR DESCRIPTION
Minor stuff, slightly decreases libjxl_dec size (probably not really when good lto is done), infinitesimally reduces memory use.
