### PR TITLE
simplify modular channel resize()

### DIFF
--- a/lib/jxl/enc_modular.cc
+++ b/lib/jxl/enc_modular.cc
@@ -522,7 +522,7 @@ Status ModularFrameEncoder::ComputeEncodingData(
             enc_state->shared.frame_header.chroma_subsampling.VShift(c);
         size_t xsize_shifted = DivCeil(xsize, 1 << gi.channel[c_out].hshift);
         size_t ysize_shifted = DivCeil(ysize, 1 << gi.channel[c_out].vshift);
-        gi.channel[c_out].resize(xsize_shifted, ysize_shifted);
+        gi.channel[c_out].shrink(xsize_shifted, ysize_shifted);
         for (size_t y = 0; y < ysize_shifted; ++y) {
           const float* const JXL_RESTRICT row_in = color->PlaneRow(c, y);
           pixel_type* const JXL_RESTRICT row_out = gi.channel[c_out].Row(y);
@@ -539,7 +539,7 @@ Status ModularFrameEncoder::ComputeEncodingData(
   for (size_t ec = 0; ec < extra_channels.size(); ec++, c++) {
     const ExtraChannelInfo& eci = metadata.extra_channel_info[ec];
     size_t ecups = frame_header.extra_channel_upsampling[ec];
-    gi.channel[c].resize(DivCeil(frame_dim.xsize_upsampled, ecups),
+    gi.channel[c].shrink(DivCeil(frame_dim.xsize_upsampled, ecups),
                          DivCeil(frame_dim.ysize_upsampled, ecups));
     gi.channel[c].hshift = gi.channel[c].vshift =
         CeilLog2Nonzero(ecups) - CeilLog2Nonzero(frame_header.upsampling);
@@ -1516,7 +1516,7 @@ void ModularFrameEncoder::AddVarDCTDC(const Image3F& dc, size_t group_index,
       Channel& ch = stream_images[stream_id].channel[c < 2 ? c ^ 1 : c];
       ch.w = xs;
       ch.h = ys;
-      ch.resize();
+      ch.shrink();
       for (size_t y = 0; y < ys; y++) {
         int32_t* quant_row = ch.plane.Row(y);
         const float* row = rect.ConstPlaneRow(dc, c, y);
@@ -1584,7 +1584,6 @@ void ModularFrameEncoder::AddACMetadata(size_t group_index, bool jpeg_transcode,
     }
   }
   image.channel[2].w = num;
-  image.channel[2].resize();
   ac_metadata_size[group_index] = num;
 }
 

--- a/lib/jxl/modular/encoding/encoding.cc
+++ b/lib/jxl/modular/encoding/encoding.cc
@@ -138,7 +138,6 @@ Status DecodeModularChannelMAANS(BitReader *br, ANSSymbolReader *reader,
   // zero pixel channel? could happen
   if (channel.w == 0 || channel.h == 0) return true;
 
-  channel.resize(channel.w, channel.h);
   bool tree_has_wp_prop_or_pred = false;
   bool is_wp_only = false;
   bool is_gradient_only = false;
@@ -479,6 +478,7 @@ Status ModularDecode(BitReader *br, Image &image, GroupHeader &header,
     if (!br->AllReadsWithinBounds()) {
       if (!allow_truncated_group) return JXL_FAILURE("Truncated input");
       ZeroFillImage(&channel.plane);
+      while (++i < nb_channels) ZeroFillImage(&image.channel[i].plane);
       return Status(StatusCode::kNotEnoughBytes);
     }
   }

--- a/lib/jxl/modular/modular_image.h
+++ b/lib/jxl/modular/modular_image.h
@@ -38,7 +38,6 @@ class Channel {
   int hshift, vshift;  // w ~= image.w >> hshift;  h ~= image.h >> vshift
   Channel(size_t iw, size_t ih, int hsh = 0, int vsh = 0)
       : plane(iw, ih), w(iw), h(ih), hshift(hsh), vshift(vsh) {}
-  Channel() : plane(0, 0), w(0), h(0), hshift(0), vshift(0) {}
 
   Channel(const Channel& other) = delete;
   Channel& operator=(const Channel& other) = delete;
@@ -56,37 +55,16 @@ class Channel {
   // Move constructor
   Channel(Channel&& other) noexcept = default;
 
-  void resize(pixel_type value = 0) {
+  void shrink() {
     if (plane.xsize() == w && plane.ysize() == h) return;
     jxl::Plane<pixel_type> resizedplane(w, h);
-    if (plane.xsize() || plane.ysize()) {
-      // copy pixels over from old plane to new plane
-      size_t y = 0;
-      for (; y < plane.ysize() && y < h; y++) {
-        const pixel_type* JXL_RESTRICT p = plane.Row(y);
-        pixel_type* JXL_RESTRICT rp = resizedplane.Row(y);
-        size_t x = 0;
-        for (; x < plane.xsize() && x < w; x++) rp[x] = p[x];
-        for (; x < w; x++) rp[x] = value;
-      }
-      for (; y < h; y++) {
-        pixel_type* JXL_RESTRICT p = resizedplane.Row(y);
-        for (size_t x = 0; x < w; x++) p[x] = value;
-      }
-    } else if (w && h && value == 0) {
-      size_t ppr = resizedplane.bytes_per_row();
-      memset(resizedplane.bytes(), 0, ppr * h);
-    } else if (w && h) {
-      FillImage(value, &resizedplane);
-    }
     plane = std::move(resizedplane);
   }
-  void resize(int nw, int nh) {
+  void shrink(int nw, int nh) {
     w = nw;
     h = nh;
-    resize();
+    shrink();
   }
-  bool is_empty() const { return (plane.ysize() == 0); }
 
   JXL_INLINE pixel_type* Row(const size_t y) { return plane.Row(y); }
   JXL_INLINE const pixel_type* Row(const size_t y) const {


### PR DESCRIPTION
The modular channel resize() function was copying and/or initializing pixels, for no good reason really. In the encoder there was one spot where copying was needed, the other instances of resize() were either just doing a shrinking of the dimensions with no need to initialize things, or a way to make sure the channel plane is actually allocated (in case of Squeeze, that wasn't always the case).

Reorganized things so this complicated resize() function is no longer needed. Channel planes are now always allocated immediately (change in MetaSqueeze), and explicit zeroing is only done when needed (when a modular decode is interrupted because of progressive: the not-yet-decoded channels all need to be zeroed then, not just the ones that weren't allocated yet — this fixes a potential uninitialized memory bug in that case).

This slightly speeds up modular decoding, in particular in the cases where squeeze was used:
before: 4064 x 2704, geomean: 23.36 MP/s [19.60, 24.32], 30 reps, 4 threads.
after: 4064 x 2704, geomean: 24.53 MP/s [20.48, 25.28], 30 reps, 4 threads.
