### PR TITLE
Add "ci.sh ossfuzz_*" commands to help repro oss-fuzz bugs

### DIFF
--- a/tools/ossfuzz-build.sh
+++ b/tools/ossfuzz-build.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+# Copyright (c) the JPEG XL Project Authors. All rights reserved.
+#
+# Use of this source code is governed by a BSD-style
+# license that can be found in the LICENSE file.
+
+# Helper builder file to replace the /src/build.sh one in oss-fuzz/
+
+if [[ -z "${FUZZING_ENGINE:-}" ]]; then
+  echo "Don't call this script directly. Use ./ci.sh ossfuzz_* commands" \
+    "instead." >&2
+  exit 1
+fi
+
+set -eux
+
+main() {
+  # Build the fuzzers in release mode but force the inclusion of JXL_DASSERT()
+  # checks.
+  build_args=(
+    -G Ninja
+    -DBUILD_TESTING=OFF
+    -DJPEGXL_ENABLE_BENCHMARK=OFF
+    -DJPEGXL_ENABLE_DEVTOOLS=ON
+    -DJPEGXL_ENABLE_EXAMPLES=OFF
+    -DJPEGXL_ENABLE_FUZZERS=ON
+    -DJPEGXL_ENABLE_MANPAGES=OFF
+    -DJPEGXL_ENABLE_SJPEG=OFF
+    -DJPEGXL_ENABLE_VIEWERS=OFF
+    -DCMAKE_BUILD_TYPE=Release
+  )
+  export CXXFLAGS="${CXXFLAGS} -DJXL_IS_DEBUG_BUILD=1"
+
+  mkdir -p ${WORK}
+  cd ${WORK}
+  cmake \
+    "${build_args[@]}" \
+    -DJPEGXL_FUZZER_LINK_FLAGS="${LIB_FUZZING_ENGINE}" \
+    "${SRC}/libjxl"
+
+  fuzzers=(
+    color_encoding_fuzzer
+    djxl_fuzzer
+    fields_fuzzer
+    icc_codec_fuzzer
+    rans_fuzzer
+  )
+  ninja "${fuzzers[@]}"
+}
+
+# Build as the regular user if not already running as that user. This avoids
+# having root files in the build directory.
+if [[ -n "${JPEGXL_UID:-}" && "${JPEGXL_UID}" != $(id -u) ]]; then
+  userspec="${JPEGXL_UID}:${JPEGXL_GID}"
+  unset JPEGXL_UID
+  unset JPEGXL_GID
+  chroot --skip-chdir --userspec="${userspec}" \
+    / $(realpath "$0") "$@"
+  exit $?
+fi
+
+main "$@"


### PR DESCRIPTION
oss-fuzz.com uses a set of docker containers to build and run the fuzzer
targets. In oss-fuzz.com these are build from libjxl's main branch or
from a given branch in CIFuzz. However building requires a few steps to
set up the docker container and doesn't support fast incremental builds.

This patch adds ossfuzz_asan, ossfuzz_msan and ossfuzz_ubsan to build
libjxl in a similar way than what oss-fuzz does in their build.sh file.
A new ossfuzz_ninja will run "ninja" with the supplied args inside the
docker container to help rebuilding the project quickly after adding
local modifications.

The source code built is always taken from the current checkout (the
ci.sh directory) and the build files are stored in the BUILD_DIR as
usual. The BUILD_DIR is in a different path inside the container and
can't be re-built outside the container.

Example usage:

BUILD_DIR=build-ossasan ./ci.sh ossfuzz_asan
BUILD_DIR=build-ossasan ./ci.sh ossfuzz_asan djxl_fuzzer
build-ossasan/tools/djxl_fuzzer my_local_test.jxl