### PR TITLE
Add reference getters to dec_frame

### DIFF
--- a/lib/jxl/dec_frame.h
+++ b/lib/jxl/dec_frame.h
@@ -104,6 +104,18 @@ class FrameDecoder {
   // Must be called exactly once per frame, after all calls to ProcessSections.
   Status FinalizeFrame();
 
+  // Returns dependencies of this frame on reference ids as a bit mask: bits 0-3
+  // indicate reference frame 0-3 for patches and blending, bits 4-7 indicate DC
+  // frames this frame depends on. Only returns a valid result after all calls
+  // to ProcessSections are finished and before FinalizeFrame.
+  int References() const;
+
+  // Returns reference id of storage location where this frame is stored as a
+  // bit flag, or 0 if not stored.
+  // Matches the bit mask used for GetReferences: bits 0-3 indicate it is stored
+  // for patching or blending, bits 4-7 indicate DC frame.
+  int SavedAs() const;
+
   // Returns offset of this section after the end of the TOC. The end of the TOC
   // is the byte position of the bit reader after InitFrame was called.
   const std::vector<uint64_t>& SectionOffsets() const {

--- a/lib/jxl/dec_patch_dictionary.cc
+++ b/lib/jxl/dec_patch_dictionary.cc
@@ -153,6 +153,14 @@ Status PatchDictionary::Decode(BitReader* br, size_t xsize, size_t ysize,
   return true;
 }
 
+int PatchDictionary::GetReferences() const {
+  int result = 0;
+  for (size_t i = 0; i < positions_.size(); ++i) {
+    result |= (1 << static_cast<int>(positions_[i].ref_pos.ref));
+  }
+  return result;
+}
+
 void PatchDictionary::ComputePatchCache() {
   patch_starts_.clear();
   sorted_patches_.clear();

--- a/lib/jxl/dec_patch_dictionary.h
+++ b/lib/jxl/dec_patch_dictionary.h
@@ -170,6 +170,10 @@ class PatchDictionary {
   Status AddTo(Image3F* opsin, const Rect& opsin_rect,
                float* const* extra_channels, const Rect& image_rect) const;
 
+  // Returns dependencies of this patch dictionary on reference frame ids as a
+  // bit mask: bits 0-3 indicate reference frame 0-3.
+  int GetReferences() const;
+
  private:
   friend class PatchDictionaryEncoder;
 


### PR DESCRIPTION
Add getters for which frame storage locations are referenced, and
referencable by, frames. This is for use for more optimal rewinding in
the API, but it is not implemented yet there.

Also added a test for a jxl image with patches to decode_test, to
prepare for when this feature is added to the API.