### PR TITLE
Simplifying speed heuristics

### DIFF
--- a/lib/jxl/enc_ac_strategy.cc
+++ b/lib/jxl/enc_ac_strategy.cc
@@ -725,18 +725,6 @@ void ProcessRectACS(PassesEncoderState* JXL_RESTRICT enc_state,
                               cmap_factors, block, scratch_space, quantized);
           entropy *= entropy_adjust[i * 2 + 1];
         }
-        // In modes faster than Hare mode, we don't use InitialQuantField -
-        // hence, we need to come up with quant field values.
-        if (cparams.speed_tier > SpeedTier::kHare &&
-            cparams.uniform_quant <= 0) {
-          // OPTIMIZE
-          float quant = 1.1f / (1.0f + max_delta_acs) / butteraugli_target;
-          for (size_t y = 0; y < cy; y++) {
-            for (size_t x = 0; x < cx; x++) {
-              config.SetQuant(bx + ix + x, by + iy + y, quant);
-            }
-          }
-        }
         // Mark blocks as chosen and write to acs image.
         ac_strategy->Set(bx + ix, by + iy, i);
         for (size_t y = 0; y < cy; y++) {

--- a/lib/jxl/enc_heuristics.cc
+++ b/lib/jxl/enc_heuristics.cc
@@ -320,12 +320,10 @@ Status DefaultEncoderHeuristics::LossyFrameHeuristics(
   if (cparams.speed_tier > SpeedTier::kHare || cparams.uniform_quant > 0) {
     enc_state->initial_quant_field =
         ImageF(shared.frame_dim.xsize_blocks, shared.frame_dim.ysize_blocks);
-    if (cparams.speed_tier >= SpeedTier::kFalcon || cparams.uniform_quant > 0) {
-      float q = cparams.uniform_quant > 0
-                    ? cparams.uniform_quant
-                    : kAcQuant / cparams.butteraugli_distance;
-      FillImage(q, &enc_state->initial_quant_field);
-    }
+    float q = cparams.uniform_quant > 0
+        ? cparams.uniform_quant
+        : kAcQuant / cparams.butteraugli_distance;
+    FillImage(q, &enc_state->initial_quant_field);
   } else {
     // Call this here, as it relies on pre-gaborish values.
     float butteraugli_distance_for_iqf = cparams.butteraugli_distance;


### PR DESCRIPTION
This removes a non-linearity in bitrate for lower qualities, and makes
testing and figuring out more linear heuristics for the ac decision tree
reversal easier.

Before:

```
Compr              Input    Compr            Compr       Compr  Decomp  Butteraugli
Method            Pixels     Size              BPP   #    MP/s    MP/s     Distance    Error p norm   PSNR   QABPP     DCT2     DCT4   DCT4X8      AFV     DCT8  DCT8X16  DCT8X32    DCT16 DCT16X32    DCT32           BPP*pnorm   Errors
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
jxl:3           17448577  3687783    1.69081203585   1   6.678  16.907   1.93303061   0.67455758824  40.72   2.632 0.000000 0.000000 0.000000 0.000000 1.008333 0.000000 0.000000 0.000000 0.000000 0.000000  1.1405500890716611        0
jxl:4           17448577  3505010    1.60701242285   1   9.584  21.662   4.23037910   0.79261957166  39.12   3.468 0.186389 0.106809 0.000000 0.000000 0.011649 0.063755 0.000000 0.120850 0.284366 0.234512  1.2737494982541968        0
jxl:5           17448577  3465175    1.58874846929   1   5.350  17.432   3.54066658   0.68679733514  40.08   2.719 0.174417 0.083569 0.000000 0.000000 0.061958 0.134370 0.000000 0.137400 0.240028 0.176588  1.0911482149124485        0
jxl:d4:3        17448577  1502115    0.68870487261   1  11.953  12.227   5.02047539   1.60729061090  34.54   2.572 0.000000 0.000000 0.000000 0.000000 1.008333 0.000000 0.000000 0.000000 0.000000 0.000000  1.1069488754229997        0
jxl:d4:4        17448577  1293010    0.59283229801   1   6.357  12.072   8.93738365   1.86403638323  32.74   3.041 0.273245 0.142726 0.000000 0.000000 0.000425 0.014150 0.000000 0.014451 0.189734 0.373599  1.1050609726557399        0
jxl:d4:5        17448577  1423632    0.65272119325   1   7.993  13.282   7.18886089   1.67507572453  34.04   2.935 0.225943 0.122772 0.000000 0.000000 0.005098 0.035842 0.000000 0.071568 0.280551 0.266555  1.0933574257015992        0
Aggregate:      17448577  2232615    1.02363172966 ---   7.697  15.237   4.58901766   1.10725914824  36.74   2.879 0.211660 0.111832 0.000000 0.000000 0.034170 0.045656 0.000000 0.064375 0.245513 0.253413  1.1334255971013936        0
```

After:

```
Compr              Input    Compr            Compr       Compr  Decomp  Butteraugli
Method            Pixels     Size              BPP   #    MP/s    MP/s     Distance    Error p norm   PSNR   QABPP     DCT2     DCT4   DCT4X8      AFV     DCT8  DCT8X16  DCT8X32    DCT16 DCT16X32    DCT32           BPP*pnorm   Errors
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
jxl:3           17448577  3687783    1.69081203585   1   6.352  17.252   1.93303061   0.67455758824  40.72   2.632 0.000000 0.000000 0.000000 0.000000 1.008333 0.000000 0.000000 0.000000 0.000000 0.000000  1.1405500890716611        0
jxl:4           17448577  3491782    1.60094751566   1   9.666  21.504   3.81185579   0.78847195777  39.26   3.386 0.186389 0.106809 0.000000 0.000000 0.011649 0.063755 0.000000 0.120850 0.284366 0.234512  1.2623022219545574        0
jxl:5           17448577  3465175    1.58874846929   1   5.180  16.973   3.54066658   0.68679733514  40.08   2.719 0.174417 0.083569 0.000000 0.000000 0.061958 0.134370 0.000000 0.137400 0.240028 0.176588  1.0911482149124485        0
jxl:d4:3        17448577  1502115    0.68870487261   1  12.376  12.556   5.02047539   1.60729061090  34.54   2.572 0.000000 0.000000 0.000000 0.000000 1.008333 0.000000 0.000000 0.000000 0.000000 0.000000  1.1069488754229997        0
jxl:d4:4        17448577  1493470    0.68474122560   1   5.814  11.554   8.03508663   1.65040093085  33.60   2.988 0.273245 0.142726 0.000000 0.000000 0.000425 0.014150 0.000000 0.014451 0.189734 0.373599  1.1300975561253708        0
jxl:d4:5        17448577  1423632    0.65272119325   1   8.018  13.383   7.18886089   1.67507572453  34.04   2.935 0.225943 0.122772 0.000000 0.000000 0.005098 0.035842 0.000000 0.071568 0.280551 0.266555  1.0933574257015992        0
Aggregate:      17448577  2285454    1.04785812682 ---   7.538  15.178   4.43073679   1.08407342858  36.92   2.859 0.211660 0.111832 0.000000 0.000000 0.034170 0.045656 0.000000 0.064375 0.245513 0.253413  1.1359551522107640        0
```

jxl:4 looks very similar before and after, possibly slightly better.
jxl:d4:4 looks possibly not as much better as the bitrate increase, and
likely further improvements are possible. I propose we consider possible
improvements after the ac decision tree reversal has been completed.