### PR TITLE
remove another unnecessary modular image field

### DIFF
--- a/lib/jxl/dec_modular.cc
+++ b/lib/jxl/dec_modular.cc
@@ -255,7 +255,6 @@ Status ModularFrameDecoder::DecodeGroup(const Rect& rect, BitReader* reader,
     gc.vshift = fc.vshift;
     gi.channel.emplace_back(std::move(gc));
   }
-  gi.nb_channels = gi.channel.size();
   if (zerofill) {
     int gic = 0;
     for (c = beginc; c < full_image.channel.size(); c++) {

--- a/lib/jxl/modular/encoding/enc_encoding.cc
+++ b/lib/jxl/modular/encoding/enc_encoding.cc
@@ -540,7 +540,7 @@ Status ModularGenericCompress(Image &image, const ModularOptions &opts,
     JXL_DEBUG_V(
         4,
         "Modular-encoded a %zux%zu bitdepth=%i nbchans=%zu image in %zu bytes",
-        image.w, image.h, image.bitdepth, image.nb_channels, bits / 8);
+        image.w, image.h, image.bitdepth, image.channel.size(), bits / 8);
   }
   (void)bits;
   return true;

--- a/lib/jxl/modular/encoding/encoding.cc
+++ b/lib/jxl/modular/encoding/encoding.cc
@@ -383,7 +383,7 @@ Status ModularDecode(BitReader *br, Image &image, GroupHeader &header,
                      const Tree *global_tree, const ANSCode *global_code,
                      const std::vector<uint8_t> *global_ctx_map,
                      bool allow_truncated_group) {
-  if (image.nb_channels < 1) return true;
+  if (image.channel.empty()) return true;
 
   // decode transforms
   JXL_RETURN_IF_ERROR(Bundle::Read(br, &header));
@@ -510,7 +510,7 @@ Status ModularGenericDecompress(BitReader *br, Image &image,
   if (image.error) return JXL_FAILURE("Corrupt file. Aborting.");
   size_t bit_pos = br->TotalBitsConsumed();
   JXL_DEBUG_V(4, "Modular-decoded a %zux%zu nbchans=%zu image from %zu bytes",
-              image.w, image.h, image.nb_channels,
+              image.w, image.h, image.channel.size(),
               (br->TotalBitsConsumed() - bit_pos) / 8);
   (void)bit_pos;
 #ifdef JXL_ENABLE_ASSERT

--- a/lib/jxl/modular/modular_image.cc
+++ b/lib/jxl/modular/modular_image.cc
@@ -42,28 +42,16 @@ void Image::undo_transforms(const weighted::Header &wp_header, int keep,
 }
 
 Image::Image(size_t iw, size_t ih, int bd, int nb_chans)
-    : w(iw),
-      h(ih),
-      bitdepth(bd),
-      nb_channels(nb_chans),
-      nb_meta_channels(0),
-      error(false) {
+    : w(iw), h(ih), bitdepth(bd), nb_meta_channels(0), error(false) {
   for (int i = 0; i < nb_chans; i++) channel.emplace_back(Channel(iw, ih));
 }
 
-Image::Image()
-    : w(0),
-      h(0),
-      bitdepth(8),
-      nb_channels(0),
-      nb_meta_channels(0),
-      error(true) {}
+Image::Image() : w(0), h(0), bitdepth(8), nb_meta_channels(0), error(true) {}
 
 Image &Image::operator=(Image &&other) noexcept {
   w = other.w;
   h = other.h;
   bitdepth = other.bitdepth;
-  nb_channels = other.nb_channels;
   nb_meta_channels = other.nb_meta_channels;
   error = other.error;
   channel = std::move(other.channel);

--- a/lib/jxl/modular/modular_image.h
+++ b/lib/jxl/modular/modular_image.h
@@ -76,26 +76,19 @@ class Transform;
 
 class Image {
  public:
-  std::vector<Channel>
-      channel;  // image data, transforms can dramatically change the number of
-                // channels and their semantics
-  std::vector<Transform>
-      transform;  // keeps track of the transforms that have been applied (and
-                  // that have to be undone when rendering the image)
+  // image data, transforms can dramatically change the number of channels and
+  // their semantics
+  std::vector<Channel> channel;
+  // transforms that have been applied (and that have to be undone)
+  std::vector<Transform> transform;
 
-  size_t w, h;  // actual dimensions of the image (channels may have different
-                // dimensions due to transforms like chroma subsampling and DCT)
+  // image dimensions (channels may have different dimensions due to transforms)
+  size_t w, h;
   int bitdepth;
-  size_t nb_channels;  // actual number of distinct channels (after undoing all
-                       // transforms except Palette; can be different from
-                       // channel.size())
-  size_t nb_meta_channels;  // first few channels might contain things like
-                            // palettes or compaction data that are not yet real
-                            // image data
+  size_t nb_meta_channels;  // first few channels might contain palette(s)
   bool error;               // true if a fatal error occurred, false otherwise
 
   Image(size_t iw, size_t ih, int bitdepth, int nb_chans);
-
   Image();
 
   Image(const Image& other) = delete;

--- a/lib/jxl/modular/transform/enc_palette.cc
+++ b/lib/jxl/modular/transform/enc_palette.cc
@@ -100,9 +100,6 @@ Status FwdPalette(Image &input, uint32_t begin_c, uint32_t end_c,
                   Predictor &predictor, const weighted::Header &wp_header) {
   JXL_QUIET_RETURN_IF_ERROR(CheckEqualChannels(input, begin_c, end_c));
   uint32_t nb = end_c - begin_c + 1;
-  if (nb < 1 || input.nb_channels < nb) {
-    return JXL_FAILURE("Corrupted transforms");
-  }
 
   size_t w = input.channel[begin_c].w;
   size_t h = input.channel[begin_c].h;
@@ -439,7 +436,6 @@ Status FwdPalette(Image &input, uint32_t begin_c, uint32_t end_c,
     predictor = Predictor::Zero;
   }
   input.nb_meta_channels++;
-  input.nb_channels -= nb - 1;
   input.channel.erase(input.channel.begin() + begin_c + 1,
                       input.channel.begin() + end_c + 1);
   input.channel.insert(input.channel.begin(), std::move(pch));

--- a/lib/jxl/modular/transform/palette.h
+++ b/lib/jxl/modular/transform/palette.h
@@ -271,7 +271,6 @@ static Status InvPalette(Image &input, uint32_t begin_c, uint32_t nb_colors,
           "UndoDeltaPaletteNoWP");
     }
   }
-  input.nb_channels += nb - 1;
   input.nb_meta_channels--;
   input.channel.erase(input.channel.begin(), input.channel.begin() + 1);
   return num_errors.load(std::memory_order_relaxed) == 0;
@@ -283,10 +282,6 @@ static Status MetaPalette(Image &input, uint32_t begin_c, uint32_t end_c,
 
   size_t nb = end_c - begin_c + 1;
   input.nb_meta_channels++;
-  if (nb < 1 || input.nb_channels < nb) {
-    return JXL_FAILURE("Corrupted transforms");
-  }
-  input.nb_channels -= nb - 1;
   input.channel.erase(input.channel.begin() + begin_c + 1,
                       input.channel.begin() + end_c + 1);
   Channel pch(nb_colors + nb_deltas, nb);

--- a/lib/jxl/modular/transform/squeeze.cc
+++ b/lib/jxl/modular/transform/squeeze.cc
@@ -146,9 +146,8 @@ void DefaultSqueezeParameters(std::vector<SqueezeParams> *parameters,
   size_t h = image.channel[image.nb_meta_channels].h;
   JXL_DEBUG_V(7, "Default squeeze parameters for %zux%zu image: ", w, h);
 
-  bool wide =
-      (w >
-       h);  // do horizontal first on wide images; vertical first on tall images
+  // do horizontal first on wide images; vertical first on tall images
+  bool wide = (w > h);
 
   if (nb_channels > 2 && image.channel[image.nb_meta_channels + 1].w == w &&
       image.channel[image.nb_meta_channels + 1].h == h) {


### PR DESCRIPTION
Get rid of `Image.nb_channels`, since it had become redundant, especially in the decoder.

Also fixes https://github.com/libjxl/libjxl/issues/184, removes/updates some stale comments, and removes a check that is already implied by an earlier check (so the condition will always fail).
