### PR TITLE
Unbreak build on FreeBSD 12.3/13.1/14.0

### DIFF
--- a/tools/cpu/os_specific.cc
+++ b/tools/cpu/os_specific.cc
@@ -48,9 +48,8 @@
 #endif  // JXL_OS_MAC
 
 #if JXL_OS_FREEBSD
-#include <sys/cpuset.h>
 #include <sys/param.h>
-#include <sys/types.h>
+#include <sys/cpuset.h>
 #include <sys/wait.h>
 #include <unistd.h>
 #endif  // JXL_OS_FREEBSD


### PR DESCRIPTION
`<sys/cpuset.h>` isn't standalone (see [cpuset_setaffinity(2)](https://man.freebsd.org/cpuset_setaffinity/2)) while `<sys/param.h>` already includes `<sys/types.h>` (see [style(9)](https://man.freebsd.org/style/9)). Recent [libc++ update](https://github.com/freebsd/freebsd-src/commit/e8d8bef961a50d4dc22501cde4fb9fb0be1b2532) on FreeBSD 14.0-CURRENT [broke build](http://www.ipv6proxy.net/go.php?u=http://beefy17.nyi.freebsd.org/data/main-i386-default/pd83453f82622_sd5c1296234/logs/jpeg-xl-0.3.7_2.log), so adjust headers.
