### PR TITLE
fix default squeeze params

### DIFF
--- a/lib/jxl/modular/transform/squeeze.cc
+++ b/lib/jxl/modular/transform/squeeze.cc
@@ -139,9 +139,7 @@ void InvVSqueeze(Image &input, int c, int rc, ThreadPool *pool) {
 
 void DefaultSqueezeParameters(std::vector<SqueezeParams> *parameters,
                               const Image &image) {
-  int nb_channels = image.nb_channels;
-  // maybe other transforms have been applied before, but let's assume the first
-  // nb_channels channels still contain the 'main' data
+  int nb_channels = image.channel.size() - image.nb_meta_channels;
 
   parameters->clear();
   size_t w = image.channel[image.nb_meta_channels].w;


### PR DESCRIPTION
The default squeeze parameters were not exactly set according to spec. It doesn't make any difference for the bitstreams produced by the current encoder, but it would make a difference if a hypothetical encoder would do two or more squeeze transforms on the same modular image, where the second or later squeeze is a default squeeze. (this would likely not be a very useful thing for a hypothetical future encoder to do, but still...)
