### PR TITLE
Pull ternary operator out of fprintf args.

### DIFF
--- a/tools/cjxl_main.cc
+++ b/tools/cjxl_main.cc
@@ -103,11 +103,12 @@ int CompressJpegXlMain(int argc, const char* argv[]) {
     compressed.swap(container_file);
     if (!args.quiet) {
       const size_t pixels = io.xsize() * io.ysize();
-      const double bpp =
-          static_cast<double>(compressed.size() * jxl::kBitsPerByte) / pixels;
-      fprintf(stderr, "Including container: %zu bytes (%.3f bpp%s).\n",
-              compressed.size(), bpp / io.frames.size(),
-              io.frames.size() == 1 ? "" : "/frame");
+      const size_t size = compressed.size();
+      const double bpp = static_cast<double>(size * jxl::kBitsPerByte) / pixels;
+      const double bppf = bpp / io.frames.size();
+      const char* suffix = (io.frames.size() == 1) ? "" : "/frame";
+      fprintf(stderr, "Including container: %zu bytes (%.3f bpp%s).\n", size,
+              bppf, suffix);
     }
   }
   if (args.file_out) {


### PR DESCRIPTION
Hopefully this will fix win64:static build that page-faults right after dumping the message to console.