### PR TITLE
push global RCT to groups if possible, parallelize otherwise

### DIFF
--- a/lib/jxl/dec_modular.h
+++ b/lib/jxl/dec_modular.h
@@ -111,6 +111,7 @@ class ModularFrameDecoder {
 
  private:
   Image full_image;
+  std::vector<Transform> global_transform;
   FrameDimensions frame_dim;
   bool do_color;
   bool have_something;

--- a/lib/jxl/modular/transform/transform.cc
+++ b/lib/jxl/modular/transform/transform.cc
@@ -23,7 +23,7 @@ Status Transform::Inverse(Image &input, const weighted::Header &wp_header,
                           ThreadPool *pool) {
   switch (id) {
     case TransformId::kRCT:
-      return InvRCT(input, begin_c, rct_type);
+      return InvRCT(input, begin_c, rct_type, pool);
     case TransformId::kSqueeze:
       return InvSqueeze(input, squeezes, pool);
     case TransformId::kPalette:


### PR DESCRIPTION
Makes global RCTs a bit faster (as e.g. used at fast modular speed settings like thunder and falcon).

Introduces a list of global transforms that are applied immediately after decoding each group instead of during finalization. For now only RCTs are moved from the global image to that list, could later add non-delta-palette transforms (channel palettes or simple color palettes) too. @veluca93 : this might be a start for a memory reduction by skipping the global image in case there are no global transforms left at that point.

In case there are still global RCTs left (e.g. when the global RCT is followed by a global squeeze or delta palette), use threads.

About 5% speedup of modular thunder decoding:
before: 4064 x 2704, geomean: 47.28 MP/s [38.06, 49.52], 30 reps, 4 threads.
after: 4064 x 2704, geomean: 49.72 MP/s [40.32, 52.68], 30 reps, 4 threads.

