### PR TITLE
Store frame dependency graph on rewind

### DIFF
--- a/lib/jxl/dec_frame.cc
+++ b/lib/jxl/dec_frame.cc
@@ -827,17 +827,13 @@ Status FrameDecoder::Flush() {
   return true;
 }
 
-int FrameDecoder::SavedAs() const {
-  if (is_finalized_) {
-    // header not parsed
-    return 0;
-  }
-  if (frame_header_.frame_type == FrameType::kDCFrame) {
+int FrameDecoder::SavedAs(const FrameHeader& header) {
+  if (header.frame_type == FrameType::kDCFrame) {
     // bits 16, 32, 64, 128 for DC level
-    return 16 << (frame_header_.dc_level - 1);
-  } else if (frame_header_.CanBeReferenced()) {
+    return 16 << (header.dc_level - 1);
+  } else if (header.CanBeReferenced()) {
     // bits 1, 2, 4 and 8 for the references
-    return 1 << frame_header_.save_as_reference;
+    return 1 << header.save_as_reference;
   }
 
   return 0;

--- a/lib/jxl/dec_frame.h
+++ b/lib/jxl/dec_frame.h
@@ -114,7 +114,9 @@ class FrameDecoder {
   // bit flag, or 0 if not stored.
   // Matches the bit mask used for GetReferences: bits 0-3 indicate it is stored
   // for patching or blending, bits 4-7 indicate DC frame.
-  int SavedAs() const;
+  // Unlike References, can be ran at any time as
+  // soon as the frame header is known.
+  static int SavedAs(const FrameHeader& header);
 
   // Returns offset of this section after the end of the TOC. The end of the TOC
   // is the byte position of the bit reader after InitFrame was called.


### PR DESCRIPTION
This stores the dependency graph between frames on rewind, so that
decoding of more frames can be avoided when skipping to a later frame
after rewind.

Improved the SkipFrameWithBlendingTest to have true dependencies between
frames that use a blending mode that depends on the pixels of both 
frames, to test this feature, and verified that making 
GetFrameDependencies return wrong output, breaks the test.
