### PR TITLE
Pass `decoded->extra_channels()` and the corresponding Rects separately to PrepareBlending

### DIFF
--- a/lib/jxl/blending.h
+++ b/lib/jxl/blending.h
@@ -54,7 +54,8 @@ class ImageBlender {
       const std::vector<ExtraChannelInfo>* extra_channel_info,
       const ColorEncoding& frame_color_encoding, const Rect& frame_rect,
       Image3F* output, const Rect& output_rect,
-      std::vector<std::pair<ImageF*, Rect>> output_extra_channels);
+      std::vector<ImageF>* output_extra_channels,
+      std::vector<Rect> output_extra_channels_rects);
   // rect is relative to the full decoded foreground.
   // But foreground here can be a subset of the full foreground, and input_rect
   // indicates where that rect is in that subset. For example, if rect =
@@ -76,7 +77,8 @@ class ImageBlender {
   // Destination, as well as background before DoBlending is called.
   Image3F* output_;
   Rect output_rect_;
-  std::vector<std::pair<ImageF*, Rect>> output_extra_channels_;
+  std::vector<ImageF>* output_extra_channels_;
+  std::vector<Rect> output_extra_channels_rects_;
   Rect cropbox_;
   Rect overlap_;
   bool done_ = false;

--- a/lib/jxl/blending_test.cc
+++ b/lib/jxl/blending_test.cc
@@ -68,7 +68,7 @@ TEST(BlendingTest, Offset) {
       &dec_state, foreground_origin, foreground.xsize(), foreground.ysize(),
       &nonserialized_metadata.m.extra_channel_info,
       background.Main().c_current(), Rect(background), output.color(),
-      Rect(*output.color()), {}));
+      Rect(*output.color()), {}, {}));
 
   static constexpr int kStep = 20;
   for (size_t x0 = 0; x0 < foreground.xsize(); x0 += kStep) {

--- a/lib/jxl/dec_reconstruct.cc
+++ b/lib/jxl/dec_reconstruct.cc
@@ -1189,20 +1189,21 @@ Status FinalizeFrameDecoding(ImageBundle* decoded,
     decoded->SetFromImage(Image3F(frame_header.nonserialized_metadata->xsize(),
                                   frame_header.nonserialized_metadata->ysize()),
                           foreground.c_current());
-    std::vector<std::pair<ImageF*, Rect>> extra_channels;
-    extra_channels.reserve(foreground.extra_channels().size());
+    std::vector<Rect> extra_channels_rects;
+    decoded->extra_channels().reserve(foreground.extra_channels().size());
+    extra_channels_rects.reserve(foreground.extra_channels().size());
     for (size_t i = 0; i < foreground.extra_channels().size(); ++i) {
       decoded->extra_channels().emplace_back(
           frame_header.nonserialized_metadata->xsize(),
           frame_header.nonserialized_metadata->ysize());
-      extra_channels.emplace_back(&decoded->extra_channels().back(),
-                                  Rect(decoded->extra_channels().back()));
+      extra_channels_rects.emplace_back(decoded->extra_channels().back());
     }
     JXL_RETURN_IF_ERROR(blender.PrepareBlending(
         dec_state, foreground.origin, foreground.xsize(), foreground.ysize(),
         &frame_header.nonserialized_metadata->m.extra_channel_info,
         foreground.c_current(), Rect(*decoded->color()),
-        /*output=*/decoded->color(), Rect(*decoded->color()), extra_channels));
+        /*output=*/decoded->color(), Rect(*decoded->color()),
+        &decoded->extra_channels(), std::move(extra_channels_rects)));
 
     std::vector<Rect> rects_to_process;
     for (size_t y = 0; y < frame_dim.ysize; y += kGroupDim) {


### PR DESCRIPTION
This prevents the pointers that we keep in `extra_channels` from being
invalidated by reallocation.