### PR TITLE
Verify JxlPixelFormat validity when setting out callback

### DIFF
--- a/lib/jxl/decode.cc
+++ b/lib/jxl/decode.cc
@@ -2111,6 +2111,11 @@ JxlDecoderStatus JxlDecoderSetImageOutCallback(JxlDecoder* dec,
         "Cannot change from image out buffer to image out callback");
   }
 
+  // Perform error checking for invalid format.
+  size_t bits_dummy;
+  JxlDecoderStatus status = PrepareSizeCheck(dec, format, &bits_dummy);
+  if (status != JXL_DEC_SUCCESS) return status;
+
   dec->image_out_buffer_set = true;
   dec->image_out_callback = callback;
   dec->image_out_opaque = opaque;


### PR DESCRIPTION
The format must be checked for having a supported amount of channels,
pixel type, etc... This was done in the size check for the image output
buffer setters, but was not done in the callback because buffer size
works differently for those.

Now the full check is done here as well to fix that.