### PR TITLE
avoid full modular image copy

### DIFF
--- a/lib/jxl/dec_frame.cc
+++ b/lib/jxl/dec_frame.cc
@@ -402,7 +402,7 @@ Status FrameDecoder::ProcessDCGroup(size_t dc_group_id, BitReader* br) {
                    frame_dim_.dc_group_dim, frame_dim_.dc_group_dim);
   JXL_RETURN_IF_ERROR(modular_frame_decoder_.DecodeGroup(
       mrect, br, 3, 1000, ModularStreamId::ModularDC(dc_group_id),
-      /*zerofill=*/false));
+      /*zerofill=*/false, nullptr, nullptr));
   if (frame_header_.encoding == FrameEncoding::kVarDCT) {
     JXL_RETURN_IF_ERROR(
         modular_frame_decoder_.DecodeAcMetadata(dc_group_id, br, dec_state_));
@@ -430,6 +430,7 @@ void FrameDecoder::FinalizeDC() {
 void FrameDecoder::AllocateOutput() {
   const CodecMetadata& metadata = *frame_header_.nonserialized_metadata;
   if (dec_state_->rgb_output == nullptr && !dec_state_->pixel_callback) {
+    modular_frame_decoder_.MaybeDropFullImage();
     decoded_->SetFromImage(Image3F(frame_dim_.xsize_upsampled_padded,
                                    frame_dim_.ysize_upsampled_padded),
                            dec_state_->output_encoding_info.color_encoding);
@@ -584,12 +585,13 @@ Status FrameDecoder::ProcessACGroup(size_t ac_group_id,
       JXL_RETURN_IF_ERROR(modular_frame_decoder_.DecodeGroup(
           mrect, br[i - decoded_passes_per_ac_group_[ac_group_id]], minShift,
           maxShift, ModularStreamId::ModularAC(ac_group_id, i),
-          /*zerofill=*/false));
+          /*zerofill=*/false, dec_state_, decoded_));
     } else if (i >= decoded_passes_per_ac_group_[ac_group_id] + num_passes &&
                force_draw) {
       JXL_RETURN_IF_ERROR(modular_frame_decoder_.DecodeGroup(
           mrect, nullptr, minShift, maxShift,
-          ModularStreamId::ModularAC(ac_group_id, i), /*zerofill=*/true));
+          ModularStreamId::ModularAC(ac_group_id, i), /*zerofill=*/true,
+          dec_state_, decoded_));
     }
   }
   decoded_passes_per_ac_group_[ac_group_id] += num_passes;

--- a/lib/jxl/dec_modular.h
+++ b/lib/jxl/dec_modular.h
@@ -88,10 +88,10 @@ class ModularFrameDecoder {
  public:
   void Init(const FrameDimensions& frame_dim) { this->frame_dim = frame_dim; }
   Status DecodeGlobalInfo(BitReader* reader, const FrameHeader& frame_header,
-                          bool allow_truncated_group = false);
+                          bool allow_truncated_group);
   Status DecodeGroup(const Rect& rect, BitReader* reader, int minShift,
-                     int maxShift, const ModularStreamId& stream,
-                     bool zerofill);
+                     int maxShift, const ModularStreamId& stream, bool zerofill,
+                     PassesDecoderState* dec_state, ImageBundle* output);
   // Decodes a VarDCT DC group (`group_id`) from the given `reader`.
   Status DecodeVarDCTDC(size_t group_id, BitReader* reader,
                         PassesDecoderState* dec_state);
@@ -108,12 +108,19 @@ class ModularFrameDecoder {
   Status FinalizeDecoding(PassesDecoderState* dec_state, jxl::ThreadPool* pool,
                           ImageBundle* output);
   bool have_dc() const { return have_something; }
+  void MaybeDropFullImage();
 
  private:
+  Status ModularImageToDecodedRect(Image& gi, PassesDecoderState* dec_state,
+                                   jxl::ThreadPool* pool, ImageBundle* output,
+                                   Rect rect);
+
   Image full_image;
+  std::vector<Transform> global_transform;
   FrameDimensions frame_dim;
   bool do_color;
   bool have_something;
+  bool use_full_image = true;
   Tree tree;
   ANSCode code;
   std::vector<uint8_t> context_map;


### PR DESCRIPTION
In cases where there are no global modular transforms except RCT (as is the case at speed falcon and faster), avoid the unnecessary copy from decoded groups to the modular `full_image` (and then to the float `decoded`).

For `-m -e 2`:

Before:
4064 x 2704, geomean: 47.20 MP/s [38.94, 49.02], 30 reps, 4 threads.
Allocations: 21465 (max bytes in use: 4.360149E+08)

After:
4064 x 2704, geomean: 57.45 MP/s [46.70, 59.76], 30 reps, 4 threads.
Allocations: 21465 (max bytes in use: 3.020612E+08)
