### PR TITLE
Support low memory if exif orientation is kept

### DIFF
--- a/lib/include/jxl/decode.h
+++ b/lib/include/jxl/decode.h
@@ -354,6 +354,8 @@ JXL_EXPORT JxlDecoderStatus JxlDecoderSubscribeEvents(JxlDecoder* dec,
  * By default, this option is disabled, and the decoder automatically corrects
  * the orientation.
  *
+ * This function must be called at the beginning, before decoding is performed.
+ *
  * @see JxlBasicInfo for the orientation field, and @see JxlOrientation for the
  * possible values.
  *

--- a/lib/jxl/decode.cc
+++ b/lib/jxl/decode.cc
@@ -612,6 +612,7 @@ void JxlDecoderDestroy(JxlDecoder* dec) {
 }
 
 void JxlDecoderRewind(JxlDecoder* dec) {
+  int keep_orientation = dec->keep_orientation;
   int events_wanted = dec->orig_events_wanted;
   std::vector<int> frame_references;
   std::vector<int> frame_saved_as;
@@ -623,6 +624,7 @@ void JxlDecoderRewind(JxlDecoder* dec) {
   frame_required.swap(dec->frame_required);
 
   JxlDecoderReset(dec);
+  dec->keep_orientation = keep_orientation;
   dec->events_wanted = events_wanted;
   dec->orig_events_wanted = events_wanted;
   frame_references.swap(dec->frame_references);
@@ -1238,7 +1240,8 @@ JxlDecoderStatus JxlDecoderProcessInternal(JxlDecoder* dec, const uint8_t* in,
         bool is_rgba = dec->image_out_format.num_channels == 4;
         dec->frame_dec->MaybeSetRGB8OutputBuffer(
             reinterpret_cast<uint8_t*>(dec->image_out_buffer),
-            GetStride(dec, dec->image_out_format), is_rgba);
+            GetStride(dec, dec->image_out_format), is_rgba,
+            !dec->keep_orientation);
       }
 
       const bool little_endian =
@@ -1259,7 +1262,7 @@ JxlDecoderStatus JxlDecoderProcessInternal(JxlDecoder* dec, const uint8_t* in,
               dec->image_out_callback(dec->image_out_opaque, x, y, num_pixels,
                                       pixels);
             },
-            is_rgba);
+            is_rgba, !dec->keep_orientation);
       }
 
       size_t pos = dec->frame_start - dec->codestream_pos;


### PR DESCRIPTION
In dec_frame, the low memory path was being disabled if the image has
exif orientation, even if the user wants to output as-is without
applying the orientation. This adds a new flag to indicate what is
intended, so the low memory path can be used if no orientation is
performed.

Also adds a test for orientation in decode_test (both with and without
keep_orientation).

Also fixes decoder rewind to keep the orientation setting around, since
settings are expected to stay after rewind.