### PR TITLE
Squeeze: skip setting DefaultSqueezeParameters when all channels are meta

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -22,3 +22,4 @@ Pieter Wuille
 Marcin Konicki <ahwayakchih@gmail.com>
 Ziemowit Zabawa <ziemek.zabawa@outlook.com>
 Petr Diblík
+Lovell Fuller

--- a/lib/jxl/modular/transform/squeeze.cc
+++ b/lib/jxl/modular/transform/squeeze.cc
@@ -140,6 +140,9 @@ void InvVSqueeze(Image &input, int c, int rc, ThreadPool *pool) {
 void DefaultSqueezeParameters(std::vector<SqueezeParams> *parameters,
                               const Image &image) {
   int nb_channels = image.channel.size() - image.nb_meta_channels;
+  if (nb_channels <= 0) {
+    return;
+  }
 
   parameters->clear();
   size_t w = image.channel[image.nb_meta_channels].w;


### PR DESCRIPTION
Hello, this is a possible solution to prevent a buffer/container overflow at line 145 when a (most likely invalid) image contains only meta channels.

https://github.com/libjxl/libjxl/blob/f6d3a89f48e7a66d235ebee73cd5db694d69b63b/lib/jxl/modular/transform/squeeze.cc#L140-L145

An example image that triggers this, found via fuzz testing, is [default-squeeze-params-overflow.txt](https://github.com/libjxl/libjxl/files/6682092/default-squeeze-params-overflow.txt)

```
READ of size 8 at 0x6140000101b0 thread T4 (pool)
--
SCARINESS: 23 (8-byte-read-container-overflow)
0x2df4915 in jxl::DefaultSqueezeParameters(std::__1::vector&lt;jxl::SqueezeParams, std::__1::allocator&lt;jxl::SqueezeParams&gt; &gt;*, jxl::Image const&amp;) libjxl/lib/jxl/modular/transform/squeeze.cc:145:52
0x2df4c27 in jxl::MetaSqueeze(jxl::Image&amp;, std::__1::vector&lt;jxl::SqueezeParams, std::__1::allocator&lt;jxl::SqueezeParams&gt; &gt;*) libjxl/lib/jxl/modular/transform/squeeze.cc:210:5
0x2622704 in jxl::Transform::MetaApply(jxl::Image&amp;) libjxl/lib/jxl/modular/transform/transform.cc:54:14
```

The approach in this PR returns early and allows the subsequent call to `CheckMetaSqueezeParams` to fail as the parameters are empty. I'm sure there are other approaches to solve this, but this is hopefully the smallest/simplest change to do so.

(Name added to AUTHORS as per contributing checklist.)
