### PR TITLE
make modular transform checks tighter and fix nb_meta_channels bug

### DIFF
--- a/lib/jxl/modular/transform/enc_palette.cc
+++ b/lib/jxl/modular/transform/enc_palette.cc
@@ -99,6 +99,7 @@ Status FwdPalette(Image &input, uint32_t begin_c, uint32_t end_c,
                   uint32_t &nb_colors, bool ordered, bool lossy,
                   Predictor &predictor, const weighted::Header &wp_header) {
   JXL_QUIET_RETURN_IF_ERROR(CheckEqualChannels(input, begin_c, end_c));
+  JXL_ASSERT(begin_c >= input.nb_meta_channels);
   uint32_t nb = end_c - begin_c + 1;
 
   size_t w = input.channel[begin_c].w;

--- a/lib/jxl/modular/transform/palette.h
+++ b/lib/jxl/modular/transform/palette.h
@@ -281,7 +281,14 @@ static Status MetaPalette(Image &input, uint32_t begin_c, uint32_t end_c,
   JXL_RETURN_IF_ERROR(CheckEqualChannels(input, begin_c, end_c));
 
   size_t nb = end_c - begin_c + 1;
-  input.nb_meta_channels++;
+  if (begin_c >= input.nb_meta_channels) {
+    input.nb_meta_channels++;
+  } else if (end_c < input.nb_meta_channels) {
+    // we remove nb-1 metachannels and add one
+    input.nb_meta_channels += 2 - nb;
+  } else {
+    return JXL_FAILURE("Error: Palette operating on mixed meta/nonmeta");
+  }
   input.channel.erase(input.channel.begin() + begin_c + 1,
                       input.channel.begin() + end_c + 1);
   Channel pch(nb_colors + nb_deltas, nb);

--- a/lib/jxl/modular/transform/transform.cc
+++ b/lib/jxl/modular/transform/transform.cc
@@ -39,7 +39,7 @@ Status Transform::MetaApply(Image &input) {
   switch (id) {
     case TransformId::kRCT:
       JXL_DEBUG_V(2, "Transform: kRCT, rct_type=%" PRIu32, rct_type);
-      return true;
+      return CheckEqualChannels(input, begin_c, begin_c + 2);
     case TransformId::kSqueeze:
       JXL_DEBUG_V(2, "Transform: kSqueeze:");
 #if JXL_DEBUG_V_LEVEL >= 2


### PR DESCRIPTION
See also the discussion in https://github.com/libjxl/libjxl/pull/209

Requires palette to operate on either all-meta or all-non-meta channels (the first being something the current encoder doesn't do), and fix the nb_meta_channels update in the all-meta case.

Also checks RCT validity at the MetaApply point instead of waiting for after decode (it would fail when doing InvRCT, but better to fail earlier).