### PR TITLE
Tuning ac strategy heuristics

### DIFF
--- a/lib/jxl/butteraugli/butteraugli.cc
+++ b/lib/jxl/butteraugli/butteraugli.cc
@@ -1245,41 +1245,42 @@ void StoreMin3(const float v, float& min0, float& min1, float& min2) {
 void FuzzyErosion(const ImageF& from, ImageF* to) {
   const size_t xsize = from.xsize();
   const size_t ysize = from.ysize();
+  static const int kStep = 3;
   for (size_t y = 0; y < ysize; ++y) {
     for (size_t x = 0; x < xsize; ++x) {
       float min0 = from.Row(y)[x];
       float min1 = 2 * min0;
       float min2 = min1;
-      if (x >= 3) {
-        float v = from.Row(y)[x - 3];
+      if (x >= kStep) {
+        float v = from.Row(y)[x - kStep];
         StoreMin3(v, min0, min1, min2);
-        if (y >= 3) {
-          float v = from.Row(y - 3)[x - 3];
+        if (y >= kStep) {
+          float v = from.Row(y - kStep)[x - kStep];
           StoreMin3(v, min0, min1, min2);
         }
-        if (y < ysize - 3) {
-          float v = from.Row(y + 3)[x - 3];
+        if (y < ysize - kStep) {
+          float v = from.Row(y + kStep)[x - kStep];
           StoreMin3(v, min0, min1, min2);
         }
       }
-      if (x < xsize - 3) {
-        float v = from.Row(y)[x + 3];
+      if (x < xsize - kStep) {
+        float v = from.Row(y)[x + kStep];
         StoreMin3(v, min0, min1, min2);
-        if (y >= 3) {
-          float v = from.Row(y - 3)[x + 3];
+        if (y >= kStep) {
+          float v = from.Row(y - kStep)[x + kStep];
           StoreMin3(v, min0, min1, min2);
         }
-        if (y < ysize - 3) {
-          float v = from.Row(y + 3)[x + 3];
+        if (y < ysize - kStep) {
+          float v = from.Row(y + kStep)[x + kStep];
           StoreMin3(v, min0, min1, min2);
         }
       }
-      if (y >= 3) {
-        float v = from.Row(y - 3)[x];
+      if (y >= kStep) {
+        float v = from.Row(y - kStep)[x];
         StoreMin3(v, min0, min1, min2);
       }
-      if (y < ysize - 3) {
-        float v = from.Row(y + 3)[x];
+      if (y < ysize - kStep) {
+        float v = from.Row(y + kStep)[x];
         StoreMin3(v, min0, min1, min2);
       }
       to->Row(y)[x] = (0.45f * min0 + 0.3f * min1 + 0.25f * min2);

--- a/tools/optimizer/simplex_fork.py
+++ b/tools/optimizer/simplex_fork.py
@@ -60,19 +60,19 @@ def EvalCacheForget():
 
 def RandomizedJxlCodecs():
   retval = []
-  minval = 0.6
-  maxval = 12.5
+  minval = 0.5
+  maxval = 11.5
   rangeval = maxval/minval
-  steps = 19
+  steps = 7
   for i in range(steps):
     mul = minval * rangeval**(float(i)/(steps - 1))
     mul *= 0.99 + 0.05 * random.random()
-    retval.append("jxl:d%.3f" % mul)
-  steps = 0
+    retval.append("jxl:epf2:d%.3f" % mul)
+  steps = 7
   for i in range(steps):
-    mul = minval * rangeval**(float(i)/(steps - 1))
+    mul = minval * rangeval**(float(i+0.5)/(steps - 1))
     mul *= 0.99 + 0.05 * random.random()
-    retval.append("jxl:d%.3f" % mul)
+    retval.append("jxl:epf0:d%.3f" % mul)
   return ",".join(retval)
 
 g_codecs = RandomizedJxlCodecs()
@@ -102,7 +102,7 @@ def Eval(vec, binary_name, cached=True):
       (binary_name,
        '--input',
        '/usr/local/google/home/jyrki/newcorpus/split/*.png',
-       '--error_pnorm=1.9',
+       '--error_pnorm=5',
        '--more_columns',
        '--codec', g_codecs),
       stdout=subprocess.PIPE,
@@ -120,7 +120,7 @@ def Eval(vec, binary_name, cached=True):
   for line in process.communicate(input=None)[0].splitlines():
     print("BE", line)
     sys.stdout.flush()
-    if line[0:3] == "jxl":
+    if line[0:3] == b'jxl':
       bpp = line.split()[3]
       dist_max = line.split()[7]
       dist_pnorm = line.split()[8]
@@ -140,7 +140,7 @@ def Eval(vec, binary_name, cached=True):
       dct32 += float(dct32str)
       n += 1
       found_score = True
-      distance = float(line.split()[0].split('d')[-1])
+      distance = float(line.split()[0].split(b'd')[-1])
       #faultybpp = 1.0 + 0.43 * ((float(bpp) * distance ** 0.74) - 1.57) ** 2
       #vec[0] *= faultybpp
 


### PR DESCRIPTION
The reversal of the decision tree produces more stable decisions and now
we can do overall more aggressive optimization of the ac strategy
heuristics.

1.33 % improvement in BPP*pnorm

Images look to have less ringing in the d0.8 - d4 range, d8-d32 not
worse.

Particularly, both jxl:d3:epf0 looks and jxl:d2:epf3 look quite a lot better
while having a lower BPP.

Before:

```
Compr                 Input    Compr            Compr       Compr  Decomp  Butteraugli
Method               Pixels     Size              BPP   #    MP/s    MP/s     Distance    Error p norm   PSNR   QABPP     DCT2     DCT4   DCT4X8      AFV     DCT8  DCT8X16  DCT8X32    DCT16 DCT16X32    DCT32           BPP*pnorm   Errors
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
jxl:d0.8:epf0      17448577  3839018    1.76015178774   1   2.214  13.751   1.82268906   0.53243755115  41.66   2.143 0.000469 0.000234 0.064522 0.033972 0.100244 0.187870 0.000000 0.246513 0.065347 0.308222  0.9371709075114463        0
jxl:d1:epf1        17448577  3358650    1.53990781025   1   3.119  21.144   1.91374373   0.61429703499  40.61   2.162 0.000586 0.000234 0.062152 0.033759 0.097783 0.199835 0.000000 0.226985 0.073505 0.312682  0.9459608019921065        0
jxl:d2:epf3        17448577  2193579    1.00573427850   1   3.117  17.043   3.44436002   0.95646373904  37.46   2.262 0.000939 0.000234 0.053349 0.033594 0.090443 0.233316 0.000000 0.170074 0.111328 0.314267  0.9619483684985939        0
jxl:d3:epf0        17448577  1644345    0.75391592105   1   2.402  23.695   4.63104630   1.27172922181  35.29   2.247 0.001760 0.000234 0.042170 0.030124 0.081985 0.243894 0.000000 0.148785 0.131605 0.327119  0.9587769075929928        0
jxl:d4:epf3        17448577  1365861    0.62623376107   1   2.968  14.837   6.93971729   1.55148313567  34.16   2.433 0.002817 0.000234 0.036330 0.028760 0.072910 0.241187 0.000000 0.140114 0.151998 0.333340  0.9715911192830359        0
jxl:d8:epf1        17448577   790541    0.36245523059   1   2.983  23.131   9.19697952   2.52667172032  30.91   2.408 0.009742 0.000234 0.017576 0.018214 0.055147 0.218322 0.000000 0.123785 0.185714 0.378881  0.9158053810144500        0
jxl:d16:epf3       17448577   449343    0.20601932180   1   2.514  13.267  21.47150230   4.61578107052  28.54   2.754 0.120777 0.021362 0.003579 0.005604 0.020056 0.126646 0.000000 0.094309 0.215732 0.400126  0.9509400857485670        0
jxl:d24:epf3       17448577   338680    0.15528143069   1   3.161  14.351  22.44577408   6.02338281245  27.28   2.728 0.198948 0.053522 0.001305 0.002736 0.009852 0.081112 0.000000 0.078229 0.210039 0.372543  0.9353195006879738        0
jxl:d32:epf3       17448577   275854    0.12647633099   1   3.223  14.457  26.11194992   7.30797489073  26.48   2.762 0.218666 0.093898 0.000484 0.001239 0.004816 0.053955 0.000000 0.060594 0.196307 0.378353  0.9242858511645232        0
Aggregate:         17448577  1086400    0.49810378720 ---   2.832  16.874   7.07983341   1.89616680255  33.18   2.422 0.007389 0.001378 0.013302 0.013125 0.040263 0.158280 0.000000 0.130501 0.137589 0.345730  0.9444878655225486        0
```

After:

```
Compr                 Input    Compr            Compr       Compr  Decomp  Butteraugli
Method               Pixels     Size              BPP   #    MP/s    MP/s     Distance    Error p norm   PSNR   QABPP     DCT2     DCT4   DCT4X8      AFV     DCT8  DCT8X16  DCT8X32    DCT16 DCT16X32    DCT32           BPP*pnorm   Errors
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
jxl:d0.8:epf0      17448577  3873678    1.77604305497   1   2.217  13.675   1.80286932   0.53070128796  41.92   2.141 0.000000 0.000000 0.190141 0.006345 0.066184 0.300542 0.000000 0.052862 0.220016 0.128700  0.9425483367374899        0
jxl:d1:epf1        17448577  3368958    1.54463392631   1   3.070  20.684   1.89055300   0.61459922866  40.76   2.184 0.000000 0.000000 0.172407 0.006613 0.059530 0.288357 0.000000 0.058026 0.241965 0.141200  0.9493308196672816        0
jxl:d2:epf3        17448577  2175013    0.99722195111   1   3.113  16.884   3.41969967   0.96686334769  37.41   2.303 0.000000 0.000234 0.123664 0.006925 0.037886 0.230616 0.000000 0.075177 0.313475 0.188325  0.9641773540352281        0
jxl:d3:epf0        17448577  1621203    0.74330554291   1   2.439  24.717   4.76665688   1.29075953821  35.16   2.339 0.000000 0.000234 0.091782 0.006184 0.028254 0.198016 0.000000 0.081501 0.355377 0.224300  0.9594287193145089        0
jxl:d4:epf3        17448577  1347224    0.61768888088   1   2.965  15.793   6.18416739   1.56304987297  34.04   2.427 0.000000 0.000234 0.073017 0.005186 0.020177 0.169223 0.000000 0.085668 0.387185 0.249359  0.9654785267858697        0
jxl:d8:epf1        17448577   797535    0.36566191042   1   3.004  24.189  10.32323933   2.45592757533  30.93   2.390 0.000000 0.000234 0.030568 0.002450 0.004992 0.096033 0.000000 0.084523 0.452885 0.328763  0.8980391690592763        0
jxl:d16:epf3       17448577   451207    0.20687394737   1   2.513  13.458  21.56897736   4.43456159618  28.56   2.564 0.000000 0.000234 0.006400 0.000418 0.000590 0.038982 0.000000 0.053126 0.425449 0.481642  0.9173952622628853        0
jxl:d24:epf3       17448577   339787    0.15578897924   1   3.123  14.381  21.47612762   5.79007389882  27.33   2.615 0.000000 0.003521 0.002431 0.000073 0.000260 0.025983 0.000000 0.037515 0.377443 0.560693  0.9020297024152206        0
jxl:d32:epf3       17448577   276682    0.12685596080   1   3.142  14.483  27.87462044   7.03442897735  26.53   2.615 0.000000 0.034038 0.001159 0.000044 0.000113 0.020290 0.000000 0.026643 0.324332 0.601597  0.8923592466303857        0
Aggregate:         17448577  1085779    0.49781874110 ---   2.822  17.121   7.09913095   1.87192913358  33.20   2.392 0.000000 0.000703 0.029104 0.001463 0.005800 0.103148 0.000000 0.057823 0.335711 0.278941  0.9318814046971197        0
```