### PR TITLE
improve benchmark_xl output a bit

### DIFF
--- a/lib/jxl/aux_out.h
+++ b/lib/jxl/aux_out.h
@@ -148,8 +148,7 @@ struct AuxOut {
       layers[i].Assimilate(victim.layers[i]);
     }
     num_blocks += victim.num_blocks;
-    num_dct2_blocks += victim.num_dct2_blocks;
-    num_dct4_blocks += victim.num_dct4_blocks;
+    num_small_blocks += victim.num_small_blocks;
     num_dct4x8_blocks += victim.num_dct4x8_blocks;
     num_afv_blocks += victim.num_afv_blocks;
     num_dct8_blocks += victim.num_dct8_blocks;
@@ -158,6 +157,8 @@ struct AuxOut {
     num_dct16_blocks += victim.num_dct16_blocks;
     num_dct16x32_blocks += victim.num_dct16x32_blocks;
     num_dct32_blocks += victim.num_dct32_blocks;
+    num_dct32x64_blocks += victim.num_dct32x64_blocks;
+    num_dct64_blocks += victim.num_dct64_blocks;
     num_butteraugli_iters += victim.num_butteraugli_iters;
     for (size_t i = 0; i < dc_pred_usage.size(); ++i) {
       dc_pred_usage[i] += victim.dc_pred_usage[i];
@@ -270,8 +271,7 @@ struct AuxOut {
   size_t num_blocks = 0;
 
   // Number of blocks that use larger DCT (set by ac_strategy).
-  size_t num_dct2_blocks = 0;
-  size_t num_dct4_blocks = 0;
+  size_t num_small_blocks = 0;
   size_t num_dct4x8_blocks = 0;
   size_t num_afv_blocks = 0;
   size_t num_dct8_blocks = 0;
@@ -280,6 +280,8 @@ struct AuxOut {
   size_t num_dct16_blocks = 0;
   size_t num_dct16x32_blocks = 0;
   size_t num_dct32_blocks = 0;
+  size_t num_dct32x64_blocks = 0;
+  size_t num_dct64_blocks = 0;
 
   std::array<uint32_t, 8> dc_pred_usage = {0};
   std::array<uint32_t, 8> dc_pred_usage_xb = {0};

--- a/lib/jxl/enc_ac_strategy.cc
+++ b/lib/jxl/enc_ac_strategy.cc
@@ -977,6 +977,7 @@ void ProcessRectACSNew(PassesEncoderState* JXL_RESTRICT enc_state,
   uint8_t priority[64] = {0};
   for (auto tx : kTransformsForMerge) {
     AcStrategy acs = AcStrategy::FromRawStrategy(tx.type);
+
     for (size_t cy = 0; cy + acs.covered_blocks_y() - 1 < rect.ysize();
          cy += acs.covered_blocks_y()) {
       for (size_t cx = 0; cx + acs.covered_blocks_x() - 1 < rect.xsize();
@@ -1088,11 +1089,10 @@ void AcStrategyHeuristics::Finalize(AuxOut* aux_out) {
   const auto& ac_strategy = enc_state->shared.ac_strategy;
   // Accounting and debug output.
   if (aux_out != nullptr) {
-    aux_out->num_dct2_blocks =
-        32 * (ac_strategy.CountBlocks(AcStrategy::Type::DCT32X64) +
-              ac_strategy.CountBlocks(AcStrategy::Type::DCT64X32));
-    aux_out->num_dct4_blocks =
-        64 * ac_strategy.CountBlocks(AcStrategy::Type::DCT64X64);
+    aux_out->num_small_blocks =
+        ac_strategy.CountBlocks(AcStrategy::Type::IDENTITY) +
+        ac_strategy.CountBlocks(AcStrategy::Type::DCT2X2) +
+        ac_strategy.CountBlocks(AcStrategy::Type::DCT4X4);
     aux_out->num_dct4x8_blocks =
         ac_strategy.CountBlocks(AcStrategy::Type::DCT4X8) +
         ac_strategy.CountBlocks(AcStrategy::Type::DCT8X4);
@@ -1114,6 +1114,11 @@ void AcStrategyHeuristics::Finalize(AuxOut* aux_out) {
         ac_strategy.CountBlocks(AcStrategy::Type::DCT32X16);
     aux_out->num_dct32_blocks =
         ac_strategy.CountBlocks(AcStrategy::Type::DCT32X32);
+    aux_out->num_dct32x64_blocks =
+        ac_strategy.CountBlocks(AcStrategy::Type::DCT32X64) +
+        ac_strategy.CountBlocks(AcStrategy::Type::DCT64X32);
+    aux_out->num_dct64_blocks =
+        ac_strategy.CountBlocks(AcStrategy::Type::DCT64X64);
   }
 
   if (WantDebugOutput(aux_out)) {

--- a/tools/benchmark/benchmark_stats.h
+++ b/tools/benchmark/benchmark_stats.h
@@ -45,11 +45,10 @@ struct BenchmarkStats {
   void Assimilate(const BenchmarkStats& victim);
 
   std::vector<ColumnValue> ComputeColumns(const std::string& codec_desc,
-                                          size_t corpus_size,
-                                          size_t num_threads) const;
+                                          size_t corpus_size) const;
 
-  std::string PrintLine(const std::string& codec_desc, size_t corpus_size,
-                        size_t num_threads) const;
+  std::string PrintLine(const std::string& codec_desc,
+                        size_t corpus_size) const;
 
   void PrintMoreStats() const;
 

--- a/tools/benchmark/benchmark_xl.cc
+++ b/tools/benchmark/benchmark_xl.cc
@@ -598,10 +598,10 @@ struct StatPrinter {
 
     const double rmse =
         std::sqrt(t.stats.distance_2 / t.stats.total_input_pixels);
-    const double psnr =
-        t.stats.total_compressed_size == 0
-            ? 0.0
-            : (t.stats.distance_2 == 0) ? 99.99 : (20 * std::log10(1 / rmse));
+    const double psnr = t.stats.total_compressed_size == 0 ? 0.0
+                        : (t.stats.distance_2 == 0)
+                            ? 99.99
+                            : (20 * std::log10(1 / rmse));
     size_t pixels = t.stats.total_input_pixels;
 
     const double enc_mps =
@@ -663,7 +663,7 @@ struct StatPrinter {
     std::string out;
 
     method_stats.PrintMoreStats();  // not concurrent
-    out += method_stats.PrintLine(method, fnames_->size(), /*num_threads=*/1);
+    out += method_stats.PrintLine(method, fnames_->size());
 
     if (Args()->write_html_report) {
       WriteHtmlReport(method, *fnames_, tasks, images,
@@ -671,7 +671,7 @@ struct StatPrinter {
     }
 
     stats_aggregate_.push_back(
-        method_stats.ComputeColumns(method, fnames_->size(), 1));
+        method_stats.ComputeColumns(method, fnames_->size()));
 
     printf("%s", out.c_str());
     fflush(stdout);


### PR DESCRIPTION
Cleanup the output of `benchmark_xl` a bit, to make it more compact (making it easier to share results in places with limited horizontal space - like here), and to show counts for 32x64 and 64x64 block selection while keeping counts for small blocks (2x2 and 4x4 are counted in the same column, and also Hornuss/'Idendity'). The two-line column labels have also been replaced by single line ones, and the `#` column (which was supposed to show number of threads, but wasn't actually doing that) has been dropped. Precision of some numbers has been reduced a bit where it made sense, and block selection is now in percentages.

Before: (output layout only, the numbers themselves are different just because that's an old version I had available)

```
i0aq8ybkquh41.png
Compr              Input    Compr            Compr       Compr  Decomp  Butteraugli                                             
Method            Pixels     Size              BPP   #    MP/s    MP/s     Distance    Error p norm           BPP*pnorm   Errors
--------------------------------------------------------------------------------------------------------------------------------
jxl:d0.7         1250000   413126    2.64400640000   1   2.346  18.170   1.25715184   0.43437593946  1.1484927639326830        0
jxl:d1           1250000   343603    2.19905920000   1   2.373  17.706   1.52354228   0.54727249880  1.2034846233900809        0
jxl:d2           1250000   239731    1.53427840000   1   2.349  16.963   2.26110888   0.84766280062  1.3005507254777089        0
jxl:d3           1250000   186392    1.19290880000   1   2.160  18.526   3.00575709   1.11965252355  1.3356433482798056        0
jxl:d4           1250000   155907    0.99780480000   1   2.497  10.856   3.82312346   1.32379377332  1.3208877812294642        0
jxl:d6           1250000   116030    0.74259200000   1   2.433  11.039   5.61902571   1.91294659990  1.4205388415103593        0
jxl:d8           1250000    91475    0.58544000000   1   2.351  10.514   7.00860691   2.49791887973  1.4623816289476526        0
jxl:d12          1250000    60347    0.38622080000   1   2.505  11.307  10.65204716   3.95764538745  1.5285249676566253        0
jxl:d16          1250000    45357    0.29028480000   1   2.520  10.774  14.70747948   5.06120378298  1.4691905279004478        0
Aggregate:       1250000   145223    0.92942972898 ---   2.390  13.562   4.07088549   1.45143116184  1.3490032713718034        0
```

After:
```
i0aq8ybkquh41.png
Encoding      kPixels    Bytes          BPP  E MP/s  D MP/s     Max norm        pnorm       BPP*pnorm   Bugs
------------------------------------------------------------------------------------------------------------
jxl:d0.7         1250   403825    2.5844800   2.111  23.336   0.99109071   0.39305022  1.015830421415      0
jxl:d1           1250   334779    2.1425856   2.140  22.264   1.38672578   0.50070776  1.072809234009      0
jxl:d2           1250   231320    1.4804480   2.177  20.756   2.16732502   0.80156836  1.186680275753      0
jxl:d3           1250   181308    1.1603712   2.069  22.691   2.85668468   1.08928696  1.263977218439      0
jxl:d4           1250   151308    0.9683712   2.096  12.997   3.41169786   1.30955763  1.268137897291      0
jxl:d6           1250   113220    0.7246080   2.044   9.740   4.85853910   1.86534986  1.351647434439      0
jxl:d8           1250    90360    0.5783040   2.146  10.689   6.89399004   2.43986587  1.410984192331      0
jxl:d12          1250    60622    0.3879808   2.151   9.465  10.55819702   3.88791635  1.508436894532      0
jxl:d16          1250    46120    0.2951680   2.140  12.913  14.74606133   4.99757752  1.475124960564      0
Aggregate:       1250   142702    0.9132909   2.119  15.086   3.76328411   1.39417034  1.273283076018      0
```


With `--more_columns`:

Before:
```
i0aq8ybkquh41.png
Compr              Input    Compr            Compr       Compr  Decomp  Butteraugli                                                                                                                                                      
Method            Pixels     Size              BPP   #    MP/s    MP/s     Distance    Error p norm   PSNR   QABPP     DCT2     DCT4   DCT4X8      AFV     DCT8  DCT8X16  DCT8X32    DCT16 DCT16X32    DCT32           BPP*pnorm   Errors
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
jxl:d0.7         1250000   413126    2.64400640000   1   2.506  16.087   1.25715184   0.43437593946  42.55   3.324 0.000000 0.000000 0.147046 0.137369 0.218009 0.268697 0.000000 0.210329 0.013516 0.009830  1.1484927639326830        0
jxl:d1           1250000   343603    2.19905920000   1   2.562  15.274   1.52354228   0.54727249880  40.69   3.350 0.000000 0.000000 0.131942 0.136960 0.220518 0.274329 0.000000 0.216473 0.013926 0.010649  1.2034846233900809        0
jxl:d2           1250000   239731    1.53427840000   1   2.535  14.401   2.26110888   0.84766280062  37.55   3.469 0.000000 0.000000 0.125081 0.143820 0.238694 0.249548 0.000000 0.205824 0.029491 0.012288  1.3005507254777089        0
jxl:d3           1250000   186392    1.19290880000   1   2.251  17.147   3.00575709   1.11965252355  35.50   3.586 0.000000 0.000000 0.125440 0.155852 0.256051 0.230912 0.000000 0.176332 0.040550 0.019660  1.3356433482798056        0
jxl:d4           1250000   155907    0.99780480000   1   2.440   9.921   3.82312346   1.32379377332  34.60   3.815 0.000000 0.000000 0.125542 0.153958 0.258406 0.231628 0.000000 0.166707 0.043827 0.024576  1.3208877812294642        0
jxl:d6           1250000   116030    0.74259200000   1   2.374   9.910   5.61902571   1.91294659990  32.27   4.173 0.001638 0.000000 0.106547 0.143155 0.263168 0.264908 0.000000 0.143360 0.045056 0.036864  1.4205388415103593        0
jxl:d8           1250000    91475    0.58544000000   1   2.355  10.021   7.00860691   2.49791887973  30.72   4.103 0.003276 0.000000 0.077516 0.115968 0.236851 0.339865 0.000000 0.126771 0.042188 0.062259  1.4623816289476526        0
jxl:d12          1250000    60347    0.38622080000   1   2.494  10.420  10.65204716   3.95764538745  28.09   4.114 0.006553 0.000000 0.029286 0.054220 0.120985 0.446566 0.000000 0.131276 0.087244 0.128614  1.5285249676566253        0
jxl:d16          1250000    45357    0.29028480000   1   2.640  10.578  14.70747948   5.06120378298  26.71   4.269 0.014745 0.000000 0.011366 0.020275 0.061132 0.386457 0.000000 0.155238 0.128614 0.226918  1.4691905279004478        0
Aggregate:       1250000   145223    0.92942972898 ---   2.459  12.331   4.07088549   1.45143116184  33.92   3.784 0.004772 0.000000 0.077853 0.101903 0.191725 0.291692 0.000000 0.167182 0.039035 0.032604  1.3490032713718034        0
```

After:
```
i0aq8ybkquh41.png
Encoding      kPixels    Bytes          BPP  E MP/s  D MP/s     Max norm        pnorm   PSNR   QABPP  SmallB  DCT4x8     AFV  DCT8x8    8x16    8x32      16   16x32      32   32x64      64       BPP*pnorm   Bugs
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
jxl:d0.7         1250   403825    2.5844800   2.176  20.921   0.99109071   0.39305022  42.97   2.584  0.0000 21.6627 20.5568 21.2838 21.9034  0.0000 12.7386  1.5155  0.8192  0.0000  0.0000  1.015830421415      0
jxl:d1           1250   334779    2.1425856   2.251  19.253   1.38672578   0.50070776  41.11   2.971  0.0000 20.0090 20.8026 21.0330 23.5418  0.0000 11.8579  2.2528  0.9830  0.0000  0.0000  1.072809234009      0
jxl:d2           1250   231320    1.4804480   2.255  18.197   2.16732502   0.80156836  37.82   3.209  0.0102 16.6758 20.8896 19.8656 26.9414  0.0000 11.8374  2.8672  1.3926  0.0000  0.0000  1.186680275753      0
jxl:d3           1250   181308    1.1603712   2.136  21.140   2.85668468   1.08928696  35.65   3.315  0.0051 14.4691 19.5584 19.2614 29.3274  0.0000 12.3290  3.7274  1.8022  0.0000  0.0000  1.263977218439      0
jxl:d4           1250   151308    0.9683712   2.135  13.516   3.41169786   1.30955763  34.64   3.304  0.0205 13.1738 18.4064 18.5395 30.3718  0.0000 13.7011  4.4646  1.8022  0.0000  0.0000  1.268137897291      0
jxl:d6           1250   113220    0.7246080   2.069  13.124   4.85853910   1.86534986  32.31   3.521  0.0000 10.3987 15.7235 17.2493 33.3107  0.0000 15.4419  6.0621  2.2938  0.0000  0.0000  1.351647434439      0
jxl:d8           1250    90360    0.5783040   2.142  13.853   6.89399004   2.43986587  30.81   3.987  0.0102  7.6698 12.8256 16.1997 35.3894  0.0000 16.4659  7.9053  3.8502  0.1638  0.0000  1.410984192331      0
jxl:d12          1250    60622    0.3879808   2.154  14.046  10.55819702   3.88791635  28.19   4.096  0.0000  3.8656  7.2141 11.1258 34.0173  0.0000 18.9030 14.7046  9.5027  1.1469  0.0000  1.508436894532      0
jxl:d16          1250    46120    0.2951680   2.324  11.127  14.74606133   4.99757752  26.82   4.353  0.0102  1.5872  3.3946  6.7686 28.5901  0.0000 21.6269 19.9885 16.3840  2.1299  0.0000  1.475124960564      0
Aggregate:       1250   142702    0.9132909   2.181  15.746   3.76328411   1.39417034  34.08   3.440  0.0102  9.5714 13.5967 15.9504 28.9282  0.0000 14.6663  5.0903  2.5768  0.7369  0.0000  1.273283076018      0
```
