### PR TITLE
Try merging 16x8 and 8x16 fairly, not sequentially

### DIFF
--- a/lib/jxl/enc_ac_strategy.cc
+++ b/lib/jxl/enc_ac_strategy.cc
@@ -642,19 +642,21 @@ void MaybeReplaceACS(size_t bx, size_t by, const ACSConfig& config,
 // bx, by addresses the 64x64 block at 8x8 subresolution
 // cx, cy addresses the left, upper 8x8 block position of the candidate
 // transform.
-void TryMergeToACSCandidate(AcStrategy::Type acs_raw, size_t bx, size_t by,
-                            size_t cx, size_t cy, const ACSConfig& config,
-                            const float* JXL_RESTRICT cmap_factors,
-                            AcStrategyImage* JXL_RESTRICT ac_strategy,
-                            const float entropy_mul,
-                            const uint8_t candidate_priority, uint8_t* priority,
-                            float* JXL_RESTRICT entropy_estimate, float* block,
-                            float* scratch_space, uint32_t* quantized) {
+void TryMergeAcs(AcStrategy::Type acs_raw, size_t bx, size_t by, size_t cx,
+                 size_t cy, const ACSConfig& config,
+                 const float* JXL_RESTRICT cmap_factors,
+                 AcStrategyImage* JXL_RESTRICT ac_strategy,
+                 const float entropy_mul, const uint8_t candidate_priority,
+                 uint8_t* priority, float* JXL_RESTRICT entropy_estimate,
+                 float* block, float* scratch_space, uint32_t* quantized) {
   AcStrategy acs = AcStrategy::FromRawStrategy(acs_raw);
   float entropy_current = 0;
   for (size_t iy = 0; iy < acs.covered_blocks_y(); ++iy) {
     for (size_t ix = 0; ix < acs.covered_blocks_x(); ++ix) {
       if (priority[(cy + iy) * 8 + (cx + ix)] >= candidate_priority) {
+        // Transform would reuse already allocated blocks and
+        // lead to invalid overlaps, for example DCT64X32 vs.
+        // DCT32X64.
         return;
       }
       entropy_current += entropy_estimate[(cy + iy) * 8 + (cx + ix)];
@@ -664,20 +666,87 @@ void TryMergeToACSCandidate(AcStrategy::Type acs_raw, size_t bx, size_t by,
       entropy_mul * EstimateEntropy(acs, (bx + cx) * 8, (by + cy) * 8, config,
                                     cmap_factors, block, scratch_space,
                                     quantized);
-
   if (entropy_candidate >= entropy_current) return;
-
   // Accept the candidate.
   for (size_t iy = 0; iy < acs.covered_blocks_y(); iy++) {
     for (size_t ix = 0; ix < acs.covered_blocks_x(); ix++) {
       entropy_estimate[(cy + iy) * 8 + cx + ix] = 0;
       priority[(cy + iy) * 8 + cx + ix] = candidate_priority;
-      ac_strategy->Set(bx + cx + ix, by + cy + iy,
-                       static_cast<AcStrategy::Type>(0));
     }
   }
   ac_strategy->Set(bx + cx, by + cy, acs_raw);
   entropy_estimate[cy * 8 + cx] = entropy_candidate;
+}
+
+// The following function tries to merge 8x8 transforms into
+// 16X8 and 8X16 DCTs fairly, by trying them and their combinations
+// with best 8x8 at the same time.
+//
+// TODO(jyrki):
+// This idea could be generalized to larger transforms.
+void Try16X8And8X16(size_t bx, size_t by, size_t cx, size_t cy,
+                    const ACSConfig& config,
+                    const float* JXL_RESTRICT cmap_factors,
+                    AcStrategyImage* JXL_RESTRICT ac_strategy,
+                    const float entropy_mul,
+                    float* JXL_RESTRICT entropy_estimate, float* block,
+                    float* scratch_space, uint32_t* quantized) {
+  constexpr AcStrategy::Type acs_raw16X8 =
+      AcStrategy::Type::DCT16X8;  // y=16, x=8
+  constexpr AcStrategy::Type acs_raw8X16 =
+      AcStrategy::Type::DCT8X16;  // y=8, x=16
+  const AcStrategy acs16X8 = AcStrategy::FromRawStrategy(acs_raw16X8);
+  const AcStrategy acs8X16 = AcStrategy::FromRawStrategy(acs_raw8X16);
+  // Current entropies from the best 8x8 transforms in this 2x2 area:
+  const float entropy00 = entropy_estimate[(cy + 0) * 8 + (cx + 0)];
+  const float entropy01 = entropy_estimate[(cy + 0) * 8 + (cx + 1)];
+  const float entropy10 = entropy_estimate[(cy + 1) * 8 + (cx + 0)];
+  const float entropy11 = entropy_estimate[(cy + 1) * 8 + (cx + 1)];
+  const float try16X8_0 =
+      entropy_mul * EstimateEntropy(acs16X8, (bx + cx + 0) * 8,
+                                    (by + cy + 0) * 8, config, cmap_factors,
+                                    block, scratch_space, quantized);
+  const float try16X8_1 =
+      entropy_mul * EstimateEntropy(acs16X8, (bx + cx + 1) * 8,
+                                    (by + cy + 0) * 8, config, cmap_factors,
+                                    block, scratch_space, quantized);
+  const float try8X16_0 =
+      entropy_mul * EstimateEntropy(acs8X16, (bx + cx + 0) * 8,
+                                    (by + cy + 0) * 8, config, cmap_factors,
+                                    block, scratch_space, quantized);
+  const float try8X16_1 =
+      entropy_mul * EstimateEntropy(acs8X16, (bx + cx + 0) * 8,
+                                    (by + cy + 1) * 8, config, cmap_factors,
+                                    block, scratch_space, quantized);
+  // Test if this block should have 16X8 or 8X16 transforms,
+  // because it can have only one or the other.
+  float cost16x8 = std::min(try16X8_0, entropy00 + entropy10) +
+                   std::min(try16X8_1, entropy01 + entropy11);
+  float cost8x16 = std::min(try8X16_0, entropy00 + entropy01) +
+                   std::min(try8X16_1, entropy10 + entropy11);
+  if (cost16x8 < cost8x16) {
+    if (try16X8_0 < entropy00 + entropy10) {
+      ac_strategy->Set(bx + cx, by + cy, acs_raw16X8);
+      entropy_estimate[(cy + 0) * 8 + cx + 0] = try16X8_0;
+      entropy_estimate[(cy + 1) * 8 + cx + 0] = 0;
+    }
+    if (try16X8_1 < entropy01 + entropy11) {
+      ac_strategy->Set(bx + cx + 1, by + cy, acs_raw16X8);
+      entropy_estimate[(cy + 0) * 8 + cx + 1] = try16X8_1;
+      entropy_estimate[(cy + 1) * 8 + cx + 1] = 0;
+    }
+  } else {
+    if (try8X16_0 < entropy00 + entropy01) {
+      ac_strategy->Set(bx + cx, by + cy, acs_raw8X16);
+      entropy_estimate[(cy + 0) * 8 + cx + 0] = try8X16_0;
+      entropy_estimate[(cy + 0) * 8 + cx + 1] = 0;
+    }
+    if (try8X16_1 < entropy10 + entropy11) {
+      ac_strategy->Set(bx + cx, by + cy + 1, acs_raw8X16);
+      entropy_estimate[(cy + 1) * 8 + cx + 0] = try8X16_1;
+      entropy_estimate[(cy + 1) * 8 + cx + 1] = 0;
+    }
+  }
 }
 
 // Legacy system traversing the integral transform selectiondecision
@@ -916,6 +985,16 @@ void ProcessRectACSOld(PassesEncoderState* JXL_RESTRICT enc_state,
 void ProcessRectACSNew(PassesEncoderState* JXL_RESTRICT enc_state,
                        const ACSConfig& config, float* entropy_adjust,
                        const Rect& rect) {
+  // Main philosophy here:
+  // 1. First find best 8x8 transform for each area.
+  // 2. Merging them into larger transforms where possibly, but
+  // starting from the smallest transforms (16x8 and 8x16).
+  // Additional complication: 16x8 and 8x16 are considered
+  // simultanouesly and fairly against each other.
+  // We are looking at 64x64 squares since the YtoX and YtoB
+  // maps happen to be at that resolution, and having
+  // integral transforms cross these boundaries leads to
+  // additional complications.
   const CompressParams& cparams = enc_state->cparams;
   const float butteraugli_target = cparams.butteraugli_distance;
   AcStrategyImage* ac_strategy = &enc_state->shared.ac_strategy;
@@ -1016,20 +1095,52 @@ void ProcessRectACSNew(PassesEncoderState* JXL_RESTRICT enc_state,
 
   // Priority is a tricky kludge to avoid collisions so that transforms
   // don't overlap.
-  uint8_t priority[64] = {0};
+  uint8_t priority[64] = {};
   for (auto tx : kTransformsForMerge) {
     AcStrategy acs = AcStrategy::FromRawStrategy(tx.type);
     for (size_t cy = 0; cy + acs.covered_blocks_y() - 1 < rect.ysize();
          cy += acs.covered_blocks_y()) {
       for (size_t cx = 0; cx + acs.covered_blocks_x() - 1 < rect.xsize();
            cx += acs.covered_blocks_x()) {
-        TryMergeToACSCandidate(tx.type, bx, by, cx, cy, config, cmap_factors,
-                               ac_strategy, tx.entropy_mul, tx.priority,
-                               &priority[0], entropy_estimate, block,
-                               scratch_space, quantized);
+        if (cy + 1 < rect.ysize() && cx + 1 < rect.xsize()) {
+          if (tx.type == AcStrategy::Type::DCT8X16) {
+            // We handle both DCT8X16 and DCT16X8 at the same time.
+            if ((cy | cx) % 2 == 0) {
+              Try16X8And8X16(bx, by, cx, cy, config, cmap_factors, ac_strategy,
+                             tx.entropy_mul, entropy_estimate, block,
+                             scratch_space, quantized);
+            }
+            continue;
+          } else if (tx.type == AcStrategy::Type::DCT16X8) {
+            // We handled both DCT8X16 and DCT16X8 at the same time,
+            // and that is above. The last column and last row,
+            // when the last column or last row is odd numbered,
+            // are still handled by TryMergeAcs.
+            continue;
+          }
+        }
+        if ((tx.type == AcStrategy::Type::DCT8X16 && cy % 2 == 1) ||
+            (tx.type == AcStrategy::Type::DCT16X8 && cx % 2 == 1)) {
+          // already covered by the 2x2 approach above.
+          continue;
+        }
+        // All other merge sizes are handled here.
+        // Some of the DCT16X8s and DCT8X16s will still leak through here
+        // when there is an odd number of 8x8 blocks, then the last row
+        // and column will get their DCT16X8s and DCT8X16s through the
+        // normal integral transform merging process.
+        TryMergeAcs(tx.type, bx, by, cx, cy, config, cmap_factors, ac_strategy,
+                    tx.entropy_mul, tx.priority, &priority[0], entropy_estimate,
+                    block, scratch_space, quantized);
       }
     }
   }
+  // TODO(jyrki):
+  // Here we could still try to do some non-aligned matching, like
+  // find a few more 16x8, 8x16 and 16x16s between the non-2-aligned
+  // blocks. This would naturally only work when the source blocks
+  // are compatible with the new merges. In practice I plan to do
+  // this additional merging for 8x8 blocks only.
 }
 
 void ProcessRectACS(PassesEncoderState* JXL_RESTRICT enc_state,

--- a/lib/jxl/enc_adaptive_quantization.cc
+++ b/lib/jxl/enc_adaptive_quantization.cc
@@ -660,7 +660,7 @@ ImageF TileDistMap(const ImageF& distmap, int tile_size, int margin,
 
 constexpr float kDcQuantPow = 0.57f;
 static const float kDcQuant = 1.12f;
-static const float kAcQuant = 0.81f;
+static const float kAcQuant = 0.814f;
 
 void FindBestQuantization(const ImageBundle& linear, const Image3F& opsin,
                           PassesEncoderState* enc_state, ThreadPool* pool,

--- a/lib/jxl/jxl_test.cc
+++ b/lib/jxl/jxl_test.cc
@@ -733,7 +733,7 @@ TEST(JxlTest, RoundtripAlpha) {
   CodecInOut io2;
   EXPECT_TRUE(DecodeFile(dparams, compressed, &io2, pool));
 
-  EXPECT_LE(compressed.size(), 10000);
+  EXPECT_LE(compressed.size(), 10077);
 
   EXPECT_LE(ButteraugliDistance(io, io2, cparams.ba_params,
                                 /*distmap=*/nullptr, pool),


### PR DESCRIPTION
Before:

```
Compr                 Input    Compr            Compr       Compr  Decomp  Butteraugli
Method               Pixels     Size              BPP   #    MP/s    MP/s     Distance    Error p norm   PSNR   QABPP     DCT2     DCT4   DCT4X8      AFV     DCT8  DCT8X16  DCT8X32    DCT16 DCT16X32    DCT32           BPP*pnorm   Errors
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
jxl:d0.8:epf0      17448577  3873678    1.77604305497   1   2.196  14.199   1.80286932   0.53070128796  41.92   2.141 0.000000 0.000000 0.190141 0.006345 0.066184 0.300542 0.000000 0.052862 0.220016 0.128700  0.9425483367374899        0
jxl:d1:epf1        17448577  3368958    1.54463392631   1   3.057  21.753   1.89055300   0.61459922866  40.76   2.184 0.000000 0.000000 0.172407 0.006613 0.059530 0.288357 0.000000 0.058026 0.241965 0.141200  0.9493308196672816        0
jxl:d2:epf3        17448577  2175013    0.99722195111   1   3.107  17.296   3.41969967   0.96686334769  37.41   2.303 0.000000 0.000234 0.123664 0.006925 0.037886 0.230616 0.000000 0.075177 0.313475 0.188325  0.9641773540352281        0
jxl:d3:epf0        17448577  1621203    0.74330554291   1   2.385  24.188   4.76665688   1.29075953821  35.16   2.339 0.000000 0.000234 0.091782 0.006184 0.028254 0.198016 0.000000 0.081501 0.355377 0.224300  0.9594287193145089        0
jxl:d4:epf3        17448577  1347224    0.61768888088   1   2.997  15.512   6.18416739   1.56304987297  34.04   2.427 0.000000 0.000234 0.073017 0.005186 0.020177 0.169223 0.000000 0.085668 0.387185 0.249359  0.9654785267858697        0
jxl:d8:epf1        17448577   797535    0.36566191042   1   3.031  25.432  10.32323933   2.45592757533  30.93   2.390 0.000000 0.000234 0.030568 0.002450 0.004992 0.096033 0.000000 0.084523 0.452885 0.328763  0.8980391690592763        0
jxl:d16:epf3       17448577   451207    0.20687394737   1   2.471  13.822  21.56897736   4.43456159618  28.56   2.564 0.000000 0.000234 0.006400 0.000418 0.000590 0.038982 0.000000 0.053126 0.425449 0.481642  0.9173952622628853        0
jxl:d24:epf3       17448577   339787    0.15578897924   1   3.104  14.946  21.47612762   5.79007389882  27.33   2.615 0.000000 0.003521 0.002431 0.000073 0.000260 0.025983 0.000000 0.037515 0.377443 0.560693  0.9020297024152206        0
jxl:d32:epf3       17448577   276682    0.12685596080   1   3.103  14.769  27.87462044   7.03442897735  26.53   2.615 0.000000 0.034038 0.001159 0.000044 0.000113 0.020290 0.000000 0.026643 0.324332 0.601597  0.8923592466303857        0
Aggregate:         17448577  1085779    0.49781874110 ---   2.805  17.520   7.09913095   1.87192913358  33.20   2.392 0.000000 0.000703 0.029104 0.001463 0.005800 0.103148 0.000000 0.057823 0.335711 0.278941  0.9318814046971197        0
```

After:

```
Compr                 Input    Compr            Compr       Compr  Decomp  Butteraugli
Method               Pixels     Size              BPP   #    MP/s    MP/s     Distance    Error p norm   PSNR   QABPP     DCT2     DCT4   DCT4X8      AFV     DCT8  DCT8X16  DCT8X32    DCT16 DCT16X32    DCT32           BPP*pnorm   Errors
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
jxl:d0.8:epf0      17448577  3874129    1.77624983401   1   2.190  13.906   1.80222321   0.52939681084  41.95   2.127 0.000000 0.000000 0.188366 0.006371 0.062457 0.346435 0.000000 0.040317 0.194810 0.125765  0.9403409973877169        0
jxl:d1:epf1        17448577  3368758    1.54454222829   1   3.019  21.232   1.90873623   0.61329670189  40.79   2.181 0.000000 0.000000 0.170558 0.006576 0.055961 0.329885 0.000000 0.046274 0.219547 0.139146  0.9472626545422989        0
jxl:d2:epf3        17448577  2176061    0.99770244874   1   3.071  17.123   3.79021478   0.96497337332  37.43   2.255 0.000000 0.000234 0.124100 0.007002 0.036440 0.263664 0.000000 0.064364 0.293961 0.186330  0.9627562975300015        0
jxl:d3:epf0        17448577  1620951    0.74319000340   1   2.402  24.855   4.76765537   1.28786214751  35.19   2.318 0.000000 0.000234 0.092772 0.006327 0.027802 0.226993 0.000000 0.072038 0.336333 0.222716  0.9571262737872117        0
jxl:d4:epf3        17448577  1346648    0.61742479057   1   2.920  15.603   6.82338524   1.56208631217  34.06   2.428 0.000000 0.000234 0.073758 0.005285 0.019916 0.193042 0.000000 0.077011 0.371369 0.249066  0.9644708141494336        0
jxl:d8:epf1        17448577   796933    0.36538589938   1   2.937  25.064   9.87168598   2.45571728749  30.94   2.378 0.000000 0.000234 0.030861 0.002574 0.004775 0.110140 0.000000 0.079843 0.444170 0.327648  0.8972844697069440        0
jxl:d16:epf3       17448577   450579    0.20658601558   1   2.507  13.265  21.56148529   4.44012931344  28.56   2.553 0.000000 0.000234 0.006437 0.000436 0.000590 0.045658 0.000000 0.051585 0.421517 0.480233  0.9172686235303881        0
jxl:d24:epf3       17448577   339753    0.15577339058   1   3.090  14.737  21.47612762   5.78196502410  27.33   2.580 0.000000 0.002817 0.002461 0.000084 0.000212 0.028829 0.000000 0.036840 0.377209 0.559402  0.9006762959908683        0
jxl:d32:epf3       17448577   276995    0.12699946821   1   3.046  14.661  24.38039017   7.02440096331  26.53   2.600 0.000000 0.033568 0.001181 0.000066 0.000121 0.022044 0.000000 0.026643 0.324537 0.600013  0.8920951868252788        0
Aggregate:         17448577  1085638    0.49775448991 ---   2.779  17.328   7.12413578   1.86962971906  33.21   2.374 0.000000 0.000680 0.029267 0.001580 0.005565 0.117348 0.000000 0.051817 0.320809 0.276844  0.9306165871311499        0
```

Looks marginally better on photographs. 0.14 % improvement in BPP * pnorm.

Looks more substantially better on low BPP anime drawing compression by reducing ringing (as verified by Scope on discord).