### PR TITLE
minor ac block ctx tweak

### DIFF
--- a/lib/jxl/enc_heuristics.cc
+++ b/lib/jxl/enc_heuristics.cc
@@ -124,8 +124,9 @@ void FindBestBlockEntropyModel(PassesEncoderState& enc_state) {
   std::vector<uint8_t> remap((qft.size() + 1) * kNumOrders);
   std::iota(remap.begin(), remap.end(), 0);
   std::vector<uint8_t> clusters(remap);
+  size_t nb_clusters = Clamp1((int)(tot / size_for_ctx_model / 2), 4, 8);
   // This is O(n^2 log n), but n <= 14.
-  while (clusters.size() > 5) {
+  while (clusters.size() > nb_clusters) {
     std::sort(clusters.begin(), clusters.end(),
               [&](int a, int b) { return counts[a] > counts[b]; });
     counts[clusters[clusters.size() - 2]] += counts[clusters.back()];


### PR DESCRIPTION
Use more distinct AC block contexts for larger images / lower distance, fewer for smaller images / higher distance.

~0.1% density improvement, no quality changes (entropy coding change only)

Before:
```
Compr              Input    Compr            Compr       Compr  Decomp  Butteraugli                                             
Method            Pixels     Size              BPP   #    MP/s    MP/s     Distance    Error p norm           BPP*pnorm   Errors
--------------------------------------------------------------------------------------------------------------------------------
jxl:d0.5        41091840 12560903    2.44543013893   1   2.159  19.226   2.49855947   0.40187863846  0.9827661346725537        0
jxl:d1          41091840  8035952    1.56448618509   1   2.070  19.190   3.43487716   0.64733777303  1.0127510029869331        0
jxl:d2          41091840  5076075    0.98824000093   1   2.216  20.968   7.71051025   1.02659294735  1.0145202152457606        0
jxl:d3          41091840  3807468    0.74126016260   1   2.110  19.189   7.86812210   1.32621341381  0.9830691707627144        0
jxl:d4          41091840  3122618    0.60792955487   1   1.910  13.220   6.56652164   1.59660002847  0.9706203446110840        0
jxl:d6          41091840  2244931    0.43705631094   1   1.882  11.660   8.46946812   2.10016541683  0.9178905494357636        0
jxl:d8          41091840  1796367    0.34972724512   1   1.966  11.631  13.48916626   2.58922420914  0.9055222496544653        0
Aggregate:      41091840  4238297    0.82513639470 ---   2.041  15.981   6.29243618   1.17406958342  0.9687675431836641        0
```

After:
```
Compr              Input    Compr            Compr       Compr  Decomp  Butteraugli                                             
Method            Pixels     Size              BPP   #    MP/s    MP/s     Distance    Error p norm           BPP*pnorm   Errors
--------------------------------------------------------------------------------------------------------------------------------
jxl:d0.5        41091840 12543452    2.44203267607   1   2.335  20.979   2.49855947   0.40187863846  0.9814007669266066        0
jxl:d1          41091840  8024259    1.56220972339   1   2.341  22.753   3.43487716   0.64733777303  1.0112773633387713        0
jxl:d2          41091840  5070092    0.98707519546   1   2.362  20.290   7.71051025   1.02659294735  1.0133244341653360        0
jxl:d3          41091840  3804231    0.74062996449   1   2.303  21.916   7.86812210   1.32621341381  0.9822333935727922        0
jxl:d4          41091840  3118613    0.60714983802   1   2.273  15.473   6.56652164   1.59660002847  0.9693754486679467        0
jxl:d6          41091840  2243973    0.43686980189   1   2.117  13.286   8.46946812   2.10016541683  0.9174988495811314        0
jxl:d8          41091840  1795358    0.34953080709   1   2.173  12.779  13.48916626   2.58922420914  0.9050136275578106        0
Aggregate:      41091840  4233971    0.82429419607 ---   2.270  17.761   6.29243618   1.17406958342  0.9677787433958489        0
```

Speeds aren't measured accurately above, I couldn't measure any real speedup or slowdown.