### PR TITLE
Start using non-aligned 16x8, 8x16 and 16x16 dcts

### DIFF
--- a/lib/jxl/enc_adaptive_quantization.cc
+++ b/lib/jxl/enc_adaptive_quantization.cc
@@ -660,7 +660,7 @@ ImageF TileDistMap(const ImageF& distmap, int tile_size, int margin,
 
 constexpr float kDcQuantPow = 0.57f;
 static const float kDcQuant = 1.12f;
-static const float kAcQuant = 0.814f;
+static const float kAcQuant = 0.7962f;
 
 void FindBestQuantization(const ImageBundle& linear, const Image3F& opsin,
                           PassesEncoderState* enc_state, ThreadPool* pool,

--- a/lib/jxl/jxl_test.cc
+++ b/lib/jxl/jxl_test.cc
@@ -234,7 +234,7 @@ TEST(JxlTest, RoundtripResample2MT) {
   cparams.resampling = 2;
   DecompressParams dparams;
   CodecInOut io2;
-  EXPECT_LE(Roundtrip(&io, cparams, dparams, &pool, &io2), 55000);
+  EXPECT_LE(Roundtrip(&io, cparams, dparams, &pool, &io2), 57000);
   EXPECT_LE(ButteraugliDistance(io, io2, cparams.ba_params,
                                 /*distmap=*/nullptr, &pool),
 #if JXL_HIGH_PRECISION

--- a/tools/optimizer/simplex_fork.py
+++ b/tools/optimizer/simplex_fork.py
@@ -61,14 +61,14 @@ def EvalCacheForget():
 def RandomizedJxlCodecs():
   retval = []
   minval = 0.5
-  maxval = 11.5
+  maxval = 24.0
   rangeval = maxval/minval
-  steps = 7
+  steps = 6
   for i in range(steps):
     mul = minval * rangeval**(float(i)/(steps - 1))
     mul *= 0.99 + 0.05 * random.random()
     retval.append("jxl:epf2:d%.3f" % mul)
-  steps = 7
+  steps = 6
   for i in range(steps):
     mul = minval * rangeval**(float(i+0.5)/(steps - 1))
     mul *= 0.99 + 0.05 * random.random()
@@ -102,7 +102,7 @@ def Eval(vec, binary_name, cached=True):
       (binary_name,
        '--input',
        '/usr/local/google/home/jyrki/newcorpus/split/*.png',
-       '--error_pnorm=5',
+       '--error_pnorm=3',
        '--more_columns',
        '--codec', g_codecs),
       stdout=subprocess.PIPE,


### PR DESCRIPTION
Slight improvement (0.44 %) on BPP * pnorm, visual inspection suggest images may
be a bit more vivid and have higher contrast. Ringing is not substantially
reduced in this change, but possibly a little. Sometimes there is more
ringing. Likely some additional improvement to counter that is possible.

Delightfully max butteraugli distance is greatly reduced (3.5 %), too.

Before:

```
Compr                 Input    Compr            Compr       Compr  Decomp  Butteraugli
Method               Pixels     Size              BPP   #    MP/s    MP/s     Distance    Error p norm   PSNR   QABPP     DCT2     DCT4   DCT4X8      AFV     DCT8  DCT8X16  DCT8X32    DCT16 DCT16X32    DCT32           BPP*pnorm   Errors
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
jxl:d0.8:epf0      17448577  3870714    1.77468409028   1   2.233  14.080   1.80222321   0.52939698283  41.95   2.125 0.000000 0.000000 0.188362 0.006371 0.062461 0.346435 0.000000 0.040317 0.194810 0.125765  0.9395124028640433        0
jxl:d1:epf1        17448577  3365010    1.54282380735   1   3.052  21.126   1.90873623   0.61329670189  40.79   2.179 0.000000 0.000000 0.170558 0.006576 0.055961 0.329885 0.000000 0.046274 0.219547 0.139146  0.9462087526504965        0
jxl:d2:epf3        17448577  2172907    0.99625637094   1   3.098  16.693   3.79021478   0.96497337332  37.43   2.252 0.000000 0.000234 0.124100 0.007002 0.036440 0.263664 0.000000 0.064364 0.293961 0.186330  0.9613608709484811        0
jxl:d3:epf0        17448577  1618162    0.74191127448   1   2.444  23.448   4.76765537   1.28786214751  35.19   2.314 0.000000 0.000234 0.092772 0.006327 0.027802 0.226993 0.000000 0.072038 0.336333 0.222716  0.9554794472159012        0
jxl:d4:epf3        17448577  1344831    0.61659171404   1   2.955  15.688   6.82338524   1.56208631217  34.06   2.425 0.000000 0.000234 0.073758 0.005285 0.019916 0.193042 0.000000 0.077011 0.371369 0.249066  0.9631694767031896        0
jxl:d8:epf1        17448577   796979    0.36540698992   1   2.969  24.594   9.87168598   2.45571728749  30.94   2.378 0.000000 0.000234 0.030861 0.002574 0.004775 0.110140 0.000000 0.079843 0.444170 0.327648  0.8973362621231278        0
jxl:d16:epf3       17448577   450579    0.20658601558   1   2.553  14.396  21.56148529   4.44012931344  28.56   2.553 0.000000 0.000234 0.006437 0.000436 0.000590 0.045658 0.000000 0.051585 0.421517 0.480233  0.9172686235303881        0
jxl:d24:epf3       17448577   339753    0.15577339058   1   3.163  15.024  21.47612762   5.78196502410  27.33   2.580 0.000000 0.002817 0.002461 0.000084 0.000212 0.028829 0.000000 0.036840 0.377209 0.559402  0.9006762959908683        0
jxl:d32:epf3       17448577   276995    0.12699946821   1   3.136  14.748  24.38039017   7.02440096331  26.53   2.600 0.000000 0.033568 0.001181 0.000066 0.000121 0.022044 0.000000 0.026643 0.324537 0.600013  0.8920951868252788        0
Aggregate:         17448577  1084859    0.49739733676 ---   2.825  17.361   7.12413578   1.86962978654  33.21   2.373 0.000000 0.000680 0.029267 0.001580 0.005565 0.117348 0.000000 0.051817 0.320809 0.276844  0.9299488765607850        0
```

After:

```
Compr                 Input    Compr            Compr       Compr  Decomp  Butteraugli
Method               Pixels     Size              BPP   #    MP/s    MP/s     Distance    Error p norm   PSNR   QABPP     DCT2     DCT4   DCT4X8      AFV     DCT8  DCT8X16  DCT8X32    DCT16 DCT16X32    DCT32           BPP*pnorm   Errors
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
jxl:d0.8:epf0      17448577  3832557    1.75718948313   1   2.166  13.940   1.65389645   0.52447176006  41.71   2.132 0.000000 0.000000 0.150953 0.019825 0.057857 0.319065 0.000000 0.359925 0.035975 0.057806  0.9215962609754337        0
jxl:d1:epf1        17448577  3341393    1.53199564641   1   3.039  21.389   1.94597673   0.60831822710  40.60   2.159 0.000000 0.000000 0.143584 0.019575 0.055411 0.275468 0.000000 0.341600 0.070600 0.095307  0.9319408755481520        0
jxl:d2:epf3        17448577  2171167    0.99545859814   1   3.135  17.221   3.37816739   0.95922362612  37.45   2.251 0.000000 0.000234 0.128773 0.022150 0.048207 0.195434 0.000000 0.222496 0.205638 0.178055  0.9548674061643109        0
jxl:d3:epf0        17448577  1620714    0.74308134125   1   2.408  25.265   4.78873014   1.28056182492  35.20   2.282 0.000000 0.000234 0.100779 0.019781 0.038703 0.160471 0.000000 0.175194 0.284572 0.223127  0.9515615984069460        0
jxl:d4:epf3        17448577  1346736    0.61746513770   1   2.948  15.613   6.19461298   1.55633537120  34.05   2.439 0.000000 0.000234 0.073963 0.016021 0.025378 0.127856 0.000000 0.157749 0.346134 0.256754  0.9609828342900819        0
jxl:d8:epf1        17448577   792789    0.36348591636   1   2.995  25.254   9.42750168   2.47607795205  30.90   2.401 0.000000 0.000234 0.035314 0.009771 0.010537 0.083826 0.000000 0.100530 0.433812 0.332166  0.9000194633758219        0
jxl:d16:epf3       17448577   455443    0.20881611148   1   2.511  14.015  21.57974815   4.41066909624  28.59   2.568 0.000000 0.000234 0.007974 0.002556 0.001137 0.037897 0.000000 0.052465 0.417438 0.487862  0.9210187697014505        0
jxl:d24:epf3       17448577   341539    0.15659225391   1   3.075  14.520  21.47615433   5.75664701811  27.35   2.588 0.000000 0.001173 0.003425 0.000997 0.000374 0.026174 0.000000 0.034493 0.373394 0.568087  0.9014463315459612        0
jxl:d32:epf3       17448577   278114    0.12751251864   1   3.156  14.529  24.35920143   6.99647483549  26.54   2.609 0.000000 0.030751 0.001694 0.000513 0.000176 0.020899 0.000000 0.024516 0.324038 0.605705  0.8921381278931616        0
Aggregate:         17448577  1084857    0.49739628292 ---   2.803  17.466   6.87529884   1.86141753689  33.18   2.375 0.000000 0.000592 0.031879 0.006887 0.007899 0.094698 0.000000 0.114460 0.218329 0.244596  0.9258621638068704        0
```