### PR TITLE
Fuzz: Prevent integer overflow in SkipBits()

### DIFF
--- a/lib/jxl/dec_bit_reader.h
+++ b/lib/jxl/dec_bit_reader.h
@@ -181,8 +181,20 @@ class BitReader {
 
     // Skip whole bytes
     const size_t whole_bytes = skip / kBitsPerByte;
-    next_byte_ += whole_bytes;
     skip %= kBitsPerByte;
+    if (JXL_UNLIKELY(whole_bytes >
+                     static_cast<size_t>(end_minus_8_ + 8 - next_byte_))) {
+      // This is already an overflow condition (skipping past the end of the bit
+      // stream). However if we increase next_byte_ too much we risk overflowing
+      // that value and potentially making it valid again (next_byte_ < end).
+      // This will set next_byte_ to the end of the stream and still consume
+      // some bits in overread_bytes_, however the TotalBitsConsumed() will be
+      // incorrect (still larger than the TotalBytes()).
+      next_byte_ = end_minus_8_ + 8;
+      skip += kBitsPerByte;
+    } else {
+      next_byte_ += whole_bytes;
+    }
 
     Refill();
     Consume(skip);


### PR DESCRIPTION
While an unsigned integer overflow is well defined, advancing next_byte_
way too much past the end of the buffer might make the pointer wrap
around and pass tests like "next_byte_ < end_minus_8_" when it actually
is before the beginning of the buffer.

Found this looking at unsigned integer overflow messages.