### PR TITLE
Allow arbitrary center for group order

### DIFF
--- a/lib/jxl/enc_frame.cc
+++ b/lib/jxl/enc_frame.cc
@@ -1339,9 +1339,27 @@ Status EncodeFrame(const CompressParams& cparams_orig,
     std::vector<coeff_order_t> ac_group_order(num_groups);
     std::iota(ac_group_order.begin(), ac_group_order.end(), 0);
     size_t group_dim = frame_dim.group_dim;
-    // The center of the image.
-    int64_t imag_cx = ib.xsize() / 2;
-    int64_t imag_cy = ib.ysize() / 2;
+
+    // The center of the image is either given by parameters or chosen
+    // to be the middle of the image by default if center_x, center_y resp.
+    // are not provided.
+
+    int64_t imag_cx;
+    if (cparams.center_x != static_cast<size_t>(-1)) {
+      JXL_RETURN_IF_ERROR(cparams.center_x < ib.xsize());
+      imag_cx = cparams.center_x;
+    } else {
+      imag_cx = ib.xsize() / 2;
+    }
+
+    int64_t imag_cy;
+    if (cparams.center_y != static_cast<size_t>(-1)) {
+      JXL_RETURN_IF_ERROR(cparams.center_y < ib.ysize());
+      imag_cy = cparams.center_y;
+    } else {
+      imag_cy = ib.ysize() / 2;
+    }
+
     // The center of the group containing the center of the image.
     int64_t cx = (imag_cx / group_dim) * group_dim + group_dim / 2;
     int64_t cy = (imag_cy / group_dim) * group_dim + group_dim / 2;

--- a/lib/jxl/enc_params.h
+++ b/lib/jxl/enc_params.h
@@ -166,6 +166,10 @@ struct CompressParams {
   // Put center groups first in the bitstream.
   bool middleout = false;
 
+  // Pixel coordinates of the center. First group will contain that center.
+  size_t center_x = static_cast<size_t>(-1);
+  size_t center_y = static_cast<size_t>(-1);
+
   int progressive_dc = -1;
 
   // If on: preserve color of invisible pixels (if off: don't care)

--- a/tools/cjxl.cc
+++ b/tools/cjxl.cc
@@ -365,6 +365,13 @@ void CompressArgs::AddCommandLineOptions(CommandLineParser* cmdline) {
                          "Put center groups first in the compressed file.",
                          &params.middleout, &SetBooleanTrue, 1);
 
+  cmdline->AddOptionValue('\0', "center_x", "0..XSIZE",
+                          "Put center groups first in the compressed file.",
+                          &params.center_x, &ParseUnsigned, 1);
+  cmdline->AddOptionValue('\0', "center_y", "0..YSIZE",
+                          "Put center groups first in the compressed file.",
+                          &params.center_y, &ParseUnsigned, 1);
+
   // Flags.
   cmdline->AddOptionFlag('\0', "progressive_ac",
                          "Use the progressive mode for AC.",


### PR DESCRIPTION
This adds command line parameters `center_x` and `center_y` allowing to
specify the first tile, i.e. the center for tile order.
When no value is given the geomemtric middle of the image is used as a
center, as it was before.