### PR TITLE
Rename to centerfirst

### DIFF
--- a/lib/jxl/enc_frame.cc
+++ b/lib/jxl/enc_frame.cc
@@ -1331,7 +1331,7 @@ Status EncodeFrame(const CompressParams& cparams_orig,
 
   std::vector<coeff_order_t>* permutation_ptr = nullptr;
   std::vector<coeff_order_t> permutation;
-  if (cparams.middleout && !(num_passes == 1 && num_groups == 1)) {
+  if (cparams.centerfirst && !(num_passes == 1 && num_groups == 1)) {
     permutation_ptr = &permutation;
     // Don't permute global DC/AC or DC.
     permutation.resize(global_ac_index + 1);

--- a/lib/jxl/enc_params.h
+++ b/lib/jxl/enc_params.h
@@ -164,7 +164,7 @@ struct CompressParams {
   bool qprogressive_mode = false;
 
   // Put center groups first in the bitstream.
-  bool middleout = false;
+  bool centerfirst = false;
 
   // Pixel coordinates of the center. First group will contain that center.
   size_t center_x = static_cast<size_t>(-1);

--- a/tools/cjxl.cc
+++ b/tools/cjxl.cc
@@ -361,9 +361,9 @@ void CompressArgs::AddCommandLineOptions(CommandLineParser* cmdline) {
                           "pixels (default: 1 if lossless, 0 if lossy).",
                           &params.keep_invisible, &ParseOverride, 1);
 
-  cmdline->AddOptionFlag('\0', "middleout",
+  cmdline->AddOptionFlag('\0', "centerfirst",
                          "Put center groups first in the compressed file.",
-                         &params.middleout, &SetBooleanTrue, 1);
+                         &params.centerfirst, &SetBooleanTrue, 1);
 
   cmdline->AddOptionValue('\0', "center_x", "0..XSIZE",
                           "Put center groups first in the compressed file.",


### PR DESCRIPTION
We rename `middleout` to `centerfirst`. This is more consistent with the
parameters `center_x` and `center_y`.