### PR TITLE
Remove the old acs decision tree altogether

### DIFF
--- a/lib/jxl/enc_ac_strategy.h
+++ b/lib/jxl/enc_ac_strategy.h
@@ -67,7 +67,6 @@ struct AcStrategyHeuristics {
   void Finalize(AuxOut* aux_out);
   ACSConfig config;
   PassesEncoderState* enc_state;
-  float entropy_adjust[2 * AcStrategy::kNumValidStrategies];
 };
 
 // Debug.


### PR DESCRIPTION
Removes the special heuristics for cheetah that lead to much worse
BPP * pnorm.

50+ % reduction in max butteraugli score (jxl:4)
12 % reduction in BPP*pnorm
Encodes faster

Before:

```
Compr              Input    Compr            Compr       Compr  Decomp  Butteraugli
Method            Pixels     Size              BPP   #    MP/s    MP/s     Distance    Error p norm   PSNR   QABPP     DCT2     DCT4   DCT4X8      AFV     DCT8  DCT8X16  DCT8X32    DCT16 DCT16X32    DCT32           BPP*pnorm   Errors
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
jxl:1           17972865  4033242    1.79525835197   1  13.759  26.484   1.93303061   0.67301624643  40.75   2.794 0.000000 0.000000 0.000000 0.000000 1.008090 0.000000 0.000000 0.000000 0.000000 0.000000  1.2082380374088753        0
jxl:2           17972865  4032490    1.79492362514   1  13.756  26.630   1.93303061   0.67301624643  40.75   2.793 0.000000 0.000000 0.000000 0.000000 1.008090 0.000000 0.000000 0.000000 0.000000 0.000000  1.2080127608189430        0
jxl:3           17972865  3797012    1.69010872780   1  12.723  25.629   1.93303061   0.67301624643  40.75   2.629 0.000000 0.000000 0.000000 0.000000 1.008090 0.000000 0.000000 0.000000 0.000000 0.000000  1.1374706320369441        0
jxl:4           17972865  3616407    1.60971865087   1  11.347  28.377   4.23037910   0.79179546603  39.16   3.467 0.185282 0.104833 0.000000 0.000000 0.013688 0.068519 0.000000 0.121883 0.282281 0.231602  1.2745679293435535        0
jxl:5           17972865  3412147    1.51879936782   1   6.607  26.474   1.95028138   0.62342391288  40.55   2.175 0.000000 0.000911 0.175087 0.000000 0.066810 0.284759 0.000000 0.305755 0.070563 0.094920  0.9468558447718746        0
jxl:6           17972865  3427199    1.52549924567   1   5.460  28.615   1.95021904   0.61761242542  40.55   2.203 0.000000 0.000911 0.141945 0.023726 0.056697 0.274810 0.000000 0.336165 0.070449 0.094920  0.9421672891005118        0
Aggregate:      17972865  3710955    1.65180328644 ---   9.976  27.013   2.20908634   0.67302550521  40.42   2.643 0.185282 0.004433 0.157647 0.023726 0.193883 0.175028 0.000000 0.232250 0.111955 0.127786  1.1117057413643976        0
```

After:

```
Compr              Input    Compr            Compr       Compr  Decomp  Butteraugli
Method            Pixels     Size              BPP   #    MP/s    MP/s     Distance    Error p norm   PSNR   QABPP     DCT2     DCT4   DCT4X8      AFV     DCT8  DCT8X16  DCT8X32    DCT16 DCT16X32    DCT32           BPP*pnorm   Errors
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
jxl:1           17972865  4033242    1.79525835197   1  13.730  26.438   1.93303061   0.67301624643  40.75   2.794 0.000000 0.000000 0.000000 0.000000 1.008090 0.000000 0.000000 0.000000 0.000000 0.000000  1.2082380374088753        0
jxl:2           17972865  4032490    1.79492362514   1  13.755  26.528   1.93303061   0.67301624643  40.75   2.793 0.000000 0.000000 0.000000 0.000000 1.008090 0.000000 0.000000 0.000000 0.000000 0.000000  1.2080127608189430        0
jxl:3           17972865  3797012    1.69010872780   1  12.735  25.332   1.93303061   0.67301624643  40.75   2.629 0.000000 0.000000 0.000000 0.000000 1.008090 0.000000 0.000000 0.000000 0.000000 0.000000  1.1374706320369441        0
jxl:4           17972865  3791410    1.68761519101   1  12.517  28.554   1.93303061   0.67301624643  40.75   2.625 0.000000 0.000000 0.000000 0.000000 1.008090 0.000000 0.000000 0.000000 0.000000 0.000000  1.1357924412699223        0
jxl:5           17972865  3412147    1.51879936782   1   6.594  26.276   1.95028138   0.62342391288  40.55   2.175 0.000000 0.000911 0.175087 0.000000 0.066810 0.284759 0.000000 0.305755 0.070563 0.094920  0.9468558447718746        0
jxl:6           17972865  3427199    1.52549924567   1   5.495  28.232   1.95021904   0.61761242542  40.55   2.203 0.000000 0.000911 0.141945 0.023726 0.056697 0.274810 0.000000 0.336165 0.070449 0.094920  0.9421672891005118        0
Aggregate:      17972865  3740298    1.66486453042 ---  10.146  26.870   1.93875351   0.65503867973  40.68   2.523 0.000000 0.000911 0.157647 0.023726 0.396947 0.279741 0.000000 0.320599 0.070506 0.094920  1.0905506639304767        0
```