### PR TITLE
Always define the fuzzer build targets

### DIFF
--- a/lib/jxl/decode.cc
+++ b/lib/jxl/decode.cc
@@ -2183,8 +2183,6 @@ JxlDecoderStatus JxlDecoderSetPreferredColorProfile(
   return JXL_DEC_SUCCESS;
 }
 
-#if JXL_IS_DEBUG_BUILD || defined(JXL_ENABLE_FUZZERS)
 void SetDecoderMemoryLimitBase_(size_t memory_limit_base) {
   memory_limit_base_ = memory_limit_base;
 }
-#endif

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -241,33 +241,33 @@ set(FUZZER_BINARIES
 )
 
 # Fuzzers.
-if(${JPEGXL_ENABLE_FUZZERS})
-  foreach(BINARY IN LISTS FUZZER_BINARIES)
+foreach(FUZZER IN LISTS FUZZER_BINARIES)
+  if(${JPEGXL_ENABLE_FUZZERS})
+    set(BINARY "${FUZZER}")
     add_executable("${BINARY}" "${BINARY}.cc")
+    target_link_libraries("${BINARY}" ${JPEGXL_FUZZER_LINK_FLAGS})
+  else()
+    # When not enabled we want a lightweight alternative for regular fuzzers
+    # that just run the target.
+    set(BINARY "${FUZZER}_runner")
+    add_executable("${BINARY}" EXCLUDE_FROM_ALL
+        "fuzzer_stub.cc" "${FUZZER}.cc")
+  endif()  # JPEGXL_ENABLE_FUZZERS
     target_include_directories("${BINARY}" PRIVATE "${CMAKE_SOURCE_DIR}")
-    target_link_libraries("${BINARY}"
+    if(${FUZZER} STREQUAL djxl_fuzzer)
+      target_link_libraries("${BINARY}"
+        jxl_dec-static
+        jxl_threads-static
+      )
+    else()
+      target_link_libraries("${BINARY}"
         jxl-static
         jxl_extras-static
         jxl_threads-static
         jxl_tool
-        ${JPEGXL_FUZZER_LINK_FLAGS}
-    )
-  endforeach()
-endif()  # JPEGXL_ENABLE_FUZZERS
-
-# For coverage we want a lightweight alternative for regular fuzzers.
-if(${JPEGXL_ENABLE_COVERAGE})
-  foreach(FUZZER IN LISTS FUZZER_BINARIES)
-    set(BINARY "${FUZZER}_runner")
-    add_executable("${BINARY}" "fuzzer_stub.cc" "${FUZZER}.cc")
-    target_include_directories("${BINARY}" PRIVATE "${CMAKE_SOURCE_DIR}")
-    if(${FUZZER} STREQUAL djxl_fuzzer)
-      target_link_libraries("${BINARY}" jxl_dec-static jxl_threads-static)
-    else()
-      target_link_libraries("${BINARY}" jxl-static jxl_extras-static jxl_threads-static jxl_tool)
+      )
     endif()
-  endforeach()
-endif()  # JPEGXL_ENABLE_COVERAGE
+endforeach()
 
 # EMSCRIPTEN doesn't support dynamic libraries so testing for linkage there
 # doesn't make much sense.


### PR DESCRIPTION
When JPEGXL_ENABLE_FUZZERS is off, we weren't defining any of the fuzzer
targets except in coverage builds (when JPEGXL_ENABLE_COVERAGE is on).
This patch instead defines the fuzzer targets as "djxl_fuzzer_runner"
when JPEGXL_ENABLE_FUZZERS is off but excluded from the "all" target.

There are no changes to the targets defined when JPEGXL_ENABLE_FUZZERS
is on, except that djxl_fuzzer depends on the decoder side only, helping
the fuzzer library with the coverage analysis by removing all the unused
encoder and extras library code.