### PR TITLE
Fuzz: Fix InvSqueeze when using channels with no pixels

### DIFF
--- a/lib/jxl/modular/transform/squeeze.cc
+++ b/lib/jxl/modular/transform/squeeze.cc
@@ -21,16 +21,17 @@ void InvHSqueeze(Image &input, int c, int rc, ThreadPool *pool) {
   JXL_ASSERT(chin.w == DivCeil(chin.w + chin_residual.w, 2));
   JXL_ASSERT(chin.h == chin_residual.h);
 
-  if (chin_residual.w == 0 || chin_residual.h == 0) {
-    input.channel[c].hshift--;
-    return;
-  }
-
   Channel chout(chin.w + chin_residual.w, chin.h, chin.hshift - 1, chin.vshift);
   JXL_DEBUG_V(4,
               "Undoing horizontal squeeze of channel %i using residuals in "
               "channel %i (going from width %zu to %zu)",
               c, rc, chin.w, chout.w);
+  if (chin_residual.w == 0 || chin_residual.h == 0) {
+    // Short-circuit for channels with no pixels.
+    input.channel[c] = std::move(chout);
+    return;
+  }
+
   RunOnPool(
       pool, 0, chin.h, ThreadPool::SkipInit(),
       [&](const int task, const int thread) {
@@ -76,11 +77,6 @@ void InvVSqueeze(Image &input, int c, int rc, ThreadPool *pool) {
   JXL_ASSERT(chin.h == DivCeil(chin.h + chin_residual.h, 2));
   JXL_ASSERT(chin.w == chin_residual.w);
 
-  if (chin_residual.w == 0 || chin_residual.h == 0) {
-    input.channel[c].vshift--;
-    return;
-  }
-
   // Note: chin.h >= chin_residual.h and at most 1 different.
   Channel chout(chin.w, chin.h + chin_residual.h, chin.hshift, chin.vshift - 1);
   JXL_DEBUG_V(
@@ -88,6 +84,12 @@ void InvVSqueeze(Image &input, int c, int rc, ThreadPool *pool) {
       "Undoing vertical squeeze of channel %i using residuals in channel "
       "%i (going from height %zu to %zu)",
       c, rc, chin.h, chout.h);
+
+  if (chin_residual.w == 0 || chin_residual.h == 0) {
+    // Short-circuit for channels with no pixels.
+    input.channel[c] = std::move(chout);
+    return;
+  }
 
   intptr_t onerow_in = chin.plane.PixelsPerRow();
   intptr_t onerow_out = chout.plane.PixelsPerRow();

--- a/lib/jxl/modular/transform/transform.cc
+++ b/lib/jxl/modular/transform/transform.cc
@@ -43,12 +43,18 @@ Status Transform::MetaApply(Image &input) {
     case TransformId::kSqueeze:
       JXL_DEBUG_V(2, "Transform: kSqueeze:");
 #if JXL_DEBUG_V_LEVEL >= 2
-      for (const auto &params : squeezes) {
-        JXL_DEBUG_V(
-            2,
-            "  squeeze params: horizontal=%d, in_place=%d, begin_c=%" PRIu32
-            ", num_c=%" PRIu32,
-            params.horizontal, params.in_place, params.begin_c, params.num_c);
+      {
+        auto squeezes_copy = squeezes;
+        if (squeezes_copy.empty()) {
+          DefaultSqueezeParameters(&squeezes_copy, input);
+        }
+        for (const auto &params : squeezes_copy) {
+          JXL_DEBUG_V(
+              2,
+              "  squeeze params: horizontal=%d, in_place=%d, begin_c=%" PRIu32
+              ", num_c=%" PRIu32,
+              params.horizontal, params.in_place, params.begin_c, params.num_c);
+        }
       }
 #endif
       return MetaSqueeze(input, &squeezes);


### PR DESCRIPTION
The short-circuit for channels with no pixels was not updating the size
of the output channel, only updating the vshift/hshift. This caused the
channel sizes to get out of sync with the MetaApply ones. This patch
fixes that and also prints the squeeze transforms when debug is enabled
and only the default transform is used.