### PR TITLE
Less ringing. Use max, not 8 norm for small blocks

### DIFF
--- a/lib/jxl/enc_ac_strategy.cc
+++ b/lib/jxl/enc_ac_strategy.cc
@@ -295,6 +295,18 @@ float EstimateEntropy(const AcStrategy& acs, size_t x, size_t y,
     // When it is only one 8x8, we don't need aggregation of values.
     quant_norm8 = config.Quant(x / 8, y / 8);
     masking = 2.0f * config.Masking(x / 8, y / 8);
+  } else if (num_blocks == 2) {
+    if (acs.covered_blocks_y() == 2) {
+      quant_norm8 =
+          std::max(config.Quant(x / 8, y / 8), config.Quant(x / 8, y / 8 + 1));
+      masking = 2.0f * std::max(config.Masking(x / 8, y / 8),
+                                config.Masking(x / 8, y / 8 + 1));
+    } else {
+      quant_norm8 =
+          std::max(config.Quant(x / 8, y / 8), config.Quant(x / 8 + 1, y / 8));
+      masking = 2.0f * std::max(config.Masking(x / 8, y / 8),
+                                config.Masking(x / 8 + 1, y / 8));
+    }
   } else {
     float masking_norm2 = 0;
     float masking_max = 0;
@@ -712,7 +724,7 @@ void ProcessRectACS(PassesEncoderState* JXL_RESTRICT enc_state,
     float entropy_mul;
   };
   static const float k8X16mul1 = -0.51923137374961237;
-  static const float k8X16mul2 = 0.92332415151304614;
+  static const float k8X16mul2 = 0.9135;
   static const float k8X16base = 1.6637730066379945f;
   const float entropy_mul16X8 =
       k8X16mul2 + k8X16mul1 / (butteraugli_target + k8X16base);


### PR DESCRIPTION
Surface area of ringing is reduced in anime drawings (improvements observed in d0.8 and d3 epf0).
0.16 % degradation in BPP*pnorm.
1.1 % improvement in butteraugli distance.

Before:

```
Compr                 Input    Compr            Compr       Compr  Decomp  Butteraugli
Method               Pixels     Size              BPP   #    MP/s    MP/s     Distance    Error p norm   PSNR   QABPP     DCT2     DCT4   DCT4X8      AFV     DCT8  DCT8X16  DCT8X32    DCT16 DCT16X32    DCT32           BPP*pnorm   Errors
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
jxl:d0.8:epf0      17972865  3936138    1.75203586073   1   2.403  14.173   1.65389645   0.52287405085  41.76   2.127 0.000000 0.000911 0.151100 0.023455 0.058096 0.317292 0.000000 0.353300 0.037489 0.058342  0.9160940877402589        0
jxl:d1:epf1        17972865  3435241    1.52907886417   1   2.568  20.446   1.94597673   0.60613908314  40.66   2.153 0.000000 0.000911 0.143825 0.023249 0.055632 0.274853 0.000000 0.335581 0.071474 0.094806  0.9268344607770000        0
jxl:d2:epf3        17972865  2240440    0.99725447223   1   2.902  17.021   3.37816739   0.95317171138  37.50   2.246 0.000000 0.001139 0.129165 0.025752 0.048442 0.196263 0.000000 0.219837 0.203627 0.175824  0.9505547519725651        0
jxl:d3:epf0        17972865  1677415    0.74664334262   1   2.814  26.323   4.78873014   1.27714086277  35.24   2.294 0.000000 0.001139 0.101757 0.023167 0.039166 0.162278 0.000000 0.174072 0.280714 0.219922  0.9535687227706663        0
jxl:d4:epf3        17972865  1395908    0.62134022595   1   2.425  14.981   6.19461298   1.55017970479  34.10   2.450 0.000000 0.001367 0.075427 0.019068 0.026005 0.130700 0.000000 0.157350 0.340851 0.252740  0.9631890080324149        0
jxl:d8:epf1        17972865   825297    0.36735245049   1   2.840  24.221   9.42750168   2.47064223360  30.93   2.416 0.000000 0.001367 0.037001 0.012149 0.011145 0.087691 0.000000 0.102412 0.427082 0.327035  0.9075964787849032        0
jxl:d16:epf3       17972865   476560    0.21212422171   1   2.893  14.698  21.57974815   4.39675459919  28.61   2.592 0.000000 0.001367 0.008945 0.003393 0.001438 0.041413 0.000000 0.055678 0.414064 0.481038  0.9326581473965152        0
jxl:d24:epf3       17972865   358350    0.15950712366   1   2.659  13.930  21.47615433   5.74263908744  27.34   2.620 0.000000 0.002279 0.004020 0.001460 0.000519 0.028850 0.000000 0.037646 0.372757 0.560346  0.9159918430296984        0
jxl:d32:epf3       17972865   292386    0.13014552772   1   2.843  13.693  24.35920143   6.98184090481  26.52   2.643 0.000000 0.030994 0.002065 0.000783 0.000242 0.022789 0.000000 0.027048 0.325383 0.598747  0.9086553689882146        0
Aggregate:         17972865  1126578    0.50145710125 ---   2.699  17.205   6.87529884   1.85532735343  33.21   2.386 0.000000 0.001796 0.033905 0.008723 0.008816 0.098424 0.000000 0.117116 0.218168 0.242060  0.9303670765158943        0
```

After:

```
Compr                 Input    Compr            Compr       Compr  Decomp  Butteraugli
Method               Pixels     Size              BPP   #    MP/s    MP/s     Distance    Error p norm   PSNR   QABPP     DCT2     DCT4   DCT4X8      AFV     DCT8  DCT8X16  DCT8X32    DCT16 DCT16X32    DCT32           BPP*pnorm   Errors
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
jxl:d0.8:epf0      17972865  3941131    1.75425832220   1   2.435  14.276   1.57823062   0.52378479117  41.77   2.110 0.000000 0.000911 0.156794 0.023519 0.063302 0.325048 0.000000 0.340281 0.033957 0.056177  0.9188538289596575        0
jxl:d1:epf1        17972865  3442238    1.53219333701   1   2.657  21.020   1.94608855   0.60635112868  40.67   2.146 0.000000 0.000911 0.149170 0.023544 0.061148 0.270801 0.000000 0.331593 0.068968 0.094179  0.9290471592556917        0
jxl:d2:epf3        17972865  2245771    0.99962738272   1   2.933  16.681   3.37816739   0.95233900788  37.52   2.246 0.000000 0.001139 0.133933 0.026137 0.052324 0.184057 0.000000 0.223440 0.203400 0.175596  0.9519841499113226        0
jxl:d3:epf0        17972865  1681591    0.74850214476   1   2.841  25.590   4.79111624   1.27498739748  35.26   2.302 0.000000 0.001139 0.106008 0.023505 0.042581 0.147279 0.000000 0.178088 0.283648 0.219922  0.9543308015555407        0
jxl:d4:epf3        17972865  1398787    0.62262171334   1   2.562  15.377   5.83378410   1.54700293572  34.12   2.440 0.000000 0.001367 0.079148 0.019499 0.028797 0.117845 0.000000 0.160184 0.344070 0.252569  0.9631976183887898        0
jxl:d8:epf1        17972865   827700    0.36842206293   1   2.876  24.488   9.44749260   2.46867853247  30.94   2.426 0.000000 0.001367 0.039063 0.012552 0.012459 0.079743 0.000000 0.103679 0.429931 0.327092  0.9095156376357284        0
jxl:d16:epf3       17972865   477034    0.21233520643   1   2.961  14.962  21.57230186   4.39498506722  28.61   2.602 0.000000 0.001367 0.009529 0.003514 0.001627 0.039754 0.000000 0.055806 0.414633 0.481095  0.9332100615257946        0
jxl:d24:epf3       17972865   359594    0.16006084728   1   2.759  13.686  21.47615433   5.74356957580  27.35   2.635 0.000000 0.002279 0.004301 0.001538 0.000641 0.027775 0.000000 0.037902 0.373070 0.560346  0.9193206127305763        0
jxl:d32:epf3       17972865   292616    0.13024790427   1   2.924  14.481  24.35920143   6.97998004002  26.52   2.645 0.000000 0.030994 0.002279 0.000829 0.000309 0.022248 0.000000 0.027120 0.325468 0.598804  0.9091277720678442        0
Aggregate:         17972865  1128881    0.50248219075 ---   2.766  17.358   6.79591927   1.85453897729  33.22   2.387 0.000000 0.001796 0.035771 0.008963 0.010000 0.093589 0.000000 0.117525 0.215593 0.240825  0.9318728081472635        0
```