### PR TITLE
Encoder: override color_transform for grayscale JPEG images with AdobeRGB ICC.

### DIFF
--- a/lib/jxl/jpeg/enc_jpeg_data.cc
+++ b/lib/jxl/jpeg/enc_jpeg_data.cc
@@ -355,7 +355,7 @@ Status DecodeImageJPG(const Span<const uint8_t> bytes, CodecInOut* io) {
 
   io->Main().chroma_subsampling = cs;
   io->Main().color_transform =
-      !is_rgb ? ColorTransform::kYCbCr : ColorTransform::kNone;
+      (!is_rgb || nbcomp == 1) ? ColorTransform::kYCbCr : ColorTransform::kNone;
 
   io->metadata.m.SetIntensityTarget(
       io->target_nits != 0 ? io->target_nits : kDefaultIntensityTarget);


### PR DESCRIPTION
Otherwise decoder puts all zeroes instead of gray channel.