### PR TITLE
Don't favor 4x4 locality in visual masking

### DIFF
--- a/lib/jxl/enc_adaptive_quantization.cc
+++ b/lib/jxl/enc_adaptive_quantization.cc
@@ -334,12 +334,17 @@ void FuzzyErosion(const Rect& from_rect, const ImageF& from,
       size_t xm1 = x >= kStep ? x - kStep : x;
       size_t xp1 = x + kStep < xsize ? x + kStep : x;
       float min0 = row[x];
-      float min1 = min0;
-      float min2 = min0;
-      float min3 = min0;
-      StoreMin4(row[xm1], min0, min1, min2, min3);
-      StoreMin4(row[xp1], min0, min1, min2, min3);
-      StoreMin4(rowt[xm1], min0, min1, min2, min3);
+      float min1 = row[xm1];
+      float min2 = row[xp1];
+      float min3 = rowt[xm1];
+      // Sort the first four values.
+      if (min0 > min1) std::swap(min0, min1);
+      if (min0 > min2) std::swap(min0, min2);
+      if (min0 > min3) std::swap(min0, min3);
+      if (min1 > min2) std::swap(min1, min2);
+      if (min1 > min3) std::swap(min1, min3);
+      if (min2 > min3) std::swap(min2, min3);
+      // The remaining five values of a 3x3 neighbourhood.
       StoreMin4(rowt[x], min0, min1, min2, min3);
       StoreMin4(rowt[xp1], min0, min1, min2, min3);
       StoreMin4(rowb[xm1], min0, min1, min2, min3);


### PR DESCRIPTION
Find the four lowest masking areas without favoring the current area.

Reduces ringing on anime and elsewhere in a very subtle way.

Before:

```
Compr                 Input    Compr            Compr       Compr  Decomp  Butteraugli
Method               Pixels     Size              BPP   #    MP/s    MP/s     Distance    Error p norm   PSNR   QABPP     DCT2     DCT4   DCT4X8      AFV     DCT8  DCT8X16  DCT8X32    DCT16 DCT16X32    DCT32           BPP*pnorm   Errors
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
jxl:d0.8:epf0      17972865  3950851    1.75858484443   1   2.429  14.353   1.65703654   0.52219718929  41.77   2.110 0.000000 0.000911 0.156007 0.024029 0.054240 0.301959 0.000000 0.372928 0.033871 0.055550  0.9183280628974582        0
jxl:d1:epf1        17972865  3451072    1.53612548695   1   2.650  20.418   1.94608855   0.60522969417  40.67   2.145 0.000000 0.000911 0.149647 0.024584 0.053399 0.254720 0.000000 0.353713 0.069138 0.093609  0.9297087586758027        0
jxl:d2:epf3        17972865  2245683    0.99958821256   1   2.898  16.772   3.53679371   0.95081954228  37.51   2.240 0.000000 0.001139 0.126622 0.025004 0.047716 0.175489 0.000000 0.239835 0.205622 0.179014  0.9504280067420582        0
jxl:d3:epf0        17972865  1681591    0.74850214476   1   2.816  24.780   4.79111624   1.27498739748  35.26   2.302 0.000000 0.001139 0.106008 0.023505 0.042581 0.147279 0.000000 0.178088 0.283648 0.219922  0.9543308015555407        0
jxl:d4:epf3        17972865  1395335    0.62108517479   1   2.510  14.989   6.68932486   1.55374567804  34.11   2.418 0.000000 0.001367 0.085828 0.020945 0.035032 0.127616 0.000000 0.150555 0.334498 0.247498  0.9650084060216808        0
jxl:d8:epf1        17972865   822443    0.36608209097   1   2.863  23.853   9.64835262   2.49146311714  30.93   2.448 0.000000 0.001367 0.043290 0.013243 0.017868 0.088175 0.000000 0.102440 0.418451 0.321109  0.9120800275070109        0
jxl:d16:epf3       17972865   475175    0.21150773680   1   2.939  14.854  21.55410767   4.43636741036  28.60   2.654 0.000000 0.001367 0.011277 0.004141 0.003578 0.045765 0.000000 0.057330 0.410617 0.473346  0.9383260305888054        0
jxl:d24:epf3       17972865   358966    0.15978131478   1   2.722  13.988  21.84295654   5.79278374263  27.33   2.680 0.000000 0.002279 0.004853 0.001808 0.001563 0.031108 0.000000 0.039640 0.371532 0.555162  0.9255786026130371        0
jxl:d32:epf3       17972865   291962    0.12995679876   1   2.907  13.879  24.39284897   7.02678130506  26.51   2.648 0.000000 0.030994 0.002311 0.000918 0.000797 0.023929 0.000000 0.028587 0.325212 0.595329  0.9131780040129822        0
Aggregate:         17972865  1127408    0.50182685604 ---   2.742  17.109   7.00286282   1.86107001319  33.21   2.396 0.000000 0.001796 0.037518 0.009553 0.013648 0.097026 0.000000 0.121205 0.214182 0.239010  0.9339349135908939        0
```

After:

```
Compr                 Input    Compr            Compr       Compr  Decomp  Butteraugli
Method               Pixels     Size              BPP   #    MP/s    MP/s     Distance    Error p norm   PSNR   QABPP     DCT2     DCT4   DCT4X8      AFV     DCT8  DCT8X16  DCT8X32    DCT16 DCT16X32    DCT32           BPP*pnorm   Errors
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
jxl:d0.8:epf0      17972865  3938627    1.75314375310   1   2.374  14.573   1.66095710   0.52341222757  41.74   2.110 0.000000 0.000911 0.152849 0.023954 0.052993 0.305185 0.000000 0.373797 0.034184 0.055607  0.9176168770590523        0
jxl:d1:epf1        17972865  3441522    1.53187463434   1   2.572  20.338   1.94606876   0.60624489804  40.64   2.135 0.000000 0.000911 0.147176 0.024545 0.052028 0.256194 0.000000 0.355465 0.069794 0.093609  0.9286911815032116        0
jxl:d2:epf3        17972865  2238762    0.99650756849   1   2.923  16.839   3.37106371   0.95334310646  37.48   2.247 0.000000 0.001139 0.124408 0.024880 0.046395 0.175980 0.000000 0.240633 0.207673 0.179413  0.9500136209566554        0
jxl:d3:epf0        17972865  1675002    0.74556927902   1   2.793  26.463   4.78873014   1.27878290743  35.23   2.301 0.000000 0.001139 0.103455 0.023345 0.041189 0.147272 0.000000 0.178217 0.287238 0.220378  0.9534212503186429        0
jxl:d4:epf3        17972865  1389724    0.61858763197   1   2.468  15.377   6.68818378   1.55791994726  34.09   2.413 0.000000 0.001367 0.083393 0.020849 0.034038 0.126882 0.000000 0.150313 0.338430 0.248125  0.9637100109673358        0
jxl:d8:epf1        17972865   819469    0.36475831761   1   2.868  24.763   9.81508255   2.49598885141  30.91   2.445 0.000000 0.001367 0.042157 0.013097 0.017345 0.087605 0.000000 0.101543 0.420587 0.322249  0.9104326942103894        0
jxl:d16:epf3       17972865   475382    0.21159987570   1   2.904  14.419  21.55410767   4.43764938689  28.60   2.662 0.000000 0.001367 0.010914 0.004073 0.003400 0.045359 0.000000 0.057302 0.411300 0.473745  0.9390060586722138        0
jxl:d24:epf3       17972865   358905    0.15975416273   1   2.634  14.266  21.84295654   5.79752265386  27.33   2.701 0.000000 0.002279 0.004817 0.001773 0.001520 0.031037 0.000000 0.039398 0.370706 0.556415  0.9261783774967229        0
jxl:d32:epf3       17972865   292769    0.13031600694   1   2.857  14.286  24.38763618   7.02597362337  26.51   2.656 0.000000 0.030994 0.002268 0.000911 0.000779 0.023836 0.000000 0.028345 0.324129 0.596810  0.9155968274353588        0
Aggregate:         17972865  1125217    0.50085154394 ---   2.703  17.421   6.98003295   1.86419771836  33.19   2.398 0.000000 0.001796 0.036721 0.009472 0.013244 0.096938 0.000000 0.121013 0.215471 0.239461  0.9336863054495367        0
```