### PR TITLE
Fix typos with codespell tool

### DIFF
--- a/ci.sh
+++ b/ci.sh
@@ -1201,7 +1201,7 @@ cmd_lint() {
     fi
     installed+=("${clang_format}")
     local tmppatch="${tmpdir}/${clang_format}.patch"
-    # We include in this linter all the changes including the uncommited changes
+    # We include in this linter all the changes including the uncommitted changes
     # to avoid printing changes already applied.
     set -x
     git -C "${MYDIR}" "${clang_format}" --binary "${clang_format}" \

--- a/deps.sh
+++ b/deps.sh
@@ -59,7 +59,7 @@ download_github() {
 main() {
   if git -C "${MYDIR}" rev-parse; then
     cat >&2 <<EOF
-Currenty directory is a git repository, downloading dependencies via git:
+Current directory is a git repository, downloading dependencies via git:
 
   git submodule update --init --recursive
 

--- a/doc/developing_in_github.md
+++ b/doc/developing_in_github.md
@@ -273,7 +273,7 @@ This mismatch can cause at least two problems:
 mismatch if e.g. API changed or a submodule was added/removed.
 
 *) when using `commit -a` your commit, which may be a technical change
-unrelated to submodule changes, will unintentially contain a change to the
+unrelated to submodule changes, will unintentionally contain a change to the
 submodules hash code, which is undesired unless you actually want to change
 the version of third_party libraries.
 

--- a/docker/scripts/jpegxl_builder.sh
+++ b/docker/scripts/jpegxl_builder.sh
@@ -363,7 +363,7 @@ install_from_source() {
     fi
 
     if [[ -e "${srcdir}/CMakeLists.txt" ]]; then
-      # Most pacakges use cmake for building which is easier to configure for
+      # Most packages use cmake for building which is easier to configure for
       # cross-compiling.
       if [[ "${package}" == "JPEG_TURBO" && "${target}" == wasm* ]]; then
         # JT erroneously detects WASM CPU as i386 and tries to use asm.

--- a/lib/extras/codec_png.cc
+++ b/lib/extras/codec_png.cc
@@ -630,7 +630,7 @@ Status CheckGray(const LodePNGColorMode& mode, bool has_icc, bool* is_gray) {
     case LCT_PALETTE: {
       if (has_icc) {
         // If an ICC profile is present, the PNG specification requires
-        // palette to be intepreted as RGB colored, not grayscale, so we must
+        // palette to be interpreted as RGB colored, not grayscale, so we must
         // output color in that case and unfortunately can't optimize it to
         // gray if the palette only has gray entries.
         *is_gray = false;

--- a/lib/include/jxl/decode.h
+++ b/lib/include/jxl/decode.h
@@ -121,7 +121,7 @@ typedef enum {
    */
   JXL_DEC_SUCCESS = 0,
 
-  /** An error occured, for example invalid input file or out of memory.
+  /** An error occurred, for example invalid input file or out of memory.
    * TODO(lode): add function to get error information from decoder.
    */
   JXL_DEC_ERROR = 1,
@@ -606,8 +606,8 @@ JXL_EXPORT JxlDecoderStatus JxlDecoderGetColorAsICCProfile(
  * JXL decoder has no color management system built in, but can convert XYB
  * color to any of the ones supported by JxlColorEncoding.
  *
- * Can only be set after the JXL_DEC_COLOR_ENCODING event occured and before
- * any other event occured, and can affect the result of
+ * Can only be set after the JXL_DEC_COLOR_ENCODING event occurred and before
+ * any other event occurred, and can affect the result of
  * JXL_COLOR_PROFILE_TARGET_DATA (but not of JXL_COLOR_PROFILE_TARGET_ORIGINAL),
  * so should be used after getting JXL_COLOR_PROFILE_TARGET_ORIGINAL but before
  * getting JXL_COLOR_PROFILE_TARGET_DATA. The color_encoding must be grayscale
@@ -682,7 +682,7 @@ JXL_EXPORT JxlDecoderStatus JxlDecoderGetFrameHeader(const JxlDecoder* dec,
  *
  * @param dec decoder object
  * @param name buffer to copy the name into
- * @param size size of the name buffer in bytes, includig zero termination
+ * @param size size of the name buffer in bytes, including zero termination
  *    character, so this must be at least JxlFrameHeader.name_length + 1.
  * @return JXL_DEC_SUCCESS if the value is available,
  *    JXL_DEC_NEED_MORE_INPUT if not yet available, JXL_DEC_ERROR in case
@@ -869,8 +869,8 @@ JxlDecoderSetImageOutCallback(JxlDecoder* dec, const JxlPixelFormat* format,
  * JxlDecoderSetImageOutBuffer will contain partial image data.
  *
  * Can be called when JxlDecoderProcessInput returns JXL_DEC_NEED_MORE_INPUT,
- * after the JXL_DEC_FRAME event already occured and before the
- * JXL_DEC_FULL_IMAGE event occured for a frame.
+ * after the JXL_DEC_FRAME event already occurred and before the
+ * JXL_DEC_FULL_IMAGE event occurred for a frame.
  *
  * @param dec decoder object
  * @return JXL_DEC_SUCCESS if image data was flushed to the output buffer, or

--- a/lib/jxl/ans_common.h
+++ b/lib/jxl/ans_common.h
@@ -79,12 +79,12 @@ struct AliasTable {
 
   // Dividing `value` by `entry_size` determines `i`, the entry which is
   // responsible for the input. If the remainder is below `cutoff`, then the
-  // mapped symbol is `i`; since `offsets[0]` stores the number of occurences of
-  // `i` "before" the start of this entry, the offset of the input will be
+  // mapped symbol is `i`; since `offsets[0]` stores the number of occurrences
+  // of `i` "before" the start of this entry, the offset of the input will be
   // `offsets[0] + remainder`. If the remainder is above cutoff, the mapped
-  // symbol is `right_value`; since `offsets[1]` stores the number of occurences
-  // of `right_value` "before" this entry, minus the `cutoff` value, the input
-  // offset is then `remainder + offsets[1]`.
+  // symbol is `right_value`; since `offsets[1]` stores the number of
+  // occurrences of `right_value` "before" this entry, minus the `cutoff` value,
+  // the input offset is then `remainder + offsets[1]`.
   static JXL_INLINE Symbol Lookup(const Entry* JXL_RESTRICT table, size_t value,
                                   size_t log_entry_size,
                                   size_t entry_size_minus_1) {

--- a/lib/jxl/butteraugli/butteraugli.cc
+++ b/lib/jxl/butteraugli/butteraugli.cc
@@ -1388,7 +1388,7 @@ inline float MaskColor(const float color[3], const float mask) {
   return color[0] * mask + color[1] * mask + color[2] * mask;
 }
 
-// Diffmap := sqrt of sum{diff images by multplied by X and Y/B masks}
+// Diffmap := sqrt of sum{diff images by multiplied by X and Y/B masks}
 void CombineChannelsToDiffmap(const ImageF& mask, const Image3F& block_diff_dc,
                               const Image3F& block_diff_ac, float xmul,
                               ImageF* result) {

--- a/lib/jxl/dct-inl.h
+++ b/lib/jxl/dct-inl.h
@@ -221,7 +221,7 @@ void DCT1DWrapper(const FromBlock& from, const ToBlock& to, size_t Mp) {
   constexpr size_t SZ = MaxLanes(FV<M_or_0>());
   HWY_ALIGN float tmp[N * SZ];
   for (size_t i = 0; i < M; i += Lanes(FV<M_or_0>())) {
-    // TODO(veluca): consider removing the temprorary memory here (as is done in
+    // TODO(veluca): consider removing the temporary memory here (as is done in
     // IDCT), if it turns out that some compilers don't optimize away the loads
     // and this is performance-critical.
     CoeffBundle<N, SZ>::LoadFromBlock(from, i, tmp);

--- a/lib/jxl/dec_ans.cc
+++ b/lib/jxl/dec_ans.cc
@@ -212,7 +212,7 @@ Status DecodeANSCodes(const size_t num_histograms,
               alphabet_sizes[c]);
         }
       } else {
-        // 0-bit codes does not requre extension tables.
+        // 0-bit codes does not require extension tables.
         result->huffman_data[c].table_.clear();
         result->huffman_data[c].table_.resize(1u << kHuffmanTableBits);
       }

--- a/lib/jxl/dec_frame.cc
+++ b/lib/jxl/dec_frame.cc
@@ -703,7 +703,7 @@ Status FrameDecoder::ProcessSections(const SectionInfo* sections, size_t num,
   if (decoded_ac_global_) {
     // The decoded image requires padding for filtering. ProcessACGlobal added
     // the padding, however when Flush is used, the image is shrunk to the
-    // output size. Add the padding back here. This is a cheap opeartion
+    // output size. Add the padding back here. This is a cheap operation
     // since the image has the original allocated size. The memory and original
     // size are already there, but for safety we require the indicated xsize and
     // ysize dimensions match the working area, see PlaneRowBoundsCheck.

--- a/lib/jxl/dec_patch_dictionary.h
+++ b/lib/jxl/dec_patch_dictionary.h
@@ -114,7 +114,7 @@ struct QuantizedPatch {
   }
 };
 
-// Pair (patch, vector of occurences).
+// Pair (patch, vector of occurrences).
 using PatchInfo =
     std::pair<QuantizedPatch, std::vector<std::pair<uint32_t, uint32_t>>>;
 
@@ -180,7 +180,7 @@ class PatchDictionary {
   const PassesSharedState* shared_;
   std::vector<PatchPosition> positions_;
 
-  // Patch occurences sorted by y.
+  // Patch occurrences sorted by y.
   std::vector<size_t> sorted_patches_;
   // Index of the first patch for each y value.
   std::vector<size_t> patch_starts_;

--- a/lib/jxl/dec_render_pipeline.h
+++ b/lib/jxl/dec_render_pipeline.h
@@ -47,7 +47,7 @@ class RenderPipelineStage {
   virtual size_t GetPaddingX(size_t c) const = 0;
   virtual size_t GetPaddingY(size_t c) const = 0;
 
-  // Log2 of the number of columsn/rows of output that this stage will produce
+  // Log2 of the number of columns/rows of output that this stage will produce
   // for the given channel.
   virtual size_t ShiftX(size_t c) const = 0;
   virtual size_t ShiftY(size_t c) const = 0;

--- a/lib/jxl/decode.cc
+++ b/lib/jxl/decode.cc
@@ -175,7 +175,7 @@ enum class DecoderStage : uint32_t {
   kInited,    // Decoder created, no JxlDecoderProcessInput called yet
   kStarted,   // Running JxlDecoderProcessInput calls
   kFinished,  // Everything done, nothing left to process
-  kError,     // Error occured, decoder object no longer useable
+  kError,     // Error occurred, decoder object no longer usable
 };
 
 enum class FrameStage : uint32_t {
@@ -411,7 +411,7 @@ struct JxlDecoderStruct {
 
   // Bitfield, for which informative events (JXL_DEC_BASIC_INFO, etc...) the
   // decoder returns a status. By default, do not return for any of the events,
-  // only return when the decoder cannot continue becasue it needs mor input or
+  // only return when the decoder cannot continue because it needs more input or
   // output data.
   int events_wanted;
   int orig_events_wanted;
@@ -1698,7 +1698,7 @@ JxlDecoderStatus JxlDecoderProcessInput(JxlDecoder* dec) {
     // it is needed. Before we got the basic info, we're still parsing the box
     // format instead. If the result is not JXL_DEC_NEED_MORE_INPUT, then
     // there is no reason yet to copy since the user may have a full buffer
-    // allowing one-shot. Once JXL_DEC_NEED_MORE_INPUT occured at least once,
+    // allowing one-shot. Once JXL_DEC_NEED_MORE_INPUT occurred at least once,
     // start copying over the codestream bytes and allow user to free them
     // instead. Next call, detected_streaming will be true.
     if (dec->got_basic_info && result == JXL_DEC_NEED_MORE_INPUT) {
@@ -1961,11 +1961,11 @@ JxlDecoderStatus JxlDecoderFlushImage(JxlDecoder* dec) {
     return JXL_DEC_ERROR;
   }
   if (dec->frame_header->encoding != jxl::FrameEncoding::kVarDCT) {
-    // Flushing does not yet work corretly if the frame uses modular encoding.
+    // Flushing does not yet work correctly if the frame uses modular encoding.
     return JXL_DEC_ERROR;
   }
   if (dec->metadata.m.num_extra_channels > 0) {
-    // Flushing does not yet work corretly if there are extra channels, which
+    // Flushing does not yet work correctly if there are extra channels, which
     // use modular
     return JXL_DEC_ERROR;
   }

--- a/lib/jxl/decode_test.cc
+++ b/lib/jxl/decode_test.cc
@@ -818,7 +818,7 @@ TEST(DecodeTest, DefaultParallelRunnerTest) {
 
 // Creates the header of a JPEG XL file with various custom parameters for
 // testing.
-// xsize, ysize: image dimentions to store in the SizeHeader, max 512.
+// xsize, ysize: image dimensions to store in the SizeHeader, max 512.
 // bits_per_sample, orientation: a selection of header parameters to test with.
 // orientation: image orientation to set in the metadata
 // alpha_bits: if non-0, alpha extra channel bits to set in the metadata. Also

--- a/lib/jxl/enc_ans.cc
+++ b/lib/jxl/enc_ans.cc
@@ -1615,7 +1615,7 @@ void WriteTokens(const std::vector<Token>& tokens,
 }
 
 void SetANSFuzzerFriendly(bool ans_fuzzer_friendly) {
-#if JXL_IS_DEBUG_BUILD  // Guard against accidential / malicious changes.
+#if JXL_IS_DEBUG_BUILD  // Guard against accidental / malicious changes.
   ans_fuzzer_friendly_ = ans_fuzzer_friendly;
 #endif
 }

--- a/lib/jxl/enc_frame.cc
+++ b/lib/jxl/enc_frame.cc
@@ -1367,7 +1367,7 @@ Status EncodeFrame(const CompressParams& cparams_orig,
     // lies in.
     double direction = -std::atan2(imag_cy - cy, imag_cx - cx);
     // This identifies the side of the central group the center of the image
-    // lies closet to. This can take values 0, 1, 2, 3 corresponding to left,
+    // lies closest to. This can take values 0, 1, 2, 3 corresponding to left,
     // bottom, right, top.
     int64_t side = std::fmod((direction + 5 * kPi / 4), 2 * kPi) * 2 / kPi;
     auto get_distance_from_center = [&](size_t gid) {

--- a/lib/jxl/enc_modular.cc
+++ b/lib/jxl/enc_modular.cc
@@ -340,7 +340,7 @@ ModularFrameEncoder::ModularFrameEncoder(const FrameHeader& frame_header,
     // Set properties.
     std::vector<uint32_t> prop_order;
     if (cparams.responsive) {
-      // Properties in order of their likelyhood of being useful for Squeeze
+      // Properties in order of their likelihood of being useful for Squeeze
       // residuals.
       prop_order = {0, 1, 4, 5, 6, 7, 8, 15, 9, 10, 11, 12, 13, 14, 2, 3};
     } else {

--- a/lib/jxl/encode_test.cc
+++ b/lib/jxl/encode_test.cc
@@ -317,7 +317,7 @@ struct Box {
   // serialized.
   bool data_size_given = true;
 
-  // If successfull, returns true and sets `in` to be the rest data (if any).
+  // If successful, returns true and sets `in` to be the rest data (if any).
   // If `in` contains a box with a size larger than `in.size()`, will not
   // modify `in`, and will return true but the data `Span<uint8_t>` will
   // remain set to nullptr.

--- a/lib/jxl/image_test_utils.h
+++ b/lib/jxl/image_test_utils.h
@@ -41,7 +41,7 @@ template <typename T>
 bool SamePixels(const Plane<T>& image1, const Plane<T>& image2,
                 const Rect rect) {
   if (!rect.IsInside(image1) || !rect.IsInside(image2)) {
-    ADD_FAILURE() << "requsted rectangle is not fully inside the image";
+    ADD_FAILURE() << "requested rectangle is not fully inside the image";
     return false;
   }
   size_t mismatches = 0;

--- a/lib/jxl_extras.cmake
+++ b/lib/jxl_extras.cmake
@@ -100,7 +100,7 @@ if (OpenEXR_FOUND)
                    ${PROJECT_BINARY_DIR}/LICENSE.libopenexr COPYONLY)
   endif()  # JPEGXL_DEP_LICENSE_DIR
   # OpenEXR generates exceptions, so we need exception support to catch them.
-  # Actully those flags counteract the ones set in JPEGXL_INTERNAL_FLAGS.
+  # Actually those flags counteract the ones set in JPEGXL_INTERNAL_FLAGS.
   if (NOT WIN32)
     set_source_files_properties(extras/codec_exr.cc PROPERTIES COMPILE_FLAGS -fexceptions)
     if (${CMAKE_CXX_COMPILER_ID} MATCHES "Clang")

--- a/third_party/HEVCSoftware/cfg/encoder_intra_main_scc_10.cfg
+++ b/third_party/HEVCSoftware/cfg/encoder_intra_main_scc_10.cfg
@@ -19,7 +19,7 @@ QuadtreeTUMaxDepthIntra       : 3
 
 #======== Coding Structure =============
 IntraPeriod                   : 1           # Period of I-Frame ( -1 = only first)
-DecodingRefreshType           : 1           # Random Accesss 0:none, 1:CRA, 2:IDR, 3:Recovery Point SEI
+DecodingRefreshType           : 1           # Random Access 0:none, 1:CRA, 2:IDR, 3:Recovery Point SEI
 GOPSize                       : 1           # GOP Size (number of B slice = GOPSize-1)
 ReWriteParamSetsFlag          : 1           # Write parameter sets with every IRAP
 #        Type POC QPoffset QPfactor tcOffsetDiv2 betaOffsetDiv2  temporal_id #ref_pics_active #ref_pics reference pictures  

--- a/tools/benchmark/benchmark_codec_webp.cc
+++ b/tools/benchmark/benchmark_codec_webp.cc
@@ -178,7 +178,7 @@ class WebPCodec : public ImageCodec {
       // TODO(lode): either ensure is_gray matches what the color profile says,
       // or set a correct color profile, e.g.
       // io->metadata.m.color_encoding = ColorEncoding::SRGB(is_gray);
-      // Return a standard failure becuase SetFromSRGB triggers a fatal assert
+      // Return a standard failure because SetFromSRGB triggers a fatal assert
       // for this instead.
       return JXL_FAILURE("Color profile is-gray mismatch");
     }

--- a/tools/box/box.cc
+++ b/tools/box/box.cc
@@ -201,7 +201,7 @@ jxl::Status DecodeJpegXlContainerOneShot(const uint8_t* data, size_t size,
       container->jpeg_reconstruction = in;
       container->jpeg_reconstruction_size = data_size;
     } else {
-      // Do nothing: box not recognized here but may be recognizeable by
+      // Do nothing: box not recognized here but may be recognizable by
       // other software.
     }
 

--- a/tools/check_author.py
+++ b/tools/check_author.py
@@ -49,7 +49,7 @@ def CheckAuthor(args):
   ret = IsAuthorInFile(
       args.email, args.name, os.path.join(args.source_dir, 'AUTHORS'))
   if not ret:
-    print("User %s <%s> not found, please add youself to the AUTHORS file" % (
+    print("User %s <%s> not found, please add yourself to the AUTHORS file" % (
               args.name, args.email),
           file=sys.stderr)
     if not args.dry_run:

--- a/tools/cmdline.h
+++ b/tools/cmdline.h
@@ -282,7 +282,7 @@ class CommandLineParser {
 
     // The text to display when referring to the value passed to this flag, for
     // example "N" in the flag '--value N'. If null, this flag accepts no value
-    // and therefor no value must be passed.
+    // and therefore no value must be passed.
     const char* metavar_;
 
     // The help string for this flag.

--- a/tools/demo_progressive_saliency_encoding.py
+++ b/tools/demo_progressive_saliency_encoding.py
@@ -134,7 +134,7 @@ def generate_demo_image(config, input_filename, output_filename):
               data_sizes[-1]) for size in data_sizes]
     time_delays = [t_next - t_prev
                    for t_next, t_prev in zip(time_offsets[1:], time_offsets)]
-    # Add a fake white initial image. As long as no useable image data is
+    # Add a fake white initial image. As long as no usable image data is
     # available, the user will see a white background.
     subprocess.call(['convert',
                      output_filename + '._step1.png',

--- a/tools/djxl_fuzzer.cc
+++ b/tools/djxl_fuzzer.cc
@@ -71,7 +71,7 @@ bool DecodeJpegXl(const uint8_t* jxl, size_t size, size_t max_pixels,
                   std::vector<uint8_t>* icc_profile) {
   SetDecoderMemoryLimitBase_(max_pixels);
   // Multi-threaded parallel runner. Limit to max 2 threads since the fuzzer
-  // itself is already multithreded.
+  // itself is already multithreaded.
   size_t num_threads =
       std::min<size_t>(2, JxlThreadParallelRunnerDefaultNumWorkerThreads());
   auto runner = JxlThreadParallelRunnerMake(nullptr, num_threads);

--- a/tools/jni/org/jpeg/jpegxl/wrapper/decoder_jni.cc
+++ b/tools/jni/org/jpeg/jpegxl/wrapper/decoder_jni.cc
@@ -90,7 +90,7 @@ jxl::Status DoDecode(JNIEnv* env, jobject data_buffer, size_t* info_pixels_size,
 
   JxlDecoder* dec = JxlDecoderCreate(NULL);
 
-  constexpr size_t kNumThreads = 0;  // Do everyting in this thread.
+  constexpr size_t kNumThreads = 0;  // Do everything in this thread.
   void* runner = JxlThreadParallelRunnerCreate(NULL, kNumThreads);
 
   struct Defer {


### PR DESCRIPTION
The proccess was manually supervised, so there's no need to worry that meaningful code has been corrupted. There still might be some other typos not detected by [`codespell`](https://github.com/codespell-project/codespell), so watch out.