### PR TITLE
Dissable ci.sh ossfuzz_ninja for msan.

### DIFF
--- a/ci.sh
+++ b/ci.sh
@@ -802,6 +802,11 @@ cmd_ossfuzz_ninja() {
   [[ -e "${BUILD_DIR}/build.ninja" ]]
   local real_build_dir=$(realpath "${BUILD_DIR}")
 
+  if [[ -e "${BUILD_DIR}/msan" ]]; then
+    echo "ossfuzz_ninja doesn't work with msan builds. Use ossfuzz_msan." >&2
+    exit 1
+  fi
+
   sudo docker run --rm -i \
     --user $(id -u):$(id -g) \
     -v "${MYDIR}":/src/libjxl \


### PR DESCRIPTION
Calling ninja directly doesn't work in the msan case because the
msan libraries need to be copied to the docker container every time.
Disable this option since there's otherwise no indication that
ninja built with the non-instrumented std libraries.