### PR TITLE
Improve failure reporting in djxl

### DIFF
--- a/tools/djxl.cc
+++ b/tools/djxl.cc
@@ -267,12 +267,16 @@ jxl::Status WriteJxlOutput(const DecompressArgs& args, const char* file_out,
   if (args.bits_per_sample != 0) bits_per_sample = args.bits_per_sample;
 
   if (args.tone_map) {
-    JXL_RETURN_IF_ERROR(jxl::ToneMapTo(args.display_nits, &io, pool));
+    jxl::Status status = jxl::ToneMapTo(args.display_nits, &io, pool);
+    if (!status) fprintf(stderr, "Failed to map tones.\n");
+    JXL_RETURN_IF_ERROR(status);
     if (c_out.tf.IsPQ() && args.color_space.empty()) {
       // Prevent writing the tone-mapped image to PQ output unless explicitly
       // requested. The result would look even dimmer than it would have without
       // tone mapping.
       c_out.tf.SetTransferFunction(jxl::TransferFunction::kSRGB);
+      status = c_out.CreateICC();
+      if (!status) fprintf(stderr, "Failed to create ICC\n");
       JXL_RETURN_IF_ERROR(c_out.CreateICC());
     }
   }

--- a/tools/djxl_main.cc
+++ b/tools/djxl_main.cc
@@ -67,7 +67,10 @@ int DecompressMain(int argc, const char* argv[]) {
   }
 
   jxl::PaddedBytes compressed;
-  if (!jxl::ReadFile(args.file_in, &compressed)) return 1;
+  if (!jxl::ReadFile(args.file_in, &compressed)) {
+    fprintf(stderr, "Failed to read file: %s.\n", args.file_in);
+    return 1;
+  }
   if (!args.quiet) {
     fprintf(stderr, "Read %zu compressed bytes.\n", compressed.size());
   }
@@ -173,11 +176,15 @@ int DecompressMain(int argc, const char* argv[]) {
               jxl::Span<const uint8_t>(container.codestream,
                                        container.codestream_size),
               args.params, &pool, &io, &stats)) {
+        // Error is already reported by DecompressJxlToPixels.
         return 1;
       }
     }
     if (!args.quiet) fprintf(stderr, "Decoded to pixels.\n");
-    if (!WriteJxlOutput(args, args.file_out, io, &pool)) return 1;
+    if (!WriteJxlOutput(args, args.file_out, io, &pool)) {
+      // Error is already reported by WriteJxlOutput.
+      return 1;
+    }
 
     if (args.print_read_bytes) {
       fprintf(stderr, "Decoded bytes: %zu\n", io.Main().decoded_bytes());


### PR DESCRIPTION
Whenever return code is not 0, user should be informed why.

Fixes #265.