### PR TITLE
Use the correct CustomTransformData

### DIFF
--- a/lib/jxl/dec_file.cc
+++ b/lib/jxl/dec_file.cc
@@ -65,8 +65,7 @@ Status DecodePreview(const DecompressParams& dparams,
   // Else: default or kOn => decode preview.
   PassesDecoderState dec_state;
   JXL_RETURN_IF_ERROR(dec_state.output_encoding_info.Set(
-      metadata.m,
-      ColorEncoding::LinearSRGB(metadata.m.color_encoding.IsGray())));
+      metadata, ColorEncoding::LinearSRGB(metadata.m.color_encoding.IsGray())));
   JXL_RETURN_IF_ERROR(DecodeFrame(dparams, &dec_state, pool, reader, preview,
                                   metadata, constraints,
                                   /*is_preview=*/true));
@@ -137,7 +136,7 @@ Status DecodeFile(const DecompressParams& dparams,
 
     PassesDecoderState dec_state;
     JXL_RETURN_IF_ERROR(dec_state.output_encoding_info.Set(
-        io->metadata.m,
+        io->metadata,
         ColorEncoding::LinearSRGB(io->metadata.m.color_encoding.IsGray())));
 
     io->frames.clear();

--- a/lib/jxl/dec_xyb.cc
+++ b/lib/jxl/dec_xyb.cc
@@ -197,14 +197,14 @@ void OpsinParams::Init(float intensity_target) {
   }
 }
 
-Status OutputEncodingInfo::Set(const ImageMetadata& metadata,
+Status OutputEncodingInfo::Set(const CodecMetadata& metadata,
                                const ColorEncoding& default_enc) {
   const auto& im = metadata.transform_data.opsin_inverse_matrix;
   float inverse_matrix[9];
   memcpy(inverse_matrix, im.inverse_matrix, sizeof(inverse_matrix));
-  float intensity_target = metadata.IntensityTarget();
-  if (metadata.xyb_encoded) {
-    const auto& orig_color_encoding = metadata.color_encoding;
+  float intensity_target = metadata.m.IntensityTarget();
+  if (metadata.m.xyb_encoded) {
+    const auto& orig_color_encoding = metadata.m.color_encoding;
     color_encoding = default_enc;
     // Figure out if we can output to this color encoding.
     do {
@@ -262,7 +262,7 @@ Status OutputEncodingInfo::Set(const ImageMetadata& metadata,
       }
     } while (false);
   } else {
-    color_encoding = metadata.color_encoding;
+    color_encoding = metadata.m.color_encoding;
   }
   if (std::abs(intensity_target - 255.0) > 0.1f || !im.all_default) {
     all_default_opsin = false;

--- a/lib/jxl/dec_xyb.h
+++ b/lib/jxl/dec_xyb.h
@@ -38,7 +38,7 @@ struct OutputEncodingInfo {
   // default_enc is used for xyb encoded image with ICC profile, in other
   // cases it has no effect. Use linear sRGB or grayscale if ICC profile is
   // not matched (not parsed or no matching ColorEncoding exists)
-  Status Set(const ImageMetadata& metadata, const ColorEncoding& default_enc);
+  Status Set(const CodecMetadata& metadata, const ColorEncoding& default_enc);
   bool all_default_opsin = true;
   bool color_encoding_is_original = false;
 };

--- a/lib/jxl/decode.cc
+++ b/lib/jxl/decode.cc
@@ -858,7 +858,7 @@ JxlDecoderStatus JxlDecoderReadAllHeaders(JxlDecoder* dec, const uint8_t* in,
       ColorEncoding::LinearSRGB(dec->metadata.m.color_encoding.IsGray());
 
   JXL_API_RETURN_IF_ERROR(dec->passes_state->output_encoding_info.Set(
-      dec->metadata.m, dec->default_enc));
+      dec->metadata, dec->default_enc));
 
   return JXL_DEC_SUCCESS;
 }
@@ -1055,7 +1055,7 @@ JxlDecoderStatus JxlDecoderProcessInternal(JxlDecoder* dec, const uint8_t* in,
       jxl::ImageBundle ib(&dec->metadata.m);
       PassesDecoderState preview_dec_state;
       JXL_API_RETURN_IF_ERROR(preview_dec_state.output_encoding_info.Set(
-          dec->metadata.m,
+          dec->metadata,
           ColorEncoding::LinearSRGB(dec->metadata.m.color_encoding.IsGray())));
       if (!DecodeFrame(dparams, &preview_dec_state, dec->thread_pool.get(),
                        reader.get(), &ib, dec->metadata,
@@ -2179,7 +2179,7 @@ JxlDecoderStatus JxlDecoderSetPreferredColorProfile(
   JXL_API_RETURN_IF_ERROR(ConvertExternalToInternalColorEncoding(
       *color_encoding, &dec->default_enc));
   JXL_API_RETURN_IF_ERROR(dec->passes_state->output_encoding_info.Set(
-      dec->metadata.m, dec->default_enc));
+      dec->metadata, dec->default_enc));
   return JXL_DEC_SUCCESS;
 }
 

--- a/lib/jxl/enc_adaptive_quantization.cc
+++ b/lib/jxl/enc_adaptive_quantization.cc
@@ -979,7 +979,7 @@ ImageBundle RoundtripImage(const Image3F& opsin, PassesEncoderState* enc_state,
   std::unique_ptr<PassesDecoderState> dec_state =
       jxl::make_unique<PassesDecoderState>();
   JXL_CHECK(dec_state->output_encoding_info.Set(
-      enc_state->shared.metadata->m,
+      *enc_state->shared.metadata,
       ColorEncoding::LinearSRGB(
           enc_state->shared.metadata->m.color_encoding.IsGray())));
   dec_state->shared = &enc_state->shared;

--- a/lib/jxl/enc_cache.cc
+++ b/lib/jxl/enc_cache.cc
@@ -145,7 +145,7 @@ void InitializePassesEncoder(const Image3F& opsin, ThreadPool* pool,
     std::unique_ptr<PassesDecoderState> dec_state =
         jxl::make_unique<PassesDecoderState>();
     JXL_CHECK(dec_state->output_encoding_info.Set(
-        shared.metadata->m,
+        *shared.metadata,
         ColorEncoding::LinearSRGB(shared.metadata->m.color_encoding.IsGray())));
     JXL_CHECK(DecodeFrame({}, dec_state.get(), pool, &br, &decoded,
                           *shared.metadata, /*constraints=*/nullptr));

--- a/lib/jxl/enc_patch_dictionary.cc
+++ b/lib/jxl/enc_patch_dictionary.cc
@@ -813,7 +813,7 @@ void FindBestPatchDictionary(const Image3F& opsin,
     ImageBundle decoded(&state->shared.metadata->m);
     PassesDecoderState dec_state;
     JXL_CHECK(dec_state.output_encoding_info.Set(
-        state->shared.metadata->m,
+        *state->shared.metadata,
         ColorEncoding::LinearSRGB(
             state->shared.metadata->m.color_encoding.IsGray())));
     JXL_CHECK(DecodeFrame({}, &dec_state, pool, &br, &decoded,

--- a/lib/jxl/image_metadata.h
+++ b/lib/jxl/image_metadata.h
@@ -340,8 +340,6 @@ struct ImageMetadata : public Fields {
   uint32_t num_extra_channels;
   std::vector<ExtraChannelInfo> extra_channel_info;
 
-  CustomTransformData transform_data;  // often default
-
   // Only present if m.have_preview.
   PreviewHeader preview_size;
   // Only present if m.have_animation.


### PR DESCRIPTION
There were two independent copies of CustomTransformData in CodecMetadata:
one directly in CodecMetadata, the other in ImageMetadata (which is the
field m of CodecMetadata)

The one being saved in the file was the one from CodecMetadata, the one
used while decoding was instead the one from the ImageMetadata.

So it ignored the opsin inverse matrix from the jxl file, due to using
the other, default initialized, one for the actual decoding.

This removes the copy from ImageMetadata, so there's only one copy
left that's both saved and used.