### PR TITLE
PNG: try to preserve the original color tags when writing

### DIFF
--- a/lib/extras/codec_png.cc
+++ b/lib/extras/codec_png.cc
@@ -510,7 +510,9 @@ class ColorEncodingWriterPNG {
     if (c.IsSRGB()) {
       JXL_RETURN_IF_ERROR(AddSRGB(c, info));
       // PNG recommends not including both sRGB and iCCP, so skip the latter.
-    } else {
+    } else if (!c.HaveFields() || !c.tf.IsGamma()) {
+      // Having a gamma value means that the source was a PNG with gAMA and
+      // without iCCP.
       JXL_ASSERT(!c.ICC().empty());
       JXL_RETURN_IF_ERROR(AddICC(c.ICC(), info));
     }

--- a/lib/include/jxl/color_encoding.h
+++ b/lib/include/jxl/color_encoding.h
@@ -127,7 +127,7 @@ typedef struct {
   /** Numerical blue primary values in CIE xy space. */
   double primaries_blue_xy[2];
 
-  /** Transfer function is have_gamma is 0 */
+  /** Transfer function if have_gamma is 0 */
   JxlTransferFunction transfer_function;
 
   /** Gamma value used when transfer_function is JXL_TRANSFER_FUNCTION_GAMMA


### PR DESCRIPTION
Currently, we are quick to convert the color information to an ICC profile (https://github.com/libjxl/libjxl/issues/266#issuecomment-873052852), which means that when decoding to PNG (with iCCP and gAMA), reencoding to JXL (reading iCCP but ignoring gAMA), and decoding to PNG again (writing iCCP only), the final PNG does not have the original gAMA tag, although it does have a functionally equivalent ICC profile. With this, its set of tags is closer to the original’s.

Because we recognized the sRGB primaries, we also used not to write them back, but now we do. We also include the recommended gAMA chunk for sRGB images.