### PR TITLE
Less ringing, more fidelity through 'info loss'

### DIFF
--- a/lib/jxl/enc_ac_strategy.h
+++ b/lib/jxl/enc_ac_strategy.h
@@ -31,6 +31,7 @@ namespace jxl {
 struct ACSConfig {
   const DequantMatrices* JXL_RESTRICT dequant;
   float info_loss_multiplier;
+  float info_loss_multiplier2;
   float* JXL_RESTRICT quant_field_row;
   size_t quant_field_stride;
   float* JXL_RESTRICT masking_field_row;

--- a/lib/jxl/enc_adaptive_quantization.cc
+++ b/lib/jxl/enc_adaptive_quantization.cc
@@ -665,7 +665,7 @@ ImageF TileDistMap(const ImageF& distmap, int tile_size, int margin,
 
 constexpr float kDcQuantPow = 0.57f;
 static const float kDcQuant = 1.12f;
-static const float kAcQuant = 0.7962f;
+static const float kAcQuant = 0.785f;
 
 void FindBestQuantization(const ImageBundle& linear, const Image3F& opsin,
                           PassesEncoderState* enc_state, ThreadPool* pool,


### PR DESCRIPTION
Adding some rms-optimization instead of only L1 optimization to
EstimateEntropy. Looks better with less ringing, although it is
a subtle change.

Max butteraugli reduced by 2.4 %.

Some more 'fidelity' in complex textures is likely the largest
outcome of this change.

Before:

```
Compr                 Input    Compr            Compr       Compr  Decomp  Butteraugli
Method               Pixels     Size              BPP   #    MP/s    MP/s     Distance    Error p norm   PSNR   QABPP     DCT2     DCT4   DCT4X8      AFV     DCT8  DCT8X16  DCT8X32    DCT16 DCT16X32    DCT32           BPP*pnorm   Errors
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
jxl:d0.8:epf0      17972865  3938627    1.75314375310   1   2.428  14.443   1.66095710   0.52341222757  41.74   2.110 0.000000 0.000911 0.152849 0.023954 0.052993 0.305185 0.000000 0.373797 0.034184 0.055607  0.9176168770590523        0
jxl:d1:epf1        17972865  3441522    1.53187463434   1   2.643  20.381   1.94606876   0.60624489804  40.64   2.135 0.000000 0.000911 0.147176 0.024545 0.052028 0.256194 0.000000 0.355465 0.069794 0.093609  0.9286911815032116        0
jxl:d2:epf3        17972865  2238762    0.99650756849   1   2.915  16.920   3.37106371   0.95334310646  37.48   2.247 0.000000 0.001139 0.124408 0.024880 0.046395 0.175980 0.000000 0.240633 0.207673 0.179413  0.9500136209566554        0
jxl:d3:epf0        17972865  1675002    0.74556927902   1   2.802  26.319   4.78873014   1.27878290743  35.23   2.301 0.000000 0.001139 0.103455 0.023345 0.041189 0.147272 0.000000 0.178217 0.287238 0.220378  0.9534212503186429        0
jxl:d4:epf3        17972865  1389724    0.61858763197   1   2.473  15.185   6.68818378   1.55791994726  34.09   2.413 0.000000 0.001367 0.083393 0.020849 0.034038 0.126882 0.000000 0.150313 0.338430 0.248125  0.9637100109673358        0
jxl:d8:epf1        17972865   819469    0.36475831761   1   2.823  23.451   9.81508255   2.49598885141  30.91   2.445 0.000000 0.001367 0.042157 0.013097 0.017345 0.087605 0.000000 0.101543 0.420587 0.322249  0.9104326942103894        0
jxl:d16:epf3       17972865   475382    0.21159987570   1   2.913  14.948  21.55410767   4.43764938689  28.60   2.662 0.000000 0.001367 0.010914 0.004073 0.003400 0.045359 0.000000 0.057302 0.411300 0.473745  0.9390060586722138        0
jxl:d24:epf3       17972865   358905    0.15975416273   1   2.650  14.568  21.84295654   5.79752265386  27.33   2.701 0.000000 0.002279 0.004817 0.001773 0.001520 0.031037 0.000000 0.039398 0.370706 0.556415  0.9261783774967229        0
jxl:d32:epf3       17972865   292769    0.13031600694   1   2.855  13.724  24.38763618   7.02597362337  26.51   2.656 0.000000 0.030994 0.002268 0.000911 0.000779 0.023836 0.000000 0.028345 0.324129 0.596810  0.9155968274353588        0
Aggregate:         17972865  1125217    0.50085154394 ---   2.717  17.310   6.98003295   1.86419771836  33.19   2.398 0.000000 0.001796 0.036721 0.009472 0.013244 0.096938 0.000000 0.121013 0.215471 0.239461  0.9336863054495367        0
```

After:

```
Compr                 Input    Compr            Compr       Compr  Decomp  Butteraugli
Method               Pixels     Size              BPP   #    MP/s    MP/s     Distance    Error p norm   PSNR   QABPP     DCT2     DCT4   DCT4X8      AFV     DCT8  DCT8X16  DCT8X32    DCT16 DCT16X32    DCT32           BPP*pnorm   Errors
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
jxl:d0.8:epf0      17972865  3952043    1.75911542205   1   2.375  13.973   1.57893729   0.52330958503  41.73   2.121 0.000000 0.000911 0.203567 0.020553 0.049902 0.230698 0.000000 0.408836 0.017035 0.068597  0.9205619615324337        0
jxl:d1:epf1        17972865  3450570    1.53590203899   1   2.818  21.209   1.94662952   0.60612205767  40.65   2.128 0.000000 0.000911 0.192140 0.020753 0.049001 0.201234 0.000000 0.396715 0.028686 0.110872  0.9309441042592400        0
jxl:d2:epf3        17972865  2246256    0.99984326372   1   2.663  16.431   3.41899276   0.95125633921  37.50   2.256 0.000000 0.001139 0.159970 0.021308 0.044515 0.151339 0.000000 0.301154 0.098338 0.223284  0.9511072428334978        0
jxl:d3:epf0        17972865  1680140    0.74785628223   1   2.757  25.813   4.57588768   1.27704026411  35.28   2.324 0.000000 0.001139 0.134923 0.020033 0.041385 0.134367 0.000000 0.233724 0.175026 0.261970  0.9550425841796468        0
jxl:d4:epf3        17972865  1390103    0.61875633072   1   2.706  15.349   5.85040092   1.56284952646  34.11   2.425 0.000000 0.001139 0.111054 0.018039 0.034800 0.120786 0.000000 0.200152 0.228554 0.289147  0.9670230384675962        0
jxl:d8:epf1        17972865   813211    0.36197278508   1   2.585  23.483   9.37444782   2.51584719998  30.89   2.406 0.000000 0.001367 0.058484 0.011665 0.018783 0.088738 0.000000 0.132865 0.326921 0.367145  0.9106682178227494        0
jxl:d16:epf3       17972865   475322    0.21157316877   1   2.825  14.337  21.55422401   4.42386021454  28.62   2.641 0.000000 0.001367 0.016729 0.003927 0.003998 0.049290 0.000000 0.072942 0.332077 0.527130  0.9359701238049873        0
jxl:d24:epf3       17972865   358029    0.15936424159   1   2.892  14.181  21.47615433   5.77418376695  27.34   2.649 0.000000 0.001367 0.007673 0.001791 0.001741 0.033907 0.000000 0.051647 0.293705 0.616068  0.9201984168450851        0
jxl:d32:epf3       17972865   292046    0.12999418846   1   2.638  13.756  25.84580421   7.02234695199  26.51   2.668 0.000000 0.016636 0.003781 0.000897 0.000957 0.026137 0.000000 0.036677 0.250632 0.672359  0.9128642931176300        0
Aggregate:         17972865  1125217    0.50085125627 ---   2.691  17.125   6.81123365   1.86408749564  33.21   2.393 0.000000 0.001552 0.051750 0.008541 0.013921 0.091328 0.000000 0.151461 0.135466 0.279207  0.9336305639835538        0
```