### PR TITLE
Tuning heuristics manually to have less ringing

### DIFF
--- a/lib/jxl/enc_ac_strategy.cc
+++ b/lib/jxl/enc_ac_strategy.cc
@@ -706,6 +706,7 @@ void FindBest16X16(size_t bx, size_t by, size_t cx, size_t cy,
   }
 }
 
+<<<<<<< HEAD
 static void SetEntropyForTransform(size_t cx, size_t cy,
                                    const AcStrategy::Type acs_raw,
                                    float entropy,
@@ -719,6 +720,8 @@ static void SetEntropyForTransform(size_t cx, size_t cy,
   entropy_estimate[cy * 8 + cx] = entropy;
 }
 
+=======
+>>>>>>> 9d88f3a (more balanced 16x32, 32x16 and 32x32 decisions)
 // The following function tries to merge 8x8 transforms into
 // 32X16 and 16X32 DCTs fairly, by trying them and their combinations
 // with best 16x16 (including the best 16X16 subdivision because of
@@ -726,7 +729,10 @@ static void SetEntropyForTransform(size_t cx, size_t cy,
 //
 // TODO(jyrki):
 // This idea could be generalized to larger transforms.
+<<<<<<< HEAD
 // Reduce code duplication within the generalized function,
+=======
+>>>>>>> 9d88f3a (more balanced 16x32, 32x16 and 32x32 decisions)
 void FindBest32X32(size_t bx, size_t by, size_t cx, size_t cy,
                    const ACSConfig& config,
                    const float* JXL_RESTRICT cmap_factors,
@@ -744,11 +750,20 @@ void FindBest32X32(size_t bx, size_t by, size_t cx, size_t cy,
   const AcStrategy acs32X32 = AcStrategy::FromRawStrategy(acs_raw32X32);
   AcStrategyRow row0 = ac_strategy->ConstRow(by + cy + 0);
   AcStrategyRow row1 = ac_strategy->ConstRow(by + cy + 2);
+<<<<<<< HEAD
   // Let's check if we can consider a 32X32 block here at all.
   // This is not necessary in the basic use of hierarchically merging
   // blocks in the simplest possible way, but is needed when we try other
   // 'floating' options of merging, possibly after a simple hierarchical
   // merge has been explored.
+=======
+  {
+    bool has32X32 = row0[bx + cx + 0].RawStrategy() == acs_raw32X32;
+    if (has32X32) {
+      return;
+    }
+  }
+>>>>>>> 9d88f3a (more balanced 16x32, 32x16 and 32x32 decisions)
   if (MultiBlockTransformCrossesHorizontalBoundary(*ac_strategy, bx + cx,
                                                    by + cy, bx + cx + 4) ||
       MultiBlockTransformCrossesHorizontalBoundary(*ac_strategy, bx + cx,
@@ -759,9 +774,12 @@ void FindBest32X32(size_t bx, size_t by, size_t cx, size_t cy,
                                                  by + cy, by + cy + 4)) {
     return;  // not suitable for 32x32 analysis, some transforms leak out.
   }
+<<<<<<< HEAD
   // For floating transforms there may be
   // already blocks selected that make either or both 32X16 and
   // 16X32 not feasible for this location.
+=======
+>>>>>>> 9d88f3a (more balanced 16x32, 32x16 and 32x32 decisions)
   const bool allow_32X16 = !MultiBlockTransformCrossesVerticalBoundary(
       *ac_strategy, bx + cx + 2, by + cy, by + cy + 4);
   const bool allow_16X32 = !MultiBlockTransformCrossesHorizontalBoundary(
@@ -773,6 +791,7 @@ void FindBest32X32(size_t bx, size_t by, size_t cx, size_t cy,
       entropy[dy >> 1][dx >> 1] += entropy_estimate[(cy + dy) * 8 + (cx + dx)];
     }
   }
+<<<<<<< HEAD
   float entropy_estimate_32X16_left = std::numeric_limits<float>::max();
   float entropy_estimate_32X16_right = std::numeric_limits<float>::max();
   float entropy_estimate_16X32_top = std::numeric_limits<float>::max();
@@ -780,12 +799,25 @@ void FindBest32X32(size_t bx, size_t by, size_t cx, size_t cy,
   if (allow_32X16) {
     if (row0[bx + cx + 0].RawStrategy() != acs_raw32X16) {
       entropy_estimate_32X16_left =
+=======
+  float try32X16_0 = std::numeric_limits<float>::max();
+  float try32X16_1 = std::numeric_limits<float>::max();
+  float try16X32_0 = std::numeric_limits<float>::max();
+  float try16X32_1 = std::numeric_limits<float>::max();
+  if (allow_32X16) {
+    if (row0[bx + cx + 0].RawStrategy() != acs_raw32X16) {
+      try32X16_0 =
+>>>>>>> 9d88f3a (more balanced 16x32, 32x16 and 32x32 decisions)
           entropy_mul * EstimateEntropy(acs32X16, (bx + cx + 0) * 8,
                                         (by + cy + 0) * 8, config, cmap_factors,
                                         block, scratch_space, quantized);
     }
     if (row0[bx + cx + 2].RawStrategy() != acs_raw32X16) {
+<<<<<<< HEAD
       entropy_estimate_32X16_right =
+=======
+      try32X16_1 =
+>>>>>>> 9d88f3a (more balanced 16x32, 32x16 and 32x32 decisions)
           entropy_mul * EstimateEntropy(acs32X16, (bx + cx + 2) * 8,
                                         (by + cy + 0) * 8, config, cmap_factors,
                                         block, scratch_space, quantized);
@@ -793,25 +825,38 @@ void FindBest32X32(size_t bx, size_t by, size_t cx, size_t cy,
   }
   if (allow_16X32) {
     if (row0[bx + cx].RawStrategy() != acs_raw16X32) {
+<<<<<<< HEAD
       entropy_estimate_16X32_top =
+=======
+      try16X32_0 =
+>>>>>>> 9d88f3a (more balanced 16x32, 32x16 and 32x32 decisions)
           entropy_mul * EstimateEntropy(acs16X32, (bx + cx + 0) * 8,
                                         (by + cy + 0) * 8, config, cmap_factors,
                                         block, scratch_space, quantized);
     }
     if (row1[bx + cx].RawStrategy() != acs_raw16X32) {
+<<<<<<< HEAD
       entropy_estimate_16X32_bottom =
+=======
+      try16X32_1 =
+>>>>>>> 9d88f3a (more balanced 16x32, 32x16 and 32x32 decisions)
           entropy_mul * EstimateEntropy(acs16X32, (bx + cx + 0) * 8,
                                         (by + cy + 2) * 8, config, cmap_factors,
                                         block, scratch_space, quantized);
     }
   }
+<<<<<<< HEAD
   float entropy_estimate_32X32 =
+=======
+  float try32X32 =
+>>>>>>> 9d88f3a (more balanced 16x32, 32x16 and 32x32 decisions)
       entropy_mul_32X32 *
       EstimateEntropy(acs32X32, (bx + cx + 0) * 8, (by + cy + 0) * 8, config,
                       cmap_factors, block, scratch_space, quantized);
 
   // Test if this block should have 32X16 or 16X32 transforms,
   // because it can have only one or the other.
+<<<<<<< HEAD
   float cost32x16 =
       std::min(entropy_estimate_32X16_left, entropy[0][0] + entropy[1][0]) +
       std::min(entropy_estimate_32X16_right, entropy[0][1] + entropy[1][1]);
@@ -844,6 +889,57 @@ void FindBest32X32(size_t bx, size_t by, size_t cx, size_t cy,
       ac_strategy->Set(bx + cx, by + cy + 2, acs_raw16X32);
       SetEntropyForTransform(cx, cy + 2, acs_raw16X32,
                              entropy_estimate_16X32_bottom, entropy_estimate);
+=======
+  float cost32x16 = std::min(try32X16_0, entropy[0][0] + entropy[1][0]) +
+                    std::min(try32X16_1, entropy[0][1] + entropy[1][1]);
+  float cost16x32 = std::min(try16X32_0, entropy[0][0] + entropy[0][1]) +
+                    std::min(try16X32_1, entropy[1][0] + entropy[1][1]);
+  if (try32X32 < cost32x16 && try32X32 < cost16x32) {
+    for (size_t dy = 0; dy < 4; ++dy) {
+      for (size_t dx = 0; dx < 4; ++dx) {
+        entropy_estimate[(cy + dy) * 8 + cx + dx] = 0;
+      }
+    }
+    ac_strategy->Set(bx + cx, by + cy, acs_raw32X32);
+    entropy_estimate[(cy + 0) * 8 + cx + 0] = try32X32;
+  } else if (cost32x16 < cost16x32) {
+    if (try32X16_0 < entropy[0][0] + entropy[1][0]) {
+      for (size_t dy = 0; dy < 4; ++dy) {
+        for (size_t dx = 0; dx < 2; ++dx) {
+          entropy_estimate[(cy + dy) * 8 + cx + dx] = 0;
+        }
+      }
+      ac_strategy->Set(bx + cx, by + cy, acs_raw32X16);
+      entropy_estimate[(cy + 0) * 8 + cx + 0] = try32X16_0;
+    }
+    if (try32X16_1 < entropy[0][1] + entropy[1][1]) {
+      for (size_t dy = 0; dy < 4; ++dy) {
+        for (size_t dx = 2; dx < 4; ++dx) {
+          entropy_estimate[(cy + dy) * 8 + cx + dx] = 0;
+        }
+      }
+      ac_strategy->Set(bx + cx + 2, by + cy, acs_raw32X16);
+      entropy_estimate[(cy + 0) * 8 + cx + 2] = try32X16_1;
+    }
+  } else {
+    if (try16X32_0 < entropy[0][0] + entropy[0][1]) {
+      for (size_t dy = 0; dy < 2; ++dy) {
+        for (size_t dx = 0; dx < 4; ++dx) {
+          entropy_estimate[(cy + dy) * 8 + cx + dx] = 0;
+        }
+      }
+      ac_strategy->Set(bx + cx, by + cy, acs_raw16X32);
+      entropy_estimate[(cy + 0) * 8 + cx + 0] = try16X32_0;
+    }
+    if (try16X32_1 < entropy[1][0] + entropy[1][1]) {
+      for (size_t dy = 2; dy < 4; ++dy) {
+        for (size_t dx = 0; dx < 4; ++dx) {
+          entropy_estimate[(cy + dy) * 8 + cx + dx] = 0;
+        }
+      }
+      ac_strategy->Set(bx + cx, by + cy + 2, acs_raw16X32);
+      entropy_estimate[(cy + 2) * 8 + cx + 0] = try16X32_1;
+>>>>>>> 9d88f3a (more balanced 16x32, 32x16 and 32x32 decisions)
     }
   }
 }

--- a/lib/jxl/enc_ac_strategy.cc
+++ b/lib/jxl/enc_ac_strategy.cc
@@ -706,7 +706,6 @@ void FindBest16X16(size_t bx, size_t by, size_t cx, size_t cy,
   }
 }
 
-<<<<<<< HEAD
 static void SetEntropyForTransform(size_t cx, size_t cy,
                                    const AcStrategy::Type acs_raw,
                                    float entropy,
@@ -720,8 +719,6 @@ static void SetEntropyForTransform(size_t cx, size_t cy,
   entropy_estimate[cy * 8 + cx] = entropy;
 }
 
-=======
->>>>>>> 9d88f3a (more balanced 16x32, 32x16 and 32x32 decisions)
 // The following function tries to merge 8x8 transforms into
 // 32X16 and 16X32 DCTs fairly, by trying them and their combinations
 // with best 16x16 (including the best 16X16 subdivision because of
@@ -729,10 +726,6 @@ static void SetEntropyForTransform(size_t cx, size_t cy,
 //
 // TODO(jyrki):
 // This idea could be generalized to larger transforms.
-<<<<<<< HEAD
-// Reduce code duplication within the generalized function,
-=======
->>>>>>> 9d88f3a (more balanced 16x32, 32x16 and 32x32 decisions)
 void FindBest32X32(size_t bx, size_t by, size_t cx, size_t cy,
                    const ACSConfig& config,
                    const float* JXL_RESTRICT cmap_factors,
@@ -750,20 +743,11 @@ void FindBest32X32(size_t bx, size_t by, size_t cx, size_t cy,
   const AcStrategy acs32X32 = AcStrategy::FromRawStrategy(acs_raw32X32);
   AcStrategyRow row0 = ac_strategy->ConstRow(by + cy + 0);
   AcStrategyRow row1 = ac_strategy->ConstRow(by + cy + 2);
-<<<<<<< HEAD
   // Let's check if we can consider a 32X32 block here at all.
   // This is not necessary in the basic use of hierarchically merging
   // blocks in the simplest possible way, but is needed when we try other
   // 'floating' options of merging, possibly after a simple hierarchical
   // merge has been explored.
-=======
-  {
-    bool has32X32 = row0[bx + cx + 0].RawStrategy() == acs_raw32X32;
-    if (has32X32) {
-      return;
-    }
-  }
->>>>>>> 9d88f3a (more balanced 16x32, 32x16 and 32x32 decisions)
   if (MultiBlockTransformCrossesHorizontalBoundary(*ac_strategy, bx + cx,
                                                    by + cy, bx + cx + 4) ||
       MultiBlockTransformCrossesHorizontalBoundary(*ac_strategy, bx + cx,
@@ -774,12 +758,9 @@ void FindBest32X32(size_t bx, size_t by, size_t cx, size_t cy,
                                                  by + cy, by + cy + 4)) {
     return;  // not suitable for 32x32 analysis, some transforms leak out.
   }
-<<<<<<< HEAD
   // For floating transforms there may be
   // already blocks selected that make either or both 32X16 and
   // 16X32 not feasible for this location.
-=======
->>>>>>> 9d88f3a (more balanced 16x32, 32x16 and 32x32 decisions)
   const bool allow_32X16 = !MultiBlockTransformCrossesVerticalBoundary(
       *ac_strategy, bx + cx + 2, by + cy, by + cy + 4);
   const bool allow_16X32 = !MultiBlockTransformCrossesHorizontalBoundary(
@@ -791,7 +772,6 @@ void FindBest32X32(size_t bx, size_t by, size_t cx, size_t cy,
       entropy[dy >> 1][dx >> 1] += entropy_estimate[(cy + dy) * 8 + (cx + dx)];
     }
   }
-<<<<<<< HEAD
   float entropy_estimate_32X16_left = std::numeric_limits<float>::max();
   float entropy_estimate_32X16_right = std::numeric_limits<float>::max();
   float entropy_estimate_16X32_top = std::numeric_limits<float>::max();
@@ -799,25 +779,12 @@ void FindBest32X32(size_t bx, size_t by, size_t cx, size_t cy,
   if (allow_32X16) {
     if (row0[bx + cx + 0].RawStrategy() != acs_raw32X16) {
       entropy_estimate_32X16_left =
-=======
-  float try32X16_0 = std::numeric_limits<float>::max();
-  float try32X16_1 = std::numeric_limits<float>::max();
-  float try16X32_0 = std::numeric_limits<float>::max();
-  float try16X32_1 = std::numeric_limits<float>::max();
-  if (allow_32X16) {
-    if (row0[bx + cx + 0].RawStrategy() != acs_raw32X16) {
-      try32X16_0 =
->>>>>>> 9d88f3a (more balanced 16x32, 32x16 and 32x32 decisions)
           entropy_mul * EstimateEntropy(acs32X16, (bx + cx + 0) * 8,
                                         (by + cy + 0) * 8, config, cmap_factors,
                                         block, scratch_space, quantized);
     }
     if (row0[bx + cx + 2].RawStrategy() != acs_raw32X16) {
-<<<<<<< HEAD
       entropy_estimate_32X16_right =
-=======
-      try32X16_1 =
->>>>>>> 9d88f3a (more balanced 16x32, 32x16 and 32x32 decisions)
           entropy_mul * EstimateEntropy(acs32X16, (bx + cx + 2) * 8,
                                         (by + cy + 0) * 8, config, cmap_factors,
                                         block, scratch_space, quantized);
@@ -825,38 +792,25 @@ void FindBest32X32(size_t bx, size_t by, size_t cx, size_t cy,
   }
   if (allow_16X32) {
     if (row0[bx + cx].RawStrategy() != acs_raw16X32) {
-<<<<<<< HEAD
       entropy_estimate_16X32_top =
-=======
-      try16X32_0 =
->>>>>>> 9d88f3a (more balanced 16x32, 32x16 and 32x32 decisions)
           entropy_mul * EstimateEntropy(acs16X32, (bx + cx + 0) * 8,
                                         (by + cy + 0) * 8, config, cmap_factors,
                                         block, scratch_space, quantized);
     }
     if (row1[bx + cx].RawStrategy() != acs_raw16X32) {
-<<<<<<< HEAD
       entropy_estimate_16X32_bottom =
-=======
-      try16X32_1 =
->>>>>>> 9d88f3a (more balanced 16x32, 32x16 and 32x32 decisions)
           entropy_mul * EstimateEntropy(acs16X32, (bx + cx + 0) * 8,
                                         (by + cy + 2) * 8, config, cmap_factors,
                                         block, scratch_space, quantized);
     }
   }
-<<<<<<< HEAD
   float entropy_estimate_32X32 =
-=======
-  float try32X32 =
->>>>>>> 9d88f3a (more balanced 16x32, 32x16 and 32x32 decisions)
       entropy_mul_32X32 *
       EstimateEntropy(acs32X32, (bx + cx + 0) * 8, (by + cy + 0) * 8, config,
                       cmap_factors, block, scratch_space, quantized);
 
   // Test if this block should have 32X16 or 16X32 transforms,
   // because it can have only one or the other.
-<<<<<<< HEAD
   float cost32x16 =
       std::min(entropy_estimate_32X16_left, entropy[0][0] + entropy[1][0]) +
       std::min(entropy_estimate_32X16_right, entropy[0][1] + entropy[1][1]);
@@ -889,57 +843,6 @@ void FindBest32X32(size_t bx, size_t by, size_t cx, size_t cy,
       ac_strategy->Set(bx + cx, by + cy + 2, acs_raw16X32);
       SetEntropyForTransform(cx, cy + 2, acs_raw16X32,
                              entropy_estimate_16X32_bottom, entropy_estimate);
-=======
-  float cost32x16 = std::min(try32X16_0, entropy[0][0] + entropy[1][0]) +
-                    std::min(try32X16_1, entropy[0][1] + entropy[1][1]);
-  float cost16x32 = std::min(try16X32_0, entropy[0][0] + entropy[0][1]) +
-                    std::min(try16X32_1, entropy[1][0] + entropy[1][1]);
-  if (try32X32 < cost32x16 && try32X32 < cost16x32) {
-    for (size_t dy = 0; dy < 4; ++dy) {
-      for (size_t dx = 0; dx < 4; ++dx) {
-        entropy_estimate[(cy + dy) * 8 + cx + dx] = 0;
-      }
-    }
-    ac_strategy->Set(bx + cx, by + cy, acs_raw32X32);
-    entropy_estimate[(cy + 0) * 8 + cx + 0] = try32X32;
-  } else if (cost32x16 < cost16x32) {
-    if (try32X16_0 < entropy[0][0] + entropy[1][0]) {
-      for (size_t dy = 0; dy < 4; ++dy) {
-        for (size_t dx = 0; dx < 2; ++dx) {
-          entropy_estimate[(cy + dy) * 8 + cx + dx] = 0;
-        }
-      }
-      ac_strategy->Set(bx + cx, by + cy, acs_raw32X16);
-      entropy_estimate[(cy + 0) * 8 + cx + 0] = try32X16_0;
-    }
-    if (try32X16_1 < entropy[0][1] + entropy[1][1]) {
-      for (size_t dy = 0; dy < 4; ++dy) {
-        for (size_t dx = 2; dx < 4; ++dx) {
-          entropy_estimate[(cy + dy) * 8 + cx + dx] = 0;
-        }
-      }
-      ac_strategy->Set(bx + cx + 2, by + cy, acs_raw32X16);
-      entropy_estimate[(cy + 0) * 8 + cx + 2] = try32X16_1;
-    }
-  } else {
-    if (try16X32_0 < entropy[0][0] + entropy[0][1]) {
-      for (size_t dy = 0; dy < 2; ++dy) {
-        for (size_t dx = 0; dx < 4; ++dx) {
-          entropy_estimate[(cy + dy) * 8 + cx + dx] = 0;
-        }
-      }
-      ac_strategy->Set(bx + cx, by + cy, acs_raw16X32);
-      entropy_estimate[(cy + 0) * 8 + cx + 0] = try16X32_0;
-    }
-    if (try16X32_1 < entropy[1][0] + entropy[1][1]) {
-      for (size_t dy = 2; dy < 4; ++dy) {
-        for (size_t dx = 0; dx < 4; ++dx) {
-          entropy_estimate[(cy + dy) * 8 + cx + dx] = 0;
-        }
-      }
-      ac_strategy->Set(bx + cx, by + cy + 2, acs_raw16X32);
-      entropy_estimate[(cy + 2) * 8 + cx + 0] = try16X32_1;
->>>>>>> 9d88f3a (more balanced 16x32, 32x16 and 32x32 decisions)
     }
   }
 }
@@ -986,9 +889,9 @@ void ProcessRectACS(PassesEncoderState* JXL_RESTRICT enc_state,
   float entropy_estimate[64] = {};
   // Favor all 8x8 transforms (against 16x8 and larger transforms)) at
   // low butteraugli_target distances.
-  static const float k8x8mul1 = -0.38173536034815592f;
-  static const float k8x8mul2 = 1.0205692427138704f;
-  static const float k8x8base = 1.5789348369698299f;
+  static const float k8x8mul1 = -0.55;
+  static const float k8x8mul2 = 1.0735757687292623f;
+  static const float k8x8base = 1.4;
   const float mul8x8 = k8x8mul2 + k8x8mul1 / (butteraugli_target + k8x8base);
   for (size_t iy = 0; iy < rect.ysize(); iy++) {
     for (size_t ix = 0; ix < rect.xsize(); ix++) {
@@ -1011,21 +914,27 @@ void ProcessRectACS(PassesEncoderState* JXL_RESTRICT enc_state,
     uint8_t encoding_speed_tier_max_limit;
     float entropy_mul;
   };
-  static const float k8X16mul1 = -0.51923137374961237;
-  static const float k8X16mul2 = 0.9145;
-  static const float k8X16base = 1.6637730066379945f;
+  static const float k8X16mul1 = -0.55;
+  static const float k8X16mul2 = 0.9019587899705066;
+  static const float k8X16base = 1.6;
   const float entropy_mul16X8 =
       k8X16mul2 + k8X16mul1 / (butteraugli_target + k8X16base);
   //  const float entropy_mul16X8 = mul8X16 * 0.91195782912371126f;
 
-  static const float k16X16mul1 = -0.3255063063403677;
-  static const float k16X16mul2 = 0.8424362630789904748;
-  static const float k16X16base = 2.19008132121404f;
+  static const float k16X16mul1 = -0.35;
+  static const float k16X16mul2 = 0.82098067020252011;
+  static const float k16X16base = 2.0;
   const float entropy_mul16X16 =
       k16X16mul2 + k16X16mul1 / (butteraugli_target + k16X16base);
   //  const float entropy_mul16X16 = mul16X16 * 0.83183417727960129f;
 
-  const float entropy_mul32X32 = 0.9822994906548809f;
+  static const float k32X16mul1 = -0.1;
+  static const float k32X16mul2 = 0.86098067020252011;
+  static const float k32X16base = 2.5;
+  const float entropy_mul16X32 =
+      k32X16mul2 + k32X16mul1 / (butteraugli_target + k32X16base);
+
+  const float entropy_mul32X32 = 0.9188333021616017f;
   // TODO(jyrki): Consider this feedback in further changes:
   // Also effectively when the multipliers for smaller blocks are
   // below 1, this raises the bar for the bigger blocks even higher
@@ -1040,8 +949,8 @@ void ProcessRectACS(PassesEncoderState* JXL_RESTRICT enc_state,
       {AcStrategy::Type::DCT8X16, 2, 4, 5, entropy_mul16X8},
       // FindBest16X16 looks for DCT16X16 and its subdivisions.
       // {AcStrategy::Type::DCT16X16, 3, entropy_mul16X16},
-      {AcStrategy::Type::DCT16X32, 4, 4, 4, 0.90254513227338527f},
-      {AcStrategy::Type::DCT32X16, 4, 4, 4, 0.90254513227338527f},
+      {AcStrategy::Type::DCT16X32, 4, 4, 4, entropy_mul16X32},
+      {AcStrategy::Type::DCT32X16, 4, 4, 4, entropy_mul16X32},
       // FIndBest32X32 looks for DCT32X32 and its subdivisions.
       // {AcStrategy::Type::DCT32X32, 5, 1, 5, 0.9822994906548809f},
       // TODO(jyrki): re-enable 64x32 and 64x64 if/when possible.
@@ -1180,15 +1089,18 @@ void AcStrategyHeuristics::Init(const Image3F& src,
   // The following constant controls the relative weights of these components.
   config.info_loss_multiplier = 138.0f;
   config.info_loss_multiplier2 = 50.46839691767866;
-  config.base_entropy = 56.030596115736621f;
-  config.zeros_mul = 7.444405659772416f;
+  // TODO(jyrki): explore base_entropy setting more.
+  // A small value (0?) works better at high distance, while a larger value
+  // may be more effective at low distance/high bpp.
+  config.base_entropy = 0.0;
+  config.zeros_mul = 7.565053364251793f;
   // Lots of +1 and -1 coefficients at high quality, it is
   // beneficial to favor them. At low qualities zeros matter more
   // and +1 / -1 coefficients are already quite harmful.
   float slope = std::min<float>(1.0f, butteraugli_target * (1.0f / 3));
   config.cost1 = 1 + slope * 8.8703248061477744f;
-  config.cost2 = 4.4417860847109791f;
-  config.cost_delta = 6.1101822565620658f;
+  config.cost2 = 4.4628149885273363f;
+  config.cost_delta = 5.3359184934516337f;
   JXL_ASSERT(enc_state->shared.ac_strategy.xsize() ==
              enc_state->shared.frame_dim.xsize_blocks);
   JXL_ASSERT(enc_state->shared.ac_strategy.ysize() ==

--- a/lib/jxl/enc_ac_strategy.cc
+++ b/lib/jxl/enc_ac_strategy.cc
@@ -726,6 +726,7 @@ static void SetEntropyForTransform(size_t cx, size_t cy,
 //
 // TODO(jyrki):
 // This idea could be generalized to larger transforms.
+// Reduce code duplication.
 void FindBest32X32(size_t bx, size_t by, size_t cx, size_t cy,
                    const ACSConfig& config,
                    const float* JXL_RESTRICT cmap_factors,

--- a/lib/jxl/enc_adaptive_quantization.cc
+++ b/lib/jxl/enc_adaptive_quantization.cc
@@ -665,7 +665,7 @@ ImageF TileDistMap(const ImageF& distmap, int tile_size, int margin,
 
 constexpr float kDcQuantPow = 0.57f;
 static const float kDcQuant = 1.12f;
-static const float kAcQuant = 0.785f;
+static const float kAcQuant = 0.787f;
 
 void FindBestQuantization(const ImageBundle& linear, const Image3F& opsin,
                           PassesEncoderState* enc_state, ThreadPool* pool,


### PR DESCRIPTION
Significantly less ringing in d16-d32, some less ringing in lower
distances, too. All numbers are worse here, but manual viewing suggest an improvement.

This was a result of lot of trial and error, manual viewing, and some
simplex_fork.py optimization.

```
Compr                 Input    Compr            Compr       Compr  Decomp  Butteraugli
Method               Pixels     Size              BPP   #    MP/s    MP/s     Distance    Error p norm   PSNR   QABPP     DCT2     DCT4   DCT4X8      AFV     DCT8  DCT8X16  DCT8X32    DCT16 DCT16X32    DCT32           BPP*pnorm   Errors
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
jxl:d0.8:epf0      17972865  3951942    1.75907046539   1   2.324  13.807   1.57893729   0.52331089591  41.73   2.121 0.000000 0.000911 0.203567 0.020553 0.049902 0.230626 0.000000 0.408822 0.017234 0.068483  0.9205407412221729        0
jxl:d1:epf1        17972865  3450706    1.53596257469   1   2.538  20.125   1.94662952   0.60610525355  40.65   2.128 0.000000 0.000911 0.192140 0.020753 0.049001 0.201177 0.000000 0.396829 0.029199 0.110303  0.9309549857768020        0
jxl:d2:epf3        17972865  2246506    0.99995454258   1   2.826  16.524   3.41899276   0.95121670445  37.50   2.246 0.000000 0.001139 0.159978 0.021315 0.044529 0.151353 0.000000 0.301396 0.104035 0.217301  0.9511734645939139        0
jxl:d3:epf0        17972865  1679780    0.74769604067   1   2.780  24.514   4.76437998   1.27694160442  35.28   2.321 0.000000 0.001139 0.135008 0.020033 0.041445 0.134325 0.000000 0.233283 0.181521 0.255816  0.9547641817919317        0
jxl:d4:epf3        17972865  1390051    0.61873318472   1   2.398  14.544   5.85040092   1.56297457360  34.10   2.430 0.000000 0.001139 0.110922 0.018061 0.034779 0.120629 0.000000 0.198984 0.239920 0.279233  0.9670642355616933        0
jxl:d8:epf1        17972865   811812    0.36135006856   1   2.788  23.422   9.37444782   2.51424949430  30.89   2.407 0.000000 0.001367 0.058295 0.011626 0.018769 0.088538 0.000000 0.128891 0.354582 0.343899  0.9085242271468007        0
jxl:d16:epf3       17972865   475248    0.21154023023   1   2.836  13.781  19.64723206   4.41670512959  28.63   2.675 0.000000 0.001367 0.016718 0.003920 0.004023 0.048898 0.000000 0.067344 0.381702 0.483488  0.9343108199727461        0
jxl:d24:epf3       17972865   358126    0.15940741779   1   2.588  13.989  21.47615433   5.75762783145  27.36   2.626 0.000000 0.001367 0.007627 0.001805 0.001705 0.033558 0.000000 0.045195 0.354981 0.561657  0.9178085852275816        0
jxl:d32:epf3       17972865   292118    0.13002623677   1   2.796  14.169  25.83151817   6.98935655673  26.53   2.639 0.000000 0.016636 0.003810 0.000904 0.000961 0.026058 0.000000 0.031706 0.315754 0.612251  0.9087997305448716        0
Aggregate:         17972865  1125031    0.50076852951 ---   2.646  16.767   6.77137520   1.86203845214  33.21   2.391 0.000000 0.001552 0.051733 0.008552 0.013905 0.091067 0.000000 0.144941 0.148250 0.266164  0.9324502575761613        0
```

```
Compr                 Input    Compr            Compr       Compr  Decomp  Butteraugli
Method               Pixels     Size              BPP   #    MP/s    MP/s     Distance    Error p norm   PSNR   QABPP     DCT2     DCT4   DCT4X8      AFV     DCT8  DCT8X16  DCT8X32    DCT16 DCT16X32    DCT32           BPP*pnorm   Errors
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
jxl:d0.8:epf0      17972865  3978806    1.77102804700   1   2.379  14.377   1.57902789   0.52086395504  41.78   2.105 0.000000 0.000911 0.229583 0.021543 0.060425 0.226524 0.000000 0.378839 0.019399 0.062045  0.9224646730469741        0
jxl:d1:epf1        17972865  3463827    1.54180293459   1   2.621  20.276   1.94598019   0.60485873749  40.68   2.119 0.000000 0.000911 0.205023 0.021429 0.055422 0.201434 0.000000 0.368441 0.040452 0.106485  0.9325729764825031        0
jxl:d2:epf3        17972865  2237796    0.99607758696   1   2.908  16.740   3.58487940   0.95352175925  37.47   2.246 0.000000 0.000911 0.150402 0.021098 0.043984 0.157941 0.000000 0.264263 0.163603 0.198272  0.9497816530707661        0
jxl:d3:epf0        17972865  1669569    0.74315096675   1   2.788  26.529   4.53973532   1.27958860382  35.22   2.301 0.000000 0.001139 0.121537 0.019339 0.038903 0.141895 0.000000 0.199824 0.238297 0.241117  0.9509275079664137        0
jxl:d4:epf3        17972865  1382640    0.61543443408   1   2.443  14.917   7.13622332   1.56464959734  34.06   2.422 0.000000 0.001139 0.098897 0.017430 0.032984 0.129639 0.000000 0.167320 0.287295 0.268465  0.9629392394641252        0
jxl:d8:epf1        17972865   809952    0.36052215381   1   2.768  24.359   9.39446449   2.50509222536  30.89   2.362 0.000000 0.001367 0.055906 0.011583 0.019691 0.101479 0.000000 0.114476 0.371247 0.329940  0.9031412445869741        0
jxl:d16:epf3       17972865   474716    0.21130342881   1   2.792  14.793  19.64636612   4.43095030955  28.64   2.691 0.000000 0.001367 0.019278 0.004486 0.005380 0.061888 0.000000 0.068569 0.387428 0.458931  0.9362749932844370        0
jxl:d24:epf3       17972865   360283    0.16036753183   1   2.606  14.792  21.55065346   5.77995514017  27.36   2.672 0.000000 0.001367 0.010209 0.002296 0.002766 0.045522 0.000000 0.050821 0.364467 0.530378  0.9269171399281144        0
jxl:d32:epf3       17972865   293127    0.13047535827   1   2.893  14.236  25.75268745   7.00993165520  26.54   2.671 0.000000 0.001367 0.005708 0.001338 0.001659 0.035231 0.000000 0.039725 0.335211 0.587808  0.9146233441551781        0
Aggregate:         17972865  1125191    0.50083983297 ---   2.683  17.404   6.92351368   1.86311414973  33.21   2.389 0.000000 0.001147 0.055917 0.009308 0.016526 0.103265 0.000000 0.139138 0.175065 0.251342  0.9331217795490244        0
```