### PR TITLE
Reduce ringing

### DIFF
--- a/lib/jxl/enc_adaptive_quantization.cc
+++ b/lib/jxl/enc_adaptive_quantization.cc
@@ -665,7 +665,7 @@ ImageF TileDistMap(const ImageF& distmap, int tile_size, int margin,
 
 constexpr float kDcQuantPow = 0.57f;
 static const float kDcQuant = 1.12f;
-static const float kAcQuant = 0.785f;
+static const float kAcQuant = 0.787f;
 
 void FindBestQuantization(const ImageBundle& linear, const Image3F& opsin,
                           PassesEncoderState* enc_state, ThreadPool* pool,

--- a/lib/jxl/passes_test.cc
+++ b/lib/jxl/passes_test.cc
@@ -287,7 +287,7 @@ TEST(PassesTest, ProgressiveDownsample2DegradesCorrectlyGrayscale) {
       ButteraugliDistance(output, output_d2, cparams.ba_params,
                           /*distmap=*/nullptr, nullptr);
 
-  EXPECT_LE(butteraugli_distance_down2_full, 3.0f);
+  EXPECT_LE(butteraugli_distance_down2_full, 3.2f);
   EXPECT_GE(butteraugli_distance_down2_full, 1.0f);
 }
 


### PR DESCRIPTION
First, overnight simplex-fork optimization of heuristics.
Second, manual tweaking of heuristics related to ac-strategy.

All numbers with the exception QABPP get slightly worse, but there is
significantly less ringing at high distances and some less in lower
distances, too.

Most effective change here was to change the base entropy to 0 in
EstimateEntropy, possibly the second most effective is calculating
distance-weighting into dct32x16 entropies.

Before:
```
Compr                 Input    Compr            Compr       Compr  Decomp  Butteraugli
Method               Pixels     Size              BPP   #    MP/s    MP/s     Distance    Error p norm   PSNR   QABPP     DCT2     DCT4   DCT4X8      AFV     DCT8  DCT8X16  DCT8X32    DCT16 DCT16X32    DCT32           BPP*pnorm   Errors
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
jxl:d0.8:epf0      17972865  3951942    1.75907046539   1   2.324  13.807   1.57893729   0.52331089591  41.73   2.121 0.000000 0.000911 0.203567 0.020553 0.049902 0.230626 0.000000 0.408822 0.017234 0.068483  0.9205407412221729        0
jxl:d1:epf1        17972865  3450706    1.53596257469   1   2.538  20.125   1.94662952   0.60610525355  40.65   2.128 0.000000 0.000911 0.192140 0.020753 0.049001 0.201177 0.000000 0.396829 0.029199 0.110303  0.9309549857768020        0
jxl:d2:epf3        17972865  2246506    0.99995454258   1   2.826  16.524   3.41899276   0.95121670445  37.50   2.246 0.000000 0.001139 0.159978 0.021315 0.044529 0.151353 0.000000 0.301396 0.104035 0.217301  0.9511734645939139        0
jxl:d3:epf0        17972865  1679780    0.74769604067   1   2.780  24.514   4.76437998   1.27694160442  35.28   2.321 0.000000 0.001139 0.135008 0.020033 0.041445 0.134325 0.000000 0.233283 0.181521 0.255816  0.9547641817919317        0
jxl:d4:epf3        17972865  1390051    0.61873318472   1   2.398  14.544   5.85040092   1.56297457360  34.10   2.430 0.000000 0.001139 0.110922 0.018061 0.034779 0.120629 0.000000 0.198984 0.239920 0.279233  0.9670642355616933        0
jxl:d8:epf1        17972865   811812    0.36135006856   1   2.788  23.422   9.37444782   2.51424949430  30.89   2.407 0.000000 0.001367 0.058295 0.011626 0.018769 0.088538 0.000000 0.128891 0.354582 0.343899  0.9085242271468007        0
jxl:d16:epf3       17972865   475248    0.21154023023   1   2.836  13.781  19.64723206   4.41670512959  28.63   2.675 0.000000 0.001367 0.016718 0.003920 0.004023 0.048898 0.000000 0.067344 0.381702 0.483488  0.9343108199727461        0
jxl:d24:epf3       17972865   358126    0.15940741779   1   2.588  13.989  21.47615433   5.75762783145  27.36   2.626 0.000000 0.001367 0.007627 0.001805 0.001705 0.033558 0.000000 0.045195 0.354981 0.561657  0.9178085852275816        0
jxl:d32:epf3       17972865   292118    0.13002623677   1   2.796  14.169  25.83151817   6.98935655673  26.53   2.639 0.000000 0.016636 0.003810 0.000904 0.000961 0.026058 0.000000 0.031706 0.315754 0.612251  0.9087997305448716        0
Aggregate:         17972865  1125031    0.50076852951 ---   2.646  16.767   6.77137520   1.86203845214  33.21   2.391 0.000000 0.001552 0.051733 0.008552 0.013905 0.091067 0.000000 0.144941 0.148250 0.266164  0.9324502575761613        0
```

After:

```
Compr                 Input    Compr            Compr       Compr  Decomp  Butteraugli
Method               Pixels     Size              BPP   #    MP/s    MP/s     Distance    Error p norm   PSNR   QABPP     DCT2     DCT4   DCT4X8      AFV     DCT8  DCT8X16  DCT8X32    DCT16 DCT16X32    DCT32           BPP*pnorm   Errors
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
jxl:d0.8:epf0      17972865  3978806    1.77102804700   1   2.379  14.377   1.57902789   0.52086395504  41.78   2.105 0.000000 0.000911 0.229583 0.021543 0.060425 0.226524 0.000000 0.378839 0.019399 0.062045  0.9224646730469741        0
jxl:d1:epf1        17972865  3463827    1.54180293459   1   2.621  20.276   1.94598019   0.60485873749  40.68   2.119 0.000000 0.000911 0.205023 0.021429 0.055422 0.201434 0.000000 0.368441 0.040452 0.106485  0.9325729764825031        0
jxl:d2:epf3        17972865  2237796    0.99607758696   1   2.908  16.740   3.58487940   0.95352175925  37.47   2.246 0.000000 0.000911 0.150402 0.021098 0.043984 0.157941 0.000000 0.264263 0.163603 0.198272  0.9497816530707661        0
jxl:d3:epf0        17972865  1669569    0.74315096675   1   2.788  26.529   4.53973532   1.27958860382  35.22   2.301 0.000000 0.001139 0.121537 0.019339 0.038903 0.141895 0.000000 0.199824 0.238297 0.241117  0.9509275079664137        0
jxl:d4:epf3        17972865  1382640    0.61543443408   1   2.443  14.917   7.13622332   1.56464959734  34.06   2.422 0.000000 0.001139 0.098897 0.017430 0.032984 0.129639 0.000000 0.167320 0.287295 0.268465  0.9629392394641252        0
jxl:d8:epf1        17972865   809952    0.36052215381   1   2.768  24.359   9.39446449   2.50509222536  30.89   2.362 0.000000 0.001367 0.055906 0.011583 0.019691 0.101479 0.000000 0.114476 0.371247 0.329940  0.9031412445869741        0
jxl:d16:epf3       17972865   474716    0.21130342881   1   2.792  14.793  19.64636612   4.43095030955  28.64   2.691 0.000000 0.001367 0.019278 0.004486 0.005380 0.061888 0.000000 0.068569 0.387428 0.458931  0.9362749932844370        0
jxl:d24:epf3       17972865   360283    0.16036753183   1   2.606  14.792  21.55065346   5.77995514017  27.36   2.672 0.000000 0.001367 0.010209 0.002296 0.002766 0.045522 0.000000 0.050821 0.364467 0.530378  0.9269171399281144        0
jxl:d32:epf3       17972865   293127    0.13047535827   1   2.893  14.236  25.75268745   7.00993165520  26.54   2.671 0.000000 0.001367 0.005708 0.001338 0.001659 0.035231 0.000000 0.039725 0.335211 0.587808  0.9146233441551781        0
Aggregate:         17972865  1125191    0.50083983297 ---   2.683  17.404   6.92351368   1.86311414973  33.21   2.389 0.000000 0.001147 0.055917 0.009308 0.016526 0.103265 0.000000 0.139138 0.175065 0.251342  0.9331217795490244        0
```