### PR TITLE
Remove ancient encoder flag

### DIFF
--- a/lib/jxl/enc_params.h
+++ b/lib/jxl/enc_params.h
@@ -153,10 +153,6 @@ struct CompressParams {
   Override gaborish = Override::kDefault;
   int epf = -1;
 
-  // TODO(deymo): Remove "gradient" once all clients stop setting this value.
-  // This flag is already deprecated and is unused in the encoder.
-  Override gradient = Override::kOff;
-
   // Progressive mode.
   bool progressive_mode = false;
 


### PR DESCRIPTION
To say that this flag is deprecated would be an understatement since it's been marked as such from the very first public commit ff09371267315c39fe0220082943c5834db04ab9 from 2019.