### PR TITLE
Add PoisonImage and CheckImageInitialized to sanitizers.h

### DIFF
--- a/lib/jxl/dec_cache.h
+++ b/lib/jxl/dec_cache.h
@@ -194,7 +194,7 @@ struct PassesDecoderState {
                               kGroupDim + 2 * kGroupDataYBorder);
 #if MEMORY_SANITIZER
       // Avoid errors due to loading vectors on the outermost padding.
-      FillImage(kSanitizerSentinel, &group_data.back());
+      FillImage(msan::kSanitizerSentinel, &group_data.back());
 #endif
     }
     if (!shared->frame_header.chroma_subsampling.Is444()) {
@@ -333,7 +333,7 @@ struct PassesDecoderState {
     }
 #if MEMORY_SANITIZER
     // Avoid errors due to loading vectors on the outermost padding.
-    FillImage(kSanitizerSentinel, &decoded);
+    FillImage(msan::kSanitizerSentinel, &decoded);
 #endif
   }
 

--- a/lib/jxl/dec_frame.cc
+++ b/lib/jxl/dec_frame.cc
@@ -439,7 +439,8 @@ void FrameDecoder::AllocateOutput() {
            y++) {
         for (size_t x = DivCeil(frame_dim_.xsize_upsampled, ecups);
              x < DivCeil(frame_dim_.xsize_upsampled_padded, ecups); x++) {
-          dec_state_->extra_channels.back().Row(y)[x] = kSanitizerSentinel;
+          dec_state_->extra_channels.back().Row(y)[x] =
+              msan::kSanitizerSentinel;
         }
       }
 #endif

--- a/lib/jxl/dec_xyb.cc
+++ b/lib/jxl/dec_xyb.cc
@@ -21,6 +21,7 @@
 #include "lib/jxl/image.h"
 #include "lib/jxl/opsin_params.h"
 #include "lib/jxl/quantizer.h"
+#include "lib/jxl/sanitizers.h"
 HWY_BEFORE_NAMESPACE();
 namespace jxl {
 namespace HWY_NAMESPACE {
@@ -31,6 +32,7 @@ using hwy::HWY_NAMESPACE::Broadcast;
 void OpsinToLinearInplace(Image3F* JXL_RESTRICT inout, ThreadPool* pool,
                           const OpsinParams& opsin_params) {
   PROFILER_FUNC;
+  JXL_CHECK_IMAGE_INITIALIZED(*inout, Rect(*inout));
 
   const size_t xsize = inout->xsize();  // not padded
   RunOnPool(
@@ -71,6 +73,7 @@ void OpsinToLinear(const Image3F& opsin, const Rect& rect, ThreadPool* pool,
   PROFILER_FUNC;
 
   JXL_ASSERT(SameSize(rect, *linear));
+  JXL_CHECK_IMAGE_INITIALIZED(opsin, rect);
 
   RunOnPool(
       pool, 0, static_cast<int>(rect.ysize()), ThreadPool::SkipInit(),
@@ -104,11 +107,13 @@ void OpsinToLinear(const Image3F& opsin, const Rect& rect, ThreadPool* pool,
         }
       },
       "OpsinToLinear(Rect)");
+  JXL_CHECK_IMAGE_INITIALIZED(*linear, rect);
 }
 
 // Transform YCbCr to RGB.
 // Could be performed in-place (i.e. Y, Cb and Cr could alias R, B and B).
 void YcbcrToRgb(const Image3F& ycbcr, Image3F* rgb, const Rect& rect) {
+  JXL_CHECK_IMAGE_INITIALIZED(ycbcr, rect);
   const HWY_CAPPED(float, GroupBorderAssigner::kPaddingXRound) df;
   const size_t S = Lanes(df);  // Step.
 
@@ -143,6 +148,7 @@ void YcbcrToRgb(const Image3F& ycbcr, Image3F* rgb, const Rect& rect) {
       Store(b_vec, df, b_row + x);
     }
   }
+  JXL_CHECK_IMAGE_INITIALIZED(*rgb, rect);
 }
 
 // NOLINTNEXTLINE(google-readability-namespace-comments)

--- a/lib/jxl/filters.h
+++ b/lib/jxl/filters.h
@@ -169,9 +169,9 @@ class FilterPipeline {
     for (size_t c = 0; c < 3; c++) {
       for (size_t y = 0; y < storage.ysize(); y++) {
         float* row = storage.PlaneRow(c, y);
-        std::fill(row, row + kMaxFilterPadding, kSanitizerSentinel);
+        std::fill(row, row + kMaxFilterPadding, msan::kSanitizerSentinel);
         std::fill(row + storage.xsize() - kMaxFilterPadding,
-                  row + storage.xsize(), kSanitizerSentinel);
+                  row + storage.xsize(), msan::kSanitizerSentinel);
       }
     }
 #endif  // MEMORY_SANITIZER

--- a/lib/jxl/image.cc
+++ b/lib/jxl/image.cc
@@ -115,9 +115,9 @@ void PlaneBase::InitializePadding(const size_t sizeof_t, Padding padding) {
     // There's a bug in msan in clang-6 when handling AVX2 operations. This
     // workaround allows tests to pass on msan, although it is slower and
     // prevents msan warnings from uninitialized images.
-    std::fill(row, kSanitizerSentinelByte, initialize_size);
+    std::fill(row, msan::kSanitizerSentinelByte, initialize_size);
 #else
-    memset(row + valid_size, kSanitizerSentinelByte,
+    memset(row + valid_size, msan::kSanitizerSentinelByte,
            initialize_size - valid_size);
 #endif  // clang6
   }

--- a/lib/jxl/sanitizers.h
+++ b/lib/jxl/sanitizers.h
@@ -9,6 +9,7 @@
 #include <stddef.h>
 
 #include "lib/jxl/base/compiler_specific.h"
+#include "lib/jxl/image.h"
 
 #ifdef MEMORY_SANITIZER
 #define JXL_MEMORY_SANITIZER 1
@@ -23,10 +24,12 @@
 #endif
 
 #if JXL_MEMORY_SANITIZER
+#include "lib/jxl/base/status.h"
 #include "sanitizer/msan_interface.h"
 #endif
 
 namespace jxl {
+namespace msan {
 
 #if JXL_MEMORY_SANITIZER
 
@@ -34,25 +37,84 @@ namespace jxl {
 constexpr uint8_t kSanitizerSentinelByte = 0x48;
 constexpr float kSanitizerSentinel = 205089.125f;
 
-static JXL_INLINE JXL_MAYBE_UNUSED void PoisonMemory(const volatile void *m,
+static JXL_INLINE JXL_MAYBE_UNUSED void PoisonMemory(const volatile void* m,
                                                      size_t size) {
   __msan_poison(m, size);
 }
 
-static JXL_INLINE JXL_MAYBE_UNUSED void UnpoisonMemory(const volatile void *m,
+static JXL_INLINE JXL_MAYBE_UNUSED void UnpoisonMemory(const volatile void* m,
                                                        size_t size) {
   __msan_unpoison(m, size);
 }
 
+// Mark all the bytes of an image (including padding) as poisoned bytes.
+static JXL_INLINE JXL_MAYBE_UNUSED void PoisonImage(const PlaneBase& im) {
+  PoisonMemory(im.bytes(), im.bytes_per_row() * im.ysize());
+}
+
+template <typename T>
+static JXL_INLINE JXL_MAYBE_UNUSED void PoisonImage(const Image3<T>& im) {
+  PoisonImage(im.Plane(0));
+  PoisonImage(im.Plane(1));
+  PoisonImage(im.Plane(2));
+}
+
+// Check that all the pixels in the provided rect of the image are initialized
+// (not poisoned). If any of the values is poisoned it will abort.
+template <typename T>
+static JXL_INLINE JXL_MAYBE_UNUSED void CheckImageInitialized(
+    const Plane<T>& im, const Rect& r, const char* message) {
+  JXL_ASSERT(r.x0() <= im.xsize());
+  JXL_ASSERT(r.x0() + r.xsize() <= im.xsize());
+  JXL_ASSERT(r.y0() <= im.ysize());
+  JXL_ASSERT(r.y0() + r.ysize() <= im.ysize());
+  for (size_t y = r.y0(); y < r.y0() + r.ysize(); y++) {
+    const auto* row = im.Row(y);
+    intptr_t ret = __msan_test_shadow(row + r.x0(), sizeof(*row) * r.xsize());
+    if (ret != -1) {
+      JXL_DEBUG(1,
+                "Checking an image of %zu x %zu, rect x0=%zu, y0=%zu, "
+                "xsize=%zu, ysize=%zu",
+                im.xsize(), im.ysize(), r.x0(), r.y0(), r.xsize(), r.ysize());
+      size_t x = ret / sizeof(*row);
+      JXL_DEBUG(1, "CheckImageInitialized failed at x=%zu, y=%zu: %s", x, y,
+                message ? message : "");
+    }
+    // This will report an error if memory is not initialized.
+    __msan_check_mem_is_initialized(row + r.x0(), sizeof(*row) * r.xsize());
+  }
+}
+
+template <typename T>
+static JXL_INLINE JXL_MAYBE_UNUSED void CheckImageInitialized(
+    const Image3<T>& im, const Rect& r, const char* message) {
+  for (size_t c = 0; c < 3; c++) {
+    std::string str_message(message);
+    str_message += " c=" + std::to_string(c);
+    CheckImageInitialized(im.Plane(c), r, str_message.c_str());
+  }
+}
+
+#define JXL_CHECK_IMAGE_INITIALIZED(im, r) \
+  ::jxl::msan::CheckImageInitialized(im, r, "im=" #im ", r=" #r);
+
 #else  // JXL_MEMORY_SANITIZER
 
-static JXL_INLINE JXL_MAYBE_UNUSED void PoisonMemory(const volatile void *,
-                                                     size_t) {}
-static JXL_INLINE JXL_MAYBE_UNUSED void UnpoisonMemory(const volatile void *,
-                                                       size_t) {}
+// In non-msan mode these functions don't use volatile since it is not needed
+// for the empty functions.
+
+static JXL_INLINE JXL_MAYBE_UNUSED void PoisonMemory(const void*, size_t) {}
+static JXL_INLINE JXL_MAYBE_UNUSED void UnpoisonMemory(const void*, size_t) {}
+
+static JXL_INLINE JXL_MAYBE_UNUSED void PoisonImage(const PlaneBase& im) {}
+template <typename T>
+static JXL_INLINE JXL_MAYBE_UNUSED void PoisonImage(const Plane<T>& im) {}
+
+#define JXL_CHECK_IMAGE_INITIALIZED(im, r)
 
 #endif
 
+}  // namespace msan
 }  // namespace jxl
 
 #endif  // LIB_JXL_SANITIZERS_H_

--- a/tools/benchmark/benchmark_codec_webp.cc
+++ b/tools/benchmark/benchmark_codec_webp.cc
@@ -173,7 +173,7 @@ class WebPCodec : public ImageCodec {
     const uint8_t* data_end = data_begin + buf->width * buf->height * 4;
     // The image data is initialized by libwebp, which we are not instrumenting
     // with msan.
-    UnpoisonMemory(data_begin, data_end - data_begin);
+    msan::UnpoisonMemory(data_begin, data_end - data_begin);
     if (io->metadata.m.color_encoding.IsGray() != is_gray) {
       // TODO(lode): either ensure is_gray matches what the color profile says,
       // or set a correct color profile, e.g.
@@ -282,7 +282,7 @@ class WebPCodec : public ImageCodec {
     WebPPictureFree(&pic);
     // Compressed image data is initialized by libwebp, which we are not
     // instrumenting with msan.
-    UnpoisonMemory(compressed->data(), compressed->size());
+    msan::UnpoisonMemory(compressed->data(), compressed->size());
     return ok;
   }
 


### PR DESCRIPTION
This adds two new Image-related msan helper functions: PoisonImage will
mark all the Image memory (including padding) as uninitialized while
CheckImageInitialized will check that the pixels inside a given Rect are
is initialized in an image.

When running a multi-thread step with per-thread temporary images we can
use PoisonImage to avoid leaking initialized memory from a previous run
in the same thread to the next run. This helps identifying where was the
uninitialized memory from.

Functions accepting images, specially those that take chunks of images
with a given rect should use CheckImageInitialized over the passed Rect
to trigger msan early when uninitialized memory bugs arise, otherwise
msan would only trigger when the uninitialized values are used in a
comparison (like NearestInt or IfThenElse).

Since now there are more functions in the sanitizers.h header and all of
them are msan-only, this also moves the functions inside the jxl::msan
namespace.