### PR TITLE
fixing uninitialized read I introduced in #288

### DIFF
--- a/lib/jxl/enc_ac_strategy.cc
+++ b/lib/jxl/enc_ac_strategy.cc
@@ -683,7 +683,7 @@ void FindBestFirstLevelDivisionForSquare(
           EstimateEntropy(acsJXK, (bx + cx + 0) * 8, (by + cy + 0) * 8, config,
                           cmap_factors, block, scratch_space, quantized);
     }
-    if (row0[bx + cx + 2].RawStrategy() != acs_rawJXK) {
+    if (row0[bx + cx + blocks_half].RawStrategy() != acs_rawJXK) {
       entropy_JXK_right =
           entropy_mul_JXK * EstimateEntropy(acsJXK, (bx + cx + blocks_half) * 8,
                                             (by + cy + 0) * 8, config,


### PR DESCRIPTION
This makes a corpus test produce exactly same results as before 288.

I had falsely assumed that the minor changes were due to the subtle
differences in calculation order.