### PR TITLE
Print uninitialized ranges when failing JXL_CHECK_IMAGE_INITIALIZED

### DIFF
--- a/lib/jxl/sanitizers.h
+++ b/lib/jxl/sanitizers.h
@@ -24,6 +24,11 @@
 #endif
 
 #if JXL_MEMORY_SANITIZER
+#include <stdio.h>
+
+#include <algorithm>
+#include <vector>
+
 #include "lib/jxl/base/status.h"
 #include "sanitizer/msan_interface.h"
 #endif
@@ -59,6 +64,101 @@ static JXL_INLINE JXL_MAYBE_UNUSED void PoisonImage(const Image3<T>& im) {
   PoisonImage(im.Plane(2));
 }
 
+// Print the uninitialized regions of an image.
+template <typename T>
+static JXL_INLINE JXL_MAYBE_UNUSED void PrintImageUninitialized(
+    const Plane<T>& im) {
+  fprintf(stderr, "Uninitialized regions for image of size %zux%zu:\n",
+          im.xsize(), im.ysize());
+
+  // A segment of uninitialized pixels in a row, in the format [first, second).
+  typedef std::pair<size_t, size_t> PixelSegment;
+
+  // Helper class to merge and print a list of rows of PixelSegment that may be
+  // the same over big ranges of rows. This compacts the output to ranges of
+  // rows like "[y0, y1): [x0, x1) [x2, x3)".
+  class RowsMerger {
+   public:
+    // Add a new row the list of rows. If the row is the same as the previous
+    // one it will be merged showing a range of rows [y0, y1), but if the new
+    // row is different the current range of rows (if any) will be printed and a
+    // new one will be started.
+    void AddRow(size_t y, std::vector<PixelSegment>&& new_row) {
+      if (start_y_ != -1 && new_row != segments_) {
+        PrintRow(y);
+      }
+      if (new_row.empty()) {
+        // Skip ranges with no uninitialized pixels.
+        start_y_ = -1;
+        segments_.clear();
+        return;
+      }
+      if (start_y_ == -1) {
+        start_y_ = y;
+        segments_ = std::move(new_row);
+      }
+    }
+
+    // Print the contents of the range of rows [start_y_, end_y) if any.
+    void PrintRow(size_t end_y) {
+      if (start_y_ == -1) return;
+      if (segments_.empty()) {
+        start_y_ = -1;
+        return;
+      }
+      if (end_y - start_y_ > 1) {
+        fprintf(stderr, " y=[%zd, %zu):", start_y_, end_y);
+      } else {
+        fprintf(stderr, " y=[%zd]:", start_y_);
+      }
+      for (const auto& seg : segments_) {
+        if (seg.first + 1 == seg.second) {
+          fprintf(stderr, " [%zd]", seg.first);
+        } else {
+          fprintf(stderr, " [%zd, %zu)", seg.first, seg.second);
+        }
+      }
+      fprintf(stderr, "\n");
+      start_y_ = -1;
+    }
+
+   private:
+    std::vector<PixelSegment> segments_;
+    // Row number of the first row in the range of rows that have |segments| as
+    // the undefined segments.
+    ssize_t start_y_ = -1;
+  } rows_merger;
+
+  class SegmentsMerger {
+   public:
+    void AddValue(size_t x) {
+      if (row.empty() || row.back().second != x) {
+        row.emplace_back(x, x + 1);
+      } else {
+        row.back().second = x + 1;
+      }
+    }
+
+    std::vector<PixelSegment> row;
+  };
+
+  for (size_t y = 0; y < im.ysize(); y++) {
+    auto* row = im.Row(y);
+    SegmentsMerger seg_merger;
+    size_t x = 0;
+    while (x < im.xsize()) {
+      intptr_t ret =
+          __msan_test_shadow(row + x, (im.xsize() - x) * sizeof(row[0]));
+      if (ret < 0) break;
+      size_t next_x = x + ret / sizeof(row[0]);
+      seg_merger.AddValue(next_x);
+      x = next_x + 1;
+    }
+    rows_merger.AddRow(y, std::move(seg_merger.row));
+  }
+  rows_merger.PrintRow(im.ysize());
+}
+
 // Check that all the pixels in the provided rect of the image are initialized
 // (not poisoned). If any of the values is poisoned it will abort.
 template <typename T>
@@ -79,6 +179,7 @@ static JXL_INLINE JXL_MAYBE_UNUSED void CheckImageInitialized(
       size_t x = ret / sizeof(*row);
       JXL_DEBUG(1, "CheckImageInitialized failed at x=%zu, y=%zu: %s", x, y,
                 message ? message : "");
+      PrintImageUninitialized(im);
     }
     // This will report an error if memory is not initialized.
     __msan_check_mem_is_initialized(row + r.x0(), sizeof(*row) * r.xsize());


### PR DESCRIPTION
On top of printing the failed expectation (what range should be
initialized and what pixel wasn't initialized) this patch now prints a
map of all the uninitialized pixel in the given image to better
understand what region is not initialized. For example, after adding
some poisoned values:

```
/src/libjxl/lib/jxl/sanitizers.h:179: Checking an image of 336 x 292, rect x0=40, y0=18, xsize=258, ysize=258
/src/libjxl/lib/jxl/sanitizers.h:182: CheckImageInitialized failed at x=0, y=61: im=*plane_out, r=Rect(x0, y0, x1 - x0, y1 - y0)
Uninitialized regions for image of size 336x292:
 y=[0, 18): [0, 336)
 y=[18, 61): [0, 40) [298, 336)
 y=[61, 65): [0, 45) [298, 336)
 y=[65, 276): [0, 40) [298, 336)
 y=[276, 292): [0, 336)
Uninitialized bytes in __msan_check_mem_is_initialized at offset 0 inside [0x7fef5769c8a0, 1032)
==1235788==WARNING: MemorySanitizer: use-of-uninitialized-value
    #0 0x55b838c8bc9e in CheckImageInitialized<float> /src/libjxl/lib/jxl/sanitizers.h:186:5
    #1 0x55b838c8bc9e in jxl::N_AVX2::DoYCbCrUpsampling(unsigned long, unsigned long, jxl::Plane<float>*, jxl::Rect const&, jxl::Rect const&, jxl::FrameDimensions const&, jxl::Plane<float>*, jxl::LoopFilter const&, jxl::Plane<float>*) /src/libjxl/lib/jxl/dec_reconstruct.cc:393:3
```