### PR TITLE
Fix clang-tidy bugprone-argument-comment errors

### DIFF
--- a/lib/jxl/modular_test.cc
+++ b/lib/jxl/modular_test.cc
@@ -126,7 +126,7 @@ TEST(ModularTest, RoundtripLossy16) {
 
 TEST(ModularTest, RoundtripExtraProperties) {
   constexpr size_t kSize = 250;
-  Image image(kSize, kSize, /*maxval=*/255, 3);
+  Image image(kSize, kSize, /*bitdepth=*/8, 3);
   ModularOptions options;
   options.max_properties = 4;
   options.predictor = Predictor::Zero;
@@ -142,7 +142,7 @@ TEST(ModularTest, RoundtripExtraProperties) {
   BitWriter writer;
   ASSERT_TRUE(ModularGenericCompress(image, options, &writer));
   writer.ZeroPadToByte();
-  Image decoded(kSize, kSize, /*maxval=*/255, image.channel.size());
+  Image decoded(kSize, kSize, /*bitdepth=*/8, image.channel.size());
   for (size_t i = 0; i < image.channel.size(); i++) {
     const Channel& ch = image.channel[i];
     decoded.channel[i] = Channel(ch.w, ch.h, ch.hshift, ch.vshift);

--- a/tools/fuzzer_stub.cc
+++ b/tools/fuzzer_stub.cc
@@ -39,7 +39,7 @@ int main(int argc, const char* argv[]) {
           const char** proc_argv = static_cast<const char**>(opaque);
           ProcessInput(proc_argv[value]);
         },
-        /* start_rage= */ 1, /* end_range= */ argc);
+        /* start_range= */ 1, /* end_range= */ argc);
   }
   return 0;
 }

--- a/tools/jni/org/jpeg/jpegxl/wrapper/decoder_jni.cc
+++ b/tools/jni/org/jpeg/jpegxl/wrapper/decoder_jni.cc
@@ -215,8 +215,8 @@ Java_org_jpeg_jpegxl_wrapper_DecoderJni_nativeGetBasicInfo(
           /* pixels_buffer= */ nullptr, /* icc_buffer= */ nullptr);
     } else {
       status =
-          DoDecode(env, data_buffer, /* pixels_size= */ nullptr,
-                   /* icc_size= */ nullptr, &info, pixel_format,
+          DoDecode(env, data_buffer, /* info_pixels_size= */ nullptr,
+                   /* info_icc_size= */ nullptr, &info, pixel_format,
                    /* pixels_buffer= */ nullptr, /* icc_buffer= */ nullptr);
     }
   }


### PR DESCRIPTION
The only actual bug fixed here is in modular_test which was passing
maxval instead of bitdepth.