### PR TITLE
Get rid of fmemopen in codec_apng.

### DIFF
--- a/lib/extras/codec_apng.cc
+++ b/lib/extras/codec_apng.cc
@@ -39,14 +39,6 @@
 #include <stdio.h>
 #include <string.h>
 
-#if defined(_WIN32) || defined(_WIN64)
-#ifndef NOMINMAX
-#define NOMINMAX
-#endif  // NOMINMAX
-#define WIN32_LEAN_AND_MEAN
-#include <windows.h>
-#endif
-
 #include <algorithm>
 #include <string>
 #include <utility>
@@ -65,22 +57,40 @@
 namespace jxl {
 
 namespace {
+
+constexpr bool isAbc(char c) {
+  return (c >= 'A' && c <= 'Z') || (c >= 'a' && c <= 'z');
+}
 #define notabc(c) ((c) < 65 || (c) > 122 || ((c) > 90 && (c) < 97))
 
-#define id_IHDR 0x52444849
-#define id_acTL 0x4C546361
-#define id_fcTL 0x4C546366
-#define id_IDAT 0x54414449
-#define id_fdAT 0x54416466
-#define id_IEND 0x444E4549
+constexpr uint32_t kId_IHDR = 0x52444849;
+constexpr uint32_t kId_acTL = 0x4C546361;
+constexpr uint32_t kId_fcTL = 0x4C546366;
+constexpr uint32_t kId_IDAT = 0x54414449;
+constexpr uint32_t kId_fdAT = 0x54416466;
+constexpr uint32_t kId_IEND = 0x444E4549;
 
 struct CHUNK {
   unsigned char* p;
   unsigned int size;
 };
+
 struct APNGFrame {
   unsigned char *p, **rows;
   unsigned int w, h, delay_num, delay_den;
+};
+
+struct Reader {
+  const uint8_t* next;
+  const uint8_t* last;
+  bool Read(void* data, size_t len) {
+    size_t cap = last - next;
+    size_t to_copy = std::min(cap, len);
+    memcpy(data, next, to_copy);
+    next += to_copy;
+    return (len == to_copy);
+  }
+  bool Eof() { return next == last; }
 };
 
 const unsigned long cMaxPNGSize = 1000000UL;
@@ -102,11 +112,11 @@ void row_fn(png_structp png_ptr, png_bytep new_row, png_uint_32 row_num,
   png_progressive_combine_row(png_ptr, frame->rows[row_num], new_row);
 }
 
-inline unsigned int read_chunk(FILE* f, CHUNK* pChunk) {
+inline unsigned int read_chunk(Reader* r, CHUNK* pChunk) {
   unsigned char len[4];
   pChunk->size = 0;
   pChunk->p = 0;
-  if (fread(&len, 4, 1, f) == 1) {
+  if (r->Read(&len, 4)) {
     const auto size = png_get_uint_32(len);
     // Check first, to avoid overflow.
     if (size > kMaxPNGChunkSize) {
@@ -116,8 +126,9 @@ inline unsigned int read_chunk(FILE* f, CHUNK* pChunk) {
     pChunk->size = size + 12;
     pChunk->p = new unsigned char[pChunk->size];
     memcpy(pChunk->p, len, 4);
-    if (fread(pChunk->p + 4, pChunk->size - 4, 1, f) == 1)
+    if (r->Read(pChunk->p + 4, pChunk->size - 4)) {
       return *(unsigned int*)(pChunk->p + 4);
+    }
   }
   return 0;
 }
@@ -179,29 +190,11 @@ int processing_finish(png_structp png_ptr, png_infop info_ptr) {
   return 0;
 }
 
-#if defined(_WIN32) || defined(_WIN64)
-FILE* fmemopen(void* buf, size_t size, const char* mode) {
-  char temp[999];
-  if (!GetTempPath(sizeof(temp), temp)) return nullptr;
-
-  char pathname[999];
-  if (!GetTempFileName(temp, "jpegxl", 0, pathname)) return nullptr;
-
-  FILE* f = fopen(pathname, "wb");
-  if (f == nullptr) return nullptr;
-  fwrite(buf, 1, size, f);
-  JXL_CHECK(fclose(f) == 0);
-
-  return fopen(pathname, mode);
-}
-
-#endif
-
 }  // namespace
 
 Status DecodeImageAPNG(Span<const uint8_t> bytes, ThreadPool* pool,
                        CodecInOut* io) {
-  FILE* f;
+  Reader r;
   unsigned int id, i, j, w, h, w0, h0, x0, y0;
   unsigned int delay_num, delay_den, dop, bop, rowbytes, imagesize;
   unsigned char sig[8];
@@ -216,16 +209,13 @@ Status DecodeImageAPNG(Span<const uint8_t> bytes, ThreadPool* pool,
   bool all_dispose_bg = true;
   APNGFrame frameRaw = {};
 
-  if (!(f = fmemopen((void*)bytes.data(), bytes.size(), "rb"))) {
-    return JXL_FAILURE("Failed to fmemopen");
-  }
+  r = {bytes.data(), bytes.data() + bytes.size()};
   // Not an aPNG => not an error
   unsigned char png_signature[8] = {137, 80, 78, 71, 13, 10, 26, 10};
-  if (fread(sig, 1, 8, f) != 8 || memcmp(sig, png_signature, 8) != 0) {
-    fclose(f);
+  if (r.Read(sig, 8) || memcmp(sig, png_signature, 8) != 0) {
     return false;
   }
-  id = read_chunk(f, &chunkIHDR);
+  id = read_chunk(&r, &chunkIHDR);
 
   io->frames.clear();
   io->dec_pixels = 0;
@@ -240,12 +230,11 @@ Status DecodeImageAPNG(Span<const uint8_t> bytes, ThreadPool* pool,
       });
 
   bool errorstate = true;
-  if (id == id_IHDR && chunkIHDR.size == 25) {
+  if (id == kId_IHDR && chunkIHDR.size == 25) {
     w0 = w = png_get_uint_32(chunkIHDR.p + 8);
     h0 = h = png_get_uint_32(chunkIHDR.p + 12);
 
     if (w > cMaxPNGSize || h > cMaxPNGSize) {
-      fclose(f);
       return false;
     }
 
@@ -265,18 +254,18 @@ Status DecodeImageAPNG(Span<const uint8_t> bytes, ThreadPool* pool,
     if (!processing_start(png_ptr, info_ptr, (void*)&frameRaw, hasInfo,
                           chunkIHDR, chunksInfo)) {
       bool last_base_was_none = true;
-      while (!feof(f)) {
-        id = read_chunk(f, &chunk);
+      while (!r.Eof()) {
+        id = read_chunk(&r, &chunk);
         if (!id) break;
         JXL_ASSERT(chunk.p != nullptr);
 
-        if (id == id_acTL && !hasInfo && !isAnimated) {
+        if (id == kId_acTL && !hasInfo && !isAnimated) {
           isAnimated = true;
           skipFirst = true;
           io->metadata.m.have_animation = true;
           io->metadata.m.animation.tps_numerator = 1000;
-        } else if (id == id_IEND ||
-                   (id == id_fcTL && (!hasInfo || isAnimated))) {
+        } else if (id == kId_IEND ||
+                   (id == kId_fcTL && (!hasInfo || isAnimated))) {
           if (hasInfo) {
             if (!processing_finish(png_ptr, info_ptr)) {
               ImageBundle bundle(&io->metadata.m);
@@ -339,7 +328,7 @@ Status DecodeImageAPNG(Span<const uint8_t> bytes, ThreadPool* pool,
             }
           }
 
-          if (id == id_IEND) {
+          if (id == kId_IEND) {
             errorstate = false;
             break;
           }
@@ -374,21 +363,21 @@ Status DecodeImageAPNG(Span<const uint8_t> bytes, ThreadPool* pool,
             bop = 0;
             if (dop == 2) dop = 1;
           }
-        } else if (id == id_IDAT) {
+        } else if (id == kId_IDAT) {
           hasInfo = true;
           if (processing_data(png_ptr, info_ptr, chunk.p, chunk.size)) {
             delete[] chunk.p;
             break;
           }
-        } else if (id == id_fdAT && isAnimated) {
+        } else if (id == kId_fdAT && isAnimated) {
           png_save_uint_32(chunk.p + 4, chunk.size - 16);
           memcpy(chunk.p + 8, "IDAT", 4);
           if (processing_data(png_ptr, info_ptr, chunk.p + 4, chunk.size - 4)) {
             delete[] chunk.p;
             break;
           }
-        } else if (notabc(chunk.p[4]) || notabc(chunk.p[5]) ||
-                   notabc(chunk.p[6]) || notabc(chunk.p[7])) {
+        } else if (!isAbc(chunk.p[4]) || !isAbc(chunk.p[5]) ||
+                   !isAbc(chunk.p[6]) || !isAbc(chunk.p[7])) {
           delete[] chunk.p;
           break;
         } else if (!hasInfo) {
@@ -410,8 +399,6 @@ Status DecodeImageAPNG(Span<const uint8_t> bytes, ThreadPool* pool,
 
   chunksInfo.clear();
   delete[] chunkIHDR.p;
-
-  fclose(f);
 
   if (errorstate) return false;
   SetIntensityTarget(io);


### PR DESCRIPTION
On windows it was emulated by creating temporary file (which was never deleted).
Drive-by: remove local defines

Fixes #6