### PR TITLE
proposal for epf change

### DIFF
--- a/lib/jxl/epf.cc
+++ b/lib/jxl/epf.cc
@@ -58,9 +58,10 @@ constexpr float kMinSigma = -3.90524291751269967465540850526868f;
 DF df;
 
 JXL_INLINE Vec<DF> Weight(Vec<DF> sad, Vec<DF> inv_sigma, Vec<DF> thres) {
+  sad = sad * Set(DF(), 1.65f);
   auto v = MulAdd(sad, inv_sigma, Set(DF(), 1.0f));
-  auto v2 = v * v;
-  return IfThenZeroElse(v <= thres, v2);
+  auto zero = Set(DF(), 0.0f);
+  return IfThenZeroElse(v <= zero, v);
 }
 
 template <bool aligned>


### PR DESCRIPTION
This is to avoid a non-linearity that is cumbersome for different
architectures and conformance testing.

Before:

```
Compr                 Input    Compr            Compr       Compr  Decomp  Butteraugli
Method               Pixels     Size              BPP   #    MP/s    MP/s     Distance    Error p norm   PSNR   QABPP     DCT2     DCT4   DCT4X8      AFV     DCT8  DCT8X16  DCT8X32    DCT16 DCT16X32    DCT32           BPP*pnorm   Errors
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
jxl:d0.8:epf0      17972865  3978806    1.77102804700   1   2.361  14.817   1.57902789   0.52086395504  41.78   2.105 0.000000 0.000911 0.229583 0.021543 0.060425 0.226524 0.000000 0.378839 0.019399 0.062045  0.9224646730469741        0
jxl:d1:epf1        17972865  3463827    1.54180293459   1   2.621  20.691   1.94598019   0.60485873749  40.68   2.119 0.000000 0.000911 0.205023 0.021429 0.055422 0.201434 0.000000 0.368441 0.040452 0.106485  0.9325729764825031        0
jxl:d2:epf3        17972865  2237796    0.99607758696   1   2.920  16.954   3.58487940   0.95352175925  37.47   2.246 0.000000 0.000911 0.150402 0.021098 0.043984 0.157941 0.000000 0.264263 0.163603 0.198272  0.9497816530707661        0
jxl:d3:epf0        17972865  1669569    0.74315096675   1   2.776  25.716   4.53973532   1.27958860382  35.22   2.301 0.000000 0.001139 0.121537 0.019339 0.038903 0.141895 0.000000 0.199824 0.238297 0.241117  0.9509275079664137        0
jxl:d4:epf3        17972865  1382640    0.61543443408   1   2.472  15.270   7.13622332   1.56464959734  34.06   2.422 0.000000 0.001139 0.098897 0.017430 0.032984 0.129639 0.000000 0.167320 0.287295 0.268465  0.9629392394641252        0
jxl:d8:epf1        17972865   809952    0.36052215381   1   2.844  24.217   9.39446449   2.50509222536  30.89   2.362 0.000000 0.001367 0.055906 0.011583 0.019691 0.101479 0.000000 0.114476 0.371247 0.329940  0.9031412445869741        0
jxl:d16:epf3       17972865   474716    0.21130342881   1   2.841  14.595  19.64636612   4.43095030955  28.64   2.691 0.000000 0.001367 0.019278 0.004486 0.005380 0.061888 0.000000 0.068569 0.387428 0.458931  0.9362749932844370        0
jxl:d24:epf3       17972865   360283    0.16036753183   1   2.649  13.924  21.55065346   5.77995514017  27.36   2.672 0.000000 0.001367 0.010209 0.002296 0.002766 0.045522 0.000000 0.050821 0.364467 0.530378  0.9269171399281144        0
jxl:d32:epf3       17972865   293127    0.13047535827   1   2.811  14.285  25.75268745   7.00993165520  26.54   2.671 0.000000 0.001367 0.005708 0.001338 0.001659 0.035231 0.000000 0.039725 0.335211 0.587808  0.9146233441551781        0
Aggregate:         17972865  1125191    0.50083983297 ---   2.694  17.364   6.92351368   1.86311414973  33.21   2.389 0.000000 0.001147 0.055917 0.009308 0.016526 0.103265 0.000000 0.139138 0.175065 0.251342  0.9331217795490244        0
```

After:

```
Compr                 Input    Compr            Compr       Compr  Decomp  Butteraugli
Method               Pixels     Size              BPP   #    MP/s    MP/s     Distance    Error p norm   PSNR   QABPP     DCT2     DCT4   DCT4X8      AFV     DCT8  DCT8X16  DCT8X32    DCT16 DCT16X32    DCT32           BPP*pnorm   Errors
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
jxl:d0.8:epf0      17972865  3978806    1.77102804700   1   2.398  14.213   1.57902789   0.52086395504  41.78   2.105 0.000000 0.000911 0.229583 0.021543 0.060425 0.226524 0.000000 0.378839 0.019399 0.062045  0.9224646730469741        0
jxl:d1:epf1        17972865  3463827    1.54180293459   1   2.641  20.917   1.94600439   0.60486049029  40.67   2.121 0.000000 0.000911 0.205023 0.021429 0.055422 0.201434 0.000000 0.368441 0.040452 0.106485  0.9325756789425728        0
jxl:d2:epf3        17972865  2237796    0.99607758696   1   2.899  16.516   3.58430505   0.95296509723  37.47   2.242 0.000000 0.000911 0.150402 0.021098 0.043984 0.157941 0.000000 0.264263 0.163603 0.198272  0.9492271745064277        0
jxl:d3:epf0        17972865  1669569    0.74315096675   1   2.769  24.327   4.53973532   1.27958860382  35.22   2.301 0.000000 0.001139 0.121537 0.019339 0.038903 0.141895 0.000000 0.199824 0.238297 0.241117  0.9509275079664137        0
jxl:d4:epf3        17972865  1382640    0.61543443408   1   2.523  15.228   7.13408566   1.56352039034  34.07   2.417 0.000000 0.001139 0.098897 0.017430 0.032984 0.129639 0.000000 0.167320 0.287295 0.268465  0.9622442865936787        0
jxl:d8:epf1        17972865   809952    0.36052215381   1   2.814  23.298   9.39596844   2.50445329294  30.89   2.360 0.000000 0.001367 0.055906 0.011583 0.019691 0.101479 0.000000 0.114476 0.371247 0.329940  0.9029108952972669        0
jxl:d16:epf3       17972865   474716    0.21130342881   1   2.864  14.656  19.67390442   4.43384173622  28.64   2.690 0.000000 0.001367 0.019278 0.004486 0.005380 0.061888 0.000000 0.068569 0.387428 0.458931  0.9368859616541297        0
jxl:d24:epf3       17972865   360283    0.16036753183   1   2.655  14.050  21.57835007   5.78683682355  27.36   2.675 0.000000 0.001367 0.010209 0.002296 0.002766 0.045522 0.000000 0.050821 0.364467 0.530378  0.9280207385080361        0
jxl:d32:epf3       17972865   293127    0.13047535827   1   2.830  13.779  25.78195763   7.01708005802  26.53   2.674 0.000000 0.001367 0.005708 0.001338 0.001659 0.035231 0.000000 0.039725 0.335211 0.587808  0.9155560345737087        0
Aggregate:         17972865  1125191    0.50083983297 ---   2.706  17.026   6.92623263   1.86338398184  33.21   2.388 0.000000 0.001147 0.055917 0.009308 0.016526 0.103265 0.000000 0.139138 0.175065 0.251342  0.9332569222178452        0
```