### PR TITLE
don't do resampling + dc frame

### DIFF
--- a/lib/jxl/enc_frame.cc
+++ b/lib/jxl/enc_frame.cc
@@ -1030,6 +1030,7 @@ Status EncodeFrame(const CompressParams& cparams_orig,
   if (cparams.ec_resampling < cparams.resampling) {
     cparams.ec_resampling = cparams.resampling;
   }
+  if (cparams.resampling > 1) cparams.progressive_dc = 0;
 
   if (frame_info.dc_level + cparams.progressive_dc > 4) {
     return JXL_FAILURE("Too many levels of progressive DC");


### PR DESCRIPTION
Spec doesn't allow the combination of upsampling and LF frames (since the upsampling factor is signaled in the main frame, and LF frame dimensions are implicit).
This overrides the use of LF frames if it will lead to encode failure.
(another option would be to override the use of upsampling)

Fixes https://github.com/libjxl/libjxl/issues/91