### PR TITLE
Set custom GIT_CLONE_PATH to a fixed path.

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -18,6 +18,9 @@ variables:
   # By default we don't fetch any third_party dependencies. Building requires to
   # fetch all the dependencies but many other workflows don't.
   GIT_SUBMODULE_STRATEGY: none
+  # Set the default checkout directory to a fixed one so it is the same across
+  # multiple jobs. cmake requires that build directory's realpath to not change.
+  GIT_CLONE_PATH: $CI_BUILDS_DIR/libjxl
 
 # A template for running in the generic cloud builders. These are tagged with
 # "linux" and run on shared VMs.


### PR DESCRIPTION
We run build and tests in different jobs, but cmake requires the build
directory to not move. gitlab-runner recently started making the
checkout directory depend on the job number, which changes between
stages. Each runner only runs one job at a time in one Pod so having
different build directories is not needed. Setting the GIT_CLONE_PATH
to a fixed value will make all the stages build/test from the same
directory path.