### PR TITLE
Fix and silence some unsigned integer overflow.

### DIFF
--- a/lib/jxl/base/compiler_specific.h
+++ b/lib/jxl/base/compiler_specific.h
@@ -129,6 +129,16 @@
 #define JXL_MUST_USE_RESULT
 #endif
 
+// Disable certain -fsanitize flags for functions that are expected to include
+// things like unsigned integer overflow. For example use in the function
+// declaration JXL_NO_SANITIZE("unsigned-integer-overflow") to silence unsigned
+// integer overflow ubsan messages.
+#if JXL_COMPILER_CLANG && JXL_HAVE_ATTRIBUTE(no_sanitize)
+#define JXL_NO_SANITIZE(X) __attribute__((no_sanitize(X)))
+#else
+#define JXL_NO_SANITIZE(X)
+#endif
+
 #if JXL_HAVE_ATTRIBUTE(__format__)
 #define JXL_FORMAT(idx_fmt, idx_arg) \
   __attribute__((__format__(__printf__, idx_fmt, idx_arg)))

--- a/lib/jxl/color_encoding_internal.cc
+++ b/lib/jxl/color_encoding_internal.cc
@@ -554,8 +554,12 @@ Status CustomTransferFunction::VisitFields(Visitor* JXL_RESTRICT visitor) {
     JXL_QUIET_RETURN_IF_ERROR(visitor->Bool(false, &have_gamma_));
 
     if (visitor->Conditional(have_gamma_)) {
+      // Gamma is represented as a 24-bit int, the exponent used is
+      // gamma_ / 1e7. Valid values are (0, 1]. On the low end side, we also
+      // limit it to kMaxGamma/1e7.
       JXL_QUIET_RETURN_IF_ERROR(visitor->Bits(24, kGammaMul, &gamma_));
-      if (gamma_ > kGammaMul || gamma_ * kMaxGamma < kGammaMul) {
+      if (gamma_ > kGammaMul ||
+          static_cast<uint64_t>(gamma_) * kMaxGamma < kGammaMul) {
         return JXL_FAILURE("Invalid gamma %u", gamma_);
       }
     }

--- a/lib/jxl/color_management.cc
+++ b/lib/jxl/color_management.cc
@@ -105,7 +105,8 @@ std::vector<uint16_t> CreateTableCurve(uint32_t N, const Func& func) {
   return table;
 }
 
-void ICCComputeMD5(const PaddedBytes& data, uint8_t sum[16]) {
+void ICCComputeMD5(const PaddedBytes& data, uint8_t sum[16])
+    JXL_NO_SANITIZE("unsigned-integer-overflow") {
   PaddedBytes data64 = data;
   data64.push_back(128);
   // Add bytes such that ((size + 8) & 63) == 0.

--- a/lib/jxl/common.h
+++ b/lib/jxl/common.h
@@ -162,7 +162,8 @@ JXL_INLINE T Clamp1(T val, T low, T hi) {
 }
 
 // Encodes non-negative (X) into (2 * X), negative (-X) into (2 * X - 1)
-constexpr uint32_t PackSigned(int32_t value) {
+constexpr uint32_t PackSigned(int32_t value)
+    JXL_NO_SANITIZE("unsigned-integer-overflow") {
   return (static_cast<uint32_t>(value) << 1) ^
          ((static_cast<uint32_t>(~value) >> 31) - 1);
 }


### PR DESCRIPTION
When reading a gamma value, the largest value (1e7) overflow uint32_t
when multiplying by 8192, which would reject some specific but valid
values of gamma. This patch fixes that check and also silences the
unsigned-integer-overflow for a few functions that intentionally do
that.