### PR TITLE
Define JPEGXL_VERSION in main CMakeLists

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -17,8 +17,9 @@ Google LLC <*@google.com>
 
 # Individuals:
 Dirk Lemstra <dirk@lemstra.org>
+Dmitry <eddie.zato@gmail.com>
 Jon Sneyers <jon@cloudinary.com>
-Pieter Wuille
 Marcin Konicki <ahwayakchih@gmail.com>
-Ziemowit Zabawa <ziemek.zabawa@outlook.com>
 Petr Diblík
+Pieter Wuille
+Ziemowit Zabawa <ziemek.zabawa@outlook.com>

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -109,7 +109,8 @@ set(JPEGXL_DEP_LICENSE_DIR "" CACHE STRING
     "Directory where to search for system dependencies \"copyright\" files.")
 set(JPEGXL_FORCE_NEON false CACHE BOOL
     "Set flags to enable NEON in arm if not enabled by your toolchain.")
-
+set(JPEGXL_VERSION "" CACHE STRING
+    "Build JPEGXL with additional version information.")
 
 # Force system dependencies.
 set(JPEGXL_FORCE_SYSTEM_GTEST false CACHE BOOL


### PR DESCRIPTION
Define `JPEGXL_VERSION` in the main CMakeLists to use it to provide additional version information when building. This flag is already used in [tools/CMakeLists](https://github.com/libjxl/libjxl/blob/main/tools/CMakeLists.txt#L58).