### PR TITLE
Update cmake project() name

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,7 +20,7 @@ if(POLICY CMP0083)
   cmake_policy(SET CMP0083 NEW)
 endif()
 
-project(JPEGXL LANGUAGES C CXX)
+project(LIBJXL LANGUAGES C CXX)
 
 include(CheckCXXSourceCompiles)
 check_cxx_source_compiles(


### PR DESCRIPTION
The project() cmake command defines the ${project_name}_VERSION variable
with the value passed in the VERSION parameter to this command. We are
currently not setting the VERSION parameter so this was defining
JPEGXL_VERSION as the empty string. Independent to this we where using
the JPEGXL_VERSION cmake variable to let integrators define a project
version to include in the tools (like the package version) which was not
working since cmake would override its value.

This patch renames the project() name to LIBJXL to workaround this
issue. We should eventually set up the version numbers in the project()
as well.