### PR TITLE
less ringing

### DIFF
--- a/lib/jxl/enc_ac_strategy.cc
+++ b/lib/jxl/enc_ac_strategy.cc
@@ -829,20 +829,20 @@ void ProcessRectACS(PassesEncoderState* JXL_RESTRICT enc_state,
   //  const float entropy_mul16X8 = mul8X16 * 0.91195782912371126f;
 
   static const float k16X16mul1 = -0.35;
-  static const float k16X16mul2 = 0.82098067020252011;
+  static const float k16X16mul2 = 0.82;
   static const float k16X16base = 2.0;
   const float entropy_mul16X16 =
       k16X16mul2 + k16X16mul1 / (butteraugli_target + k16X16base);
   //  const float entropy_mul16X16 = mul16X16 * 0.83183417727960129f;
 
   static const float k32X16mul1 = -0.1;
-  static const float k32X16mul2 = 0.86098067020252011;
+  static const float k32X16mul2 = 0.84;
   static const float k32X16base = 2.5;
   const float entropy_mul16X32 =
       k32X16mul2 + k32X16mul1 / (butteraugli_target + k32X16base);
 
-  const float entropy_mul32X32 = 0.9188333021616017f;
-  const float entropy_mul64X64 = 1.50f;
+  const float entropy_mul32X32 = 0.9;
+  const float entropy_mul64X64 = 1.43f;
   // TODO(jyrki): Consider this feedback in further changes:
   // Also effectively when the multipliers for smaller blocks are
   // below 1, this raises the bar for the bigger blocks even higher
@@ -863,8 +863,8 @@ void ProcessRectACS(PassesEncoderState* JXL_RESTRICT enc_state,
       // subdivisions. {AcStrategy::Type::DCT32X32, 5, 1, 5,
       // 0.9822994906548809f},
       // TODO(jyrki): re-enable 64x32 and 64x64 if/when possible.
-      {AcStrategy::Type::DCT64X32, 6, 1, 3, 1.27f},
-      {AcStrategy::Type::DCT32X64, 6, 1, 3, 1.27f},
+      {AcStrategy::Type::DCT64X32, 6, 1, 3, 1.26f},
+      {AcStrategy::Type::DCT32X64, 6, 1, 3, 1.26f},
       // {AcStrategy::Type::DCT64X64, 8, 1, 3, 2.0846542128012948f},
   };
   /*

--- a/lib/jxl/enc_adaptive_quantization.cc
+++ b/lib/jxl/enc_adaptive_quantization.cc
@@ -63,7 +63,7 @@ using hwy::HWY_NAMESPACE::Rebind;
 // masking.
 float ComputeMaskForAcStrategyUse(const float out_val) {
   const float kMul = 1.0f;
-  const float kOffset = 0.4f;
+  const float kOffset = 0.001f;
   return kMul / (out_val + kOffset);
 }
 
@@ -665,7 +665,7 @@ ImageF TileDistMap(const ImageF& distmap, int tile_size, int margin,
 
 constexpr float kDcQuantPow = 0.57f;
 static const float kDcQuant = 1.12f;
-static const float kAcQuant = 0.787f;
+static const float kAcQuant = 0.7886f;
 
 void FindBestQuantization(const ImageBundle& linear, const Image3F& opsin,
                           PassesEncoderState* enc_state, ThreadPool* pool,


### PR DESCRIPTION
This reduces ringing by a very small amount. Also improves other quality
metrics (0.01 % BPP*pnorm win, i.e., by even less than impact on ringing).

This works by reducing a stabilization epsilon in converting visual
masking data from adaptive quantization into use by ac strategy
computation. The stabilization epsilon affects the balance of integral
transform, so that is compensated for in the respective constants.

A lower stabilization epsilon increases the importance of a fully flat area
in integral transform split, and makes it more likely not to be
connected with a block containing high visual activity.

Before:

```
Compr                 Input    Compr            Compr       Compr  Decomp  Butteraugli
Method               Pixels     Size              BPP   #    MP/s    MP/s     Distance    Error p norm   PSNR   QABPP     DCT2     DCT4   DCT4X8      AFV     DCT8  DCT8X16  DCT8X32    DCT16 DCT16X32    DCT32           BPP*pnorm   Errors
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
jxl:d0.8:epf0      18628225  4051673    1.74001462834   1   2.320  14.745   1.57902789   0.52106338925  41.91   2.063 0.000879 0.000879 0.226199 0.021029 0.059065 0.236716 0.000000 0.374746 0.020778 0.058983  0.9066579195887609        0
jxl:d1:epf1        18628225  3527161    1.51475988721   1   2.775  20.152   1.94598019   0.60464260811  40.80   2.076 0.000879 0.001099 0.202101 0.020940 0.054090 0.206935 0.000000 0.365484 0.045872 0.102189  0.9158883688673196        0
jxl:d2:epf3        18628225  2281074    0.97962054893   1   2.877  16.367   3.58487940   0.95084151460  37.59   2.201 0.001539 0.001099 0.148244 0.020765 0.042931 0.156170 0.000000 0.259625 0.173568 0.196464  0.9314638864721871        0
jxl:d3:epf0        18628225  1702937    0.73133623842   1   2.715  24.711   4.53973532   1.27485806562  35.35   2.256 0.001539 0.001099 0.120110 0.019036 0.038049 0.139961 0.000000 0.195776 0.242226 0.244123  0.9323499022368545        0
jxl:d4:epf3        18628225  1411342    0.60610906299   1   2.674  15.201   7.13622332   1.55500204793  34.19   2.371 0.001649 0.001099 0.097830 0.017195 0.032257 0.128005 0.000000 0.164045 0.286505 0.274412  0.9425008342243508        0
jxl:d8:epf1        18628225   828411    0.35576594120   1   2.664  24.561   9.39446449   2.48434097548  31.01   2.319 0.002088 0.001319 0.055781 0.011512 0.019195 0.100245 0.000000 0.112373 0.365800 0.337133  0.8838439054026407        0
jxl:d16:epf3       18628225   486906    0.20910462484   1   2.830  14.795  19.64636612   4.39987121745  28.75   2.646 0.006706 0.001319 0.019359 0.004569 0.005290 0.061346 0.000000 0.067517 0.380862 0.460101  0.9200334202543667        0
jxl:d24:epf3       18628225   370224    0.15899485861   1   2.808  14.632  21.55065346   5.75132072604  27.47   2.640 0.020119 0.029903 0.010169 0.002288 0.002731 0.045116 0.000000 0.050325 0.358983 0.487916  0.9144304256486561        0
jxl:d32:epf3       18628225   301556    0.12950498504   1   2.785  14.600  25.75268745   6.98057732822  26.64   2.642 0.035840 0.051672 0.005651 0.001312 0.001635 0.034672 0.000000 0.039290 0.330921 0.506771  0.9040195624822678        0
Aggregate:         18628225  1150375    0.49403507188 ---   2.712  17.341   6.92351368   1.85542960711  33.32   2.347 0.003149 0.002472 0.055433 0.009201 0.016188 0.103119 0.000000 0.137117 0.179143 0.243796  0.9166472993078344        0
```

After:

```
Compr                 Input    Compr            Compr       Compr  Decomp  Butteraugli
Method               Pixels     Size              BPP   #    MP/s    MP/s     Distance    Error p norm   PSNR   QABPP     DCT2     DCT4   DCT4X8      AFV     DCT8  DCT8X16  DCT8X32    DCT16 DCT16X32    DCT32           BPP*pnorm   Errors
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
jxl:d0.8:epf0      18628225  4056564    1.74211509685   1   2.327  14.826   1.57177663   0.52136998154  41.93   2.075 0.000879 0.000879 0.232150 0.021277 0.060824 0.220919 0.000000 0.333299 0.038067 0.090866  0.9082865158818235        0
jxl:d1:epf1        18628225  3527458    1.51488743560   1   2.778  21.082   1.94598031   0.60525471410  40.81   2.075 0.000879 0.001099 0.206437 0.021215 0.055667 0.193591 0.000000 0.316093 0.080421 0.123958  0.9168927617276345        0
jxl:d2:epf3        18628225  2276969    0.97785763271   1   2.869  16.305   3.58473778   0.95295073209  37.56   2.196 0.001429 0.001099 0.149261 0.020981 0.043237 0.146173 0.000000 0.209615 0.234668 0.193770  0.9318501469689160        0
jxl:d3:epf0        18628225  1698938    0.72961884452   1   2.707  25.419   4.51204920   1.27633155187  35.31   2.266 0.001539 0.001099 0.118701 0.019201 0.037730 0.131763 0.000000 0.155854 0.299753 0.236152  0.9312355521019807        0
jxl:d4:epf3        18628225  1409869    0.60547647454   1   2.653  14.755   7.13725281   1.55616459511  34.17   2.367 0.001539 0.001099 0.097187 0.017308 0.032202 0.120556 0.000000 0.130142 0.335868 0.266991  0.9422210528544848        0
jxl:d8:epf1        18628225   831150    0.35694222074   1   2.654  23.545   9.39110851   2.47977505736  31.01   2.323 0.001978 0.001319 0.055794 0.011784 0.019270 0.095346 0.000000 0.093655 0.400019 0.326194  0.8851364159171169        0
jxl:d16:epf3       18628225   487417    0.20932407677   1   2.818  14.654  19.64636803   4.39120985006  28.75   2.613 0.004837 0.001539 0.020108 0.004895 0.005620 0.060714 0.000000 0.058708 0.407330 0.443280  0.9191859477702774        0
jxl:d24:epf3       18628225   369052    0.15849153636   1   2.843  14.547  21.46730042   5.74277556080  27.47   2.626 0.009564 0.032542 0.011062 0.002538 0.003009 0.045522 0.000000 0.044553 0.383445 0.475273  0.9101813216292727        0
jxl:d32:epf3       18628225   302027    0.12970725874   1   2.791  14.452  25.75357819   6.97978677103  26.64   2.654 0.020888 0.053651 0.006187 0.001467 0.001820 0.035064 0.000000 0.035112 0.357114 0.496437  0.9053290086816004        0
Aggregate:         18628225  1150226    0.49397106792 ---   2.711  17.298   6.91212759   1.85549313421  33.32   2.345 0.002576 0.002549 0.056986 0.009574 0.016782 0.099049 0.000000 0.116168 0.227210 0.255833  0.9165599250253633        0
```