### PR TITLE
Support extra channel output

### DIFF
--- a/lib/include/jxl/decode.h
+++ b/lib/include/jxl/decode.h
@@ -828,6 +828,58 @@ JxlDecoderSetImageOutCallback(JxlDecoder* dec, const JxlPixelFormat* format,
                               JxlImageOutCallback callback, void* opaque);
 
 /**
+ * Returns the minimum size in bytes of an extra channel pixel buffer for the
+ * given format. This is the buffer for JxlDecoderSetExtraChannelBuffer.
+ * Requires the basic image information is available in the decoder.
+ *
+ * @param dec decoder object
+ * @param format format of the pixels. The num_channels value is ignored and is
+ * always treated to be 1.
+ * @param size output value, buffer size in bytes
+ * @param index which extra channel to get, matching the index used in @see
+ * JxlDecoderGetExtraChannelInfo. Must be smaller than num_extra_channels in the
+ * associated JxlBasicInfo.
+ * @return JXL_DEC_SUCCESS on success, JXL_DEC_ERROR on error, such as
+ *    information not available yet or invalid index.
+ */
+JXL_EXPORT JxlDecoderStatus JxlDecoderExtraChannelBufferSize(
+    const JxlDecoder* dec, const JxlPixelFormat* format, size_t* size,
+    uint32_t index);
+
+/**
+ * Sets the buffer to write an extra channel to. This can be set when
+ * the JXL_DEC_FRAME or JXL_DEC_NEED_IMAGE_OUT_BUFFER event occurs, and applies
+ * only for the current frame. The size of the buffer must be at least as large
+ * as given by JxlDecoderExtraChannelBufferSize. The buffer follows the format
+ * described by JxlPixelFormat, but where num_channels is 1. The buffer is owned
+ * by the caller. The amount of extra channels is given by the
+ * num_extra_channels field in the associated JxlBasicInfo, and the information
+ * of individual extra channels can be queried with @see
+ * JxlDecoderGetExtraChannelInfo. To get multiple extra channels, this function
+ * must be called multiple times, once for each wanted index. Not all images
+ * have extra channels. The alpha channel is an extra channel and can be gotten
+ * as part of the color channels when using an RGBA pixel buffer with
+ * JxlDecoderSetImageOutBuffer, but additionally also can be gotten separately
+ * as extra channel. The color channels themselves cannot be gotten this way.
+ *
+ *
+ * @param dec decoder object
+ * @param format format of the pixels. Object owned by user and its contents
+ * are copied internally. The num_channels value is ignored and is always
+ * treated to be 1.
+ * @param buffer buffer type to output the pixel data to
+ * @param size size of buffer in bytes
+ * @param index which extra channel to get, matching the index used in @see
+ * JxlDecoderGetExtraChannelInfo. Must be smaller than num_extra_channels in the
+ * associated JxlBasicInfo.
+ * @return JXL_DEC_SUCCESS on success, JXL_DEC_ERROR on error, such as
+ * size too small or invalid index.
+ */
+JXL_EXPORT JxlDecoderStatus
+JxlDecoderSetExtraChannelBuffer(JxlDecoder* dec, const JxlPixelFormat* format,
+                                void* buffer, size_t size, uint32_t index);
+
+/**
  * Sets output buffer for reconstructed JPEG codestream.
  *
  * The data is owned by the caller
@@ -860,8 +912,6 @@ JXL_EXPORT JxlDecoderStatus JxlDecoderSetJPEGBuffer(JxlDecoder* dec,
  * JxlDecoderReleaseJPEGBuffer was already called.
  */
 JXL_EXPORT size_t JxlDecoderReleaseJPEGBuffer(JxlDecoder* dec);
-
-/* TODO(lode): add way to output extra channels */
 
 /**
  * Outputs progressive step towards the decoded image so far when only partial

--- a/lib/include/jxl/types.h
+++ b/lib/include/jxl/types.h
@@ -84,7 +84,7 @@ typedef enum {
  */
 typedef struct {
   /** Amount of channels available in a pixel buffer.
-   * 1: single-channel data, e.g. grayscale
+   * 1: single-channel data, e.g. grayscale or a single extra channel
    * 2: single-channel + alpha
    * 3: trichromatic, e.g. RGB
    * 4: trichromatic + alpha

--- a/lib/jxl/dec_external_image.cc
+++ b/lib/jxl/dec_external_image.cc
@@ -512,5 +512,17 @@ Status ConvertToExternal(const jxl::ImageBundle& ib, size_t bits_per_sample,
       pool, out_image, out_size, out_callback, out_opaque, undo_orientation);
 }
 
+Status ConvertToExternal(const jxl::ImageF& channel, size_t bits_per_sample,
+                         bool float_out, JxlEndianness endianness,
+                         size_t stride, jxl::ThreadPool* pool, void* out_image,
+                         size_t out_size, JxlImageOutCallback out_callback,
+                         void* out_opaque, jxl::Orientation undo_orientation) {
+  const ImageF* channels[1];
+  channels[0] = &channel;
+  return ConvertChannelsToExternal(
+      channels, 1, bits_per_sample, float_out, endianness, stride, pool,
+      out_image, out_size, out_callback, out_opaque, undo_orientation);
+}
+
 }  // namespace jxl
 #endif  // HWY_ONCE

--- a/lib/jxl/dec_external_image.h
+++ b/lib/jxl/dec_external_image.h
@@ -40,6 +40,22 @@ Status ConvertToExternal(const jxl::ImageBundle& ib, size_t bits_per_sample,
                          size_t out_size, JxlImageOutCallback out_callback,
                          void* out_opaque, jxl::Orientation undo_orientation);
 
+// Converts single-channel image to interleaved void* pixel buffer with the
+// given format, with a single channel.
+// bits_per_sample: must be 8, 16 or 32, and must be 32 if float_out
+// is true. 1 and 32 int are not yet implemented.
+// This supports the features needed for the C API to get extra channels.
+// stride_out is output scanline size in bytes, must be >=
+// output_xsize * output_bytes_per_pixel.
+// undo_orientation is an EXIF orientation to undo. Depending on the
+// orientation, the output xsize and ysize are swapped compared to input
+// xsize and ysize.
+Status ConvertToExternal(const jxl::ImageF& channel, size_t bits_per_sample,
+                         bool float_out, JxlEndianness endianness,
+                         size_t stride_out, jxl::ThreadPool* thread_pool,
+                         void* out_image, size_t out_size,
+                         JxlImageOutCallback out_callback, void* out_opaque,
+                         jxl::Orientation undo_orientation);
 }  // namespace jxl
 
 #endif  // LIB_JXL_DEC_EXTERNAL_IMAGE_H_

--- a/lib/jxl/decode_test.cc
+++ b/lib/jxl/decode_test.cc
@@ -498,7 +498,7 @@ std::vector<uint8_t> DecodeWithAPI(JxlDecoder* dec,
 
   EXPECT_EQ(JXL_DEC_FULL_IMAGE, JxlDecoderProcessInput(dec));
 
-  // After the full image is gotten, JxlDecoderProcessInput should return
+  // After the full image was output, JxlDecoderProcessInput should return
   // success to indicate all is done.
   EXPECT_EQ(JXL_DEC_SUCCESS, JxlDecoderProcessInput(dec));
 
@@ -2413,6 +2413,87 @@ TEST(DecodeTest, AnimationTestStreaming) {
 
   JxlThreadParallelRunnerDestroy(runner);
   JxlDecoderDestroy(dec);
+}
+
+TEST(DecodeTest, ExtraChannelTest) {
+  size_t xsize = 55, ysize = 257;
+  std::vector<uint8_t> pixels = jxl::test::GetSomeTestImage(xsize, ysize, 4, 0);
+  JxlPixelFormat format_orig = {4, JXL_TYPE_UINT16, JXL_BIG_ENDIAN, 0};
+
+  jxl::CompressParams cparams;
+  cparams.SetLossless();  // Lossless to verify pixels exactly after roundtrip.
+  jxl::PaddedBytes compressed = jxl::CreateTestJXLCodestream(
+      jxl::Span<const uint8_t>(pixels.data(), pixels.size()), xsize, ysize, 4,
+      cparams, kCSBF_None, JXL_ORIENT_IDENTITY, false);
+
+  size_t align = 17;
+  JxlPixelFormat format = {3, JXL_TYPE_UINT8, JXL_LITTLE_ENDIAN, align};
+
+  JxlDecoder* dec = JxlDecoderCreate(NULL);
+
+  EXPECT_EQ(JXL_DEC_SUCCESS, JxlDecoderSubscribeEvents(
+                                 dec, JXL_DEC_BASIC_INFO | JXL_DEC_FULL_IMAGE));
+
+  EXPECT_EQ(JXL_DEC_SUCCESS,
+            JxlDecoderSetInput(dec, compressed.data(), compressed.size()));
+  EXPECT_EQ(JXL_DEC_BASIC_INFO, JxlDecoderProcessInput(dec));
+  JxlBasicInfo info;
+  EXPECT_EQ(JXL_DEC_SUCCESS, JxlDecoderGetBasicInfo(dec, &info));
+  EXPECT_EQ(1, info.num_extra_channels);
+  EXPECT_EQ(JXL_FALSE, info.alpha_premultiplied);
+
+  JxlExtraChannelInfo extra_info;
+  EXPECT_EQ(JXL_DEC_SUCCESS,
+            JxlDecoderGetExtraChannelInfo(dec, 0, &extra_info));
+  EXPECT_EQ(0, extra_info.type);
+
+  EXPECT_EQ(JXL_DEC_NEED_IMAGE_OUT_BUFFER, JxlDecoderProcessInput(dec));
+  size_t buffer_size;
+  EXPECT_EQ(JXL_DEC_SUCCESS,
+            JxlDecoderImageOutBufferSize(dec, &format, &buffer_size));
+  size_t extra_size;
+  EXPECT_EQ(JXL_DEC_SUCCESS,
+            JxlDecoderExtraChannelBufferSize(dec, &format, &extra_size, 0));
+
+  std::vector<uint8_t> image(buffer_size);
+  std::vector<uint8_t> extra(extra_size);
+  size_t bytes_per_pixel =
+      format.num_channels * GetDataBits(format.data_type) / jxl::kBitsPerByte;
+  size_t stride = bytes_per_pixel * info.xsize;
+  if (format.align > 1) {
+    stride = jxl::DivCeil(stride, format.align) * format.align;
+  }
+
+  EXPECT_EQ(JXL_DEC_SUCCESS, JxlDecoderSetImageOutBuffer(
+                                 dec, &format, image.data(), image.size()));
+  EXPECT_EQ(JXL_DEC_SUCCESS, JxlDecoderSetExtraChannelBuffer(
+                                 dec, &format, extra.data(), extra.size(), 0));
+
+  EXPECT_EQ(JXL_DEC_FULL_IMAGE, JxlDecoderProcessInput(dec));
+
+  // After the full image was output, JxlDecoderProcessInput should return
+  // success to indicate all is done.
+  EXPECT_EQ(JXL_DEC_SUCCESS, JxlDecoderProcessInput(dec));
+  JxlDecoderDestroy(dec);
+
+  EXPECT_EQ(0, ComparePixels(pixels.data(), image.data(), xsize, ysize,
+                             format_orig, format));
+
+  // Compare the extracted extra channel with the original alpha channel
+
+  std::vector<uint8_t> alpha(pixels.size() / 4);
+  for (size_t i = 0; i < pixels.size(); i += 8) {
+    size_t index_alpha = i / 4;
+    alpha[index_alpha + 0] = pixels[i + 6];
+    alpha[index_alpha + 1] = pixels[i + 7];
+  }
+  JxlPixelFormat format_alpha = format;
+  format_alpha.num_channels = 1;
+  JxlPixelFormat format_orig_alpha = format_orig;
+  format_orig_alpha.num_channels = 1;
+
+  EXPECT_EQ(0, ComparePixels(alpha.data(), extra.data(), xsize, ysize,
+                             format_orig_alpha, format_alpha));
 }
 
 TEST(DecodeTest, SkipFrameTest) {


### PR DESCRIPTION
Allows outputting extra channels to individual single-channel buffers,
similar to the main image output

Adds two new functions to the API: JxlDecoderExtraChannelBufferSize
and JxlDecoderSetExtraChannelBuffer