### PR TITLE
Fix name mismatch "associated" and "premultiplied"

### DIFF
--- a/examples/jxlinfo.c
+++ b/examples/jxlinfo.c
@@ -127,7 +127,7 @@ int PrintBasicInfo(FILE* file) {
           free(name);
           printf("  name: %s\n", name);
         }
-        printf("  alpha_associated: %d\n", extra.alpha_associated);
+        printf("  alpha_premultiplied: %d\n", extra.alpha_premultiplied);
         printf("  spot_color: %f %f %f %f\n", extra.spot_color[0],
                extra.spot_color[1], extra.spot_color[2], extra.spot_color[3]);
         printf("  cfa_channel: %u\n", extra.cfa_channel);

--- a/lib/include/jxl/codestream_header.h
+++ b/lib/include/jxl/codestream_header.h
@@ -203,15 +203,20 @@ typedef struct JxlBasicInfo {
   uint32_t num_extra_channels;
 
   /** Bit depth of the encoded alpha channel, or 0 if there is no alpha channel.
+   * If present, matches the alpha_bits value of the JxlExtraChannelInfo
+   * associated with this alpha channel.
    */
   uint32_t alpha_bits;
 
-  /** Alpha channel floating point exponent bits, or 0 if they are unsigned
-   * integer.
+  /** Alpha channel floating point exponent bits, or 0 if they are unsigned. If
+   * present, matches the alpha_bits value of the JxlExtraChannelInfo associated
+   * with this alpha channel. integer.
    */
   uint32_t alpha_exponent_bits;
 
-  /** Whether the alpha channel is premultiplied
+  /** Whether the alpha channel is premultiplied. Only used if there is a main
+   * alpha channel. Matches the alpha_premultiplied value of the
+   * JxlExtraChannelInfo associated with this alpha channel.
    */
   JXL_BOOL alpha_premultiplied;
 
@@ -257,7 +262,7 @@ typedef struct {
   /** Whether alpha channel uses premultiplied alpha. Only applicable if
    * type is JXL_CHANNEL_ALPHA.
    */
-  JXL_BOOL alpha_associated;
+  JXL_BOOL alpha_premultiplied;
 
   /** Spot color of the current spot channel in linear RGBA. Only applicable if
    * type is JXL_CHANNEL_SPOT_COLOR.

--- a/lib/jxl/decode.cc
+++ b/lib/jxl/decode.cc
@@ -1812,7 +1812,7 @@ JxlDecoderStatus JxlDecoderGetExtraChannelInfo(const JxlDecoder* dec,
           : 0;
   info->dim_shift = channel.dim_shift;
   info->name_length = channel.name.size();
-  info->alpha_associated = channel.alpha_associated;
+  info->alpha_premultiplied = channel.alpha_associated;
   info->spot_color[0] = channel.spot_color[0];
   info->spot_color[1] = channel.spot_color[1];
   info->spot_color[2] = channel.spot_color[2];

--- a/lib/jxl/decode_test.cc
+++ b/lib/jxl/decode_test.cc
@@ -974,7 +974,7 @@ TEST(DecodeTest, BasicInfoTest) {
           EXPECT_EQ(0, JxlDecoderGetExtraChannelInfo(dec, 0, &extra));
           EXPECT_EQ(alpha_bits[i], extra.bits_per_sample);
           EXPECT_EQ(JXL_CHANNEL_ALPHA, extra.type);
-          EXPECT_EQ(0, extra.alpha_associated);
+          EXPECT_EQ(0, extra.alpha_premultiplied);
           // Verify the name "alpha_test" given to the alpha channel
           EXPECT_EQ(10, extra.name_length);
           char name[11];

--- a/tools/conformance/djxl_conformance.cc
+++ b/tools/conformance/djxl_conformance.cc
@@ -467,7 +467,7 @@ bool DecodeJXL(const DecodeOptions& opts) {
       METADATA_CHANNEL(exponent_bits_per_sample);
       METADATA_CHANNEL(dim_shift);
       channel_i->Add("name", JSONValue(extra_channel_names[i]));
-      METADATA_CHANNEL(alpha_associated);
+      METADATA_CHANNEL(alpha_premultiplied);
       METADATA_CHANNEL(cfa_channel);
       // TODO(deymo): Spot color.
     }


### PR DESCRIPTION
Fix name mismatch in the API. These are corresponding fields and
it was a historical error that they appeared independently with
a different name.

Also add to the comments that they match that of the main alpha
extra channel.

This renames a field in the API, but I believe that because the API
did not yet support outputting extra channels, usage of this field
should be extremely rare.