### PR TITLE
fuzz / bitstream bug: squeezing meta channnels

### DIFF
--- a/lib/jxl/modular/transform/squeeze.cc
+++ b/lib/jxl/modular/transform/squeeze.cc
@@ -235,6 +235,15 @@ Status MetaSqueeze(Image &image, std::vector<SqueezeParams> *parameters) {
     uint32_t endc = (*parameters)[i].begin_c + (*parameters)[i].num_c - 1;
 
     uint32_t offset;
+    if (beginc < image.nb_meta_channels) {
+      if (endc >= image.nb_meta_channels) {
+        return JXL_FAILURE("Invalid squeeze: mix of meta and nonmeta channels");
+      }
+      if (!in_place)
+        return JXL_FAILURE(
+            "Invalid squeeze: meta channels require in-place residuals");
+      image.nb_meta_channels += (*parameters)[i].num_c;
+    }
     if (in_place) {
       offset = endc + 1;
     } else {


### PR DESCRIPTION
See also https://github.com/libjxl/libjxl/pull/323

The Modular Squeeze transform, with custom parameters, can do weird things, some of which can lead to trouble.

Squeeze can be applied to metachannels (i.e. palettes), which is fine, except for two things:

-  if it leads to the channel list becoming of the form `[meta channels]* [normal channels]* [meta channels]*`, that violates the implicit invariant that everything starting with `nb_meta_channels` are not meta channels. If that implicit invariant does not hold, there can be channels that never get decoded, leading to uninitialized memory getting read.
- it should update the `nb_meta_channels` counter because effectively the squeeze residuals of a meta channel should also be considered to be a meta channel.

The way to avoid trouble that is implemented in this PR is as follows:

- If a custom Squeeze parameter includes meta channels, it can _only_ operate on meta channels (otherwise the invariant mentioned above would break).
- If a custom Squeeze parameter operates on meta channels, it has to put the residuals `in_place` (and not at the end of the channel list), again to avoid breaking the above invariant.
- The `nb_meta_channels` counter gets updated correctly.

The first two conditions are technically not really a spec bug, in the sense that the spec does not describe these conditions but since that leads to undefined results (pixel values depend on things that are not decoded), such a bitstream has undefined behavior.  (it would still be best to explicitly add these conditions to the spec). The not-updated `nb_meta_channels` counter is a spec bug though.

There are other ways to fix the spec bug: not allowing Squeeze on meta channels at all would also work (though I see some minor value in allowing it; it could make sense for compressing large palettes).

The problematic case was found by fuzzing; the encoder doesn't do any custom Squeeze params at all, and default Squeeze params only operate on non-meta channels. So this PR or any other fix for this spec bug does not affect any existing bitstreams created by cjxl / libjxl. Theoretically it does affect potential future encoders that apply Squeeze to palette data, so for a future-proof decoder it has to be fixed. (not that I expect that to be a terribly useful thing to do for future encoders, but you never know)