### PR TITLE
Fix Threads::Threads definition when JPEGXL_STATIC=1

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -631,10 +631,12 @@ x86_64:static:
     - SKIP_TEST=1 ./ci.sh release
         -DJPEGXL_DEP_LICENSE_DIR=/usr/share/doc
         -DJPEGXL_STATIC=ON
-        -DBUILD_TESTING=OFF
         -DJPEGXL_ENABLE_VIEWERS=OFF
         -DJPEGXL_ENABLE_PLUGINS=OFF
         -DJPEGXL_ENABLE_OPENEXR=OFF
+    # Spot check built binaries
+    - build/tools/cjxl
+        third_party/testdata/wesaturate/64px/cvo9xd_keong_macan_srgb8.png
 
 win64:static:
   <<: *linux_host_build_template

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -152,6 +152,13 @@ if(JPEGXL_STATIC)
   set(BUILD_SHARED_LIBS 0)
   set(CMAKE_EXE_LINKER_FLAGS
       "${CMAKE_EXE_LINKER_FLAGS} -static -static-libgcc -static-libstdc++")
+endif()  # JPEGXL_STATIC
+
+# Threads
+set(THREADS_PREFER_PTHREAD_FLAG YES)
+find_package(Threads REQUIRED)
+
+if(JPEGXL_STATIC)
   if (MINGW)
     # In MINGW libstdc++ uses pthreads directly. When building statically a
     # program (regardless of whether the source code uses pthread or not) the
@@ -167,9 +174,19 @@ if(JPEGXL_STATIC)
     # will be discarded anyway.
     # This adds these flags as dependencies for *all* targets. Adding this to
     # CMAKE_EXE_LINKER_FLAGS instead would cause them to be included before any
-    # object files and therefore discarded.
+    # object files and therefore discarded. This should be set in the
+    # INTERFACE_LINK_LIBRARIES of Threads::Threads but some third_part targets
+    # don't depend on it.
     link_libraries(-Wl,-Bstatic -lstdc++ -lpthread -Wl,-Bdynamic)
-  endif()  # MINGW
+  elseif(CMAKE_USE_PTHREADS_INIT)
+    # Set pthreads as a whole-archive, otherwise weak symbols in the static
+    # libraries will discard pthreads symbols leading to segmentation fault at
+    # runtime.
+    message(STATUS "Using -lpthread as --whole-archive")
+    set_target_properties(Threads::Threads PROPERTIES
+      INTERFACE_LINK_LIBRARIES
+          "-Wl,--whole-archive;-lpthread;-Wl,--no-whole-archive")
+  endif()
 endif()  # JPEGXL_STATIC
 
 if (MSVC)
@@ -248,9 +265,6 @@ set(CMAKE_CXX_EXTENSIONS OFF)
 set(CMAKE_CXX_STANDARD_REQUIRED YES)
 
 add_subdirectory(third_party)
-
-set(THREADS_PREFER_PTHREAD_FLAG YES)
-find_package(Threads REQUIRED)
 
 # Copy the JXL license file to the output build directory.
 configure_file("${CMAKE_CURRENT_SOURCE_DIR}/LICENSE"

--- a/lib/jxl_benchmark.cmake
+++ b/lib/jxl_benchmark.cmake
@@ -21,6 +21,13 @@ if(NOT MINGW)
 find_package(benchmark QUIET)
 
 if(benchmark_FOUND)
+  if(JPEGXL_STATIC AND NOT MINGW)
+    # benchmark::benchmark hardcodes the librt.so which obviously doesn't
+    # compile in static mode.
+    set_target_properties(benchmark::benchmark PROPERTIES
+      INTERFACE_LINK_LIBRARIES "Threads::Threads;-lrt")
+  endif()
+
   # Compiles all the benchmark files into a single binary. Individual benchmarks
   # can be run with --benchmark_filter.
   add_executable(jxl_gbench "${JPEGXL_INTERNAL_SOURCES_GBENCH}")


### PR DESCRIPTION
This sets Threads::Threads to use -Wl,--whole-archive for -lpthread when
compiling with JPEGXL_STATIC=1 since otherwise weak symbols in libstdc++
would not be resolved to pthread's library. This is more of a workaround
for compiling static binaries. The fix modifies the link libraries
properties of Threads::Threads.

Also fixes the -lrt flag in benchmark::benchmark making the benchmark
also compile in static mode when JPEGXL_STATIC=1. There are no changes
to the build when JPEGXL_STATIC=0.

Fixes #332.