### PR TITLE
Fix pixbufloader-jxl and add a test

### DIFF
--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -65,14 +65,17 @@ jobs:
           cmake \
           doxygen \
           libbrotli-dev \
+          libgdk-pixbuf2.0-dev \
           libgif-dev \
           libgtest-dev \
+          libgtk2.0-dev  \
           libjpeg-dev \
           libopenexr-dev \
           libpng-dev \
           libwebp-dev \
           ninja-build \
           pkg-config \
+          xvfb \
           ${{ matrix.apt_pkgs }} \
         #
         echo "CC=clang-7" >> $GITHUB_ENV

--- a/plugins/gdk-pixbuf/CMakeLists.txt
+++ b/plugins/gdk-pixbuf/CMakeLists.txt
@@ -13,7 +13,7 @@ if (NOT Gdk-Pixbuf_FOUND)
 endif ()
 
 add_library(pixbufloader-jxl SHARED pixbufloader-jxl.c)
-target_link_libraries(pixbufloader-jxl jxl-static jxl_threads-static PkgConfig::Gdk-Pixbuf)
+target_link_libraries(pixbufloader-jxl jxl_dec-static jxl_threads-static PkgConfig::Gdk-Pixbuf)
 
 pkg_get_variable(GDK_PIXBUF_MODULEDIR gdk-pixbuf-2.0 gdk_pixbuf_moduledir)
 install(TARGETS pixbufloader-jxl LIBRARY DESTINATION "${GDK_PIXBUF_MODULEDIR}")
@@ -22,3 +22,45 @@ install(TARGETS pixbufloader-jxl LIBRARY DESTINATION "${GDK_PIXBUF_MODULEDIR}")
 # mime type image/jxl to
 # /usr/share/thumbnailers/gdk-pixbuf-thumbnailer.thumbnailer
 install(FILES ${CMAKE_CURRENT_SOURCE_DIR}/jxl.thumbnailer DESTINATION share/thumbnailers/)
+
+if(BUILD_TESTING AND NOT MINGW)
+  pkg_check_modules(Gdk IMPORTED_TARGET gdk-2.0)
+  if (Gdk_FOUND)
+    # Test for loading a .jxl file using the pixbufloader library via GDK. This
+    # requires to have the image/jxl mime type and loader library configured,
+    # which we do in a fake environment in the CMAKE_CURRENT_BINARY_DIR.
+    add_executable(pixbufloader_test pixbufloader_test.cc)
+    target_link_libraries(pixbufloader_test PkgConfig::Gdk)
+
+    # Create a mime cache for test.
+    add_custom_command(
+      OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/mime/mime.cache"
+      COMMAND env XDG_DATA_HOME=${CMAKE_CURRENT_BINARY_DIR}
+        xdg-mime install --novendor
+        "${CMAKE_SOURCE_DIR}/plugins/mime/image-jxl.xml"
+      DEPENDS "${CMAKE_SOURCE_DIR}/plugins/mime/image-jxl.xml"
+    )
+    add_custom_target(pixbufloader_test_mime
+      DEPENDS "${CMAKE_CURRENT_BINARY_DIR}/mime/mime.cache"
+    )
+    add_dependencies(pixbufloader_test pixbufloader_test_mime)
+
+    # Use a fake X server to run the test if xvfb is installed.
+    find_program (XVFB_PROGRAM xvfb-run)
+    if(XVFB_PROGRAM)
+      set(XVFB_PROGRAM_PREFIX "${XVFB_PROGRAM};-a")
+    else()
+      set(XVFB_PROGRAM_PREFIX "")
+    endif()
+
+    add_test(
+      NAME pixbufloader_test_jxl
+      COMMAND
+        ${XVFB_PROGRAM_PREFIX} $<TARGET_FILE:pixbufloader_test>
+        "${CMAKE_CURRENT_SOURCE_DIR}/loaders_test.cache"
+        "${CMAKE_SOURCE_DIR}/third_party/testdata/jxl/blending/cropped_traffic_light.jxl"
+      WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+    )
+    set_tests_properties(pixbufloader_test_jxl PROPERTIES SKIP_RETURN_CODE 254)
+  endif()  # Gdk_FOUND
+endif()  # BUILD_TESTING

--- a/plugins/gdk-pixbuf/loaders_test.cache
+++ b/plugins/gdk-pixbuf/loaders_test.cache
@@ -1,0 +1,13 @@
+# GdkPixbuf Image Loader Modules file for testing
+#
+# Generated with:
+#  GDK_PIXBUF_MODULEDIR=`pwd`/build/plugins/gdk-pixbuf/ gdk-pixbuf-query-loaders
+#
+# Modified to use the library from the current working directory at runtime.
+#
+"./libpixbufloader-jxl.so"
+"JPEG XL" 4 "gdk-pixbuf" "JPEG XL image" "Apache 2"
+"image/jxl" ""
+"jxl" ""
+"\327LM\n" "    " 100
+

--- a/plugins/gdk-pixbuf/pixbufloader-jxl.c
+++ b/plugins/gdk-pixbuf/pixbufloader-jxl.c
@@ -96,6 +96,7 @@ uint8_t *JxlMemoryToPixels(const uint8_t *next_in, size_t size, size_t *stride,
       break;
     }
   }
+  JxlDecoderDestroy(dec);
   if (success){
     return pixels;
   } else {

--- a/plugins/gdk-pixbuf/pixbufloader_test.cc
+++ b/plugins/gdk-pixbuf/pixbufloader_test.cc
@@ -1,0 +1,41 @@
+// Copyright (c) the JPEG XL Project Authors. All rights reserved.
+//
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+#include <gdk-pixbuf/gdk-pixbuf.h>
+#include <gdk/gdk.h>
+#include <glib.h>
+#include <stdlib.h>
+
+int main(int argc, char* argv[]) {
+  if (argc != 3) {
+    fprintf(stderr, "Usage: %s <loaders.cache> <image.jxl>\n", argv[0]);
+    return 1;
+  }
+
+  const char* loaders_cache = argv[1];
+  const char* filename = argv[2];
+  setenv("GDK_PIXBUF_MODULE_FILE", loaders_cache, true);
+
+  // XDG_DATA_HOME is the path where we look for the mime cache.
+  // XDG_DATA_DIRS directories are used in addition to XDG_DATA_HOME.
+  setenv("XDG_DATA_HOME", ".", true);
+  setenv("XDG_DATA_DIRS", "", true);
+
+  if (!gdk_init_check(nullptr, nullptr)) {
+    fprintf(stderr, "This test requires a DISPLAY\n");
+    // Signals ctest that we should mark this test as skipped.
+    return 254;
+  }
+  GError* error = nullptr;
+  GdkPixbuf* pb = gdk_pixbuf_new_from_file(filename, &error);
+  if (pb != nullptr) {
+    g_object_unref(pb);
+    return 0;
+  } else {
+    fprintf(stderr, "Error loading file: %s\n", filename);
+    g_assert_no_error(error);
+    return 1;
+  }
+}


### PR DESCRIPTION
The pixbufloader-jxl was not destroying the decoder object after
decoding and therefore leaking memory. This patch fixes that by adding
the missing call to `JxlDecoderDestroy`.

A new test will try to load a .jxl file from disk using the
pixbufloader-jxl plugin. This would detect leaks when running in asan
mode.

A drive by fix, the pixbufloader doesn't need the full library, only the
decoder side.

Fixes #299