### PR TITLE
Butteraugli changes for less visual masking

### DIFF
--- a/lib/jxl/butteraugli/butteraugli.cc
+++ b/lib/jxl/butteraugli/butteraugli.cc
@@ -1223,7 +1223,7 @@ void DiffPrecompute(const ImageF& xyb, float mul, float bias_arg, ImageF* out) {
 // std::log(80.0) / std::log(255.0);
 constexpr float kIntensityTargetNormalizationHack = 0.79079917404f;
 static const float kInternalGoodQualityThreshold =
-    17.1984479671f * kIntensityTargetNormalizationHack;
+    17.8f * kIntensityTargetNormalizationHack;
 static const float kGlobalScale = 1.0 / kInternalGoodQualityThreshold;
 
 void StoreMin3(const float v, float& min0, float& min1, float& min2) {
@@ -1336,9 +1336,9 @@ void MaskPsychoImage(const PsychoImage& pi0, const PsychoImage& pi1,
   ImageF mask0(xsize, ysize);
   ImageF mask1(xsize, ysize);
   static const float muls[3] = {
-      8.75000241361f,
-      0.620978104816f,
-      0.307585098253f,
+      2.5f,
+      0.4f,
+      0.4f,
   };
   // Silly and unoptimized approach here. TODO(jyrki): rework this.
   for (size_t y = 0; y < ysize; ++y) {

--- a/lib/jxl/jxl_test.cc
+++ b/lib/jxl/jxl_test.cc
@@ -1198,7 +1198,7 @@ TEST(JxlTest, RoundtripYCbCr420) {
   // we're comparing an original PNG with a YCbCr 4:2:0 version
   EXPECT_LE(ButteraugliDistance(io, io3, cparams.ba_params,
                                 /*distmap=*/nullptr, pool),
-            2.5);
+            2.8);
 }
 
 TEST(JxlTest, RoundtripDots) {

--- a/lib/jxl/passes_test.cc
+++ b/lib/jxl/passes_test.cc
@@ -174,7 +174,7 @@ TEST(PassesTest, AllDownsampleFeasible) {
   EXPECT_LE(compressed.size(), 240000);
   float target_butteraugli[9] = {};
   target_butteraugli[1] = 2.5f;
-  target_butteraugli[2] = 14.5f;
+  target_butteraugli[2] = 16.0f;
   target_butteraugli[4] = 20.0f;
   target_butteraugli[8] = 80.0f;
 


### PR DESCRIPTION
This may improve butteraugli's behaviour in neural compression.

Here, reflected on jpeg xl's butteraugli implementation. Manual review
shows little changes in quality, possibly some less ringing at very high
distances such as d24, reviewed at effort 9.

Before:

```
Encoding           kPixels    Bytes          BPP  E MP/s  D MP/s     Max norm        pnorm   PSNR   QABPP  SmallB  DCT4x8     AFV  DCT8x8    8x16    8x32      16   16x32      32   32x64      64       BPP*pnorm   Bugs
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
jxl:9:d0.8:epf0      18628  4039653    1.7348526   0.161  15.096   1.07709587   0.50579125  41.95   1.743  0.8644 23.2150  2.1277  6.0825 22.0919  0.0000 33.3299  3.8067  9.0866  0.0880  0.0880  0.877473252924      0
jxl:d1               18628  3527453    1.5148853   2.859  21.520   1.94598031   0.60525471  40.81   2.075  0.8441 20.6438  2.1215  5.5668 19.3592  0.0000 31.6093  8.0422 12.3958  0.0880  0.1099  0.916891462077      0
jxl:9:d1:epf1        18628  3448430    1.4809484   0.194  21.047   1.39711511   0.60325353  40.67   1.700  0.8441 20.6438  2.1215  5.5668 19.3592  0.0000 31.6093  8.0422 12.3958  0.0880  0.1099  0.893387355597      0
jxl:9:d2:epf3        18628  2129301    0.9144407   0.244  16.709   2.42722654   0.99992879  37.09   2.005  0.7569 14.9262  2.0981  4.3238 14.6173  0.0000 20.9616 23.4668 19.3770  0.1429  0.1099  0.914375634324      0
jxl:9:d3:epf0        18628  1564780    0.6720039   0.278  26.311   3.67514110   1.36133004  34.76   2.104  0.6009 11.8702  1.9202  3.7730 13.1764  0.0000 15.5855 29.9753 23.6153  0.1539  0.1099  0.914819107779      0
jxl:9:d4:epf3        18628  1288409    0.5533148   0.274  15.679   4.61898184   1.67644064  33.60   2.216  0.4910  9.7188  1.7309  3.2202 12.0557  0.0000 13.0142 33.5869 26.6991  0.1539  0.1099  0.927599364837      0
jxl:9:d8:epf1        18628   758491    0.3257384   0.279  24.716   8.87771797   2.75744131  30.45   2.342  0.2443  5.5795  1.1784  1.9271  9.5346  0.0000  9.3656 40.0019 32.6194  0.1979  0.1319  0.898204490497      0
jxl:d16:epf3         18628   487417    0.2093241   2.836  14.706  19.64636803   4.39120985  28.75   2.613  0.0770  2.0109  0.4896  0.5621  6.0715  0.0000  5.8708 40.7330 44.3281  0.4837  0.1539  0.919185947770      0
jxl:9:d24:epf3       18628   332528    0.1428061   0.275  14.736  24.21018219   6.73768246  26.73   2.747  0.0292  1.1063  0.2539  0.3010  4.5522  0.0000  4.4553 38.3446 47.5274  0.9565  3.2542  0.962182096493      0
jxl:d32:epf3         18628   302027    0.1297073   2.924  14.545  25.75357819   6.97978677  26.64   2.654  0.0062  0.6188  0.1467  0.1821  3.5064  0.0000  3.5112 35.7115 49.6437  2.0889  5.3651  0.905329008682      0
Aggregate:           18628  1228541    0.5276040   0.504  18.051   5.14988443   1.72988535  33.68   2.192  0.2328  6.4815  1.0368  1.8920 10.5914  0.0000 12.8399 20.4796 23.7952  0.2314  0.2344  0.912694479780      0
```

After:

```
Encoding           kPixels    Bytes          BPP  E MP/s  D MP/s     Max norm        pnorm   PSNR   QABPP  SmallB  DCT4x8     AFV  DCT8x8    8x16    8x32      16   16x32      32   32x64      64       BPP*pnorm   Bugs
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
jxl:9:d0.8:epf0      18628  4113352    1.7665030   0.159  14.805   1.14422667   0.51133574  42.13   1.775  0.8644 23.2150  2.1277  6.0825 22.0919  0.0000 33.3299  3.8067  9.0866  0.0880  0.0880  0.903276131158      0
jxl:d1               18628  3527453    1.5148853   2.814  21.559   2.04353905   0.62403298  40.81   2.185  0.8441 20.6438  2.1215  5.5668 19.3592  0.0000 31.6093  8.0422 12.3958  0.0880  0.1099  0.945338382791      0
jxl:9:d1:epf1        18628  3501586    1.5037766   0.188  20.745   1.36324441   0.61074277  40.82   1.749  0.8441 20.6438  2.1215  5.5668 19.3592  0.0000 31.6093  8.0422 12.3958  0.0880  0.1099  0.918420653973      0
jxl:9:d2:epf3        18628  2149302    0.9230303   0.242  17.000   2.51492643   1.02022531  37.18   2.055  0.7569 14.9262  2.0981  4.3238 14.6173  0.0000 20.9616 23.4668 19.3770  0.1429  0.1099  0.941698870335      0
jxl:9:d3:epf0        18628  1580224    0.6786364   0.273  26.276   3.57645774   1.40160991  34.84   2.180  0.6009 11.8702  1.9202  3.7730 13.1764  0.0000 15.5855 29.9753 23.6153  0.1539  0.1099  0.951183535603      0
jxl:9:d4:epf3        18628  1296459    0.5567719   0.272  14.907   4.76603270   1.70618355  33.66   2.290  0.4910  9.7188  1.7309  3.2202 12.0557  0.0000 13.0142 33.5869 26.6991  0.1539  0.1099  0.949955038798      0
jxl:9:d8:epf1        18628   760093    0.3264264   0.270  24.997   8.83749199   2.81075742  30.49   2.384  0.2443  5.5795  1.1784  1.9271  9.5346  0.0000  9.3656 40.0019 32.6194  0.1979  0.1319  0.917505361044      0
jxl:d16:epf3         18628   487417    0.2093241   2.797  14.869  19.44379234   4.35726267  28.75   2.608  0.0770  2.0109  0.4896  0.5621  6.0715  0.0000  5.8708 40.7330 44.3281  0.4837  0.1539  0.912079984672      0
jxl:9:d24:epf3       18628   329954    0.1417007   0.275  14.882  24.05065727   6.63677163  26.73   2.717  0.0292  1.1063  0.2539  0.3010  4.5522  0.0000  4.4553 38.3446 47.5274  0.9565  3.2542  0.940434999765      0
jxl:d32:epf3         18628   302027    0.1297073   2.924  14.742  25.24743271   6.85394857  26.64   2.622  0.0062  0.6188  0.1467  0.1821  3.5064  0.0000  3.5112 35.7115 49.6437  2.0889  5.3651  0.889006880431      0
Aggregate:           18628  1235084    0.5304138   0.497  18.013   5.19285064   1.74705101  33.74   2.233  0.2328  6.4815  1.0368  1.8920 10.5914  0.0000 12.8399 20.4796 23.7952  0.2314  0.2344  0.926660035467      0
```

Butteraugli's internal calibration scores are reduced by this change (about 1.5 % for spearman's correlation on the reference corpus). No quality reduction was observable in JPEG XL effort 9 due to this change
at careful review at equal BPP.