### PR TITLE
Limit the static stack size of all functions in release mode to 3 kB

### DIFF
--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -26,6 +26,9 @@ jobs:
         include:
           - name: release
             test_in_pr: true
+            # Track static stack size on build and check it doesn't exceed 3 kB.
+            env_stack_size: 1
+            max_stack: 3000
           - name: debug
           # Build scalar-only hwy instructions.
           - name: scalar
@@ -54,6 +57,8 @@ jobs:
 
     env:
       CCACHE_DIR: ${{ github.workspace }}/.ccache
+      # Whether we track the stack size.
+      STACK_SIZE: ${{ matrix.env_stack_size }}
 
     steps:
     - name: Install build deps
@@ -120,6 +125,7 @@ jobs:
       if: matrix.mode == 'release' || matrix.name == 'release'
       run: |
         tools/build_stats.py --save build/stats.json \
+          --max-stack ${{ matrix.max_stack || '0' }} \
           cjxl djxl libjxl.so libjxl_dec.so
     # Run the tests on push and when requested in pull_request.
     - name: Test ${{ matrix.mode }}

--- a/tools/build_stats.py
+++ b/tools/build_stats.py
@@ -23,6 +23,7 @@ import os
 import re
 import struct
 import subprocess
+import sys
 import tempfile
 
 # Ignore functions with stack size smaller than this value.
@@ -372,6 +373,17 @@ def SizeStats(args):
     with open(args.save, 'w') as f:
       json.dump(stats, f)
 
+  # Check the maximum stack size.
+  exit_code = 0
+  if args.max_stack:
+    for name, size in tgt_stack_sizes.items():
+      if size > args.max_stack:
+        print('Error: %s exceeds stack limit: %d vs %d' % (
+                  name, size, args.max_stack),
+              file=sys.stderr)
+        exit_code = 1
+
+  return exit_code
 
 def main():
   parser = argparse.ArgumentParser(description=__doc__)
@@ -388,8 +400,12 @@ def main():
   parser.add_argument('--binutils', default='',
                       help='prefix path to binutils tools, such as '
                            'aarch64-linux-gnu-')
+  parser.add_argument('--max-stack', default=None, type=int,
+                      help=('Maximum static stack size of a function. If a '
+                            'static stack is larger it will exit with an error '
+                            'code.'))
   args = parser.parse_args()
-  SizeStats(args)
+  sys.exit(SizeStats(args))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Ideally we would enforce a smaller static size limit but at the moment
there are a few functions that require more than 1 kB of static stack.