### PR TITLE
Fix setting the SIMD target in the djxl_fuzzer.

### DIFF
--- a/tools/djxl_fuzzer.cc
+++ b/tools/djxl_fuzzer.cc
@@ -493,7 +493,7 @@ int TestOneInput(const uint8_t* data, size_t size) {
   size_t max_pixels = 1 << 21;
 
   const auto targets = hwy::SupportedAndGeneratedTargets();
-  hwy::SetSupportedTargetsForTest(getFlag(targets.size() - 1));
+  hwy::SetSupportedTargetsForTest(targets[getFlag(targets.size() - 1)]);
   DecodeJpegXl(data, size, max_pixels, spec, &pixels, &jpeg, &xsize, &ysize,
                &icc);
   hwy::SetSupportedTargetsForTest(0);


### PR DESCRIPTION
SetSupportedTargetsForTest() expects a target mask, not an index in the
targets array.