### PR TITLE
More bits for red and blue areas

### DIFF
--- a/lib/jxl/enc_adaptive_quantization.cc
+++ b/lib/jxl/enc_adaptive_quantization.cc
@@ -197,6 +197,67 @@ V GammaModulation(const D d, const size_t x, const size_t y,
   return MulAdd(kGam, FastLog2f(d, overall_ratio), out_val);
 }
 
+template <class D, class V>
+V ColorModulation(const D d, const size_t x, const size_t y,
+                  const ImageF& xyb_x, const ImageF& xyb_y, const ImageF& xyb_b,
+                  const double butteraugli_target, V out_val) {
+  static const float kStrengthMul = 2.177823400325309;
+  static const float kRedRampStart = 0.0073200141118951231;
+  static const float kRedRampLength = 0.019421555948474039;
+  static const float kBlueRampLength = 0.086890611400405895;
+  static const float kBlueRampStart = 0.26973418507870539;
+  const float strength = kStrengthMul * (1.0f - 0.25f * butteraugli_target);
+  if (strength < 0) {
+    return out_val;
+  }
+  // x values are smaller than y and b values, need to take the difference into
+  // account.
+  const float red_strength = strength * 5.992297772961519f;
+  const float blue_strength = strength;
+  {
+    // Reduce some bits from areas not blue or red.
+    const float offset = strength * -0.009174542291185913f;
+    out_val += Set(d, offset);
+  }
+  // Calculate how much of the 8x8 block is covered with blue or red.
+  auto blue_coverage = Zero(d);
+  auto red_coverage = Zero(d);
+  for (size_t dy = 0; dy < 8; ++dy) {
+    const float* const JXL_RESTRICT row_in_x = xyb_x.Row(y + dy);
+    const float* const JXL_RESTRICT row_in_y = xyb_y.Row(y + dy);
+    const float* const JXL_RESTRICT row_in_b = xyb_b.Row(y + dy);
+    for (size_t dx = 0; dx < 8; dx += Lanes(d)) {
+      const auto pixel_x =
+          Max(Set(d, 0.0f), Load(d, row_in_x + x + dx) - Set(d, kRedRampStart));
+      const auto pixel_y = Load(d, row_in_y + x + dx);
+      const auto pixel_b =
+          Max(Set(d, 0.0f),
+              Load(d, row_in_b + x + dx) - pixel_y - Set(d, kBlueRampStart));
+      const auto blue_slope = Min(pixel_b, Set(d, kBlueRampLength));
+      const auto red_slope = Min(pixel_x, Set(d, kRedRampLength));
+      red_coverage += red_slope;
+      blue_coverage += blue_slope;
+    }
+  }
+
+  // Saturate when the high red or high blue coverage is above a level.
+  // The idea here is that if a certain fraction of the block is red or
+  // blue we consider as if it was fully red or blue.
+  static const float ratio = 30.610615782142737f;  // out of 64 pixels.
+
+  auto overall_red_coverage = SumOfLanes(red_coverage);
+  overall_red_coverage =
+      Min(overall_red_coverage, Set(d, ratio * kRedRampLength));
+  overall_red_coverage *= Set(d, red_strength / ratio);
+
+  auto overall_blue_coverage = SumOfLanes(blue_coverage);
+  overall_blue_coverage =
+      Min(overall_blue_coverage, Set(d, ratio * kBlueRampLength));
+  overall_blue_coverage *= Set(d, blue_strength / ratio);
+
+  return overall_red_coverage + overall_blue_coverage + out_val;
+}
+
 // Change precision in 8x8 blocks that have high frequency content.
 template <class D, class V>
 V HfModulation(const D d, const size_t x, const size_t y, const ImageF& xyb,
@@ -238,8 +299,8 @@ V HfModulation(const D d, const size_t x, const size_t y, const ImageF& xyb,
 }
 
 void PerBlockModulations(const float butteraugli_target, const ImageF& xyb_x,
-                         const ImageF& xyb_y, const float scale,
-                         const Rect& rect, ImageF* out) {
+                         const ImageF& xyb_y, const ImageF& xyb_b,
+                         const float scale, const Rect& rect, ImageF* out) {
   JXL_ASSERT(SameSize(xyb_x, xyb_y));
   JXL_ASSERT(DivCeil(xyb_x.xsize(), kBlockDim) == out->xsize());
   JXL_ASSERT(DivCeil(xyb_x.ysize(), kBlockDim) == out->ysize());
@@ -266,6 +327,8 @@ void PerBlockModulations(const float butteraugli_target, const ImageF& xyb_x,
       auto out_val = Set(df, row_out[ix]);
       out_val = ComputeMask(df, out_val);
       out_val = HfModulation(df, x, y, xyb_y, out_val);
+      out_val = ColorModulation(df, x, y, xyb_x, xyb_y, xyb_b,
+                                butteraugli_target, out_val);
       out_val = GammaModulation(df, x, y, xyb_x, xyb_y, out_val);
       // We want multiplicative quantization field, so everything
       // until this point has been modulating the exponent.
@@ -506,8 +569,8 @@ struct AdaptiveQuantizationImpl {
         mask_row[x] = ComputeMaskForAcStrategyUse(aq_map_row[x]);
       }
     }
-    PerBlockModulations(butteraugli_target, xyb.Plane(0), xyb.Plane(1), scale,
-                        rect, &aq_map);
+    PerBlockModulations(butteraugli_target, xyb.Plane(0), xyb.Plane(1),
+                        xyb.Plane(2), scale, rect, &aq_map);
   }
   std::vector<ImageF> pre_erosion;
   ImageF aq_map;

--- a/lib/jxl/jxl_test.cc
+++ b/lib/jxl/jxl_test.cc
@@ -234,7 +234,9 @@ TEST(JxlTest, RoundtripResample2MT) {
   cparams.resampling = 2;
   DecompressParams dparams;
   CodecInOut io2;
-  EXPECT_LE(Roundtrip(&io, cparams, dparams, &pool, &io2), 57000);
+  // TODO(veluca): Figure out why msan and release produce different
+  // file size.
+  EXPECT_LE(Roundtrip(&io, cparams, dparams, &pool, &io2), 60000);
   EXPECT_LE(ButteraugliDistance(io, io2, cparams.ba_params,
                                 /*distmap=*/nullptr, &pool),
 #if JXL_HIGH_PRECISION

--- a/tools/optimizer/simplex_fork.py
+++ b/tools/optimizer/simplex_fork.py
@@ -61,15 +61,15 @@ def EvalCacheForget():
 def RandomizedJxlCodecs():
   retval = []
   minval = 0.5
-  maxval = 24.0
+  maxval = 3.3
   rangeval = maxval/minval
-  steps = 6
+  steps = 7
   for i in range(steps):
     mul = minval * rangeval**(float(i)/(steps - 1))
     mul *= 0.99 + 0.05 * random.random()
     retval.append("jxl:epf2:d%.3f" % mul)
-  steps = 6
-  for i in range(steps):
+  steps = 7
+  for i in range(steps - 1):
     mul = minval * rangeval**(float(i+0.5)/(steps - 1))
     mul *= 0.99 + 0.05 * random.random()
     retval.append("jxl:epf0:d%.3f" % mul)
@@ -101,7 +101,7 @@ def Eval(vec, binary_name, cached=True):
   process = subprocess.Popen(
       (binary_name,
        '--input',
-       '/usr/local/google/home/jyrki/newcorpus/split/*.png',
+       '/usr/local/google/home/jyrki/mix_corpus/*.png',
        '--error_pnorm=3',
        '--more_columns',
        '--codec', g_codecs),
@@ -122,64 +122,15 @@ def Eval(vec, binary_name, cached=True):
     sys.stdout.flush()
     if line[0:3] == b'jxl':
       bpp = line.split()[3]
-      dist_max = line.split()[7]
-      dist_pnorm = line.split()[8]
-      dct2str = line.split()[11]
-      dct4str = line.split()[12]
-      dct4x8str = line.split()[13]
-      dct8str = line.split()[14]
-      dct8x16str = line.split()[15]
-      dct16str = line.split()[16]
-      dct16x32str = line.split()[17]
-      dct32str = line.split()[18]
+      dist_pnorm = line.split()[7]
       vec[0] *= float(dist_pnorm) * float(bpp) / 16.0
       #vec[0] *= (float(dist_max) * float(bpp) / 16.0) ** 0.2
-      dct2 += float(dct2str)
-      dct4 += float(dct4str)
-      dct16 += float(dct16str)
-      dct32 += float(dct32str)
       n += 1
       found_score = True
       distance = float(line.split()[0].split(b'd')[-1])
       #faultybpp = 1.0 + 0.43 * ((float(bpp) * distance ** 0.74) - 1.57) ** 2
       #vec[0] *= faultybpp
 
-  """
-  # favor small changes
-  for k in vec[1:]:
-    vec[0] *= 1 + 1e-9 * k * k
-
-  dct2 = dct2 / (n + 1e-9)
-  dct4 = dct4 / (n + 1e-9)
-  dct16 = dct16 / (n + 1e-9)
-  dct32 = dct32 / (n + 1e-9)
-  dct16 += 0.1 * dct32
-  dct4 += 0.1 * dct2
-  print "dct2/4/16/32", dct2, dct4, dct16, dct32, vec[0]
-
-  dct2limit = 0.02
-  if dct2 < dct2limit:
-     print "low dct2", dct2, vec[0]
-     vec[0] *= (1.0 + 50.0 * (dct2limit - dct2) ** 2)**n
-     print "corrected dct2", dct2, vec[0]
-
-  dct4limit = 0.025
-  if dct4 < dct4limit:
-     print "low dct4", dct4, vec[0]
-     vec[0] *= (1.0 + 15.0 * (dct4limit - dct4) ** 2)**n
-     print "corrected dct4", dct4, vec[0]
-
-  dct16limit = 0.02
-  if dct16 < dct16limit:
-     print "low dct16", dct16, vec[0]
-     vec[0] *= (1.0 + 5.0 * (dct16limit - dct16) ** 2)**n
-     print "corrected dct16", dct16, vec[0]
-  dct32limit = 0.02
-  if dct32 < dct32limit:
-     print "low dct32", dct32, vec[0]
-     vec[0] *= (1.0 + 5.0 * (dct32limit - dct32) ** 2)**n
-     print "corrected dct32", dct32, vec[0]
-  """
   print("eval: ", vec)
   if (vec[0] <= 0.0):
     vec[0] = 1e30


### PR DESCRIPTION
jyrki31-split:
0.4 % BPP*pnorm improvement at d0.8, 0.35 % at d1
1 % improvement in Max norm
    
jpeg-xl a-d corpus:
0.6 % improvement at d0.8
Improvement diminishes at higher distances
    
Improvement diminishes at higher distances.

Inspired by a problem reported by Lee on discord, will likely not fix it fully but may be a step in the right direction.

Manual viewing suggests that this is an improvement, particularly when there are red, blue or magenta backgrounds, and that the new heuristics are slightly more balanced overall.

 *jyrki31-split corpus*

```
Before:

Encoding         kPixels    Bytes          BPP  E MP/s  D MP/s     Max norm        pnorm   PSNR   QABPP  SmallB  DCT4x8     AFV  DCT8x8    8x16    8x32      16   16x32      32   32x64      64       BPP*pnorm   Bugs
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
jxl:d0.8:epf0      18628  4056564    1.7421151   2.320  14.581   1.71093929   0.52787251  41.93   2.136  0.8644 23.2150  2.1277  6.0825 22.0919  0.0000 33.3299  3.8067  9.0866  0.0880  0.0880  0.919614661333      0
jxl:d1:epf1        18628  3527458    1.5148874   2.736  20.045   1.98152363   0.61224048  40.81   2.163  0.8441 20.6438  2.1215  5.5668 19.3592  0.0000 31.6093  8.0422 12.3958  0.0880  0.1099  0.927475417072      0
jxl:d2:epf3        18628  2276969    0.9778576   2.814  16.786   3.74098301   0.96437130  37.56   2.283  0.7569 14.9262  2.0981  4.3238 14.6173  0.0000 20.9616 23.4668 19.3770  0.1429  0.1099  0.943017834652      0
jxl:d3:epf0        18628  1698938    0.7296188   2.702  26.035   4.74970627   1.30345580  35.31   2.371  0.6009 11.8702  1.9202  3.7730 13.1764  0.0000 15.5855 29.9753 23.6153  0.1539  0.1099  0.951025914798      0
jxl:d4:epf3        18628  1409869    0.6054765   2.633  15.347   6.93611193   1.56838568  34.17   2.442  0.4910  9.7188  1.7309  3.2202 12.0557  0.0000 13.0142 33.5869 26.6991  0.1539  0.1099  0.949620630245      0
jxl:d8:epf1        18628   831150    0.3569422   2.628  23.851   9.41790104   2.51031730  31.01   2.392  0.2443  5.5795  1.1784  1.9271  9.5346  0.0000  9.3656 40.0019 32.6194  0.1979  0.1319  0.896038232567      0
jxl:d16:epf3       18628   487417    0.2093241   2.750  14.679  19.18319321   4.29914771  28.75   2.571  0.0770  2.0109  0.4896  0.5621  6.0715  0.0000  5.8708 40.7330 44.3281  0.4837  0.1539  0.899915125560      0
jxl:d24:epf3       18628   369052    0.1584915   2.796  14.021  21.58929062   5.61166761  27.47   2.594  0.0292  1.1063  0.2539  0.3010  4.5522  0.0000  4.4553 38.3446 47.5274  0.9565  3.2542  0.889401821038      0
jxl:d32:epf3       18628   302027    0.1297073   2.756  14.154  25.21546555   6.78267440  26.64   2.597  0.0062  0.6188  0.1467  0.1821  3.5064  0.0000  3.5112 35.7115 49.6437  2.0889  5.3651  0.879762103632      0
Aggregate:         18628  1150226    0.4939711   2.678  17.264   7.01416325   1.85630710  33.32   2.388  0.2017  5.6986  0.9575  1.6782  9.9049  0.0000 11.6168 22.7210 25.5833  0.2577  0.2550  0.916962001005      0

After:

Encoding         kPixels    Bytes          BPP  E MP/s  D MP/s     Max norm        pnorm   PSNR   QABPP  SmallB  DCT4x8     AFV  DCT8x8    8x16    8x32      16   16x32      32   32x64      64       BPP*pnorm   Bugs
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
jxl:d0.8:epf0      18628  4069270    1.7475718   2.364  14.744   1.62047815   0.52414554  42.03   2.138  0.8668 23.2731  2.1428  6.0406 22.0252  0.0000 33.3107  3.8699  9.0756  0.0880  0.0880  0.915981947296      0
jxl:d1:epf1        18628  3538329    1.5195561   2.779  20.340   1.98231220   0.60820848  40.90   2.161  0.8428 20.6671  2.1287  5.5994 19.3454  0.0000 31.5145  8.1164 12.3683  0.0880  0.1099  0.924206869957      0
jxl:d2:epf3        18628  2280499    0.9793736   2.831  16.748   3.58673501   0.96292183  37.59   2.295  0.7620 14.9262  2.0830  4.3516 14.6682  0.0000 21.0083 23.4284 19.3001  0.1429  0.1099  0.943060235169      0
jxl:d3:epf0        18628  1698986    0.7296395   2.733  25.876   4.78043222   1.30297237  35.32   2.354  0.6043 11.8808  1.9095  3.7778 13.1736  0.0000 15.6404 30.0303 23.4998  0.1539  0.1099  0.950700051939      0
jxl:d4:epf3        18628  1409869    0.6054765   2.689  15.216   6.93611193   1.56838568  34.17   2.442  0.4910  9.7188  1.7309  3.2202 12.0557  0.0000 13.0142 33.5869 26.6991  0.1539  0.1099  0.949620630245      0
jxl:d8:epf1        18628   831150    0.3569422   2.711  23.647   9.41790104   2.51031730  31.01   2.392  0.2443  5.5795  1.1784  1.9271  9.5346  0.0000  9.3656 40.0019 32.6194  0.1979  0.1319  0.896038232567      0
jxl:d16:epf3       18628   487417    0.2093241   2.806  14.994  19.18319321   4.29914771  28.75   2.571  0.0770  2.0109  0.4896  0.5621  6.0715  0.0000  5.8708 40.7330 44.3281  0.4837  0.1539  0.899915125560      0
jxl:d24:epf3       18628   369052    0.1584915   2.815  13.724  21.58929062   5.61166761  27.47   2.594  0.0292  1.1063  0.2539  0.3010  4.5522  0.0000  4.4553 38.3446 47.5274  0.9565  3.2542  0.889401821038      0
jxl:d32:epf3       18628   302027    0.1297073   2.763  13.797  25.21546555   6.78267440  26.64   2.597  0.0062  0.6188  0.1467  0.1821  3.5064  0.0000  3.5112 35.7115 49.6437  2.0889  5.3651  0.879762103632      0
Aggregate:         18628  1151220    0.4943984   2.718  17.215   6.94469425   1.85309889  33.34   2.388  0.2020  5.7015  0.9572  1.6794  9.9044  0.0000 11.6196 22.7864 25.5484  0.2577  0.2550  0.916169051895      0
```

*jpeg xl class a-d corpus*
        
```
Before:

    Encoding         kPixels    Bytes          BPP  E MP/s  D MP/s     Max norm        pnorm   PSNR   QABPP  SmallB  DCT4x8     AFV  DCT8x8    8x16    8x32      16   16x32      32   32x64      64       BPP*pnorm   Bugs
    ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
    jxl:d0.8:epf0      29551  6541927    1.7709799   2.247  21.105   3.18002248   0.57311540  40.34   2.670  0.8490 19.9701  1.0445  5.4366 21.5695  0.0000 40.3426  3.8047  4.8927  0.9772  1.1781  1.014975831891      0
    jxl:d1:epf1        29551  5641270    1.5271610   2.200  21.603   3.53180790   0.66847727  39.39   2.701  0.8173 17.4845  1.0558  4.6485 19.5454  0.0000 40.1650  8.1118  5.9635  1.0811  1.1920  1.020872388657      0
    jxl:d2:epf3        29551  3490430    0.9449022   2.399  13.696   8.19105339   1.07461422  36.53   2.855  0.7560 11.2668  1.0902  3.2057 12.3311  0.0000 22.6021 34.7724 11.5735  1.1920  1.2752  1.015405345725      0
    jxl:d3:epf0        29551  2562405    0.6936745   2.243  30.110  10.76627636   1.42179981  34.64   2.919  0.6822  8.5539  1.0889  2.8189 10.4980  0.0000 14.3456 42.9986 16.5702  1.2059  1.3029  0.986266211898      0
    jxl:d4:epf3        29551  2110536    0.5713480   2.268  19.913  10.23806953   1.68083890  33.51   2.955  0.5871  6.7921  1.0174  2.3974  9.2605  0.0000 10.9143 45.2492 21.3313  1.1712  1.3445  0.960343904476      0
    jxl:d8:epf1        29551  1206773    0.3266882   2.327  26.632  13.49176693   2.66241591  30.54   2.768  0.2887  3.9323  0.7688  1.4699  7.0537  0.0000  7.0082 45.9977 30.8222  1.3098  1.4138  0.869779994960      0
    jxl:d16:epf3       29551   692306    0.1874157   2.380  16.734  23.26285934   4.57630347  28.32   2.944  0.0537  1.7189  0.3905  0.5356  4.7975  0.0000  4.3158 39.1316 44.8317  1.7118  2.5780  0.857671228343      0
    jxl:d24:epf3       29551   513658    0.1390535   2.442  16.125  24.99697876   5.89148093  26.99   2.921  0.0162  1.1078  0.2510  0.3487  3.7393  0.0000  3.5821 33.5753 51.8381  1.8365  3.7700  0.819231159255      0
    jxl:d32:epf3       29551   414804    0.1122925   2.410  16.068  27.92841721   7.06830293  26.13   2.783  0.0039  0.7625  0.1657  0.2332  2.9999  0.0000  2.9566 29.4933 56.2562  2.0375  5.1561  0.793717615772      0
    Aggregate:         29551  1708460    0.4625010   2.323  19.628  10.92758122   1.99438255  32.56   2.833  0.1808  4.7809  0.6343  1.4847  8.3239  0.0000 10.6989 24.9316 19.8616  1.3503  1.8229  0.922403925061      0
    
After:
    
    Encoding         kPixels    Bytes          BPP  E MP/s  D MP/s     Max norm        pnorm   PSNR   QABPP  SmallB  DCT4x8     AFV  DCT8x8    8x16    8x32      16   16x32      32   32x64      64       BPP*pnorm   Bugs
    ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
    jxl:d0.8:epf0      29551  6554567    1.7744017   2.302  23.390   3.15145683   0.56864224  40.40   2.643  0.8420 19.9916  1.0484  5.4701 21.4274  0.0000 40.5540  3.6869  4.8962  0.9702  1.1781  1.008999733745      0
    jxl:d1:epf1        29551  5651250    1.5298627   2.292  22.017   3.53256750   0.66406493  39.44   2.662  0.8137 17.5495  1.0614  4.6586 19.4094  0.0000 40.4994  7.9265  5.9080  1.0465  1.1920  1.015928155744      0
    jxl:d2:epf3        29551  3491264    0.9451280   2.385  15.260   8.18065357   1.07465353  36.54   2.884  0.7502 11.2881  1.0870  3.1844 12.2873  0.0000 22.6809 34.7430 11.5839  1.1851  1.2752  1.015685114638      0
    jxl:d3:epf0        29551  2559882    0.6929914   2.428  31.295  10.90255547   1.42321246  34.64   2.886  0.6781  8.5443  1.0889  2.8174 10.5218  0.0000 14.2607 43.1511 16.5009  1.1989  1.3029  0.986274062778      0
    jxl:d4:epf3        29551  2110536    0.5713480   2.418  19.488  10.23806953   1.68083890  33.51   2.955  0.5871  6.7921  1.0174  2.3974  9.2605  0.0000 10.9143 45.2492 21.3313  1.1712  1.3445  0.960343904476      0
    jxl:d8:epf1        29551  1206773    0.3266882   2.373  29.059  13.49176693   2.66241591  30.54   2.768  0.2887  3.9323  0.7688  1.4699  7.0537  0.0000  7.0082 45.9977 30.8222  1.3098  1.4138  0.869779994960      0
    jxl:d16:epf3       29551   692306    0.1874157   2.469  17.296  23.26285934   4.57630347  28.32   2.944  0.0537  1.7189  0.3905  0.5356  4.7975  0.0000  4.3158 39.1316 44.8317  1.7118  2.5780  0.857671228343      0
    jxl:d24:epf3       29551   513658    0.1390535   2.438  16.568  24.99697876   5.89148093  26.99   2.921  0.0162  1.1078  0.2510  0.3487  3.7393  0.0000  3.5821 33.5753 51.8381  1.8365  3.7700  0.819231159255      0
    jxl:d32:epf3       29551   414804    0.1122925   2.455  17.127  27.92841721   7.06830293  26.13   2.783  0.0039  0.7625  0.1657  0.2332  2.9999  0.0000  2.9566 29.4933 56.2562  2.0375  5.1561  0.793717615772      0
    Aggregate:         29551  1709020    0.4626527   2.395  20.653  10.93061669   1.99140906  32.57   2.825  0.1803  4.7839  0.6348  1.4849  8.3102  0.0000 10.7121 24.7883 19.8353  1.3426  1.8229  0.921330790849      0
```
