### PR TITLE
allow redundant quant table in jbrd

### DIFF
--- a/lib/jxl/dec_frame.cc
+++ b/lib/jxl/dec_frame.cc
@@ -542,16 +542,26 @@ Status FrameDecoder::ProcessACGlobal(BitReader* br) {
     size_t num_components = jpeg_data->components.size();
     bool is_gray = (num_components == 1);
     auto jpeg_c_map = JpegOrder(frame_header_.color_transform, is_gray);
+    size_t qt_set = 0;
     for (size_t c = 0; c < num_components; c++) {
       // TODO(eustas): why 1-st quant table for gray?
       size_t quant_c = is_gray ? 1 : c;
       size_t qpos = jpeg_data->components[jpeg_c_map[c]].quant_idx;
       JXL_CHECK(qpos != jpeg_data->quant.size());
+      qt_set |= 1 << qpos;
       for (size_t x = 0; x < 8; x++) {
         for (size_t y = 0; y < 8; y++) {
           jpeg_data->quant[qpos].values[x * 8 + y] =
               (*qe[0].qraw.qtable)[quant_c * 64 + y * 8 + x];
         }
+      }
+    }
+    for (size_t i = 0; i < jpeg_data->quant.size(); i++) {
+      if (qt_set & (1 << i)) continue;
+      if (i == 0) return JXL_FAILURE("First quant table unused.");
+      // Unused quant table is set to copy of previous quant table
+      for (size_t j = 0; j < 64; j++) {
+        jpeg_data->quant[i].values[j] = jpeg_data->quant[i - 1].values[j];
       }
     }
   }

--- a/lib/jxl/jpeg/jpeg_data.cc
+++ b/lib/jxl/jpeg/jpeg_data.cc
@@ -144,15 +144,14 @@ Status JPEGData::VisitFields(Visitor* visitor) {
   }
 
   JPEGComponentType component_type =
-      components.size() == 1 && components[0].id == 1
-          ? JPEGComponentType::kGray
-          : components.size() == 3 && components[0].id == 1 &&
-                    components[1].id == 2 && components[2].id == 3
-                ? JPEGComponentType::kYCbCr
-                : components.size() == 3 && components[0].id == 'R' &&
-                          components[1].id == 'G' && components[2].id == 'B'
-                      ? JPEGComponentType::kRGB
-                      : JPEGComponentType::kCustom;
+      components.size() == 1 && components[0].id == 1 ? JPEGComponentType::kGray
+      : components.size() == 3 && components[0].id == 1 &&
+              components[1].id == 2 && components[2].id == 3
+          ? JPEGComponentType::kYCbCr
+      : components.size() == 3 && components[0].id == 'R' &&
+              components[1].id == 'G' && components[2].id == 'B'
+          ? JPEGComponentType::kRGB
+          : JPEGComponentType::kCustom;
   JXL_RETURN_IF_ERROR(
       visitor->Bits(2, JPEGComponentType::kYCbCr,
                     reinterpret_cast<uint32_t*>(&component_type)));
@@ -196,10 +195,15 @@ Status JPEGData::VisitFields(Visitor* visitor) {
     }
     used_tables |= 1U << components[i].quant_idx;
   }
-  if (used_tables + 1 != 1U << quant.size()) {
-    return JXL_FAILURE("Not all quant tables are used (%" PRIuS
-                       " tables, %" PRIx64 " used table mask)",
-                       quant.size(), static_cast<uint64_t>(used_tables));
+  for (size_t i = 0; i < quant.size(); i++) {
+    if (used_tables & (1 << i)) continue;
+    if (i == 0) return JXL_FAILURE("First quant table unused.");
+    // Unused quant table has to be set to copy of previous quant table
+    for (size_t j = 0; j < 64; j++) {
+      if (quant[i].values[j] != quant[i - 1].values[j]) {
+        return JXL_FAILURE("Non-trivial unused quant table");
+      }
+    }
   }
 
   uint32_t num_huff = huffman_code.size();


### PR DESCRIPTION
See https://github.com/libjxl/libjxl/issues/346

This changes the behavior of `jbrd` so that if there are quantization tables that are not actually used (so the jxl codestream will not actually contain the values), it does not throw an error but it assumes that the unused table is exactly equal to the previous table. At encode time it checks if this is true, at decode time it is assumed that it is true.

The spec (18181-2) is a bit vague on this — it only says

> Qk are corresponding quantization factors from the codestream (see ISO/IEC 18181-1 / C.6.2)

but it's not really clarified/specified what exactly "corresponding" means here. We could clarify/extend the spec later, and specify what a decoder is supposed to do when there are no "corresponding" quantization factors.

Since there do seem to be JPEGs in the wild that do have a redundant quantization table, and it always seems to be just a duplication of the chroma quant table, I think it's worthwhile to interpret the spec a bit freely here and consider "corresponding" to mean "corresponding to what's in the jxl codestream if it is used, identical to the previous QuantTable otherwise".