### PR TITLE
Use CopyImageTo() instead of loop in dec_modular

### DIFF
--- a/lib/jxl/dec_modular.cc
+++ b/lib/jxl/dec_modular.cc
@@ -322,13 +322,9 @@ Status ModularFrameDecoder::DecodeGroup(const Rect& rect, BitReader* reader,
     Rect r(rect.x0() >> fc.hshift, rect.y0() >> fc.vshift,
            rect.xsize() >> fc.hshift, rect.ysize() >> fc.vshift, fc.w, fc.h);
     if (r.xsize() == 0 || r.ysize() == 0) continue;
-    for (size_t y = 0; y < r.ysize(); ++y) {
-      pixel_type* const JXL_RESTRICT row_out = r.Row(&fc.plane, y);
-      const pixel_type* const JXL_RESTRICT row_in = gi.channel[gic].Row(y);
-      for (size_t x = 0; x < r.xsize(); ++x) {
-        row_out[x] = row_in[x];
-      }
-    }
+    CopyImageTo(/*rect_from=*/Rect(0, 0, r.xsize(), r.ysize()),
+                /*from=*/gi.channel[gic].plane,
+                /*rect_to=*/r, /*to=*/&fc.plane);
     gic++;
   }
   return true;


### PR DESCRIPTION
CopyImageTo() has JXL_DASSERT() to check for the boundaries of the image
and the passed rects, so size mismatch errors trigger more reliably in
debug builds.