### PR TITLE
Fuzz: Update the nb_meta_channels in squeeze when applying.

### DIFF
--- a/lib/jxl/modular/transform/squeeze.cc
+++ b/lib/jxl/modular/transform/squeeze.cc
@@ -295,6 +295,12 @@ Status InvSqueeze(Image &input, std::vector<SqueezeParams> parameters,
     } else {
       offset = input.channel.size() + beginc - endc - 1;
     }
+    if (beginc < input.nb_meta_channels) {
+      // This is checked in MetaSqueeze.
+      JXL_ASSERT(input.nb_meta_channels > parameters[i].num_c);
+      input.nb_meta_channels -= parameters[i].num_c;
+    }
+
     for (uint32_t c = beginc; c <= endc; c++) {
       uint32_t rc = offset + c - beginc;
       if ((input.channel[c].w < input.channel[rc].w) ||


### PR DESCRIPTION
MetaSqueeze() started updating the nb_meta_channels value in #331, but
we also need to update the value back when applying the transform. This
was leading to the transforms getting out of sync with when
meta-applying versus inverse applying them later.