### PR TITLE
Fuzz: Return error if Gaborish weights lead to invalid kernel.

### DIFF
--- a/lib/jxl/adaptive_reconstruction_test.cc
+++ b/lib/jxl/adaptive_reconstruction_test.cc
@@ -134,10 +134,10 @@ void EnsureUnchanged(const float background, const float foreground,
   jxl::PassesDecoderState state;
   JXL_CHECK(
       jxl::InitializePassesSharedState(frame_header, &state.shared_storage));
-  state.Init();
+  JXL_CHECK(state.Init());
   state.InitForAC(/*pool=*/nullptr);
 
-  state.filter_weights.Init(lf, frame_dim);
+  JXL_CHECK(state.filter_weights.Init(lf, frame_dim));
   FillImage(-0.5f, &state.filter_weights.sigma);
 
   for (size_t idx_image = 0; idx_image < images.size(); ++idx_image) {

--- a/lib/jxl/dec_cache.h
+++ b/lib/jxl/dec_cache.h
@@ -253,7 +253,7 @@ struct PassesDecoderState {
   OutputEncodingInfo output_encoding_info;
 
   // Initializes decoder-specific structures using information from *shared.
-  void Init() {
+  Status Init() {
     x_dm_multiplier =
         std::pow(1 / (1.25f), shared->frame_header.x_qm_scale - 2.0f);
     b_dm_multiplier =
@@ -267,7 +267,7 @@ struct PassesDecoderState {
 
     group_border_assigner.Init(shared->frame_dim);
     const LoopFilter& lf = shared->frame_header.loop_filter;
-    filter_weights.Init(lf, shared->frame_dim);
+    JXL_RETURN_IF_ERROR(filter_weights.Init(lf, shared->frame_dim));
     for (auto& fp : filter_pipelines) {
       // De-initialize FilterPipelines.
       fp.num_filters = 0;
@@ -275,6 +275,7 @@ struct PassesDecoderState {
     for (size_t i = 0; i < 3; i++) {
       upsamplers[i].Init(2 << i, shared->metadata->transform_data);
     }
+    return true;
   }
 
   // Initialize the decoder state after all of DC is decoded.

--- a/lib/jxl/dec_frame.cc
+++ b/lib/jxl/dec_frame.cc
@@ -288,7 +288,7 @@ Status FrameDecoder::InitFrame(BitReader* JXL_RESTRICT br, ImageBundle* decoded,
   }
   JXL_RETURN_IF_ERROR(
       InitializePassesSharedState(frame_header_, &dec_state_->shared_storage));
-  dec_state_->Init();
+  JXL_RETURN_IF_ERROR(dec_state_->Init());
   modular_frame_decoder_.Init(frame_dim_);
 
   if (decoded->IsJPEG()) {

--- a/lib/jxl/enc_adaptive_quantization.cc
+++ b/lib/jxl/enc_adaptive_quantization.cc
@@ -1059,7 +1059,7 @@ ImageBundle RoundtripImage(const Image3F& opsin, PassesEncoderState* enc_state,
                                             enc_state->cparams);
   InitializePassesEncoder(opsin, pool, enc_state, modular_frame_encoder.get(),
                           nullptr);
-  dec_state->Init();
+  JXL_CHECK(dec_state->Init());
   dec_state->InitForAC(pool);
 
   ImageBundle decoded(&enc_state->shared.metadata->m);

--- a/lib/jxl/filters.h
+++ b/lib/jxl/filters.h
@@ -19,7 +19,8 @@ namespace jxl {
 
 struct FilterWeights {
   // Initialize the FilterWeights for the passed LoopFilter and FrameDimensions.
-  void Init(const LoopFilter& lf, const FrameDimensions& frame_dim);
+  // Returns an error if the weights are invalid.
+  Status Init(const LoopFilter& lf, const FrameDimensions& frame_dim);
 
   // Normalized weights for gaborish, in XYB order, each weight for Manhattan
   // distance of 0, 1 and 2 respectively.
@@ -30,7 +31,7 @@ struct FilterWeights {
   ImageF sigma;
 
  private:
-  void GaborishWeights(const LoopFilter& lf);
+  Status GaborishWeights(const LoopFilter& lf);
 };
 
 static constexpr size_t kMaxFinalizeRectPadding = 9;

--- a/tools/epf.cc
+++ b/tools/epf.cc
@@ -55,7 +55,7 @@ jxl::Status RunEPF(uint32_t epf_iters, const float distance,
   jxl::FillImage(static_cast<uint8_t>(sharpness_parameter),
                  &state.shared_storage.epf_sharpness);
 
-  state.filter_weights.Init(lf, frame_dim);
+  JXL_RETURN_IF_ERROR(state.filter_weights.Init(lf, frame_dim));
   ComputeSigma(jxl::Rect(state.shared_storage.epf_sharpness), &state);
 
   // Call with `force_fir` set to true to force to apply filters to all of the


### PR DESCRIPTION
Spec says that the coefficients of the kernel used in Gaborish are
normalized to sum 1, but if the sum is already near 0 this is undefined.

This patch catches that case and returns a JXL_FAILURE instead of
creating NaNs or infs in the output.