### PR TITLE
fix modular nb_meta_channels counter

### DIFF
--- a/lib/jxl/modular/transform/palette.h
+++ b/lib/jxl/modular/transform/palette.h
@@ -271,7 +271,13 @@ static Status InvPalette(Image &input, uint32_t begin_c, uint32_t nb_colors,
           "UndoDeltaPaletteNoWP");
     }
   }
-  input.nb_meta_channels--;
+  if (c0 >= input.nb_meta_channels) {
+    input.nb_meta_channels--;
+  } else {
+    JXL_ASSERT(c0 + nb - 1 < input.nb_meta_channels);
+    JXL_ASSERT(static_cast<int>(input.nb_meta_channels) >= 2 - nb);
+    input.nb_meta_channels -= 2 - nb;
+  }
   input.channel.erase(input.channel.begin(), input.channel.begin() + 1);
   return num_errors.load(std::memory_order_relaxed) == 0;
 }
@@ -283,11 +289,10 @@ static Status MetaPalette(Image &input, uint32_t begin_c, uint32_t end_c,
   size_t nb = end_c - begin_c + 1;
   if (begin_c >= input.nb_meta_channels) {
     input.nb_meta_channels++;
-  } else if (end_c < input.nb_meta_channels) {
+  } else {
+    JXL_ASSERT(end_c < input.nb_meta_channels);
     // we remove nb-1 metachannels and add one
     input.nb_meta_channels += 2 - nb;
-  } else {
-    return JXL_FAILURE("Error: Palette operating on mixed meta/nonmeta");
   }
   input.channel.erase(input.channel.begin() + begin_c + 1,
                       input.channel.begin() + end_c + 1);

--- a/lib/jxl/modular/transform/transform.cc
+++ b/lib/jxl/modular/transform/transform.cc
@@ -81,6 +81,9 @@ Status CheckEqualChannels(const Image &image, uint32_t c1, uint32_t c2) {
         "Invalid channel range: %u..%u (there are only %zu channels)", c1, c2,
         image.channel.size());
   }
+  if (c1 < image.nb_meta_channels && c2 >= image.nb_meta_channels) {
+    return JXL_FAILURE("Invalid: transforming mix of meta and nonmeta");
+  }
   const auto &ch1 = image.channel[c1];
   for (size_t c = c1 + 1; c <= c2; c++) {
     const auto &ch2 = image.channel[c];


### PR DESCRIPTION
Fuzzing hasn't found a problem case yet afaik, but in the palette transform there was a similar problem as in https://github.com/libjxl/libjxl/pull/370 : the nb_meta_channels counter was not properly decremented in the inverse transform.

Also now checking for doing transforms on an invalid mix of meta/nonmeta channels in CheckEqualChannels(), so it will also cause RCT to fail when tried to be applied to a mix of meta and nonmeta channels.