### PR TITLE
Remove usage of %n.

### DIFF
--- a/bash_test.sh
+++ b/bash_test.sh
@@ -208,6 +208,21 @@ EOF
   return $ret
 }
 
+# Test that we don't use %n in C++ code to avoid using it in printf and scanf.
+# This test is not very precise but in cases where "module n" is needed we would
+# normally have "% n" instead of "%n". Using %n is not allowed in Android 10+.
+test_percent_n() {
+  local ret=0
+  local f
+  for f in $(git ls-files | grep -E '(\.cc|\.cpp|\.h)$'); do
+    if grep -i -H -n -E '%h*n' "$f" >&2; then
+      echo "Don't use \"%n\"." >&2
+      ret=1
+    fi
+  done
+  return ${ret}
+}
+
 main() {
   local ret=0
   cd "${MYDIR}"

--- a/lib/extras/codec_pgx.cc
+++ b/lib/extras/codec_pgx.cc
@@ -171,8 +171,10 @@ Status EncodeHeader(const ImageBundle& ib, const size_t bits_per_sample,
   }
 
   // Use ML (Big Endian), LM may not be well supported by all decoders.
-  snprintf(header, kMaxHeaderSize, "PG ML + %zu %zu %zu\n%n", bits_per_sample,
-           ib.xsize(), ib.ysize(), chars_written);
+  *chars_written = snprintf(header, kMaxHeaderSize, "PG ML + %zu %zu %zu\n",
+                            bits_per_sample, ib.xsize(), ib.ysize());
+  JXL_RETURN_IF_ERROR(static_cast<unsigned int>(*chars_written) <
+                      kMaxHeaderSize);
   return true;
 }
 

--- a/lib/extras/codec_pnm.cc
+++ b/lib/extras/codec_pnm.cc
@@ -352,20 +352,28 @@ Status EncodeHeader(const ImageBundle& ib, const size_t bits_per_sample,
   if (bits_per_sample == 32) {  // PFM
     const char type = ib.IsGray() ? 'f' : 'F';
     const double scale = little_endian ? -1.0 : 1.0;
-    snprintf(header, kMaxHeaderSize, "P%c\n%zu %zu\n%.1f\n%n", type,
-             ib.oriented_xsize(), ib.oriented_ysize(), scale, chars_written);
+    *chars_written =
+        snprintf(header, kMaxHeaderSize, "P%c\n%zu %zu\n%.1f\n", type,
+                 ib.oriented_xsize(), ib.oriented_ysize(), scale);
+    JXL_RETURN_IF_ERROR(static_cast<unsigned int>(*chars_written) <
+                        kMaxHeaderSize);
   } else if (bits_per_sample == 1) {  // PBM
     if (!ib.IsGray()) {
       return JXL_FAILURE("Cannot encode color as PBM");
     }
-    snprintf(header, kMaxHeaderSize, "P4\n%zu %zu\n%n", ib.oriented_xsize(),
-             ib.oriented_ysize(), chars_written);
+    *chars_written = snprintf(header, kMaxHeaderSize, "P4\n%zu %zu\n",
+                              ib.oriented_xsize(), ib.oriented_ysize());
+    JXL_RETURN_IF_ERROR(static_cast<unsigned int>(*chars_written) <
+                        kMaxHeaderSize);
   } else {  // PGM/PPM
     const uint32_t max_val = (1U << bits_per_sample) - 1;
     if (max_val >= 65536) return JXL_FAILURE("PNM cannot have > 16 bits");
     const char type = ib.IsGray() ? '5' : '6';
-    snprintf(header, kMaxHeaderSize, "P%c\n%zu %zu\n%u\n%n", type,
-             ib.oriented_xsize(), ib.oriented_ysize(), max_val, chars_written);
+    *chars_written =
+        snprintf(header, kMaxHeaderSize, "P%c\n%zu %zu\n%u\n", type,
+                 ib.oriented_xsize(), ib.oriented_ysize(), max_val);
+    JXL_RETURN_IF_ERROR(static_cast<unsigned int>(*chars_written) <
+                        kMaxHeaderSize);
   }
   return true;
 }


### PR DESCRIPTION
%n is error prone and some environments start to complain about its
usage. Remove %n usage and add a check to avoid re-introducing it.

Tested that `cjxl third_party/sjpeg/tests/testdata/test_exif_xmp.png`
still parses the metadata correctly.