### PR TITLE
fuzz: fix assert in the exotic case of doing palette on palettes

### DIFF
--- a/lib/jxl/modular/transform/palette.h
+++ b/lib/jxl/modular/transform/palette.h
@@ -272,11 +272,13 @@ static Status InvPalette(Image &input, uint32_t begin_c, uint32_t nb_colors,
     }
   }
   if (c0 >= input.nb_meta_channels) {
+    // Palette was done on normal channels
     input.nb_meta_channels--;
   } else {
-    JXL_ASSERT(c0 + nb - 1 < input.nb_meta_channels);
+    // Palette was done on metachannels
     JXL_ASSERT(static_cast<int>(input.nb_meta_channels) >= 2 - nb);
     input.nb_meta_channels -= 2 - nb;
+    JXL_ASSERT(begin_c + nb - 1 < input.nb_meta_channels);
   }
   input.channel.erase(input.channel.begin(), input.channel.begin() + 1);
   return num_errors.load(std::memory_order_relaxed) == 0;
@@ -288,8 +290,10 @@ static Status MetaPalette(Image &input, uint32_t begin_c, uint32_t end_c,
 
   size_t nb = end_c - begin_c + 1;
   if (begin_c >= input.nb_meta_channels) {
+    // Palette was done on normal channels
     input.nb_meta_channels++;
   } else {
+    // Palette was done on metachannels
     JXL_ASSERT(end_c < input.nb_meta_channels);
     // we remove nb-1 metachannels and add one
     input.nb_meta_channels += 2 - nb;


### PR DESCRIPTION
Made a braino in the original assert here: the assert talks about the situation _after_ the inverse transform (checking that it is indeed a case where all affected channels were metachannels), so it has to use the updated `nb_meta_channels` and `begin_c` instead of `c0`.