### PR TITLE
fuzz: return early when there is no modular data to decode

### DIFF
--- a/lib/jxl/dec_modular.cc
+++ b/lib/jxl/dec_modular.cc
@@ -185,6 +185,7 @@ Status ModularFrameDecoder::DecodeGlobalInfo(BitReader* reader,
   Image gi(frame_dim.xsize, frame_dim.ysize, metadata.bit_depth.bits_per_sample,
            nb_chans + nb_extra);
 
+  all_same_shift = true;
   if (frame_header.color_transform == ColorTransform::kYCbCr) {
     for (size_t c = 0; c < nb_chans; c++) {
       gi.channel[c].hshift = frame_header.chroma_subsampling.HShift(c);
@@ -194,6 +195,9 @@ Status ModularFrameDecoder::DecodeGlobalInfo(BitReader* reader,
       size_t ysize_shifted =
           DivCeil(frame_dim.ysize, 1 << gi.channel[c].vshift);
       gi.channel[c].shrink(xsize_shifted, ysize_shifted);
+      if (gi.channel[c].hshift != gi.channel[0].hshift ||
+          gi.channel[c].vshift != gi.channel[0].vshift)
+        all_same_shift = false;
     }
   }
 
@@ -203,6 +207,9 @@ Status ModularFrameDecoder::DecodeGlobalInfo(BitReader* reader,
                          DivCeil(frame_dim.ysize_upsampled, ecups));
     gi.channel[c].hshift = gi.channel[c].vshift =
         CeilLog2Nonzero(ecups) - CeilLog2Nonzero(frame_header.upsampling);
+    if (gi.channel[c].hshift != gi.channel[0].hshift ||
+        gi.channel[c].vshift != gi.channel[0].vshift)
+      all_same_shift = false;
   }
 
   ModularOptions options;
@@ -227,7 +234,7 @@ Status ModularFrameDecoder::DecodeGlobalInfo(BitReader* reader,
       have_something = true;
   }
   // move global transforms to groups if possible
-  if (!have_something) {
+  if (!have_something && all_same_shift) {
     if (gi.transform.size() == 1 && gi.transform[0].id == TransformId::kRCT) {
       global_transform = gi.transform;
       gi.transform.clear();
@@ -239,7 +246,7 @@ Status ModularFrameDecoder::DecodeGlobalInfo(BitReader* reader,
 }
 
 void ModularFrameDecoder::MaybeDropFullImage() {
-  if (full_image.transform.empty() && !have_something) {
+  if (full_image.transform.empty() && !have_something && all_same_shift) {
     use_full_image = false;
     for (auto& ch : full_image.channel) {
       // keep metadata on channels around, but dealloc their planes
@@ -288,6 +295,9 @@ Status ModularFrameDecoder::DecodeGroup(const Rect& rect, BitReader* reader,
     }
   }
   if (zerofill && use_full_image) return true;
+  // Return early if there's nothing to decode. Otherwise there might be
+  // problems later (in ModularImageToDecodedRect).
+  if (gi.channel.empty()) return true;
   ModularOptions options;
   if (!zerofill) {
     if (!ModularGenericDecompress(
@@ -455,7 +465,7 @@ Status ModularFrameDecoder::ModularImageToDecodedRect(
   }
   JXL_DASSERT(rect.IsInside(decoded));
 
-  int c = 0;
+  size_t c = 0;
   if (do_color) {
     const bool rgb_from_gray =
         metadata->m.color_encoding.IsGray() &&
@@ -466,7 +476,7 @@ Status ModularFrameDecoder::ModularImageToDecodedRect(
       float factor = full_image.bitdepth < 32
                          ? 1.f / ((1u << full_image.bitdepth) - 1)
                          : 0;
-      int c_in = c;
+      size_t c_in = c;
       if (frame_header.color_transform == ColorTransform::kXYB) {
         factor = dec_state->shared->matrices.DCQuants()[c];
         // XYB is encoded as YX(B-Y)
@@ -474,6 +484,7 @@ Status ModularFrameDecoder::ModularImageToDecodedRect(
       } else if (rgb_from_gray) {
         c_in = 0;
       }
+      JXL_ASSERT(c_in < gi.channel.size());
       Channel& ch_in = gi.channel[c_in];
       // TODO(eustas): could we detect it on earlier stage?
       if (ch_in.w == 0 || ch_in.h == 0) {
@@ -551,6 +562,7 @@ Status ModularFrameDecoder::ModularImageToDecodedRect(
     size_t ecups = frame_header.extra_channel_upsampling[ec];
     const size_t ec_xsize = DivCeil(frame_dim.xsize_upsampled, ecups);
     const size_t ec_ysize = DivCeil(frame_dim.ysize_upsampled, ecups);
+    JXL_ASSERT(c < gi.channel.size());
     Channel& ch_in = gi.channel[c];
     // For x0, y0 there's no need to do a DivCeil().
     JXL_DASSERT(rect.x0() % (1ul << ch_in.hshift) == 0);

--- a/lib/jxl/dec_modular.h
+++ b/lib/jxl/dec_modular.h
@@ -121,6 +121,7 @@ class ModularFrameDecoder {
   bool do_color;
   bool have_something;
   bool use_full_image = true;
+  bool all_same_shift;
   Tree tree;
   ANSCode code;
   std::vector<uint8_t> context_map;


### PR DESCRIPTION
When a modular dc or ac group is empty, a 0-channel image gets decoded, and in the old flow that just meant that all of those 0 channels would get copied to the modular full_image.

In the new flow however (where full_image is avoided), it created trouble because a 0-channel image would still cause a call to ModularImageToDecodedRect(), which would then try to access non-existing channels.

Returning early when a 0-channel group image is about to get decoded solves that.
Still adding an assert to check for access to non-existing channels.

~~There could still be a remaining bug that can arise when a modular group e.g. contains data for some extrachannels but not for others (because they have a different dim_shift / upsampling factor). I haven't seen a fuzzcase for that yet, but it is something that can happen so it needs to be fixed (not in this pull request though).~~

Also don't do the no-full-image thing when not all modular channels have the same shift. That avoids the potential problem where some channels are encoded in the DC groups and others in the AC groups, which would cause trouble since ModularImageToDecodedRect() assumes all channels are available. This is a temporary fix; a better but more complicated fix would be to update ModularImageToDecodedRect() to work on the subset of channels that was just decoded.