### PR TITLE
plugins/gdk-pixbuf: Link against the shared lib

### DIFF
--- a/plugins/gdk-pixbuf/CMakeLists.txt
+++ b/plugins/gdk-pixbuf/CMakeLists.txt
@@ -13,7 +13,7 @@ if (NOT Gdk-Pixbuf_FOUND)
 endif ()
 
 add_library(pixbufloader-jxl SHARED pixbufloader-jxl.c)
-target_link_libraries(pixbufloader-jxl jxl_dec-static jxl_threads-static PkgConfig::Gdk-Pixbuf)
+target_link_libraries(pixbufloader-jxl jxl_dec jxl_threads PkgConfig::Gdk-Pixbuf)
 
 pkg_get_variable(GDK_PIXBUF_MODULEDIR gdk-pixbuf-2.0 gdk_pixbuf_moduledir)
 install(TARGETS pixbufloader-jxl LIBRARY DESTINATION "${GDK_PIXBUF_MODULEDIR}")


### PR DESCRIPTION
The gdk-pixbuf plugin only uses public API so it can be built against
the shared library.

Tested with: `./ci.sh test -R pixbuf`