### PR TITLE
Add clang-format 10 and 11 to the allowed list.

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -32,6 +32,8 @@ jobs:
           clang-format-7 \
           clang-format-8 \
           clang-format-9 \
+          clang-format-10 \
+          clang-format-11 \
         #
     - name: Checkout the source
       uses: actions/checkout@v2

--- a/ci.sh
+++ b/ci.sh
@@ -1187,7 +1187,7 @@ cmd_fuzz() {
 cmd_lint() {
   merge_request_commits
   { set +x; } 2>/dev/null
-  local versions=(${1:-6.0 7 8 9})
+  local versions=(${1:-6.0 7 8 9 10 11})
   local clang_format_bins=("${versions[@]/#/clang-format-}" clang-format)
   local tmpdir=$(mktemp -d)
   CLEANUP_FILES+=("${tmpdir}")


### PR DESCRIPTION
clang-format evolved over time and different versions don't exactly
agree on certain formatting, so we accept any formatting as valid. This
patch includes versions 10 and 11 to the list.