### PR TITLE
Build release binaries on post-submit

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,169 @@
+# Copyright (c) the JPEG XL Project Authors. All rights reserved.
+#
+# Use of this source code is governed by a BSD-style
+# license that can be found in the LICENSE file.
+
+# Workflow for building the release binaries.
+#
+# This workflow runs as a post-submit step, when pushing to main or the release
+# branches (v*.*.x), and when creating a release in GitHub.
+#
+# In the GitHub release case, in addition to build the release binaries it also
+# uploads the binaries to the given release automatically.
+
+name: Release build / deploy
+on:
+  push:
+    branches:
+      - main
+      - v*.*.x
+  release:
+    types: [ published ]
+
+jobs:
+  ubuntu_static_x86_64:
+    name: Release linux x86_64 static
+    runs-on: [ubuntu-latest]
+    steps:
+    - name: Install build deps
+      run: |
+        sudo apt update
+        sudo apt install -y \
+          asciidoc \
+          clang \
+          cmake \
+          doxygen \
+          libbrotli-dev \
+          libgdk-pixbuf2.0-dev \
+          libgif-dev \
+          libgtest-dev \
+          libgtk2.0-dev  \
+          libjpeg-dev \
+          libopenexr-dev \
+          libpng-dev \
+          libwebp-dev \
+          ninja-build \
+          pkg-config \
+        #
+        echo "CC=clang" >> $GITHUB_ENV
+        echo "CXX=clang++" >> $GITHUB_ENV
+
+    - name: Checkout the source
+      uses: actions/checkout@v2
+      with:
+        submodules: true
+        fetch-depth: 1
+
+    - name: Build
+      env:
+        SKIP_TEST: 1
+      run: |
+        ./ci.sh release \
+          -DJPEGXL_DEP_LICENSE_DIR=/usr/share/doc \
+          -DJPEGXL_STATIC=ON \
+          -DBUILD_TESTING=OFF \
+          -DJPEGXL_ENABLE_VIEWERS=OFF \
+          -DJPEGXL_ENABLE_PLUGINS=OFF \
+          -DJPEGXL_ENABLE_OPENEXR=OFF \
+
+    - name: Upload artifacts
+      uses: actions/upload-artifact@v2
+      with:
+        name: linux-x86_64-static
+        path: |
+          build/LICENSE*
+          build/tools/cjxl
+          build/tools/djxl
+          build/tools/benchmark_xl
+
+    - name: Package release tarball
+      if: github.event_name == 'release'
+      run: |
+        tar -zcvf ${{ runner.workspace }}/release_file.tar.gz -C build/tools \
+          cjxl djxl benchmark_xl
+
+    - name: Upload binaries to release
+      if: github.event_name == 'release'
+      uses: svenstaro/upload-release-action@v1-release
+      with:
+        repo_token: ${{ secrets.GITHUB_TOKEN }}
+        file: ${{ runner.workspace }}/release_file.tar.gz
+        asset_name: jxl-linux-x86_64-static-${{ github.event.release.tag_name }}.tar.gz
+        tag: ${{ github.ref }}
+        overwrite: true
+
+  # Build a .deb package for the ubuntu-latest
+  release_ubuntu_pkg:
+    name: Ubuntu release package / ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-20.04, ubuntu-18.04]
+
+    steps:
+    - name: Install build deps
+      run: |
+        sudo apt update
+        sudo apt install -y \
+          devscripts \
+          build-essential \
+        #
+
+    - name: Checkout the source
+      uses: actions/checkout@v2
+      with:
+        submodules: true
+        fetch-depth: 1
+
+    - name: Install gtest (only 18.04)
+      if: matrix.os == 'ubuntu-18.04'
+        # In Ubuntu 18.04 no package installed the libgtest.a. libgtest-dev
+        # installs the source files only.
+      run: |
+        sudo apt install -y libgtest-dev cmake
+        for prj in googletest googlemock; do
+          (cd /usr/src/googletest/${prj}/ &&
+           sudo cmake CMakeLists.txt -DCMAKE_INSTALL_PREFIX=/usr &&
+           sudo make all install)
+        done
+        # Remove libgmock-dev dependency in Ubuntu 18.04. It doesn't exist there.
+        sed '/libgmock-dev,/d' -i debian/control
+
+    - name: Build hwy
+      run: |
+        sudo apt build-dep -y ./third_party/highway
+        ./ci.sh debian_build highway
+        sudo dpkg -i build/debs/libhwy-dev_*_amd64.deb
+
+    - name: Build libjxl
+      run: |
+        sudo apt build-dep -y .
+        ./ci.sh debian_build jpeg-xl
+
+    - name: Stats
+      run: |
+        ./ci.sh debian_stats
+
+    - name: Upload artifacts
+      uses: actions/upload-artifact@v2
+      with:
+        name: debs-amd64-${{ matrix.os }}
+        path: |
+          build/debs/*jxl*.*
+
+    - name: Package release tarball
+      if: github.event_name == 'release'
+      run: |
+        (cd build/debs/; find -maxdepth 1 -name '*jxl*.*') | \
+        tar -zcvf ${{ runner.workspace }}/release_file.tar.gz \
+          -C build/debs/ -T -
+
+    - name: Upload binaries to release
+      if: github.event_name == 'release'
+      uses: svenstaro/upload-release-action@v1-release
+      with:
+        repo_token: ${{ secrets.GITHUB_TOKEN }}
+        file: ${{ runner.workspace }}/release_file.tar.gz
+        asset_name: jxl-debs-${{ matrix.os }}-${{ github.event.release.tag_name }}.tar.gz
+        tag: ${{ github.ref }}
+        overwrite: true


### PR DESCRIPTION
Release binaries include the Debian packages for Ubuntu 18.04 and 20.04
and static linux binaries for x86_64.

The binaries are built from main and the release branches whenever a
new commit is pushed there, and the artifacts are automatically attached
to releases in GitHub when a release is created.