### PR TITLE
Avoid UB in enc_ma.cc.

### DIFF
--- a/lib/jxl/modular/encoding/enc_ma.cc
+++ b/lib/jxl/modular/encoding/enc_ma.cc
@@ -943,6 +943,7 @@ void CollectPixelSamples(const Image &image, const ModularOptions &options,
                          std::vector<uint32_t> &channel_pixel_count,
                          std::vector<pixel_type> &pixel_samples,
                          std::vector<pixel_type> &diff_samples) {
+  if (options.nb_repeats == 0) return;
   if (group_pixel_count.size() <= group_id) {
     group_pixel_count.resize(group_id + 1);
   }


### PR DESCRIPTION
Creating a geometric distribution with fraction 0 causes divisions by 0
and invalid float-to-int conversions. Fixes #409.