### PR TITLE
Fix for division by zero in masking

### DIFF
--- a/lib/jxl/enc_adaptive_quantization.cc
+++ b/lib/jxl/enc_adaptive_quantization.cc
@@ -118,14 +118,15 @@ V RatioOfDerivativesOfCubicRootToSimpleGamma(const D d, V v) {
   // SimpleGamma(v * v * v) is the psychovisual space in butteraugli.
   // This ratio allows quantization to move from jxl's opsin space to
   // butteraugli's log-gamma space.
+  float kEpsilon = 1e-2;
   v = ZeroIfNegative(v);
   const auto kNumMul = Set(d, kSGRetMul * 3 * kSGmul);
-  const auto kVOffset = Set(d, kSGVOffset * kLog2);
+  const auto kVOffset = Set(d, kSGVOffset * kLog2 + kEpsilon);
   const auto kDenMul = Set(d, kLog2 * kSGmul);
 
   const auto v2 = v * v;
 
-  const auto num = kNumMul * v2;
+  const auto num = MulAdd(kNumMul, v2, Set(d, kEpsilon));
   const auto den = MulAdd(kDenMul * v, v2, kVOffset);
   return invert ? num / den : den / num;
 }


### PR DESCRIPTION
The code before causes inf's to appear in the masking field, leading to
confusion and debug asserts to fail. Adding a small bias to both sides
of a / b to converge to 1.0 instead of inf for small values.

Before:

```
Encoding         kPixels    Bytes          BPP  E MP/s  D MP/s     Max norm        pnorm   PSNR   QABPP  SmallB  DCT4x8     AFV  DCT8x8    8x16    8x32      16   16x32      32   32x64      64       BPP*pnorm   Bugs
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
jxl:d0.8:epf0      29551  6554567    1.7744017   2.296  24.016   3.15145683   0.56864224  40.40   2.643  0.8420 19.9916  1.0484  5.4701 21.4274  0.0000 40.5540  3.6869  4.8962  0.9702  1.1781  1.008999733745      0
jxl:d1:epf1        29551  5651250    1.5298627   2.273  23.248   3.53256750   0.66406493  39.44   2.662  0.8137 17.5495  1.0614  4.6586 19.4094  0.0000 40.4994  7.9265  5.9080  1.0465  1.1920  1.015928155744      0
jxl:d2:epf3        29551  3491264    0.9451280   2.531  14.920   8.18065357   1.07465353  36.54   2.884  0.7502 11.2881  1.0870  3.1844 12.2873  0.0000 22.6809 34.7430 11.5839  1.1851  1.2752  1.015685114638      0
jxl:d3:epf0        29551  2559882    0.6929914   2.464  34.430  10.90255547   1.42321246  34.64   2.886  0.6781  8.5443  1.0889  2.8174 10.5218  0.0000 14.2607 43.1511 16.5009  1.1989  1.3029  0.986274062778      0
jxl:d4:epf3        29551  2110536    0.5713480   2.626  21.259  10.23806953   1.68083890  33.51   2.955  0.5871  6.7921  1.0174  2.3974  9.2605  0.0000 10.9143 45.2492 21.3313  1.1712  1.3445  0.960343904476      0
jxl:d8:epf1        29551  1206773    0.3266882   2.645  22.439  13.49176693   2.66241591  30.54   2.768  0.2887  3.9323  0.7688  1.4699  7.0537  0.0000  7.0082 45.9977 30.8222  1.3098  1.4138  0.869779994960      0
jxl:d16:epf3       29551   692306    0.1874157   2.739  17.432  23.26285934   4.57630347  28.32   2.944  0.0537  1.7189  0.3905  0.5356  4.7975  0.0000  4.3158 39.1316 44.8317  1.7118  2.5780  0.857671228343      0
jxl:d24:epf3       29551   513658    0.1390535   2.714  14.341  24.99697876   5.89148093  26.99   2.921  0.0162  1.1078  0.2510  0.3487  3.7393  0.0000  3.5821 33.5753 51.8381  1.8365  3.7700  0.819231159255      0
jxl:d32:epf3       29551   414804    0.1122925   2.786  17.291  27.92841721   7.06830293  26.13   2.783  0.0039  0.7625  0.1657  0.2332  2.9999  0.0000  2.9566 29.4933 56.2562  2.0375  5.1561  0.793717615772      0
jxl:d5             29551  1736901    0.4702004   2.496  17.702  10.13597965   1.96851552  32.48   3.174  0.4806  5.7402  0.9722  2.1124  8.5030  0.0000  9.1237 46.1051 24.4707  1.1989  1.3583  0.925596786750      0
jxl:d6             29551  1515492    0.4102623   2.620  17.947   9.95078278   2.18919785  31.73   2.858  0.4186  5.0186  0.9018  1.9013  7.8459  0.0000  8.1950 46.4343 26.7854  1.2059  1.3583  0.898145275437      0
jxl:d7             29551  1353691    0.3664608   2.546  14.949  10.54708958   2.44315778  31.11   2.962  0.3582  4.4657  0.8425  1.7124  7.5197  0.0000  7.6120 46.1051 28.8090  1.2544  1.3860  0.895321443697      0
jxl:d8             29551  1206757    0.3266839   2.690  17.271  13.49211407   2.71148709  30.61   2.841  0.2887  3.9323  0.7688  1.4699  7.0537  0.0000  7.0082 45.9977 30.8222  1.3098  1.4138  0.885799226381      0
jxl:d10            29551   998662    0.2703500   2.640  15.020  13.25542259   3.20652247  29.80   2.938  0.1899  3.0892  0.6341  1.1106  6.3360  0.0000  6.0276 44.4193 35.4170  1.3860  1.4553  0.866883510890      0
jxl:d12            29551   854427    0.2313039   2.734  17.713  13.94793034   3.70962848  29.17   2.832  0.1250  2.4635  0.5230  0.8451  5.6776  0.0000  5.3086 42.5326 39.5890  1.5177  1.4831  0.858051411724      0
jxl:d14            29551   761397    0.2061195   2.709  15.211  21.95223808   4.16695177  28.73   2.879  0.0723  1.9751  0.4318  0.6387  5.1154  0.0000  4.7134 40.3149 43.4699  1.8088  1.5247  0.858890034916      0
Aggregate:         29551  1441472    0.3902240   2.590  18.549  11.73734809   2.31846556  31.64   2.868  0.2011  4.2164  0.6620  1.3979  7.5969  0.0000  8.7199 32.0214 24.5007  1.3543  1.6364  0.904720981707      0
```

After:

```
Encoding         kPixels    Bytes          BPP  E MP/s  D MP/s     Max norm        pnorm   PSNR   QABPP  SmallB  DCT4x8     AFV  DCT8x8    8x16    8x32      16   16x32      32   32x64      64       BPP*pnorm   Bugs
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
jxl:d0.8:epf0      29551  6554668    1.7744290   2.449  24.858   3.15145683   0.56863229  40.40   2.643  0.8427 19.9948  1.0482  5.4712 21.4209  0.0000 40.5575  3.6852  4.8962  0.9702  1.1781  1.008997630995      0
jxl:d1:epf1        29551  5651094    1.5298204   2.320  22.469   3.53256750   0.66403981  39.44   2.662  0.8139 17.5547  1.0610  4.6567 19.4047  0.0000 40.4994  7.9282  5.9080  1.0465  1.1920  1.015861670536      0
jxl:d2:epf3        29551  3491370    0.9451567   2.650  16.234   8.18065357   1.07480311  36.54   2.889  0.7502 11.2902  1.0870  3.1836 12.2843  0.0000 22.6757 34.7499 11.5839  1.1851  1.2752  1.015857327940      0
jxl:d3:epf0        29551  2559899    0.6929961   2.564  34.360  10.90255547   1.42360926  34.64   2.887  0.6781  8.5413  1.0889  2.8165 10.5205  0.0000 14.2642 43.1563 16.4974  1.1989  1.3029  0.986555598207      0
jxl:d4:epf3        29551  2110631    0.5713737   2.384  20.495  10.23806953   1.68089907  33.51   2.956  0.5871  6.7947  1.0172  2.3976  9.2571  0.0000 10.9186 45.2423 21.3347  1.1712  1.3445  0.960421510770      0
jxl:d8:epf1        29551  1206769    0.3266872   2.414  30.868  13.49176693   2.66244276  30.54   2.768  0.2887  3.9303  0.7688  1.4692  7.0537  0.0000  7.0073 46.0012 30.8222  1.3098  1.4138  0.869785883270      0
jxl:d16:epf3       29551   692298    0.1874136   2.748  16.588  23.26285934   4.57624757  28.32   2.944  0.0537  1.7178  0.3903  0.5356  4.7936  0.0000  4.3123 39.1298 44.8421  1.7118  2.5780  0.857650840410      0
jxl:d24:epf3       29551   513518    0.1390156   2.675  16.995  24.99697876   5.89138879  26.99   2.920  0.0162  1.1056  0.2510  0.3465  3.7358  0.0000  3.5795 33.5926 51.8312  1.8365  3.7700  0.818995064036      0
jxl:d32:epf3       29551   414762    0.1122812   2.764  16.160  27.92841721   7.06834475  26.13   2.783  0.0039  0.7625  0.1657  0.2332  2.9991  0.0000  2.9540 29.4933 56.2596  2.0375  5.1561  0.793641945452      0
jxl:d5             29551  1737112    0.4702575   2.394  19.440  10.13597965   1.96858139  32.48   3.174  0.4806  5.7382  0.9726  2.1105  8.4917  0.0000  9.1245 46.1190 24.4707  1.1989  1.3583  0.925740201459      0
jxl:d6             29551  1515570    0.4102834   2.546  16.898   9.95078278   2.18901455  31.73   2.858  0.4188  5.0188  0.9020  1.9002  7.8411  0.0000  8.1950 46.4395 26.7854  1.2059  1.3583  0.898116298257      0
jxl:d7             29551  1353765    0.3664808   2.611  18.050  10.54708958   2.44290050  31.11   2.962  0.3584  4.4678  0.8414  1.7133  7.5132  0.0000  7.6146 46.1068 28.8090  1.2544  1.3860  0.895276096769      0
jxl:d8             29551  1206753    0.3266828   2.569  16.931  13.49211407   2.71152148  30.61   2.841  0.2887  3.9303  0.7688  1.4692  7.0537  0.0000  7.0073 46.0012 30.8222  1.3098  1.4138  0.885807526396      0
jxl:d10            29551   998783    0.2703828   2.639  16.978  13.25542259   3.20628277  29.80   2.938  0.1899  3.0898  0.6341  1.1091  6.3299  0.0000  6.0258 44.4245 35.4204  1.3860  1.4553  0.866923733631      0
jxl:d12            29551   854486    0.2313198   2.618  16.709  13.94793034   3.70954741  29.17   2.832  0.1250  2.4626  0.5232  0.8448  5.6724  0.0000  5.3094 42.5343 39.5924  1.5177  1.4831  0.858091908828      0
jxl:d14            29551   761310    0.2060960   2.534  15.363  21.95223808   4.16689356  28.73   2.879  0.0723  1.9734  0.4321  0.6371  5.1071  0.0000  4.7108 40.3218 43.4768  1.8088  1.5247  0.858779899140      0
Aggregate:         29551  1441470    0.3902236   2.552  19.371  11.73734809   2.31848485  31.64   2.868  0.2012  4.2154  0.6620  1.3968  7.5923  0.0000  8.7186 32.0240 24.5014  1.3543  1.6364  0.904727450348      0
```