### PR TITLE
Set JPEGXL_VERSION macro from git hash at build time.

### DIFF
--- a/ci.sh
+++ b/ci.sh
@@ -89,7 +89,7 @@ if [[ ! -z "${HWY_BASELINE_TARGETS}" ]]; then
 fi
 
 # Version inferred from the CI variables.
-CI_COMMIT_SHA=${CI_COMMIT_SHA:-}
+CI_COMMIT_SHA=${CI_COMMIT_SHA:-${GITHUB_SHA:-}}
 JPEGXL_VERSION=${JPEGXL_VERSION:-${CI_COMMIT_SHA:0:8}}
 
 # Benchmark parameters

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -56,11 +56,6 @@ else()
 endif()
 endif()  # JPEGXL_ENABLE_VIEWERS
 
-# The JPEGXL_VERSION is set from the builders.
-if(NOT DEFINED JPEGXL_VERSION OR JPEGXL_VERSION STREQUAL "")
-  set(JPEGXL_VERSION "(unknown)")
-endif()
-
 set(TOOL_BINARIES
   cjxl
   djxl
@@ -69,8 +64,10 @@ set(TOOL_BINARIES
 
 add_library(jxl_tool STATIC
   cmdline.cc
+  codec_config.cc
   cpu/cpu.cc
   cpu/os_specific.cc
+  tool_version.cc
 )
 target_compile_options(jxl_tool PUBLIC "${JPEGXL_INTERNAL_FLAGS}")
 target_link_libraries(jxl_tool jxl-static)
@@ -78,26 +75,68 @@ target_link_libraries(jxl_tool jxl-static)
 target_include_directories(jxl_tool
   PUBLIC "${PROJECT_SOURCE_DIR}")
 
-# Main compressors.
-add_library(cjxltool STATIC
+# The JPEGXL_VERSION is set from the builders.
+if(NOT DEFINED JPEGXL_VERSION OR JPEGXL_VERSION STREQUAL "")
+  find_package(Git QUIET)
+  execute_process(
+      COMMAND "${GIT_EXECUTABLE}" rev-parse --short HEAD
+      OUTPUT_VARIABLE GIT_REV
+      WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"
+      ERROR_QUIET)
+  string(STRIP "${GIT_REV}" GIT_REV)
+  if(GIT_REV STREQUAL "")
+    set(JPEGXL_VERSION "(unknown)")
+  endif()
+endif()
+
+if(NOT DEFINED JPEGXL_VERSION OR JPEGXL_VERSION STREQUAL "")
+  # We are building from a git environment and the user didn't set
+  # JPEGXL_VERSION. Make a target that computes the GIT_REV at build-time always
+  # but only updates the file if it changed. This allows rebuilds without
+  # modifying cmake files to update the JPEGXL_VERSION.
+  message(STATUS "Building with JPEGXL_VERSION=${GIT_REV} (auto-updated)")
+  add_custom_target(
+    tool_version_git
+    ${CMAKE_COMMAND}
+      -D JPEGXL_ROOT_DIR=${CMAKE_SOURCE_DIR}
+      -D DST=${CMAKE_CURRENT_BINARY_DIR}/tool_version_git.h
+      -P ${CMAKE_CURRENT_SOURCE_DIR}/git_version.cmake
+    BYPRODUCTS "${CMAKE_CURRENT_BINARY_DIR}/tool_version_git.h"
+  )
+  add_dependencies(jxl_tool tool_version_git)
+
+  set_source_files_properties(tool_version.cc PROPERTIES
+    COMPILE_DEFINITIONS JPEGXL_VERSION_FROM_GIT=1
+    INCLUDE_DIRECTORIES "${CMAKE_CURRENT_BINARY_DIR}"
+  )
+  # Note: Ninja looks for dependencies on the jxl_tool target before running
+  # the tool_version_git targets, so when updating the tool_version_git.h the
+  # jxl_tool target is not rebuilt. This forces to generate it at configure time
+  # if needed.
+  execute_process(
+    COMMAND ${CMAKE_COMMAND}
+      -D JPEGXL_ROOT_DIR=${CMAKE_SOURCE_DIR}
+      -D DST=${CMAKE_CURRENT_BINARY_DIR}/tool_version_git.h
+      -P ${CMAKE_CURRENT_SOURCE_DIR}/git_version.cmake)
+else()
+  message(STATUS "Building with JPEGXL_VERSION=${JPEGXL_VERSION}")
+  set_source_files_properties(tool_version.cc PROPERTIES
+    COMPILE_DEFINITIONS JPEGXL_VERSION=\"${JPEGXL_VERSION}\")
+endif()
+
+# Main compressor.
+add_executable(cjxl
   cjxl.cc
-  codec_config.cc
   speed_stats.cc
+  cjxl_main.cc
 )
-target_compile_definitions(cjxltool
-  PRIVATE "-DJPEGXL_VERSION=\"${JPEGXL_VERSION}\"")
-target_include_directories(cjxltool
-  PUBLIC "${PROJECT_SOURCE_DIR}")
-target_link_libraries(cjxltool
+target_link_libraries(cjxl
     box
     jxl-static
     jxl_extras-static
     jxl_threads-static
 )
 
-
-add_executable(cjxl cjxl_main.cc)
-target_link_libraries(cjxl cjxltool)
 
 # Main decompressor.
 add_library(djxltool STATIC
@@ -110,16 +149,11 @@ target_link_libraries(djxltool
     jxl_extras-static
     jxl_threads-static
 )
-target_compile_definitions(djxltool
-  PRIVATE "-DJPEGXL_VERSION=\"${JPEGXL_VERSION}\"")
 
 add_executable(djxl
-    codec_config.cc
     djxl_main.cc
 )
 target_link_libraries(djxl djxltool)
-target_compile_definitions(djxl
-  PRIVATE "-DJPEGXL_VERSION=\"${JPEGXL_VERSION}\"")
 
 # Other developer tools.
 if(${JPEGXL_ENABLE_DEVTOOLS})
@@ -134,7 +168,6 @@ if(${JPEGXL_ENABLE_DEVTOOLS})
   )
 
   add_executable(fuzzer_corpus fuzzer_corpus.cc)
-  target_link_libraries(fuzzer_corpus cjxltool)
 
   add_executable(ssimulacra_main ssimulacra_main.cc ssimulacra.cc)
   add_executable(butteraugli_main butteraugli_main.cc)
@@ -164,15 +197,11 @@ if(${JPEGXL_ENABLE_BENCHMARK})
     benchmark/benchmark_codec_jxl.h
     benchmark/benchmark_codec_png.cc
     benchmark/benchmark_codec_png.h
-    codec_config.cc
-    codec_config.h
     speed_stats.cc
     speed_stats.h
     ../third_party/dirent.cc
   )
   target_link_libraries(benchmark_xl Threads::Threads)
-  target_compile_definitions(benchmark_xl
-    PRIVATE "-DJPEGXL_VERSION=\"${JPEGXL_VERSION}\"")
   if(MINGW)
   # MINGW doesn't support glob.h.
   target_compile_definitions(benchmark_xl PRIVATE "-DHAS_GLOB=0")

--- a/tools/codec_config.cc
+++ b/tools/codec_config.cc
@@ -8,6 +8,7 @@
 #include <hwy/targets.h>
 
 #include "lib/jxl/base/status.h"
+#include "tools/tool_version.h"
 
 namespace jpegxl {
 namespace tools {
@@ -23,7 +24,7 @@ std::string CodecConfigString(uint32_t lib_version) {
     config += version_str;
   }
 
-  std::string version = JPEGXL_VERSION;
+  std::string version = kJpegxlVersion;
   if (version != "(unknown)") {
     config += version + ' ';
   }

--- a/tools/git_version.cmake
+++ b/tools/git_version.cmake
@@ -1,0 +1,34 @@
+# Copyright (c) the JPEG XL Project Authors. All rights reserved.
+#
+# Use of this source code is governed by a BSD-style
+# license that can be found in the LICENSE file.
+
+# git_version.cmake is a script which creates tools_version_git.h in the build
+# directory if building from a git repository.
+find_package(Git QUIET)
+
+# Check that this script was invoked with the necessary arguments.
+if(NOT IS_DIRECTORY "${JPEGXL_ROOT_DIR}")
+  message(FATAL_ERROR "JPEGXL_ROOT_DIR is invalid")
+endif()
+
+execute_process(
+  COMMAND "${GIT_EXECUTABLE}" rev-parse --short HEAD
+  OUTPUT_VARIABLE GIT_REV
+  WORKING_DIRECTORY "${JPEGXL_ROOT_DIR}"
+  OUTPUT_STRIP_TRAILING_WHITESPACE
+  ERROR_QUIET)
+
+# The define line in the file.
+set(JPEGXL_VERSION_DEFINE "#define JPEGXL_VERSION \"${GIT_REV}\"\n")
+
+# Update the header file only if needed.
+if(EXISTS "${DST}")
+  file(READ "${DST}" ORIG_DST)
+  if(NOT ORIG_DST STREQUAL JPEGXL_VERSION_DEFINE)
+    message(STATUS "Changing JPEGXL_VERSION to ${GIT_REV}")
+    file(WRITE "${DST}" "${JPEGXL_VERSION_DEFINE}")
+  endif()
+else()
+  file(WRITE "${DST}" "${JPEGXL_VERSION_DEFINE}")
+endif()

--- a/tools/tool_version.cc
+++ b/tools/tool_version.cc
@@ -1,0 +1,18 @@
+// Copyright (c) the JPEG XL Project Authors. All rights reserved.
+//
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+#include "tools/tool_version.h"
+
+#ifdef JPEGXL_VERSION_FROM_GIT
+#include "tool_version_git.h"
+#endif
+
+namespace jpegxl {
+namespace tools {
+
+const char* kJpegxlVersion = JPEGXL_VERSION;
+
+}  // namespace tools
+}  // namespace jpegxl

--- a/tools/tool_version.h
+++ b/tools/tool_version.h
@@ -1,0 +1,22 @@
+// Copyright (c) the JPEG XL Project Authors. All rights reserved.
+//
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+#ifndef TOOLS_TOOL_VERSION_H_
+#define TOOLS_TOOL_VERSION_H_
+
+#include <string>
+
+namespace jpegxl {
+namespace tools {
+
+// Package version as defined by the JPEGXL_VERSION macro. This is not the
+// library semantic versioning number, but instead additional information on the
+// tool version.
+extern const char* kJpegxlVersion;
+
+}  // namespace tools
+}  // namespace jpegxl
+
+#endif  // TOOLS_TOOL_VERSION_H_


### PR DESCRIPTION
This sets the JPEGXL_VERSION macro used in the tools from the short git
hash at build time, updating it only when needed to avoid rebuilding
every time. Unfortunately, ninja checks for the header timestamp before
running the target that generates it so when only updating the hash, the
tool_version.cc.o file is not regenerated. This doesn't affect make, or
when running `ci.sh release` or similar commands.

GitHub/GitLab builders use the hash of the built reference, so this code
doesn't run in the workflow/pipelines anyway.

Tested with:
  - `./ci.sh release`
  - `./ci.sh release -DJPEGXL_VERSION="foo bar"`
  - `mkdir build; cd build; cmake ..`

Test rebuilt after amending a commit.