### PR TITLE
Silence some unsigned-integer-overflow warnings

### DIFF
--- a/lib/jxl/common.h
+++ b/lib/jxl/common.h
@@ -169,7 +169,10 @@ constexpr uint32_t PackSigned(int32_t value)
 }
 
 // Reverse to PackSigned, i.e. UnpackSigned(PackSigned(X)) == X.
-constexpr intptr_t UnpackSigned(size_t value) {
+// (((~value) & 1) - 1) is either 0 or 0xFF...FF and it will have an expected
+// unsigned-integer-overflow.
+constexpr intptr_t UnpackSigned(size_t value)
+    JXL_NO_SANITIZE("unsigned-integer-overflow") {
   return static_cast<intptr_t>((value >> 1) ^ (((~value) & 1) - 1));
 }
 

--- a/lib/jxl/dec_upsample.cc
+++ b/lib/jxl/dec_upsample.cc
@@ -56,7 +56,8 @@ void InitKernel(const float* weights, CacheAlignedUniquePtr* kernel_storage,
       size_t y = std::min(i, j);
       size_t x = std::max(i, j);
       // Take the weight from "triangle" coordinates.
-      float weight = weights[M * N2 * y - y * (y - 1) / 2 + x - y];
+      float weight =
+          weights[M * N2 * y - y * (static_cast<ssize_t>(y) - 1) / 2 + x - y];
       kernels[offset * stride + kernel] = weight;
     }
   }

--- a/lib/jxl/modular/encoding/context_predict.h
+++ b/lib/jxl/modular/encoding/context_predict.h
@@ -86,7 +86,7 @@ struct State {
 
   // Approximates 4+(maxweight<<24)/(x+1), avoiding division
   JXL_INLINE uint32_t ErrorWeight(uint64_t x, uint32_t maxweight) const {
-    int shift = FloorLog2Nonzero(x + 1) - 5;
+    int shift = static_cast<int>(FloorLog2Nonzero(x + 1)) - 5;
     if (shift < 0) shift = 0;
     return 4 + ((maxweight * divlookup[x >> shift]) >> shift);
   }

--- a/lib/jxl/modular/encoding/dec_ma.cc
+++ b/lib/jxl/modular/encoding/dec_ma.cc
@@ -44,8 +44,9 @@ Status DecodeTree(BitReader *br, ANSSymbolReader *reader,
       return JXL_FAILURE("Tree is too large");
     }
     to_decode--;
-    int property =
-        reader->ReadHybridUint(kPropertyContext, br, context_map) - 1;
+    int property = static_cast<int>(reader->ReadHybridUint(kPropertyContext, br,
+                                                           context_map)) -
+                   1;
     if (property < -1 || property >= 256) {
       return JXL_FAILURE("Invalid tree property value");
     }

--- a/lib/threads/thread_parallel_runner_internal.cc
+++ b/lib/threads/thread_parallel_runner_internal.cc
@@ -122,7 +122,9 @@ void ThreadParallelRunner::RunRange(ThreadParallelRunner* self,
     // guided
     const uint32_t num_reserved =
         self->num_reserved_.load(std::memory_order_relaxed);
-    const uint32_t num_remaining = num_tasks - num_reserved;
+    // It is possible that more tasks are reserved than ready to run.
+    const uint32_t num_remaining =
+        num_tasks - std::min(num_reserved, num_tasks);
     const uint32_t my_size =
         std::max(num_remaining / (num_worker_threads * 4), 1u);
 #endif


### PR DESCRIPTION
All of these are harmless, but evaluating and silencing them makes it
easier to spot ones that can be problematic.