### PR TITLE
New CMake flags to disable cjxl/djxl and JNI

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -75,12 +75,16 @@ set(JPEGXL_ENABLE_FUZZERS ${ENABLE_FUZZERS_DEFAULT} CACHE BOOL
     "Build JPEGXL fuzzer targets.")
 set(JPEGXL_ENABLE_DEVTOOLS false CACHE BOOL
     "Build JPEGXL developer tools.")
+set(JPEGXL_ENABLE_TOOLS true CACHE BOOL
+    "Build JPEGXL user tools: cjxl and djxl.")
 set(JPEGXL_ENABLE_MANPAGES true CACHE BOOL
     "Build and install man pages for the command-line tools.")
 set(JPEGXL_ENABLE_BENCHMARK true CACHE BOOL
     "Build JPEGXL benchmark tools.")
 set(JPEGXL_ENABLE_EXAMPLES true CACHE BOOL
     "Build JPEGXL library usage examples.")
+set(JPEGXL_ENABLE_JNI true CACHE BOOL
+    "Build JPEGXL JNI Java wrapper, if Java dependencies are installed.")
 set(JPEGXL_ENABLE_SJPEG true CACHE BOOL
     "Build JPEGXL with support for encoding with sjpeg.")
 set(JPEGXL_ENABLE_OPENEXR true CACHE BOOL

--- a/lib/jxl_extras.cmake
+++ b/lib/jxl_extras.cmake
@@ -28,7 +28,8 @@ set(JPEGXL_EXTRAS_SOURCES
 # We only define a static library for jxl_extras since it uses internal parts
 # of jxl library which are not accessible from outside the library in the
 # shared library case.
-add_library(jxl_extras-static STATIC "${JPEGXL_EXTRAS_SOURCES}")
+add_library(jxl_extras-static STATIC EXCLUDE_FROM_ALL
+  "${JPEGXL_EXTRAS_SOURCES}")
 target_compile_options(jxl_extras-static PRIVATE "${JPEGXL_INTERNAL_FLAGS}")
 set_property(TARGET jxl_extras-static PROPERTY POSITION_INDEPENDENT_CODE ON)
 target_include_directories(jxl_extras-static PUBLIC "${PROJECT_SOURCE_DIR}")

--- a/third_party/lcms2.cmake
+++ b/third_party/lcms2.cmake
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-add_library(lcms2 STATIC
+add_library(lcms2 STATIC EXCLUDE_FROM_ALL
   lcms/src/cmsalpha.c
   lcms/src/cmscam02.c
   lcms/src/cmscgats.c

--- a/third_party/lodepng.cmake
+++ b/third_party/lodepng.cmake
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-add_library(lodepng STATIC
+add_library(lodepng STATIC EXCLUDE_FROM_ALL
   lodepng/lodepng.cpp
   lodepng/lodepng.h
 )

--- a/third_party/skcms.cmake
+++ b/third_party/skcms.cmake
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-add_library(skcms STATIC skcms/skcms.cc)
+add_library(skcms STATIC EXCLUDE_FROM_ALL skcms/skcms.cc)
 target_include_directories(skcms PUBLIC "${CMAKE_CURRENT_LIST_DIR}/skcms/")
 
 include(CheckCXXCompilerFlag)

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -10,7 +10,7 @@ if(WIN32)
   if (NOT Qt5_FOUND)
     message(WARNING "Qt5 was not found.")
   else()
-    add_library(icc_detect STATIC
+    add_library(icc_detect STATIC EXCLUDE_FROM_ALL
       icc_detect/icc_detect_win32.cc
       icc_detect/icc_detect.h
     )
@@ -24,7 +24,7 @@ if(WIN32)
 elseif(APPLE)
   find_package(Qt5 QUIET COMPONENTS Widgets)
   if (Qt5_FOUND)
-    add_library(icc_detect STATIC
+    add_library(icc_detect STATIC EXCLUDE_FROM_ALL
       icc_detect/icc_detect_empty.cc
       icc_detect/icc_detect.h
     )
@@ -46,7 +46,7 @@ else()
     set(CMAKE_MODULE_PATH ${ECM_FIND_MODULE_DIR})
     find_package(XCB COMPONENTS XCB)
     if (XCB_FOUND)
-      add_library(icc_detect STATIC
+      add_library(icc_detect STATIC EXCLUDE_FROM_ALL
         icc_detect/icc_detect_x11.cc
         icc_detect/icc_detect.h
       )
@@ -56,13 +56,10 @@ else()
 endif()
 endif()  # JPEGXL_ENABLE_VIEWERS
 
-set(TOOL_BINARIES
-  cjxl
-  djxl
-  # Other tools are added conditionally below.
-)
+# Tools are added conditionally below.
+set(TOOL_BINARIES)
 
-add_library(jxl_tool STATIC
+add_library(jxl_tool STATIC EXCLUDE_FROM_ALL
   cmdline.cc
   codec_config.cc
   cpu/cpu.cc
@@ -123,36 +120,43 @@ else()
     COMPILE_DEFINITIONS JPEGXL_VERSION=\"${JPEGXL_VERSION}\")
 endif()
 
-# Main compressor.
-add_executable(cjxl
-  cjxl.cc
-  speed_stats.cc
-  cjxl_main.cc
-)
-target_link_libraries(cjxl
-    box
-    jxl-static
-    jxl_extras-static
-    jxl_threads-static
-)
+if(JPEGXL_ENABLE_TOOLS)
+  list(APPEND TOOL_BINARIES
+    cjxl
+    djxl
+  )
+
+  # Main compressor.
+  add_executable(cjxl
+    cjxl.cc
+    speed_stats.cc
+    cjxl_main.cc
+  )
+  target_link_libraries(cjxl
+      box
+      jxl-static
+      jxl_extras-static
+      jxl_threads-static
+  )
 
 
-# Main decompressor.
-add_library(djxltool STATIC
-  djxl.cc
-  speed_stats.cc
-)
-target_link_libraries(djxltool
-    box
-    jxl-static
-    jxl_extras-static
-    jxl_threads-static
-)
+  # Main decompressor.
+  add_library(djxltool STATIC
+    djxl.cc
+    speed_stats.cc
+  )
+  target_link_libraries(djxltool
+      box
+      jxl-static
+      jxl_extras-static
+      jxl_threads-static
+  )
 
-add_executable(djxl
-    djxl_main.cc
-)
+  add_executable(djxl
+      djxl_main.cc
+  )
 target_link_libraries(djxl djxltool)
+endif()  # JPEGXL_ENABLE_TOOLS
 
 # Other developer tools.
 if(${JPEGXL_ENABLE_DEVTOOLS})
@@ -257,6 +261,7 @@ foreach(BINARY IN LISTS TOOL_BINARIES)
   target_link_libraries("${BINARY}" box jxl-static jxl_extras-static jxl_threads-static jxl_tool)
 endforeach()
 install(TARGETS ${TOOL_BINARIES} RUNTIME DESTINATION "${CMAKE_INSTALL_BINDIR}")
+message(STATUS "Building tools: ${TOOL_BINARIES}")
 
 set(FUZZER_BINARIES
   color_encoding_fuzzer
@@ -356,6 +361,7 @@ set_target_properties(jxl_emcc PROPERTIES LINK_FLAGS "\
 ")
 endif ()  # JPEGXL_EMSCRIPTEN
 
+if(JPEGXL_ENABLE_JNI)
 find_package(JNI QUIET)
 find_package(Java QUIET)
 
@@ -396,3 +402,4 @@ if ("${JNI_FOUND}" AND "${Java_FOUND}")
     )
   endif()  # JPEGXL_ENABLE_FUZZERS
 endif()  # JNI_FOUND & Java_FOUND
+endif()  # JPEGXL_ENABLE_JNI

--- a/tools/box/CMakeLists.txt
+++ b/tools/box/CMakeLists.txt
@@ -3,7 +3,7 @@
 # Use of this source code is governed by a BSD-style
 # license that can be found in the LICENSE file.
 
-add_library(box STATIC
+add_library(box STATIC EXCLUDE_FROM_ALL
   box.cc
   box.h
 )


### PR DESCRIPTION
New `JPEGXL_ENABLE_TOOLS` flags (default enabled) lets the user disable
cjxl/djxl tools and the new `JPEGXL_ENABLE_JNI` lets the user disable
building the JNI wrappers.

A few intermediate libraries that should  be only compiled if the tools
that need them are also compiled are now marked as EXCLUDE_FROM_ALL.
This allows user to only compile the jxl libraries.

Fixes #421