### PR TITLE
Bump GIF requirement to version 5.1

### DIFF
--- a/lib/jxl_extras.cmake
+++ b/lib/jxl_extras.cmake
@@ -37,7 +37,7 @@ target_link_libraries(jxl_extras-static PUBLIC
   lodepng
 )
 
-find_package(GIF 5)
+find_package(GIF 5.1)
 if(GIF_FOUND)
   target_sources(jxl_extras-static PRIVATE
     extras/codec_gif.cc


### PR DESCRIPTION
We use `DGifCloseFile` which in version 5.1 got an extra parameter
`int *ErrorCode` not present in 5.0. This means that we need at least
version 5.1 to compile.

Fixes #420