### PR TITLE
Remove ConvertImageInternal HasRGBBuffer assert

### DIFF
--- a/lib/jxl/decode.cc
+++ b/lib/jxl/decode.cc
@@ -914,7 +914,6 @@ static JxlDecoderStatus ConvertImageInternal(
   jxl::Orientation undo_orientation = dec->keep_orientation
                                           ? jxl::Orientation::kIdentity
                                           : dec->metadata.m.GetOrientation();
-  JXL_DASSERT(!dec->frame_dec || !dec->frame_dec->HasRGBBuffer());
 
   jxl::Status status(true);
   if (want_extra_channel) {


### PR DESCRIPTION
ConvertImageInternal Used to have a much larger implementation and
be specific to the RGB output case, the assert then made sense.

Now ConvertImageInternal is a small wrapper around ConvertImageExternal
and is used for much more than just RGB: also preview image and extra channels.

The assert was checking that when calling this function, the slow code
path of the decoder (without internal RGB buffer) was being taken. However
now that this function is also used for preview image and extra channels,
such check does not belong here.

The cases where this function is used in the RGB context already have
a clear `HasRGBBuffer` if condition, so the assert does not need to
be moved there, it can just be removed.

This fixes a fuzzer-found DASSERT issue.