### PR TITLE
Attempt at improving patch heuristics.

### DIFF
--- a/lib/jxl/patch_dictionary_test.cc
+++ b/lib/jxl/patch_dictionary_test.cc
@@ -31,7 +31,7 @@ TEST(PatchDictionaryTest, GrayscaleModular) {
 
   CodecInOut io2;
   // Without patches: ~25k
-  EXPECT_LE(Roundtrip(&io, cparams, dparams, pool, &io2), 8000);
+  EXPECT_LE(Roundtrip(&io, cparams, dparams, pool, &io2), 9000);
   VerifyRelativeError(*io.Main().color(), *io2.Main().color(), 1e-7f, 0);
 }
 


### PR DESCRIPTION
Tested on Scope's tuning corpus and two images where patches are
actually beneficial.

```
Before, with patches:
Encoding      kPixels    Bytes          BPP  E MP/s  D MP/s     Max norm        pnorm       BPP*pnorm   Bugs
------------------------------------------------------------------------------------------------------------
jxl:m         1878734 281242090    1.1975809   0.795   7.574   0.00008272   0.00000160  0.000001916570      0
Aggregate:    1878734 281242090    1.1975809   0.795   7.574   0.00008272   0.00000160  0.000001916570      0

Encoding      kPixels    Bytes          BPP  E MP/s  D MP/s     Max norm        pnorm       BPP*pnorm   Bugs
------------------------------------------------------------------------------------------------------------
jxl              9761  1846121    1.5129461   5.194  41.117   2.00728846   0.65858851  0.996408896673      0
Aggregate:       9761  1846121    1.5129461   5.194  41.117   2.00728846   0.65858851  0.996408896673      0

Before, without patches:
Encoding      kPixels    Bytes          BPP  E MP/s  D MP/s     Max norm        pnorm       BPP*pnorm   Bugs
------------------------------------------------------------------------------------------------------------
jxl:m         1878734 280713937    1.1953319   1.022   7.540   0.00000000   0.00000000  0.000000000000      0
Aggregate:    1878734 280713937    1.1953319   1.022   7.540   0.00000000   0.00000000  0.000000000000      0

Encoding      kPixels    Bytes          BPP  E MP/s  D MP/s     Max norm        pnorm       BPP*pnorm   Bugs
------------------------------------------------------------------------------------------------------------
jxl              9761  1903057    1.5596067  22.800  40.232   1.99977922   0.67200947  1.048070443168      0
Aggregate:       9761  1903057    1.5596067  22.800  40.232   1.99977922   0.67200947  1.048070443168      0

After:
Encoding      kPixels    Bytes          BPP  E MP/s  D MP/s     Max norm        pnorm       BPP*pnorm   Bugs
------------------------------------------------------------------------------------------------------------
jxl:m         1878734 280971393    1.1964282   0.792   7.444   0.00008272   0.00000129  0.000001544135      0
Aggregate:    1878734 280971393    1.1964282   0.792   7.444   0.00008272   0.00000129  0.000001544135      0

Encoding      kPixels    Bytes          BPP  E MP/s  D MP/s     Max norm        pnorm       BPP*pnorm   Bugs
------------------------------------------------------------------------------------------------------------
jxl              9761  1845739    1.5126330   5.190  41.530   1.99977922   0.65995833  0.998274762067      0
Aggregate:       9761  1845739    1.5126330   5.190  41.530   1.99977922   0.65995833  0.998274762067      0
```