### PR TITLE
Include Debian package version in the tool

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -1,4 +1,7 @@
 #!/usr/bin/make -f
+
+include /usr/share/dpkg/pkg-info.mk
+
 %:
 	dh $@ --buildsystem=cmake
 
@@ -6,6 +9,7 @@ override_dh_auto_configure:
 	# TODO(deymo): Remove the DCMAKE_BUILD_TYPE once builds without NDEBUG
 	# are as useful as Release builds.
 	dh_auto_configure -- \
+	  -DJPEGXL_VERSION=$(DEB_VERSION) \
 	  -DCMAKE_BUILD_TYPE=RelWithDebInfo \
 	  -DJPEGXL_FORCE_SYSTEM_GTEST=ON \
 	  -DJPEGXL_FORCE_SYSTEM_BROTLI=ON \


### PR DESCRIPTION
When running the cjxl/djxl tools we include two versions, the library
semantic version numbers (MAJOR.MINOR.PATCH) as reported by the library
and an arbitrary string that comes from the package. The arbitrary
string is normally the git hash or other version or build information.
For the Debian packages this now includes the Debian package version
string.