### PR TITLE
Add columns with aggregate stats when using --extra_metrics.

### DIFF
--- a/tools/benchmark/benchmark_stats.h
+++ b/tools/benchmark/benchmark_stats.h
@@ -69,10 +69,11 @@ struct BenchmarkStats {
   std::vector<float> extra_metrics;
 };
 
-std::string PrintHeader();
+std::string PrintHeader(const std::vector<std::string>& extra_metrics_names);
 
 // Given the rows of all printed statistics, print an aggregate row.
 std::string PrintAggregate(
+    size_t num_extra_metrics,
     const std::vector<std::vector<ColumnValue>>& aggregate);
 
 }  // namespace jxl

--- a/tools/benchmark/benchmark_xl.cc
+++ b/tools/benchmark/benchmark_xl.cc
@@ -690,12 +690,14 @@ struct StatPrinter {
       printf("```\n");
     }
     if (fnames_->size() == 1) printf("%s\n", (*fnames_)[0].c_str());
-    printf("%s", PrintHeader().c_str());
+    printf("%s", PrintHeader(*extra_metrics_names_).c_str());
     fflush(stdout);
   }
 
   void PrintStatsFooter() {
-    printf("%s", PrintAggregate(stats_aggregate_).c_str());
+    printf(
+        "%s",
+        PrintAggregate(extra_metrics_names_->size(), stats_aggregate_).c_str());
     if (Args()->markdown) printf("```\n");
     printf("\n");
     fflush(stdout);

--- a/tools/benchmark/metrics/prepare_metrics.sh
+++ b/tools/benchmark/metrics/prepare_metrics.sh
@@ -14,11 +14,11 @@ main() {
   local zipurl
   local repourl
   for repourl in \
-    'https://github.com/veluca93/IQA-optimization.git'
-    'https://github.com/Netflix/vmaf.git'
+    'https://github.com/veluca93/IQA-optimization.git' \
+    'https://github.com/Netflix/vmaf.git' \
     'https://github.com/thorfdbg/difftest_ng.git'
   do
-    local reponame=$(basename "${repourl}")
+    local reponame=$(basename "${repourl%.git}")
     local dirname=$(basename "${reponame}")
     if [[ ! -e "${dirname}" ]]; then
       git clone "${repourl}"

--- a/tools/benchmark/metrics/vmaf.sh
+++ b/tools/benchmark/metrics/vmaf.sh
@@ -37,7 +37,7 @@ ffmpeg "${srgb[@]}" -i "$exr_decoded" -pix_fmt yuv444p10le "${srgb[@]}" -y "$yuv
   yuv444p10le \
   "$(identify -format '%w' "$original")" "$(identify -format '%h' "$original")" \
   "$yuv_original" "$yuv_decoded" \
-  ../../../third_party/vmaf/model/vmaf_v0.6.1.pkl \
+  "$(dirname "$0")/../../../third_party/vmaf/model/vmaf_v0.6.1.pkl" \
   --log-fmt csv --log "$vmaf_csv" &>/dev/null
 
 read_csv="$(cat <<'END'


### PR DESCRIPTION
Example output:

```
luca@desktop ~/libjxl/build extra_metrics_columns $ ninja tools/benchmark_xl && ./tools/benchmark_xl --codec jxl,jxl:d2,jxl:d4,jxl:d6,jxl:d8 --input "/data/jpeg_xl_data/jyrki31/*.png" --extra_metrics SSIMULACRA:../tools/benchmark/metrics/ssimulacra.sh 2>/dev/null

Encoding      kPixels    Bytes          BPP  E MP/s  D MP/s     Max norm        pnorm       BPP*pnorm   Bugs  SSIMULACRA
------------------------------------------------------------------------------------------------------------------------
jxl             13270  2682333    1.6170262   3.525  24.327   1.79344261   0.62184480  1.005539343779      0      0.0181
jxl:d2          13270  1693780    1.0210838   3.653  26.097   3.12266779   0.98560314  1.006383363499      0      0.0302
jxl:d4          13270  1020994    0.6154993   3.330  18.295   5.23591089   1.58709224  0.976854153535      0      0.0498
jxl:d6          13270   730354    0.4402889   3.265  18.103   7.62232971   2.12317523  0.934810584656      0      0.0668
jxl:d8          13270   583853    0.3519718   3.263  17.832   9.35825157   2.58076015  0.908354830875      0      0.0809
Aggregate:      13270  1146162    0.6909559   3.404  20.644   4.61421251   1.39747468  0.965593378881      0      0.0430
```