### PR TITLE
CMake setting to bundle libskcms.a into libjxl.a

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -91,6 +91,8 @@ set(JPEGXL_ENABLE_OPENEXR true CACHE BOOL
     "Build JPEGXL with support for OpenEXR if available.")
 set(JPEGXL_ENABLE_SKCMS true CACHE BOOL
     "Build with skcms instead of lcms2.")
+set(JPEGXL_BUNDLE_SKCMS true CACHE BOOL
+    "When building with skcms, bundle it into libjxl.a.")
 set(JPEGXL_ENABLE_VIEWERS false CACHE BOOL
     "Build JPEGXL viewer tools for evaluation.")
 set(JPEGXL_ENABLE_TCMALLOC ${ENABLE_TCMALLOC_DEFAULT} CACHE BOOL

--- a/lib/jxl/enc_color_management.cc
+++ b/lib/jxl/enc_color_management.cc
@@ -36,7 +36,7 @@
 #include "lib/jxl/linalg.h"
 #include "lib/jxl/transfer_functions-inl.h"
 #if JPEGXL_ENABLE_SKCMS
-#include "skcms.h"
+#include "lib/jxl/enc_jxl_skcms.h"
 #else  // JPEGXL_ENABLE_SKCMS
 #include "lcms2.h"
 #include "lcms2_plugin.h"

--- a/lib/jxl/enc_jxl_skcms.h
+++ b/lib/jxl/enc_jxl_skcms.h
@@ -1,0 +1,54 @@
+// Copyright (c) the JPEG XL Project Authors. All rights reserved.
+//
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+#ifndef LIB_JXL_ENC_JXL_SKCMS_H_
+#define LIB_JXL_ENC_JXL_SKCMS_H_
+
+// skcms wrapper to rename the skcms symbols to avoid conflicting names with
+// other projects using skcms as well. When using JPEGXL_BUNDLE_SKCMS the
+// bundled functions will be renamed from skcms_ to jxl_skcms_
+
+#ifdef SKCMS_API
+#error "Must include jxl_skcms.h and not skcms.h directly"
+#endif  // SKCMS_API
+
+#if JPEGXL_BUNDLE_SKCMS
+
+#define skcms_252_random_bytes jxl_skcms_252_random_bytes
+#define skcms_AdaptToXYZD50 jxl_skcms_AdaptToXYZD50
+#define skcms_ApproximateCurve jxl_skcms_ApproximateCurve
+#define skcms_ApproximatelyEqualProfiles jxl_skcms_ApproximatelyEqualProfiles
+#define skcms_AreApproximateInverses jxl_skcms_AreApproximateInverses
+#define skcms_GetCHAD jxl_skcms_GetCHAD
+#define skcms_GetTagByIndex jxl_skcms_GetTagByIndex
+#define skcms_GetTagBySignature jxl_skcms_GetTagBySignature
+#define skcms_GetWTPT jxl_skcms_GetWTPT
+#define skcms_Identity_TransferFunction jxl_skcms_Identity_TransferFunction
+#define skcms_MakeUsableAsDestination jxl_skcms_MakeUsableAsDestination
+#define skcms_MakeUsableAsDestinationWithSingleCurve \
+  jxl_skcms_MakeUsableAsDestinationWithSingleCurve
+#define skcms_Matrix3x3_concat jxl_skcms_Matrix3x3_concat
+#define skcms_Matrix3x3_invert jxl_skcms_Matrix3x3_invert
+#define skcms_MaxRoundtripError jxl_skcms_MaxRoundtripError
+#define skcms_Parse jxl_skcms_Parse
+#define skcms_PrimariesToXYZD50 jxl_skcms_PrimariesToXYZD50
+#define skcms_sRGB_Inverse_TransferFunction \
+  jxl_skcms_sRGB_Inverse_TransferFunction
+#define skcms_sRGB_profile jxl_skcms_sRGB_profile
+#define skcms_sRGB_TransferFunction jxl_skcms_sRGB_TransferFunction
+#define skcms_TransferFunction_eval jxl_skcms_TransferFunction_eval
+#define skcms_TransferFunction_invert jxl_skcms_TransferFunction_invert
+#define skcms_TransferFunction_makeHLGish jxl_skcms_TransferFunction_makeHLGish
+#define skcms_TransferFunction_makePQish jxl_skcms_TransferFunction_makePQish
+#define skcms_Transform jxl_skcms_Transform
+#define skcms_TransformWithPalette jxl_skcms_TransformWithPalette
+#define skcms_TRCs_AreApproximateInverse jxl_skcms_TRCs_AreApproximateInverse
+#define skcms_XYZD50_profile jxl_skcms_XYZD50_profile
+
+#endif  // JPEGXL_BUNDLE_SKCMS
+
+#include "skcms.h"
+
+#endif  // LIB_JXL_ENC_JXL_SKCMS_H_

--- a/lib/lib.gni
+++ b/lib/lib.gni
@@ -263,6 +263,7 @@ libjxl_enc_sources = [
     "jxl/enc_icc_codec.h",
     "jxl/enc_image_bundle.cc",
     "jxl/enc_image_bundle.h",
+    "jxl/enc_jxl_skcms.h",
     "jxl/enc_modular.cc",
     "jxl/enc_modular.h",
     "jxl/enc_noise.cc",

--- a/third_party/skcms.cmake
+++ b/third_party/skcms.cmake
@@ -21,4 +21,11 @@ if(CXX_WPSABI_SUPPORTED)
   target_compile_options(skcms PRIVATE -Wno-psabi)
 endif()
 
+if(JPEGXL_BUNDLE_SKCMS)
+  target_compile_options(skcms
+    PRIVATE
+      -DJPEGXL_BUNDLE_SKCMS=1
+      -include${CMAKE_SOURCE_DIR}/lib/jxl/enc_jxl_skcms.h)
+endif()
+
 set_property(TARGET skcms PROPERTY POSITION_INDEPENDENT_CODE ON)


### PR DESCRIPTION
skcms is only a single .cc file with a C API, but not widely available
as a standalone package or library. We currently require to use a CMS in
the encoder side of the library to convert from arbitrary color spaces
when encoding, among probably other things. The user can select from
either skcms (the default) or lcms2 for the CMS library. In the skcms
case libjxl.so was bundling the libskcms.a symbols (since skcms is built
as a static library) but libjxl.a wasn't, resulting in an unusable
static library being packaged and installed.

This patch adds a default-on setting to bundle skcms.cc into libjxl.a
when using skcms, however, we rename all the function from `skcms_` to
`jxl_skcms_` to avoid issues with potential projects that would
include skcms from elsewhere. Until there's a packaged version of skcms
or we provide an external way to provide a CMS on the encoder side this
at least makes libjxl.a link a sample program.

Fixes #428