### PR TITLE
Build example projects against the installed library.

### DIFF
--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -127,6 +127,24 @@ jobs:
         tools/build_stats.py --save build/stats.json \
           --max-stack ${{ matrix.max_stack || '0' }} \
           cjxl djxl libjxl.so libjxl_dec.so
+    # Check that we can build the example project against the installed libs.
+    - name: Install and build examples
+      if: matrix.mode == 'release' || matrix.name == 'release'
+      run: |
+        set -x
+        sudo cmake --build build -- install
+        cmake -Bbuild-example -Hexamples -G Ninja
+        cmake --build build-example
+        if ldd build-example/decode_oneshot_static | grep libjxl; then
+          echo "decode_oneshot_static is not using the static lib" >&2
+          exit 1
+        fi
+        # Test that the built binaries run.
+        echo -e -n "PF\n1 1\n-1.0\nrrrrggggbbbb" > test.pfm
+        build-example/encode_oneshot test.pfm test.jxl
+        build-example/encode_oneshot_static test.pfm test-static.jxl
+        build-example/decode_oneshot test.jxl dec.pfm dec.icc
+        build-example/decode_oneshot_static test.jxl dec-static.pfm dec-static.icc
     # Run the tests on push and when requested in pull_request.
     - name: Test ${{ matrix.mode }}
       if: |

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -352,7 +352,7 @@ endif()
 
 # Example usage code.
 if (${JPEGXL_ENABLE_EXAMPLES})
-add_subdirectory(examples)
+include(examples/examples.cmake)
 endif ()
 
 # Plugins for third-party software

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -3,17 +3,54 @@
 # Use of this source code is governed by a BSD-style
 # license that can be found in the LICENSE file.
 
+# Example project using libjxl.
+
+cmake_minimum_required(VERSION 3.10)
+
+project(SAMPLE_LIBJXL LANGUAGES C CXX)
+
+# Use pkg-config to find libjxl.
+find_package(PkgConfig)
+pkg_check_modules(Jxl REQUIRED IMPORTED_TARGET libjxl)
+pkg_check_modules(JxlThreads REQUIRED IMPORTED_TARGET libjxl_threads)
+
+# Build the example encoder/decoder binaries using the default shared libraries
+# installed.
 add_executable(decode_oneshot decode_oneshot.cc)
-target_link_libraries(decode_oneshot jxl_dec jxl_threads)
+target_link_libraries(decode_oneshot PkgConfig::Jxl PkgConfig::JxlThreads)
+
 add_executable(encode_oneshot encode_oneshot.cc)
-target_link_libraries(encode_oneshot jxl jxl_threads)
+target_link_libraries(encode_oneshot PkgConfig::Jxl PkgConfig::JxlThreads)
 
 add_executable(jxlinfo jxlinfo.c)
-target_link_libraries(jxlinfo jxl)
+target_link_libraries(jxlinfo PkgConfig::Jxl)
 
-if(NOT ${SANITIZER} STREQUAL "none")
-  # Linking a C test binary with the C++ JPEG XL implementation when using
-  # address sanitizer is not well supported by clang 9, so force using clang++
-  # for linking this test if a sanitizer is used.
-  set_target_properties(jxlinfo PROPERTIES LINKER_LANGUAGE CXX)
-endif()  # SANITIZER != "none"
+
+# Building a static binary with the static libjxl dependencies. How to load
+# static library configs from pkg-config and how to build static binaries
+# depends on the platform, and building static binaries in general has problems.
+# If you don't need static binaries you can remove this section.
+add_library(StaticJxl INTERFACE IMPORTED GLOBAL)
+set_target_properties(StaticJxl PROPERTIES
+    INTERFACE_INCLUDE_DIRECTORIES "${Jxl_STATIC_INCLUDE_DIR}"
+    INTERFACE_COMPILE_OPTIONS "${Jxl_STATIC_CFLAGS_OTHER}"
+    INTERFACE_LINK_LIBRARIES "${Jxl_STATIC_LDFLAGS}"
+)
+add_library(StaticJxlThreads INTERFACE IMPORTED GLOBAL)
+set_target_properties(StaticJxlThreads PROPERTIES
+    INTERFACE_INCLUDE_DIRECTORIES "${JxlThreads_STATIC_INCLUDE_DIR}"
+    INTERFACE_COMPILE_OPTIONS "${JxlThreads_STATIC_CFLAGS_OTHER}"
+    # libgcc uses weak symbols for pthread which means that -lpthread is not
+    # linked when compiling a static binary. This is a platform-specific fix for
+    # that.
+    INTERFACE_LINK_LIBRARIES
+      "${JxlThreads_STATIC_LDFLAGS} -Wl,--whole-archive -lpthread -Wl,--no-whole-archive"
+)
+
+add_executable(decode_oneshot_static decode_oneshot.cc)
+target_link_libraries(decode_oneshot_static
+  -static StaticJxl StaticJxlThreads)
+
+add_executable(encode_oneshot_static encode_oneshot.cc)
+target_link_libraries(encode_oneshot_static
+  -static StaticJxl StaticJxlThreads)

--- a/examples/examples.cmake
+++ b/examples/examples.cmake
@@ -1,0 +1,19 @@
+# Copyright (c) the JPEG XL Project Authors. All rights reserved.
+#
+# Use of this source code is governed by a BSD-style
+# license that can be found in the LICENSE file.
+
+add_executable(decode_oneshot ${CMAKE_CURRENT_LIST_DIR}/decode_oneshot.cc)
+target_link_libraries(decode_oneshot jxl_dec jxl_threads)
+add_executable(encode_oneshot ${CMAKE_CURRENT_LIST_DIR}/encode_oneshot.cc)
+target_link_libraries(encode_oneshot jxl jxl_threads)
+
+add_executable(jxlinfo ${CMAKE_CURRENT_LIST_DIR}/jxlinfo.c)
+target_link_libraries(jxlinfo jxl)
+
+if(NOT ${SANITIZER} STREQUAL "none")
+  # Linking a C test binary with the C++ JPEG XL implementation when using
+  # address sanitizer is not well supported by clang 9, so force using clang++
+  # for linking this test if a sanitizer is used.
+  set_target_properties(jxlinfo PROPERTIES LINKER_LANGUAGE CXX)
+endif()  # SANITIZER != "none"


### PR DESCRIPTION
Creates a new examples/CMakeLists.txt example project importing libjxl
with pkg-config and building against both the shared and static
libraries.

Added a new test step to the "./ci.sh release" builder checking that the
installed library can be used by the example tools both in static builds
and regular builds using the shared libraries.