### PR TITLE
Make skcms-obj an OBJECT library

### DIFF
--- a/lib/jxl.cmake
+++ b/lib/jxl.cmake
@@ -448,7 +448,7 @@ set(JPEGXL_INTERNAL_OBJECTS
   $<TARGET_OBJECTS:jxl_dec-obj>
 )
 if (JPEGXL_ENABLE_SKCMS AND JPEGXL_BUNDLE_SKCMS)
-  list(APPEND JPEGXL_INTERNAL_OBJECTS $<TARGET_OBJECTS:skcms>)
+  list(APPEND JPEGXL_INTERNAL_OBJECTS $<TARGET_OBJECTS:skcms-obj>)
 endif()
 
 # Private static library. This exposes all the internal functions and is used


### PR DESCRIPTION
When bundling skcms into libjxl.a we want to include the object files
with `$<TARGET_OBJECTS:lib>` which is only supported for OBJECT
libraries in older versions of cmake. This patch makes a new skcms-obj
library similar to what we do with jxl_dec-obj and jxl_enc-obj.
This fixes the build for debian:buster.

In MSVC, the flag to include a header is /FI, this patch splits that
case which fixes the MSVC windows build.