### PR TITLE
Implement sharper 2x2 downsampling kernel

### DIFF
--- a/lib/jxl/jxl_test.cc
+++ b/lib/jxl/jxl_test.cc
@@ -240,7 +240,7 @@ TEST(JxlTest, RoundtripResample2MT) {
   EXPECT_LE(ButteraugliDistance(io, io2, cparams.ba_params,
                                 /*distmap=*/nullptr, &pool),
 #if JXL_HIGH_PRECISION
-            4.5);
+            5.5);
 #else
             12.5);
 #endif


### PR DESCRIPTION
Uses a 12x12 downsampling kernel instead of the 2x2 box kernel for the
case of downsampling factor of 2.

Resulting rescaled images look sharper, and ringing is reduced by clamping pixels to be withing the colors of a small region around them. This clamping reduces ringing but also makes the result less sharp looking that it could be in other regions. This can be fixed in future pull requests

This helps improve the quality of using the --resampling=2 option when
targetting low bitrates, such as 0.1bpp.

Benchmark before:

```
Encoding                kPixels    Bytes          BPP  E MP/s  D MP/s     Max norm        pnorm   PSNR   QABPP  SmallB  DCT4x8     AFV  DCT8x8    8x16    8x32      16   16x32      32   32x64      64       BPP*pnorm   Bugs
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
jxl:resampling=2:d12      13270   148001    0.0892214  18.600  43.680  34.67691422   8.58743488  26.11   2.365  0.0053  0.7697  0.1548  0.3226  2.3419  0.0000  2.5136 13.5230  5.7487  0.0309  0.0000  0.766182937786      0
jxl:resampling=2:d11      13270   157479    0.0949351  18.933  43.964  30.46087074   8.07704341  26.28   2.396  0.0101  0.9105  0.1645  0.3863  2.4837  0.0000  2.7007 13.1989  5.5404  0.0154  0.0000  0.766795287059      0
jxl:resampling=2:d10      13270   170260    0.1026401  18.943  45.749  32.32899094   7.55780424  26.48   2.401  0.0178  1.0851  0.1987  0.4881  2.6033  0.0000  2.8338 13.0677  5.1160  0.0000  0.0000  0.775733661590      0
jxl:resampling=2:d9       13270   186204    0.1122518  17.850  44.409  28.52398491   6.96983712  26.69   2.383  0.0251  1.2867  0.2305  0.5551  2.7875  0.0000  3.0711 12.6549  4.7996  0.0000  0.0000  0.782376874388      0
jxl:resampling=2:d8       13270   205013    0.1235907  18.430  44.635  24.14496613   6.39222974  26.94   2.372  0.0347  1.5259  0.2653  0.6448  3.0142  0.0000  3.3856 12.1417  4.3983  0.0000  0.0000  0.790020109416      0
jxl:resampling=2:d7       13270   227832    0.1373470  18.208  44.357  25.27951431   5.87160911  27.22   2.447  0.0453  1.8389  0.2898  0.7895  3.1579  0.0000  3.5476 11.5669  4.1746  0.0000  0.0000  0.806447737456      0
jxl:resampling=2:d6       13270   254307    0.1533072  18.633  45.478  20.50077438   5.36567214  27.51   2.405  0.0579  2.0661  0.3357  0.8609  3.3142  0.0000  3.7675 11.0422  3.9662  0.0000  0.0000  0.822596422531      0
jxl:resampling=2:d5       13270   288260    0.1737756  17.345  42.794  18.58884430   4.82811386  27.83   2.438  0.0728  2.4919  0.3723  0.9737  3.5573  0.0000  4.0453 10.2782  3.6190  0.0000  0.0000  0.839008297229      0
jxl:resampling=2:d4       13270   341367    0.2057908  17.809  45.208  18.83680916   4.27894325  28.24   2.539  0.0931  3.0523  0.4447  1.1107  3.7704  0.0000  4.4157  9.2442  3.2795  0.0000  0.0000  0.880567053342      0
jxl:resampling=2:d3       13270   421170    0.2538995  16.775  48.487  17.38426781   3.75071762  28.67   2.732  0.1264  3.9600  0.4967  1.3118  4.1157  0.0000  5.0639  7.3730  2.9631  0.0000  0.0000  0.952305225588      0
jxl:resampling=2:d2       13270   565796    0.3410863  18.498  49.682  17.05453491   3.31079180  29.18   3.404  0.1548  5.1049  0.5295  1.4656  4.4167  0.0000  6.9177  4.2749  2.5464  0.0000  0.0000  1.129265638302      0
jxl:resampling=2:d1       13270   872859    0.5261971  17.373  47.804  17.43588257   3.00640841  29.70   5.021  0.1355  7.1135  0.4799  1.8630  4.9423  0.0000  8.2488  0.7601  1.8674  0.0000  0.0000  1.581963436114      0
Aggregate:                13270   274074    0.1652235  18.105  45.478  23.01287545   5.36411405  27.55   2.669  0.0429  2.0704  0.3042  0.7880  3.2894  0.0000  3.9354  8.2823  3.8156  0.0218  0.0000  0.886277919464      0
```

Benchmark after:

```
Encoding                kPixels    Bytes          BPP  E MP/s  D MP/s     Max norm        pnorm   PSNR   QABPP  SmallB  DCT4x8     AFV  DCT8x8    8x16    8x32      16   16x32      32   32x64      64       BPP*pnorm   Bugs
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
jxl:resampling=2:d12      13270   145457    0.0876878   6.856  45.291  36.62533951   9.23914463  25.96   2.599  0.0121  0.7953  0.1225  0.3207  2.2686  0.0000  2.2570 12.9520  6.6824  0.0000  0.0000  0.810159933723      0
jxl:resampling=2:d11      13270   154752    0.0932912   6.879  45.254  33.83205414   8.71733613  26.13   2.602  0.0140  0.9149  0.1302  0.3564  2.3853  0.0000  2.3882 12.8015  6.4200  0.0000  0.0000  0.813250674754      0
jxl:resampling=2:d10      13270   165119    0.0995409   6.874  45.425  33.95508194   8.21182460  26.30   2.649  0.0222  1.0924  0.1563  0.4476  2.4895  0.0000  2.5676 12.7475  5.8876  0.0000  0.0000  0.817412141181      0
jxl:resampling=2:d9       13270   180660    0.1089097   6.719  45.264  32.19402313   7.62825199  26.50   2.658  0.0318  1.2549  0.1755  0.5329  2.6776  0.0000  2.6930 12.4581  5.5867  0.0000  0.0000  0.830790280128      0
jxl:resampling=2:d8       13270   199259    0.1201219   6.774  43.587  27.57675362   6.97236700  26.76   2.623  0.0429  1.4782  0.2045  0.6303  2.9303  0.0000  3.0287 12.0491  5.0465  0.0000  0.0000  0.837534209073      0
jxl:resampling=2:d7       13270   223392    0.1346703   6.611  44.698  25.95250130   6.37529624  27.05   2.729  0.0535  1.7333  0.2522  0.7364  3.0798  0.0000  3.1309 11.6479  4.7764  0.0000  0.0000  0.858563369853      0
jxl:resampling=2:d6       13270   253518    0.1528316   6.791  46.469  23.16202164   5.73224977  27.41   2.718  0.0694  2.0241  0.2952  0.8141  3.1521  0.0000  3.2409 11.3161  4.4987  0.0000  0.0000  0.876068924218      0
jxl:resampling=2:d5       13270   293597    0.1769930   6.687  45.494  18.80857468   5.03405886  27.82   2.643  0.0979  2.3800  0.3492  0.9052  3.3344  0.0000  3.4357 10.6178  4.2903  0.0000  0.0000  0.890992960247      0
jxl:resampling=2:d4       13270   352864    0.2127217   6.691  46.555  18.35779572   4.39781770  28.28   2.768  0.1297  2.9891  0.4157  1.0494  3.5438  0.0000  3.7019  9.8230  3.7579  0.0000  0.0000  0.935511100707      0
jxl:resampling=2:d3       13270   446063    0.2689060   6.641  50.665  17.90767860   3.81060740  28.80   3.247  0.1727  3.9368  0.4553  1.2414  3.8418  0.0000  4.1996  8.1832  3.3798  0.0000  0.0000  1.024695377176      0
jxl:resampling=2:d2       13270   609657    0.3675276   6.805  50.307  16.82785416   3.33735245  29.39   4.032  0.1944  5.2438  0.5098  1.4700  4.0955  0.0000  5.7834  5.1507  2.9631  0.0000  0.0000  1.226569067334      0
jxl:resampling=2:d1       13270   953497    0.5748092   6.724  49.545  16.64366531   3.02732431  29.94   5.930  0.1760  7.1516  0.4075  1.8548  4.5450  0.0000  8.0733  0.8565  2.3458  0.0000  0.0000  1.740133823383      0
Aggregate:                13270   276943    0.1669532   6.754  46.494  24.12580754   5.66641083  27.50   2.998  0.0579  2.0476  0.2591  0.7528  3.1249  0.0000  3.4514  8.5723  4.4353  0.0000  0.0000  0.946025392345      0
```