### PR TITLE
Fix docs

### DIFF
--- a/doc/building_and_testing.md
+++ b/doc/building_and_testing.md
@@ -2,7 +2,7 @@
 
 This file describes the building and testing facilities provided by the `ci.sh`
 script. It assumes you already have the build environment set up, preferably
-Docker (see [instructions](building_in_docker.md)).
+Docker (see [instructions](developing_in_docker.md)).
 
 ## Basic building
 

--- a/doc/building_wasm.md
+++ b/doc/building_wasm.md
@@ -17,7 +17,7 @@ variables are set:
 ## Requirements
 
 [CMake](https://cmake.org/) is used as a build system. To install it, follow
-[Debian build instructions](building_in_debian.md).
+[Debian build instructions](developing_in_debian.md).
 
 [Emscripten SDK](https://emscripten.org/) is required for building
 WebAssembly artifacts. To install it, follow the

--- a/doc/developing_in_github.md
+++ b/doc/developing_in_github.md
@@ -69,7 +69,7 @@ propose to include changes in the main repository via a Pull Request.
 
 Once you are done you should have your repository at
 
- https://github.com/{{USERNAME}}/libjxl
+ https://<!-- not a link -->github.com<!-- not a link -->/*{{USERNAME}}*/libjxl
 
 where {{USERNAME}} denotes your GitHub username.
 

--- a/doc/developing_in_windows.md
+++ b/doc/developing_in_windows.md
@@ -83,5 +83,5 @@ vcpkg above.
 
 The project is now ready for use. To build, simply press F7 (or choose
 Build All from the Build menu). This writes binaries to
-`out/build/x64-Clang-Release/tools`. The main [README.md](README.md) explains
+`out/build/x64-Clang-Release/tools`. The main [README.md](../README.md) explains
 how to use the encoder/decoder and benchmark binaries.


### PR DESCRIPTION
- Some links were pointing to old filenames.
- A pseudo-link (that shouldn't be clicked) is now unclickable.