### PR TITLE
Remove lcms/skcms from libjxl_dec deps.

### DIFF
--- a/lib/jxl.cmake
+++ b/lib/jxl.cmake
@@ -392,14 +392,8 @@ if (JPEGXL_ENABLE_SKCMS)
   target_include_directories(jxl_enc-obj PRIVATE
     $<TARGET_PROPERTY:skcms,INCLUDE_DIRECTORIES>
   )
-  target_include_directories(jxl_dec-obj PRIVATE
-    $<TARGET_PROPERTY:skcms,INCLUDE_DIRECTORIES>
-  )
 else ()
   target_include_directories(jxl_enc-obj PRIVATE
-    $<TARGET_PROPERTY:lcms2,INCLUDE_DIRECTORIES>
-  )
-  target_include_directories(jxl_dec-obj PRIVATE
     $<TARGET_PROPERTY:lcms2,INCLUDE_DIRECTORIES>
   )
 endif ()


### PR DESCRIPTION
We only use lcms/skcms on the encoder side for now.