### PR TITLE
Fix non-high precision test after PR 445

### DIFF
--- a/lib/jxl/jxl_test.cc
+++ b/lib/jxl/jxl_test.cc
@@ -242,7 +242,7 @@ TEST(JxlTest, RoundtripResample2MT) {
 #if JXL_HIGH_PRECISION
             5.5);
 #else
-            12.5);
+            13);
 #endif
 }
 


### PR DESCRIPTION
https://github.com/libjxl/libjxl/pull/445 increases butteraugli for downsampling case (visually the images look sharper as intended)

That PR increased the allowed score for the high precision case but not the other case, causing the test to fail for non high precision

Fixing here.