### PR TITLE
Update GIMP plugin to use public API and add save dialog

### DIFF
--- a/plugins/gimp/CMakeLists.txt
+++ b/plugins/gimp/CMakeLists.txt
@@ -11,18 +11,14 @@ if (NOT Gimp_FOUND)
   return ()
 endif ()
 
-option(JPEGXL_ENABLE_GIMP_SAVING "Enable saving to JPEG XL from GIMP" OFF)
-
 add_executable(file-jxl WIN32
   common.h
+  common.cc
   file-jxl-load.cc
   file-jxl-load.h
   file-jxl-save.cc
   file-jxl-save.h
   file-jxl.cc)
-if (JPEGXL_ENABLE_GIMP_SAVING)
-  target_compile_definitions(file-jxl PRIVATE -DJPEGXL_ENABLE_GIMP_SAVING=1)
-endif ()
 target_link_libraries(file-jxl jxl-static jxl_threads-static PkgConfig::Gimp)
 
 pkg_get_variable(GIMP_LIB_DIR gimp-2.0 gimplibdir)

--- a/plugins/gimp/common.cc
+++ b/plugins/gimp/common.cc
@@ -1,0 +1,27 @@
+// Copyright (c) the JPEG XL Project Authors. All rights reserved.
+//
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+#include "plugins/gimp/common.h"
+
+namespace jxl {
+
+JpegXlGimpProgress::JpegXlGimpProgress(const char *message) {
+  cur_progress = 0;
+  max_progress = 100;
+
+  gimp_progress_init_printf("%s\n", message);
+}
+
+void JpegXlGimpProgress::update() {
+  gimp_progress_update((float)++cur_progress / (float)max_progress);
+  return;
+}
+
+void JpegXlGimpProgress::finished() {
+  gimp_progress_update(1.0);
+  return;
+}
+
+}  // namespace jxl

--- a/plugins/gimp/common.h
+++ b/plugins/gimp/common.h
@@ -7,49 +7,38 @@
 #define PLUGINS_GIMP_COMMON_H_
 
 #include <libgimp/gimp.h>
+#include <libgimp/gimpui.h>
+#include <math.h>
+
+#include <fstream>
+#include <iterator>
+#include <string>
+#include <vector>
+
+#define PLUG_IN_BINARY "file-jxl"
+#define SAVE_PROC "file-jxl-save"
+
+// Defined by both FUIF and glib.
+#undef MAX
+#undef MIN
+#undef CLAMP
+
+#include "jxl/resizable_parallel_runner.h"
+#include "jxl/resizable_parallel_runner_cxx.h"
 
 namespace jxl {
 
-// FromFloat expects a value between 0 and 1, and ToFloat returns such values
-// from GIMP values.
-template <GimpPrecision>
-struct BufferFormat;
-template <>
-struct BufferFormat<GIMP_PRECISION_U8_GAMMA> {
-  using Sample = uint8_t;
-  static Sample FromFloat(const float x) {
-    return static_cast<Sample>(std::round(x * 255.f));
-  }
-  static float ToFloat(const Sample s) { return s; }
-};
-template <>
-struct BufferFormat<GIMP_PRECISION_U16_GAMMA> {
-  using Sample = uint16_t;
-  static Sample FromFloat(const float x) {
-    return static_cast<Sample>(std::round(x * 65535.f));
-  }
-  static float ToFloat(const Sample s) { return s * (1.f / 65535.f); }
-};
-template <>
-struct BufferFormat<GIMP_PRECISION_U32_GAMMA> {
-  using Sample = uint32_t;
-  static Sample FromFloat(const float x) {
-    return static_cast<Sample>(std::round(x * 4294967295.f));
-  }
-  static float ToFloat(const Sample s) { return s * (1.f / 4294967295.f); }
-};
-template <>
-struct BufferFormat<GIMP_PRECISION_HALF_GAMMA> {
-  using Sample = float;
-  static Sample FromFloat(const float x) { return x; }
-  static float ToFloat(const Sample s) { return s; }
-};
-template <>
-struct BufferFormat<GIMP_PRECISION_FLOAT_GAMMA> {
-  using Sample = float;
-  static Sample FromFloat(const float x) { return x; }
-  static float ToFloat(const Sample s) { return s; }
-};
+class JpegXlGimpProgress {
+ public:
+  explicit JpegXlGimpProgress(const char *message);
+  void update();
+  void finished();
+
+ private:
+  int cur_progress;
+  int max_progress;
+
+};  // class JpegXlGimpProgress
 
 }  // namespace jxl
 

--- a/plugins/gimp/file-jxl-load.cc
+++ b/plugins/gimp/file-jxl-load.cc
@@ -5,168 +5,335 @@
 
 #include "plugins/gimp/file-jxl-load.h"
 
-// Defined by both FUIF and glib.
-#undef MAX
-#undef MIN
-#undef CLAMP
-
-#include "lib/jxl/alpha.h"
-#include "lib/jxl/base/file_io.h"
-#include "lib/jxl/base/thread_pool_internal.h"
-#include "lib/jxl/dec_file.h"
-#include "plugins/gimp/common.h"
+#define _PROFILE_TARGET_ JXL_COLOR_PROFILE_TARGET_DATA
 
 namespace jxl {
 
-namespace {
+bool LoadJpegXlImage(const gchar *const filename, gint32 *const image_id) {
+  std::vector<uint8_t> icc_profile;
+  GimpColorProfile *profile = nullptr;
+  bool is_linear = false;
 
-template <GimpPrecision precision, bool has_alpha, size_t num_channels>
-void FillBuffer(
-    const CodecInOut& io,
-    std::vector<typename BufferFormat<precision>::Sample>* const pixel_data) {
-  pixel_data->reserve(io.xsize() * io.ysize() * (num_channels + has_alpha));
-  for (size_t y = 0; y < io.ysize(); ++y) {
-    const float* rows[num_channels];
-    for (size_t c = 0; c < num_channels; ++c) {
-      rows[c] = io.Main().color().ConstPlaneRow(c, y);
-    }
-    const float* const alpha_row =
-        has_alpha ? io.Main().alpha().ConstRow(y) : nullptr;
-    for (size_t x = 0; x < io.xsize(); ++x) {
-      const float alpha = has_alpha ? alpha_row[x] : 1.f;
-      const float alpha_multiplier =
-          has_alpha && io.Main().AlphaIsPremultiplied()
-              ? 1.f / std::max(kSmallAlpha, alpha)
-              : 1.f;
-      for (const float* const row : rows) {
-        pixel_data->push_back(BufferFormat<precision>::FromFloat(
-            std::max(0.f, std::min(1.f, alpha_multiplier * row[x]))));
-      }
-      if (has_alpha) {
-        pixel_data->push_back(
-            BufferFormat<precision>::FromFloat(255.f * alpha));
-      }
-    }
-  }
-}
+  gint32 layer;
 
-template <GimpPrecision precision>
-Status FillGimpLayer(const gint32 layer, const CodecInOut& io,
-                     GimpImageType layer_type) {
-  std::vector<typename BufferFormat<precision>::Sample> pixel_data;
-  switch (layer_type) {
-    case GIMP_GRAY_IMAGE:
-      FillBuffer<precision, /*has_alpha=*/false, /*num_channels=*/1>(
-          io, &pixel_data);
-      break;
-    case GIMP_GRAYA_IMAGE:
-      FillBuffer<precision, /*has_alpha=*/true, /*num_channels=*/1>(
-          io, &pixel_data);
-      break;
-    case GIMP_RGB_IMAGE:
-      FillBuffer<precision, /*has_alpha=*/false, /*num_channels=*/3>(
-          io, &pixel_data);
-      break;
-    case GIMP_RGBA_IMAGE:
-      FillBuffer<precision, /*has_alpha=*/true, /*num_channels=*/3>(
-          io, &pixel_data);
-      break;
-    default:
-      return false;
-  }
-
-  GeglBuffer* buffer = gimp_drawable_get_buffer(layer);
-  gegl_buffer_set(buffer, GEGL_RECTANGLE(0, 0, io.xsize(), io.ysize()), 0,
-                  nullptr, pixel_data.data(), GEGL_AUTO_ROWSTRIDE);
-  g_clear_object(&buffer);
-  return true;
-}
-
-}  // namespace
-
-Status LoadJpegXlImage(const gchar* const filename, gint32* const image_id) {
-  PaddedBytes compressed;
-  JXL_RETURN_IF_ERROR(ReadFile(filename, &compressed));
-
-  // TODO(deymo): Use C API instead of the ThreadPoolInternal.
-  ThreadPoolInternal pool;
-  DecompressParams dparams;
-  CodecInOut io;
-  JXL_RETURN_IF_ERROR(DecodeFile(dparams, compressed, &io, &pool));
-
-  const ColorEncoding& color_encoding = io.metadata.m.color_encoding;
-  JXL_RETURN_IF_ERROR(io.TransformTo(color_encoding, &pool));
-
-  GimpColorProfile* profile = nullptr;
-  if (color_encoding.IsSRGB()) {
-    profile = gimp_color_profile_new_rgb_srgb();
-  } else if (color_encoding.IsLinearSRGB()) {
-    profile = gimp_color_profile_new_rgb_srgb_linear();
-  } else {
-    profile = gimp_color_profile_new_from_icc_profile(
-        color_encoding.ICC().data(), color_encoding.ICC().size(),
-        /*error=*/nullptr);
-  }
-  if (profile == nullptr) {
-    return JXL_FAILURE(
-        "Failed to create GIMP color profile from %zu bytes of ICC data",
-        color_encoding.ICC().size());
-  }
+  gpointer pixels_buffer;
+  size_t buffer_size;
 
   GimpImageBaseType image_type;
-  GimpImageType layer_type;
+  GimpImageType layer_type = GIMP_RGB_IMAGE;
+  GimpPrecision precision = GIMP_PRECISION_U16_GAMMA;
+  JxlBasicInfo info = {};
+  JxlPixelFormat format = {};
 
-  if (io.Main().IsGray()) {
-    image_type = GIMP_GRAY;
-    if (io.Main().HasAlpha()) {
-      layer_type = GIMP_GRAYA_IMAGE;
-    } else {
-      layer_type = GIMP_GRAY_IMAGE;
-    }
-  } else {
-    image_type = GIMP_RGB;
-    if (io.Main().HasAlpha()) {
-      layer_type = GIMP_RGBA_IMAGE;
-    } else {
-      layer_type = GIMP_RGB_IMAGE;
-    }
+  format.num_channels = 4;
+  format.data_type = JXL_TYPE_UINT8;
+  format.endianness = JXL_NATIVE_ENDIAN;
+  format.align = 0;
+
+  JpegXlGimpProgress gimp_load_progress(
+      ("Opening:" + (std::string)filename).c_str());
+  gimp_load_progress.update();
+
+  // read file
+  std::ifstream instream(filename, std::ios::in | std::ios::binary);
+  std::vector<uint8_t> compressed((std::istreambuf_iterator<char>(instream)),
+                                  std::istreambuf_iterator<char>());
+  instream.close();
+
+  gimp_load_progress.update();
+
+  // multi-threaded parallel runner.
+  auto runner = JxlResizableParallelRunnerMake(nullptr);
+
+  auto dec = JxlDecoderMake(nullptr);
+  if (JXL_DEC_SUCCESS !=
+      JxlDecoderSubscribeEvents(dec.get(), JXL_DEC_BASIC_INFO |
+                                               JXL_DEC_COLOR_ENCODING |
+                                               JXL_DEC_FULL_IMAGE)) {
+    g_printerr("JXL Error: JxlDecoderSubscribeEvents failed\n");
+    return false;
   }
 
-  GimpPrecision precision;
-  Status (*fill_layer)(gint32 layer, const CodecInOut& io, GimpImageType);
-  if (io.metadata.m.bit_depth.floating_point_sample) {
-    if (io.metadata.m.bit_depth.bits_per_sample <= 16) {
-      precision = GIMP_PRECISION_HALF_GAMMA;
-      fill_layer = &FillGimpLayer<GIMP_PRECISION_HALF_GAMMA>;
-    } else {
-      precision = GIMP_PRECISION_FLOAT_GAMMA;
-      fill_layer = &FillGimpLayer<GIMP_PRECISION_FLOAT_GAMMA>;
-    }
-  } else {
-    if (io.metadata.m.bit_depth.bits_per_sample <= 8) {
-      precision = GIMP_PRECISION_U8_GAMMA;
-      fill_layer = &FillGimpLayer<GIMP_PRECISION_U8_GAMMA>;
-    } else if (io.metadata.m.bit_depth.bits_per_sample <= 16) {
-      precision = GIMP_PRECISION_U16_GAMMA;
-      fill_layer = &FillGimpLayer<GIMP_PRECISION_U16_GAMMA>;
-    } else {
-      precision = GIMP_PRECISION_U32_GAMMA;
-      fill_layer = &FillGimpLayer<GIMP_PRECISION_U32_GAMMA>;
-    }
+  if (JXL_DEC_SUCCESS != JxlDecoderSetParallelRunner(dec.get(),
+                                                     JxlResizableParallelRunner,
+                                                     runner.get())) {
+    g_printerr("JXL Error: JxlDecoderSetParallelRunner failed\n");
+    return false;
   }
 
-  *image_id = gimp_image_new_with_precision(io.xsize(), io.ysize(), image_type,
-                                            precision);
-  gimp_image_set_color_profile(*image_id, profile);
-  g_clear_object(&profile);
-  const gint32 layer = gimp_layer_new(
-      *image_id, "image", io.xsize(), io.ysize(), layer_type, /*opacity=*/100,
-      gimp_image_get_default_new_layer_mode(*image_id));
+  // grand decode loop... Is there  a better way to organize this?
+  JxlDecoderSetInput(dec.get(), compressed.data(), compressed.size());
+
+  while (true) {
+    gimp_load_progress.update();
+
+    JxlDecoderStatus status = JxlDecoderProcessInput(dec.get());
+
+    if (status == JXL_DEC_BASIC_INFO) {
+      // g_message("JXL_DEC_BASIC_INFO");
+      if (JXL_DEC_SUCCESS != JxlDecoderGetBasicInfo(dec.get(), &info)) {
+        g_printerr("JXL Error: JxlDecoderGetBasicInfo failed\n");
+        return false;
+      }
+
+      JxlResizableParallelRunnerSetThreads(
+          runner.get(),
+          JxlResizableParallelRunnerSuggestThreads(info.xsize, info.ysize));
+    } else if (status == JXL_DEC_COLOR_ENCODING) {
+      // Load ICC profile
+      size_t icc_size = 0;
+
+      if (JXL_DEC_SUCCESS != JxlDecoderGetICCProfileSize(dec.get(), &format,
+                                                         _PROFILE_TARGET_,
+                                                         &icc_size)) {
+        g_printerr("JXL Warning: JxlDecoderGetICCProfileSize failed\n");
+      }
+
+      if (icc_size > 0) {
+        icc_profile.resize(icc_size);
+        if (JXL_DEC_SUCCESS != JxlDecoderGetColorAsICCProfile(
+                                   dec.get(), &format, _PROFILE_TARGET_,
+                                   icc_profile.data(), icc_profile.size())) {
+          g_printerr("JXL Warning: JxlDecoderGetColorAsICCProfile failed\n");
+        }
+
+        profile = gimp_color_profile_new_from_icc_profile(
+            icc_profile.data(), icc_profile.size(), /*error=*/nullptr);
+
+        if (profile) {
+          is_linear = gimp_color_profile_is_linear(profile);
+          g_printerr("JXL Info: Setting is_linear = %d\n", is_linear);
+        } else {
+          g_printerr("JXL Warning: Failed to read ICC profile.\n");
+        }
+      } else {
+        g_printerr("JXL Warning: Empty ICC data.\n");
+      }
+
+      // Internal color profile detection...
+      JxlColorEncoding color_encoding;
+      if (JXL_DEC_SUCCESS ==
+          JxlDecoderGetColorAsEncodedProfile(
+              dec.get(), &format, _PROFILE_TARGET_, &color_encoding)) {
+        g_printerr("JXL Info: Internal profile detected.\n");
+
+        // figure out linearity of internal profile
+        switch (color_encoding.transfer_function) {
+          case JXL_TRANSFER_FUNCTION_LINEAR:
+            is_linear = true;
+            break;
+
+          case JXL_TRANSFER_FUNCTION_709:
+          case JXL_TRANSFER_FUNCTION_PQ:
+          case JXL_TRANSFER_FUNCTION_HLG:
+          case JXL_TRANSFER_FUNCTION_GAMMA:
+          case JXL_TRANSFER_FUNCTION_DCI:
+          case JXL_TRANSFER_FUNCTION_SRGB:
+            is_linear = false;
+            break;
+
+          case JXL_TRANSFER_FUNCTION_UNKNOWN:
+          default:
+            if (profile) {
+              g_printerr(
+                  "Info: Unknown transfer function.  "
+                  "ICC profile is present.");
+            } else {
+              g_printerr(
+                  "Info: Unknown transfer function.  "
+                  "No ICC profile present.");
+            }
+            break;
+        }
+
+        switch (color_encoding.color_space) {
+          case JXL_COLOR_SPACE_RGB:
+            if (color_encoding.white_point == JXL_WHITE_POINT_D65 &&
+                color_encoding.primaries == JXL_PRIMARIES_SRGB) {
+              if (is_linear) {
+                profile = gimp_color_profile_new_rgb_srgb_linear();
+              } else {
+                profile = gimp_color_profile_new_rgb_srgb();
+              }
+            } else if (!is_linear &&
+                       color_encoding.white_point == JXL_WHITE_POINT_D65 &&
+                       (color_encoding.primaries_green_xy[0] == 0.2100 ||
+                        color_encoding.primaries_green_xy[1] == 0.7100)) {
+              // Probably Adobe RGB
+              profile = gimp_color_profile_new_rgb_adobe();
+            } else if (profile) {
+              g_printerr(
+                  "JXL Info: Unknown RGB colorspace. Using ICC profile.\n");
+            } else {
+              g_printerr(
+                  "JXL Info: Unknown RGB colorspace. Treating as sRGB.\n");
+              if (is_linear) {
+                profile = gimp_color_profile_new_rgb_srgb_linear();
+              } else {
+                profile = gimp_color_profile_new_rgb_srgb();
+              }
+            }
+            break;
+
+          case JXL_COLOR_SPACE_GRAY:
+            if (!profile) {
+              if (is_linear) {
+                profile = gimp_color_profile_new_d65_gray_linear();
+              } else {
+                profile = gimp_color_profile_new_d65_gray_srgb_trc();
+              }
+            }
+            break;
+          case JXL_COLOR_SPACE_XYB:
+          case JXL_COLOR_SPACE_UNKNOWN:
+          default:
+            if (profile) {
+              g_printerr("JXL Info: Unknown colorspace. Using ICC profile.\n");
+            } else {
+              g_error(
+                  "Warning: Unknown colorspace. Treating as sRGB profile.\n");
+
+              if (is_linear) {
+                profile = gimp_color_profile_new_rgb_srgb_linear();
+              } else {
+                profile = gimp_color_profile_new_rgb_srgb();
+              }
+            }
+            break;
+        }
+      }
+
+      // set pixel format
+      if (info.num_color_channels > 1) {
+        if (info.alpha_bits == 0) {
+          image_type = GIMP_RGB;
+          layer_type = GIMP_RGB_IMAGE;
+          format.num_channels = info.num_color_channels;
+        } else {
+          image_type = GIMP_RGB;
+          layer_type = GIMP_RGBA_IMAGE;
+          format.num_channels = info.num_color_channels + 1;
+        }
+      } else if (info.num_color_channels == 1) {
+        if (info.alpha_bits == 0) {
+          image_type = GIMP_GRAY;
+          layer_type = GIMP_GRAY_IMAGE;
+          format.num_channels = info.num_color_channels;
+        } else {
+          image_type = GIMP_GRAY;
+          layer_type = GIMP_GRAYA_IMAGE;
+          format.num_channels = info.num_color_channels + 1;
+        }
+      }
+
+      // Set bit depth and linearity
+      if (info.bits_per_sample <= 8) {
+        if (is_linear) {
+          format.data_type = JXL_TYPE_UINT8;
+          precision = GIMP_PRECISION_U8_LINEAR;
+        } else {
+          format.data_type = JXL_TYPE_UINT8;
+          precision = GIMP_PRECISION_U8_GAMMA;
+        }
+      } else if (info.bits_per_sample <= 16) {
+        if (info.exponent_bits_per_sample > 0) {
+          if (is_linear) {
+            format.data_type = JXL_TYPE_FLOAT16;
+            precision = GIMP_PRECISION_HALF_LINEAR;
+          } else {
+            format.data_type = JXL_TYPE_FLOAT16;
+            precision = GIMP_PRECISION_HALF_GAMMA;
+          }
+        } else if (is_linear) {
+          format.data_type = JXL_TYPE_UINT16;
+          precision = GIMP_PRECISION_U16_LINEAR;
+        } else {
+          format.data_type = JXL_TYPE_UINT16;
+          precision = GIMP_PRECISION_U16_GAMMA;
+        }
+      } else {
+        if (info.exponent_bits_per_sample > 0) {
+          if (is_linear) {
+            format.data_type = JXL_TYPE_FLOAT;
+            precision = GIMP_PRECISION_FLOAT_LINEAR;
+          } else {
+            format.data_type = JXL_TYPE_FLOAT;
+            precision = GIMP_PRECISION_FLOAT_GAMMA;
+          }
+        } else if (is_linear) {
+          format.data_type = JXL_TYPE_UINT32;
+          precision = GIMP_PRECISION_U32_LINEAR;
+        } else {
+          format.data_type = JXL_TYPE_UINT32;
+          precision = GIMP_PRECISION_U32_GAMMA;
+        }
+      }
+
+      // create new image with profile
+      *image_id = gimp_image_new_with_precision(info.xsize, info.ysize,
+                                                image_type, precision);
+
+      if (profile) {
+        gimp_image_set_color_profile(*image_id, profile);
+      } else {
+        g_printerr("JXL Error: No color profile.\n");
+      }
+    } else if (status == JXL_DEC_NEED_IMAGE_OUT_BUFFER) {
+      // g_message("JXL_DEC_NEED_IMAGE_OUT_BUFFER");
+      if (JXL_DEC_SUCCESS !=
+          JxlDecoderImageOutBufferSize(dec.get(), &format, &buffer_size)) {
+        g_printerr("JXL Error: JxlDecoderImageOutBufferSize failed\n");
+        return false;
+      }
+
+      pixels_buffer = g_malloc(buffer_size);
+
+      if (JXL_DEC_SUCCESS != JxlDecoderSetImageOutBuffer(dec.get(), &format,
+                                                         pixels_buffer,
+                                                         buffer_size)) {
+        g_printerr("JXL Error: JxlDecoderSetImageOutBuffer failed\n");
+        return false;
+      }
+    } else if (status == JXL_DEC_FULL_IMAGE) {
+      // g_message("JXL_DEC_FULL_IMAGE");
+      // create and insert layer
+      layer = gimp_layer_new(*image_id, "Background", info.xsize, info.ysize,
+                             layer_type, /*opacity=*/100,
+                             gimp_image_get_default_new_layer_mode(*image_id));
+
+      gimp_image_insert_layer(*image_id, layer, /*parent_id=*/-1,
+                              /*position=*/0);
+
+      // move image to layer buffer; need to clear layer buffer to update layer
+      GeglBuffer *buffer = gimp_drawable_get_buffer(layer);
+      gegl_buffer_set(buffer, GEGL_RECTANGLE(0, 0, info.xsize, info.ysize), 0,
+                      nullptr, pixels_buffer, GEGL_AUTO_ROWSTRIDE);
+
+      g_clear_object(&buffer);
+    } else if (status == JXL_DEC_SUCCESS) {
+      // g_message("JXL_DEC_SUCCESS");
+      // All decoding successfully finished.
+      // It's not required to call JxlDecoderReleaseInput(dec.get())
+      // since the decoder will be destroyed.
+      break;
+    } else if (status == JXL_DEC_NEED_MORE_INPUT) {
+      // g_message("JXL_DEC_NEED_MORE_INPUT");
+      g_printerr("JXL Error: Already provided all input\n");
+      return false;
+    } else if (status == JXL_DEC_ERROR) {
+      // g_message("JXL_DEC_ERROR");
+      g_printerr("JXL Error: Decoder error\n");
+      return false;
+    } else {
+      g_printerr("JXL Error: Unknown decoder status\n");
+      return false;
+    }
+  }  // end grand decode loop
+
+  gimp_load_progress.update();
   gimp_image_set_filename(*image_id, filename);
-  gimp_image_insert_layer(*image_id, layer, /*parent_id=*/-1, /*position=*/0);
 
-  JXL_RETURN_IF_ERROR(fill_layer(layer, io, layer_type));
-
+  gimp_load_progress.finished();
   return true;
 }
 

--- a/plugins/gimp/file-jxl-load.h
+++ b/plugins/gimp/file-jxl-load.h
@@ -6,14 +6,14 @@
 #ifndef PLUGINS_GIMP_FILE_JXL_LOAD_H_
 #define PLUGINS_GIMP_FILE_JXL_LOAD_H_
 
-#include <libgimp/gimp.h>
-
-#include "lib/jxl/base/status.h"
+#include "jxl/decode.h"
+#include "jxl/decode_cxx.h"
+#include "plugins/gimp/common.h"
 
 namespace jxl {
 
-Status LoadJpegXlImage(const gchar* filename, gint32* image_id);
+bool LoadJpegXlImage(const gchar* filename, gint32* image_id);
 
-}
+}  // namespace jxl
 
 #endif  // PLUGINS_GIMP_FILE_JXL_LOAD_H_

--- a/plugins/gimp/file-jxl-save.cc
+++ b/plugins/gimp/file-jxl-save.cc
@@ -5,128 +5,884 @@
 
 #include "plugins/gimp/file-jxl-save.h"
 
-// Defined by both FUIF and glib.
-#undef MAX
-#undef MIN
-#undef CLAMP
+#define PLUG_IN_BINARY "file-jxl"
+#define SAVE_PROC "file-jxl-save"
 
-#include "lib/jxl/alpha.h"
-#include "lib/jxl/base/file_io.h"
-#include "lib/jxl/base/thread_pool_internal.h"
-#include "lib/jxl/enc_file.h"
-#include "plugins/gimp/common.h"
+#define SCALE_WIDTH 200
 
 namespace jxl {
 
 namespace {
 
-template <bool has_alpha, size_t alpha_bits = 16>
-Status ReadBuffer(const size_t xsize, const size_t ysize,
-                  const std::vector<float>& pixel_data, PaddedBytes icc,
-                  CodecInOut* const io) {
-  constexpr float alpha_multiplier = has_alpha ? 1.f / 255 : 0.f;
-  Image3F image(xsize, ysize);
-  ImageF alpha;
-  if (has_alpha) {
-    alpha = ImageF(xsize, ysize);
-  }
-  const float* current_sample = pixel_data.data();
-  for (size_t y = 0; y < ysize; ++y) {
-    float* rows[3];
-    for (size_t c = 0; c < 3; ++c) {
-      rows[c] = image.PlaneRow(c, y);
-    }
-    float* const alpha_row = has_alpha ? alpha.Row(y) : nullptr;
-    for (size_t x = 0; x < xsize; ++x) {
-      for (float* const row : rows) {
-        row[x] = BufferFormat<GIMP_PRECISION_FLOAT_GAMMA>::ToFloat(
-            *current_sample++);
-      }
-      if (has_alpha) {
-        alpha_row[x] = alpha_multiplier *
-                       BufferFormat<GIMP_PRECISION_FLOAT_GAMMA>::ToFloat(
-                           *current_sample++);
-      }
-    }
-  }
+class JpegXlSaveOpts {
+ public:
+  float distance;
+  float quality;
 
-  ColorEncoding color_encoding;
-  JXL_RETURN_IF_ERROR(color_encoding.SetICC(std::move(icc)));
-  io->metadata.m.color_encoding = color_encoding;
-  io->SetFromImage(std::move(image), color_encoding);
-  if (has_alpha) {
-    io->metadata.m.SetAlphaBits(alpha_bits);
-    io->Main().SetAlpha(std::move(alpha), /*alpha_is_premultiplied=*/false);
+  bool lossless = false;
+  bool is_linear = false;
+  bool has_alpha = false;
+  bool is_gray = false;
+
+  bool advanced_mode = false;
+  bool use_container = true;
+  bool save_exif = false;
+  int encoding_effort = 7;
+  int faster_decoding = 0;
+
+  std::string babl_format_str = "RGB u16";
+  std::string babl_type_str = "u16";
+  std::string babl_model_str = "RGB";
+
+  JxlPixelFormat pixel_format;
+  JxlBasicInfo basic_info;
+
+  // functions
+  JpegXlSaveOpts();
+
+  bool set_distance(float dist);
+  bool set_quality(float qual);
+  bool set_dimensions(int x, int y);
+  bool set_num_channels(int channels);
+
+  bool update_distance();
+  bool update_quality();
+
+  bool set_model(int gimp_model);
+
+  bool update_babl_format();
+  bool set_babl_model(std::string model);
+  bool set_babl_type(std::string type);
+
+  bool set_pixel_type(int type);
+  bool set_precision(int gimp_precision);
+
+ private:
+};  // class JpegXlSaveOpts
+
+JpegXlSaveOpts jxl_save_opts;
+
+static bool gui_on_change_quality(GtkAdjustment* adj_qual,
+                                  GtkAdjustment* adj_dist) {
+  jxl_save_opts.quality = gtk_adjustment_get_value(adj_qual);
+  jxl_save_opts.update_distance();
+  gtk_adjustment_set_value(adj_dist, jxl_save_opts.distance);
+  return true;
+}
+
+static bool gui_on_change_distance(GtkAdjustment* adj_dist,
+                                   GtkAdjustment* adj_qual) {
+  float new_distance = gtk_adjustment_get_value(adj_dist);
+  jxl_save_opts.distance = new_distance;
+  jxl_save_opts.update_quality();
+  gtk_adjustment_set_value(adj_qual, jxl_save_opts.quality);
+
+  // updating quality can change distance again
+  // set it again to ensure user value is maintained
+  if (jxl_save_opts.distance != new_distance) {
+    gtk_adjustment_set_value(adj_dist, new_distance);
   }
   return true;
 }
+
+static bool gui_on_change_lossless(GtkWidget* toggle,
+                                   GtkAdjustment* adjustments[]) {
+  GtkAdjustment* adj_distance = adjustments[0];
+  GtkAdjustment* adj_quality = adjustments[1];
+  GtkAdjustment* adj_effort = adjustments[2];
+
+  jxl_save_opts.lossless =
+      gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(toggle));
+
+  g_message("lossless = %d", jxl_save_opts.lossless);
+
+  if (jxl_save_opts.lossless) {
+    gimp_scale_entry_set_sensitive((GtkObject*)adj_distance, false);
+    gimp_scale_entry_set_sensitive((GtkObject*)adj_quality, false);
+    gtk_adjustment_set_value(adj_quality, 100.0f);
+    gtk_adjustment_set_value(adj_distance, 0.0f);
+
+    jxl_save_opts.distance = 0;
+    jxl_save_opts.update_quality();
+
+    gtk_adjustment_set_value(adj_effort, 3);
+    jxl_save_opts.encoding_effort = 3;
+  } else {
+    gimp_scale_entry_set_sensitive((GtkObject*)adj_distance, true);
+    gimp_scale_entry_set_sensitive((GtkObject*)adj_quality, true);
+    gtk_adjustment_set_value(adj_quality, 100.0f);
+    gtk_adjustment_set_value(adj_distance, 0.1f);
+
+    jxl_save_opts.distance = 0.1f;
+    jxl_save_opts.update_quality();
+
+    gtk_adjustment_set_value(adj_effort, 7);
+    jxl_save_opts.encoding_effort = 7;
+  }
+  return true;
+}
+
+static bool gui_on_change_codestream(GtkWidget* toggle) {
+  jxl_save_opts.use_container =
+      !gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(toggle));
+  return true;
+}
+
+static bool gui_on_change_uses_original_profile(GtkWidget* toggle) {
+  jxl_save_opts.basic_info.uses_original_profile =
+      gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(toggle));
+  return true;
+}
+
+static bool gui_on_change_advanced_mode(GtkWidget* toggle,
+                                        std::vector<GtkWidget*> advanced_opts) {
+  jxl_save_opts.advanced_mode =
+      gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(toggle));
+
+  GtkWidget* frame = advanced_opts[0];
+
+  gtk_widget_set_sensitive(frame, jxl_save_opts.advanced_mode);
+
+  if (!jxl_save_opts.advanced_mode) {
+    jxl_save_opts.lossless = false;
+    gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(advanced_opts[1]), false);
+
+    jxl_save_opts.use_container = true;
+    gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(advanced_opts[2]), false);
+
+    jxl_save_opts.basic_info.uses_original_profile = false;
+    gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(advanced_opts[3]), false);
+
+    // save metadata
+    // gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(advanced_opts[4]), false);
+
+    jxl_save_opts.encoding_effort = 7;
+    gtk_adjustment_set_value((GtkAdjustment*)advanced_opts[5], 7);
+
+    jxl_save_opts.faster_decoding = 0;
+    gtk_adjustment_set_value((GtkAdjustment*)advanced_opts[6], 0);
+  }
+  return true;
+}
+
+bool SaveDialog() {
+  gboolean run;
+  GtkWidget* dialog;
+  GtkWidget* content_area;
+  GtkWidget* main_vbox;
+  GtkWidget* frame;
+  GtkWidget* toggle;
+  GtkWidget* table;
+  GtkWidget* vbox;
+  GtkWidget* toggle_lossless;
+  GtkWidget* frame_advanced;
+  GtkAdjustment* entry_distance;
+  GtkAdjustment* entry_quality;
+  GtkAdjustment* entry_effort;
+  GtkAdjustment* entry_faster;
+
+  // initialize export dialog
+  gimp_ui_init(PLUG_IN_BINARY, true);
+  dialog = gimp_export_dialog_new("JPEG XL", PLUG_IN_BINARY, SAVE_PROC);
+
+  gtk_window_set_resizable(GTK_WINDOW(dialog), true);
+  content_area = gimp_export_dialog_get_content_area(dialog);
+
+  main_vbox = gtk_vbox_new(false, 6);
+  gtk_container_set_border_width(GTK_CONTAINER(main_vbox), 6);
+  gtk_box_pack_start(GTK_BOX(content_area), main_vbox, true, true, 0);
+  gtk_widget_show(main_vbox);
+
+  // Standard Settings Frame
+  frame = gtk_frame_new("Standard Settings");
+  gtk_frame_set_shadow_type(GTK_FRAME(frame), GTK_SHADOW_ETCHED_IN);
+  gtk_box_pack_start(GTK_BOX(main_vbox), frame, true, true, 0);
+  gtk_widget_show(frame);
+
+  vbox = gtk_vbox_new(false, 6);
+  gtk_container_set_border_width(GTK_CONTAINER(vbox), 6);
+  gtk_container_add(GTK_CONTAINER(frame), vbox);
+  gtk_widget_show(vbox);
+
+  // Butteraugli Distance
+  static gchar distance_help[] =
+      "Butteraugli distance.  Use lower values for higher quality.";
+  frame = gtk_frame_new("Butteraugli Distance");
+  gimp_help_set_help_data(frame, distance_help, nullptr);
+  gtk_frame_set_shadow_type(GTK_FRAME(frame), GTK_SHADOW_NONE);
+  gtk_box_pack_start(GTK_BOX(vbox), frame, false, false, 0);
+  gtk_widget_show(frame);
+
+  // Distance Scale
+  table = gtk_table_new(1, 3, false);
+  gtk_table_set_col_spacings(GTK_TABLE(table), 6);
+  gtk_container_add(GTK_CONTAINER(frame), table);
+  gtk_widget_show(table);
+
+  entry_distance = (GtkAdjustment*)gimp_scale_entry_new(
+      GTK_TABLE(table), 0, 0, "", SCALE_WIDTH, 0, jxl_save_opts.distance, 0.0,
+      45.0, 0.001, 1.0, 3, true, 0.0, 0.0, distance_help, "file-jxl-save");
+
+  gimp_scale_entry_set_logarithmic((GtkObject*)entry_distance, true);
+
+  // JPEG-style Quality
+  static gchar quality_help[] =
+      "JPEG-style Quality setting is remapped to distance.  "
+      "Values roughly match libjpeg quality.";
+  frame = gtk_frame_new("JPEG-style Quality");
+  gimp_help_set_help_data(frame, quality_help, nullptr);
+  gtk_frame_set_shadow_type(GTK_FRAME(frame), GTK_SHADOW_NONE);
+  gtk_box_pack_start(GTK_BOX(vbox), frame, false, false, 0);
+  gtk_widget_show(frame);
+
+  // Quality Scale
+  table = gtk_table_new(1, 3, false);
+  gtk_table_set_col_spacings(GTK_TABLE(table), 6);
+  gtk_container_add(GTK_CONTAINER(frame), table);
+  gtk_widget_show(table);
+
+  entry_quality = (GtkAdjustment*)gimp_scale_entry_new(
+      GTK_TABLE(table), 0, 0, "", SCALE_WIDTH, 0, jxl_save_opts.quality, 0.0,
+      100.0, 1.0, 10.0, 2, true, 0.0, 0.0, quality_help, "file-jxl-save");
+
+  // Distance and Quality Signals
+  g_signal_connect(entry_distance, "value-changed",
+                   G_CALLBACK(gui_on_change_distance), entry_quality);
+  g_signal_connect(entry_quality, "value-changed",
+                   G_CALLBACK(gui_on_change_quality), entry_distance);
+
+  // Advanced Settings Frame
+  std::vector<GtkWidget*> advanced_opts;
+
+  frame_advanced = gtk_frame_new("Advanced Settings");
+  gimp_help_set_help_data(frame_advanced,
+                          "Advanced Settings that shouldn't be used.", nullptr);
+  gtk_frame_set_shadow_type(GTK_FRAME(frame_advanced), GTK_SHADOW_ETCHED_IN);
+  gtk_box_pack_start(GTK_BOX(main_vbox), frame_advanced, true, true, 0);
+  gtk_widget_show(frame_advanced);
+
+  gtk_widget_set_sensitive(frame_advanced, false);
+
+  vbox = gtk_vbox_new(false, 6);
+  gtk_container_set_border_width(GTK_CONTAINER(vbox), 6);
+  gtk_container_add(GTK_CONTAINER(frame_advanced), vbox);
+  gtk_widget_show(vbox);
+
+  advanced_opts.push_back(frame_advanced);
+
+  // lossless convenience checkbox
+  static gchar lossless_help[] =
+      "Compress using modular lossless mode.  "
+      "Effort is set to 3 to improve performance.";
+  toggle_lossless = gtk_check_button_new_with_label("Lossless Mode");
+  gimp_help_set_help_data(toggle_lossless, lossless_help, nullptr);
+  gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(toggle_lossless),
+                               jxl_save_opts.lossless);
+  gtk_box_pack_start(GTK_BOX(vbox), toggle_lossless, false, false, 0);
+  gtk_widget_show(toggle_lossless);
+
+  advanced_opts.push_back(toggle_lossless);
+
+  // save raw codestream
+  static gchar codestream_help[] =
+      "Save the raw codestream, without a container.  "
+      "Not recommended.  The container is required for "
+      "metadata, and the overhead is miniscule.";
+  toggle = gtk_check_button_new_with_label("Raw Codestream");
+  gimp_help_set_help_data(toggle, codestream_help, nullptr);
+  gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(toggle),
+                               !jxl_save_opts.use_container);
+  gtk_box_pack_start(GTK_BOX(vbox), toggle, false, false, 0);
+  gtk_widget_show(toggle);
+
+  g_signal_connect(toggle, "toggled", G_CALLBACK(gui_on_change_codestream),
+                   nullptr);
+
+  advanced_opts.push_back(toggle);
+
+  // uses_original_profile
+  static gchar uses_original_profile_help[] =
+      "Prevents conversion to XYB colorspace.  "
+      "File sizes are approximately doubled.  "
+      "This option is not recommended.";
+  toggle = gtk_check_button_new_with_label("Use Original Color Profile");
+  gimp_help_set_help_data(toggle, uses_original_profile_help, nullptr);
+  gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(toggle),
+                               jxl_save_opts.basic_info.uses_original_profile);
+  gtk_box_pack_start(GTK_BOX(vbox), toggle, false, false, 0);
+  gtk_widget_show(toggle);
+
+  g_signal_connect(toggle, "toggled",
+                   G_CALLBACK(gui_on_change_uses_original_profile), nullptr);
+
+  advanced_opts.push_back(toggle);
+
+  // Save Exif Metadata
+  toggle = gtk_check_button_new_with_label("Save Exif Metadata");
+  gimp_help_set_help_data(
+      toggle, "This feature is not yet available in the API.", nullptr);
+  gtk_box_pack_start(GTK_BOX(vbox), toggle, false, false, 0);
+  gtk_widget_set_sensitive(toggle, false);
+  gtk_widget_show(toggle);
+
+  advanced_opts.push_back(toggle);
+
+  // Encoding Effort
+  static gchar effort_help[] =
+      "Encoding Effort: Higher number is more effort (slower).\n\tDefault = 7.";
+  frame = gtk_frame_new("Encoding Effort");
+  gimp_help_set_help_data(frame, effort_help, nullptr);
+  gtk_frame_set_shadow_type(GTK_FRAME(frame), GTK_SHADOW_NONE);
+  gtk_box_pack_start(GTK_BOX(vbox), frame, false, false, 0);
+  gtk_widget_show(frame);
+
+  // Effort Scale
+  table = gtk_table_new(1, 3, false);
+  gtk_table_set_col_spacings(GTK_TABLE(table), 6);
+  gtk_container_add(GTK_CONTAINER(frame), table);
+  gtk_widget_show(table);
+
+  entry_effort = (GtkAdjustment*)gimp_scale_entry_new(
+      GTK_TABLE(table), 0, 0, "", SCALE_WIDTH, 0, jxl_save_opts.encoding_effort,
+      1, 9, 1, 2, 0, true, 0.0, 0.0, effort_help, "file-jxl-save");
+
+  // Effort Signals
+  g_signal_connect(entry_effort, "value-changed",
+                   G_CALLBACK(gimp_int_adjustment_update),
+                   &jxl_save_opts.encoding_effort);
+
+  advanced_opts.push_back((GtkWidget*)entry_effort);
+
+  // signal for lossless toggle
+  // has to be put here to change effort setting
+  GtkAdjustment* adjustments[] = {entry_distance, entry_quality, entry_effort};
+  g_signal_connect(toggle_lossless, "toggled",
+                   G_CALLBACK(gui_on_change_lossless), adjustments);
+
+  // Faster Decoding
+  static gchar faster_help[] =
+      "Faster Decoding to improve decoding speed.  "
+      "Higher values give higher speed at the expense of quality.\n"
+      "\tDefault = 0.";
+  frame = gtk_frame_new("Faster Decoding");
+  gimp_help_set_help_data(frame, faster_help, nullptr);
+  gtk_frame_set_shadow_type(GTK_FRAME(frame), GTK_SHADOW_NONE);
+  gtk_box_pack_start(GTK_BOX(vbox), frame, false, false, 0);
+  gtk_widget_show(frame);
+
+  // Faster Decoding Scale
+  table = gtk_table_new(1, 3, false);
+  gtk_table_set_col_spacings(GTK_TABLE(table), 6);
+  gtk_container_add(GTK_CONTAINER(frame), table);
+  gtk_widget_show(table);
+
+  entry_faster = (GtkAdjustment*)gimp_scale_entry_new(
+      GTK_TABLE(table), 0, 0, "", SCALE_WIDTH, 0, jxl_save_opts.faster_decoding,
+      0, 5, 1, 1, 0, true, 0.0, 0.0, faster_help, "file-jxl-save");
+
+  advanced_opts.push_back((GtkWidget*)entry_faster);
+
+  // Faster Decoding Signals
+  g_signal_connect(entry_faster, "value-changed",
+                   G_CALLBACK(gimp_int_adjustment_update),
+                   &jxl_save_opts.faster_decoding);
+
+  // Enable Advanced Settings
+  frame = gtk_frame_new(0);
+  gimp_help_set_help_data(frame, "Advanced Settings shouldn't be used.",
+                          nullptr);
+  gtk_frame_set_shadow_type(GTK_FRAME(frame), GTK_SHADOW_NONE);
+  gtk_box_pack_start(GTK_BOX(main_vbox), frame, true, true, 0);
+  gtk_widget_show(frame);
+
+  vbox = gtk_vbox_new(false, 6);
+  gtk_container_set_border_width(GTK_CONTAINER(vbox), 6);
+  gtk_container_add(GTK_CONTAINER(frame), vbox);
+  gtk_widget_show(vbox);
+
+  static gchar advanced_help[] = "Use advanced settings with care.";
+  toggle = gtk_check_button_new_with_label("Enable Advanced Settings");
+  gimp_help_set_help_data(toggle, advanced_help, nullptr);
+  gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(toggle),
+                               jxl_save_opts.advanced_mode);
+  gtk_box_pack_start(GTK_BOX(vbox), toggle, false, false, 0);
+  gtk_widget_show(toggle);
+
+  g_signal_connect(toggle, "toggled", G_CALLBACK(gui_on_change_advanced_mode),
+                   &advanced_opts);
+
+  // show dialog
+  gtk_widget_show(dialog);
+
+  GtkAllocation allocation;
+  gtk_widget_get_allocation(dialog, &allocation);
+
+  int height = allocation.height;
+  gtk_widget_set_size_request(dialog, height * 1.4, height);
+
+  run = (gimp_dialog_run(GIMP_DIALOG(dialog)) == GTK_RESPONSE_OK);
+  gtk_widget_destroy(dialog);
+
+  return run;
+}  // SaveDialog
+
+JpegXlSaveOpts::JpegXlSaveOpts() {
+  set_distance(1.0f);
+
+  pixel_format.num_channels = 4;
+  pixel_format.data_type = JXL_TYPE_UINT8;
+  pixel_format.endianness = JXL_NATIVE_ENDIAN;
+  pixel_format.align = 0;
+
+  basic_info.alpha_bits = 0;
+  basic_info.alpha_exponent_bits = 0;
+  basic_info.uses_original_profile = false;
+  basic_info.intensity_target = 255.0f;
+  basic_info.orientation = JXL_ORIENT_IDENTITY;
+
+  return;
+}  // JpegXlSaveOpts constructor
+
+bool JpegXlSaveOpts::set_model(int gimp_model) {
+  switch (gimp_model) {
+    case GIMP_GRAY_IMAGE:
+      if (is_linear) {
+        set_babl_model("Y");
+        set_num_channels(1);
+      } else {
+        set_babl_model("Y'");
+        set_num_channels(1);
+      }
+      return true;
+
+    case GIMP_GRAYA_IMAGE:
+      if (is_linear) {
+        set_babl_model("YA");
+        set_num_channels(2);
+      } else {
+        set_babl_model("Y'A");
+        set_num_channels(2);
+      }
+      return true;
+
+    case GIMP_RGB_IMAGE:
+      if (is_linear) {
+        set_babl_model("RGB");
+        set_num_channels(3);
+      } else {
+        set_babl_model("R'G'B'");
+        set_num_channels(3);
+      }
+      return true;
+
+    case GIMP_RGBA_IMAGE:
+      if (is_linear) {
+        set_babl_model("RGBA");
+        set_num_channels(4);
+      } else {
+        set_babl_model("R'G'B'A");
+        set_num_channels(4);
+      }
+      return true;
+
+    default:
+      g_printerr("JXL Error: Unsupported pixel format.\n");
+      return false;
+  }
+}  // JpegXlSaveOpts::set_model
+
+bool JpegXlSaveOpts::set_distance(float dist) {
+  distance = dist;
+  return update_quality();
+}
+
+bool JpegXlSaveOpts::set_quality(float qual) {
+  quality = qual;
+  return update_distance();
+}
+
+bool JpegXlSaveOpts::update_quality() {
+  float qual;
+
+  if (distance < 0.1f) {
+    qual = 100;
+  } else if (distance <= 6.4) {
+    qual = 100 - (distance - 0.1) / 0.09f;
+    lossless = false;
+  } else {
+    qual = 30 - 5 * (log(6.25 * distance - 40)) / log(2.5);
+    lossless = false;
+  }
+
+  if (qual < 0) {
+    quality = 0.0;
+  } else if (qual >= 100) {
+    quality = 100.0;
+  } else {
+    quality = qual;
+  }
+
+  return true;
+}
+
+bool JpegXlSaveOpts::update_distance() {
+  float dist;
+  if (quality >= 30) {
+    dist = 0.1 + (100 - quality) * 0.09;
+  } else {
+    dist = 6.4 + pow(2.5, (30 - quality) / 5.0f) / 6.25f;
+  }
+
+  distance = dist;
+  return true;
+}
+
+bool JpegXlSaveOpts::set_dimensions(int x, int y) {
+  basic_info.xsize = x;
+  basic_info.ysize = y;
+  return true;
+}
+
+bool JpegXlSaveOpts::set_num_channels(int channels) {
+  switch (channels) {
+    case 1:
+      pixel_format.num_channels = 1;
+      basic_info.num_color_channels = 1;
+      basic_info.num_extra_channels = 0;
+      basic_info.alpha_bits = 0;
+      basic_info.alpha_exponent_bits = 0;
+      break;
+    case 2:
+      pixel_format.num_channels = 2;
+      basic_info.num_color_channels = 1;
+      basic_info.num_extra_channels = 1;
+      basic_info.alpha_bits = basic_info.bits_per_sample;
+      basic_info.alpha_exponent_bits = basic_info.exponent_bits_per_sample;
+      break;
+    case 3:
+      pixel_format.num_channels = 3;
+      basic_info.num_color_channels = 3;
+      basic_info.num_extra_channels = 0;
+      basic_info.alpha_bits = 0;
+      basic_info.alpha_exponent_bits = 0;
+      break;
+    case 4:
+      pixel_format.num_channels = 4;
+      basic_info.num_color_channels = 3;
+      basic_info.num_extra_channels = 1;
+      basic_info.alpha_bits = basic_info.bits_per_sample;
+      basic_info.alpha_exponent_bits = basic_info.exponent_bits_per_sample;
+      break;
+    default:
+      set_num_channels(3);
+  }  // switch
+  return true;
+}  // JpegXlSaveOpts::set_num_channels
+
+bool JpegXlSaveOpts::update_babl_format() {
+  babl_format_str = babl_model_str + " " + babl_type_str;
+  return true;
+}
+
+bool JpegXlSaveOpts::set_babl_model(std::string model) {
+  babl_model_str = model;
+  return update_babl_format();
+}
+
+bool JpegXlSaveOpts::set_babl_type(std::string type) {
+  babl_type_str = type;
+  return update_babl_format();
+}
+
+bool JpegXlSaveOpts::set_pixel_type(int type) {
+  switch (type) {
+    case JXL_TYPE_FLOAT16:
+      set_babl_type("half");
+      pixel_format.data_type = JXL_TYPE_FLOAT16;
+      basic_info.bits_per_sample = 16;
+      basic_info.exponent_bits_per_sample = 5;
+      break;
+
+    case JXL_TYPE_FLOAT:
+      set_babl_type("float");
+      pixel_format.data_type = JXL_TYPE_FLOAT;
+      basic_info.bits_per_sample = 32;
+      basic_info.exponent_bits_per_sample = 8;
+      break;
+
+    // UINT32 is not yet supported.  Using UINT16 instead.
+    // See documentation of JxlEncoderAddImageFrame().
+    case JXL_TYPE_UINT32:
+    case JXL_TYPE_UINT16:
+      set_babl_type("u16");
+      pixel_format.data_type = JXL_TYPE_UINT16;
+      basic_info.bits_per_sample = 16;
+      basic_info.exponent_bits_per_sample = 0;
+      break;
+
+    case JXL_TYPE_UINT8:
+    default:
+      set_babl_type("u8");
+      pixel_format.data_type = JXL_TYPE_UINT8;
+      basic_info.bits_per_sample = 8;
+      basic_info.exponent_bits_per_sample = 0;
+      break;
+  }
+
+  return true;
+}  // JpegXlSaveOpts::set_pixel_type
+
+bool JpegXlSaveOpts::set_precision(int gimp_precision) {
+  switch (gimp_precision) {
+    // Note: all floating point formats save as linear
+    // to prevent gamma interpretation problems when viewing.
+    // See documentation of JxlEncoderAddImageFrame().
+    case GIMP_PRECISION_HALF_GAMMA:
+    case GIMP_PRECISION_HALF_LINEAR:
+      is_linear = true;
+      set_pixel_type(JXL_TYPE_FLOAT16);
+      break;
+    case GIMP_PRECISION_FLOAT_GAMMA:
+    case GIMP_PRECISION_FLOAT_LINEAR:
+      is_linear = true;
+      set_pixel_type(JXL_TYPE_FLOAT);
+      break;
+
+    // Note: all INT formats save as non-linear to prevent
+    // gamma interpretation problems when viewing.
+    // See documentation of JxlEncoderAddImageFrame().
+    case GIMP_PRECISION_U32_GAMMA:
+    case GIMP_PRECISION_U32_LINEAR:
+      is_linear = false;
+      set_pixel_type(JXL_TYPE_UINT32);
+      break;
+    case GIMP_PRECISION_U16_GAMMA:
+    case GIMP_PRECISION_U16_LINEAR:
+      is_linear = false;
+      set_pixel_type(JXL_TYPE_UINT16);
+      break;
+
+    default:
+    case GIMP_PRECISION_U8_LINEAR:
+    case GIMP_PRECISION_U8_GAMMA:
+      is_linear = false;
+      set_pixel_type(JXL_TYPE_UINT8);
+      break;
+  }
+  return true;
+}  // JpegXlSaveOpts::set_precision
 
 }  // namespace
 
-Status SaveJpegXlImage(const gint32 image_id, const gint32 drawable_id,
-                       const gint32 orig_image_id,
-                       const gchar* const filename) {
-  GimpColorProfile* profile =
-      gimp_image_get_effective_color_profile(orig_image_id);
-  gsize icc_size;
-  const guint8* const icc_bytes =
-      gimp_color_profile_get_icc_profile(profile, &icc_size);
-  PaddedBytes icc;
-  icc.assign(icc_bytes, icc_bytes + icc_size);
-  g_clear_object(&profile);
+bool SaveJpegXlImage(const gint32 image_id, const gint32 drawable_id,
+                     const gint32 orig_image_id, const gchar* const filename) {
+  if (!SaveDialog()) {
+    return true;
+  }
 
-  const Babl* format;
-  Status (*read_buffer)(size_t, size_t, const std::vector<float>&, PaddedBytes,
-                        CodecInOut*);
-  const bool has_alpha = gimp_drawable_has_alpha(drawable_id);
-  if (has_alpha) {
-    format = babl_format("R'G'B'A float");
-    read_buffer = &ReadBuffer</*has_alpha=*/true>;
+  gint32 nlayers;
+  gint32* layers;
+
+  JpegXlGimpProgress gimp_save_progress(
+      ("Saving JPEG XL file:" + std::string(filename)).c_str());
+  gimp_save_progress.update();
+
+  // try to get ICC color profile...
+  std::vector<uint8_t> icc;
+
+  GimpColorProfile* profile = gimp_image_get_color_profile(image_id);
+
+  if (profile) {
+    jxl_save_opts.is_linear = gimp_color_profile_is_linear(profile);
+    jxl_save_opts.is_gray = gimp_color_profile_is_gray(profile);
+
+    g_printerr("JXL Info: Extracting ICC Profile...\n");
+    gsize icc_size;
+    const guint8* const icc_bytes =
+        gimp_color_profile_get_icc_profile(profile, &icc_size);
+
+    icc.assign(icc_bytes, icc_bytes + icc_size);
   } else {
-    format = babl_format("R'G'B' float");
-    read_buffer = &ReadBuffer</*has_alpha=*/false>;
+    g_printerr("JXL Info: No ICC profile.  Exporting image anyway.\n");
   }
 
-  CodecInOut io;
+  gimp_save_progress.update();
 
-  GeglBuffer* gegl_buffer = gimp_drawable_get_buffer(drawable_id);
+  jxl_save_opts.set_dimensions(gimp_image_width(image_id),
+                               gimp_image_height(image_id));
 
-  // TODO(lode): is there a way to query whether the data type if float or int
-  // from gegl_buffer_get_format instead?
-  GimpPrecision precision = gimp_image_get_precision(image_id);
-  if (precision == GIMP_PRECISION_HALF_GAMMA) {
-    io.metadata.m.bit_depth.bits_per_sample = 16;
-    io.metadata.m.bit_depth.exponent_bits_per_sample = 5;
-  } else if (precision == GIMP_PRECISION_FLOAT_GAMMA) {
-    io.metadata.m.SetFloat32Samples();
-  } else {  // unsigned integer
-    // TODO(lode): handle GIMP_PRECISION_DOUBLE_GAMMA. 64-bit per channel is not
-    // supported by io.metadata.m.
-    const Babl* native_format = gegl_buffer_get_format(gegl_buffer);
-    uint32_t bits_per_sample = 8 *
-                               babl_format_get_bytes_per_pixel(native_format) /
-                               babl_format_get_n_components(native_format);
-    io.metadata.m.SetUintSamples(bits_per_sample);
+  layers = gimp_image_get_layers(image_id, &nlayers);
+
+  for (gint32 i = 0; i < nlayers; i++) {
+    if (gimp_drawable_has_alpha(layers[i])) {
+      jxl_save_opts.has_alpha = true;
+      break;
+    }
   }
 
-  const GeglRectangle rect = *gegl_buffer_get_extent(gegl_buffer);
-  std::vector<float> pixel_data(rect.width * rect.height * (3 + has_alpha));
-  gegl_buffer_get(gegl_buffer, &rect, 1., format, pixel_data.data(),
-                  GEGL_AUTO_ROWSTRIDE, GEGL_ABYSS_NONE);
-  g_clear_object(&gegl_buffer);
+  gimp_save_progress.update();
 
-  JXL_RETURN_IF_ERROR(
-      read_buffer(rect.width, rect.height, pixel_data, std::move(icc), &io));
-  CompressParams params;
-  PassesEncoderState encoder_state;
-  PaddedBytes compressed;
-  ThreadPoolInternal pool;
-  params.butteraugli_distance = 1.f;
-  JXL_RETURN_IF_ERROR(EncodeFile(params, &io, &encoder_state, &compressed,
-                                 /*aux_out=*/nullptr, &pool));
-  JXL_RETURN_IF_ERROR(WriteFile(compressed, filename));
+  // JxlEncoderAddImageFrame() doesn't currently support
+  // JXL_TYPE_UINT32.  Rebuilding babl_format to match
+  // the JxlPixelFormat to allow  export to UINT16.
+  //
+  // When this is no longer necessary, will be able to
+  // replace extraneous code with just:
+  //    native_format = gegl_buffer_get_format(buffer);
+  //
+  const Babl* native_format;
+  jxl_save_opts.set_precision(gimp_image_get_precision(image_id));
+  jxl_save_opts.set_model(gimp_drawable_type(drawable_id));
+  native_format = babl_format(jxl_save_opts.babl_format_str.c_str());
 
+  gimp_save_progress.update();
+
+  // multi-threaded parallel runner.
+  auto runner = JxlResizableParallelRunnerMake(nullptr);
+
+  JxlResizableParallelRunnerSetThreads(
+      runner.get(),
+      JxlResizableParallelRunnerSuggestThreads(jxl_save_opts.basic_info.xsize,
+                                               jxl_save_opts.basic_info.ysize));
+
+  auto enc = JxlEncoderMake(/*memory_manager=*/nullptr);
+  JxlEncoderUseContainer(enc.get(), jxl_save_opts.use_container);
+
+  if (JXL_ENC_SUCCESS != JxlEncoderSetParallelRunner(enc.get(),
+                                                     JxlResizableParallelRunner,
+                                                     runner.get())) {
+    g_printerr("JXL Error: JxlEncoderSetParallelRunner failed\n");
+    return false;
+  }
+
+  if (JXL_ENC_SUCCESS !=
+      JxlEncoderSetBasicInfo(enc.get(), &jxl_save_opts.basic_info)) {
+    g_printerr("JXL Error: JxlEncoderSetBasicInfo failed\n");
+    return false;
+  }
+
+  // try to use ICC profile
+  if (icc.size() > 0 && !gimp_color_profile_is_gray) {
+    if (JXL_ENC_SUCCESS !=
+        JxlEncoderSetICCProfile(enc.get(), icc.data(), icc.size())) {
+      g_printerr("JXL Warning: JxlEncoderSetICCProfile failed.\n");
+      jxl_save_opts.basic_info.uses_original_profile = false;
+    }
+  } else {
+    g_printerr("JXL Warning: Using internal profile.\n");
+    jxl_save_opts.basic_info.uses_original_profile = false;
+  }
+
+  // detect internal color profile
+  JxlColorEncoding color_encoding = {};
+
+  if (jxl_save_opts.is_linear) {
+    JxlColorEncodingSetToLinearSRGB(
+        &color_encoding,
+        /*is_gray=*/jxl_save_opts.pixel_format.num_channels < 3);
+  } else {
+    JxlColorEncodingSetToSRGB(
+        &color_encoding,
+        /*is_gray=*/jxl_save_opts.pixel_format.num_channels < 3);
+  }
+
+  if (JXL_ENC_SUCCESS !=
+      JxlEncoderSetColorEncoding(enc.get(), &color_encoding)) {
+    g_printerr("JXL Warning: JxlEncoderSetColorEncoding failed\n");
+  }
+
+  // set encoder options
+  JxlEncoderOptions* enc_opts;
+  enc_opts = JxlEncoderOptionsCreate(enc.get(), nullptr);
+
+  JxlEncoderOptionsSetEffort(enc_opts, jxl_save_opts.encoding_effort);
+  JxlEncoderOptionsSetDecodingSpeed(enc_opts, jxl_save_opts.faster_decoding);
+
+  if (jxl_save_opts.lossless || jxl_save_opts.distance < 0.01f) {
+    if (jxl_save_opts.basic_info.exponent_bits_per_sample > 0) {
+      // lossless mode doesn't work with floating point
+      jxl_save_opts.distance = 0.01;
+      JxlEncoderOptionsSetLossless(enc_opts, false);
+      JxlEncoderOptionsSetDistance(enc_opts, 0.01);
+    } else {
+      JxlEncoderOptionsSetDistance(enc_opts, 0);
+      JxlEncoderOptionsSetLossless(enc_opts, true);
+    }
+  } else {
+    JxlEncoderOptionsSetLossless(enc_opts, false);
+    JxlEncoderOptionsSetDistance(enc_opts, jxl_save_opts.distance);
+  }
+
+  // process layers and compress into JXL
+  std::vector<uint8_t> compressed;
+  compressed.resize(262144);
+  uint8_t* next_out = compressed.data();
+  size_t avail_out = compressed.size();
+
+  size_t buffer_size = jxl_save_opts.basic_info.xsize *
+                       jxl_save_opts.basic_info.ysize *
+                       jxl_save_opts.pixel_format.num_channels *
+                       (jxl_save_opts.basic_info.bits_per_sample >> 3);
+
+  nlayers = 1;  // just process one layer for now
+  for (gint32 i = 0; i < nlayers; i++) {
+    gimp_save_progress.update();
+
+    // copy image into buffer...
+    gpointer pixels_buffer;
+    pixels_buffer = g_malloc(buffer_size);
+
+    GeglBuffer* buffer = gimp_drawable_get_buffer(layers[i]);
+    gegl_buffer_get(buffer,
+                    GEGL_RECTANGLE(0, 0, jxl_save_opts.basic_info.xsize,
+                                   jxl_save_opts.basic_info.ysize),
+                    1.0, native_format, pixels_buffer, GEGL_AUTO_ROWSTRIDE,
+                    GEGL_ABYSS_NONE);
+
+    g_clear_object(&buffer);
+
+    gimp_save_progress.update();
+
+    // compress layer
+    if (JXL_ENC_SUCCESS !=
+        JxlEncoderAddImageFrame(enc_opts, &jxl_save_opts.pixel_format,
+                                pixels_buffer, buffer_size)) {
+      g_printerr("JXL Error: JxlEncoderAddImageFrame failed\n");
+      return false;
+    }
+
+    // get data from encoder
+    JxlEncoderStatus process_result = JXL_ENC_NEED_MORE_OUTPUT;
+    while (process_result == JXL_ENC_NEED_MORE_OUTPUT) {
+      gimp_save_progress.update();
+
+      process_result =
+          JxlEncoderProcessOutput(enc.get(), &next_out, &avail_out);
+      if (process_result == JXL_ENC_NEED_MORE_OUTPUT) {
+        size_t offset = next_out - compressed.data();
+        compressed.resize(compressed.size() + 262144);
+        next_out = compressed.data() + offset;
+        avail_out = compressed.size() - offset;
+      }
+    }
+
+    if (JXL_ENC_SUCCESS != process_result) {
+      g_printerr("JXL Error: JxlEncoderProcessOutput failed\n");
+      return false;
+    }
+  }
+
+  JxlEncoderCloseInput(enc.get());
+
+  compressed.resize(next_out - compressed.data());
+
+  // write file
+  std::ofstream outstream(filename, std::ios::out | std::ios::binary);
+  copy(compressed.begin(), compressed.end(),
+       std::ostream_iterator<uint8_t>(outstream));
+
+  gimp_save_progress.finished();
   return true;
-}
+}  // SaveJpegXlImage()
 
 }  // namespace jxl

--- a/plugins/gimp/file-jxl-save.h
+++ b/plugins/gimp/file-jxl-save.h
@@ -6,15 +6,15 @@
 #ifndef PLUGINS_GIMP_FILE_JXL_SAVE_H_
 #define PLUGINS_GIMP_FILE_JXL_SAVE_H_
 
-#include <libgimp/gimp.h>
-
-#include "lib/jxl/base/status.h"
+#include "jxl/encode.h"
+#include "jxl/encode_cxx.h"
+#include "plugins/gimp/common.h"
 
 namespace jxl {
 
-Status SaveJpegXlImage(gint32 image_id, gint32 drawable_id,
-                       gint32 orig_image_id, const gchar* filename);
+bool SaveJpegXlImage(gint32 image_id, gint32 drawable_id, gint32 orig_image_id,
+                     const gchar* filename);
 
-}
+}  // namespace jxl
 
 #endif  // PLUGINS_GIMP_FILE_JXL_SAVE_H_

--- a/plugins/gimp/file-jxl.cc
+++ b/plugins/gimp/file-jxl.cc
@@ -3,13 +3,11 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-#include <glib/gi18n.h>
-#include <libgimp/gimp.h>
-#include <libgimp/gimpui.h>
 #include <string.h>
 
 #include <string>
 
+#include "plugins/gimp/common.h"
 #include "plugins/gimp/file-jxl-load.h"
 #include "plugins/gimp/file-jxl-save.h"
 
@@ -116,18 +114,6 @@ void Run(const gchar* const name, const gint nparams,
     values[1].type = GIMP_PDB_IMAGE;
     values[1].data.d_image = image_id;
   } else if (strcmp(name, kSaveProc) == 0) {
-#if !JPEGXL_ENABLE_GIMP_SAVING
-    *nreturn_vals = 2;
-    values[0].data.d_status = GIMP_PDB_EXECUTION_ERROR;
-    values[1].type = GIMP_PDB_STRING;
-    static gchar compatibility_message[] =
-        "Saving is disabled in this build of the JPEG XL plugin. Rebuild it "
-        "with -DJPEGXL_ENABLE_GIMP_SAVING=1 to enable the functionality, but "
-        "be aware that files created in this fashion may not work in future "
-        "versions of the decoder.";
-    values[1].data.d_string = compatibility_message;
-    return;
-#endif
     if (nparams != 5) {
       values[0].data.d_status = GIMP_PDB_CALLING_ERROR;
       return;
@@ -140,6 +126,7 @@ void Run(const gchar* const name, const gint nparams,
     const GimpExportReturn export_result = gimp_export_image(
         &image_id, &drawable_id, "JPEG XL",
         static_cast<GimpExportCapabilities>(GIMP_EXPORT_CAN_HANDLE_RGB |
+                                            GIMP_EXPORT_CAN_HANDLE_GRAY |
                                             GIMP_EXPORT_CAN_HANDLE_ALPHA));
     switch (export_result) {
       case GIMP_EXPORT_CANCEL:
@@ -150,7 +137,6 @@ void Run(const gchar* const name, const gint nparams,
       case GIMP_EXPORT_EXPORT:
         break;
     }
-    gimp_progress_init_printf(_("Saving JPEG XL file \"%s\""), filename);
     if (!SaveJpegXlImage(image_id, drawable_id, orig_image_id, filename)) {
       return;
     }


### PR DESCRIPTION
* Remove libjxl internals
* Use multi-threaded parallel runner
* Allow saving without requiring compiler flag
* Load multiple frames as layers
* Save non-linear uint8/16 and linear float16/32
* Save alpha channel in uint8/16 formats
* Add save options dialog

The following issues are resolved: #100, #229, #417, [wg1#234](https://gitlab.com/wg1/jpeg-xl/-/issues/234), [wg1#184](https://gitlab.com/wg1/jpeg-xl/-/issues/184).

![save_dialog](https://user-images.githubusercontent.com/8353098/130511766-6a945f12-4573-4427-8167-26ba23da6073.png)
