### PR TITLE
`jxl_from_tree`: always initialize `quantization_adjustment`

### DIFF
--- a/tools/jxl_from_tree.cc
+++ b/tools/jxl_from_tree.cc
@@ -419,8 +419,7 @@ int JxlFromTree(const char* in, const char* out, const char* tree_out) {
   *metadata = io.metadata;
   JXL_RETURN_IF_ERROR(metadata->size.Set(io.xsize(), io.ysize()));
 
-  metadata->m.xyb_encoded =
-      cparams.color_transform == ColorTransform::kXYB ? true : false;
+  metadata->m.xyb_encoded = cparams.color_transform == ColorTransform::kXYB;
 
   JXL_RETURN_IF_ERROR(WriteHeaders(metadata.get(), &writer, nullptr));
   writer.ZeroPadToByte();

--- a/tools/jxl_from_tree.cc
+++ b/tools/jxl_from_tree.cc
@@ -24,7 +24,7 @@ namespace jxl {
 
 namespace {
 struct SplineData {
-  int32_t quantization_adjustment;
+  int32_t quantization_adjustment = 1;
   std::vector<Spline> splines;
 };
 


### PR DESCRIPTION
Avoids an uninitialized read.