### PR TITLE
Improve ringing reduction balance of 2x2 downsampling

### DIFF
--- a/lib/jxl/jxl_test.cc
+++ b/lib/jxl/jxl_test.cc
@@ -218,7 +218,7 @@ TEST(JxlTest, RoundtripResample2) {
   cparams.resampling = 2;
   DecompressParams dparams;
   CodecInOut io2;
-  EXPECT_LE(Roundtrip(&io, cparams, dparams, pool, &io2), 15777);
+  EXPECT_LE(Roundtrip(&io, cparams, dparams, pool, &io2), 15877);
   EXPECT_LE(ButteraugliDistance(io, io2, cparams.ba_params,
                                 /*distmap=*/nullptr, pool),
             12.5);
@@ -240,9 +240,9 @@ TEST(JxlTest, RoundtripResample2MT) {
   EXPECT_LE(ButteraugliDistance(io, io2, cparams.ba_params,
                                 /*distmap=*/nullptr, &pool),
 #if JXL_HIGH_PRECISION
-            5.5);
+            6);
 #else
-            13);
+            13.5);
 #endif
 }
 


### PR DESCRIPTION
The 2x2 downsampling with 12x12 kernel is followed by a ringing
reduction. This ringing reduction also makes the image less
sharp than it could be in places where there is no visible ringing.

This MR implements a selective ringing reduction, in more noisy
areas it's less reduced.

Pair programmed with Jyrki.

The images look sharper, as intended. The benchmark results don't
show this, it can be visually checked, when using the --resampling=2
option in the encoder.

There are also less "jaggies" in diagonal lines after this MR. The
borders around sharp boundaries, such as letters of text, look sharper
with some overshoot, but no multiple-pixel-distance ringing.

Benchmark before:

```
Encoding                kPixels    Bytes          BPP  E MP/s  D MP/s     Max norm        pnorm   PSNR   QABPP  SmallB  DCT4x8     AFV  DCT8x8    8x16    8x32      16   16x32      32   32x64      64       BPP*pnorm   Bugs
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
jxl:resampling=2:d12      13270   145277    0.0875793   3.755  23.228  36.62536621   9.25051451  25.96   2.603  0.0116  0.7948  0.1191  0.3173  2.2590  0.0000  2.2590 12.9365  6.7133  0.0000  0.0000  0.810153142974      0
jxl:resampling=2:d11      13270   154590    0.0931935   4.611  23.462  33.83208084   8.71449496  26.13   2.595  0.0135  0.9101  0.1302  0.3559  2.3853  0.0000  2.3902 12.7976  6.4278  0.0000  0.0000  0.812134556087      0
jxl:resampling=2:d10      13270   164911    0.0994155   3.926  20.865  33.95512390   8.21609525  26.30   2.649  0.0212  1.0991  0.1514  0.4485  2.4779  0.0000  2.5696 12.7475  5.8953  0.0000  0.0000  0.816807017905      0
jxl:resampling=2:d9       13270   180422    0.1087662   4.716  22.145  33.55891037   7.63707670  26.50   2.667  0.0313  1.2592  0.1722  0.5286  2.6679  0.0000  2.7142 12.4581  5.5790  0.0000  0.0000  0.830655633366      0
jxl:resampling=2:d8       13270   198835    0.1198663   3.963  22.493  27.13867188   6.96930060  26.76   2.608  0.0405  1.4791  0.1982  0.6255  2.9197  0.0000  3.0403 12.0530  5.0542  0.0000  0.0000  0.835384475369      0
jxl:resampling=2:d7       13270   223172    0.1345377   4.477  22.007  25.95090866   6.37816113  27.06   2.733  0.0511  1.7318  0.2455  0.7287  3.0595  0.0000  3.1464 11.6479  4.7996  0.0000  0.0000  0.858103278829      0
jxl:resampling=2:d6       13270   253087    0.1525718   3.789  22.294  23.41822052   5.72340113  27.41   2.712  0.0694  2.0227  0.2865  0.8040  3.1319  0.0000  3.2544 11.3277  4.5141  0.0000  0.0000  0.873229486478      0
jxl:resampling=2:d5       13270   293248    0.1767826   4.532  23.613  18.99783325   5.03995385  27.82   2.646  0.0940  2.3945  0.3400  0.8990  3.3084  0.0000  3.4512 10.5715  4.3520  0.0000  0.0000  0.890975964647      0
jxl:resampling=2:d4       13270   352427    0.2124582   3.746  21.920  18.35805893   4.39765570  28.28   2.772  0.1302  2.9935  0.4041  1.0369  3.5148  0.0000  3.7232  9.8191  3.7887  0.0000  0.0000  0.934318110503      0
jxl:resampling=2:d3       13270   445398    0.2685052   4.499  26.201  17.90765953   3.81329058  28.80   3.235  0.1693  3.9585  0.4384  1.2235  3.8235  0.0000  4.2421  8.1447  3.4106  0.0000  0.0000  1.023888188752      0
jxl:resampling=2:d2       13270   609190    0.3672461   3.985  26.046  16.82825661   3.33926633  29.39   4.026  0.1905  5.2525  0.4895  1.4584  4.0704  0.0000  5.8047  5.1430  3.0017  0.0000  0.0000  1.226332374773      0
jxl:resampling=2:d1       13270   953164    0.5746084   4.670  25.456  16.64369392   3.02940511  29.94   5.923  0.1717  7.1516  0.3800  1.8375  4.4688  0.0000  8.2180  0.8295  2.3535  0.0000  0.0000  1.740721744393      0
Aggregate:                13270   276604    0.1667486   4.206  23.253  24.21947832   5.66836718  27.50   2.996  0.0563  2.0506  0.2512  0.7466  3.1059  0.0000  3.4700  8.5415  4.4588  0.0000  0.0000  0.945192060045      0
```

After:

```
Encoding                kPixels    Bytes          BPP  E MP/s  D MP/s     Max norm        pnorm   PSNR   QABPP  SmallB  DCT4x8     AFV  DCT8x8    8x16    8x32      16   16x32      32   32x64      64       BPP*pnorm   Bugs
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
jxl:resampling=2:d12      13270   141512    0.0853095   3.569  22.520  38.78550339  10.13336620  25.72   2.771  0.0058  0.7818  0.0675  0.3019  2.1943  0.0000  2.0352 12.5160  7.5081  0.0000  0.0000  0.864472885326      0
jxl:resampling=2:d11      13270   151301    0.0912108   4.372  23.520  39.17184067   9.56706856  25.88   2.827  0.0082  0.9028  0.0752  0.3627  2.2744  0.0000  2.2455 12.4195  7.1222  0.0000  0.0000  0.872619782526      0
jxl:resampling=2:d10      13270   161117    0.0971283   3.596  20.152  36.74286652   9.05098156  26.05   2.859  0.0106  1.0504  0.0950  0.4437  2.4615  0.0000  2.3631 12.3887  6.5975  0.0000  0.0000  0.879106349254      0
jxl:resampling=2:d9       13270   176087    0.1061529   4.396  22.760  31.91337967   8.35809721  26.25   2.846  0.0130  1.1898  0.1109  0.5165  2.6091  0.0000  2.5522 12.2459  6.1731  0.0000  0.0000  0.887235850438      0
jxl:resampling=2:d8       13270   193400    0.1165899   3.602  21.738  30.96194077   7.76511208  26.49   2.891  0.0178  1.3861  0.1283  0.6009  2.8174  0.0000  2.7085 11.9566  5.7950  0.0000  0.0000  0.905333452676      0
jxl:resampling=2:d7       13270   217796    0.1312968   4.334  23.239  26.79394913   7.04668138  26.79   2.919  0.0203  1.6581  0.1654  0.7215  3.0065  0.0000  2.9014 11.6363  5.3012  0.0000  0.0000  0.925206987459      0
jxl:resampling=2:d6       13270   249433    0.1503690   3.473  21.557  23.85705566   6.29404486  27.17   2.988  0.0299  1.9035  0.1997  0.8025  3.0412  0.0000  3.0711 11.4627  4.8999  0.0000  0.0000  0.946429163140      0
jxl:resampling=2:d5       13270   293431    0.1768929   4.190  24.247  22.24300194   5.46723243  27.62   2.895  0.0429  2.3154  0.2325  0.9207  3.2062  0.0000  3.2447 10.7104  4.7379  0.0000  0.0000  0.967114514538      0
jxl:resampling=2:d4       13270   356571    0.2149564   3.436  21.202  17.99481392   4.71010681  28.14   2.933  0.0598  2.9472  0.2908  1.0335  3.4396  0.0000  3.3528  9.9657  4.3212  0.0000  0.0000  1.012467622955      0
jxl:resampling=2:d3       13270   454005    0.2736938   4.195  25.229  17.62007523   3.98770134  28.69   3.118  0.0723  3.9387  0.3299  1.2250  3.7521  0.0000  3.8350  8.4919  3.7656  0.0000  0.0000  1.091409247812      0
jxl:resampling=2:d2       13270   620932    0.3743246   3.465  23.767  15.41382122   3.43530806  29.30   3.715  0.0902  5.2428  0.3463  1.4483  4.0752  0.0000  5.3610  5.5674  3.2795  0.0000  0.0000  1.285920441076      0
jxl:resampling=2:d1       13270   977998    0.5895794   4.195  27.158  15.76509762   3.08724171  29.89   5.253  0.0714  7.0682  0.2614  1.8929  4.5459  0.0000  8.0559  1.0610  2.4538  0.0000  0.0000  1.820174265563      0
Aggregate:                13270   274634    0.1655615   3.883  23.020  25.02854142   6.11816610  27.30   3.114  0.0257  1.9894  0.1666  0.7421  3.0440  0.0000  3.2104  8.7498  4.9245  0.0000  0.0000  1.012932537142      0
```