### PR TITLE
experimental encode option to separate photo/nonphoto

### DIFF
--- a/lib/jxl.cmake
+++ b/lib/jxl.cmake
@@ -253,6 +253,8 @@ set(JPEGXL_INTERNAL_SOURCES_ENC
   jxl/enc_modular.h
   jxl/enc_noise.cc
   jxl/enc_noise.h
+  jxl/enc_nonphoto_separation.cc
+  jxl/enc_nonphoto_separation.h
   jxl/enc_params.h
   jxl/enc_patch_dictionary.cc
   jxl/enc_patch_dictionary.h

--- a/lib/jxl/enc_cache.cc
+++ b/lib/jxl/enc_cache.cc
@@ -80,6 +80,7 @@ void InitializePassesEncoder(const Image3F& opsin, ThreadPool* pool,
     cparams.noise = Override::kOff;
     cparams.patches = Override::kOff;
     cparams.gaborish = Override::kOff;
+    cparams.separate = Override::kOff;
     cparams.epf = 0;
     cparams.max_error_mode = true;
     cparams.resampling = 1;

--- a/lib/jxl/enc_modular.cc
+++ b/lib/jxl/enc_modular.cc
@@ -731,10 +731,9 @@ Status ModularFrameEncoder::ComputeEncodingData(
       // assuming default Squeeze here
       int component = ((i - gi.nb_meta_channels) % nb_chans);
       // last 4 channels are final chroma residuals
-      if (nb_chans > 2 && i >= gi.channel.size() - 4) {
+      if (nb_chans > 2 && i >= gi.channel.size() - 4 && cparams.responsive) {
         component = 1;
       }
-
       if (cparams.color_transform == ColorTransform::kXYB && component < 3) {
         q = (component == 0 ? quality : cquality) * squeeze_quality_factor_xyb *
             squeeze_xyb_qtable[component][shift];

--- a/lib/jxl/enc_nonphoto_separation.cc
+++ b/lib/jxl/enc_nonphoto_separation.cc
@@ -1,0 +1,166 @@
+// Copyright (c) the JPEG XL Project Authors. All rights reserved.
+//
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+#include "lib/jxl/enc_nonphoto_separation.h"
+
+#include <stdint.h>
+#include <stdlib.h>
+#include <sys/types.h>
+
+#include <algorithm>
+#include <random>
+#include <string>
+#include <tuple>
+#include <utility>
+#include <vector>
+
+#include "lib/jxl/ans_params.h"
+#include "lib/jxl/base/compiler_specific.h"
+#include "lib/jxl/base/override.h"
+#include "lib/jxl/base/status.h"
+#include "lib/jxl/common.h"
+#include "lib/jxl/dec_cache.h"
+#include "lib/jxl/dec_frame.h"
+#include "lib/jxl/enc_ans.h"
+#include "lib/jxl/enc_cache.h"
+#include "lib/jxl/enc_frame.h"
+#include "lib/jxl/enc_patch_dictionary.h"
+#include "lib/jxl/entropy_coder.h"
+#include "lib/jxl/frame_header.h"
+#include "lib/jxl/image.h"
+#include "lib/jxl/image_bundle.h"
+#include "lib/jxl/image_ops.h"
+
+namespace jxl {
+
+constexpr size_t kSeparationRes = 32;
+constexpr uint16_t kNonPhotoThreshold =
+    0.2 * 5 * kSeparationRes * kSeparationRes;
+
+float FindSeparation(const Image3F& opsin, ImageU* separation,
+                     const CompressParams& cparams, ThreadPool* pool) {
+  ImageU sep(DivCeil(opsin.xsize(), kSeparationRes),
+             DivCeil(opsin.ysize(), kSeparationRes));
+  separation->Swap(sep);
+  ZeroFillImage(separation);
+  static const float scale_factor[3] = {1.f / 32768.0f, 1.f / 2048.0f,
+                                        1.f / 2048.0f};
+
+  for (size_t c = 0; c < 3; ++c) {
+    for (size_t y = 1; y < opsin.ysize(); y++) {
+      const float* JXL_RESTRICT p = opsin.PlaneRow(c, y);
+      const float* JXL_RESTRICT ptop = opsin.PlaneRow(c, y - 1);
+      uint16_t* JXL_RESTRICT s = separation->Row(y / kSeparationRes);
+      for (size_t x = 1; x < opsin.xsize(); x++) {
+        // absolute gradient residual
+        float agr = std::abs(p[x - 1] + ptop[x] - ptop[x - 1] - p[x]);
+        // if not smooth (near-zero) but also not strong edge: likely
+        // photographic
+        if (agr > 0.5f * scale_factor[c] && agr < 100.f * scale_factor[c]) {
+          if (s[x / kSeparationRes] < 0xfffe)
+            s[x / kSeparationRes] += (c == 1 ? 1 : 2);
+        }
+      }
+    }
+  }
+  // avoid small islands and count photo vs nonphoto
+  // do a few iterations of 'Game of Life' to remove islands/holes
+  constexpr int kIters = 10;
+  size_t photo = 0, nonphoto = 0;
+  for (int i = 0; i < kIters; i++) {
+    for (size_t y = 0; y < separation->ysize(); y++) {
+      uint16_t* JXL_RESTRICT s = separation->Row(y);
+      uint16_t* JXL_RESTRICT sp = separation->Row(y > 0 ? y - 1 : 0);
+      uint16_t* JXL_RESTRICT sn =
+          separation->Row(y + 1 < separation->ysize() ? y + 1 : y);
+      for (size_t x = 0; x < separation->xsize(); x++) {
+        bool W = (x > 0 ? s[x - 1] : s[x]) < kNonPhotoThreshold;
+        bool N = sp[x] < kNonPhotoThreshold;
+        bool NW = (x > 0 ? sp[x - 1] : sp[x]) < kNonPhotoThreshold;
+        bool E = (x + 1 < separation->xsize() ? s[x + 1] : s[x]) <
+                 kNonPhotoThreshold;
+        bool NE = (x + 1 < separation->xsize() ? sp[x + 1] : sp[x]) <
+                  kNonPhotoThreshold;
+        bool S = sn[x] < kNonPhotoThreshold;
+        bool SW = (x > 0 ? sn[x - 1] : sn[x]) < kNonPhotoThreshold;
+        bool SE = (x + 1 < separation->xsize() ? sn[x + 1] : sn[x]) <
+                  kNonPhotoThreshold;
+        int count = W + N + NW + E + NE + S + SW + SE;
+        if (count <= 2) s[x] = 0xffff;  // most neighbors are photo
+        if (count >= 7) s[x] = 0;       // most neighbors are nonphoto
+        if (!W && !E && count <= 5) s[x] = 0xffff;
+        if (!N && !S && count <= 5) s[x] = 0xffff;
+        if (i == kIters - 1) {
+          if (s[x] < kNonPhotoThreshold) {
+            s[x] = 0;
+            nonphoto++;
+          } else {
+            s[x] = 0xffff;
+            photo++;
+          }
+        }
+      }
+    }
+  }
+
+  return (nonphoto * 1.f / (nonphoto + photo));
+}
+
+void EncodeAndSubtract(Image3F* JXL_RESTRICT opsin, const ImageU& separation,
+                       const CompressParams& orig_cparams,
+                       PassesEncoderState* JXL_RESTRICT state, ThreadPool* pool,
+                       AuxOut* aux_out) {
+  size_t xsize = opsin->xsize();
+  size_t ysize = opsin->ysize();
+  Image3F nonphoto(xsize, ysize);
+  ZeroFillImage(&nonphoto);
+  for (size_t c = 0; c < 3; ++c) {
+    for (size_t y = 0; y < ysize; y++) {
+      const uint16_t* JXL_RESTRICT s = separation.Row(y / kSeparationRes);
+      float* JXL_RESTRICT p = opsin->PlaneRow(c, y);
+      float* JXL_RESTRICT np = nonphoto.PlaneRow(c, y);
+      for (size_t x = 0; x < xsize; x++) {
+        if (s[x / kSeparationRes] < kNonPhotoThreshold) {
+          np[x] = p[x];
+        }
+      }
+    }
+  }
+  CompressParams cparams = orig_cparams;
+  // TODO(jon): tweak quality settings
+  cparams.quality_pair.first = 75.f - cparams.butteraugli_distance * 12.f;
+  cparams.quality_pair.second = 100.f - cparams.butteraugli_distance * 4.f;
+  RoundtripPatchFrame(&nonphoto, state, 2, cparams, pool, true);
+
+  for (size_t c = 0; c < 3; ++c) {
+    for (size_t y = 0; y < ysize; y++) {
+      float* JXL_RESTRICT p = opsin->PlaneRow(c, y);
+      const float* JXL_RESTRICT np =
+          state->shared.reference_frames[2].frame->color()->ConstPlaneRow(c, y);
+      for (size_t x = 0; x < xsize; x++) {
+        p[x] -= np[x];
+      }
+    }
+  }
+
+  std::vector<PatchPosition> position;
+  PatchReferencePosition ref_pos;
+  ref_pos.xsize = xsize;
+  ref_pos.ysize = ysize;
+  ref_pos.x0 = 0;
+  ref_pos.y0 = 0;
+  ref_pos.ref = 2;
+  // Add color channels, ignore other channels.
+  std::vector<PatchBlending> blending_info(
+      state->shared.metadata->m.extra_channel_info.size() + 1,
+      PatchBlending{PatchBlendMode::kNone, 0, false});
+  blending_info[0].mode = PatchBlendMode::kAdd;
+  position.emplace_back(PatchPosition{0, 0, blending_info, ref_pos});
+
+  PatchDictionaryEncoder::SetPositions(&state->shared.image_features.patches,
+                                       std::move(position));
+}
+
+}  // namespace jxl

--- a/lib/jxl/enc_nonphoto_separation.h
+++ b/lib/jxl/enc_nonphoto_separation.h
@@ -1,0 +1,37 @@
+// Copyright (c) the JPEG XL Project Authors. All rights reserved.
+//
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+#ifndef LIB_JXL_ENC_NONPHOTO_SEPARATION_H_
+#define LIB_JXL_ENC_NONPHOTO_SEPARATION_H_
+
+// Separates nonphotographic and photographic parts of an image,
+// so VarDCT can be used for photographic parts and Modular for nonphoto
+
+#include "lib/jxl/aux_out_fwd.h"
+#include "lib/jxl/base/data_parallel.h"
+#include "lib/jxl/base/status.h"
+#include "lib/jxl/common.h"
+#include "lib/jxl/enc_cache.h"
+#include "lib/jxl/enc_params.h"
+#include "lib/jxl/image.h"
+
+namespace jxl {
+
+// Heuristic to split an image in a nonphoto and a photo part
+// `separation` is 0 for nonphoto and nonzero for photo parts
+// Returns fraction of the image that is nonphoto
+float FindSeparation(const Image3F& opsin, ImageU* separation,
+                     const CompressParams& cparams, ThreadPool* pool);
+
+// Encode the nonphoto part as a separate frame, and subtract the
+// decoded nonphoto frame from the remaining image
+void EncodeAndSubtract(Image3F* JXL_RESTRICT opsin, const ImageU& separation,
+                       const CompressParams& orig_cparams,
+                       PassesEncoderState* JXL_RESTRICT state, ThreadPool* pool,
+                       AuxOut* aux_out);
+
+}  // namespace jxl
+
+#endif  // LIB_JXL_ENC_NONPHOTO_SEPARATION_H_

--- a/lib/jxl/enc_params.h
+++ b/lib/jxl/enc_params.h
@@ -151,6 +151,7 @@ struct CompressParams {
   Override dots = Override::kDefault;
   Override patches = Override::kDefault;
   Override gaborish = Override::kDefault;
+  Override separate = Override::kOff;  // off for now, still experimental
   int epf = -1;
 
   // Progressive mode.

--- a/lib/jxl/enc_patch_dictionary.cc
+++ b/lib/jxl/enc_patch_dictionary.cc
@@ -602,9 +602,6 @@ std::vector<PatchInfo> FindTextLikePatches(
 void FindBestPatchDictionary(const Image3F& opsin,
                              PassesEncoderState* JXL_RESTRICT state,
                              ThreadPool* pool, AuxOut* aux_out, bool is_xyb) {
-  state->shared.image_features.patches = PatchDictionary();
-  state->shared.image_features.patches.SetPassesSharedState(&state->shared);
-
   std::vector<PatchInfo> info =
       FindTextLikePatches(opsin, state, pool, aux_out, is_xyb);
 
@@ -752,12 +749,38 @@ void FindBestPatchDictionary(const Image3F& opsin,
   }
 
   CompressParams cparams = state->cparams;
-  cparams.resampling = 1;
-  cparams.ec_resampling = 1;
   // Recursive application of patches could create very weird issues.
   cparams.patches = Override::kOff;
+  // TODO(veluca): possibly change heuristics here.
+  if (!cparams.modular_mode) {
+    cparams.quality_pair.first = cparams.quality_pair.second =
+        90.f - cparams.butteraugli_distance * 5.f;
+  }
+
+  RoundtripPatchFrame(
+      &reference_frame, state, 0, cparams, pool,
+      (!cparams.modular_mode && cparams.butteraugli_distance <
+                                    kMinButteraugliToSubtractOriginalPatches) ||
+          (cparams.modular_mode && cparams.quality_pair.first > 99));
+
+  // TODO(veluca): this assumes that applying patches is commutative, which is
+  // not true for all blending modes. This code only produces kAdd patches, so
+  // this works out.
+  std::sort(positions.begin(), positions.end());
+  PatchDictionaryEncoder::SetPositions(&state->shared.image_features.patches,
+                                       std::move(positions));
+}
+
+void RoundtripPatchFrame(Image3F* reference_frame,
+                         PassesEncoderState* JXL_RESTRICT state, int idx,
+                         CompressParams& cparams, ThreadPool* pool,
+                         bool subtract) {
+  FrameInfo patch_frame_info;
+  cparams.resampling = 1;
+  cparams.ec_resampling = 1;
   cparams.dots = Override::kOff;
   cparams.noise = Override::kOff;
+  cparams.separate = Override::kOff;
   cparams.modular_mode = true;
   cparams.responsive = 0;
   cparams.progressive_dc = 0;
@@ -765,31 +788,19 @@ void FindBestPatchDictionary(const Image3F& opsin,
   cparams.qprogressive_mode = false;
   // Use gradient predictor and not Predictor::Best.
   cparams.options.predictor = Predictor::Gradient;
-  // TODO(veluca): possibly change heuristics here.
-  if (!cparams.modular_mode) {
-    cparams.quality_pair.first = cparams.quality_pair.second =
-        80 - cparams.butteraugli_distance * 12;
-  } else {
-    cparams.quality_pair.first = (100 + 3 * cparams.quality_pair.first) * 0.25f;
-    cparams.quality_pair.second =
-        (100 + 3 * cparams.quality_pair.second) * 0.25f;
-  }
-  FrameInfo patch_frame_info;
-  patch_frame_info.save_as_reference = 0;  // always saved.
+  patch_frame_info.save_as_reference = idx;  // always saved.
   patch_frame_info.frame_type = FrameType::kReferenceOnly;
   patch_frame_info.save_before_color_transform = true;
-
   ImageBundle ib(&state->shared.metadata->m);
   // TODO(veluca): metadata.color_encoding is a lie: ib is in XYB, but there is
   // no simple way to express that yet.
   patch_frame_info.ib_needs_color_transform = false;
-  patch_frame_info.save_as_reference = 0;
-  ib.SetFromImage(std::move(reference_frame),
+  ib.SetFromImage(std::move(*reference_frame),
                   state->shared.metadata->m.color_encoding);
   if (!ib.metadata()->extra_channel_info.empty()) {
-    // Add dummy extra channels to the patch image: patches do not yet support
-    // extra channels, but the codec expects that the amount of extra channels
-    // in frames matches that in the metadata of the codestream.
+    // Add dummy extra channels to the patch image: patch encoding does not yet
+    // support extra channels, but the codec expects that the amount of extra
+    // channels in frames matches that in the metadata of the codestream.
     std::vector<ImageF> extra_channels;
     extra_channels.reserve(ib.metadata()->extra_channel_info.size());
     for (size_t i = 0; i < ib.metadata()->extra_channel_info.size(); i++) {
@@ -797,18 +808,17 @@ void FindBestPatchDictionary(const Image3F& opsin,
       // Must initialize the image with data to not affect blending with
       // uninitialized memory.
       // TODO(lode): patches must copy and use the real extra channels instead.
-      FillImage(1.0f, &extra_channels.back());
+      ZeroFillImage(&extra_channels.back());
     }
     ib.SetExtraChannels(std::move(extra_channels));
   }
-
   PassesEncoderState roundtrip_state;
   auto special_frame = std::unique_ptr<BitWriter>(new BitWriter());
   JXL_CHECK(EncodeFrame(cparams, patch_frame_info, state->shared.metadata, ib,
                         &roundtrip_state, pool, special_frame.get(), nullptr));
   const Span<const uint8_t> encoded = special_frame->GetSpan();
   state->special_frames.emplace_back(std::move(special_frame));
-  if (cparams.butteraugli_distance < kMinButteraugliToSubtractOriginalPatches) {
+  if (subtract) {
     BitReader br(encoded);
     ImageBundle decoded(&state->shared.metadata->m);
     PassesDecoderState dec_state;
@@ -818,19 +828,20 @@ void FindBestPatchDictionary(const Image3F& opsin,
             state->shared.metadata->m.color_encoding.IsGray())));
     JXL_CHECK(DecodeFrame({}, &dec_state, pool, &br, &decoded,
                           *state->shared.metadata, /*constraints=*/nullptr));
+    // if the frame itself uses patches, we need to decode another frame
+    if (!dec_state.shared_storage.reference_frames[idx]
+             .storage.color()
+             ->xsize())
+      JXL_CHECK(DecodeFrame({}, &dec_state, pool, &br, &decoded,
+                            *state->shared.metadata, /*constraints=*/nullptr));
     JXL_CHECK(br.Close());
-    state->shared.reference_frames[0] =
-        std::move(dec_state.shared_storage.reference_frames[0]);
+    state->shared.reference_frames[idx] =
+        std::move(dec_state.shared_storage.reference_frames[idx]);
   } else {
-    state->shared.reference_frames[0].storage = std::move(ib);
+    state->shared.reference_frames[idx].storage = std::move(ib);
   }
-  state->shared.reference_frames[0].frame =
-      &state->shared.reference_frames[0].storage;
-  // TODO(veluca): this assumes that applying patches is commutative, which is
-  // not true for all blending modes. This code only produces kAdd patches, so
-  // this works out.
-  std::sort(positions.begin(), positions.end());
-  PatchDictionaryEncoder::SetPositions(&state->shared.image_features.patches,
-                                       std::move(positions));
+  state->shared.reference_frames[idx].frame =
+      &state->shared.reference_frames[idx].storage;
 }
+
 }  // namespace jxl

--- a/lib/jxl/enc_patch_dictionary.h
+++ b/lib/jxl/enc_patch_dictionary.h
@@ -39,7 +39,12 @@ class PatchDictionaryEncoder {
 
   static void SetPositions(PatchDictionary* pdic,
                            std::vector<PatchPosition> positions) {
-    pdic->positions_ = std::move(positions);
+    if (pdic->positions_.empty()) {
+      pdic->positions_ = std::move(positions);
+    } else {
+      pdic->positions_.insert(pdic->positions_.end(), positions.begin(),
+                              positions.end());
+    }
     pdic->ComputePatchCache();
   }
 
@@ -50,6 +55,11 @@ void FindBestPatchDictionary(const Image3F& opsin,
                              PassesEncoderState* JXL_RESTRICT state,
                              ThreadPool* pool, AuxOut* aux_out,
                              bool is_xyb = true);
+
+void RoundtripPatchFrame(Image3F* reference_frame,
+                         PassesEncoderState* JXL_RESTRICT state, int idx,
+                         CompressParams& cparams, ThreadPool* pool,
+                         bool subtract);
 
 }  // namespace jxl
 

--- a/lib/lib.gni
+++ b/lib/lib.gni
@@ -268,6 +268,8 @@ libjxl_enc_sources = [
     "jxl/enc_modular.h",
     "jxl/enc_noise.cc",
     "jxl/enc_noise.h",
+    "jxl/enc_nonphoto_separation.cc",
+    "jxl/enc_nonphoto_separation.h",
     "jxl/enc_params.h",
     "jxl/enc_patch_dictionary.cc",
     "jxl/enc_patch_dictionary.h",

--- a/tools/benchmark/benchmark_codec_jxl.cc
+++ b/tools/benchmark/benchmark_codec_jxl.cc
@@ -195,6 +195,8 @@ class JxlCodec : public ImageCodec {
     } else if (param.substr(0, 16) == "faster_decoding=") {
       cparams_.decoding_speed_tier =
           strtol(param.substr(16).c_str(), nullptr, 10);
+    } else if (param == "separate") {
+      cparams_.separate = Override::kDefault;
     } else {
       return JXL_FAILURE("Unrecognized param");
     }

--- a/tools/cjxl.cc
+++ b/tools/cjxl.cc
@@ -404,6 +404,9 @@ void CompressArgs::AddCommandLineOptions(CommandLineParser* cmdline) {
   cmdline->AddOptionValue('\0', "num_reps", "N", "how many times to compress.",
                           &num_reps, &ParseUnsigned, 1);
 
+  cmdline->AddOptionValue('\0', "separate", "0|1",
+                          "force disable/enable photo/nonphoto separation.",
+                          &params.separate, &ParseOverride, 1);
   cmdline->AddOptionValue('\0', "noise", "0|1",
                           "force disable/enable noise generation.",
                           &params.noise, &ParseOverride, 1);


### PR DESCRIPTION
Experimental new encode option: use a heuristic to segment the image in a 'non-photographic' frame (encoded as one big Modular patch) and a 'photographic' frame (encoded with VarDCT).

Adds option `--separate` to `cjxl` and `:separate` to `benchmark_xl`.

For purely photographic images, nothing changes:
```
ClassA_8bit_WOMAN_2048x2560_8b_RGB.ppm.png
Encoding           kPixels    Bytes          BPP  E MP/s  D MP/s     Max norm        pnorm       BPP*pnorm   Bugs
-----------------------------------------------------------------------------------------------------------------
jxl                   5242  1012909    1.5455765   2.240  22.835   1.58223844   0.72176611  1.115544727980      0
jxl:separate          5242  1012909    1.5455765   2.209  22.227   1.58223844   0.72176611  1.115544727980      0
jxl:d2                5242   573982    0.8758270   2.293  26.302   2.50792503   1.14105979  0.999371004474      0
jxl:d2:separate       5242   573982    0.8758270   2.258  25.700   2.50792503   1.14105979  0.999371004474      0
jxl:d3                5242   405090    0.6181183   2.101  26.757   3.64472771   1.47448571  0.911406582982      0
jxl:d3:separate       5242   405090    0.6181183   2.057  25.487   3.64472771   1.47448571  0.911406582982      0
jxl:d4                5242   317770    0.4848785   2.173  23.465   5.19127607   1.77691296  0.861586962345      0
jxl:d4:separate       5242   317770    0.4848785   2.120  21.702   5.19127607   1.77691296  0.861586962345      0
jxl:d5                5242   253703    0.3871201   2.049  17.798   5.40515137   2.02050212  0.782176893495      0
jxl:d5:separate       5242   253703    0.3871201   2.016  16.311   5.40515137   2.02050212  0.782176893495      0
jxl:d8                5242   165478    0.2524994   2.104  12.066   8.57151699   2.81566771  0.710954377614      0
jxl:d8:separate       5242   165478    0.2524994   2.002  11.501   8.57151699   2.81566771  0.710954377614      0
Aggregate:            5242   382707    0.5839647   2.133  20.266   3.89252916   1.51882844  0.886942136940      0
```

For images with mixed content (photographic and non-photographic), e.g. screenshots, there is improvement in density and/or quality, at a significant cost in speed (since every pixel now has to be en/decoded twice, and modular is slower than vardct).

```
ClassD_APPLE_BasketBallScreen_2560x1440p_60_8b_sRGB_444_000.ppm.png
Encoding           kPixels    Bytes          BPP  E MP/s  D MP/s     Max norm        pnorm       BPP*pnorm   Bugs
-----------------------------------------------------------------------------------------------------------------
jxl                   3686   539560    1.1709201   1.740  22.284   1.86591029   0.59592572  0.697781424948      0
jxl:separate          3686   508903    1.1043902   0.686   4.030   1.86904216   0.58647276  0.647694768009      0
jxl:d2                3686   378848    0.8221528   1.789  23.700   3.60270667   0.93827879  0.771408511975      0
jxl:d2:separate       3686   386761    0.8393251   0.693   4.048   2.72729421   0.89300560  0.749521998627      0
jxl:d3                3686   304257    0.6602799   1.920  20.920   4.17911577   1.23043588  0.812432138116      0
jxl:d3:separate       3686   300881    0.6529536   0.678   4.075   3.40603662   1.15302044  0.752868800803      0
jxl:d4                3686   260803    0.5659787   1.757  13.622   5.61551571   1.53005294  0.865977425136      0
jxl:d4:separate       3686   260396    0.5650955   0.714   3.265   4.79680634   1.41190841  0.797863068805      0
jxl:d5                3686   230743    0.5007444   1.862  13.121   9.02261162   1.94301577  0.972954183865      0
jxl:d5:separate       3686   231775    0.5029839   0.733   3.812   5.08324289   1.62798567  0.818850646509      0
jxl:d8                3686   175870    0.3816623   1.842  13.084  11.13273525   2.79994567  1.068633777045      0
jxl:d8:separate       3686   176740    0.3835503   0.781   3.815   8.94032955   2.29880910  0.881709027172      0
Aggregate:            3686   293928    0.6378640   1.138   8.115   4.44799786   1.27394654  0.812604582185      0
```

Some random set of screenshots of web pages:

```
Encoding           kPixels    Bytes          BPP  E MP/s  D MP/s     Max norm        pnorm       BPP*pnorm   Bugs
-----------------------------------------------------------------------------------------------------------------
jxl                  36985  2849759    0.6164120   1.359  19.235   1.78403163   0.46892691  0.289052175402      0
jxl:separate         36985  2654679    0.5742156   0.522   2.690   1.86124766   0.47861078  0.274825765127      0
jxl:d2               36985  2099251    0.4540747   1.300  16.626   2.79433775   0.68565403  0.311338161781      0
jxl:d2:separate      36985  1973840    0.4269479   0.527   2.769   3.27381372   0.79201851  0.338150652521      0
jxl:d3               36985  1728765    0.3739374   1.278  16.897   3.59079909   0.92820842  0.347091851396      0
jxl:d3:separate      36985  1513837    0.3274478   0.526   2.773   3.94483590   1.01497889  0.332352599932      0
jxl:d4               36985  1514723    0.3276394   1.313   9.755   4.50415182   1.17167084  0.383885577253      0
jxl:d4:separate      36985  1311492    0.2836799   0.519   2.439   5.75397873   1.22489805  0.347478984859      0
jxl:d5               36985  1364146    0.2950692   1.306   9.542   5.63838196   1.34581602  0.397108792331      0
jxl:d5:separate      36985  1166335    0.2522820   0.526   2.432   5.85580349   1.42177396  0.358687977349      0
jxl:d8               36985  1098335    0.2375734   1.320   9.243   8.36438560   1.92916231  0.458317611681      0
jxl:d8:separate      36985   952220    0.2059682   0.523   2.493   8.84434223   2.00251733  0.412454966596      0
Aggregate:           36985  1595042    0.3450128   0.829   5.790   4.16484129   1.01657973  0.350732997284      0
```

A screenshot without photos:

```
nonphoto_JonScreenshot_1200x1400_8bit_sRGB.ppm
Encoding           kPixels    Bytes          BPP  E MP/s  D MP/s     Max norm        pnorm       BPP*pnorm   Bugs
-----------------------------------------------------------------------------------------------------------------
jxl                   1680   126861    0.6041000   1.522  23.253   1.45755124   0.48071558  0.290400280210      0
jxl:separate          1680    95937    0.4568429   0.663   3.988   1.97986507   0.51830797  0.236785291859      0
jxl:d2                1680   100106    0.4766952   1.551  23.522   2.04487586   0.59050652  0.281491644342      0
jxl:d2:separate       1680    83271    0.3965286   0.674   3.800   2.47553658   0.66703835  0.264499765771      0
jxl:d3                1680    84446    0.4021238   1.628  22.564   3.11525416   0.82836638  0.333105843060      0
jxl:d3:separate       1680    65852    0.3135810   0.645   4.012   3.45098448   0.88062276  0.276146523784      0
jxl:d4                1680    75510    0.3595714   1.385  12.150   3.51071453   0.96273206  0.346170943750      0
jxl:d4:separate       1680    59945    0.2854524   0.636   3.829   3.82543087   1.04554191  0.298452427438      0
jxl:d5                1680    68877    0.3279857   1.521   9.113   4.62320328   1.21067688  0.397084722550      0
jxl:d5:separate       1680    56307    0.2681286   0.775   4.081   4.57283163   1.24783859  0.334581178027      0
jxl:d8                1680    54622    0.2601048   1.734  13.062   7.50739479   1.96001851  0.509810148368      0
jxl:d8:separate       1680    46993    0.2237762   0.847   4.169   6.74285936   1.84275243  0.412364119521      0
Aggregate:            1680    73638    0.3506563   1.045   8.019   3.38426324   0.92516399  0.324414565760      0
```

A very simple non-photographic image:
```
nonphoto_Shoe_1200x1200_8bit_sRGB.ppm
Encoding           kPixels    Bytes          BPP  E MP/s  D MP/s     Max norm        pnorm       BPP*pnorm   Bugs
-----------------------------------------------------------------------------------------------------------------
jxl                   1440    68081    0.3782278   1.730  27.168   1.18159676   0.39840771  0.150688864381      0
jxl:separate          1440    14433    0.0801833   0.870   5.226   0.49221122   0.33553675  0.026904455382      0
jxl:d2                1440    52913    0.2939611   1.686  27.900   1.95478404   0.50796866  0.149323031257      0
jxl:d2:separate       1440    16281    0.0904500   0.866   5.105   0.81310773   0.26954522  0.024380365595      0
jxl:d3                1440    45853    0.2547389   1.692  24.646   3.08892727   0.72302095  0.184181552277      0
jxl:d3:separate       1440    13472    0.0748444   0.768   5.988   1.28829277   0.41423037  0.031002841866      0
jxl:d4                1440    40388    0.2243778   1.607  10.331   3.99391294   1.05776073  0.237338003073      0
jxl:d4:separate       1440    11794    0.0655222   0.803   3.648   1.28586423   0.41412423  0.027134339618      0
jxl:d5                1440    37490    0.2082778   1.717  12.042   5.47232533   1.44772728  0.301529420452      0
jxl:d5:separate       1440    10911    0.0606167   0.826   5.106   0.66365898   0.32848285  0.019911535201      0
jxl:d8                1440    27286    0.1515889   1.494  12.939   7.85023355   2.40268859  0.364220893387      0
jxl:d8:separate       1440    10870    0.0603889   0.912   5.214   1.56810331   0.40915836  0.024708618928      0
Aggregate:            1440    23624    0.1312456   1.178   9.385   1.75342885   0.56778812  0.074519716333      0
```

The heuristics can probably be improved a lot to get better results, this is mostly a proof of concept to show that A) something like this can be done, and B) it can give substantial improvements on (partially) nonphotographic images.

One issue that needs to be addressed before we can think about doing this by default is the decode speed impact.

Here is an example of an image decoded with `djxl -s 8` so you can see the nonphoto parts sharply (since they are encoded first, as a patch) and the photo parts blurred (since you see the upsampled DC):
![ClassD_APPLE_BasketBallScreen_2560x1440p_60_8b_sRGB_444_000 ppm png jxl](https://user-images.githubusercontent.com/15010068/129902950-7c0dc54d-aab4-4a80-bd66-eeed2d776e72.png)
