### PR TITLE
Iterative downsampling algorithm

### DIFF
--- a/lib/jxl/enc_heuristics.cc
+++ b/lib/jxl/enc_heuristics.cc
@@ -207,14 +207,54 @@ bool DefaultEncoderHeuristics::HandlesColorConversion(
          !cparams.modular_mode && !ib.HasAlpha();
 }
 
+namespace {
+
+void StoreMin2(const float v, float& min1, float& min2) {
+  if (v < min2) {
+    if (v < min1) {
+      min2 = min1;
+      min1 = v;
+    } else {
+      min2 = v;
+    }
+  }
+}
+
+void CreateMask(const ImageF& image, ImageF& mask) {
+  for (size_t y = 0; y < image.ysize(); y++) {
+    auto* row_n = y > 0 ? image.Row(y - 1) : image.Row(y);
+    auto* row_in = image.Row(y);
+    auto* row_s = y + 1 < image.ysize() ? image.Row(y + 1) : image.Row(y);
+    auto* row_out = mask.Row(y);
+    for (size_t x = 0; x < image.xsize(); x++) {
+      // Center, west, east, north, south values and their absolute difference
+      float c = row_in[x];
+      float w = x > 0 ? row_in[x - 1] : row_in[x];
+      float e = x + 1 < image.xsize() ? row_in[x + 1] : row_in[x];
+      float n = row_n[x];
+      float s = row_s[x];
+      float dw = std::abs(c - w);
+      float de = std::abs(c - e);
+      float dn = std::abs(c - n);
+      float ds = std::abs(c - s);
+      float min = std::numeric_limits<float>::max();
+      float min2 = std::numeric_limits<float>::max();
+      StoreMin2(dw, min, min2);
+      StoreMin2(de, min, min2);
+      StoreMin2(dn, min, min2);
+      StoreMin2(ds, min, min2);
+      row_out[x] = min2;
+    }
+  }
+}
+
 // Downsamples the image by a factor of 2 with a kernel that's sharper than
 // the standard 2x2 box kernel used by DownsampleImage.
 // The kernel is optimized against the result of the 2x2 upsampling kernel used
 // by the decoder. Ringing is slightly reduced by clamping the values of the
 // resulting pixels within certain bounds of a small region in the original
 // image.
-static void DownsampleImage2_Sharper(const ImageF& input, const ImageF& mask,
-                                     ImageF* output) {
+void DownsampleImage2_Sharper(const ImageF& input, ImageF* output) {
   const int64_t kernelx = 12;
   const int64_t kernely = 12;
 
@@ -271,6 +311,12 @@ static void DownsampleImage2_Sharper(const ImageF& input, const ImageF& mask,
   int64_t xsize = input.xsize();
   int64_t ysize = input.ysize();
 
+  ImageF box_downsample = CopyImage(input);
+  DownsampleImage(&box_downsample, 2);
+
+  ImageF mask(box_downsample.xsize(), box_downsample.ysize());
+  CreateMask(box_downsample, mask);
+
   for (size_t y = 0; y < output->ysize(); y++) {
     float* row_out = output->Row(y);
     const float* row_in[kernely];
@@ -287,8 +333,8 @@ static void DownsampleImage2_Sharper(const ImageF& input, const ImageF& mask,
       // get min and max values of the original image in the support
       float min = std::numeric_limits<float>::max();
       float max = std::numeric_limits<float>::min();
-      // kernelx - R and kernely - R are the radius of a square region in which
-      // the values of a pixel are bounded to reduce ringing.
+      // kernelx - R and kernely - R are the radius of a rectangular region in
+      // which the values of a pixel are bounded to reduce ringing.
       static constexpr int64_t R = 5;
       for (int64_t ky = R; ky + R < kernely; ky++) {
         for (int64_t kx = R; kx + R < kernelx; kx++) {
@@ -327,48 +373,6 @@ static void DownsampleImage2_Sharper(const ImageF& input, const ImageF& mask,
   }
 }
 
-static void GetMin2(const float v, float& min1, float& min2) {
-  if (v < min2) {
-    if (v < min1) {
-      min2 = min1;
-      min1 = v;
-    } else {
-      min2 = v;
-    }
-  }
-}
-
-void CreateMask(const Image3F& image, Image3F& mask) {
-  for (size_t c = 0; c < 3; c++) {
-    for (size_t y = 0; y < image.ysize(); y++) {
-      auto* row_n = y > 0 ? image.PlaneRow(c, y - 1) : image.PlaneRow(c, y);
-      auto* row_in = image.PlaneRow(c, y);
-      auto* row_s = y + 1 < image.ysize() ? image.PlaneRow(c, y + 1)
-                                          : image.PlaneRow(c, y);
-      auto* row_out = mask.PlaneRow(c, y);
-      for (size_t x = 0; x < image.xsize(); x++) {
-        // Center, west, east, north, south values and their absolute difference
-        float c = row_in[x];
-        float w = x > 0 ? row_in[x - 1] : row_in[x];
-        float e = x + 1 < image.xsize() ? row_in[x + 1] : row_in[x];
-        float n = row_n[x];
-        float s = row_s[x];
-        float dw = std::abs(c - w);
-        float de = std::abs(c - e);
-        float dn = std::abs(c - n);
-        float ds = std::abs(c - s);
-        float min = std::numeric_limits<float>::max();
-        float min2 = std::numeric_limits<float>::max();
-        GetMin2(dw, min, min2);
-        GetMin2(de, min, min2);
-        GetMin2(dn, min, min2);
-        GetMin2(ds, min, min2);
-        row_out[x] = min2;
-      }
-    }
-  }
-}
-
 void DownsampleImage2_Sharper(Image3F* opsin) {
   // Allocate extra space to avoid a reallocation when padding.
   Image3F downsampled(DivCeil(opsin->xsize(), 2) + kBlockDim,
@@ -376,18 +380,326 @@ void DownsampleImage2_Sharper(Image3F* opsin) {
   downsampled.ShrinkTo(downsampled.xsize() - kBlockDim,
                        downsampled.ysize() - kBlockDim);
 
-  Image3F box_downsample = CopyImage(*opsin);
-  DownsampleImage(&box_downsample, 2);
-
-  Image3F mask(box_downsample.xsize(), box_downsample.ysize());
-  CreateMask(box_downsample, mask);
-
   for (size_t c = 0; c < 3; c++) {
-    DownsampleImage2_Sharper(opsin->Plane(c), mask.Plane(c),
-                             &downsampled.Plane(c));
+    DownsampleImage2_Sharper(opsin->Plane(c), &downsampled.Plane(c));
   }
   *opsin = std::move(downsampled);
 }
+
+// The default upsampling kernels used by Upsampler in the decoder.
+static const constexpr int64_t kSize = 5;
+
+static const float kernel00[25] = {
+    -0.01716200f, -0.03452303f, -0.04022174f, -0.02921014f, -0.00624645f,
+    -0.03452303f, 0.14111091f,  0.28896755f,  0.00278718f,  -0.01610267f,
+    -0.04022174f, 0.28896755f,  0.56661550f,  0.03777607f,  -0.01986694f,
+    -0.02921014f, 0.00278718f,  0.03777607f,  -0.03144731f, -0.01185068f,
+    -0.00624645f, -0.01610267f, -0.01986694f, -0.01185068f, -0.00213539f,
+};
+static const float kernel01[25] = {
+    -0.00624645f, -0.01610267f, -0.01986694f, -0.01185068f, -0.00213539f,
+    -0.02921014f, 0.00278718f,  0.03777607f,  -0.03144731f, -0.01185068f,
+    -0.04022174f, 0.28896755f,  0.56661550f,  0.03777607f,  -0.01986694f,
+    -0.03452303f, 0.14111091f,  0.28896755f,  0.00278718f,  -0.01610267f,
+    -0.01716200f, -0.03452303f, -0.04022174f, -0.02921014f, -0.00624645f,
+};
+static const float kernel10[25] = {
+    -0.00624645f, -0.02921014f, -0.04022174f, -0.03452303f, -0.01716200f,
+    -0.01610267f, 0.00278718f,  0.28896755f,  0.14111091f,  -0.03452303f,
+    -0.01986694f, 0.03777607f,  0.56661550f,  0.28896755f,  -0.04022174f,
+    -0.01185068f, -0.03144731f, 0.03777607f,  0.00278718f,  -0.02921014f,
+    -0.00213539f, -0.01185068f, -0.01986694f, -0.01610267f, -0.00624645f,
+};
+static const float kernel11[25] = {
+    -0.00213539f, -0.01185068f, -0.01986694f, -0.01610267f, -0.00624645f,
+    -0.01185068f, -0.03144731f, 0.03777607f,  0.00278718f,  -0.02921014f,
+    -0.01986694f, 0.03777607f,  0.56661550f,  0.28896755f,  -0.04022174f,
+    -0.01610267f, 0.00278718f,  0.28896755f,  0.14111091f,  -0.03452303f,
+    -0.00624645f, -0.02921014f, -0.04022174f, -0.03452303f, -0.01716200f,
+};
+
+// Does exactly the same as the Upsampler in dec_upsampler for 2x2 pixels, with
+// default CustomTransformData.
+// TODO(lode): use Upsampler instead. However, it requires pre-initialization
+// and padding on the left side of the image which requires refactoring the
+// other code using this.
+static void UpsampleImage(const ImageF& input, ImageF* output) {
+  int64_t xsize = input.xsize();
+  int64_t ysize = input.ysize();
+  int64_t xsize2 = output->xsize();
+  int64_t ysize2 = output->ysize();
+  for (int64_t y = 0; y < ysize2; y++) {
+    for (int64_t x = 0; x < xsize2; x++) {
+      auto kernel = kernel00;
+      if ((x & 1) && (y & 1))
+        kernel = kernel11;
+      else if (x & 1)
+        kernel = kernel10;
+      else if (y & 1)
+        kernel = kernel01;
+      float sum = 0;
+      int64_t x2 = x / 2;
+      int64_t y2 = y / 2;
+
+      // get min and max values of the original image in the support
+      float min = std::numeric_limits<float>::max();
+      float max = std::numeric_limits<float>::min();
+
+      for (int64_t ky = 0; ky < kSize; ky++) {
+        for (int64_t kx = 0; kx < kSize; kx++) {
+          int64_t xi = x2 - kSize / 2 + kx;
+          int64_t yi = y2 - kSize / 2 + ky;
+          if (xi < 0) xi = 0;
+          if (xi >= xsize) xi = input.xsize() - 1;
+          if (yi < 0) yi = 0;
+          if (yi >= ysize) yi = input.ysize() - 1;
+          min = std::min<float>(min, input.Row(yi)[xi]);
+          max = std::max<float>(max, input.Row(yi)[xi]);
+        }
+      }
+
+      for (int64_t ky = 0; ky < kSize; ky++) {
+        for (int64_t kx = 0; kx < kSize; kx++) {
+          int64_t xi = x2 - kSize / 2 + kx;
+          int64_t yi = y2 - kSize / 2 + ky;
+          if (xi < 0) xi = 0;
+          if (xi >= xsize) xi = input.xsize() - 1;
+          if (yi < 0) yi = 0;
+          if (yi >= ysize) yi = input.ysize() - 1;
+          sum += input.Row(yi)[xi] * kernel[ky * kSize + kx];
+        }
+      }
+      output->Row(y)[x] = sum;
+      if (output->Row(y)[x] < min) output->Row(y)[x] = min;
+      if (output->Row(y)[x] > max) output->Row(y)[x] = max;
+    }
+  }
+}
+
+// Returns the derivative of Upsampler, with respect to input pixel x2, y2, to
+// output pixel x, y (ignoring the clamping).
+float UpsamplerDeriv(int64_t x2, int64_t y2, int64_t x, int64_t y) {
+  auto kernel = kernel00;
+  if ((x & 1) && (y & 1))
+    kernel = kernel11;
+  else if (x & 1)
+    kernel = kernel10;
+  else if (y & 1)
+    kernel = kernel01;
+
+  int64_t ix = x / 2;
+  int64_t iy = y / 2;
+  int64_t kx = x2 - ix + kSize / 2;
+  int64_t ky = y2 - iy + kSize / 2;
+
+  // This should not happen.
+  if (kx < 0 || kx >= kSize || ky < 0 || ky >= kSize) return 0;
+
+  return kernel[ky * kSize + kx];
+}
+
+// Apply the derivative of the Upsampler to the input, reversing the effect of
+// its coefficients. The output image is 2x2 times smaller than the input.
+void AntiUpsample(const ImageF& input, ImageF* d) {
+  int64_t xsize = input.xsize();
+  int64_t ysize = input.ysize();
+  int64_t xsize2 = d->xsize();
+  int64_t ysize2 = d->ysize();
+  int64_t k0 = kSize - 1;
+  int64_t k1 = kSize;
+  for (int64_t y2 = 0; y2 < ysize2; ++y2) {
+    auto* row = d->Row(y2);
+    for (int64_t x2 = 0; x2 < xsize2; ++x2) {
+      int64_t x0 = x2 * 2 - k0;
+      if (x0 < 0) x0 = 0;
+      int64_t x1 = x2 * 2 + k1 + 1;
+      if (x1 > xsize) x1 = xsize;
+      int64_t y0 = y2 * 2 - k0;
+      if (y0 < 0) y0 = 0;
+      int64_t y1 = y2 * 2 + k1 + 1;
+      if (y1 > ysize) y1 = ysize;
+
+      float sum = 0;
+      for (int64_t y = y0; y < y1; ++y) {
+        const auto* row_in = input.Row(y);
+        for (int64_t x = x0; x < x1; ++x) {
+          double deriv = UpsamplerDeriv(x2, y2, x, y);
+          sum += deriv * row_in[x];
+        }
+      }
+      row[x2] = sum;
+    }
+  }
+}
+
+// Element-wise multiplies two images.
+template <typename T>
+void ElwiseMul(const Plane<T>& image1, const Plane<T>& image2, Plane<T>* out) {
+  const size_t xsize = image1.xsize();
+  const size_t ysize = image1.ysize();
+  JXL_CHECK(xsize == image2.xsize());
+  JXL_CHECK(ysize == image2.ysize());
+  JXL_CHECK(xsize == out->xsize());
+  JXL_CHECK(ysize == out->ysize());
+  for (size_t y = 0; y < ysize; ++y) {
+    const T* const JXL_RESTRICT row1 = image1.Row(y);
+    const T* const JXL_RESTRICT row2 = image2.Row(y);
+    T* const JXL_RESTRICT row_out = out->Row(y);
+    for (size_t x = 0; x < xsize; ++x) {
+      row_out[x] = row1[x] * row2[x];
+    }
+  }
+}
+
+// Element-wise divides two images.
+template <typename T>
+void ElwiseDiv(const Plane<T>& image1, const Plane<T>& image2, Plane<T>* out) {
+  const size_t xsize = image1.xsize();
+  const size_t ysize = image1.ysize();
+  JXL_CHECK(xsize == image2.xsize());
+  JXL_CHECK(ysize == image2.ysize());
+  JXL_CHECK(xsize == out->xsize());
+  JXL_CHECK(ysize == out->ysize());
+  for (size_t y = 0; y < ysize; ++y) {
+    const T* const JXL_RESTRICT row1 = image1.Row(y);
+    const T* const JXL_RESTRICT row2 = image2.Row(y);
+    T* const JXL_RESTRICT row_out = out->Row(y);
+    for (size_t x = 0; x < xsize; ++x) {
+      row_out[x] = row1[x] / row2[x];
+    }
+  }
+}
+
+void ReduceRinging(const ImageF& initial, const ImageF& mask, ImageF& down) {
+  int64_t xsize2 = down.xsize();
+  int64_t ysize2 = down.ysize();
+
+  for (size_t y = 0; y < down.ysize(); y++) {
+    const float* row_mask = mask.Row(y);
+    float* row_out = down.Row(y);
+    for (size_t x = 0; x < down.xsize(); x++) {
+      float v = down.Row(y)[x];
+      float min = initial.Row(y)[x];
+      float max = initial.Row(y)[x];
+      for (int64_t yi = -1; yi < 2; yi++) {
+        for (int64_t xi = -1; xi < 2; xi++) {
+          int64_t x2 = (int64_t)x + xi;
+          int64_t y2 = (int64_t)y + yi;
+          if (x2 < 0 || y2 < 0 || x2 >= (int64_t)xsize2 ||
+              y2 >= (int64_t)ysize2)
+            continue;
+          min = std::min<float>(min, initial.Row(y2)[x2]);
+          max = std::max<float>(max, initial.Row(y2)[x2]);
+        }
+      }
+
+      row_out[x] = v;
+
+      // Clamp the pixel within the value  of a small area to prevent ringning.
+      // The mask determines how much to clamp, clamp more to reduce more
+      // ringing in smooth areas, clamp less in noisy areas to get more
+      // sharpness. Higher mask_multiplier gives less clamping, so less
+      // ringing reduction.
+      const constexpr float mask_multiplier = 2;
+      float a = row_mask[x] * mask_multiplier;
+      float clip_min = min - a;
+      float clip_max = max + a;
+      if (row_out[x] < clip_min) row_out[x] = clip_min;
+      if (row_out[x] > clip_max) row_out[x] = clip_max;
+    }
+  }
+}
+
+// TODO(lode): move this to a separate file enc_downsample.cc
+void DownsampleImage2_Iterative(const ImageF& orig, ImageF* output) {
+  int64_t xsize = orig.xsize();
+  int64_t ysize = orig.ysize();
+  int64_t xsize2 = DivCeil(orig.xsize(), 2);
+  int64_t ysize2 = DivCeil(orig.ysize(), 2);
+
+  ImageF box_downsample = CopyImage(orig);
+  DownsampleImage(&box_downsample, 2);
+  ImageF mask(box_downsample.xsize(), box_downsample.ysize());
+  CreateMask(box_downsample, mask);
+
+  output->ShrinkTo(xsize2, ysize2);
+
+  // Initial result image using the sharper downsampling.
+  // Allocate extra space to avoid a reallocation when padding.
+  ImageF initial(DivCeil(orig.xsize(), 2) + kBlockDim,
+                 DivCeil(orig.ysize(), 2) + kBlockDim);
+  initial.ShrinkTo(initial.xsize() - kBlockDim, initial.ysize() - kBlockDim);
+  DownsampleImage2_Sharper(orig, &initial);
+
+  ImageF down = CopyImage(initial);
+  ImageF up(xsize, ysize);
+  ImageF corr(xsize, ysize);
+  ImageF corr2(xsize2, ysize2);
+
+  // In the weights map, relatively higher values will allow less ringing but
+  // also less sharpness. With all constant values, it optimizes equally
+  // everywhere. Even in this case, the weights2 computed from
+  // this is still used and differs at the borders of the image.
+  // TODO(lode): Make use of the weights field for anti-ringing and clamping,
+  // the values are all set to 1 for now, but it is intended to be used for
+  // reducing ringing based on the mask, and taking clamping into account.
+  ImageF weights(xsize, ysize);
+  for (size_t y = 0; y < weights.ysize(); y++) {
+    auto* row = weights.Row(y);
+    for (size_t x = 0; x < weights.xsize(); x++) {
+      row[x] = 1;
+    }
+  }
+  ImageF weights2(xsize2, ysize2);
+  AntiUpsample(weights, &weights2);
+
+  const size_t num_it = 3;
+  for (size_t it = 0; it < num_it; ++it) {
+    UpsampleImage(down, &up);
+    corr = LinComb<float>(1, orig, -1, up);
+    ElwiseMul(corr, weights, &corr);
+    AntiUpsample(corr, &corr2);
+    ElwiseDiv(corr2, weights2, &corr2);
+
+    down = LinComb<float>(1, down, 1, corr2);
+  }
+
+  ReduceRinging(initial, mask, down);
+
+  // can't just use CopyImage, because the output image was prepared with
+  // padding.
+  for (size_t y = 0; y < down.ysize(); y++) {
+    for (size_t x = 0; x < down.xsize(); x++) {
+      float v = down.Row(y)[x];
+      output->Row(y)[x] = v;
+    }
+  }
+}
+
+void DownsampleImage2_Iterative(Image3F* opsin) {
+  // Allocate extra space to avoid a reallocation when padding.
+  Image3F downsampled(DivCeil(opsin->xsize(), 2) + kBlockDim,
+                      DivCeil(opsin->ysize(), 2) + kBlockDim);
+  downsampled.ShrinkTo(downsampled.xsize() - kBlockDim,
+                       downsampled.ysize() - kBlockDim);
+
+  Image3F rgb(opsin->xsize(), opsin->ysize());
+  OpsinParams opsin_params;  // TODO: use the ones that are actually used
+  opsin_params.Init(kDefaultIntensityTarget);
+  OpsinToLinear(*opsin, Rect(rgb), nullptr, &rgb, opsin_params);
+
+  ImageF mask(opsin->xsize(), opsin->ysize());
+  ButteraugliParams butter_params;
+  ButteraugliComparator butter(rgb, butter_params);
+  butter.Mask(&mask);
+  ImageF mask_fuzzy(opsin->xsize(), opsin->ysize());
+
+  for (size_t c = 0; c < 3; c++) {
+    DownsampleImage2_Iterative(opsin->Plane(c), &downsampled.Plane(c));
+  }
+  *opsin = std::move(downsampled);
+}
+}  // namespace
 
 Status DefaultEncoderHeuristics::LossyFrameHeuristics(
     PassesEncoderState* enc_state, ModularFrameEncoder* modular_frame_encoder,
@@ -436,7 +748,17 @@ Status DefaultEncoderHeuristics::LossyFrameHeuristics(
     // In VarDCT mode, LossyFrameHeuristics takes care of running downsampling
     // after noise, if necessary.
     if (cparams.resampling == 2) {
-      DownsampleImage2_Sharper(opsin);
+      // TODO(lode): use the regular DownsampleImage, or adapt to the custom
+      // coefficients, if there is are custom upscaling coefficients in
+      // CustomTransformData
+      if (cparams.speed_tier <= SpeedTier::kSquirrel) {
+        // TODO(lode): DownsampleImage2_Iterative is currently too slow to
+        // be used for squirrel, make it faster, and / or enable it only for
+        // kitten.
+        DownsampleImage2_Iterative(opsin);
+      } else {
+        DownsampleImage2_Sharper(opsin);
+      }
     } else {
       DownsampleImage(opsin, cparams.resampling);
     }

--- a/lib/jxl/jxl_test.cc
+++ b/lib/jxl/jxl_test.cc
@@ -218,10 +218,10 @@ TEST(JxlTest, RoundtripResample2) {
   cparams.resampling = 2;
   DecompressParams dparams;
   CodecInOut io2;
-  EXPECT_LE(Roundtrip(&io, cparams, dparams, pool, &io2), 16000);
+  EXPECT_LE(Roundtrip(&io, cparams, dparams, pool, &io2), 16900);
   EXPECT_LE(ButteraugliDistance(io, io2, cparams.ba_params,
                                 /*distmap=*/nullptr, pool),
-            12.5);
+            12);
 }
 TEST(JxlTest, RoundtripResample2MT) {
   ThreadPoolInternal pool(4);
@@ -236,11 +236,11 @@ TEST(JxlTest, RoundtripResample2MT) {
   CodecInOut io2;
   // TODO(veluca): Figure out why msan and release produce different
   // file size.
-  EXPECT_LE(Roundtrip(&io, cparams, dparams, &pool, &io2), 60000);
+  EXPECT_LE(Roundtrip(&io, cparams, dparams, &pool, &io2), 64500);
   EXPECT_LE(ButteraugliDistance(io, io2, cparams.ba_params,
                                 /*distmap=*/nullptr, &pool),
 #if JXL_HIGH_PRECISION
-            6);
+            5.5);
 #else
             13.5);
 #endif


### PR DESCRIPTION
Add iterative downsampling algorithm (designed by Jyrki) in addition to the sharper downsampling with fixed 12x12 kernel, which optimizes the result per-pixel.

Ringing reduction is done with a mask after the optimization. Future MR's can perform ringing reduction, as well as take clamping into account, during the iterations.

The results have less jagged edges, less ringing artefacts and look sharper than the fixed 12x12 kernel.

Before:

```
Encoding                kPixels    Bytes          BPP  E MP/s  D MP/s     Max norm        pnorm   PSNR   QABPP  SmallB  DCT4x8     AFV  DCT8x8    8x16    8x32      16   16x32      32   32x64      64       BPP*pnorm   Bugs
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
jxl:resampling=2:d12      19569   222570    0.0909848   3.916  23.334  38.65586853   9.60127382  25.71   2.735  0.0307  1.1528  0.1815  0.3522  2.6163  0.0000  2.1715 11.2500  7.6395  0.0105  0.0000  0.873570344989      0
jxl:resampling=2:d11      19569   236570    0.0967079   4.113  22.799  37.15847015   9.06648500  25.86   2.762  0.0432  1.3045  0.2083  0.3987  2.7020  0.0000  2.3429 11.0590  7.3360  0.0105  0.0000  0.876800964287      0
jxl:resampling=2:d10      19569   252326    0.1031489   4.065  21.428  37.18645096   8.55468807  26.03   2.792  0.0566  1.4720  0.2414  0.4837  2.8504  0.0000  2.4528 11.0354  6.8023  0.0105  0.0000  0.882406265000      0
jxl:resampling=2:d9       19569   273430    0.1117760   3.971  22.226  35.55849075   7.93410261  26.21   2.761  0.0759  1.6862  0.2646  0.5612  2.9727  0.0000  2.5796 10.8130  6.4517  0.0000  0.0000  0.886842253123      0
jxl:resampling=2:d8       19569   299540    0.1224496   3.964  22.522  37.61449814   7.38192059  26.43   2.851  0.1001  1.9112  0.3035  0.6740  3.1382  0.0000  2.7719 10.4101  6.0959  0.0000  0.0000  0.903912924211      0
jxl:resampling=2:d7       19569   333347    0.1362696   3.921  23.021  36.45663071   6.77111795  26.69   2.907  0.1220  2.2225  0.3565  0.7620  3.3220  0.0000  2.9041  9.9915  5.7244  0.0000  0.0000  0.922697473638      0
jxl:resampling=2:d6       19569   378281    0.1546383   3.811  20.978  41.24525070   6.08733749  27.03   2.943  0.1472  2.4989  0.4170  0.8238  3.4541  0.0000  3.0048  9.7482  5.3110  0.0000  0.0000  0.941335223593      0
jxl:resampling=2:d5       19569   437874    0.1789994   3.894  23.437  34.56504059   5.36175100  27.41   2.908  0.1916  2.8848  0.4719  0.9062  3.5758  0.0000  3.0349  9.2171  5.1227  0.0000  0.0000  0.959750177646      0
jxl:resampling=2:d4       19569   523464    0.2139879   3.922  22.705  34.54360962   4.71677790  27.82   2.980  0.2358  3.4528  0.5419  1.0449  3.7321  0.0000  3.2376  8.3668  4.7930  0.0000  0.0000  1.009333407764      0
jxl:resampling=2:d3       19569   653550    0.2671660   3.824  24.593  33.02649307   4.07540064  28.24   3.170  0.3162  4.3384  0.6335  1.2319  3.9538  0.0000  3.5189  7.0953  4.3168  0.0000  0.0000  1.088808567452      0
jxl:resampling=2:d2       19569   875677    0.3579698   3.951  24.614  31.77740288   3.60432816  28.72   3.929  0.4232  5.5341  0.6920  1.3948  4.2011  0.0000  4.5052  4.9918  3.6628  0.0000  0.0000  1.290240499009      0
jxl:resampling=2:d1       19569  1351305    0.5524027   3.918  23.759  28.76305008   3.30118116  29.16   5.595  0.4585  7.1231  0.6390  1.8177  4.4725  0.0000  6.3445  1.8706  2.6791  0.0000  0.0000  1.823581356748      0
Aggregate:                19569   412573    0.1686566   3.938  22.927  35.39924265   6.00636770  27.09   3.122  0.1322  2.5260  0.3753  0.7760  3.3691  0.0000  3.0940  8.0754  5.2843  0.0105  0.0000  1.013013790344      0
```

After:

```
Encoding                kPixels    Bytes          BPP  E MP/s  D MP/s     Max norm        pnorm   PSNR   QABPP  SmallB  DCT4x8     AFV  DCT8x8    8x16    8x32      16   16x32      32   32x64      64       BPP*pnorm   Bugs
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
jxl:resampling=2:d12      19569   240329    0.0982446   0.491  24.362  32.99139786   8.54311807  26.07   2.592  0.0219  1.2251  0.1691  0.3745  2.7929  0.0000  2.3272 11.3154  7.1790  0.0000  0.0000  0.839315008656      0
jxl:resampling=2:d11      19569   256115    0.1046978   0.499  24.509  31.88960648   8.06357225  26.23   2.663  0.0320  1.4108  0.1933  0.4330  2.9237  0.0000  2.4724 11.1689  6.7709  0.0000  0.0000  0.844238003083      0
jxl:resampling=2:d10      19569   272917    0.1115663   0.497  24.269  33.17551041   7.63593687  26.40   2.689  0.0422  1.5904  0.2185  0.5183  3.0682  0.0000  2.5639 10.9674  6.4360  0.0000  0.0000  0.851913144616      0
jxl:resampling=2:d9       19569   294599    0.1204297   0.500  24.026  33.59854126   7.16272533  26.57   2.746  0.0562  1.8258  0.2518  0.5959  3.1997  0.0000  2.6869 10.6822  6.1064  0.0000  0.0000  0.862604992679      0
jxl:resampling=2:d8       19569   321175    0.1312938   0.495  23.871  36.60672379   6.66613532  26.78   2.705  0.0752  2.0822  0.2907  0.6851  3.4097  0.0000  2.8740 10.3316  5.6564  0.0000  0.0000  0.875222067618      0
jxl:resampling=2:d7       19569   356855    0.1458795   0.498  23.883  41.36652756   6.16651901  27.03   2.761  0.1004  2.3913  0.3368  0.7973  3.5699  0.0000  2.9956  9.9968  5.2168  0.0000  0.0000  0.899568547238      0
jxl:resampling=2:d6       19569   404992    0.1655575   0.491  24.091  33.81350708   5.53510594  27.40   2.764  0.1190  2.7131  0.3931  0.9049  3.6255  0.0000  3.0689  9.5572  5.0232  0.0000  0.0000  0.916378271956      0
jxl:resampling=2:d5       19569   471713    0.1928325   0.498  23.974  35.62249374   4.97003952  27.81   2.962  0.1599  3.1359  0.4523  0.9772  3.6896  0.0000  3.0793  9.1020  4.8087  0.0000  0.0000  0.958385178840      0
jxl:resampling=2:d4       19569   562272    0.2298523   0.498  24.082  32.60614777   4.32896088  28.27   2.925  0.2015  3.7579  0.5180  1.1237  3.8616  0.0000  3.2900  8.2412  4.4110  0.0000  0.0000  0.995021626266      0
jxl:resampling=2:d3       19569   698860    0.2856884   0.497  27.201  28.92568398   3.72299992  28.74   3.112  0.2502  4.7348  0.6040  1.2888  4.0251  0.0000  3.6157  6.9043  3.9820  0.0000  0.0000  1.063617837045      0
jxl:resampling=2:d2       19569   932772    0.3813097   0.494  26.285  29.37020302   3.20209677  29.27   3.660  0.3329  5.9651  0.6475  1.4759  4.2122  0.0000  4.5955  4.8741  3.3017  0.0000  0.0000  1.220990694821      0
jxl:resampling=2:d1       19569  1432183    0.5854650   0.498  25.017  27.72473335   2.82789307  29.77   5.173  0.3745  7.5640  0.6024  1.8206  4.4764  0.0000  6.4413  1.6299  2.4959  0.0000  0.0000  1.655632333276      0
Aggregate:                19569   442841    0.1810298   0.496  24.611  32.95825069   5.40511433  27.50   3.003  0.1035  2.7291  0.3536  0.8213  3.5364  0.0000  3.1959  7.9115  4.9116  0.0000  0.0000  0.978486668034      0
```
