### PR TITLE
refactor and fix patch frame encoding

### DIFF
--- a/lib/jxl/enc_frame.cc
+++ b/lib/jxl/enc_frame.cc
@@ -1131,6 +1131,10 @@ Status EncodeFrame(const CompressParams& cparams_orig,
 
   const std::vector<ImageF>* extra_channels = &ib.extra_channels();
   std::vector<ImageF> extra_channels_storage;
+  // Clear patches
+  passes_enc_state->shared.image_features.patches = PatchDictionary();
+  passes_enc_state->shared.image_features.patches.SetPassesSharedState(
+      &passes_enc_state->shared);
 
   if (ib.IsJPEG()) {
     JXL_RETURN_IF_ERROR(lossy_frame_encoder.ComputeJPEGTranscodingData(
@@ -1164,6 +1168,7 @@ Status EncodeFrame(const CompressParams& cparams_orig,
     bool lossless = (frame_header->encoding == FrameEncoding::kModular &&
                      cparams.quality_pair.first == 100);
     if (ib.HasAlpha() && !ib.AlphaIsPremultiplied() &&
+        frame_header->frame_type == FrameType::kRegularFrame &&
         !ApplyOverride(cparams.keep_invisible, lossless) &&
         cparams.ec_resampling == cparams.resampling) {
       // simplify invisible pixels

--- a/lib/jxl/enc_modular.cc
+++ b/lib/jxl/enc_modular.cc
@@ -731,10 +731,9 @@ Status ModularFrameEncoder::ComputeEncodingData(
       // assuming default Squeeze here
       int component = ((i - gi.nb_meta_channels) % nb_chans);
       // last 4 channels are final chroma residuals
-      if (nb_chans > 2 && i >= gi.channel.size() - 4) {
+      if (nb_chans > 2 && i >= gi.channel.size() - 4 && cparams.responsive) {
         component = 1;
       }
-
       if (cparams.color_transform == ColorTransform::kXYB && component < 3) {
         q = (component == 0 ? quality : cquality) * squeeze_quality_factor_xyb *
             squeeze_xyb_qtable[component][shift];

--- a/lib/jxl/enc_patch_dictionary.cc
+++ b/lib/jxl/enc_patch_dictionary.cc
@@ -602,9 +602,6 @@ std::vector<PatchInfo> FindTextLikePatches(
 void FindBestPatchDictionary(const Image3F& opsin,
                              PassesEncoderState* JXL_RESTRICT state,
                              ThreadPool* pool, AuxOut* aux_out, bool is_xyb) {
-  state->shared.image_features.patches = PatchDictionary();
-  state->shared.image_features.patches.SetPassesSharedState(&state->shared);
-
   std::vector<PatchInfo> info =
       FindTextLikePatches(opsin, state, pool, aux_out, is_xyb);
 
@@ -752,10 +749,31 @@ void FindBestPatchDictionary(const Image3F& opsin,
   }
 
   CompressParams cparams = state->cparams;
-  cparams.resampling = 1;
-  cparams.ec_resampling = 1;
   // Recursive application of patches could create very weird issues.
   cparams.patches = Override::kOff;
+  // TODO(veluca): possibly change heuristics here.
+  if (!cparams.modular_mode) {
+    cparams.quality_pair.first = cparams.quality_pair.second =
+        90.f - cparams.butteraugli_distance * 5.f;
+  }
+
+  RoundtripPatchFrame(&reference_frame, state, 0, cparams, pool, true);
+
+  // TODO(veluca): this assumes that applying patches is commutative, which is
+  // not true for all blending modes. This code only produces kAdd patches, so
+  // this works out.
+  std::sort(positions.begin(), positions.end());
+  PatchDictionaryEncoder::SetPositions(&state->shared.image_features.patches,
+                                       std::move(positions));
+}
+
+void RoundtripPatchFrame(Image3F* reference_frame,
+                         PassesEncoderState* JXL_RESTRICT state, int idx,
+                         CompressParams& cparams, ThreadPool* pool,
+                         bool subtract) {
+  FrameInfo patch_frame_info;
+  cparams.resampling = 1;
+  cparams.ec_resampling = 1;
   cparams.dots = Override::kOff;
   cparams.noise = Override::kOff;
   cparams.modular_mode = true;
@@ -765,31 +783,19 @@ void FindBestPatchDictionary(const Image3F& opsin,
   cparams.qprogressive_mode = false;
   // Use gradient predictor and not Predictor::Best.
   cparams.options.predictor = Predictor::Gradient;
-  // TODO(veluca): possibly change heuristics here.
-  if (!cparams.modular_mode) {
-    cparams.quality_pair.first = cparams.quality_pair.second =
-        80 - cparams.butteraugli_distance * 12;
-  } else {
-    cparams.quality_pair.first = (100 + 3 * cparams.quality_pair.first) * 0.25f;
-    cparams.quality_pair.second =
-        (100 + 3 * cparams.quality_pair.second) * 0.25f;
-  }
-  FrameInfo patch_frame_info;
-  patch_frame_info.save_as_reference = 0;  // always saved.
+  patch_frame_info.save_as_reference = idx;  // always saved.
   patch_frame_info.frame_type = FrameType::kReferenceOnly;
   patch_frame_info.save_before_color_transform = true;
-
   ImageBundle ib(&state->shared.metadata->m);
   // TODO(veluca): metadata.color_encoding is a lie: ib is in XYB, but there is
   // no simple way to express that yet.
   patch_frame_info.ib_needs_color_transform = false;
-  patch_frame_info.save_as_reference = 0;
-  ib.SetFromImage(std::move(reference_frame),
+  ib.SetFromImage(std::move(*reference_frame),
                   state->shared.metadata->m.color_encoding);
   if (!ib.metadata()->extra_channel_info.empty()) {
-    // Add dummy extra channels to the patch image: patches do not yet support
-    // extra channels, but the codec expects that the amount of extra channels
-    // in frames matches that in the metadata of the codestream.
+    // Add dummy extra channels to the patch image: patch encoding does not yet
+    // support extra channels, but the codec expects that the amount of extra
+    // channels in frames matches that in the metadata of the codestream.
     std::vector<ImageF> extra_channels;
     extra_channels.reserve(ib.metadata()->extra_channel_info.size());
     for (size_t i = 0; i < ib.metadata()->extra_channel_info.size(); i++) {
@@ -797,18 +803,17 @@ void FindBestPatchDictionary(const Image3F& opsin,
       // Must initialize the image with data to not affect blending with
       // uninitialized memory.
       // TODO(lode): patches must copy and use the real extra channels instead.
-      FillImage(1.0f, &extra_channels.back());
+      ZeroFillImage(&extra_channels.back());
     }
     ib.SetExtraChannels(std::move(extra_channels));
   }
-
   PassesEncoderState roundtrip_state;
   auto special_frame = std::unique_ptr<BitWriter>(new BitWriter());
   JXL_CHECK(EncodeFrame(cparams, patch_frame_info, state->shared.metadata, ib,
                         &roundtrip_state, pool, special_frame.get(), nullptr));
   const Span<const uint8_t> encoded = special_frame->GetSpan();
   state->special_frames.emplace_back(std::move(special_frame));
-  if (cparams.butteraugli_distance < kMinButteraugliToSubtractOriginalPatches) {
+  if (subtract) {
     BitReader br(encoded);
     ImageBundle decoded(&state->shared.metadata->m);
     PassesDecoderState dec_state;
@@ -818,19 +823,20 @@ void FindBestPatchDictionary(const Image3F& opsin,
             state->shared.metadata->m.color_encoding.IsGray())));
     JXL_CHECK(DecodeFrame({}, &dec_state, pool, &br, &decoded,
                           *state->shared.metadata, /*constraints=*/nullptr));
+    // if the frame itself uses patches, we need to decode another frame
+    if (!dec_state.shared_storage.reference_frames[idx]
+             .storage.color()
+             ->xsize())
+      JXL_CHECK(DecodeFrame({}, &dec_state, pool, &br, &decoded,
+                            *state->shared.metadata, /*constraints=*/nullptr));
     JXL_CHECK(br.Close());
-    state->shared.reference_frames[0] =
-        std::move(dec_state.shared_storage.reference_frames[0]);
+    state->shared.reference_frames[idx] =
+        std::move(dec_state.shared_storage.reference_frames[idx]);
   } else {
-    state->shared.reference_frames[0].storage = std::move(ib);
+    state->shared.reference_frames[idx].storage = std::move(ib);
   }
-  state->shared.reference_frames[0].frame =
-      &state->shared.reference_frames[0].storage;
-  // TODO(veluca): this assumes that applying patches is commutative, which is
-  // not true for all blending modes. This code only produces kAdd patches, so
-  // this works out.
-  std::sort(positions.begin(), positions.end());
-  PatchDictionaryEncoder::SetPositions(&state->shared.image_features.patches,
-                                       std::move(positions));
+  state->shared.reference_frames[idx].frame =
+      &state->shared.reference_frames[idx].storage;
 }
+
 }  // namespace jxl

--- a/lib/jxl/enc_patch_dictionary.h
+++ b/lib/jxl/enc_patch_dictionary.h
@@ -39,7 +39,12 @@ class PatchDictionaryEncoder {
 
   static void SetPositions(PatchDictionary* pdic,
                            std::vector<PatchPosition> positions) {
-    pdic->positions_ = std::move(positions);
+    if (pdic->positions_.empty()) {
+      pdic->positions_ = std::move(positions);
+    } else {
+      pdic->positions_.insert(pdic->positions_.end(), positions.begin(),
+                              positions.end());
+    }
     pdic->ComputePatchCache();
   }
 
@@ -50,6 +55,11 @@ void FindBestPatchDictionary(const Image3F& opsin,
                              PassesEncoderState* JXL_RESTRICT state,
                              ThreadPool* pool, AuxOut* aux_out,
                              bool is_xyb = true);
+
+void RoundtripPatchFrame(Image3F* reference_frame,
+                         PassesEncoderState* JXL_RESTRICT state, int idx,
+                         CompressParams& cparams, ThreadPool* pool,
+                         bool subtract);
 
 }  // namespace jxl
 


### PR DESCRIPTION
Refactors the patch frame encoding into a separate function (preparing for https://github.com/libjxl/libjxl/pull/466).

Also fixes a regression in patch frame encoding that caused the modular quality of patch frames to be set incorrectly: it was basically always (almost) lossless. Setting it correctly gives considerable bpp*pnorm savings. The heuristic that would skip correct subtraction of decoded patches at d >= 3 has to be disabled, because with lossy patches it is important to subtract the decoded patches at all distances (otherwise pnorm suffers a lot).

Also fixes a bug in modular non-squeeze lossy. It magically doesn't change anything in the case of 3-channel images, because uint overflow would make the condition fail anyway, but for images with > 3 channels it would incorrectly make e.g. alpha get the chroma quantization factors (while luma quant factors would make more sense). Also in the squeeze case with > 3 channels it could probably do out-of-bounds reads since `component` could become > 2.

On a set of 9 screenshots, this gives a ~10% improvement in bpp*pnorm, more on higher distances than on lower distances
(3.3% at d1, 8.1% at d3, 18.5% at d10):

Before:
```
Encoding      kPixels    Bytes          BPP  E MP/s  D MP/s     Max norm        pnorm       BPP*pnorm   Bugs
------------------------------------------------------------------------------------------------------------
jxl:d1          42351  3517042    0.6643524   1.265  16.952   1.85774827   0.47749056  0.317222024849      0
jxl:d2          42351  2578886    0.4871393   1.284  17.106   3.60270667   0.70404982  0.342970304915      0
jxl:d3          42351  2117858    0.4000533   1.314  17.706   4.17911577   0.94978332  0.379963920819      0
jxl:d4          42351  1851313    0.3497042   1.295   8.645   5.61551571   1.19430598  0.417653806443      0
jxl:d6          42351  1530393    0.2890839   1.385   9.055   9.04470348   1.58707108  0.458796750994      0
jxl:d8          42351  1329062    0.2510535   1.327   9.296  11.13273525   2.00382515  0.503067255492      0
jxl:d10         42351  1176994    0.2223285   1.252   8.778  13.25551033   2.40369586  0.534410212932      0
Aggregate:      42351  1886817    0.3564108   1.303  11.849   5.75720619   1.16513895  0.415268071878      0
```

After:
```
Encoding      kPixels    Bytes          BPP  E MP/s  D MP/s     Max norm        pnorm       BPP*pnorm   Bugs
------------------------------------------------------------------------------------------------------------
jxl:d1          42351  3398772    0.6420118   1.414  17.991   1.86134648   0.47783172  0.306773608396      0
jxl:d2          42351  2419076    0.4569519   1.365  17.550   3.60270667   0.70498191  0.322142831554      0
jxl:d3          42351  1944497    0.3673062   1.341  18.255   4.08376122   0.95060837  0.349164350220      0
jxl:d4          42351  1664484    0.3144131   1.436   9.254   5.61551571   1.19765852  0.376559508773      0
jxl:d6          42351  1329371    0.2511118   1.397   9.215   9.04063320   1.58889877  0.398991290262      0
jxl:d8          42351  1118338    0.2112487   1.374  10.114  11.13273525   2.00768927  0.424121769686      0
jxl:d10         42351   963826    0.1820621   1.413   9.217  13.24004269   2.39469086  0.435982521274      0
Aggregate:      42351  1682274    0.3177734   1.391  12.429   5.73851421   1.16597696  0.370516520619      0
```

