### PR TITLE
remove unnecessary patch clamping

### DIFF
--- a/lib/jxl/enc_modular.cc
+++ b/lib/jxl/enc_modular.cc
@@ -231,7 +231,7 @@ Status float_to_int(const float* const row_in, pixel_type* const row_out,
   JXL_ASSERT(sizeof(pixel_type) * 8 >= bits);
   if (!fp) {
     for (size_t x = 0; x < xsize; ++x) {
-      row_out[x] = row_in[x] * factor + 0.5f;
+      row_out[x] = row_in[x] * factor + (row_in[x] < 0 ? -0.5f : 0.5f);
     }
     return true;
   }

--- a/lib/jxl/jxl_test.cc
+++ b/lib/jxl/jxl_test.cc
@@ -1224,7 +1224,7 @@ TEST(JxlTest, RoundtripYCbCr420) {
   CodecInOut io3;
   EXPECT_TRUE(DecodeFile(dparams, compressed, &io3, pool));
 
-  EXPECT_LE(compressed.size(), 1320000u);
+  EXPECT_LE(compressed.size(), 1325000u);
 
   // we're comparing an original PNG with a YCbCr 4:2:0 version
   EXPECT_THAT(ButteraugliDistance(io, io3, cparams.ba_params,


### PR DESCRIPTION
Get rid of unnecessary clamping of patches.

Also fix rounding in enc_modular when converting from negative floats to ints.

Small density improvement for lossless, e.g. on this set of 9 screenshots:

Before:
```
Encoding      kPixels    Bytes          BPP  E MP/s  D MP/s     Max norm        pnorm       BPP*pnorm   Bugs
------------------------------------------------------------------------------------------------------------
jxl:m           42351  9372482    1.7704171   0.560   4.682   0.00007111   0.00000944  0.000016714712      0
```

After:
```
Encoding      kPixels    Bytes          BPP  E MP/s  D MP/s     Max norm        pnorm       BPP*pnorm   Bugs
------------------------------------------------------------------------------------------------------------
jxl:m           42351  9292883    1.7553812   0.573   4.854   0.00015157   0.00001035  0.000018172242      0
```

(Note: pnorm is not zero when patches are used because patch arithmetic (addition) is done with floats, introducing tiny rounding errors since A can be different from A-B+B. When saving the image in integers, it is still lossless though.)