### PR TITLE
print error when encountering non-recompressable (cmyk or corrupt) JPEG

### DIFF
--- a/lib/extras/codec_jpg.cc
+++ b/lib/extras/codec_jpg.cc
@@ -244,7 +244,9 @@ Status DecodeImageJPG(const Span<const uint8_t> bytes, ThreadPool* pool,
 
   // Use brunsli JPEG decoder to read quantized coefficients.
   if (target == DecodeTarget::kQuantizedCoeffs) {
-    return jxl::jpeg::DecodeImageJPG(bytes, io);
+    Status could_decode = jxl::jpeg::DecodeImageJPG(bytes, io);
+    if (!could_decode) fprintf(stderr, "Corrupt or CMYK JPEG.\n");
+    return could_decode;
   }
 
 #if JPEGXL_ENABLE_JPEG


### PR DESCRIPTION
See https://github.com/libjxl/libjxl/issues/468

Corrupt JPEGs and CMYK JPEGs cannot be losslessly recompressed to jxl.
Instead of just saying "failed to read", write a more useful error message in this case.