### PR TITLE
flag to stop parsing options, fixes #433

### DIFF
--- a/tools/cmdline.cc
+++ b/tools/cmdline.cc
@@ -47,6 +47,8 @@ void CommandLineParser::PrintHelp() const {
 bool CommandLineParser::Parse(int argc, const char* argv[]) {
   if (argc) program_name_ = argv[0];
   int i = 1;  // argv[0] is the program name.
+  // if false, stop matching options and take only positional arguments
+  bool parse_options = true;
   while (i < argc) {
     if (!strcmp("-h", argv[i]) || !strcmp("--help", argv[i])) {
       help_ = true;
@@ -56,9 +58,15 @@ bool CommandLineParser::Parse(int argc, const char* argv[]) {
     if (!strcmp("-v", argv[i]) || !strcmp("--verbose", argv[i])) {
       verbosity++;
     }
+    // after "--", filenames starting with "-" can be used
+    if (!strcmp("--", argv[i])) {
+      parse_options = false;
+      i++;
+      continue;
+    }
     bool found = false;
     for (const auto& option : options_) {
-      if (option->Match(argv[i])) {
+      if (option->Match(argv[i], parse_options)) {
         // Parsing advances the value i on success.
         const char* arg = argv[i];
         if (!option->Parse(argc, argv, &i)) {

--- a/tools/cmdline.h
+++ b/tools/cmdline.h
@@ -41,7 +41,7 @@ class CommandLineParser {
     virtual bool matched() const = 0;
 
     // Returns whether this option matches the passed command line argument.
-    virtual bool Match(const char* arg) const = 0;
+    virtual bool Match(const char* arg, bool parse_options) const = 0;
 
     // Parses the option. The passed i points to the argument with the flag
     // that matches either the short or the long name.
@@ -135,9 +135,10 @@ class CommandLineParser {
 
     // Only match non-flag values. This means that you can't pass '-foo' as a
     // positional argument, but it helps with detecting when passed a flag with
-    // a typo.
-    bool Match(const char* arg) const override {
-      return !matched_ && arg[0] != '-';
+    // a typo. After '--', option matching is disabled so positional arguments
+    // starting with '-' can be used.
+    bool Match(const char* arg, bool parse_options) const override {
+      return !matched_ && (!parse_options || arg[0] != '-');
     }
 
     bool Parse(const int argc, const char* argv[], int* i) override {
@@ -210,8 +211,8 @@ class CommandLineParser {
     int verbosity_level() const override { return verbosity_level_; }
     bool matched() const override { return matched_; }
 
-    bool Match(const char* arg) const override {
-      return MatchShort(arg) || MatchLong(arg);
+    bool Match(const char* arg, bool parse_options) const override {
+      return parse_options && (MatchShort(arg) || MatchLong(arg));
     }
 
     bool Parse(const int argc, const char* argv[], int* i) override {


### PR DESCRIPTION
See #433. If for whatever reason you need things to work on filenames that start with a dash, you can now do `cjxl -q 80 -- -myweirdfile.png -myweirdoutputfile.jxl`.