### PR TITLE
Increase RoundtripResample2 threshold

### DIFF
--- a/lib/jxl/jxl_test.cc
+++ b/lib/jxl/jxl_test.cc
@@ -218,7 +218,7 @@ TEST(JxlTest, RoundtripResample2) {
   cparams.resampling = 2;
   DecompressParams dparams;
   CodecInOut io2;
-  EXPECT_LE(Roundtrip(&io, cparams, dparams, pool, &io2), 16900);
+  EXPECT_LE(Roundtrip(&io, cparams, dparams, pool, &io2), 17000);
   EXPECT_LE(ButteraugliDistance(io, io2, cparams.ba_params,
                                 /*distmap=*/nullptr, pool),
             12);


### PR DESCRIPTION
scalar and arm32 builds produced a sligthly bigger file. This fixes the
failures for scalar and arm32.