### PR TITLE
Add float16 support to public API

### DIFF
--- a/lib/extras/codec_pgx.cc
+++ b/lib/extras/codec_pgx.cc
@@ -258,7 +258,7 @@ Status DecodeImagePGX(const Span<const uint8_t> bytes, ThreadPool* pool,
       /*alpha_is_premultiplied=*/false,
       io->metadata.m.bit_depth.bits_per_sample,
       header.big_endian ? JXL_BIG_ENDIAN : JXL_LITTLE_ENDIAN, flipped_y, pool,
-      &ib));
+      &ib, /*float_in=*/false));
   io->frames.push_back(std::move(ib));
   SetIntensityTarget(io);
   return true;

--- a/lib/extras/codec_png.cc
+++ b/lib/extras/codec_png.cc
@@ -817,11 +817,11 @@ Status DecodeImagePNG(const Span<const uint8_t> bytes, ThreadPool* pool,
 
   const JxlEndianness endianness = JXL_BIG_ENDIAN;  // PNG requirement
   const Span<const uint8_t> span(out, out_size);
-  const bool ok =
-      ConvertFromExternal(span, w, h, io->metadata.m.color_encoding, has_alpha,
-                          /*alpha_is_premultiplied=*/false,
-                          io->metadata.m.bit_depth.bits_per_sample, endianness,
-                          /*flipped_y=*/false, pool, &io->Main());
+  const bool ok = ConvertFromExternal(
+      span, w, h, io->metadata.m.color_encoding, has_alpha,
+      /*alpha_is_premultiplied=*/false,
+      io->metadata.m.bit_depth.bits_per_sample, endianness,
+      /*flipped_y=*/false, pool, &io->Main(), /*float_in=*/false);
   JXL_RETURN_IF_ERROR(ok);
   io->dec_pixels = w * h;
   io->metadata.m.bit_depth.bits_per_sample = io->Main().DetectRealBitdepth();

--- a/lib/extras/codec_pnm.cc
+++ b/lib/extras/codec_pnm.cc
@@ -500,13 +500,14 @@ Status DecodeImagePNM(const Span<const uint8_t> bytes, ThreadPool* pool,
     io->Main() = std::move(bundle);
   } else {
     const bool flipped_y = header.bits_per_sample == 32;  // PFMs are flipped
+    const bool float_in = header.bits_per_sample == 32;
     const Span<const uint8_t> span(pos, bytes.data() + bytes.size() - pos);
     JXL_RETURN_IF_ERROR(ConvertFromExternal(
         span, header.xsize, header.ysize, io->metadata.m.color_encoding,
         /*has_alpha=*/false, /*alpha_is_premultiplied=*/false,
         io->metadata.m.bit_depth.bits_per_sample,
         header.big_endian ? JXL_BIG_ENDIAN : JXL_LITTLE_ENDIAN, flipped_y, pool,
-        &io->Main()));
+        &io->Main(), float_in));
   }
   if (!header.floating_point) {
     io->metadata.m.bit_depth.bits_per_sample = io->Main().DetectRealBitdepth();

--- a/lib/include/jxl/encode.h
+++ b/lib/include/jxl/encode.h
@@ -170,14 +170,15 @@ JXL_EXPORT JxlEncoderStatus JxlEncoderAddJPEGFrame(
  * Currently only some pixel formats are supported:
  * - JXL_TYPE_UINT8
  * - JXL_TYPE_UINT16
+ * - JXL_TYPE_FLOAT16, with nominal range 0..1
  * - JXL_TYPE_FLOAT, with nominal range 0..1
  *
  * The color profile of the pixels depends on the value of uses_original_profile
  * in the JxlBasicInfo. If true, the pixels are assumed to be encoded in the
  * original profile that is set with JxlEncoderSetColorEncoding or
  * JxlEncoderSetICCProfile. If false, the pixels are assumed to be nonlinear
- * sRGB for integer data types (JXL_TYPE_UINT8 and JXL_TYPE_UINT16), and linear
- * sRGB for floating point data types (JXL_TYPE_FLOAT).
+ * sRGB for integer data types (JXL_TYPE_UINT8, JXL_TYPE_UINT16), and linear
+ * sRGB for floating point data types (JXL_TYPE_FLOAT16, JXL_TYPE_FLOAT).
  *
  * @param options set of encoder options to use when encoding the frame.
  * @param pixel_format format for pixels. Object owned by the caller and its

--- a/lib/jxl/decode_test.cc
+++ b/lib/jxl/decode_test.cc
@@ -255,7 +255,7 @@ PaddedBytes CreateTestJXLCodestream(
   EXPECT_TRUE(ConvertFromExternal(
       pixels, xsize, ysize, color_encoding, /*has_alpha=*/include_alpha,
       /*alpha_is_premultiplied=*/false, bitdepth, JXL_BIG_ENDIAN,
-      /*flipped_y=*/false, &pool, &io.Main()));
+      /*flipped_y=*/false, &pool, &io.Main(), /*float_in=*/false));
   jxl::PaddedBytes jpeg_data;
   if (jpeg_codestream != nullptr) {
 #if JPEGXL_ENABLE_JPEG
@@ -1452,7 +1452,7 @@ TEST_P(DecodeTestParam, PixelTest) {
     EXPECT_TRUE(ConvertFromExternal(
         bytes, config.xsize, config.ysize, color_encoding, config.include_alpha,
         /*alpha_is_premultiplied=*/false, 16, JXL_BIG_ENDIAN,
-        /*flipped_y=*/false, nullptr, &io.Main()));
+        /*flipped_y=*/false, nullptr, &io.Main(), /*float_in=*/false));
 
     for (size_t i = 0; i < pixels.size(); i++) pixels[i] = 0;
     EXPECT_TRUE(ConvertToExternal(
@@ -1734,7 +1734,7 @@ TEST(DecodeTest, PixelTestWithICCProfileLossy) {
   EXPECT_TRUE(ConvertFromExternal(
       span0, xsize, ysize, color_encoding0,
       /*has_alpha=*/false, false, 16, format_orig.endianness,
-      /*flipped_y=*/false, /*pool=*/nullptr, &io0.Main()));
+      /*flipped_y=*/false, /*pool=*/nullptr, &io0.Main(), /*float_in=*/false));
 
   // The output pixels are expected to be in the same colorspace as the input
   // profile, as the profile can be represented by enum values.
@@ -1742,10 +1742,10 @@ TEST(DecodeTest, PixelTestWithICCProfileLossy) {
   jxl::Span<const uint8_t> span1(pixels2.data(), pixels2.size());
   jxl::CodecInOut io1;
   io1.SetSize(xsize, ysize);
-  EXPECT_TRUE(
-      ConvertFromExternal(span1, xsize, ysize, color_encoding1,
-                          /*has_alpha=*/false, false, 32, format.endianness,
-                          /*flipped_y=*/false, /*pool=*/nullptr, &io1.Main()));
+  EXPECT_TRUE(ConvertFromExternal(
+      span1, xsize, ysize, color_encoding1,
+      /*has_alpha=*/false, false, 32, format.endianness,
+      /*flipped_y=*/false, /*pool=*/nullptr, &io1.Main(), /*float_in=*/true));
 
   jxl::ButteraugliParams ba;
   EXPECT_LE(ButteraugliDistance(io0, io1, ba, /*distmap=*/nullptr, nullptr),
@@ -1786,10 +1786,11 @@ TEST(DecodeTest, PixelTestOpaqueSrgbLossy) {
     jxl::Span<const uint8_t> span0(pixels.data(), pixels.size());
     jxl::CodecInOut io0;
     io0.SetSize(xsize, ysize);
-    EXPECT_TRUE(ConvertFromExternal(
-        span0, xsize, ysize, color_encoding0,
-        /*has_alpha=*/false, false, 16, format_orig.endianness,
-        /*flipped_y=*/false, /*pool=*/nullptr, &io0.Main()));
+    EXPECT_TRUE(ConvertFromExternal(span0, xsize, ysize, color_encoding0,
+                                    /*has_alpha=*/false, false, 16,
+                                    format_orig.endianness,
+                                    /*flipped_y=*/false, /*pool=*/nullptr,
+                                    &io0.Main(), /*float_in=*/false));
 
     jxl::ColorEncoding color_encoding1 = jxl::ColorEncoding::SRGB(false);
     jxl::Span<const uint8_t> span1(pixels2.data(), pixels2.size());
@@ -1797,17 +1798,19 @@ TEST(DecodeTest, PixelTestOpaqueSrgbLossy) {
     if (channels == 4) {
       io1.metadata.m.SetAlphaBits(8);
       io1.SetSize(xsize, ysize);
-      EXPECT_TRUE(ConvertFromExternal(
-          span1, xsize, ysize, color_encoding1,
-          /*has_alpha=*/true, false, 8, format.endianness,
-          /*flipped_y=*/false, /*pool=*/nullptr, &io1.Main()));
+      EXPECT_TRUE(ConvertFromExternal(span1, xsize, ysize, color_encoding1,
+                                      /*has_alpha=*/true, false, 8,
+                                      format.endianness,
+                                      /*flipped_y=*/false, /*pool=*/nullptr,
+                                      &io1.Main(), /*float_in=*/false));
       io1.metadata.m.SetAlphaBits(0);
       io1.Main().ClearExtraChannels();
     } else {
-      EXPECT_TRUE(ConvertFromExternal(
-          span1, xsize, ysize, color_encoding1,
-          /*has_alpha=*/false, false, 8, format.endianness,
-          /*flipped_y=*/false, /*pool=*/nullptr, &io1.Main()));
+      EXPECT_TRUE(ConvertFromExternal(span1, xsize, ysize, color_encoding1,
+                                      /*has_alpha=*/false, false, 8,
+                                      format.endianness,
+                                      /*flipped_y=*/false, /*pool=*/nullptr,
+                                      &io1.Main(), /*float_in=*/false));
     }
 
     jxl::ButteraugliParams ba;
@@ -1850,10 +1853,11 @@ TEST(DecodeTest, PixelTestOpaqueSrgbLossyNoise) {
     jxl::Span<const uint8_t> span0(pixels.data(), pixels.size());
     jxl::CodecInOut io0;
     io0.SetSize(xsize, ysize);
-    EXPECT_TRUE(ConvertFromExternal(
-        span0, xsize, ysize, color_encoding0,
-        /*has_alpha=*/false, false, 16, format_orig.endianness,
-        /*flipped_y=*/false, /*pool=*/nullptr, &io0.Main()));
+    EXPECT_TRUE(ConvertFromExternal(span0, xsize, ysize, color_encoding0,
+                                    /*has_alpha=*/false, false, 16,
+                                    format_orig.endianness,
+                                    /*flipped_y=*/false, /*pool=*/nullptr,
+                                    &io0.Main(), /*float_in=*/false));
 
     jxl::ColorEncoding color_encoding1 = jxl::ColorEncoding::SRGB(false);
     jxl::Span<const uint8_t> span1(pixels2.data(), pixels2.size());
@@ -1861,17 +1865,19 @@ TEST(DecodeTest, PixelTestOpaqueSrgbLossyNoise) {
     if (channels == 4) {
       io1.metadata.m.SetAlphaBits(8);
       io1.SetSize(xsize, ysize);
-      EXPECT_TRUE(ConvertFromExternal(
-          span1, xsize, ysize, color_encoding1,
-          /*has_alpha=*/true, false, 8, format.endianness,
-          /*flipped_y=*/false, /*pool=*/nullptr, &io1.Main()));
+      EXPECT_TRUE(ConvertFromExternal(span1, xsize, ysize, color_encoding1,
+                                      /*has_alpha=*/true, false, 8,
+                                      format.endianness,
+                                      /*flipped_y=*/false, /*pool=*/nullptr,
+                                      &io1.Main(), /*float_in=*/false));
       io1.metadata.m.SetAlphaBits(0);
       io1.Main().ClearExtraChannels();
     } else {
-      EXPECT_TRUE(ConvertFromExternal(
-          span1, xsize, ysize, color_encoding1,
-          /*has_alpha=*/false, false, 8, format.endianness,
-          /*flipped_y=*/false, /*pool=*/nullptr, &io1.Main()));
+      EXPECT_TRUE(ConvertFromExternal(span1, xsize, ysize, color_encoding1,
+                                      /*has_alpha=*/false, false, 8,
+                                      format.endianness,
+                                      /*flipped_y=*/false, /*pool=*/nullptr,
+                                      &io1.Main(), /*float_in=*/false));
     }
 
     jxl::ButteraugliParams ba;
@@ -2211,7 +2217,8 @@ TEST(DecodeTest, AnimationTest) {
         jxl::Span<const uint8_t>(frames[i].data(), frames[i].size()), xsize,
         ysize, jxl::ColorEncoding::SRGB(/*is_gray=*/false), /*has_alpha=*/false,
         /*alpha_is_premultiplied=*/false, /*bits_per_sample=*/16,
-        JXL_BIG_ENDIAN, /*flipped_y=*/false, /*pool=*/nullptr, &bundle));
+        JXL_BIG_ENDIAN, /*flipped_y=*/false, /*pool=*/nullptr, &bundle,
+        /*float_in=*/false));
     bundle.duration = frame_durations[i];
     io.frames.push_back(std::move(bundle));
   }
@@ -2313,7 +2320,8 @@ TEST(DecodeTest, AnimationTestStreaming) {
         jxl::Span<const uint8_t>(frames[i].data(), frames[i].size()), xsize,
         ysize, jxl::ColorEncoding::SRGB(/*is_gray=*/false), /*has_alpha=*/false,
         /*alpha_is_premultiplied=*/false, /*bits_per_sample=*/16,
-        JXL_BIG_ENDIAN, /*flipped_y=*/false, /*pool=*/nullptr, &bundle));
+        JXL_BIG_ENDIAN, /*flipped_y=*/false, /*pool=*/nullptr, &bundle,
+        /*float_in=*/false));
     bundle.duration = frame_durations[i];
     io.frames.push_back(std::move(bundle));
   }
@@ -2533,7 +2541,8 @@ TEST(DecodeTest, SkipFrameTest) {
         jxl::Span<const uint8_t>(frames[i].data(), frames[i].size()), xsize,
         ysize, jxl::ColorEncoding::SRGB(/*is_gray=*/false), /*has_alpha=*/false,
         /*alpha_is_premultiplied=*/false, /*bits_per_sample=*/16,
-        JXL_BIG_ENDIAN, /*flipped_y=*/false, /*pool=*/nullptr, &bundle));
+        JXL_BIG_ENDIAN, /*flipped_y=*/false, /*pool=*/nullptr, &bundle,
+        /*float_in=*/false));
     bundle.duration = frame_durations[i];
     io.frames.push_back(std::move(bundle));
   }
@@ -2669,7 +2678,7 @@ TEST(DecodeTest, SkipFrameWithBlendingTest) {
           /*has_alpha=*/false,
           /*alpha_is_premultiplied=*/false, /*bits_per_sample=*/16,
           JXL_BIG_ENDIAN, /*flipped_y=*/false, /*pool=*/nullptr,
-          &bundle_internal));
+          &bundle_internal, /*float_in=*/false));
       bundle_internal.duration = 0;
       bundle_internal.use_for_next_frame = true;
       io.frames.push_back(std::move(bundle_internal));
@@ -2684,7 +2693,8 @@ TEST(DecodeTest, SkipFrameWithBlendingTest) {
         jxl::Span<const uint8_t>(frame.data(), frame.size()), xsize, ysize,
         jxl::ColorEncoding::SRGB(/*is_gray=*/false), /*has_alpha=*/false,
         /*alpha_is_premultiplied=*/false, /*bits_per_sample=*/16,
-        JXL_BIG_ENDIAN, /*flipped_y=*/false, /*pool=*/nullptr, &bundle));
+        JXL_BIG_ENDIAN, /*flipped_y=*/false, /*pool=*/nullptr, &bundle,
+        /*float_in=*/false));
     bundle.duration = frame_durations[i];
     // Create some variation in which frames depend on which.
     if (i != 3 && i != 9 && i != 10) {

--- a/lib/jxl/enc_external_image.cc
+++ b/lib/jxl/enc_external_image.cc
@@ -21,6 +21,38 @@
 namespace jxl {
 namespace {
 
+// Based on highway scalar implementation, for testing
+float LoadFloat16(uint16_t bits16) {
+  const uint32_t sign = bits16 >> 15;
+  const uint32_t biased_exp = (bits16 >> 10) & 0x1F;
+  const uint32_t mantissa = bits16 & 0x3FF;
+
+  // Subnormal or zero
+  if (biased_exp == 0) {
+    const float subnormal = (1.0f / 16384) * (mantissa * (1.0f / 1024));
+    return sign ? -subnormal : subnormal;
+  }
+
+  // Normalized: convert the representation directly (faster than ldexp/tables).
+  const uint32_t biased_exp32 = biased_exp + (127 - 15);
+  const uint32_t mantissa32 = mantissa << (23 - 10);
+  const uint32_t bits32 = (sign << 31) | (biased_exp32 << 23) | mantissa32;
+
+  float result;
+  memcpy(&result, &bits32, 4);
+  return result;
+}
+
+float LoadLEFloat16(const uint8_t* p) {
+  uint16_t bits16 = LoadLE16(p);
+  return LoadFloat16(bits16);
+}
+
+float LoadBEFloat16(const uint8_t* p) {
+  uint16_t bits16 = LoadBE16(p);
+  return LoadFloat16(bits16);
+}
+
 // Loads a float in big endian
 float LoadBEFloat(const uint8_t* p) {
   float value;
@@ -56,7 +88,8 @@ Status ConvertFromExternal(Span<const uint8_t> bytes, size_t xsize,
                            size_t ysize, const ColorEncoding& c_current,
                            bool has_alpha, bool alpha_is_premultiplied,
                            size_t bits_per_sample, JxlEndianness endianness,
-                           bool flipped_y, ThreadPool* pool, ImageBundle* ib) {
+                           bool flipped_y, ThreadPool* pool, ImageBundle* ib,
+                           bool float_in) {
   if (bits_per_sample < 1 || bits_per_sample > 32) {
     return JXL_FAILURE("Invalid bits_per_sample value.");
   }
@@ -92,18 +125,11 @@ Status ConvertFromExternal(Span<const uint8_t> bytes, size_t xsize,
     alpha = ImageF(xsize, ysize);
   }
 
-  // Matches the old behavior of PackedImage.
-  // TODO(sboukortt): make this a parameter.
-  const bool float_in = bits_per_sample == 32;
-
   const auto get_y = [flipped_y, ysize](const size_t y) {
     return flipped_y ? ysize - 1 - y : y;
   };
 
   if (float_in) {
-    if (bits_per_sample != 32) {
-      return JXL_FAILURE("non-32-bit float not supported");
-    }
     for (size_t c = 0; c < color_channels; ++c) {
       RunOnPool(
           pool, 0, static_cast<uint32_t>(ysize), ThreadPool::SkipInit(),
@@ -112,15 +138,29 @@ Status ConvertFromExternal(Span<const uint8_t> bytes, size_t xsize,
             size_t i =
                 row_size * task + (c * bits_per_sample / jxl::kBitsPerByte);
             float* JXL_RESTRICT row_out = color.PlaneRow(c, y);
-            if (little_endian) {
-              for (size_t x = 0; x < xsize; ++x) {
-                row_out[x] = LoadLEFloat(in + i);
-                i += bytes_per_pixel;
+            if (bits_per_sample <= 16) {
+              if (little_endian) {
+                for (size_t x = 0; x < xsize; ++x) {
+                  row_out[x] = LoadLEFloat16(in + i);
+                  i += bytes_per_pixel;
+                }
+              } else {
+                for (size_t x = 0; x < xsize; ++x) {
+                  row_out[x] = LoadBEFloat16(in + i);
+                  i += bytes_per_pixel;
+                }
               }
             } else {
-              for (size_t x = 0; x < xsize; ++x) {
-                row_out[x] = LoadBEFloat(in + i);
-                i += bytes_per_pixel;
+              if (little_endian) {
+                for (size_t x = 0; x < xsize; ++x) {
+                  row_out[x] = LoadLEFloat(in + i);
+                  i += bytes_per_pixel;
+                }
+              } else {
+                for (size_t x = 0; x < xsize; ++x) {
+                  row_out[x] = LoadBEFloat(in + i);
+                  i += bytes_per_pixel;
+                }
               }
             }
           },
@@ -179,9 +219,6 @@ Status ConvertFromExternal(Span<const uint8_t> bytes, size_t xsize,
 
   if (has_alpha) {
     if (float_in) {
-      if (bits_per_sample != 32) {
-        return JXL_FAILURE("non-32-bit float not supported");
-      }
       RunOnPool(
           pool, 0, static_cast<uint32_t>(ysize), ThreadPool::SkipInit(),
           [&](const int task, int /*thread*/) {
@@ -189,15 +226,29 @@ Status ConvertFromExternal(Span<const uint8_t> bytes, size_t xsize,
             size_t i = row_size * task +
                        (color_channels * bits_per_sample / jxl::kBitsPerByte);
             float* JXL_RESTRICT row_out = alpha.Row(y);
-            if (little_endian) {
-              for (size_t x = 0; x < xsize; ++x) {
-                row_out[x] = LoadLEFloat(in + i);
-                i += bytes_per_pixel;
+            if (bits_per_sample <= 16) {
+              if (little_endian) {
+                for (size_t x = 0; x < xsize; ++x) {
+                  row_out[x] = LoadLEFloat16(in + i);
+                  i += bytes_per_pixel;
+                }
+              } else {
+                for (size_t x = 0; x < xsize; ++x) {
+                  row_out[x] = LoadBEFloat16(in + i);
+                  i += bytes_per_pixel;
+                }
               }
             } else {
-              for (size_t x = 0; x < xsize; ++x) {
-                row_out[x] = LoadBEFloat(in + i);
-                i += bytes_per_pixel;
+              if (little_endian) {
+                for (size_t x = 0; x < xsize; ++x) {
+                  row_out[x] = LoadLEFloat(in + i);
+                  i += bytes_per_pixel;
+                }
+              } else {
+                for (size_t x = 0; x < xsize; ++x) {
+                  row_out[x] = LoadBEFloat(in + i);
+                  i += bytes_per_pixel;
+                }
               }
             }
           },
@@ -255,14 +306,21 @@ Status BufferToImageBundle(const JxlPixelFormat& pixel_format, uint32_t xsize,
                            const jxl::ColorEncoding& c_current,
                            jxl::ImageBundle* ib) {
   size_t bitdepth;
+  bool float_in;
 
-  // TODO(zond): Make this accept more than float and uint8/16.
+  // TODO(zond): Make this accept uint32.
   if (pixel_format.data_type == JXL_TYPE_FLOAT) {
     bitdepth = 32;
+    float_in = true;
+  } else if (pixel_format.data_type == JXL_TYPE_FLOAT16) {
+    bitdepth = 16;
+    float_in = true;
   } else if (pixel_format.data_type == JXL_TYPE_UINT8) {
     bitdepth = 8;
+    float_in = false;
   } else if (pixel_format.data_type == JXL_TYPE_UINT16) {
     bitdepth = 16;
+    float_in = false;
   } else {
     return JXL_FAILURE("unsupported bitdepth");
   }
@@ -273,7 +331,7 @@ Status BufferToImageBundle(const JxlPixelFormat& pixel_format, uint32_t xsize,
       /*has_alpha=*/pixel_format.num_channels == 2 ||
           pixel_format.num_channels == 4,
       /*alpha_is_premultiplied=*/false, bitdepth, pixel_format.endianness,
-      /*flipped_y=*/false, pool, ib));
+      /*flipped_y=*/false, pool, ib, float_in));
   ib->VerifyMetadata();
 
   return true;

--- a/lib/jxl/enc_external_image.h
+++ b/lib/jxl/enc_external_image.h
@@ -37,7 +37,8 @@ Status ConvertFromExternal(Span<const uint8_t> bytes, size_t xsize,
                            size_t ysize, const ColorEncoding& c_current,
                            bool has_alpha, bool alpha_is_premultiplied,
                            size_t bits_per_sample, JxlEndianness endianness,
-                           bool flipped_y, ThreadPool* pool, ImageBundle* ib);
+                           bool flipped_y, ThreadPool* pool, ImageBundle* ib,
+                           bool float_in);
 
 Status BufferToImageBundle(const JxlPixelFormat& pixel_format, uint32_t xsize,
                            uint32_t ysize, const void* buffer, size_t size,

--- a/lib/jxl/enc_external_image_gbench.cc
+++ b/lib/jxl/enc_external_image_gbench.cc
@@ -32,7 +32,7 @@ void BM_EncExternalImage_ConvertImageRGBA(benchmark::State& state) {
           /*alpha_is_premultiplied=*/false,
           /*bits_per_sample=*/8, JXL_NATIVE_ENDIAN,
           /*flipped_y=*/false,
-          /*pool=*/nullptr, &ib));
+          /*pool=*/nullptr, &ib, /*float_in=*/false));
     }
   }
 

--- a/lib/jxl/enc_external_image_test.cc
+++ b/lib/jxl/enc_external_image_test.cc
@@ -30,18 +30,18 @@ TEST(ExternalImageTest, InvalidSize) {
       Span<const uint8_t>(buf, 10), /*xsize=*/10, /*ysize=*/100,
       /*c_current=*/ColorEncoding::SRGB(), /*has_alpha=*/true,
       /*alpha_is_premultiplied=*/false, /*bits_per_sample=*/16, JXL_BIG_ENDIAN,
-      /*flipped_y=*/false, nullptr, &ib));
+      /*flipped_y=*/false, nullptr, &ib, /*float_in=*/false));
   EXPECT_FALSE(ConvertFromExternal(
       Span<const uint8_t>(buf, sizeof(buf) - 1), /*xsize=*/10, /*ysize=*/100,
       /*c_current=*/ColorEncoding::SRGB(), /*has_alpha=*/true,
       /*alpha_is_premultiplied=*/false, /*bits_per_sample=*/16, JXL_BIG_ENDIAN,
-      /*flipped_y=*/false, nullptr, &ib));
-  EXPECT_TRUE(
-      ConvertFromExternal(Span<const uint8_t>(buf, sizeof(buf)), /*xsize=*/10,
-                          /*ysize=*/100, /*c_current=*/ColorEncoding::SRGB(),
-                          /*has_alpha=*/true, /*alpha_is_premultiplied=*/false,
-                          /*bits_per_sample=*/16, JXL_BIG_ENDIAN,
-                          /*flipped_y=*/false, nullptr, &ib));
+      /*flipped_y=*/false, nullptr, &ib, /*float_in=*/false));
+  EXPECT_TRUE(ConvertFromExternal(
+      Span<const uint8_t>(buf, sizeof(buf)), /*xsize=*/10,
+      /*ysize=*/100, /*c_current=*/ColorEncoding::SRGB(),
+      /*has_alpha=*/true, /*alpha_is_premultiplied=*/false,
+      /*bits_per_sample=*/16, JXL_BIG_ENDIAN,
+      /*flipped_y=*/false, nullptr, &ib, /*float_in=*/false));
 }
 #endif
 

--- a/lib/jxl/roundtrip_test.cc
+++ b/lib/jxl/roundtrip_test.cc
@@ -52,21 +52,26 @@ jxl::CodecInOut ConvertTestImage(const std::vector<uint8_t>& buf,
     }
   }
   size_t bitdepth = 0;
+  bool float_in = false;
   switch (pixel_format.data_type) {
     case JXL_TYPE_FLOAT:
       bitdepth = 32;
+      float_in = true;
       io.metadata.m.SetFloat32Samples();
       break;
     case JXL_TYPE_FLOAT16:
       bitdepth = 16;
+      float_in = true;
       io.metadata.m.SetFloat16Samples();
       break;
     case JXL_TYPE_UINT8:
       bitdepth = 8;
+      float_in = false;
       io.metadata.m.SetUintSamples(8);
       break;
     case JXL_TYPE_UINT16:
       bitdepth = 16;
+      float_in = false;
       io.metadata.m.SetUintSamples(16);
       break;
     default:
@@ -82,12 +87,12 @@ jxl::CodecInOut ConvertTestImage(const std::vector<uint8_t>& buf,
   } else {
     color_encoding = jxl::ColorEncoding::SRGB(is_gray);
   }
-  EXPECT_TRUE(
-      ConvertFromExternal(jxl::Span<const uint8_t>(buf.data(), buf.size()),
-                          xsize, ysize, color_encoding, has_alpha,
-                          /*alpha_is_premultiplied=*/false,
-                          /*bits_per_sample=*/bitdepth, pixel_format.endianness,
-                          /*flipped_y=*/false, /*pool=*/nullptr, &io.Main()));
+  EXPECT_TRUE(ConvertFromExternal(
+      jxl::Span<const uint8_t>(buf.data(), buf.size()), xsize, ysize,
+      color_encoding, has_alpha,
+      /*alpha_is_premultiplied=*/false,
+      /*bits_per_sample=*/bitdepth, pixel_format.endianness,
+      /*flipped_y=*/false, /*pool=*/nullptr, &io.Main(), float_in));
   return io;
 }
 

--- a/lib/jxl/test_utils.h
+++ b/lib/jxl/test_utils.h
@@ -367,7 +367,7 @@ jxl::CodecInOut SomeTestImageToCodecInOut(const std::vector<uint8_t>& buf,
       /*has_alpha=*/num_channels == 2 || num_channels == 4,
       /*alpha_is_premultiplied=*/false, /*bits_per_sample=*/16, JXL_BIG_ENDIAN,
       /*flipped_y=*/false, /*pool=*/nullptr,
-      /*ib=*/&io.Main()));
+      /*ib=*/&io.Main(), /*float_in=*/false));
   return io;
 }
 

--- a/tools/benchmark/benchmark_codec_avif.cc
+++ b/tools/benchmark/benchmark_codec_avif.cc
@@ -311,7 +311,8 @@ class AvifCodec : public ImageCodec {
                                   rgb_image.height * rgb_image.rowBytes),
               rgb_image.width, rgb_image.height, color, has_alpha,
               /*alpha_is_premultiplied=*/false, rgb_image.depth,
-              JXL_NATIVE_ENDIAN, /*flipped_y=*/false, pool, &ib));
+              JXL_NATIVE_ENDIAN, /*flipped_y=*/false, pool, &ib,
+              /*float_in=*/false));
           io->frames.push_back(std::move(ib));
           io->dec_pixels += rgb_image.width * rgb_image.height;
         }

--- a/tools/benchmark/benchmark_codec_webp.cc
+++ b/tools/benchmark/benchmark_codec_webp.cc
@@ -37,9 +37,9 @@ Status FromSRGB(const size_t xsize, const size_t ysize, const bool is_gray,
   const ColorEncoding& c = ColorEncoding::SRGB(is_gray);
   const size_t bits_per_sample = (is_16bit ? 2 : 1) * kBitsPerByte;
   const Span<const uint8_t> span(pixels, end - pixels);
-  return ConvertFromExternal(span, xsize, ysize, c, has_alpha,
-                             alpha_is_premultiplied, bits_per_sample,
-                             endianness, /*flipped_y=*/false, pool, ib);
+  return ConvertFromExternal(
+      span, xsize, ysize, c, has_alpha, alpha_is_premultiplied, bits_per_sample,
+      endianness, /*flipped_y=*/false, pool, ib, /*float_in=*/false);
 }
 
 struct WebPArgs {

--- a/tools/fuzzer_corpus.cc
+++ b/tools/fuzzer_corpus.cc
@@ -216,7 +216,7 @@ bool GenerateFile(const char* output_dir, const ImageSpec& spec,
         /*has_alpha=*/has_alpha,
         /*alpha_is_premultiplied=*/spec.alpha_is_premultiplied,
         io.metadata.m.bit_depth.bits_per_sample, JXL_LITTLE_ENDIAN,
-        false /* flipped_y */, nullptr, &ib));
+        false /* flipped_y */, nullptr, &ib, /*float_in=*/false));
     io.frames.push_back(std::move(ib));
   }
 


### PR DESCRIPTION
A parameter to flag whether the input is float or not was added to  ConvertFromExternal() so it can differentiate between uint16 and float16 images.  Existing calls to ConvertFromExternal were modified.  Checks to reject float16 in the external API were removed.