### PR TITLE
Move the DecoderHints out of the libjxl library.

### DIFF
--- a/lib/extras/codec.cc
+++ b/lib/extras/codec.cc
@@ -84,39 +84,39 @@ Codec CodecFromExtension(const std::string& extension,
   return Codec::kUnknown;
 }
 
-Status SetFromBytes(const Span<const uint8_t> bytes, CodecInOut* io,
+Status SetFromBytes(const Span<const uint8_t> bytes,
+                    const ColorHints& color_hints, CodecInOut* io,
                     ThreadPool* pool, Codec* orig_codec) {
   if (bytes.size() < kMinBytes) return JXL_FAILURE("Too few bytes");
 
   io->metadata.m.bit_depth.bits_per_sample = 0;  // (For is-set check below)
 
   Codec codec;
-  if (DecodeImagePNG(bytes, pool, io)) {
+  if (DecodeImagePNG(bytes, color_hints, pool, io)) {
     codec = Codec::kPNG;
   }
 #if JPEGXL_ENABLE_APNG
-  else if (DecodeImageAPNG(bytes, pool, io)) {
+  else if (DecodeImageAPNG(bytes, color_hints, pool, io)) {
     codec = Codec::kPNG;
   }
 #endif
-  else if (DecodeImagePGX(bytes, pool, io)) {
+  else if (DecodeImagePGX(bytes, color_hints, pool, io)) {
     codec = Codec::kPGX;
-  } else if (DecodeImagePNM(bytes, pool, io)) {
+  } else if (DecodeImagePNM(bytes, color_hints, pool, io)) {
     codec = Codec::kPNM;
   }
 #if JPEGXL_ENABLE_GIF
-  else if (DecodeImageGIF(bytes, pool, io)) {
+  else if (DecodeImageGIF(bytes, color_hints, pool, io)) {
     codec = Codec::kGIF;
   }
 #endif
-  else if (DecodeImageJPG(bytes, pool, io)) {
+  else if (DecodeImageJPG(bytes, color_hints, pool, io)) {
     codec = Codec::kJPG;
-  }
-  else if (DecodeImagePSD(bytes, pool, io)) {
+  } else if (DecodeImagePSD(bytes, color_hints, pool, io)) {
     codec = Codec::kPSD;
   }
 #if JPEGXL_ENABLE_EXR
-  else if (DecodeImageEXR(bytes, pool, io)) {
+  else if (DecodeImageEXR(bytes, color_hints, pool, io)) {
     codec = Codec::kEXR;
   }
 #endif
@@ -129,12 +129,12 @@ Status SetFromBytes(const Span<const uint8_t> bytes, CodecInOut* io,
   return true;
 }
 
-Status SetFromFile(const std::string& pathname, CodecInOut* io,
-                   ThreadPool* pool, Codec* orig_codec) {
+Status SetFromFile(const std::string& pathname, const ColorHints& color_hints,
+                   CodecInOut* io, ThreadPool* pool, Codec* orig_codec) {
   PaddedBytes encoded;
   JXL_RETURN_IF_ERROR(ReadFile(pathname, &encoded));
-  JXL_RETURN_IF_ERROR(
-      SetFromBytes(Span<const uint8_t>(encoded), io, pool, orig_codec));
+  JXL_RETURN_IF_ERROR(SetFromBytes(Span<const uint8_t>(encoded), color_hints,
+                                   io, pool, orig_codec));
   return true;
 }
 

--- a/lib/extras/codec.h
+++ b/lib/extras/codec.h
@@ -13,6 +13,7 @@
 
 #include <string>
 
+#include "lib/extras/color_hints.h"
 #include "lib/jxl/base/compiler_specific.h"
 #include "lib/jxl/base/data_parallel.h"
 #include "lib/jxl/base/padded_bytes.h"
@@ -58,13 +59,21 @@ Codec CodecFromExtension(const std::string& extension,
                          size_t* JXL_RESTRICT bits_per_sample);
 
 // Decodes "bytes" and sets io->metadata.m.
-// dec_hints may specify the "color_space" (otherwise, defaults to sRGB).
-Status SetFromBytes(const Span<const uint8_t> bytes, CodecInOut* io,
-                    ThreadPool* pool = nullptr, Codec* orig_codec = nullptr);
+// color_space_hint may specify the color space, otherwise, defaults to sRGB.
+Status SetFromBytes(const Span<const uint8_t> bytes,
+                    const ColorHints& color_hints, CodecInOut* io,
+                    ThreadPool* pool, Codec* orig_codec);
+// Helper function to use no color_space_hint.
+JXL_INLINE Status SetFromBytes(const Span<const uint8_t> bytes, CodecInOut* io,
+                               ThreadPool* pool = nullptr,
+                               Codec* orig_codec = nullptr) {
+  return SetFromBytes(bytes, ColorHints(), io, pool, orig_codec);
+}
 
 // Reads from file and calls SetFromBytes.
-Status SetFromFile(const std::string& pathname, CodecInOut* io,
-                   ThreadPool* pool = nullptr, Codec* orig_codec = nullptr);
+Status SetFromFile(const std::string& pathname, const ColorHints& color_hints,
+                   CodecInOut* io, ThreadPool* pool = nullptr,
+                   Codec* orig_codec = nullptr);
 
 // Replaces "bytes" with an encoding of pixels transformed from c_current
 // color space to c_desired.

--- a/lib/extras/codec_apng.cc
+++ b/lib/extras/codec_apng.cc
@@ -192,8 +192,8 @@ int processing_finish(png_structp png_ptr, png_infop info_ptr) {
 
 }  // namespace
 
-Status DecodeImageAPNG(Span<const uint8_t> bytes, ThreadPool* pool,
-                       CodecInOut* io) {
+Status DecodeImageAPNG(Span<const uint8_t> bytes, const ColorHints& color_hints,
+                       ThreadPool* pool, CodecInOut* io) {
   Reader r;
   unsigned int id, i, j, w, h, w0, h0, x0, y0;
   unsigned int delay_num, delay_den, dop, bop, rowbytes, imagesize;
@@ -223,11 +223,8 @@ Status DecodeImageAPNG(Span<const uint8_t> bytes, ThreadPool* pool,
   io->metadata.m.SetAlphaBits(8);
   io->metadata.m.color_encoding =
       ColorEncoding::SRGB();  // todo: get data from png metadata
-  (void)io->dec_hints.Foreach(
-      [](const std::string& key, const std::string& /*value*/) {
-        JXL_WARNING("APNG decoder ignoring %s hint", key.c_str());
-        return true;
-      });
+  JXL_RETURN_IF_ERROR(ApplyColorHints(color_hints, /*color_already_set=*/true,
+                                      /*is_gray=*/false, io));
 
   bool errorstate = true;
   if (id == kId_IHDR && chunkIHDR.size == 25) {

--- a/lib/extras/codec_apng.h
+++ b/lib/extras/codec_apng.h
@@ -10,6 +10,7 @@
 
 #include <stdint.h>
 
+#include "lib/extras/color_hints.h"
 #include "lib/jxl/base/data_parallel.h"
 #include "lib/jxl/base/padded_bytes.h"
 #include "lib/jxl/base/span.h"
@@ -18,8 +19,9 @@
 
 namespace jxl {
 
-// Decodes `bytes` into `io`. io->dec_hints are ignored.
-Status DecodeImageAPNG(const Span<const uint8_t> bytes, ThreadPool* pool,
+// Decodes `bytes` into `io`. color_space_hint is ignored.
+Status DecodeImageAPNG(const Span<const uint8_t> bytes,
+                       const ColorHints& color_hints, ThreadPool* pool,
                        CodecInOut* io);
 
 }  // namespace jxl

--- a/lib/extras/codec_exr.cc
+++ b/lib/extras/codec_exr.cc
@@ -127,8 +127,8 @@ class InMemoryOStream : public OpenEXR::OStream {
 
 }  // namespace
 
-Status DecodeImageEXR(Span<const uint8_t> bytes, ThreadPool* pool,
-                      CodecInOut* io) {
+Status DecodeImageEXR(Span<const uint8_t> bytes, const ColorHints& color_hints,
+                      ThreadPool* pool, CodecInOut* io) {
   // Get the number of threads we should be using for OpenEXR.
   // OpenEXR creates its own set of threads, independent from ours. `pool` is
   // only used for converting from a buffer of OpenEXR::Rgba to Image3F.

--- a/lib/extras/codec_exr.h
+++ b/lib/extras/codec_exr.h
@@ -8,6 +8,7 @@
 
 // Encodes OpenEXR images in memory.
 
+#include "lib/extras/color_hints.h"
 #include "lib/jxl/base/data_parallel.h"
 #include "lib/jxl/base/padded_bytes.h"
 #include "lib/jxl/base/span.h"
@@ -17,9 +18,9 @@
 
 namespace jxl {
 
-// Decodes `bytes` into `io`. io->dec_hints are ignored.
-Status DecodeImageEXR(Span<const uint8_t> bytes, ThreadPool* pool,
-                      CodecInOut* io);
+// Decodes `bytes` into `io`. color_hints are ignored.
+Status DecodeImageEXR(Span<const uint8_t> bytes, const ColorHints& color_hints,
+                      ThreadPool* pool, CodecInOut* io);
 
 // Transforms from io->c_current to `c_desired` (with the transfer function set
 // to linear as that is the OpenEXR convention) and encodes into `bytes`.

--- a/lib/extras/codec_gif.h
+++ b/lib/extras/codec_gif.h
@@ -10,6 +10,7 @@
 
 #include <stdint.h>
 
+#include "lib/extras/color_hints.h"
 #include "lib/jxl/base/data_parallel.h"
 #include "lib/jxl/base/padded_bytes.h"
 #include "lib/jxl/base/span.h"
@@ -18,8 +19,9 @@
 
 namespace jxl {
 
-// Decodes `bytes` into `io`. io->dec_hints are ignored.
-Status DecodeImageGIF(const Span<const uint8_t> bytes, ThreadPool* pool,
+// Decodes `bytes` into `io`. color_hints are ignored.
+Status DecodeImageGIF(const Span<const uint8_t> bytes,
+                      const ColorHints& color_hints, ThreadPool* pool,
                       CodecInOut* io);
 
 }  // namespace jxl

--- a/lib/extras/codec_jpg.h
+++ b/lib/extras/codec_jpg.h
@@ -11,6 +11,7 @@
 #include <stdint.h>
 
 #include "lib/extras/codec.h"
+#include "lib/extras/color_hints.h"
 #include "lib/jxl/base/data_parallel.h"
 #include "lib/jxl/base/padded_bytes.h"
 #include "lib/jxl/base/span.h"
@@ -30,11 +31,12 @@ static inline bool IsJPG(const Span<const uint8_t> bytes) {
   return true;
 }
 
-// Decodes `bytes` into `io`. io->dec_hints are ignored.
+// Decodes `bytes` into `io`. color_hints are ignored.
 // `elapsed_deinterleave`, if non-null, will be set to the time (in seconds)
 // that it took to deinterleave the raw JSAMPLEs to planar floats.
-Status DecodeImageJPG(Span<const uint8_t> bytes, ThreadPool* pool,
-                      CodecInOut* io, double* elapsed_deinterleave = nullptr);
+Status DecodeImageJPG(Span<const uint8_t> bytes, const ColorHints& color_hints,
+                      ThreadPool* pool, CodecInOut* io,
+                      double* elapsed_deinterleave = nullptr);
 
 // Encodes into `bytes`.
 Status EncodeImageJPG(const CodecInOut* io, JpegEncoder encoder, size_t quality,

--- a/lib/extras/codec_pgx.h
+++ b/lib/extras/codec_pgx.h
@@ -11,6 +11,7 @@
 #include <stddef.h>
 #include <stdint.h>
 
+#include "lib/extras/color_hints.h"
 #include "lib/jxl/base/data_parallel.h"
 #include "lib/jxl/base/padded_bytes.h"
 #include "lib/jxl/base/span.h"
@@ -20,9 +21,9 @@
 
 namespace jxl {
 
-// Decodes `bytes` into `io`. io->dec_hints may specify "color_space", which
-// defaults to sRGB.
-Status DecodeImagePGX(const Span<const uint8_t> bytes, ThreadPool* pool,
+// Decodes `bytes` into `io`.
+Status DecodeImagePGX(const Span<const uint8_t> bytes,
+                      const ColorHints& color_hints, ThreadPool* pool,
                       CodecInOut* io);
 
 // Transforms from io->c_current to `c_desired` and encodes into `bytes`.

--- a/lib/extras/codec_png.h
+++ b/lib/extras/codec_png.h
@@ -14,6 +14,7 @@
 // TODO(janwas): workaround for incorrect Win64 codegen (cause unknown)
 #include <hwy/highway.h>
 
+#include "lib/extras/color_hints.h"
 #include "lib/jxl/base/data_parallel.h"
 #include "lib/jxl/base/padded_bytes.h"
 #include "lib/jxl/base/span.h"
@@ -23,8 +24,9 @@
 
 namespace jxl {
 
-// Decodes `bytes` into `io`. io->dec_hints are ignored.
-Status DecodeImagePNG(const Span<const uint8_t> bytes, ThreadPool* pool,
+// Decodes `bytes` into `io`.
+Status DecodeImagePNG(const Span<const uint8_t> bytes,
+                      const ColorHints& color_hints, ThreadPool* pool,
                       CodecInOut* io);
 
 // Transforms from io->c_current to `c_desired` and encodes into `bytes`.

--- a/lib/extras/codec_pnm.h
+++ b/lib/extras/codec_pnm.h
@@ -14,6 +14,7 @@
 // TODO(janwas): workaround for incorrect Win64 codegen (cause unknown)
 #include <hwy/highway.h>
 
+#include "lib/extras/color_hints.h"
 #include "lib/jxl/base/data_parallel.h"
 #include "lib/jxl/base/padded_bytes.h"
 #include "lib/jxl/base/span.h"
@@ -23,9 +24,10 @@
 
 namespace jxl {
 
-// Decodes `bytes` into `io`. io->dec_hints may specify "color_space", which
+// Decodes `bytes` into `io`. color_hints may specify "color_space", which
 // defaults to sRGB.
-Status DecodeImagePNM(const Span<const uint8_t> bytes, ThreadPool* pool,
+Status DecodeImagePNM(const Span<const uint8_t> bytes,
+                      const ColorHints& color_hints, ThreadPool* pool,
                       CodecInOut* io);
 
 // Transforms from io->c_current to `c_desired` and encodes into `bytes`.

--- a/lib/extras/codec_psd.cc
+++ b/lib/extras/codec_psd.cc
@@ -187,7 +187,8 @@ Status decode_layer(const uint8_t*& pos, const uint8_t* maxpos,
 
 }  // namespace
 
-Status DecodeImagePSD(const Span<const uint8_t> bytes, ThreadPool* pool,
+Status DecodeImagePSD(const Span<const uint8_t> bytes,
+                      const ColorHints& color_hints, ThreadPool* pool,
                       CodecInOut* io) {
   const uint8_t* pos = bytes.data();
   const uint8_t* maxpos = bytes.data() + bytes.size();
@@ -229,6 +230,7 @@ Status DecodeImagePSD(const Span<const uint8_t> bytes, ThreadPool* pool,
   bool hasmergeddata = true;
   bool have_alpha = false;
   bool merged_has_alpha = false;
+  bool color_already_set = false;
   size_t metalength = get_be_int(4, pos, maxpos);
   const uint8_t* metaoffset = pos;
   while (pos < metaoffset + metalength) {
@@ -257,6 +259,7 @@ Status DecodeImagePSD(const Span<const uint8_t> bytes, ThreadPool* pool,
       if (!io->metadata.m.color_encoding.SetICC(std::move(icc))) {
         return JXL_FAILURE("PSD: Invalid color profile");
       }
+      color_already_set = true;
     } else if (id == 1057) {  // compatibility mode or not?
       if (get_be_int(4, pos, maxpos) != 1) {
         return JXL_FAILURE("PSD: expected version=1 in id=1057 resource block");
@@ -309,6 +312,9 @@ Status DecodeImagePSD(const Span<const uint8_t> bytes, ThreadPool* pool,
     pos += blocklength;
     if (blocklength & 1) pos++;  // padding again
   }
+
+  JXL_RETURN_IF_ERROR(ApplyColorHints(color_hints, color_already_set,
+                                      /*is_gray=*/false, io));
 
   size_t layerlength = get_be_int(4 * version, pos, maxpos);
   const uint8_t* after_layers_pos = pos + layerlength;

--- a/lib/extras/codec_psd.h
+++ b/lib/extras/codec_psd.h
@@ -11,6 +11,7 @@
 #include <stddef.h>
 #include <stdint.h>
 
+#include "lib/extras/color_hints.h"
 #include "lib/jxl/base/padded_bytes.h"
 #include "lib/jxl/base/span.h"
 #include "lib/jxl/base/status.h"
@@ -20,7 +21,8 @@
 namespace jxl {
 
 // Decodes `bytes` into `io`.
-Status DecodeImagePSD(const Span<const uint8_t> bytes, ThreadPool* pool,
+Status DecodeImagePSD(const Span<const uint8_t> bytes,
+                      const ColorHints& color_hints, ThreadPool* pool,
                       CodecInOut* io);
 
 // Not implemented yet

--- a/lib/extras/color_hints.cc
+++ b/lib/extras/color_hints.cc
@@ -1,0 +1,61 @@
+// Copyright (c) the JPEG XL Project Authors. All rights reserved.
+//
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+#include "lib/extras/color_hints.h"
+
+#include "lib/jxl/base/file_io.h"
+#include "lib/jxl/color_encoding_internal.h"
+
+namespace jxl {
+
+Status ApplyColorHints(const ColorHints& color_hints,
+                       const bool color_already_set, const bool is_gray,
+                       CodecInOut* io) {
+  if (color_already_set) {
+    return color_hints.Foreach(
+        [](const std::string& key, const std::string& /*value*/) {
+          JXL_WARNING("Decoder ignoring %s hint", key.c_str());
+          return true;
+        });
+  }
+
+  bool got_color_space = false;
+
+  JXL_RETURN_IF_ERROR(color_hints.Foreach(
+      [is_gray, io, &got_color_space](const std::string& key,
+                                      const std::string& value) -> Status {
+        ColorEncoding* c_original = &io->metadata.m.color_encoding;
+        if (key == "color_space") {
+          if (!ParseDescription(value, c_original) ||
+              !c_original->CreateICC()) {
+            return JXL_FAILURE("Failed to apply color_space");
+          }
+
+          if (is_gray != io->metadata.m.color_encoding.IsGray()) {
+            return JXL_FAILURE("mismatch between file and color_space hint");
+          }
+
+          got_color_space = true;
+        } else if (key == "icc_pathname") {
+          PaddedBytes icc;
+          JXL_RETURN_IF_ERROR(ReadFile(value, &icc));
+          JXL_RETURN_IF_ERROR(c_original->SetICC(std::move(icc)));
+          got_color_space = true;
+        } else {
+          JXL_WARNING("Ignoring %s hint", key.c_str());
+        }
+        return true;
+      }));
+
+  if (!got_color_space) {
+    JXL_WARNING("No color_space/icc_pathname given, assuming sRGB");
+    JXL_RETURN_IF_ERROR(io->metadata.m.color_encoding.SetSRGB(
+        is_gray ? ColorSpace::kGray : ColorSpace::kRGB));
+  }
+
+  return true;
+}
+
+}  // namespace jxl

--- a/lib/extras/color_hints.h
+++ b/lib/extras/color_hints.h
@@ -1,0 +1,70 @@
+// Copyright (c) the JPEG XL Project Authors. All rights reserved.
+//
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+#ifndef LIB_EXTRAS_COLOR_HINTS_H_
+#define LIB_EXTRAS_COLOR_HINTS_H_
+
+// Not all the formats implemented in the extras lib support bundling color
+// information into the file, and those that support it may not have it.
+// To allow attaching color information to those file formats the caller can
+// define these color hints.
+
+#include <stddef.h>
+#include <stdint.h>
+
+#include <string>
+#include <vector>
+
+#include "lib/jxl/base/status.h"
+#include "lib/jxl/codec_in_out.h"
+
+namespace jxl {
+
+class ColorHints {
+ public:
+  // key=color_space, value=Description(c/pp): specify the ColorEncoding of
+  //   the pixels for decoding. Otherwise, if the codec did not obtain an ICC
+  //   profile from the image, assume sRGB.
+  //
+  // Strings are taken from the command line, so avoid spaces for convenience.
+  void Add(const std::string& key, const std::string& value) {
+    kv_.emplace_back(key, value);
+  }
+
+  // Calls `func(key, value)` for each key/value in the order they were added,
+  // returning false immediately if `func` returns false.
+  template <class Func>
+  Status Foreach(const Func& func) const {
+    for (const KeyValue& kv : kv_) {
+      Status ok = func(kv.key, kv.value);
+      if (!ok) {
+        return JXL_FAILURE("ColorHints::Foreach returned false");
+      }
+    }
+    return true;
+  }
+
+ private:
+  // Splitting into key/value avoids parsing in each codec.
+  struct KeyValue {
+    KeyValue(std::string key, std::string value)
+        : key(std::move(key)), value(std::move(value)) {}
+
+    std::string key;
+    std::string value;
+  };
+
+  std::vector<KeyValue> kv_;
+};
+
+// Apply the color hints to the decoded image in CodecInOut if any.
+// color_already_set tells whether the color encoding was already set, in which
+// case the hints are ignored if any hint is passed.
+Status ApplyColorHints(const ColorHints& color_hints, bool color_already_set,
+                       bool is_gray, CodecInOut* io);
+
+}  // namespace jxl
+
+#endif  // LIB_EXTRAS_COLOR_HINTS_H_

--- a/lib/jxl/codec_in_out.h
+++ b/lib/jxl/codec_in_out.h
@@ -61,44 +61,6 @@ Status VerifyDimensions(const SizeConstraints* constraints, T xs, T ys) {
 
 using CodecIntervals = std::array<CodecInterval, 4>;  // RGB[A] or Y[A]
 
-// Allows passing arbitrary metadata to decoders (required for PNM).
-class DecoderHints {
- public:
-  // key=color_space, value=Description(c/pp): specify the ColorEncoding of
-  //   the pixels for decoding. Otherwise, if the codec did not obtain an ICC
-  //   profile from the image, assume sRGB.
-  //
-  // Strings are taken from the command line, so avoid spaces for convenience.
-  void Add(const std::string& key, const std::string& value) {
-    kv_.emplace_back(key, value);
-  }
-
-  // Calls `func(key, value)` for each key/value in the order they were added,
-  // returning false immediately if `func` returns false.
-  template <class Func>
-  Status Foreach(const Func& func) const {
-    for (const KeyValue& kv : kv_) {
-      Status ok = func(kv.key, kv.value);
-      if (!ok) {
-        return JXL_FAILURE("DecoderHints::Foreach returned false");
-      }
-    }
-    return true;
-  }
-
- private:
-  // Splitting into key/value avoids parsing in each codec.
-  struct KeyValue {
-    KeyValue(std::string key, std::string value)
-        : key(std::move(key)), value(std::move(value)) {}
-
-    std::string key;
-    std::string value;
-  };
-
-  std::vector<KeyValue> kv_;
-};
-
 // Optional text/EXIF metadata.
 struct Blobs {
   PaddedBytes exif;
@@ -200,8 +162,6 @@ class CodecInOut {
   // -- DECODER INPUT:
 
   SizeConstraints constraints;
-  // Used to set c_current for codecs that lack color space metadata.
-  DecoderHints dec_hints;
   // Decode to pixels or keep JPEG as quantized DCT coefficients
   DecodeTarget dec_target = DecodeTarget::kPixels;
 

--- a/lib/jxl_extras.cmake
+++ b/lib/jxl_extras.cmake
@@ -19,6 +19,8 @@ set(JPEGXL_EXTRAS_SOURCES
   extras/codec_pnm.h
   extras/codec_psd.cc
   extras/codec_psd.h
+  extras/color_hints.cc
+  extras/color_hints.h
   extras/time.cc
   extras/time.h
   extras/tone_mapping.cc

--- a/tools/args.h
+++ b/tools/args.h
@@ -14,6 +14,7 @@
 #include <string>
 #include <vector>
 
+#include "lib/extras/color_hints.h"
 #include "lib/jxl/base/override.h"
 #include "lib/jxl/base/status.h"
 #include "lib/jxl/codec_in_out.h"  // DecoderHints
@@ -99,7 +100,7 @@ static inline bool ParseDouble(const char* arg, double* out) {
 }
 
 static inline bool ParseAndAppendKeyValue(const char* arg,
-                                          jxl::DecoderHints* out) {
+                                          jxl::ColorHints* out) {
   const char* eq = strchr(arg, '=');
   if (!eq) {
     fprintf(stderr, "Expected argument as 'key=value' but received '%s'\n",

--- a/tools/benchmark/benchmark_args.cc
+++ b/tools/benchmark/benchmark_args.cc
@@ -109,11 +109,11 @@ Status BenchmarkArgs::AddCommandLineOptions() {
            "HLG transfer function)",
            0);
 
-  AddString(&dec_hints_string, "dec-hints",
-            "Decoder hints for the input images to encoder. Comma separated "
-            "key=value pairs. The key color_space indicates ColorEncoding (see "
-            "ParseDescription; e.g. RGB_D65_SRG_Rel_709) for input images "
-            "without color encoding (such as PNM)");
+  AddString(&color_hints_string, "dec-hints",
+            "Color encoding hints for the input images to encoder. Comma "
+            "separated key=value pairs. The key color_space indicates "
+            "ColorEncoding (see ParseDescription; e.g. RGB_D65_SRG_Rel_709) "
+            "for input images without color encoding (such as PNM)");
 
   AddUnsigned(
       &override_bitdepth, "override_bitdepth",
@@ -255,15 +255,15 @@ Status BenchmarkArgs::ValidateArgs() {
     return JXL_FAILURE("override_bitdepth must be <= 32");
   }
 
-  if (!dec_hints_string.empty()) {
-    std::vector<std::string> hints = SplitString(dec_hints_string, ',');
+  if (!color_hints_string.empty()) {
+    std::vector<std::string> hints = SplitString(color_hints_string, ',');
     for (const auto& hint : hints) {
       std::vector<std::string> kv = SplitString(hint, '=');
       if (kv.size() != 2) {
         return JXL_FAILURE(
             "dec-hints key value pairs must have the form 'key=value'");
       }
-      dec_hints.Add(kv[0], kv[1]);
+      color_hints.Add(kv[0], kv[1]);
     }
   }
 

--- a/tools/benchmark/benchmark_args.h
+++ b/tools/benchmark/benchmark_args.h
@@ -15,6 +15,7 @@
 #include <string>
 #include <vector>
 
+#include "lib/extras/color_hints.h"
 #include "lib/jxl/base/override.h"
 #include "lib/jxl/base/status.h"
 #include "lib/jxl/butteraugli/butteraugli.h"
@@ -116,8 +117,8 @@ struct BenchmarkArgs {
 
   float intensity_target;
 
-  std::string dec_hints_string;
-  jxl::DecoderHints dec_hints;
+  std::string color_hints_string;
+  jxl::ColorHints color_hints;
 
   size_t override_bitdepth;
 

--- a/tools/benchmark/benchmark_codec_custom.cc
+++ b/tools/benchmark/benchmark_codec_custom.cc
@@ -130,7 +130,7 @@ class CustomCodec : public ImageCodec {
         },
         png_filename, speed_stats));
     io->target_nits = saved_intensity_target_;
-    return SetFromFile(png_filename, io, pool);
+    return SetFromFile(png_filename, ColorHints(), io, pool);
   }
 
  private:

--- a/tools/benchmark/benchmark_codec_jpeg.cc
+++ b/tools/benchmark/benchmark_codec_jpeg.cc
@@ -102,8 +102,8 @@ class JPEGCodec : public ImageCodec {
                     jpegxl::tools::SpeedStats* speed_stats) override {
     double elapsed_deinterleave;
     const double start = Now();
-    JXL_RETURN_IF_ERROR(
-        DecodeImageJPG(compressed, pool, io, &elapsed_deinterleave));
+    JXL_RETURN_IF_ERROR(DecodeImageJPG(compressed, ColorHints(), pool, io,
+                                       &elapsed_deinterleave));
     const double end = Now();
     speed_stats->NotifyElapsed(end - start - elapsed_deinterleave);
     return true;

--- a/tools/benchmark/benchmark_codec_png.cc
+++ b/tools/benchmark/benchmark_codec_png.cc
@@ -52,7 +52,7 @@ class PNGCodec : public ImageCodec {
                     ThreadPoolInternal* pool, CodecInOut* io,
                     jpegxl::tools::SpeedStats* speed_stats) override {
     const double start = Now();
-    JXL_RETURN_IF_ERROR(DecodeImagePNG(compressed, pool, io));
+    JXL_RETURN_IF_ERROR(DecodeImagePNG(compressed, ColorHints(), pool, io));
     const double end = Now();
     speed_stats->NotifyElapsed(end - start);
     return true;

--- a/tools/benchmark/benchmark_xl.cc
+++ b/tools/benchmark/benchmark_xl.cc
@@ -21,6 +21,7 @@
 #include "jxl/decode.h"
 #include "lib/extras/codec.h"
 #include "lib/extras/codec_png.h"
+#include "lib/extras/color_hints.h"
 #include "lib/extras/time.h"
 #include "lib/jxl/alpha.h"
 #include "lib/jxl/base/cache_aligned.h"
@@ -67,7 +68,7 @@ Status WritePNG(Image3F&& image, ThreadPool* pool,
 
 Status ReadPNG(const std::string& filename, Image3F* image) {
   CodecInOut io;
-  JXL_CHECK(SetFromFile(filename, &io));
+  JXL_CHECK(SetFromFile(filename, ColorHints(), &io));
   *image = CopyImage(*io.Main().color());
   return true;
 }
@@ -977,12 +978,11 @@ class Benchmark {
           Status ok = true;
 
           loaded_images[i].target_nits = Args()->intensity_target;
-          loaded_images[i].dec_hints = Args()->dec_hints;
           loaded_images[i].dec_target = jpeg_transcoding_requested
                                             ? DecodeTarget::kQuantizedCoeffs
                                             : DecodeTarget::kPixels;
           if (!Args()->decode_only) {
-            ok = SetFromFile(fnames[i], &loaded_images[i]);
+            ok = SetFromFile(fnames[i], Args()->color_hints, &loaded_images[i]);
           }
           if (!ok) {
             if (!Args()->silent_errors) {

--- a/tools/butteraugli_main.cc
+++ b/tools/butteraugli_main.cc
@@ -11,6 +11,7 @@
 
 #include "lib/extras/codec.h"
 #include "lib/extras/codec_png.h"
+#include "lib/extras/color_hints.h"
 #include "lib/jxl/base/data_parallel.h"
 #include "lib/jxl/base/file_io.h"
 #include "lib/jxl/base/padded_bytes.h"
@@ -44,21 +45,20 @@ Status RunButteraugli(const char* pathname1, const char* pathname2,
                       const std::string& distmap_filename,
                       const std::string& colorspace_hint, double p,
                       float intensity_target) {
-  CodecInOut io1;
+  ColorHints color_hints;
   if (!colorspace_hint.empty()) {
-    io1.dec_hints.Add("color_space", colorspace_hint);
+    color_hints.Add("color_space", colorspace_hint);
   }
+
+  CodecInOut io1;
   ThreadPoolInternal pool(4);
-  if (!SetFromFile(pathname1, &io1, &pool)) {
+  if (!SetFromFile(pathname1, color_hints, &io1, &pool)) {
     fprintf(stderr, "Failed to read image from %s\n", pathname1);
     return false;
   }
 
   CodecInOut io2;
-  if (!colorspace_hint.empty()) {
-    io2.dec_hints.Add("color_space", colorspace_hint);
-  }
-  if (!SetFromFile(pathname2, &io2, &pool)) {
+  if (!SetFromFile(pathname2, color_hints, &io2, &pool)) {
     fprintf(stderr, "Failed to read image from %s\n", pathname2);
     return false;
   }

--- a/tools/cjxl.cc
+++ b/tools/cjxl.cc
@@ -73,7 +73,7 @@ static double ApproximateDistanceForBPP(double bpp) {
 jxl::Status LoadSaliencyMap(const std::string& filename_heatmap,
                             jxl::ThreadPool* pool, jxl::ImageF* out_map) {
   jxl::CodecInOut io_heatmap;
-  if (!SetFromFile(filename_heatmap, &io_heatmap, pool)) {
+  if (!SetFromFile(filename_heatmap, jxl::ColorHints(), &io_heatmap, pool)) {
     return JXL_FAILURE("Could not load heatmap.");
   }
   *out_map = std::move(io_heatmap.Main().color()->Plane(0));
@@ -462,7 +462,7 @@ void CompressArgs::AddCommandLineOptions(CommandLineParser* cmdline) {
       'x', "dec-hints", "key=value",
       "color_space indicates the ColorEncoding, see Description();\n"
       "icc_pathname refers to a binary file containing an ICC profile.",
-      &dec_hints, &ParseAndAppendKeyValue, 1);
+      &color_hints, &ParseAndAppendKeyValue, 1);
 
   cmdline->AddOptionValue(
       '\0', "override_bitdepth", "0=use from image, 1-32=override",
@@ -741,11 +741,11 @@ jxl::Status LoadAll(CompressArgs& args, jxl::ThreadPoolInternal* pool,
   const double t0 = jxl::Now();
 
   io->target_nits = args.intensity_target;
-  io->dec_hints = args.dec_hints;
   io->dec_target = (args.jpeg_transcode ? jxl::DecodeTarget::kQuantizedCoeffs
                                         : jxl::DecodeTarget::kPixels);
   jxl::Codec input_codec;
-  if (!SetFromFile(args.params.file_in, io, nullptr, &input_codec)) {
+  if (!SetFromFile(args.params.file_in, args.color_hints, io, nullptr,
+                   &input_codec)) {
     fprintf(stderr, "Failed to read image %s.\n", args.params.file_in);
     return false;
   }

--- a/tools/cjxl.h
+++ b/tools/cjxl.h
@@ -11,6 +11,7 @@
 #include <string>
 #include <utility>
 
+#include "lib/extras/color_hints.h"
 #include "lib/jxl/base/data_parallel.h"
 #include "lib/jxl/base/override.h"
 #include "lib/jxl/base/padded_bytes.h"
@@ -53,8 +54,10 @@ struct CompressArgs {
   const char* file_out = nullptr;
   jxl::Override print_profile = jxl::Override::kDefault;
 
+  // Decoding source image flags
+  jxl::ColorHints color_hints;
+
   // JXL flags
-  jxl::DecoderHints dec_hints;
   size_t override_bitdepth = 0;
   jxl::CompressParams params;
   size_t num_threads;

--- a/tools/decode_and_encode.cc
+++ b/tools/decode_and_encode.cc
@@ -28,9 +28,10 @@ int Convert(int argc, char** argv) {
   const std::string& pathname_out = argv[3];
 
   CodecInOut io;
+  ColorHints color_hints;
   ThreadPoolInternal pool(4);
-  io.dec_hints.Add("color_space", desc);
-  if (!SetFromFile(pathname_in, &io, &pool)) {
+  color_hints.Add("color_space", desc);
+  if (!SetFromFile(pathname_in, color_hints, &io, &pool)) {
     fprintf(stderr, "Failed to read %s\n", pathname_in.c_str());
     return 1;
   }

--- a/tools/epf_main.cc
+++ b/tools/epf_main.cc
@@ -50,7 +50,7 @@ int main(int argc, const char** argv) {
 
   jxl::ThreadPoolInternal pool(num_threads);
   jxl::CodecInOut io;
-  if (!jxl::SetFromFile(input_filename, &io, &pool)) {
+  if (!jxl::SetFromFile(input_filename, jxl::ColorHints(), &io, &pool)) {
     fprintf(stderr, "Failed to read from \"%s\".\n", input_filename);
     return EXIT_FAILURE;
   }

--- a/tools/ssimulacra_main.cc
+++ b/tools/ssimulacra_main.cc
@@ -30,8 +30,8 @@ int Run(int argc, char** argv) {
 
   jxl::CodecInOut io1;
   jxl::CodecInOut io2;
-  JXL_CHECK(SetFromFile(argv[input_arg], &io1));
-  JXL_CHECK(SetFromFile(argv[input_arg + 1], &io2));
+  JXL_CHECK(SetFromFile(argv[input_arg], jxl::ColorHints(), &io1));
+  JXL_CHECK(SetFromFile(argv[input_arg + 1], jxl::ColorHints(), &io2));
   JXL_CHECK(
       io1.TransformTo(jxl::ColorEncoding::LinearSRGB(io1.Main().IsGray())));
   JXL_CHECK(


### PR DESCRIPTION
The DecoderHints are hints not for the JXL decoder, but for decoders of
all the other formats supported by the extras libraries. These "hints"
are only ever used for specifying the "color_space" (Description of
ColorEncoding) or the path to an ICC profile blob. This is useful when
loading images from format that don't specify the color space (like PNM)
and in cases where the color space is just not included in a given file.

The hints were part of the CodecInOut but were really only used by the
decoders in extras/ as an input together with the encoded image bytes.

This patch moves the DecoderHints to the extras/ library and renames it
to ColorHints since this is only used for color encoding.

One small side-effect of this refactor is that now the GIF and PSD
decoders supports parsing the color hints if passed.