### PR TITLE
Add libjxl_extras to lib.gni and build_cleaner.py

### DIFF
--- a/lib/jxl_extras.cmake
+++ b/lib/jxl_extras.cmake
@@ -3,12 +3,12 @@
 # Use of this source code is governed by a BSD-style
 # license that can be found in the LICENSE file.
 
+# codec_jpg is included always for loading of lossless reconstruction but
+# decoding to pixels is only supported if libjpeg is found and
+# JPEGXL_ENABLE_JPEG=1.
 set(JPEGXL_EXTRAS_SOURCES
   extras/codec.cc
   extras/codec.h
-  # codec_jpg is included always for loading of lossless reconstruction but
-  # decoding to pixels is only supported if libjpeg is found and
-  # JPEGXL_ENABLE_JPEG=1.
   extras/codec_jpg.cc
   extras/codec_jpg.h
   extras/codec_pgx.cc

--- a/lib/lib.gni
+++ b/lib/lib.gni
@@ -390,6 +390,27 @@ libjxl_testlib_sources = [
     "jxl/testdata.h",
 ]
 
+libjxl_extras_sources = [
+    "extras/codec.cc",
+    "extras/codec.h",
+    "extras/codec_jpg.cc",
+    "extras/codec_jpg.h",
+    "extras/codec_pgx.cc",
+    "extras/codec_pgx.h",
+    "extras/codec_png.cc",
+    "extras/codec_png.h",
+    "extras/codec_pnm.cc",
+    "extras/codec_pnm.h",
+    "extras/codec_psd.cc",
+    "extras/codec_psd.h",
+    "extras/color_hints.cc",
+    "extras/color_hints.h",
+    "extras/time.cc",
+    "extras/time.h",
+    "extras/tone_mapping.cc",
+    "extras/tone_mapping.h",
+]
+
 libjxl_threads_sources = [
     "threads/resizable_parallel_runner.cc",
     "threads/thread_parallel_runner.cc",

--- a/tools/build_cleaner.py
+++ b/tools/build_cleaner.py
@@ -42,11 +42,12 @@ def GetPrefixLibFiles(repo_files, prefix, suffixes=('.h', '.cc', '.ui')):
 #   * tests-only sources,
 #   * google benchmark sources,
 #   * threads library sources,
+#   * extras library sources,
 #   * libjxl (encoder+decoder) public include/ headers and
 #   * threads public include/ headers.
 JxlSources = collections.namedtuple(
     'JxlSources', ['dec', 'enc', 'test', 'gbench', 'threads',
-                   'jxl_public_hdrs', 'threads_public_hdrs'])
+                   'extras', 'jxl_public_hdrs', 'threads_public_hdrs'])
 
 def SplitLibFiles(repo_files):
   """Splits the library files into the different groups.
@@ -68,6 +69,12 @@ def SplitLibFiles(repo_files):
   gbench_srcs = sorted(fn for fn in lib_srcs + extras_srcs
                        if fn.endswith('_gbench.cc'))
   lib_srcs = [fn for fn in lib_srcs if fn not in gbench_srcs]
+  # Exclude optional codecs from extras.
+  exclude_extras = ['/codec_gif', '/codec_apng', '/codec_exr']
+  extras_srcs = [fn for fn in extras_srcs if fn not in gbench_srcs and
+                 not any(patt in fn for patt in testonly) and
+                 not any(patt in fn for patt in exclude_extras)]
+
 
   enc_srcs = [fn for fn in lib_srcs
               if os.path.basename(fn).startswith('enc_') or
@@ -117,7 +124,7 @@ def SplitLibFiles(repo_files):
   threads_public_hdrs = [fn for fn in public_hdrs if '_parallel_runner' in fn]
   jxl_public_hdrs = list(sorted(set(public_hdrs) - set(threads_public_hdrs)))
   return JxlSources(dec_srcs, enc_srcs, test_srcs, gbench_srcs, thread_srcs,
-                    jxl_public_hdrs, threads_public_hdrs)
+                    extras_srcs, jxl_public_hdrs, threads_public_hdrs)
 
 
 def CleanFile(args, filename, pattern_data_list):
@@ -238,6 +245,16 @@ def BuildCleaner(args):
   gni_patterns.append((
       r'libjxl_threads_sources = \[\n([^\]]+)\]',
       ''.join('    "%s",\n' % fn[len('lib/'):] for fn in jxl_src.threads)))
+
+  # libjxl_extras
+  ok = CleanFile(
+      args, 'lib/jxl_extras.cmake',
+      [(r'set\(JPEGXL_EXTRAS_SOURCES\n([^\)]+)\)',
+        ''.join('  %s\n' % fn[len('lib/'):] for fn in jxl_src.extras))]) and ok
+
+  gni_patterns.append((
+      r'libjxl_extras_sources = \[\n([^\]]+)\]',
+      ''.join('    "%s",\n' % fn[len('lib/'):] for fn in jxl_src.extras)))
 
   # libjxl_profiler
   profiler_srcs = [fn[len('lib/'):] for fn in repo_files


### PR DESCRIPTION
This includes the non-optional parts of libjxl_extras to avoid
forgetting those files in the lib.gni build files.