### PR TITLE
add color transform to frame header api struct

### DIFF
--- a/lib/include/jxl/codestream_header.h
+++ b/lib/include/jxl/codestream_header.h
@@ -282,6 +282,18 @@ typedef struct {
   uint64_t extensions;
 } JxlHeaderExtensions;
 
+/** Color transform of a frame.
+    XYB: likely indicates that the frame is lossy.
+    RGB: no transform was used; possibly the frame was encoded in a lossless
+   way. YCBCR: JPEG's YCbCr transform was used, e.g. because it is a
+   recompressed JPEG.
+ */
+typedef enum {
+  JXL_XYB = 0,
+  JXL_RGB = 1,
+  JXL_YCBCR = 2,
+} JxlColorTransform;
+
 /** The header of one displayed frame. */
 typedef struct {
   /** How long to wait after rendering in ticks. The duration in seconds of a
@@ -303,6 +315,10 @@ typedef struct {
    * Excludes null termination character.
    */
   uint32_t name_length;
+
+  /** Color transform the frame uses.
+   */
+  JxlColorTransform color_transform;
 
   /** Indicates this is the last animation frame.
    */

--- a/lib/jxl/decode.cc
+++ b/lib/jxl/decode.cc
@@ -2265,6 +2265,8 @@ JxlDecoderStatus JxlDecoderGetFrameHeader(const JxlDecoder* dec,
     }
   }
   header->name_length = dec->frame_header->name.size();
+  header->color_transform =
+      static_cast<JxlColorTransform>(dec->frame_header->color_transform);
   header->is_last = dec->frame_header->is_last;
 
   return JXL_DEC_SUCCESS;


### PR DESCRIPTION
Split from https://github.com/libjxl/libjxl/pull/487

Adds a field to the frame header api struct so applications can see if frames are using XYB, RGB or YCbCr.

See also the discussion in https://github.com/libjxl/libjxl/issues/432
