### PR TITLE
Fix build for GIMP plugin with new compilers

### DIFF
--- a/plugins/gimp/file-jxl-save.cc
+++ b/plugins/gimp/file-jxl-save.cc
@@ -762,7 +762,7 @@ bool SaveJpegXlImage(const gint32 image_id, const gint32 drawable_id,
   }
 
   // try to use ICC profile
-  if (icc.size() > 0 && !gimp_color_profile_is_gray) {
+  if (icc.size() > 0 && !gimp_color_profile_is_gray(profile)) {
     if (JXL_ENC_SUCCESS !=
         JxlEncoderSetICCProfile(enc.get(), icc.data(), icc.size())) {
       g_printerr("JXL Warning: JxlEncoderSetICCProfile failed.\n");


### PR DESCRIPTION
`!gimp_color_profile_is_gray` was converting the address of the function
to bool instead of calling it and then using the result. New compilers
actually have a warning for this.