### PR TITLE
implement brob box

### DIFF
--- a/tools/cjxl_main.cc
+++ b/tools/cjxl_main.cc
@@ -88,18 +88,16 @@ int CompressJpegXlMain(int argc, const char* argv[]) {
     JpegXlContainer container;
     container.codestream = compressed.data();
     container.codestream_size = compressed.size();
+    jxl::PaddedBytes exif(4, 0);  // implicit tiff header offset zero
     if (!io.blobs.exif.empty()) {
-      container.exif = io.blobs.exif.data();
-      container.exif_size = io.blobs.exif.size();
+      exif.append(io.blobs.exif);
+      container.addBlob("Exif", exif.data(), exif.size());
     }
-    auto append_xml = [&container](const jxl::PaddedBytes& bytes) {
-      if (bytes.empty()) return;
-      container.xml.emplace_back(bytes.data(), bytes.size());
-    };
-    append_xml(io.blobs.xmp);
+    if (!io.blobs.xmp.empty()) {
+      container.addBlob("xml ", io.blobs.xmp.data(), io.blobs.xmp.size());
+    }
     if (!io.blobs.jumbf.empty()) {
-      container.jumb = io.blobs.jumbf.data();
-      container.jumb_size = io.blobs.jumbf.size();
+      container.addBlob("jumb", io.blobs.jumbf.data(), io.blobs.jumbf.size());
     }
     jxl::PaddedBytes jpeg_data;
     if (io.Main().IsJPEG()) {

--- a/tools/djxl_main.cc
+++ b/tools/djxl_main.cc
@@ -151,16 +151,13 @@ int DecompressMain(int argc, const char* argv[]) {
                      jxl::PaddedBytes& target) {
       target.assign(bytes, bytes + size);
     };
-    if (container.exif_size) {
-      assign(container.exif, container.exif_size, io.blobs.exif);
+    const BrobBlob* exif = container.getBlob("Exif");
+    if (exif != nullptr) {
+      assign(exif->udata, exif->udata_size, io.blobs.exif);
     }
-    if (!container.xml.empty()) {
-      assign(container.xml[0].first, container.xml[0].second, io.blobs.xmp);
-    }
-    if (container.xml.size() > 1) {
-      fprintf(stderr,
-              "Warning: more than one XML box found, assuming first one is XMP "
-              "and ignoring others\n");
+    const BrobBlob* xmp = container.getBlob("xml ");
+    if (xmp != nullptr) {
+      assign(xmp->udata, xmp->udata_size, io.blobs.xmp);
     }
     // Set JPEG quality.
     // TODO(veluca): the decoder should set this value, and the argument should


### PR DESCRIPTION
Implements `brob` box support in the cjxl/djxl tooling. This still has to be migrated to the api (but for that we first need to decide on an api for it, and deal with streaming).

Obviously, brotli-compressing metadata can result in nice savings if this metadata is large.
For example, for this image:
https://www.iptc.org/std/photometadata/examples/IPTC-PhotometadataRef-Std2019.1.jpg


IPTC-PhotometadataRef-Std2019.1.jpg: 129915 bytes
No `brob` (before): cjxl recompresses to 103807 bytes
With `brob` (after): cjxl recompresses to 76713 bytes
