### PR TITLE
metadata api proposal

### DIFF
--- a/lib/include/jxl/decode.h
+++ b/lib/include/jxl/decode.h
@@ -931,6 +931,29 @@ JXL_EXPORT size_t JxlDecoderReleaseJPEGBuffer(JxlDecoder* dec);
  */
 JXL_EXPORT JxlDecoderStatus JxlDecoderFlushImage(JxlDecoder* dec);
 
+/**
+ * Retrieves a metadata blob that is stored in the JPEG XL container.
+ * Returns the uncompressed blob in case it was Brotli-compressed.
+ * The data is owned by the decoder object; the returned pointer becomes invalid
+ * when the decoder is destroyed or reset.
+ *
+ * @param dec decoder object
+ * @param type 4-byte code representing the type of metadata. Examples are
+ * "Exif", "xml " (for XMP), and "jumb".
+ * @param index the index of the metadata blob of this type (there could be
+ * multiple blobs of the same type). Typically 0.
+ * @param data output pointer to the blob data
+ * @param size size in bytes of the blob data
+ * @return JXL_DEC_SUCCESS if the requested blob was found and successfully
+ * decompressed, JXL_DEC_ERROR if the requested blob was not found or an error
+ * happened during decompression, JXL_DEC_NEED_MORE_INPUT if not enough data
+ * was available to retrieve the blob or to determine that it is not there.
+ */
+JXL_EXPORT JxlDecoderStatus JxlDecoderGetMetadata(JxlDecoder* dec,
+                                                  const char* type,
+                                                  uint32_t index,
+                                                  uint8_t** data, size_t* size);
+
 #if defined(__cplusplus) || defined(c_plusplus)
 }
 #endif

--- a/lib/include/jxl/encode.h
+++ b/lib/include/jxl/encode.h
@@ -282,6 +282,32 @@ JXL_EXPORT JxlEncoderStatus JxlEncoderUseContainer(JxlEncoder* enc,
                                                    JXL_BOOL use_container);
 
 /**
+ * Adds a metadata blob to the JPEG XL container.
+ * Blobs are treated as a black box: there is no verification whatsoever that
+ * their content is valid.
+ * Blobs can either be stored in an uncompressed way, or wrapped in a "brob"
+ * box, applying Brotli compression.
+ * If metadata is added, the JPEG XL container format will implicitly be used.
+ *
+ * @param enc encoder object.
+ * @param type 4-byte code representing the type of metadata. The only values
+ * defined in 18181-2:2021 are "Exif", "xml " (for XMP), and "jumb", though
+ * this function can be used to add custom metadata blobs with other types.
+ * @param data pointer to the (uncompressed) blob data. This pointer has to
+ * remain valid until encoding has been completed.
+ * @param size size of the metadata blob.
+ * @param compressed true if the blob is to be stored with Brotli compression,
+ * false if it is to be stored uncompressed.
+ * @return JXL_ENC_SUCCESS if the operation was successful, JXL_ENC_ERROR or
+ * JXL_ENC_NOT_SUPPORTED otherwise
+ */
+JXL_EXPORT JxlEncoderStatus JxlEncoderAddMetadata(JxlEncoder* enc,
+                                                  const char* type,
+                                                  const uint8_t* data,
+                                                  size_t size,
+                                                  JXL_BOOL compressed);
+
+/**
  * Sets lossless/lossy mode for the provided options. Default is lossy.
  *
  * @param options set of encoder options to update with the new mode


### PR DESCRIPTION
Proposal for an  encode/decode api for metadata blobs (Exif, XMP, JUMBF). This is just the api, no implementation yet.

Aim is to make compression of metadata completely transparent on the decode side: you always get the uncompressed metadata, no matter if it's e.g. an `xml ` box or a `brob` box containing compressed `xml ` data. On the encode side, you can choose whether to use compression or not.