### PR TITLE
Add Instructions to Cross Compile for Windows using Crossroad

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,11 +145,12 @@ format: Cloudinary and Google.
 
 ### Development process
 *   [Docker setup - **start here**](doc/developing_in_docker.md)
-*   [Building on Debian](doc/developing_in_debian.md) - for experts only
-*   [Building on Windows](doc/developing_in_windows.md) - for experts only
+*   [Building on Debian](doc/developing_in_debian.md) - for experts
+*   [Building on Windows](doc/developing_in_windows.md) - for experts
+*   [Cross Compiling for Windows with Crossroad](doc/developing_with_crossroad.md) - for experts
 *   [More information on testing/build options](doc/building_and_testing.md)
-*   [Git guide for JPEG XL](doc/developing_in_github.md) - for developers only
-*   [Fuzzing](doc/fuzzing.md) - for developers only
+*   [Git guide for JPEG XL](doc/developing_in_github.md) - for developers
+*   [Fuzzing](doc/fuzzing.md) - for developers
 *   [Building Web Assembly artifacts](doc/building_wasm.md)
 
 ### Contact

--- a/doc/developing_in_debian.md
+++ b/doc/developing_in_debian.md
@@ -1,7 +1,10 @@
 # Developing in Debian
 
 These instructions assume an up-to-date Debian/Ubuntu system.
-For other platforms, please instead use the [Docker container](developing_in_docker.md).
+For other platforms, please instead use the following:
+
+* [Developing in Docker](developing_in_docker.md).
+* [Cross Compiling for Windows with Crossroad](developing_with_crossroad.md).
 
 ## Minimum build dependencies
 

--- a/doc/developing_with_crossroad.md
+++ b/doc/developing_with_crossroad.md
@@ -1,0 +1,92 @@
+# Cross Compiling for Windows with Crossroad
+
+[Crossroad](https://pypi.org/project/crossroad/) is a tool to set up cross-compilation environments on GNU/Linux distributions.  These instructions assume a Debian/Ubuntu system.  However, they can likely be adapted to other Linux environments.  Since Ubuntu can be run on Windows through WSL, these instruction may be useful for developing directly on Windows.
+
+## Installing Crossroad
+
+Crossroad requires tools included with `python3-docutils` and `mingw-w64`.  They may be installed using:
+
+    sudo aptitude install python3-docutils mingw-w64
+
+The `zstandard` python package is also required, but is not available in the repositories.  It may be installed using `pip`.
+
+    pip3 install zstandard
+
+After the dependencies are installed, crossroad itself maybe installed with `pip`.
+
+    pip3 install crossroad
+
+If there are errors while running crossroad, it may need to be downloaded and installed directly using `setup.py`.  Instructions are on the crossroad homepage.
+
+## Update Debian Alternatives
+
+Since `libjxl` uses C++ features that require posix threads, the symlinks used by the Debian alternative system need to be updated:
+
+    sudo update-alternatives --config x86_64-w64-mingw32-g++
+
+Select the option that indicates `posix` usage.  Repeat for `gcc` and `i686`:
+
+    sudo update-alternatives --config x86_64-w64-mingw32-gcc
+    sudo update-alternatives --config i686-w64-mingw32-gcc
+    sudo update-alternatives --config i686-w64-mingw32-g++
+
+## Create a New Crossroad Project
+
+Crossroad supports the following platforms:
+
+    native               Native platform (x86_64 GNU/Linux)
+    android-x86          Generic Android/Bionic on x86
+    android-mips64       Generic Android/Bionic on MIPS64
+    android-x86-64       Generic Android/Bionic on x86-64
+    w64                  Windows 64-bit
+    w32                  Windows 32-bit
+    android-arm64        Generic Android/Bionic on ARM64
+    android-mips         Generic Android/Bionic on MIPS
+    android-arm          Generic Android/Bionic on ARM
+
+To begin cross compiling for Windows, a new project needs to be created:
+
+    crossroad w64 [project-name]
+
+## Install Dependencies
+
+Since the `gimp` development package is required to build the GIMP plugin and also includes most of the packages required by `libjxl`, install it first.
+
+    crossroad install gimp
+
+`gtest` and `brotli` are also required.
+
+    crossroad install gtest brotli
+
+If any packages are later found to be missing, you may search for them using:
+
+    crossroad search [...]
+
+## Building
+
+Download the source from the libjxl [releases](https://github.com/libjxl/libjxl/releases) page.  Alternatively, you may obtain the latest development version with `git`.  Run `./deps.sh` to ensure additional third-party dependencies are downloaded.
+
+Within the source direction, create a build directory.  If you haven't already, start your crossroad project and run `cmake`:
+```
+mkdir build
+cd build
+crossroad w64 libjxl
+crossroad cmake -DCMAKE_BUILD_TYPE=Release \
+   -DBUILD_TESTING=OFF -DJPEGXL_ENABLE_BENCHMARK=OFF \
+   -DJPEGXL_ENABLE_PLUGINS=ON -DJPEGXL_FORCE_SYSTEM_BROTLI=ON \
+   -DJPEGXL_FORCE_SYSTEM_GTEST=ON ..
+```
+
+Check the output to see if any dependencies were missed and need to be installed.  If all went well, you may now run `cmake` to build `libjxl`:
+
+    cmake --build .
+
+## GIMP Plugin
+
+To use the GIMP plugin:
+
+1. If you haven't already, [download](https://www.gimp.org/downloads/) and install the stable version of GIMP (currently 2.10.24).
+
+2. Create a new folder: `C:\Program Files\GIMP 2\lib\gimp\2.0\plug-ins\file-jxl`
+
+3. Copy `build/plugins/gimp/file-jxl.exe` to the new folder.


### PR DESCRIPTION
This pull request adds instructions to `libjxl/doc` to cross compile for Windows on Linux using [crossroad](https://pypi.org/project/crossroad/).  Since Ubuntu can be run on WSL, this method may be useful for developing directly on Windows.