### PR TITLE
plugins/gdk-pixbuf: fix signature

### DIFF
--- a/plugins/gdk-pixbuf/pixbufloader-jxl.c
+++ b/plugins/gdk-pixbuf/pixbufloader-jxl.c
@@ -260,7 +260,7 @@ void fill_vtable(GdkPixbufModule *module) {
 void fill_info(GdkPixbufFormat *info) {
   static GdkPixbufModulePattern signature[] = {
       {"\xFF\x0A", "  ", 100},
-      {"\x00\x00\x00\x0CJXL \x0D\x0A\x87\x0A", "            ", 100},
+      {"...\x0CJXL \x0D\x0A\x87\x0A", "zzz         ", 100},
       {NULL, NULL, 0},
   };
 

--- a/plugins/gimp/file-jxl.cc
+++ b/plugins/gimp/file-jxl.cc
@@ -49,7 +49,7 @@ void Query() {
     gimp_register_magic_load_handler(
         kLoadProc, "jxl", "",
         "0,string,\xFF\x0A,"
-        "0,string,\x00\x00\x00\x0CJXL \x0D\x0A\x87\x0A");
+        "0,string,\\000\\000\\000\x0CJXL\\040\\015\\012\x87\\012");
   }
 
   {


### PR DESCRIPTION
Signature pattern cannot contain \x00 as that gets misinterpreted as null-terminator, so use z mask designed to work around that issue.
Updates #505.