### PR TITLE
Add basic animation support to encoder API

### DIFF
--- a/examples/encode_oneshot.cc
+++ b/examples/encode_oneshot.cc
@@ -191,6 +191,8 @@ bool EncodeJxlOneshot(const std::vector<float>& pixels, const uint32_t xsize,
     return false;
   }
 
+  JxlEncoderCloseInput(enc.get());
+
   compressed->resize(64);
   uint8_t* next_out = compressed->data();
   size_t avail_out = compressed->size() - (next_out - compressed->data());


### PR DESCRIPTION
To use, Set JxlBasicInfo `have_animation` and send frames with `JxlEncoderAddImageFrame`.  If have_animation is not set first, only the first frame will be encoded.  This is to prevent generating codestreams that cannot be decoded by either the API or `djxl`.

-----

In `encode.cc`, frames are queued with an empty FrameInfo.  When multiple frames are encoded, `djxl` cannot process the output file:

    ../lib/jxl/dec_file.cc:172: JXL_FAILURE: DecodeFile reader position not at EOF.

Setting `is_last` (depending on whether the queue is empty and `JxlEncoderCloseInput` has been called) prevents the error from occurring, but then only one frame is decoded.  Setting animation metadata allows both the API and `djxl` to decode all frames.