### PR TITLE
Rewrite the GDK-Pixbuf plugin.

### DIFF
--- a/plugins/gdk-pixbuf/CMakeLists.txt
+++ b/plugins/gdk-pixbuf/CMakeLists.txt
@@ -15,7 +15,7 @@ endif ()
 add_library(pixbufloader-jxl SHARED pixbufloader-jxl.c)
 # Note: This only needs the decoder library, but we don't install the decoder
 # shared library.
-target_link_libraries(pixbufloader-jxl jxl jxl_threads PkgConfig::Gdk-Pixbuf)
+target_link_libraries(pixbufloader-jxl jxl jxl_threads skcms-interface PkgConfig::Gdk-Pixbuf)
 
 pkg_get_variable(GDK_PIXBUF_MODULEDIR gdk-pixbuf-2.0 gdk_pixbuf_moduledir)
 install(TARGETS pixbufloader-jxl LIBRARY DESTINATION "${GDK_PIXBUF_MODULEDIR}")

--- a/plugins/gdk-pixbuf/README.md
+++ b/plugins/gdk-pixbuf/README.md
@@ -1,24 +1,38 @@
 ## JPEG XL GDK Pixbuf
 
 
-If already installed by the [Installing section of README.md](../../README.md#installing), then the plugin should be in the correct place, e.g.
+The plugin may already have been installed when following the instructions from the
+[Installing section of README.md](../../README.md#installing), in which case it should
+already be in the correct place, e.g.
 
 ```/usr/lib/x86_64-linux-gnu/gdk-pixbuf-2.0/2.10.0/loaders/libpixbufloader-jxl.so```
 
-Otherwise we can link them manually:
+Otherwise we can copy it manually:
 
 ```bash
 sudo cp $your_build_directory/plugins/gdk-pixbuf/libpixbufloader-jxl.so /usr/lib/x86_64-linux-gnu/gdk-pixbuf-2.0/2.10.0/loaders/libpixbufloader-jxl.so
 ```
 
 
-Then we update the cache, for example with:
+Then we need to update the cache, for example with:
 
 ```bash
 sudo /usr/lib/x86_64-linux-gnu/gdk-pixbuf-2.0/gdk-pixbuf-query-loaders --update-cache
 ```
 
-In order to get thumbnails with this, first one has to add the jxl MIME type, see [../mime/README.md](../mime/README.md).
+In order to get thumbnails with this, first one has to add the jxl MIME type, see
+[../mime/README.md](../mime/README.md).
+
+Ensure that the thumbnailer file is installed in the correct place,
+`/usr/share/thumbnailers/jxl.thumbnailer` or `/usr/local/share/thumbnailers/jxl.thumbnailer`.
+
+The file should have been copied automatically when following the instructions
+in the [Installing section of README.md](../../README.md#installing), but
+otherwise it can be copied manually:
+
+```bash
+sudo cp plugins/gdk-pixbuf/jxl.thumbnailer /usr/local/share/thumbnailers/jxl.thumbnailer
+```
 
 Update the Mime database with
 ```bash

--- a/plugins/gdk-pixbuf/loaders_test.cache
+++ b/plugins/gdk-pixbuf/loaders_test.cache
@@ -1,13 +1,16 @@
 # GdkPixbuf Image Loader Modules file for testing
+# Automatically generated file, do not edit
+# Created by gdk-pixbuf-query-loaders from gdk-pixbuf-2.42.2
 #
 # Generated with:
 #  GDK_PIXBUF_MODULEDIR=`pwd`/build/plugins/gdk-pixbuf/ gdk-pixbuf-query-loaders
 #
 # Modified to use the library from the current working directory at runtime.
-#
 "./libpixbufloader-jxl.so"
-"JPEG XL" 4 "gdk-pixbuf" "JPEG XL image" "Apache 2"
+"jxl" 4 "gdk-pixbuf" "JPEG XL image" "BSD-3"
 "image/jxl" ""
 "jxl" ""
-"\327LM\n" "    " 100
+"\377\n" "  " 100
+"...\fJXL \r\n\207\n" "zzz         " 100
+
 

--- a/plugins/gdk-pixbuf/pixbufloader-jxl.c
+++ b/plugins/gdk-pixbuf/pixbufloader-jxl.c
@@ -7,254 +7,262 @@
 #include <gdk-pixbuf/gdk-pixbuf.h>
 #undef GDK_PIXBUF_ENABLE_BACKEND
 
+#include "jxl/codestream_header.h"
 #include "jxl/decode.h"
-
-static void DestroyPixels(guchar *pixels, gpointer data) { free(pixels); }
+#include "jxl/resizable_parallel_runner.h"
+#include "jxl/types.h"
+#include "skcms.h"
 
 typedef struct {
-  GdkPixbufModuleSizeFunc size_func;
-  GdkPixbufModuleUpdatedFunc update_func;
-  GdkPixbufModulePreparedFunc prepare_func;
+  GdkPixbufModuleSizeFunc image_size_callback;
+  GdkPixbufModulePreparedFunc pixbuf_prepared_callback;
+  GdkPixbufModuleUpdatedFunc area_updated_callback;
   gpointer user_data;
-  GdkPixbuf *pixbuf;
-  GError **error;
 
-  FILE *increment_buffer;
-  char *increment_buffer_ptr;
-  size_t increment_buffer_size;
+  GdkPixbuf *output;
 
-} JxlContext;
+  JxlParallelRunner *parallel_runner;
+  JxlDecoder *decoder;
+  JxlPixelFormat pixel_format;
 
-uint8_t *JxlMemoryToPixels(const uint8_t *next_in, size_t size, size_t *stride,
-                           size_t *xsize, size_t *ysize, int *has_alpha) {
-  JxlDecoder *dec = JxlDecoderCreate(NULL);
-  *has_alpha = 1;
-  uint8_t *pixels = NULL;
-  if (!dec) {
-    fprintf(stderr, "JxlDecoderCreate failed\n");
-    return 0;
+  gboolean done;
+  gboolean alpha_premultiplied;
+
+  gpointer icc_buff;
+  skcms_ICCProfile icc;
+
+} GdkPixbufJXLDecoderState;
+
+static gpointer begin_load(GdkPixbufModuleSizeFunc size_func,
+                           GdkPixbufModulePreparedFunc prepare_func,
+                           GdkPixbufModuleUpdatedFunc update_func,
+                           gpointer user_data, GError **error) {
+  GdkPixbufJXLDecoderState *decoder_state =
+      g_malloc0(sizeof(GdkPixbufJXLDecoderState));
+  decoder_state->image_size_callback = size_func;
+  decoder_state->pixbuf_prepared_callback = prepare_func;
+  decoder_state->area_updated_callback = update_func;
+  decoder_state->user_data = user_data;
+
+  if (!(decoder_state->parallel_runner =
+            JxlResizableParallelRunnerCreate(NULL))) {
+    g_set_error(error, GDK_PIXBUF_ERROR, GDK_PIXBUF_ERROR_FAILED,
+                "Creation of the JXL parallel runner failed");
+    goto cleanup;
   }
-  if (JXL_DEC_SUCCESS !=
-      JxlDecoderSubscribeEvents(dec, JXL_DEC_BASIC_INFO | JXL_DEC_FULL_IMAGE)) {
-    fprintf(stderr, "JxlDecoderSubscribeEvents failed\n");
-    JxlDecoderDestroy(dec);
-    return 0;
+
+  if (!(decoder_state->decoder = JxlDecoderCreate(NULL))) {
+    g_set_error(error, GDK_PIXBUF_ERROR, GDK_PIXBUF_ERROR_FAILED,
+                "Creation of the JXL decoder failed");
+    goto cleanup;
   }
 
-  JxlBasicInfo info;
-  int success = 0;
-  JxlPixelFormat format = {4, JXL_TYPE_UINT8, JXL_NATIVE_ENDIAN, 0};
-  JxlDecoderSetInput(dec, next_in, size);
+  JxlDecoderStatus status;
 
-  for (;;) {
-    JxlDecoderStatus status = JxlDecoderProcessInput(dec);
+  if ((status = JxlDecoderSetParallelRunner(
+           decoder_state->decoder, JxlResizableParallelRunner,
+           decoder_state->parallel_runner)) != JXL_DEC_SUCCESS) {
+    g_set_error(error, GDK_PIXBUF_ERROR, GDK_PIXBUF_ERROR_FAILED,
+                "JxlDecoderSetParallelRunner failed: %x", status);
+    goto cleanup;
+  }
+  if ((status = JxlDecoderSubscribeEvents(
+           decoder_state->decoder,
+           JXL_DEC_BASIC_INFO | JXL_DEC_COLOR_ENCODING | JXL_DEC_FULL_IMAGE)) !=
+      JXL_DEC_SUCCESS) {
+    g_set_error(error, GDK_PIXBUF_ERROR, GDK_PIXBUF_ERROR_FAILED,
+                "JxlDecoderSubscribeEvents failed: %x", status);
+    goto cleanup;
+  }
 
-    if (status == JXL_DEC_ERROR) {
-      fprintf(stderr, "Decoder error\n");
-      break;
-    } else if (status == JXL_DEC_NEED_MORE_INPUT) {
-      fprintf(stderr, "Error, already provided all input\n");
-      break;
-    } else if (status == JXL_DEC_BASIC_INFO) {
-      if (JXL_DEC_SUCCESS != JxlDecoderGetBasicInfo(dec, &info)) {
-        fprintf(stderr, "JxlDecoderGetBasicInfo failed\n");
-        break;
-      }
-      *xsize = info.xsize;
-      *ysize = info.ysize;
-      *stride = info.xsize * 4;
-    } else if (status == JXL_DEC_NEED_IMAGE_OUT_BUFFER) {
-      size_t buffer_size;
-      if (JXL_DEC_SUCCESS !=
-          JxlDecoderImageOutBufferSize(dec, &format, &buffer_size)) {
-        fprintf(stderr, "JxlDecoderImageOutBufferSize failed\n");
-        break;
-      }
-      if (buffer_size != *stride * *ysize) {
-        fprintf(stderr, "Invalid out buffer size %zu %zu\n", buffer_size,
-                *stride * *ysize);
-        break;
-      }
-      size_t pixels_buffer_size = buffer_size * sizeof(uint8_t);
-      pixels = malloc(pixels_buffer_size);
-      void *pixels_buffer = (void *)pixels;
-      if (JXL_DEC_SUCCESS != JxlDecoderSetImageOutBuffer(dec, &format,
-                                                         pixels_buffer,
-                                                         pixels_buffer_size)) {
-        fprintf(stderr, "JxlDecoderSetImageOutBuffer failed\n");
-        break;
-      }
-    } else if (status == JXL_DEC_FULL_IMAGE) {
-      // This means the decoder has decoded all pixels into the buffer.
-      success = 1;
-      break;
-    } else if (status == JXL_DEC_SUCCESS) {
-      fprintf(stderr, "Decoding finished before receiving pixel data\n");
-      break;
-    } else {
-      fprintf(stderr, "Unexpected decoder status: %d\n", status);
-      break;
-    }
-  }
-  JxlDecoderDestroy(dec);
-  if (success) {
-    return pixels;
-  } else {
-    free(pixels);
-    return NULL;
-  }
+  decoder_state->pixel_format.data_type = JXL_TYPE_FLOAT;
+  decoder_state->pixel_format.endianness = JXL_NATIVE_ENDIAN;
+
+  return decoder_state;
+cleanup:
+  JxlResizableParallelRunnerDestroy(decoder_state->parallel_runner);
+  JxlDecoderDestroy(decoder_state->decoder);
+  g_free(decoder_state);
+  return NULL;
 }
 
-static GdkPixbuf *gdk_pixbuf__jxl_image_load(FILE *f, GError **error) {
-  size_t data_size;
-  int status;
-  gpointer data;
-
-  // Get data size
-  status = fseek(f, 0, SEEK_END);
-  if (status) {
-    g_set_error(error, GDK_PIXBUF_ERROR, GDK_PIXBUF_ERROR_FAILED,
-                "Failed to find end of file");
+static gboolean stop_load(gpointer context, GError **error) {
+  GdkPixbufJXLDecoderState *decoder_state = context;
+  if (decoder_state->output) {
+    g_object_unref(decoder_state->output);
   }
-  data_size = ftell(f);
-  fseek(f, 0, SEEK_SET);
-  status = fseek(f, 0, SEEK_SET);
-  if (status) {
-    g_set_error(error, GDK_PIXBUF_ERROR, GDK_PIXBUF_ERROR_FAILED,
-                "Failed to set pointer to beginning of file");
-  }
-
-  // Get data
-  data = g_malloc(data_size);
-  status = (fread(data, data_size, 1, f) == 1);
-  if (!status) {
-    g_set_error(error, GDK_PIXBUF_ERROR, GDK_PIXBUF_ERROR_FAILED,
-                "Failed to read file");
-    g_free(data);
-    return NULL;
-  }
-  size_t xsize, ysize, stride;
-  int has_alpha;
-  uint8_t *decoded =
-      JxlMemoryToPixels(data, data_size, &stride, &xsize, &ysize, &has_alpha);
-  g_free(data);
-  if (!decoded) {
-    g_set_error(error, GDK_PIXBUF_ERROR, GDK_PIXBUF_ERROR_FAILED,
-                "Failed to decode data");
-    return NULL;
-  }
-
-  GdkPixbuf *pixbuf =
-      gdk_pixbuf_new_from_data(decoded, GDK_COLORSPACE_RGB, has_alpha, 8, xsize,
-                               ysize, stride, &DestroyPixels, NULL);
-
-  if (!pixbuf) {
-    g_set_error(error, GDK_PIXBUF_ERROR, GDK_PIXBUF_ERROR_FAILED,
-                "Failed to create output pixbuf");
-    free(decoded);
-    return NULL;
-  }
-
-  return pixbuf;
-}
-
-static gpointer gdk_pixbuf__jxl_image_begin_load(
-    GdkPixbufModuleSizeFunc size_func, GdkPixbufModulePreparedFunc prepare_func,
-    GdkPixbufModuleUpdatedFunc update_func, gpointer user_data,
-    GError **error) {
-  JxlContext *context = g_new(JxlContext, 1);
-  context->size_func = size_func;
-  context->prepare_func = prepare_func;
-  context->update_func = update_func;
-  context->user_data = user_data;
-  context->error = error;
-
-  context->increment_buffer = open_memstream(&context->increment_buffer_ptr,
-                                             &context->increment_buffer_size);
-
-  if (!context->increment_buffer) {
-    perror("Cannot create increment buffer.");
-    g_free(context);
-    return NULL;
-  }
-
-  return context;
-}
-
-static gboolean gdk_pixbuf__jxl_image_stop_load(gpointer user_context,
-                                                GError **error) {
-  JxlContext *context = (JxlContext *)user_context;
-
-  int status = fflush(context->increment_buffer);
-  status |= fseek(context->increment_buffer, 0L, SEEK_SET);
-
-  if (status != 0) {
-    perror("Cannot flush and rewind increment buffer.");
-    fclose(context->increment_buffer);
-    free(context->increment_buffer_ptr);
-    g_free(context);
-    return FALSE;
-  }
-
-  context->pixbuf =
-      gdk_pixbuf__jxl_image_load(context->increment_buffer, error);
-
-  gint width = gdk_pixbuf_get_width(context->pixbuf);
-  gint height = gdk_pixbuf_get_height(context->pixbuf);
-  if (context->size_func) {
-    context->size_func(&width, &height, context->user_data);
-  }
-
-  if (context->prepare_func) {
-    (*context->prepare_func)(context->pixbuf, NULL, context->user_data);
-  }
-
-  if (context->update_func) {
-    (*context->update_func)(
-        context->pixbuf, 0, 0, gdk_pixbuf_get_width(context->pixbuf),
-        gdk_pixbuf_get_height(context->pixbuf), context->user_data);
-  }
-
-  fclose(context->increment_buffer);
-
-  free(context->increment_buffer_ptr);
-
-  g_object_unref(context->pixbuf);
-  g_free(context);
-
+  JxlResizableParallelRunnerDestroy(decoder_state->parallel_runner);
+  JxlDecoderDestroy(decoder_state->decoder);
+  g_free(decoder_state->icc_buff);
+  g_free(decoder_state);
   return TRUE;
 }
 
-static gboolean gdk_pixbuf__jxl_image_load_increment(gpointer user_context,
-                                                     const guchar *buf,
-                                                     guint size,
-                                                     GError **error) {
-  JxlContext *context = (JxlContext *)user_context;
+static void draw_pixels(void *context, size_t x, size_t y, size_t num_pixels,
+                        const void *pixels) {
+  GdkPixbufJXLDecoderState *decoder_state = context;
+  gboolean has_alpha = decoder_state->pixel_format.num_channels == 4;
 
-  int status = fwrite(buf, size, sizeof(guchar), context->increment_buffer);
+  guchar *dst = gdk_pixbuf_get_pixels(decoder_state->output) +
+                decoder_state->pixel_format.num_channels * x +
+                gdk_pixbuf_get_rowstride(decoder_state->output) * y;
 
-  if (status != sizeof(guchar)) {
+  skcms_Transform(
+      pixels,
+      has_alpha ? skcms_PixelFormat_RGBA_ffff : skcms_PixelFormat_RGB_fff,
+      decoder_state->alpha_premultiplied ? skcms_AlphaFormat_PremulAsEncoded
+                                         : skcms_AlphaFormat_Unpremul,
+      &decoder_state->icc, dst,
+      has_alpha ? skcms_PixelFormat_RGBA_8888 : skcms_PixelFormat_RGB_888,
+      skcms_AlphaFormat_Unpremul, skcms_sRGB_profile(), num_pixels);
+}
+
+static gboolean load_increment(gpointer context, const guchar *buf, guint size,
+                               GError **error) {
+  GdkPixbufJXLDecoderState *decoder_state = context;
+  if (decoder_state->done == TRUE) {
     g_set_error(error, GDK_PIXBUF_ERROR, GDK_PIXBUF_ERROR_FAILED,
-                "Can't write to increment buffer.");
+                "JXL decoder load_increment called after end of file");
     return FALSE;
   }
 
-  status = fflush(context->increment_buffer);
+  JxlDecoderStatus status;
 
-  if (status != 0) {
+  if ((status = JxlDecoderSetInput(decoder_state->decoder, buf, size)) !=
+      JXL_DEC_SUCCESS) {
+    // Should never happen if things are done properly.
     g_set_error(error, GDK_PIXBUF_ERROR, GDK_PIXBUF_ERROR_FAILED,
-                "Can't flush the increment buffer.");
+                "JXL decoder logic error: %x", status);
     return FALSE;
   }
 
+  for (;;) {
+    status = JxlDecoderProcessInput(decoder_state->decoder);
+    switch (status) {
+      case JXL_DEC_NEED_MORE_INPUT: {
+        JxlDecoderReleaseInput(decoder_state->decoder);
+        return TRUE;
+      }
+      case JXL_DEC_SUCCESS: {
+        decoder_state->done = TRUE;
+        return TRUE;
+      }
+      case JXL_DEC_BASIC_INFO: {
+        JxlBasicInfo info;
+        if (JxlDecoderGetBasicInfo(decoder_state->decoder, &info) !=
+            JXL_DEC_SUCCESS) {
+          g_set_error(error, GDK_PIXBUF_ERROR, GDK_PIXBUF_ERROR_FAILED,
+                      "JXLDecoderGetBasicInfo failed");
+          return FALSE;
+        }
+        decoder_state->pixel_format.num_channels = info.alpha_bits > 0 ? 4 : 3;
+        decoder_state->alpha_premultiplied = info.alpha_premultiplied;
+        gint width = info.xsize;
+        gint height = info.ysize;
+        if (decoder_state->image_size_callback) {
+          decoder_state->image_size_callback(&width, &height,
+                                             decoder_state->user_data);
+        }
+        // GDK convention for signaling being interested only in the basic info.
+        if (width == 0 || height == 0) {
+          decoder_state->done = TRUE;
+          return TRUE;
+        }
+        // TODO(veluca): support rescaling.
+        decoder_state->output =
+            gdk_pixbuf_new(GDK_COLORSPACE_RGB, info.alpha_bits > 0,
+                           /*bits_per_sample=*/8, info.xsize, info.ysize);
+        if (decoder_state->output == NULL) {
+          g_set_error(error, GDK_PIXBUF_ERROR, GDK_PIXBUF_ERROR_FAILED,
+                      "Failed to allocate output pixel buffer");
+          return FALSE;
+        }
+        // Set an appropriate number of threads for the image size.
+        JxlResizableParallelRunnerSetThreads(
+            decoder_state->parallel_runner,
+            JxlResizableParallelRunnerSuggestThreads(info.xsize, info.ysize));
+
+        if (decoder_state->pixbuf_prepared_callback) {
+          decoder_state->pixbuf_prepared_callback(decoder_state->output, NULL,
+                                                  decoder_state->user_data);
+        }
+        decoder_state->pixel_format.align =
+            gdk_pixbuf_get_rowstride(decoder_state->output);
+        break;
+      }
+      case JXL_DEC_COLOR_ENCODING: {
+        // Get the ICC color profile of the pixel data
+        size_t icc_size;
+        if (JXL_DEC_SUCCESS != JxlDecoderGetICCProfileSize(
+                                   decoder_state->decoder,
+                                   &decoder_state->pixel_format,
+                                   JXL_COLOR_PROFILE_TARGET_DATA, &icc_size)) {
+          g_set_error(error, GDK_PIXBUF_ERROR, GDK_PIXBUF_ERROR_FAILED,
+                      "JxlDecoderGetICCProfileSize failed");
+          return FALSE;
+        }
+        if (!(decoder_state->icc_buff = g_malloc(icc_size))) {
+          g_set_error(error, GDK_PIXBUF_ERROR, GDK_PIXBUF_ERROR_FAILED,
+                      "Allocating ICC profile failed");
+          return FALSE;
+        }
+        if (JXL_DEC_SUCCESS !=
+            JxlDecoderGetColorAsICCProfile(decoder_state->decoder,
+                                           &decoder_state->pixel_format,
+                                           JXL_COLOR_PROFILE_TARGET_DATA,
+                                           decoder_state->icc_buff, icc_size)) {
+          g_set_error(error, GDK_PIXBUF_ERROR, GDK_PIXBUF_ERROR_FAILED,
+                      "JxlDecoderGetColorAsICCProfile failed");
+          return FALSE;
+        }
+        if (!skcms_Parse(decoder_state->icc_buff, icc_size,
+                         &decoder_state->icc)) {
+          g_set_error(error, GDK_PIXBUF_ERROR, GDK_PIXBUF_ERROR_FAILED,
+                      "Invalid ICC profile from JXL image decoder");
+          return FALSE;
+        }
+        break;
+      }
+      case JXL_DEC_NEED_IMAGE_OUT_BUFFER: {
+        if (JXL_DEC_SUCCESS !=
+            JxlDecoderSetImageOutCallback(decoder_state->decoder,
+                                          &decoder_state->pixel_format,
+                                          draw_pixels, decoder_state)) {
+          g_set_error(error, GDK_PIXBUF_ERROR, GDK_PIXBUF_ERROR_FAILED,
+                      "JxlDecoderSetImageOutCallback failed");
+          return FALSE;
+        }
+        break;
+      }
+      case JXL_DEC_FULL_IMAGE: {
+        // TODO(veluca): consider doing partial updates.
+        if (decoder_state->area_updated_callback) {
+          decoder_state->area_updated_callback(
+              decoder_state->output, 0, 0,
+              gdk_pixbuf_get_width(decoder_state->output),
+              gdk_pixbuf_get_height(decoder_state->output),
+              decoder_state->user_data);
+        }
+        // TODO(veluca): for animations, this will eventually only leave the
+        // last frame.
+        break;
+      }
+      default: {
+        g_set_error(error, GDK_PIXBUF_ERROR, GDK_PIXBUF_ERROR_FAILED,
+                    "Unexpected JxlDecoderProcessInput return code: %x",
+                    status);
+        return FALSE;
+      }
+    }
+  }
   return TRUE;
 }
 
 void fill_vtable(GdkPixbufModule *module) {
-  module->load = gdk_pixbuf__jxl_image_load;
-  module->begin_load = gdk_pixbuf__jxl_image_begin_load;
-  module->stop_load = gdk_pixbuf__jxl_image_stop_load;
-  module->load_increment = gdk_pixbuf__jxl_image_load_increment;
+  module->begin_load = begin_load;
+  module->stop_load = stop_load;
+  module->load_increment = load_increment;
+  // TODO(veluca): implement animation and saving.
 }
 
 void fill_info(GdkPixbufFormat *info) {
@@ -273,6 +281,7 @@ void fill_info(GdkPixbufFormat *info) {
   info->description = "JPEG XL image";
   info->mime_types = mime_types;
   info->extensions = extensions;
+  // TODO(veluca): add writing support.
   info->flags = GDK_PIXBUF_FORMAT_THREADSAFE;
-  info->license = "Apache 2";
+  info->license = "BSD-3";
 }

--- a/third_party/skcms.cmake
+++ b/third_party/skcms.cmake
@@ -15,10 +15,17 @@
 add_library(skcms-obj OBJECT EXCLUDE_FROM_ALL skcms/skcms.cc)
 target_include_directories(skcms-obj PUBLIC "${CMAKE_CURRENT_LIST_DIR}/skcms/")
 
+# This library is meant to be compiled/used by external libs (such as plugins)
+# that need to use skcms. We use a wrapper for libjxl.
+add_library(skcms-interface INTERFACE)
+target_sources(skcms-interface INTERFACE ${CMAKE_CURRENT_LIST_DIR}/skcms/skcms.cc)
+target_include_directories(skcms-interface INTERFACE ${CMAKE_CURRENT_LIST_DIR}/skcms)
+
 include(CheckCXXCompilerFlag)
 check_cxx_compiler_flag("-Wno-psabi" CXX_WPSABI_SUPPORTED)
 if(CXX_WPSABI_SUPPORTED)
   target_compile_options(skcms-obj PRIVATE -Wno-psabi)
+  target_compile_options(skcms-interface INTERFACE -Wno-psabi)
 endif()
 
 if(JPEGXL_BUNDLE_SKCMS)


### PR DESCRIPTION
The new version supports ICC profiles in the input JXL file, real
incremental loading and multithreading.

Pair programmed with Moritz.

Still TODO are animation and saving.

Fixes #512.