### PR TITLE
tweak size header encoding (512x256 can be 'small' too)

### DIFF
--- a/lib/jxl/headers.cc
+++ b/lib/jxl/headers.cc
@@ -63,15 +63,15 @@ Status SizeHeader::Set(size_t xsize64, size_t ysize64) {
   const uint32_t xsize32 = static_cast<uint32_t>(xsize64);
   const uint32_t ysize32 = static_cast<uint32_t>(ysize64);
   if (xsize64 == 0 || ysize64 == 0) return JXL_FAILURE("Empty image");
-  small_ = xsize64 <= 256 && ysize64 <= 256 && (xsize64 % kBlockDim) == 0 &&
-           (ysize64 % kBlockDim) == 0;
+  ratio_ = FindAspectRatio(xsize32, ysize32);
+  small_ = ysize64 <= 256 && (ysize64 % kBlockDim) == 0 &&
+           (ratio_ != 0 || (xsize64 <= 256 && (xsize64 % kBlockDim) == 0));
   if (small_) {
     ysize_div8_minus_1_ = ysize32 / 8 - 1;
   } else {
     ysize_ = ysize32;
   }
 
-  ratio_ = FindAspectRatio(xsize32, ysize32);
   if (ratio_ == 0) {
     if (small_) {
       xsize_div8_minus_1_ = xsize32 / 8 - 1;


### PR DESCRIPTION
Silly little tweak in the encoding of SizeHeader: in some cases, even if the width is > 256, we can still use the shorter `small` encoding because the width can be derived from the height using the aspect ratio encoding.

This can save 1 byte for a 512x256 image.