### PR TITLE
Simplifying stock palette indexing

### DIFF
--- a/lib/jxl/modular/transform/palette.h
+++ b/lib/jxl/modular/transform/palette.h
@@ -19,18 +19,24 @@ namespace palette_internal {
 
 static constexpr int kMaxPaletteLookupTableSize = 1 << 16;
 
-static constexpr int kCubePow = 3;
+static constexpr int kRgbChannels = 3;
 
 // 5x5x5 color cube for the larger cube.
 static constexpr int kLargeCube = 5;
 
 // Smaller interleaved color cube to fill the holes of the larger cube.
-static constexpr int kSmallCube = kLargeCube - 1;
-// kSmallCube ** kCubePow
+static constexpr int kSmallCube = 4;
+static constexpr int kSmallCubeBits = 2;
+// kSmallCube ** 3
 static constexpr int kLargeCubeOffset = kSmallCube * kSmallCube * kSmallCube;
 
-static constexpr pixel_type Scale(int value, int bit_depth, int denom) {
-  return (value * ((static_cast<pixel_type_w>(1) << bit_depth) - 1)) / denom;
+static inline pixel_type Scale(uint64_t value, uint64_t bit_depth,
+                               uint64_t denom) {
+  // return (value * ((static_cast<pixel_type_w>(1) << bit_depth) - 1)) / denom;
+  // We only call this function with kSmallCube or kLargeCube - 1 as denom,
+  // allowing us to avoid a division here.
+  JXL_ASSERT(denom == 4);
+  return (value * ((static_cast<uint64_t>(1) << bit_depth) - 1)) >> 2;
 }
 
 // The purpose of this function is solely to extend the interpretation of
@@ -62,7 +68,7 @@ static pixel_type GetPaletteValue(const pixel_type *const palette, int index,
             {64, -64, -64},  {96, 0, 96},     {45, -45, 24},   {24, 45, -45},
             {64, 64, -64},   {128, 128, 0},   {0, 0, -128},    {-24, 45, -45},
         }};
-    if (c >= kDeltaPalette[0].size()) {
+    if (c >= kRgbChannels) {
       return 0;
     }
     // Do not open the brackets, otherwise INT32_MIN negation could overflow.
@@ -76,32 +82,28 @@ static pixel_type GetPaletteValue(const pixel_type *const palette, int index,
     }
     return result;
   } else if (palette_size <= index && index < palette_size + kLargeCubeOffset) {
-    if (c >= kCubePow) return 0;
+    if (c >= kRgbChannels) return 0;
     index -= palette_size;
-    if (c > 0) {
-      int divisor = kSmallCube;
-      for (size_t i = 1; i < c; ++i) {
-        divisor *= kSmallCube;
-      }
-      index /= divisor;
-    }
+    index >>= c * kSmallCubeBits;
     return Scale(index % kSmallCube, bit_depth, kSmallCube) +
            (1 << (std::max(0, bit_depth - 3)));
   } else if (palette_size + kLargeCubeOffset <= index) {
-    if (c >= kCubePow) return 0;
+    if (c >= kRgbChannels) return 0;
     index -= palette_size + kLargeCubeOffset;
     // TODO(eustas): should we take care of ambiguity created by
     //               index >= kLargeCube ** 3 ?
-    if (c > 0) {
-      int divisor = kLargeCube;
-      for (size_t i = 1; i < c; ++i) {
-        divisor *= kLargeCube;
-      }
-      index /= divisor;
+    switch (c) {
+      case 0:
+        break;
+      case 1:
+        index /= kLargeCube;
+        break;
+      case 2:
+        index /= kLargeCube * kLargeCube;
+        break;
     }
     return Scale(index % kLargeCube, bit_depth, kLargeCube - 1);
   }
-
   return palette[c * onerow + static_cast<size_t>(index)];
 }
 


### PR DESCRIPTION
Simplifying divisions to shifts in the stock palette value generation. 

Before:

```
Encoding          kPixels    Bytes          BPP  E MP/s  D MP/s     Max norm        pnorm       BPP*pnorm   Bugs
----------------------------------------------------------------------------------------------------------------
jxl:m               18628 20623382    8.8568318   0.426   3.572   0.00004654   0.00000021  0.000001818792      0
jxl:d0.7            18628  4455150    1.9132902   2.301  14.336   1.59264278   0.47658482  0.911845053323      0
jxl:m:q95           18628  6402674    2.7496657   1.106   4.778   1.14431751   0.35536362  0.977131162284      0
jxl:m:p7:lp:P7      18628  7127590    3.0609851   0.084   6.182   6.79819155   0.61806553  1.891889392155      0
jxl:m:p0:lp:P0      18628 11385144    4.8894166   0.087   6.991   6.10237932   0.62416251  3.051790528555      0
Aggregate:          18628  8625275    3.7041749   0.380   6.380   0.32306191   0.02663974  0.098678258206      0
```

After:

```
Encoding          kPixels    Bytes          BPP  E MP/s  D MP/s     Max norm        pnorm       BPP*pnorm   Bugs
----------------------------------------------------------------------------------------------------------------
jxl:m               18628 20623382    8.8568318   0.426   3.571   0.00004654   0.00000021  0.000001818792      0
jxl:d0.7            18628  4455150    1.9132902   2.309  14.259   1.59264278   0.47658482  0.911845053323      0
jxl:m:q95           18628  6402674    2.7496657   1.114   4.691   1.14431751   0.35536362  0.977131162284      0
jxl:m:p7:lp:P7      18628  7127590    3.0609851   0.080   6.420   6.79819155   0.61806553  1.891889392155      0
jxl:m:p0:lp:P0      18628 11385144    4.8894166   0.082   7.142   6.10237932   0.62416251  3.051790528555      0
Aggregate:          18628  8625275    3.7041749   0.373   6.426   0.32306191   0.02663974  0.098678258206      0
```