### PR TITLE
Modular decode: reduce tree size limit by a factor of 16

### DIFF
--- a/lib/jxl/dec_modular.cc
+++ b/lib/jxl/dec_modular.cc
@@ -161,7 +161,7 @@ Status ModularFrameDecoder::DecodeGlobalInfo(BitReader* reader,
   bool has_tree = reader->ReadBits(1);
   if (has_tree) {
     size_t tree_size_limit =
-        1024 + frame_dim.xsize * frame_dim.ysize * nb_chans;
+        1024 + frame_dim.xsize * frame_dim.ysize * nb_chans / 16;
     JXL_RETURN_IF_ERROR(DecodeTree(reader, &tree, tree_size_limit));
     JXL_RETURN_IF_ERROR(
         DecodeHistograms(reader, (tree.size() + 1) / 2, &code, &context_map));

--- a/lib/jxl/modular/encoding/ma_common.h
+++ b/lib/jxl/modular/encoding/ma_common.h
@@ -21,7 +21,7 @@ enum MATreeContext : size_t {
   kNumTreeContexts = 6,
 };
 
-static constexpr size_t kMaxTreeSize = 1 << 26;
+static constexpr size_t kMaxTreeSize = 1 << 22;
 
 }  // namespace jxl
 


### PR DESCRIPTION
As discussed in and fixes #528

The reduction applies to both the per-pixel limit and the overall limit, which means the maximum memory consumption of a frame's decode tree will be ~0.3MB (previously ~5.2GB).

