### PR TITLE
Add pipeline executions that allow ssh access.

### DIFF
--- a/.github/workflows/debug_ci.yml
+++ b/.github/workflows/debug_ci.yml
@@ -1,0 +1,59 @@
+# Copyright (c) the JPEG XL Project Authors. All rights reserved.
+#
+# Use of this source code is governed by a BSD-style
+# license that can be found in the LICENSE file.
+
+# Workflow for building and then debugging on a specific commit.
+
+name: Build and Test debugging
+on:
+  push:
+    branches:
+      - ci-*-debug
+
+jobs:
+  ubuntu_build:
+    name: Ubuntu Build and SSH
+    runs-on: [ubuntu-latest]
+
+    steps:
+    - name: Install build deps
+      run: |
+        sudo apt update
+        sudo apt install -y \
+          ccache \
+          clang-7 \
+          cmake \
+          doxygen \
+          libbrotli-dev \
+          libgdk-pixbuf2.0-dev \
+          libgif-dev \
+          libgtest-dev \
+          libgtk2.0-dev  \
+          libjpeg-dev \
+          libopenexr-dev \
+          libpng-dev \
+          libwebp-dev \
+          ninja-build \
+          pkg-config \
+          xvfb \
+          ${{ matrix.apt_pkgs }} \
+        #
+        echo "CC=clang-7" >> $GITHUB_ENV
+        echo "CXX=clang++-7" >> $GITHUB_ENV
+    - name: Checkout the source
+      uses: actions/checkout@v2
+      with:
+        submodules: true
+        fetch-depth: 2
+    - name: Build
+      run: |
+        ./ci.sh $(echo ${{ github.ref }} | sed 's_refs/heads/ci-\([a-z]*\)-debug_\1_') \
+          -DJPEGXL_FORCE_SYSTEM_BROTLI=ON
+      env:
+        SKIP_TEST: 1
+    - name: Setup tmate session
+      uses: mxschmitt/action-tmate@v3
+
+
+


### PR DESCRIPTION
Those pipelines will build a release, debug, asan, msan or opt build
when pushed to a branch ci-{release, debug, ...}-debug name, and then
start a tmate session in the resulting environment that can be used to
access the CI environment for debugging purposes.