### PR TITLE
Auto resample for high distance

### DIFF
--- a/lib/jxl/enc_params.h
+++ b/lib/jxl/enc_params.h
@@ -243,6 +243,10 @@ struct CompressParams {
   bool use_new_heuristics = false;
 
   // Down/upsample the image before encoding / after decoding by this factor.
+  // The resampling value can also be set to 0 to automatically choose based
+  // on distance, however EncodeFrame doesn't support this, so it is
+  // required to process the CompressParams to set a valid positive resampling
+  // value and altered butteraugli score if this is used.
   size_t resampling = 1;
   size_t ec_resampling = 1;
   // Skip the downsampling before encoding if this is true.

--- a/tools/cjxl.cc
+++ b/tools/cjxl.cc
@@ -307,7 +307,7 @@ void CompressArgs::AddCommandLineOptions(CommandLineParser* cmdline) {
   // Target distance/size/bpp
   opt_distance_id = cmdline->AddOptionValue(
       'd', "distance", "maxError",
-      ("Max. butteraugli distance, lower = higher quality. Range: 0 .. 15.\n"
+      ("Max. butteraugli distance, lower = higher quality. Range: 0 .. 25.\n"
        "    0.0 = mathematically lossless. Default for already-lossy input "
        "(JPEG/GIF).\n"
        "    1.0 = visually lossless. Default for other input.\n"
@@ -420,9 +420,11 @@ void CompressArgs::AddCommandLineOptions(CommandLineParser* cmdline) {
   cmdline->AddOptionValue('\0', "patches", "0|1",
                           "force disable/enable patches generation.",
                           &params.patches, &ParseOverride, 1);
-  cmdline->AddOptionValue('\0', "resampling", "1|2|4|8",
-                          "Subsample all color channels by this factor.",
-                          &params.resampling, &ParseUnsigned, 1);
+  cmdline->AddOptionValue(
+      '\0', "resampling", "0|1|2|4|8",
+      "Subsample all color channels by this factor, or use 0 to choose the "
+      "resampling factor based on distance.",
+      &params.resampling, &ParseUnsigned, 0);
   cmdline->AddOptionValue(
       '\0', "ec_resampling", "1|2|4|8",
       "Subsample all extra channels by this factor. If this value is smaller "
@@ -617,7 +619,7 @@ jxl::Status CompressArgs::ValidateArgs(const CommandLineParser& cmdline) {
 
   if (got_distance) {
     constexpr float butteraugli_min_dist = 0.1f;
-    constexpr float butteraugli_max_dist = 15.0f;
+    constexpr float butteraugli_max_dist = 25.0f;
     if (!(0 <= params.butteraugli_distance &&
           params.butteraugli_distance <= butteraugli_max_dist)) {
       fprintf(stderr, "Invalid/out of range distance, try 0 to %g.\n",


### PR DESCRIPTION
By default, let cjxl choose resampling=2 if requested distance >= 20

This also increases the allowed --distance given to cjxl to go up to 20,
previously it only was allowed up to 15.

For these bit rates, using the 2x2 resampling looks better on most
images.

The distance itself is lowered to 6 (and slightly more for higher
original distance), which roughly ends up at similar bit rate. This
depends on the image but is relatively close overall.

While there are lower distances where rescaling works better as well, it
depends on the image, 20 is a conservative choice.

This only implements it for the cjxl binary tool for now, not for the encoder
API (which doesn't yet support the resampling option; to be added soon)
nor for the benchmark.

To force using no resampling anyway, you can still use resampling=1.