### PR TITLE
make encode api not ignore orientation field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
  - API: New functions to decode extra channels:
    `JxlDecoderExtraChannelBufferSize` and `JxlDecoderSetExtraChannelBuffer`.
+ - API: New function `JxlEncoderInitBasicInfo` to initialize `JxlBasicInfo`
+   (only needed when encoding). NOTE: it is now required to call this function
+   when using the encoder. Padding was added to the struct for forward
+   compatibility.
+ - API: Support for encoding oriented images.
 
 ## [0.5] - 2021-08-02
 ### Added

--- a/examples/encode_oneshot.cc
+++ b/examples/encode_oneshot.cc
@@ -162,13 +162,12 @@ bool EncodeJxlOneshot(const std::vector<float>& pixels, const uint32_t xsize,
 
   JxlPixelFormat pixel_format = {3, JXL_TYPE_FLOAT, JXL_NATIVE_ENDIAN, 0};
 
-  JxlBasicInfo basic_info = {};
+  JxlBasicInfo basic_info;
+  JxlEncoderInitBasicInfo(&basic_info);
   basic_info.xsize = xsize;
   basic_info.ysize = ysize;
   basic_info.bits_per_sample = 32;
   basic_info.exponent_bits_per_sample = 8;
-  basic_info.alpha_exponent_bits = 0;
-  basic_info.alpha_bits = 0;
   basic_info.uses_original_profile = JXL_FALSE;
   if (JXL_ENC_SUCCESS != JxlEncoderSetBasicInfo(enc.get(), &basic_info)) {
     fprintf(stderr, "JxlEncoderSetBasicInfo failed\n");

--- a/lib/include/jxl/codestream_header.h
+++ b/lib/include/jxl/codestream_header.h
@@ -229,6 +229,11 @@ typedef struct JxlBasicInfo {
    * used if have_animation is JXL_TRUE.
    */
   JxlAnimationHeader animation;
+
+  /** Padding for forwards-compatibility, in case more fields are exposed
+   * in a future version of the library.
+   */
+  uint8_t padding[108];
 } JxlBasicInfo;
 
 /** Information for a single extra channel.

--- a/lib/include/jxl/encode.h
+++ b/lib/include/jxl/encode.h
@@ -235,6 +235,17 @@ JXL_EXPORT JxlEncoderStatus JxlEncoderSetICCProfile(JxlEncoder* enc,
                                                     size_t size);
 
 /**
+ * Initializes a JxlBasicInfo struct to default values.
+ * For forwards-compatibility, this function has to be called before values
+ * are assigned to the struct fields.
+ * The default values correspond to an 8-bit RGB image, no alpha or any
+ * other extra channels.
+ *
+ * @param info global image metadata. Object owned by the caller.
+ */
+JXL_EXPORT void JxlEncoderInitBasicInfo(JxlBasicInfo* info);
+
+/**
  * Sets the global metadata of the image encoded by this encoder.
  *
  * @param enc encoder object.

--- a/lib/jxl/decode.cc
+++ b/lib/jxl/decode.cc
@@ -1771,6 +1771,10 @@ JxlDecoderStatus JxlDecoderProcessInput(JxlDecoder* dec) {
   return result;
 }
 
+// To ensure ABI forward-compatibility, this struct has a constant size.
+static_assert(sizeof(JxlBasicInfo) == 204,
+              "JxlBasicInfo struct size should remain constant");
+
 JxlDecoderStatus JxlDecoderGetBasicInfo(const JxlDecoder* dec,
                                         JxlBasicInfo* info) {
   if (!dec->got_basic_info) return JXL_DEC_NEED_MORE_INPUT;

--- a/lib/jxl/encode_test.cc
+++ b/lib/jxl/encode_test.cc
@@ -544,10 +544,7 @@ TEST(EncodeTest, JXL_TRANSCODE_JPEG_TEST(JPEGFrameTest)) {
 
       if (!skip_basic_info) {
         JxlBasicInfo basic_info;
-        basic_info.exponent_bits_per_sample = 0;
-        basic_info.bits_per_sample = 8;
-        basic_info.alpha_bits = 0;
-        basic_info.alpha_exponent_bits = 0;
+        JxlEncoderInitBasicInfo(&basic_info);
         basic_info.xsize = orig_io.xsize();
         basic_info.ysize = orig_io.ysize();
         basic_info.uses_original_profile = true;

--- a/lib/jxl/test_utils.h
+++ b/lib/jxl/test_utils.h
@@ -13,6 +13,7 @@
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
 #include "jxl/codestream_header.h"
+#include "jxl/encode.h"
 #include "lib/jxl/aux_out_fwd.h"
 #include "lib/jxl/base/data_parallel.h"
 #include "lib/jxl/codec_in_out.h"
@@ -55,6 +56,7 @@ namespace test {
 
 void JxlBasicInfoSetFromPixelFormat(JxlBasicInfo* basic_info,
                                     const JxlPixelFormat* pixel_format) {
+  JxlEncoderInitBasicInfo(basic_info);
   switch (pixel_format->data_type) {
     case JXL_TYPE_FLOAT:
       basic_info->bits_per_sample = 32;


### PR DESCRIPTION
Addresses one of the issues reported in https://github.com/libjxl/libjxl/issues/513: the encode api was not doing anything with the orientation field.

Also had to explicitly initialize JxlBasicInfo when it is used for encoding, otherwise, with uninitialized values for orientation, it does random orientations or has the value set to something out of range.

(making it so that initializing orientation to zero, as you would get with the `{}` initialization, makes it do the identity transform; I suggest we do the same when in the future more optional fields are passed to the encoder, like max_nits: let's use the zero value as acting like a sensible default value)