### PR TITLE
Stop marking all other symbols as local in the .version file

### DIFF
--- a/lib/jxl/jxl.version
+++ b/lib/jxl/jxl.version
@@ -1,7 +1,4 @@
 JXL_0 {
   global:
     Jxl*;
-
-  local:
-    *;
 };


### PR DESCRIPTION
We already set the default visibility of all symbols to hidden
(CXX_VISIBILITY_PRESET) so this is not necessary. Having this was
causing the type_info weak objects to be also local, meaning that
programs would return a different typeid() pointer for the same
object depending on where was the function called from (what .so). In
particular, the `JxlParallelRunner` function type was different between
libjxl (where it is called) and libjxl_threads (where functions are
defined) cause an asan failure with clang-7. This patch solves that
issue since the loader is able to match the (now global) weak typeinfo
symbols when loading these libraries.