### PR TITLE
Remove most other symbols from the shared library.

### DIFF
--- a/lib/jxl.cmake
+++ b/lib/jxl.cmake
@@ -400,9 +400,6 @@ endif ()
 
 # Headers for exporting/importing public headers
 include(GenerateExportHeader)
-# TODO(deymo): Add these visibility properties to the static dependencies of
-# jxl_{dec,enc}-obj since those are currently compiled with the default
-# visibility.
 set_target_properties(jxl_dec-obj PROPERTIES
   CXX_VISIBILITY_PRESET hidden
   VISIBILITY_INLINES_HIDDEN 1
@@ -424,8 +421,6 @@ target_include_directories(jxl_enc-obj PUBLIC
 
 # Private static library. This exposes all the internal functions and is used
 # for tests.
-# TODO(lode): this library is missing symbols, more encoder-only code needs to
-# be moved to JPEGXL_INTERNAL_SOURCES_ENC before this works
 add_library(jxl_dec-static STATIC
   $<TARGET_OBJECTS:jxl_dec-obj>
 )
@@ -543,6 +538,11 @@ foreach(target IN ITEMS jxl jxl_dec)
   set_property(TARGET ${target} APPEND_STRING PROPERTY
       LINK_FLAGS " -Wl,--version-script=${CMAKE_CURRENT_SOURCE_DIR}/jxl/jxl.version")
   endif()  # APPLE
+  # This hides the default visibility symbols from static libraries bundled into
+  # the shared library. In particular this prevents exposing symbols from hwy
+  # and skcms in the shared library.
+  set_property(TARGET ${target} APPEND_STRING PROPERTY
+      LINK_FLAGS " -Wl,--exclude-libs=ALL")
 endforeach()
 
 # Only install libjxl shared library. The libjxl_dec is not installed since it

--- a/lib/jxl/jxl.version
+++ b/lib/jxl/jxl.version
@@ -1,4 +1,17 @@
 JXL_0 {
   global:
     Jxl*;
+
+  local:
+    # Hide all the std namespace symbols. std namespace is explicitly marked
+    # as visibility(default) and header-only functions or methods (such as those
+    # from templates) should be exposed in shared libraries as weak symbols but
+    # this is only needed when we expose those types in the shared library API
+    # in any way. We don't use C++ std types in the API and we also don't
+    # support exceptions in the library.
+    # See https://gcc.gnu.org/bugzilla/show_bug.cgi?id=36022 for a discussion
+    # about this.
+    extern "C++" {
+      *std::*;
+    };
 };

--- a/third_party/skcms.cmake
+++ b/third_party/skcms.cmake
@@ -39,7 +39,11 @@ if(JPEGXL_BUNDLE_SKCMS)
   endif()
 endif()
 
-set_property(TARGET skcms-obj PROPERTY POSITION_INDEPENDENT_CODE ON)
+set_target_properties(skcms-obj PROPERTIES
+  POSITION_INDEPENDENT_CODE ON
+  CXX_VISIBILITY_PRESET hidden
+  VISIBILITY_INLINES_HIDDEN 1
+)
 
 add_library(skcms STATIC EXCLUDE_FROM_ALL $<TARGET_OBJECTS:skcms-obj>)
 target_include_directories(skcms


### PR DESCRIPTION
hwy is always linked in statically (even when installed) and skcms is
sometimes bundled with libjxl.a, however functions from those libraries
shouldn't be exposed in the libjxl library. For hwy, we use
`-Wl,--exclude-libs=ALL` at link time, which would also work for skcms
but in the latter case we build it locally so there's no reason to also
mark it as hidden at build time.

The std:: namespace includes a lot of header-only functions that are not
always inlined (like template ones) and thus create weak symbols with
the functions. The std namespace is marked explicitly as default
visibility because those symbols should be exposed in shared libraries
when using std types in the library interface (functions or exceptions)
but our API is C only so we don't need them there. Removing the symbols
makes the library a little bit smaller in the case of templated
functions that were actually inlined and it removes about 100 symbols
from the dynamic symbol table.

This doesn't remove the typeinfo for all the other types when compiled
with rtti (like in asan/ubsan).