### PR TITLE
better handling of exif (in particular orientation)

### DIFF
--- a/lib/extras/enc/apng.cc
+++ b/lib/extras/enc/apng.cc
@@ -49,6 +49,7 @@
 #include "lib/jxl/dec_external_image.h"
 #include "lib/jxl/enc_color_management.h"
 #include "lib/jxl/enc_image_bundle.h"
+#include "lib/jxl/exif.h"
 #include "lib/jxl/frame_header.h"
 #include "lib/jxl/headers.h"
 #include "lib/jxl/image.h"
@@ -70,7 +71,12 @@ class BlobsWriterPNG {
  public:
   static Status Encode(const Blobs& blobs, std::vector<std::string>* strings) {
     if (!blobs.exif.empty()) {
-      JXL_RETURN_IF_ERROR(EncodeBase16("exif", blobs.exif, strings));
+      // PNG viewers typically ignore Exif orientation but not all of them do
+      // (and e.g. cjxl doesn't), so we overwrite the Exif orientation to the
+      // identity to avoid repeated orientation.
+      PaddedBytes exif(blobs.exif);
+      ResetExifOrientation(exif);
+      JXL_RETURN_IF_ERROR(EncodeBase16("exif", exif, strings));
     }
     if (!blobs.iptc.empty()) {
       JXL_RETURN_IF_ERROR(EncodeBase16("iptc", blobs.iptc, strings));

--- a/lib/extras/enc/jpg.cc
+++ b/lib/extras/enc/jpg.cc
@@ -19,8 +19,10 @@
 #include "lib/jxl/base/status.h"
 #include "lib/jxl/color_encoding_internal.h"
 #include "lib/jxl/common.h"
+#include "lib/jxl/dec_external_image.h"
 #include "lib/jxl/enc_color_management.h"
 #include "lib/jxl/enc_image_bundle.h"
+#include "lib/jxl/exif.h"
 #include "lib/jxl/image.h"
 #include "lib/jxl/image_bundle.h"
 #include "lib/jxl/sanitizers.h"
@@ -33,7 +35,6 @@ namespace extras {
 
 namespace {
 
-constexpr float kJPEGSampleMultiplier = MAXJSAMPLE;
 constexpr unsigned char kICCSignature[12] = {
     0x49, 0x43, 0x43, 0x5F, 0x50, 0x52, 0x4F, 0x46, 0x49, 0x4C, 0x45, 0x00};
 constexpr int kICCMarker = JPEG_APP0 + 2;
@@ -42,13 +43,6 @@ constexpr size_t kMaxBytesInMarker = 65533;
 constexpr unsigned char kExifSignature[6] = {0x45, 0x78, 0x69,
                                              0x66, 0x00, 0x00};
 constexpr int kExifMarker = JPEG_APP0 + 1;
-
-constexpr float kJPEGSampleMin = 0;
-constexpr float kJPEGSampleMax = MAXJSAMPLE;
-
-// TODO (jon): take orientation into account when writing jpeg output
-// TODO (jon): write Exif blob also in sjpeg encoding
-// TODO (jon): overwrite orientation in Exif blob to avoid double orientation
 
 void WriteICCProfile(jpeg_compress_struct* const cinfo,
                      const PaddedBytes& icc) {
@@ -74,14 +68,13 @@ void WriteICCProfile(jpeg_compress_struct* const cinfo,
   }
 }
 void WriteExif(jpeg_compress_struct* const cinfo, const PaddedBytes& exif) {
-  if (exif.size() < 4) return;
   jpeg_write_m_header(
       cinfo, kExifMarker,
-      static_cast<unsigned int>(exif.size() - 4 + sizeof kExifSignature));
+      static_cast<unsigned int>(exif.size() + sizeof kExifSignature));
   for (const unsigned char c : kExifSignature) {
     jpeg_write_m_byte(cinfo, c);
   }
-  for (size_t i = 4; i < exif.size(); ++i) {
+  for (size_t i = 0; i < exif.size(); ++i) {
     jpeg_write_m_byte(cinfo, exif[i]);
   }
 }
@@ -115,8 +108,8 @@ Status EncodeWithLibJpeg(const ImageBundle* ib, const CodecInOut* io,
   unsigned char* buffer = nullptr;
   unsigned long size = 0;
   jpeg_mem_dest(&cinfo, &buffer, &size);
-  cinfo.image_width = ib->xsize();
-  cinfo.image_height = ib->ysize();
+  cinfo.image_width = ib->oriented_xsize();
+  cinfo.image_height = ib->oriented_ysize();
   if (ib->IsGray()) {
     cinfo.input_components = 1;
     cinfo.in_color_space = JCS_GRAYSCALE;
@@ -134,27 +127,27 @@ Status EncodeWithLibJpeg(const ImageBundle* ib, const CodecInOut* io,
   if (!ib->IsSRGB()) {
     WriteICCProfile(&cinfo, ib->c_current().ICC());
   }
-  WriteExif(&cinfo, io->blobs.exif);
+  if (!io->blobs.exif.empty()) {
+    PaddedBytes exif(io->blobs.exif);
+    ResetExifOrientation(exif);
+    WriteExif(&cinfo, exif);
+  }
   if (cinfo.input_components > 3 || cinfo.input_components < 0)
     return JXL_FAILURE("invalid numbers of components");
 
-  std::unique_ptr<JSAMPLE[]> row(
-      new JSAMPLE[cinfo.input_components * cinfo.image_width]);
-  for (size_t y = 0; y < ib->ysize(); ++y) {
-    const float* const JXL_RESTRICT input_row[3] = {
-        ib->color().ConstPlaneRow(0, y), ib->color().ConstPlaneRow(1, y),
-        ib->color().ConstPlaneRow(2, y)};
-    for (size_t x = 0; x < ib->xsize(); ++x) {
-      for (size_t c = 0; c < static_cast<size_t>(cinfo.input_components); ++c) {
-        JXL_RETURN_IF_ERROR(c < 3);
-        row[cinfo.input_components * x + c] = static_cast<JSAMPLE>(
-            std::max(std::min(kJPEGSampleMultiplier * input_row[c][x] + .5f,
-                              kJPEGSampleMax),
-                     kJPEGSampleMin));
-      }
-    }
-    JSAMPROW rows[] = {row.get()};
-    jpeg_write_scanlines(&cinfo, rows, 1);
+  size_t stride =
+      ib->oriented_xsize() * cinfo.input_components * sizeof(JSAMPLE);
+  PaddedBytes raw_bytes(stride * ib->oriented_ysize());
+  JXL_RETURN_IF_ERROR(ConvertToExternal(
+      *ib, BITS_IN_JSAMPLE, /*float_out=*/false, cinfo.input_components,
+      JXL_BIG_ENDIAN, stride, nullptr, raw_bytes.data(), raw_bytes.size(),
+      /*out_callback=*/nullptr,
+      /*out_opaque=*/nullptr, ib->metadata()->GetOrientation()));
+
+  for (size_t y = 0; y < ib->oriented_ysize(); ++y) {
+    JSAMPROW row[] = {raw_bytes.data() + y * stride};
+
+    jpeg_write_scanlines(&cinfo, row, 1);
   }
   jpeg_finish_compress(&cinfo);
   jpeg_destroy_compress(&cinfo);
@@ -167,7 +160,8 @@ Status EncodeWithLibJpeg(const ImageBundle* ib, const CodecInOut* io,
   return true;
 }
 
-Status EncodeWithSJpeg(const ImageBundle* ib, size_t quality,
+Status EncodeWithSJpeg(const ImageBundle* ib, const CodecInOut* io,
+                       size_t quality,
                        const YCbCrChromaSubsampling& chroma_subsampling,
                        PaddedBytes* bytes) {
 #if !JPEGXL_ENABLE_SJPEG
@@ -178,6 +172,11 @@ Status EncodeWithSJpeg(const ImageBundle* ib, size_t quality,
     param.iccp.assign(ib->metadata()->color_encoding.ICC().begin(),
                       ib->metadata()->color_encoding.ICC().end());
   }
+  PaddedBytes exif(io->blobs.exif);
+  if (!exif.empty()) {
+    ResetExifOrientation(exif);
+    param.exif.assign(exif.begin(), exif.end());
+  }
   if (chroma_subsampling.Is444()) {
     param.yuv_mode = SJPEG_YUV_444;
   } else if (chroma_subsampling.Is420()) {
@@ -185,24 +184,17 @@ Status EncodeWithSJpeg(const ImageBundle* ib, size_t quality,
   } else {
     return JXL_FAILURE("sjpeg does not support this chroma subsampling mode");
   }
-  std::vector<uint8_t> rgb;
-  rgb.reserve(ib->xsize() * ib->ysize() * 3);
-  for (size_t y = 0; y < ib->ysize(); ++y) {
-    const float* const rows[] = {
-        ib->color().ConstPlaneRow(0, y),
-        ib->color().ConstPlaneRow(1, y),
-        ib->color().ConstPlaneRow(2, y),
-    };
-    for (size_t x = 0; x < ib->xsize(); ++x) {
-      for (const float* const row : rows) {
-        rgb.push_back(static_cast<uint8_t>(
-            std::max(0.f, std::min(255.f, roundf(255.f * row[x])))));
-      }
-    }
-  }
+  size_t stride = ib->oriented_xsize() * 3;
+  PaddedBytes rgb(ib->xsize() * ib->ysize() * 3);
+  JXL_RETURN_IF_ERROR(ConvertToExternal(
+      *ib, 8, /*float_out=*/false, 3, JXL_BIG_ENDIAN, stride, nullptr,
+      rgb.data(), rgb.size(), /*out_callback=*/nullptr,
+      /*out_opaque=*/nullptr, ib->metadata()->GetOrientation()));
+
   std::string output;
-  JXL_RETURN_IF_ERROR(sjpeg::Encode(rgb.data(), ib->xsize(), ib->ysize(),
-                                    ib->xsize() * 3, param, &output));
+  JXL_RETURN_IF_ERROR(sjpeg::Encode(rgb.data(), ib->oriented_xsize(),
+                                    ib->oriented_ysize(), stride, param,
+                                    &output));
   bytes->assign(
       reinterpret_cast<const uint8_t*>(output.data()),
       reinterpret_cast<const uint8_t*>(output.data() + output.size()));
@@ -234,7 +226,7 @@ Status EncodeImageJPG(const CodecInOut* io, JpegEncoder encoder, size_t quality,
       break;
     case JpegEncoder::kSJpeg:
       JXL_RETURN_IF_ERROR(
-          EncodeWithSJpeg(ib, quality, chroma_subsampling, bytes));
+          EncodeWithSJpeg(ib, io, quality, chroma_subsampling, bytes));
       break;
     default:
       return JXL_FAILURE("tried to use an unknown JPEG encoder");

--- a/lib/jxl.cmake
+++ b/lib/jxl.cmake
@@ -110,6 +110,8 @@ set(JPEGXL_INTERNAL_SOURCES_DEC
   jxl/entropy_coder.h
   jxl/epf.cc
   jxl/epf.h
+  jxl/exif.cc
+  jxl/exif.h
   jxl/fast_dct-inl.h
   jxl/fast_dct.cc
   jxl/fast_dct.h

--- a/lib/jxl/enc_file.cc
+++ b/lib/jxl/enc_file.cc
@@ -20,6 +20,7 @@
 #include "lib/jxl/enc_cache.h"
 #include "lib/jxl/enc_frame.h"
 #include "lib/jxl/enc_icc_codec.h"
+#include "lib/jxl/exif.h"
 #include "lib/jxl/frame_header.h"
 #include "lib/jxl/headers.h"
 #include "lib/jxl/image_bundle.h"
@@ -63,51 +64,6 @@ PassDefinition progressive_passes_dc_quant_ac_full_ac[] = {
     {/*num_coefficients=*/8, /*shift=*/0, /*salient_only=*/false,
      /*suitable_for_downsampling_of_at_least=*/0},
 };
-
-constexpr uint16_t kExifOrientationTag = 274;
-
-// Parses the Exif data just enough to extract any render-impacting info.
-// If the Exif data is invalid or could not be parsed, then it is treated
-// as a no-op.
-// TODO (jon): tag 1 can be used to represent Adobe RGB 1998 if it has value
-// "R03"
-// TODO (jon): set intrinsic dimensions according to
-// https://discourse.wicg.io/t/proposal-exif-image-resolution-auto-and-from-image/4326/24
-void InterpretExif(const PaddedBytes& exif, CodecMetadata* metadata) {
-  if (exif.size() < 12) return;  // not enough bytes for a valid exif blob
-  const uint8_t* t = exif.data();
-  bool bigendian = false;
-  if (LoadLE32(t) == 0x2A004D4D) {
-    bigendian = true;
-  } else if (LoadLE32(t) != 0x002A4949) {
-    return;  // not a valid tiff header
-  }
-  t += 4;
-  uint32_t offset = (bigendian ? LoadBE32(t) : LoadLE32(t));
-  if (exif.size() < 12 + offset + 2 || offset < 8) return;
-  t += offset - 4;
-  uint16_t nb_tags = (bigendian ? LoadBE16(t) : LoadLE16(t));
-  t += 2;
-  while (nb_tags > 0) {
-    if (t + 12 >= exif.data() + exif.size()) return;
-    uint16_t tag = (bigendian ? LoadBE16(t) : LoadLE16(t));
-    t += 2;
-    uint16_t type = (bigendian ? LoadBE16(t) : LoadLE16(t));
-    t += 2;
-    uint32_t count = (bigendian ? LoadBE32(t) : LoadLE32(t));
-    t += 4;
-    uint16_t value = (bigendian ? LoadBE16(t) : LoadLE16(t));
-    t += 4;
-    if (tag == kExifOrientationTag) {
-      if (type == 3 && count == 1) {
-        if (value >= 1 && value <= 8) {
-          metadata->m.orientation = value;
-        }
-      }
-    }
-    nb_tags--;
-  }
-}
 
 Status PrepareCodecMetadataFromIO(const CompressParams& cparams,
                                   const CodecInOut* io,

--- a/lib/jxl/exif.cc
+++ b/lib/jxl/exif.cc
@@ -1,0 +1,89 @@
+// Copyright (c) the JPEG XL Project Authors. All rights reserved.
+//
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+#include "lib/jxl/exif.h"
+
+namespace jxl {
+
+constexpr uint16_t kExifOrientationTag = 274;
+
+// Checks if a blob looks like Exif, and if so, sets bigendian
+// according to the tiff endianness
+bool IsExif(const PaddedBytes& exif, bool* bigendian) {
+  if (exif.size() < 12) return false;  // not enough bytes for a valid exif blob
+  const uint8_t* t = exif.data();
+  if (LoadLE32(t) == 0x2A004D4D) {
+    *bigendian = true;
+    return true;
+  } else if (LoadLE32(t) == 0x002A4949) {
+    *bigendian = false;
+    return true;
+  }
+  return false;  // not a valid tiff header
+}
+
+// Finds the position of an Exif tag, or 0 if it is not found
+size_t FindExifTagPosition(const PaddedBytes& exif, uint16_t tagname) {
+  bool bigendian;
+  if (!IsExif(exif, &bigendian)) return 0;
+  const uint8_t* t = exif.data() + 4;
+  uint32_t offset = (bigendian ? LoadBE32(t) : LoadLE32(t));
+  if (exif.size() < 12 + offset + 2 || offset < 8) return 0;
+  t += offset - 4;
+  uint16_t nb_tags = (bigendian ? LoadBE16(t) : LoadLE16(t));
+  t += 2;
+  while (nb_tags > 0) {
+    if (t + 12 >= exif.data() + exif.size()) return 0;
+    uint16_t tag = (bigendian ? LoadBE16(t) : LoadLE16(t));
+    t += 2;
+    if (tag == tagname) return static_cast<size_t>(t - exif.data());
+    t += 10;
+    nb_tags--;
+  }
+  return 0;
+}
+
+// TODO (jon): tag 1 can be used to represent Adobe RGB 1998 if it has value
+// "R03"
+// TODO (jon): set intrinsic dimensions according to
+// https://discourse.wicg.io/t/proposal-exif-image-resolution-auto-and-from-image/4326/24
+void InterpretExif(const PaddedBytes& exif, CodecMetadata* metadata) {
+  bool bigendian;
+  if (!IsExif(exif, &bigendian)) return;
+  size_t o_pos = FindExifTagPosition(exif, kExifOrientationTag);
+  if (o_pos) {
+    const uint8_t* t = exif.data() + o_pos;
+    uint16_t type = (bigendian ? LoadBE16(t) : LoadLE16(t));
+    t += 2;
+    uint32_t count = (bigendian ? LoadBE32(t) : LoadLE32(t));
+    t += 4;
+    uint16_t value = (bigendian ? LoadBE16(t) : LoadLE16(t));
+    t += 4;
+    if (type == 3 && count == 1 && value >= 1 && value <= 8) {
+      metadata->m.orientation = value;
+    }
+  }
+}
+
+void ResetExifOrientation(PaddedBytes& exif) {
+  bool bigendian;
+  if (!IsExif(exif, &bigendian)) return;
+  size_t o_pos = FindExifTagPosition(exif, kExifOrientationTag);
+  if (o_pos) {
+    uint8_t* t = exif.data() + o_pos;
+    uint16_t type = (bigendian ? LoadBE16(t) : LoadLE16(t));
+    t += 2;
+    uint32_t count = (bigendian ? LoadBE32(t) : LoadLE32(t));
+    t += 4;
+    if (type == 3 && count == 1) {
+      if (bigendian)
+        StoreBE16(1, t);
+      else
+        StoreLE16(1, t);
+    }
+  }
+}
+
+}  // namespace jxl

--- a/lib/jxl/exif.h
+++ b/lib/jxl/exif.h
@@ -1,0 +1,27 @@
+// Copyright (c) the JPEG XL Project Authors. All rights reserved.
+//
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+#ifndef LIB_JXL_EXIF_H_
+#define LIB_JXL_EXIF_H_
+
+// Basic parsing of Exif (just enough for the render-impacting things
+// like orientation)
+
+#include "lib/jxl/base/padded_bytes.h"
+#include "lib/jxl/image_metadata.h"
+
+namespace jxl {
+
+// Parses the Exif data just enough to extract any render-impacting info.
+// If the Exif data is invalid or could not be parsed, then it is treated
+// as a no-op.
+void InterpretExif(const PaddedBytes& exif, CodecMetadata* metadata);
+
+// Sets the Exif orientation to the identity, to avoid repeated orientation
+void ResetExifOrientation(PaddedBytes& exif);
+
+}  // namespace jxl
+
+#endif  // LIB_JXL_EXIF_H_

--- a/lib/lib.gni
+++ b/lib/lib.gni
@@ -128,6 +128,8 @@ libjxl_dec_sources = [
     "jxl/entropy_coder.h",
     "jxl/epf.cc",
     "jxl/epf.h",
+    "jxl/exif.cc",
+    "jxl/exif.h",
     "jxl/fast_dct-inl.h",
     "jxl/fast_dct.cc",
     "jxl/fast_dct.h",


### PR DESCRIPTION
There were some issues with Exif metadata handling in cjxl/djxl (see also https://github.com/libjxl/libjxl/issues/540):

- `djxl foo.jxl bar.jpg -j --use_sjpeg` wrote no exif metadata
- `djxl foo.jxl bar.jpg -j` (using libjpeg) wrote malformed exif metadata
- `djxl foo.jxl bar.jpg -j` did not orient the image, which is not good (it would maybe be OK if we always wrote exif metadata that does the appropriate orientation, but there could also just not be any exif, e.g. when you do `cjxl oriented.jpg foo.jxl --strip`.
- `djxl foo.jxl bar.png` orients the image (which is good), but also writes exif metadata which might lead to repeated orientation (most viewers ignore exif orientation in png files, but some don't, and also cjxl doesn't)

This PR attempts to fix those issues in the following way:
- `djxl` now always writes (correct) exif metadata when outputting jpg
- `djxl` now orients the image before outputting a lossy jpg
- if the exif does orientation, its orientation field gets overwritten to the identity when writing png/lossy jpg output, so there is no repeated orientation
- the original exif is still preserved in the jxl bitstream, overwriting with the identity is only done just before writing png / lossy jpg output. When writing a reconstructed lossless jpg, we still want the original exif to be preserved.


This PR is not trying to get things right in the encode api, where I think currently no Exif inspection is done yet to set the codestream orientation correctly.

