### PR TITLE
Move most of extras/ code to its own namespace jxl::extras

### DIFF
--- a/lib/extras/codec.cc
+++ b/lib/extras/codec.cc
@@ -92,31 +92,31 @@ Status SetFromBytes(const Span<const uint8_t> bytes,
   io->metadata.m.bit_depth.bits_per_sample = 0;  // (For is-set check below)
 
   Codec codec;
-  if (DecodeImagePNG(bytes, color_hints, pool, io)) {
+  if (extras::DecodeImagePNG(bytes, color_hints, pool, io)) {
     codec = Codec::kPNG;
   }
 #if JPEGXL_ENABLE_APNG
-  else if (DecodeImageAPNG(bytes, color_hints, pool, io)) {
+  else if (extras::DecodeImageAPNG(bytes, color_hints, pool, io)) {
     codec = Codec::kPNG;
   }
 #endif
-  else if (DecodeImagePGX(bytes, color_hints, pool, io)) {
+  else if (extras::DecodeImagePGX(bytes, color_hints, pool, io)) {
     codec = Codec::kPGX;
-  } else if (DecodeImagePNM(bytes, color_hints, pool, io)) {
+  } else if (extras::DecodeImagePNM(bytes, color_hints, pool, io)) {
     codec = Codec::kPNM;
   }
 #if JPEGXL_ENABLE_GIF
-  else if (DecodeImageGIF(bytes, color_hints, pool, io)) {
+  else if (extras::DecodeImageGIF(bytes, color_hints, pool, io)) {
     codec = Codec::kGIF;
   }
 #endif
-  else if (DecodeImageJPG(bytes, color_hints, pool, io)) {
+  else if (extras::DecodeImageJPG(bytes, color_hints, pool, io)) {
     codec = Codec::kJPG;
-  } else if (DecodeImagePSD(bytes, color_hints, pool, io)) {
+  } else if (extras::DecodeImagePSD(bytes, color_hints, pool, io)) {
     codec = Codec::kPSD;
   }
 #if JPEGXL_ENABLE_EXR
-  else if (DecodeImageEXR(bytes, color_hints, pool, io)) {
+  else if (extras::DecodeImageEXR(bytes, color_hints, pool, io)) {
     codec = Codec::kEXR;
   }
 #endif
@@ -152,28 +152,34 @@ Status Encode(const CodecInOut& io, const Codec codec,
 
   switch (codec) {
     case Codec::kPNG:
-      return EncodeImagePNG(&io, c_desired, bits_per_sample, pool, bytes);
+      return extras::EncodeImagePNG(&io, c_desired, bits_per_sample, pool,
+                                    bytes);
     case Codec::kJPG:
 #if JPEGXL_ENABLE_JPEG
-      return EncodeImageJPG(
-          &io, io.use_sjpeg ? JpegEncoder::kSJpeg : JpegEncoder::kLibJpeg,
-          io.jpeg_quality, YCbCrChromaSubsampling(), pool, bytes,
-          io.Main().IsJPEG() ? DecodeTarget::kQuantizedCoeffs
-                             : DecodeTarget::kPixels);
+      return EncodeImageJPG(&io,
+                            io.use_sjpeg ? extras::JpegEncoder::kSJpeg
+                                         : extras::JpegEncoder::kLibJpeg,
+                            io.jpeg_quality, YCbCrChromaSubsampling(), pool,
+                            bytes,
+                            io.Main().IsJPEG() ? DecodeTarget::kQuantizedCoeffs
+                                               : DecodeTarget::kPixels);
 #else
       return JXL_FAILURE("JPEG XL was built without JPEG support");
 #endif
     case Codec::kPNM:
-      return EncodeImagePNM(&io, c_desired, bits_per_sample, pool, bytes);
+      return extras::EncodeImagePNM(&io, c_desired, bits_per_sample, pool,
+                                    bytes);
     case Codec::kPGX:
-      return EncodeImagePGX(&io, c_desired, bits_per_sample, pool, bytes);
+      return extras::EncodeImagePGX(&io, c_desired, bits_per_sample, pool,
+                                    bytes);
     case Codec::kGIF:
       return JXL_FAILURE("Encoding to GIF is not implemented");
     case Codec::kPSD:
-      return EncodeImagePSD(&io, c_desired, bits_per_sample, pool, bytes);
+      return extras::EncodeImagePSD(&io, c_desired, bits_per_sample, pool,
+                                    bytes);
     case Codec::kEXR:
 #if JPEGXL_ENABLE_EXR
-      return EncodeImageEXR(&io, c_desired, pool, bytes);
+      return extras::EncodeImageEXR(&io, c_desired, pool, bytes);
 #else
       return JXL_FAILURE("JPEG XL was built without OpenEXR support");
 #endif

--- a/lib/extras/codec_apng.cc
+++ b/lib/extras/codec_apng.cc
@@ -55,6 +55,7 @@
 #include "png.h" /* original (unpatched) libpng is ok */
 
 namespace jxl {
+namespace extras {
 
 namespace {
 
@@ -404,4 +405,5 @@ Status DecodeImageAPNG(Span<const uint8_t> bytes, const ColorHints& color_hints,
   return true;
 }
 
+}  // namespace extras
 }  // namespace jxl

--- a/lib/extras/codec_apng.h
+++ b/lib/extras/codec_apng.h
@@ -18,12 +18,14 @@
 #include "lib/jxl/codec_in_out.h"
 
 namespace jxl {
+namespace extras {
 
 // Decodes `bytes` into `io`. color_space_hint is ignored.
 Status DecodeImageAPNG(const Span<const uint8_t> bytes,
                        const ColorHints& color_hints, ThreadPool* pool,
                        CodecInOut* io);
 
+}  // namespace extras
 }  // namespace jxl
 
 #endif  // LIB_EXTRAS_CODEC_APNG_H_

--- a/lib/extras/codec_exr.cc
+++ b/lib/extras/codec_exr.cc
@@ -17,6 +17,7 @@
 #include "lib/jxl/color_management.h"
 
 namespace jxl {
+namespace extras {
 
 namespace {
 
@@ -347,4 +348,5 @@ Status EncodeImageEXR(const CodecInOut* io, const ColorEncoding& c_desired,
   return true;
 }
 
+}  // namespace extras
 }  // namespace jxl

--- a/lib/extras/codec_exr.h
+++ b/lib/extras/codec_exr.h
@@ -17,6 +17,7 @@
 #include "lib/jxl/color_encoding_internal.h"
 
 namespace jxl {
+namespace extras {
 
 // Decodes `bytes` into `io`. color_hints are ignored.
 Status DecodeImageEXR(Span<const uint8_t> bytes, const ColorHints& color_hints,
@@ -27,6 +28,7 @@ Status DecodeImageEXR(Span<const uint8_t> bytes, const ColorHints& color_hints,
 Status EncodeImageEXR(const CodecInOut* io, const ColorEncoding& c_desired,
                       ThreadPool* pool, PaddedBytes* bytes);
 
+}  // namespace extras
 }  // namespace jxl
 
 #endif  // LIB_EXTRAS_CODEC_EXR_H_

--- a/lib/extras/codec_gif.cc
+++ b/lib/extras/codec_gif.cc
@@ -24,6 +24,7 @@
 #include "lib/jxl/sanitizers.h"
 
 namespace jxl {
+namespace extras {
 
 namespace {
 
@@ -336,4 +337,5 @@ Status DecodeImageGIF(Span<const uint8_t> bytes, const ColorHints& color_hints,
   return true;
 }
 
+}  // namespace extras
 }  // namespace jxl

--- a/lib/extras/codec_gif.h
+++ b/lib/extras/codec_gif.h
@@ -18,12 +18,14 @@
 #include "lib/jxl/codec_in_out.h"
 
 namespace jxl {
+namespace extras {
 
 // Decodes `bytes` into `io`. color_hints are ignored.
 Status DecodeImageGIF(const Span<const uint8_t> bytes,
                       const ColorHints& color_hints, ThreadPool* pool,
                       CodecInOut* io);
 
+}  // namespace extras
 }  // namespace jxl
 
 #endif  // LIB_EXTRAS_CODEC_GIF_H_

--- a/lib/extras/codec_jpg.cc
+++ b/lib/extras/codec_jpg.cc
@@ -40,6 +40,7 @@
 #endif
 
 namespace jxl {
+namespace extras {
 
 #if JPEGXL_ENABLE_JPEG
 namespace {
@@ -515,4 +516,5 @@ Status EncodeImageJPG(const CodecInOut* io, JpegEncoder encoder, size_t quality,
 #endif  // JPEGXL_ENABLE_JPEG
 }
 
+}  // namespace extras
 }  // namespace jxl

--- a/lib/extras/codec_jpg.h
+++ b/lib/extras/codec_jpg.h
@@ -19,6 +19,7 @@
 #include "lib/jxl/codec_in_out.h"
 
 namespace jxl {
+namespace extras {
 
 enum class JpegEncoder {
   kLibJpeg,
@@ -44,6 +45,7 @@ Status EncodeImageJPG(const CodecInOut* io, JpegEncoder encoder, size_t quality,
                       ThreadPool* pool, PaddedBytes* bytes,
                       DecodeTarget target = DecodeTarget::kPixels);
 
+}  // namespace extras
 }  // namespace jxl
 
 #endif  // LIB_EXTRAS_CODEC_JPG_H_

--- a/lib/extras/codec_pgx.cc
+++ b/lib/extras/codec_pgx.cc
@@ -27,6 +27,7 @@
 #include "lib/jxl/luminance.h"
 
 namespace jxl {
+namespace extras {
 namespace {
 
 struct HeaderPGX {
@@ -321,4 +322,5 @@ void TestCodecPGX() {
   }
 }
 
+}  // namespace extras
 }  // namespace jxl

--- a/lib/extras/codec_pgx.h
+++ b/lib/extras/codec_pgx.h
@@ -20,6 +20,7 @@
 #include "lib/jxl/color_encoding_internal.h"
 
 namespace jxl {
+namespace extras {
 
 // Decodes `bytes` into `io`.
 Status DecodeImagePGX(const Span<const uint8_t> bytes,
@@ -32,6 +33,7 @@ Status EncodeImagePGX(const CodecInOut* io, const ColorEncoding& c_desired,
                       PaddedBytes* bytes);
 
 void TestCodecPGX();
+}  // namespace extras
 }  // namespace jxl
 
 #endif  // LIB_EXTRAS_CODEC_PGX_H_

--- a/lib/extras/codec_png.cc
+++ b/lib/extras/codec_png.cc
@@ -31,6 +31,7 @@
 #include "lib/jxl/luminance.h"
 
 namespace jxl {
+namespace extras {
 namespace {
 
 #define JXL_PNG_VERBOSE 0
@@ -847,4 +848,5 @@ Status EncodeImagePNG(const CodecInOut* io, const ColorEncoding& c_desired,
   return true;
 }
 
+}  // namespace extras
 }  // namespace jxl

--- a/lib/extras/codec_png.h
+++ b/lib/extras/codec_png.h
@@ -23,6 +23,7 @@
 #include "lib/jxl/color_encoding_internal.h"
 
 namespace jxl {
+namespace extras {
 
 // Decodes `bytes` into `io`.
 Status DecodeImagePNG(const Span<const uint8_t> bytes,
@@ -34,6 +35,7 @@ Status EncodeImagePNG(const CodecInOut* io, const ColorEncoding& c_desired,
                       size_t bits_per_sample, ThreadPool* pool,
                       PaddedBytes* bytes);
 
+}  // namespace extras
 }  // namespace jxl
 
 #endif  // LIB_EXTRAS_CODEC_PNG_H_

--- a/lib/extras/codec_pnm.cc
+++ b/lib/extras/codec_pnm.cc
@@ -29,6 +29,7 @@
 #include "lib/jxl/luminance.h"
 
 namespace jxl {
+namespace extras {
 namespace {
 
 struct HeaderPNM {
@@ -573,4 +574,5 @@ void TestCodecPNM() {
   JXL_CHECK(std::abs(d - -3.141592) < 1E-15);
 }
 
+}  // namespace extras
 }  // namespace jxl

--- a/lib/extras/codec_pnm.h
+++ b/lib/extras/codec_pnm.h
@@ -23,6 +23,7 @@
 #include "lib/jxl/color_encoding_internal.h"
 
 namespace jxl {
+namespace extras {
 
 // Decodes `bytes` into `io`. color_hints may specify "color_space", which
 // defaults to sRGB.
@@ -37,6 +38,7 @@ Status EncodeImagePNM(const CodecInOut* io, const ColorEncoding& c_desired,
 
 void TestCodecPNM();
 
+}  // namespace extras
 }  // namespace jxl
 
 #endif  // LIB_EXTRAS_CODEC_PNM_H_

--- a/lib/extras/codec_psd.cc
+++ b/lib/extras/codec_psd.cc
@@ -28,6 +28,7 @@
 #include "lib/jxl/luminance.h"
 
 namespace jxl {
+namespace extras {
 namespace {
 
 uint64_t get_be_int(int bytes, const uint8_t*& pos, const uint8_t* maxpos) {
@@ -612,4 +613,5 @@ Status EncodeImagePSD(const CodecInOut* io, const ColorEncoding& c_desired,
   return JXL_FAILURE("PSD encoding not yet implemented");
 }
 
+}  // namespace extras
 }  // namespace jxl

--- a/lib/extras/codec_psd.h
+++ b/lib/extras/codec_psd.h
@@ -19,6 +19,7 @@
 #include "lib/jxl/color_encoding_internal.h"
 
 namespace jxl {
+namespace extras {
 
 // Decodes `bytes` into `io`.
 Status DecodeImagePSD(const Span<const uint8_t> bytes,
@@ -30,6 +31,7 @@ Status EncodeImagePSD(const CodecInOut* io, const ColorEncoding& c_desired,
                       size_t bits_per_sample, ThreadPool* pool,
                       PaddedBytes* bytes);
 
+}  // namespace extras
 }  // namespace jxl
 
 #endif  // LIB_EXTRAS_CODEC_PSD_H_

--- a/lib/extras/codec_test.cc
+++ b/lib/extras/codec_test.cc
@@ -25,6 +25,7 @@
 #include "lib/jxl/testdata.h"
 
 namespace jxl {
+namespace extras {
 namespace {
 
 CodecInOut CreateTestImage(const size_t xsize, const size_t ysize,
@@ -374,4 +375,5 @@ TEST(CodecTest, TestPNM) { TestCodecPNM(); }
 TEST(CodecTest, TestPGX) { TestCodecPGX(); }
 
 }  // namespace
+}  // namespace extras
 }  // namespace jxl

--- a/lib/extras/color_hints.cc
+++ b/lib/extras/color_hints.cc
@@ -10,6 +10,7 @@
 #include "lib/jxl/color_encoding_internal.h"
 
 namespace jxl {
+namespace extras {
 
 Status ApplyColorHints(const ColorHints& color_hints,
                        const bool color_already_set, const bool is_gray,
@@ -62,4 +63,5 @@ Status ApplyColorHints(const ColorHints& color_hints,
   return true;
 }
 
+}  // namespace extras
 }  // namespace jxl

--- a/lib/extras/color_hints.h
+++ b/lib/extras/color_hints.h
@@ -59,12 +59,15 @@ class ColorHints {
   std::vector<KeyValue> kv_;
 };
 
+namespace extras {
+
 // Apply the color hints to the decoded image in CodecInOut if any.
 // color_already_set tells whether the color encoding was already set, in which
 // case the hints are ignored if any hint is passed.
 Status ApplyColorHints(const ColorHints& color_hints, bool color_already_set,
                        bool is_gray, CodecInOut* io);
 
+}  // namespace extras
 }  // namespace jxl
 
 #endif  // LIB_EXTRAS_COLOR_HINTS_H_

--- a/lib/jxl/decode_test.cc
+++ b/lib/jxl/decode_test.cc
@@ -260,9 +260,9 @@ PaddedBytes CreateTestJXLCodestream(
   if (jpeg_codestream != nullptr) {
 #if JPEGXL_ENABLE_JPEG
     jxl::PaddedBytes jpeg_bytes;
-    EXPECT_TRUE(EncodeImageJPG(&io, jxl::JpegEncoder::kLibJpeg, /*quality=*/70,
-                               jxl::YCbCrChromaSubsampling(), &pool,
-                               &jpeg_bytes, jxl::DecodeTarget::kPixels));
+    EXPECT_TRUE(EncodeImageJPG(&io, jxl::extras::JpegEncoder::kLibJpeg,
+                               /*quality=*/70, jxl::YCbCrChromaSubsampling(),
+                               &pool, &jpeg_bytes, jxl::DecodeTarget::kPixels));
     jpeg_codestream->append(jpeg_bytes.data(),
                             jpeg_bytes.data() + jpeg_bytes.size());
     EXPECT_TRUE(jxl::jpeg::DecodeImageJPG(

--- a/lib/jxl/jxl_test.cc
+++ b/lib/jxl/jxl_test.cc
@@ -1359,7 +1359,7 @@ jxl::Status DecompressJxlToJPEGForTest(
     return JXL_FAILURE("Failed to decode JXL to JPEG");
   }
   io.jpeg_quality = 95;
-  if (!EncodeImageJPG(&io, jxl::JpegEncoder::kLibJpeg, io.jpeg_quality,
+  if (!EncodeImageJPG(&io, jxl::extras::JpegEncoder::kLibJpeg, io.jpeg_quality,
                       jxl::YCbCrChromaSubsampling(), pool, output,
                       jxl::DecodeTarget::kQuantizedCoeffs)) {
     return JXL_FAILURE("Failed to generate JPEG");

--- a/tools/benchmark/benchmark_codec_custom.cc
+++ b/tools/benchmark/benchmark_codec_custom.cc
@@ -100,7 +100,7 @@ class CustomCodec : public ImageCodec {
     const size_t bits = io->metadata.m.bit_depth.bits_per_sample;
     PaddedBytes png;
     JXL_RETURN_IF_ERROR(
-        EncodeImagePNG(io, io->Main().c_current(), bits, pool, &png));
+        extras::EncodeImagePNG(io, io->Main().c_current(), bits, pool, &png));
     JXL_RETURN_IF_ERROR(WriteFile(png, png_filename));
     std::vector<std::string> arguments = compress_args_;
     arguments.push_back(png_filename);

--- a/tools/benchmark/benchmark_codec_jpeg.cc
+++ b/tools/benchmark/benchmark_codec_jpeg.cc
@@ -23,6 +23,8 @@
 #include "lib/jxl/codec_in_out.h"
 #include "tools/cmdline.h"
 
+using jxl::extras::JpegEncoder;
+
 namespace jxl {
 
 namespace {
@@ -102,8 +104,8 @@ class JPEGCodec : public ImageCodec {
                     jpegxl::tools::SpeedStats* speed_stats) override {
     double elapsed_deinterleave;
     const double start = Now();
-    JXL_RETURN_IF_ERROR(DecodeImageJPG(compressed, ColorHints(), pool, io,
-                                       &elapsed_deinterleave));
+    JXL_RETURN_IF_ERROR(extras::DecodeImageJPG(compressed, ColorHints(), pool,
+                                               io, &elapsed_deinterleave));
     const double end = Now();
     speed_stats->NotifyElapsed(end - start - elapsed_deinterleave);
     return true;

--- a/tools/benchmark/benchmark_codec_png.cc
+++ b/tools/benchmark/benchmark_codec_png.cc
@@ -40,8 +40,8 @@ class PNGCodec : public ImageCodec {
                   jpegxl::tools::SpeedStats* speed_stats) override {
     const size_t bits = io->metadata.m.bit_depth.bits_per_sample;
     const double start = Now();
-    JXL_RETURN_IF_ERROR(
-        EncodeImagePNG(io, io->Main().c_current(), bits, pool, compressed));
+    JXL_RETURN_IF_ERROR(extras::EncodeImagePNG(io, io->Main().c_current(), bits,
+                                               pool, compressed));
     const double end = Now();
     speed_stats->NotifyElapsed(end - start);
     return true;
@@ -52,7 +52,8 @@ class PNGCodec : public ImageCodec {
                     ThreadPoolInternal* pool, CodecInOut* io,
                     jpegxl::tools::SpeedStats* speed_stats) override {
     const double start = Now();
-    JXL_RETURN_IF_ERROR(DecodeImagePNG(compressed, ColorHints(), pool, io));
+    JXL_RETURN_IF_ERROR(
+        extras::DecodeImagePNG(compressed, ColorHints(), pool, io));
     const double end = Now();
     speed_stats->NotifyElapsed(end - start);
     return true;

--- a/tools/benchmark/benchmark_xl.cc
+++ b/tools/benchmark/benchmark_xl.cc
@@ -62,7 +62,8 @@ Status WritePNG(Image3F&& image, ThreadPool* pool,
   io.metadata.m.color_encoding = ColorEncoding::SRGB();
   io.SetFromImage(std::move(image), io.metadata.m.color_encoding);
   PaddedBytes compressed;
-  JXL_CHECK(EncodeImagePNG(&io, io.Main().c_current(), 8, pool, &compressed));
+  JXL_CHECK(
+      extras::EncodeImagePNG(&io, io.Main().c_current(), 8, pool, &compressed));
   return WriteFile(compressed, filename);
 }
 

--- a/tools/butteraugli_main.cc
+++ b/tools/butteraugli_main.cc
@@ -37,7 +37,8 @@ Status WritePNG(Image3F&& image, const std::string& filename) {
   io.metadata.m.color_encoding = ColorEncoding::SRGB();
   io.SetFromImage(std::move(image), io.metadata.m.color_encoding);
   PaddedBytes compressed;
-  JXL_CHECK(EncodeImagePNG(&io, io.Main().c_current(), 8, &pool, &compressed));
+  JXL_CHECK(extras::EncodeImagePNG(&io, io.Main().c_current(), 8, &pool,
+                                   &compressed));
   return WriteFile(compressed, filename);
 }
 

--- a/tools/djxl.cc
+++ b/tools/djxl.cc
@@ -221,11 +221,11 @@ jxl::Status DecompressJxlToJPEG(const JpegXlContainer& container,
   if (!DecodeJpegXlToJpeg(args.params, container, &io, pool)) {
     return JXL_FAILURE("Failed to decode JXL to JPEG");
   }
-  if (!EncodeImageJPG(
-          &io,
-          io.use_sjpeg ? jxl::JpegEncoder::kSJpeg : jxl::JpegEncoder::kLibJpeg,
-          io.jpeg_quality, jxl::YCbCrChromaSubsampling(), pool, output,
-          jxl::DecodeTarget::kQuantizedCoeffs)) {
+  if (!EncodeImageJPG(&io,
+                      io.use_sjpeg ? jxl::extras::JpegEncoder::kSJpeg
+                                   : jxl::extras::JpegEncoder::kLibJpeg,
+                      io.jpeg_quality, jxl::YCbCrChromaSubsampling(), pool,
+                      output, jxl::DecodeTarget::kQuantizedCoeffs)) {
     return JXL_FAILURE("Failed to generate JPEG");
   }
   stats->SetImageSize(io.xsize(), io.ysize());

--- a/tools/fuzzer_corpus.cc
+++ b/tools/fuzzer_corpus.cc
@@ -225,7 +225,7 @@ bool GenerateFile(const char* output_dir, const ImageSpec& spec,
     // metadata and encode it in the beginning of the compressed bytes.
     jxl::PaddedBytes jpeg_bytes;
     JXL_RETURN_IF_ERROR(
-        EncodeImageJPG(&io, jxl::JpegEncoder::kLibJpeg, /*quality=*/70,
+        EncodeImageJPG(&io, jxl::extras::JpegEncoder::kLibJpeg, /*quality=*/70,
                        jxl::YCbCrChromaSubsampling(), /*pool=*/nullptr,
                        &jpeg_bytes, jxl::DecodeTarget::kPixels));
     JXL_RETURN_IF_ERROR(jxl::jpeg::DecodeImageJPG(


### PR DESCRIPTION
This is in line with the coding style and makes it harder to depend on
extras/ code accidentally. codec.cc code will be moved at a later point.