### PR TITLE
Move PGX test-only code to new codec_pgx_test.cc

### DIFF
--- a/lib/extras/codec_pgx.cc
+++ b/lib/extras/codec_pgx.cc
@@ -269,58 +269,5 @@ Status EncodeImagePGX(const CodecInOut* io, const ColorEncoding& c_desired,
   return true;
 }
 
-void TestCodecPGX() {
-  {
-    std::string pgx = "PG ML + 8 2 3\npixels";
-
-    CodecInOut io;
-    ThreadPool* pool = nullptr;
-
-    Status ok = DecodeImagePGX(MakeSpan(pgx.c_str()), ColorHints(), pool, &io);
-    JXL_CHECK(ok == true);
-
-    ScaleImage(255.f, io.Main().color());
-
-    JXL_CHECK(!io.metadata.m.bit_depth.floating_point_sample);
-    JXL_CHECK(io.metadata.m.bit_depth.bits_per_sample == 8);
-    JXL_CHECK(io.metadata.m.color_encoding.IsGray());
-    JXL_CHECK(io.xsize() == 2);
-    JXL_CHECK(io.ysize() == 3);
-    float eps = 1e-5;
-    ExpectNear<float>('p', io.Main().color()->Plane(0).Row(0)[0], eps);
-    ExpectNear<float>('i', io.Main().color()->Plane(0).Row(0)[1], eps);
-    ExpectNear<float>('x', io.Main().color()->Plane(0).Row(1)[0], eps);
-    ExpectNear<float>('e', io.Main().color()->Plane(0).Row(1)[1], eps);
-    ExpectNear<float>('l', io.Main().color()->Plane(0).Row(2)[0], eps);
-    ExpectNear<float>('s', io.Main().color()->Plane(0).Row(2)[1], eps);
-  }
-
-  {
-    std::string pgx = "PG ML + 16 2 3\np_i_x_e_l_s_";
-
-    CodecInOut io;
-    ThreadPool* pool = nullptr;
-
-    Status ok = DecodeImagePGX(MakeSpan(pgx.c_str()), ColorHints(), pool, &io);
-    JXL_CHECK(ok == true);
-
-    ScaleImage(255.f, io.Main().color());
-
-    JXL_CHECK(!io.metadata.m.bit_depth.floating_point_sample);
-    JXL_CHECK(io.metadata.m.bit_depth.bits_per_sample == 16);
-    JXL_CHECK(io.metadata.m.color_encoding.IsGray());
-    JXL_CHECK(io.xsize() == 2);
-    JXL_CHECK(io.ysize() == 3);
-    float eps = 1e-7;
-    const auto& plane = io.Main().color()->Plane(0);
-    ExpectNear(256.0f * 'p' + '_', plane.Row(0)[0] * 257, eps);
-    ExpectNear(256.0f * 'i' + '_', plane.Row(0)[1] * 257, eps);
-    ExpectNear(256.0f * 'x' + '_', plane.Row(1)[0] * 257, eps);
-    ExpectNear(256.0f * 'e' + '_', plane.Row(1)[1] * 257, eps);
-    ExpectNear(256.0f * 'l' + '_', plane.Row(2)[0] * 257, eps);
-    ExpectNear(256.0f * 's' + '_', plane.Row(2)[1] * 257, eps);
-  }
-}
-
 }  // namespace extras
 }  // namespace jxl

--- a/lib/extras/codec_pgx.h
+++ b/lib/extras/codec_pgx.h
@@ -32,7 +32,6 @@ Status EncodeImagePGX(const CodecInOut* io, const ColorEncoding& c_desired,
                       size_t bits_per_sample, ThreadPool* pool,
                       PaddedBytes* bytes);
 
-void TestCodecPGX();
 }  // namespace extras
 }  // namespace jxl
 

--- a/lib/extras/codec_pgx_test.cc
+++ b/lib/extras/codec_pgx_test.cc
@@ -1,0 +1,74 @@
+// Copyright (c) the JPEG XL Project Authors. All rights reserved.
+//
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+#include "lib/extras/codec_pgx.h"
+
+#include <stddef.h>
+
+#include "gtest/gtest.h"
+
+namespace jxl {
+namespace extras {
+namespace {
+
+Span<const uint8_t> MakeSpan(const char* str) {
+  return Span<const uint8_t>(reinterpret_cast<const uint8_t*>(str),
+                             strlen(str));
+}
+
+TEST(CodecPGXTest, Test8bits) {
+  std::string pgx = "PG ML + 8 2 3\npixels";
+
+  CodecInOut io;
+  ThreadPool* pool = nullptr;
+
+  EXPECT_TRUE(DecodeImagePGX(MakeSpan(pgx.c_str()), ColorHints(), pool, &io));
+
+  ScaleImage(255.f, io.Main().color());
+
+  EXPECT_FALSE(io.metadata.m.bit_depth.floating_point_sample);
+  EXPECT_EQ(8u, io.metadata.m.bit_depth.bits_per_sample);
+  EXPECT_TRUE(io.metadata.m.color_encoding.IsGray());
+  EXPECT_EQ(2u, io.xsize());
+  EXPECT_EQ(3u, io.ysize());
+
+  float eps = 1e-5;
+  EXPECT_NEAR('p', io.Main().color()->Plane(0).Row(0)[0], eps);
+  EXPECT_NEAR('i', io.Main().color()->Plane(0).Row(0)[1], eps);
+  EXPECT_NEAR('x', io.Main().color()->Plane(0).Row(1)[0], eps);
+  EXPECT_NEAR('e', io.Main().color()->Plane(0).Row(1)[1], eps);
+  EXPECT_NEAR('l', io.Main().color()->Plane(0).Row(2)[0], eps);
+  EXPECT_NEAR('s', io.Main().color()->Plane(0).Row(2)[1], eps);
+}
+
+TEST(CodecPGXTest, Test16bits) {
+  std::string pgx = "PG ML + 16 2 3\np_i_x_e_l_s_";
+
+  CodecInOut io;
+  ThreadPool* pool = nullptr;
+
+  EXPECT_TRUE(DecodeImagePGX(MakeSpan(pgx.c_str()), ColorHints(), pool, &io));
+
+  ScaleImage(255.f, io.Main().color());
+
+  EXPECT_FALSE(io.metadata.m.bit_depth.floating_point_sample);
+  EXPECT_EQ(16u, io.metadata.m.bit_depth.bits_per_sample);
+  EXPECT_TRUE(io.metadata.m.color_encoding.IsGray());
+  EXPECT_EQ(2u, io.xsize());
+  EXPECT_EQ(3u, io.ysize());
+
+  float eps = 1e-7;
+  const auto& plane = io.Main().color()->Plane(0);
+  EXPECT_NEAR(256.0f * 'p' + '_', plane.Row(0)[0] * 257, eps);
+  EXPECT_NEAR(256.0f * 'i' + '_', plane.Row(0)[1] * 257, eps);
+  EXPECT_NEAR(256.0f * 'x' + '_', plane.Row(1)[0] * 257, eps);
+  EXPECT_NEAR(256.0f * 'e' + '_', plane.Row(1)[1] * 257, eps);
+  EXPECT_NEAR(256.0f * 'l' + '_', plane.Row(2)[0] * 257, eps);
+  EXPECT_NEAR(256.0f * 's' + '_', plane.Row(2)[1] * 257, eps);
+}
+
+}  // namespace
+}  // namespace extras
+}  // namespace jxl

--- a/lib/extras/codec_test.cc
+++ b/lib/extras/codec_test.cc
@@ -372,7 +372,6 @@ TEST(CodecTest, TestWideGamut) {
 }
 
 TEST(CodecTest, TestPNM) { TestCodecPNM(); }
-TEST(CodecTest, TestPGX) { TestCodecPGX(); }
 
 }  // namespace
 }  // namespace extras

--- a/lib/jxl_tests.cmake
+++ b/lib/jxl_tests.cmake
@@ -4,6 +4,7 @@
 # license that can be found in the LICENSE file.
 
 set(TEST_FILES
+  extras/codec_pgx_test.cc
   extras/codec_test.cc
   extras/color_description_test.cc
   jxl/ac_strategy_test.cc


### PR DESCRIPTION
These codec-specific tests should use the existing testing mechanism
which also allows to convert them to gtest instead of relying on
ASSERTs.