### PR TITLE
Remove JPEG's DecodeTarget parameter.

### DIFF
--- a/lib/extras/codec_jpg.cc
+++ b/lib/extras/codec_jpg.cc
@@ -236,20 +236,21 @@ void MyOutputMessage(j_common_ptr cinfo) {
 }  // namespace
 #endif  // JPEGXL_ENABLE_JPEG
 
+Status DecodeImageJPGCoefficients(Span<const uint8_t> bytes, CodecInOut* io) {
+  // Use brunsli JPEG decoder to read quantized coefficients.
+  if (!jpeg::DecodeImageJPG(bytes, io)) {
+    fprintf(stderr, "Corrupt or CMYK JPEG.\n");
+    return false;
+  }
+  return true;
+}
+
 Status DecodeImageJPG(const Span<const uint8_t> bytes,
                       const ColorHints& color_hints, ThreadPool* pool,
                       CodecInOut* io, double* const elapsed_deinterleave) {
   if (elapsed_deinterleave != nullptr) *elapsed_deinterleave = 0;
   // Don't do anything for non-JPEG files (no need to report an error)
   if (!IsJPG(bytes)) return false;
-  const DecodeTarget target = io->dec_target;
-
-  // Use brunsli JPEG decoder to read quantized coefficients.
-  if (target == DecodeTarget::kQuantizedCoeffs) {
-    Status could_decode = jxl::jpeg::DecodeImageJPG(bytes, io);
-    if (!could_decode) fprintf(stderr, "Corrupt or CMYK JPEG.\n");
-    return could_decode;
-  }
 
 #if JPEGXL_ENABLE_JPEG
   // TODO(veluca): use JPEGData also for pixels?
@@ -471,23 +472,22 @@ Status EncodeWithSJpeg(const ImageBundle* ib, size_t quality,
 }
 #endif  // JPEGXL_ENABLE_JPEG
 
+Status EncodeImageJPGCoefficients(const CodecInOut* io, PaddedBytes* bytes) {
+  auto write = [&bytes](const uint8_t* buf, size_t len) {
+    bytes->append(buf, buf + len);
+    return len;
+  };
+  return jpeg::WriteJpeg(*io->Main().jpeg_data, write);
+}
+
 Status EncodeImageJPG(const CodecInOut* io, JpegEncoder encoder, size_t quality,
                       YCbCrChromaSubsampling chroma_subsampling,
-                      ThreadPool* pool, PaddedBytes* bytes,
-                      const DecodeTarget target) {
+                      ThreadPool* pool, PaddedBytes* bytes) {
   if (io->Main().HasAlpha()) {
     return JXL_FAILURE("alpha is not supported");
   }
   if (quality > 100) {
     return JXL_FAILURE("please specify a 0-100 JPEG quality");
-  }
-
-  if (target == DecodeTarget::kQuantizedCoeffs) {
-    auto write = [&bytes](const uint8_t* buf, size_t len) {
-      bytes->append(buf, buf + len);
-      return len;
-    };
-    return jpeg::WriteJpeg(*io->Main().jpeg_data, write);
   }
 
 #if JPEGXL_ENABLE_JPEG

--- a/lib/extras/codec_jpg.h
+++ b/lib/extras/codec_jpg.h
@@ -42,8 +42,17 @@ Status DecodeImageJPG(Span<const uint8_t> bytes, const ColorHints& color_hints,
 // Encodes into `bytes`.
 Status EncodeImageJPG(const CodecInOut* io, JpegEncoder encoder, size_t quality,
                       YCbCrChromaSubsampling chroma_subsampling,
-                      ThreadPool* pool, PaddedBytes* bytes,
-                      DecodeTarget target = DecodeTarget::kPixels);
+                      ThreadPool* pool, PaddedBytes* bytes);
+
+// Temporary wrappers to load the JPEG coefficients to a CodecInOut. This should
+// be replaced by calling the corresponding JPEG input and output functions on
+// the API.
+
+// Decodes the JPEG image coefficients to a CodecIO for lossless recompression.
+Status DecodeImageJPGCoefficients(Span<const uint8_t> bytes, CodecInOut* io);
+
+// Reconstructs the JPEG from the coefficients and metadata in CodecInOut.
+Status EncodeImageJPGCoefficients(const CodecInOut* io, PaddedBytes* bytes);
 
 }  // namespace extras
 }  // namespace jxl

--- a/lib/jxl/decode_test.cc
+++ b/lib/jxl/decode_test.cc
@@ -262,7 +262,7 @@ PaddedBytes CreateTestJXLCodestream(
     jxl::PaddedBytes jpeg_bytes;
     EXPECT_TRUE(EncodeImageJPG(&io, jxl::extras::JpegEncoder::kLibJpeg,
                                /*quality=*/70, jxl::YCbCrChromaSubsampling(),
-                               &pool, &jpeg_bytes, jxl::DecodeTarget::kPixels));
+                               &pool, &jpeg_bytes));
     jpeg_codestream->append(jpeg_bytes.data(),
                             jpeg_bytes.data() + jpeg_bytes.size());
     EXPECT_TRUE(jxl::jpeg::DecodeImageJPG(

--- a/lib/jxl/jxl_test.cc
+++ b/lib/jxl/jxl_test.cc
@@ -1359,9 +1359,7 @@ jxl::Status DecompressJxlToJPEGForTest(
     return JXL_FAILURE("Failed to decode JXL to JPEG");
   }
   io.jpeg_quality = 95;
-  if (!EncodeImageJPG(&io, jxl::extras::JpegEncoder::kLibJpeg, io.jpeg_quality,
-                      jxl::YCbCrChromaSubsampling(), pool, output,
-                      jxl::DecodeTarget::kQuantizedCoeffs)) {
+  if (!extras::EncodeImageJPGCoefficients(&io, output)) {
     return JXL_FAILURE("Failed to generate JPEG");
   }
   return true;

--- a/tools/djxl.cc
+++ b/tools/djxl.cc
@@ -221,11 +221,7 @@ jxl::Status DecompressJxlToJPEG(const JpegXlContainer& container,
   if (!DecodeJpegXlToJpeg(args.params, container, &io, pool)) {
     return JXL_FAILURE("Failed to decode JXL to JPEG");
   }
-  if (!EncodeImageJPG(&io,
-                      io.use_sjpeg ? jxl::extras::JpegEncoder::kSJpeg
-                                   : jxl::extras::JpegEncoder::kLibJpeg,
-                      io.jpeg_quality, jxl::YCbCrChromaSubsampling(), pool,
-                      output, jxl::DecodeTarget::kQuantizedCoeffs)) {
+  if (!jxl::extras::EncodeImageJPGCoefficients(&io, output)) {
     return JXL_FAILURE("Failed to generate JPEG");
   }
   stats->SetImageSize(io.xsize(), io.ysize());

--- a/tools/fuzzer_corpus.cc
+++ b/tools/fuzzer_corpus.cc
@@ -224,10 +224,9 @@ bool GenerateFile(const char* output_dir, const ImageSpec& spec,
     // If this image is supposed to be a reconstructible JPEG, collect the JPEG
     // metadata and encode it in the beginning of the compressed bytes.
     jxl::PaddedBytes jpeg_bytes;
-    JXL_RETURN_IF_ERROR(
-        EncodeImageJPG(&io, jxl::extras::JpegEncoder::kLibJpeg, /*quality=*/70,
-                       jxl::YCbCrChromaSubsampling(), /*pool=*/nullptr,
-                       &jpeg_bytes, jxl::DecodeTarget::kPixels));
+    JXL_RETURN_IF_ERROR(EncodeImageJPG(
+        &io, jxl::extras::JpegEncoder::kLibJpeg, /*quality=*/70,
+        jxl::YCbCrChromaSubsampling(), /*pool=*/nullptr, &jpeg_bytes));
     JXL_RETURN_IF_ERROR(jxl::jpeg::DecodeImageJPG(
         jxl::Span<const uint8_t>(jpeg_bytes.data(), jpeg_bytes.size()), &io));
     jxl::PaddedBytes jpeg_data;


### PR DESCRIPTION
DecodeTarget was telling DecodeImageJPG whether we should load the pixel
or the JPEG coefficients. To load the JPEG coefficients we were actually
using the library internal API. Loading the coefficients is used for
pixel-lossless (but not byte-lossless) encoding of JPEG files. This is
not currently supported in the public API, but it would certainly be
a different workflow than loading the pixels (either we pass an image
with coefficient values or we pass the JPEG file like in lossless
recompression).

This patch splits out this workflow from DecodeImageJPG and
EncodeImageJPG so we can start migrating those functions to use the
external types.