### PR TITLE
make "cjxl - -" encode stdin to stdout

### DIFF
--- a/lib/jxl/base/cache_aligned.cc
+++ b/lib/jxl/base/cache_aligned.cc
@@ -46,9 +46,9 @@ constexpr size_t CacheAligned::kAlignment;
 constexpr size_t CacheAligned::kAlias;
 
 void CacheAligned::PrintStats() {
-  printf("Allocations: %zu (max bytes in use: %E)\n",
-         size_t(num_allocations.load(std::memory_order_relaxed)),
-         double(max_bytes_in_use.load(std::memory_order_relaxed)));
+  fprintf(stderr, "Allocations: %zu (max bytes in use: %E)\n",
+          size_t(num_allocations.load(std::memory_order_relaxed)),
+          double(max_bytes_in_use.load(std::memory_order_relaxed)));
 }
 
 size_t CacheAligned::NextOffset() {

--- a/lib/jxl/base/file_io.h
+++ b/lib/jxl/base/file_io.h
@@ -35,7 +35,8 @@ class FileWrapper {
   FileWrapper& operator=(const FileWrapper& other) = delete;
 
   explicit FileWrapper(const std::string& pathname, const char* mode)
-      : file_(fopen(pathname.c_str(), mode)) {}
+      : file_(pathname == "-" ? (mode[0] == 'r' ? stdin : stdout)
+                              : fopen(pathname.c_str(), mode)) {}
 
   ~FileWrapper() {
     if (file_ != nullptr) {
@@ -55,6 +56,17 @@ class FileWrapper {
 template <typename ContainerType>
 static inline Status ReadFile(const std::string& pathname,
                               ContainerType* JXL_RESTRICT bytes) {
+  // Special case for stdin
+  if (pathname == "-") {
+    int byte;
+    bytes->clear();
+    while (true) {
+      byte = getchar();
+      if (byte == EOF) break;
+      bytes->push_back(byte);
+    }
+    return true;
+  }
   FileWrapper f(pathname, "rb");
   if (f == nullptr) return JXL_FAILURE("Failed to open file for reading");
 

--- a/tools/cmdline.cc
+++ b/tools/cmdline.cc
@@ -64,9 +64,14 @@ bool CommandLineParser::Parse(int argc, const char* argv[]) {
       i++;
       continue;
     }
+    // special case: "-" is a filename denoting stdin or stdout
+    bool parse_this_option = true;
+    if (!strcmp("-", argv[i])) {
+      parse_this_option = false;
+    }
     bool found = false;
     for (const auto& option : options_) {
-      if (option->Match(argv[i], parse_options)) {
+      if (option->Match(argv[i], parse_options && parse_this_option)) {
         // Parsing advances the value i on success.
         const char* arg = argv[i];
         if (!option->Parse(argc, argv, &i)) {


### PR DESCRIPTION
See https://github.com/libjxl/libjxl/issues/542

This makes a positional argument `-` correspond to stdin or stdout (whichever makes sense). It works for `cjxl`; for `djxl` it works to take the jxl input from stdin, but you cannot decode stdout because the output codec selection is done based on filename extension. We could change that and add an option to explicitly choose an output codec, but then there's also the issue that djxl can produce multiple output files (in case of animation), which doesn't make much sense when outputting to stdout.