### PR TITLE
Fix building gdk pixbuf plugin with lcms

### DIFF
--- a/third_party/CMakeLists.txt
+++ b/third_party/CMakeLists.txt
@@ -192,7 +192,7 @@ else()
 endif()
 
 # *cms
-if (JPEGXL_ENABLE_SKCMS)
+if (JPEGXL_ENABLE_SKCMS OR JPEGXL_ENABLE_PLUGINS)
   if( NOT EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/skcms/skcms.h" )
     message(FATAL_ERROR "Please run ${PROJECT_SOURCE_DIR}/deps.sh to fetch the "
             "build dependencies.")


### PR DESCRIPTION
The gdk pixbuf loader plugin depends directly on skcms, regardless of
whether libjxl uses lcms or skcms. This patch builds skcms when the
plugins are enabled.

Fixes #563