### PR TITLE
move encode-only code out of dec_patch_dictionary.h

### DIFF
--- a/lib/jxl/dec_patch_dictionary.h
+++ b/lib/jxl/dec_patch_dictionary.h
@@ -23,8 +23,6 @@
 
 namespace jxl {
 
-constexpr size_t kMaxPatchSize = 32;
-
 enum class PatchBlendMode : uint8_t {
   // The new values are the old ones. Useful to skip some channels.
   kNone = 0,
@@ -76,47 +74,6 @@ struct PatchBlending {
   uint32_t alpha_channel;
   bool clamp;
 };
-
-struct QuantizedPatch {
-  size_t xsize;
-  size_t ysize;
-  QuantizedPatch() {
-    for (size_t i = 0; i < 3; i++) {
-      pixels[i].resize(kMaxPatchSize * kMaxPatchSize);
-      fpixels[i].resize(kMaxPatchSize * kMaxPatchSize);
-    }
-  }
-  std::vector<int8_t> pixels[3] = {};
-  // Not compared. Used only to retrieve original pixels to construct the
-  // reference image.
-  std::vector<float> fpixels[3] = {};
-  bool operator==(const QuantizedPatch& other) const {
-    if (xsize != other.xsize) return false;
-    if (ysize != other.ysize) return false;
-    for (size_t c = 0; c < 3; c++) {
-      if (memcmp(pixels[c].data(), other.pixels[c].data(),
-                 sizeof(int8_t) * xsize * ysize) != 0)
-        return false;
-    }
-    return true;
-  }
-
-  bool operator<(const QuantizedPatch& other) const {
-    if (xsize != other.xsize) return xsize < other.xsize;
-    if (ysize != other.ysize) return ysize < other.ysize;
-    for (size_t c = 0; c < 3; c++) {
-      int cmp = memcmp(pixels[c].data(), other.pixels[c].data(),
-                       sizeof(int8_t) * xsize * ysize);
-      if (cmp > 0) return false;
-      if (cmp < 0) return true;
-    }
-    return false;
-  }
-};
-
-// Pair (patch, vector of occurrences).
-using PatchInfo =
-    std::pair<QuantizedPatch, std::vector<std::pair<uint32_t, uint32_t>>>;
 
 // Position and size of the patch in the reference frame.
 struct PatchReferencePosition {

--- a/lib/jxl/enc_detect_dots.h
+++ b/lib/jxl/enc_detect_dots.h
@@ -15,6 +15,7 @@
 
 #include "lib/jxl/base/data_parallel.h"
 #include "lib/jxl/dec_patch_dictionary.h"
+#include "lib/jxl/enc_patch_dictionary.h"
 #include "lib/jxl/image.h"
 
 namespace jxl {

--- a/lib/jxl/enc_dot_dictionary.h
+++ b/lib/jxl/enc_dot_dictionary.h
@@ -21,6 +21,7 @@
 #include "lib/jxl/dec_patch_dictionary.h"
 #include "lib/jxl/enc_bit_writer.h"
 #include "lib/jxl/enc_params.h"
+#include "lib/jxl/enc_patch_dictionary.h"
 #include "lib/jxl/image.h"
 
 namespace jxl {

--- a/lib/jxl/enc_patch_dictionary.h
+++ b/lib/jxl/enc_patch_dictionary.h
@@ -30,6 +30,49 @@
 
 namespace jxl {
 
+constexpr size_t kMaxPatchSize = 32;
+
+struct QuantizedPatch {
+  size_t xsize;
+  size_t ysize;
+  QuantizedPatch() {
+    for (size_t i = 0; i < 3; i++) {
+      pixels[i].resize(kMaxPatchSize * kMaxPatchSize);
+      fpixels[i].resize(kMaxPatchSize * kMaxPatchSize);
+    }
+  }
+  std::vector<int8_t> pixels[3] = {};
+  // Not compared. Used only to retrieve original pixels to construct the
+  // reference image.
+  std::vector<float> fpixels[3] = {};
+  bool operator==(const QuantizedPatch& other) const {
+    if (xsize != other.xsize) return false;
+    if (ysize != other.ysize) return false;
+    for (size_t c = 0; c < 3; c++) {
+      if (memcmp(pixels[c].data(), other.pixels[c].data(),
+                 sizeof(int8_t) * xsize * ysize) != 0)
+        return false;
+    }
+    return true;
+  }
+
+  bool operator<(const QuantizedPatch& other) const {
+    if (xsize != other.xsize) return xsize < other.xsize;
+    if (ysize != other.ysize) return ysize < other.ysize;
+    for (size_t c = 0; c < 3; c++) {
+      int cmp = memcmp(pixels[c].data(), other.pixels[c].data(),
+                       sizeof(int8_t) * xsize * ysize);
+      if (cmp > 0) return false;
+      if (cmp < 0) return true;
+    }
+    return false;
+  }
+};
+
+// Pair (patch, vector of occurrences).
+using PatchInfo =
+    std::pair<QuantizedPatch, std::vector<std::pair<uint32_t, uint32_t>>>;
+
 // Friend class of PatchDictionary.
 class PatchDictionaryEncoder {
  public:


### PR DESCRIPTION
Like the title says: remove things from dec_patch_dictionary.h that are only used in the encoder.