### PR TITLE
Fix building with LLVM LLD: check "-Wl,--exclude-libs=ALL"

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -26,3 +26,4 @@ Pieter Wuille
 xiota
 Ziemowit Zabawa <ziemek.zabawa@outlook.com>
 Andrius Lukas Narbutas <andrius4669@gmail.com>
+Misaki Kasumi <misakikasumi@outlook.com>

--- a/lib/jxl.cmake
+++ b/lib/jxl.cmake
@@ -523,6 +523,13 @@ set_target_properties(jxl_dec PROPERTIES
   LIBRARY_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}"
   RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}")
 
+# Check whether the linker support excluding libs
+set(LINKER_EXCLUDE_LIBS_FLAG "-Wl,--exclude-libs=ALL")
+include(CheckCSourceCompiles)
+list(APPEND CMAKE_EXE_LINKER_FLAGS ${LINKER_EXCLUDE_LIBS_FLAG})
+check_c_source_compiles("int main(){return 0;}" LINKER_SUPPORT_EXCLUDE_LIBS)
+list(REMOVE_ITEM CMAKE_EXE_LINKER_FLAGS ${LINKER_EXCLUDE_LIBS_FLAG})
+
 # Add a jxl.version file as a version script to tag symbols with the
 # appropriate version number. This script is also used to limit what's exposed
 # in the shared library from the static dependencies bundled here.
@@ -541,8 +548,10 @@ foreach(target IN ITEMS jxl jxl_dec)
   # This hides the default visibility symbols from static libraries bundled into
   # the shared library. In particular this prevents exposing symbols from hwy
   # and skcms in the shared library.
-  set_property(TARGET ${target} APPEND_STRING PROPERTY
-      LINK_FLAGS " -Wl,--exclude-libs=ALL")
+  if(${LINKER_SUPPORT_EXCLUDE_LIBS})
+    set_property(TARGET ${target} APPEND_STRING PROPERTY
+        LINK_FLAGS " ${LINKER_EXCLUDE_LIBS_FLAG}")
+  endif()
 endforeach()
 
 # Only install libjxl shared library. The libjxl_dec is not installed since it


### PR DESCRIPTION
In 63a481a, linker flag `-Wl,--exclude-libs=ALL` is added. However, LLVM LLD does not support it. Building with LLVM toolchain would result in failure.

This PR check whether the linker support this flag. If it does not, the flag will not be added. A not-so-pretty method with `CheckCSourceCompiles` is used, because CMake 3.10 does not support `CheckLinkerFlag` or `CMAKE_REQUIRED_LINK_OPTIONS`.