### PR TITLE
Always build sjpeg as a static library.

### DIFF
--- a/third_party/sjpeg.cmake
+++ b/third_party/sjpeg.cmake
@@ -19,5 +19,9 @@ set(SJPEG_BUILD_EXAMPLES NO CACHE BOOL "Examples")
 # This setting makes it prefer the new version.
 set(OpenGL_GL_PREFERENCE GLVND)
 
+# Build SJPEG as a static library.
+set(BUILD_SHARED_LIBS_BACKUP ${BUILD_SHARED_LIBS})
+set(BUILD_SHARED_LIBS OFF)
 add_subdirectory(sjpeg EXCLUDE_FROM_ALL)
 target_include_directories(sjpeg PUBLIC "${CMAKE_CURRENT_LIST_DIR}/sjpeg/src/")
+set(BUILD_SHARED_LIBS ${BUILD_SHARED_LIBS_BACKUP})


### PR DESCRIPTION
sjpeg is bundled into the tools and not installed. This patch builds
sjpeg as a static library even if libjxl is built as a shared library.