### PR TITLE
Make progressive decode work (better)

### DIFF
--- a/lib/jxl/dec_frame.cc
+++ b/lib/jxl/dec_frame.cc
@@ -153,8 +153,8 @@ Status DecodeFrame(const DecompressParams& dparams,
       true));
 
   // Handling of progressive decoding.
+  const FrameHeader& frame_header = frame_decoder.GetFrameHeader();
   {
-    const FrameHeader& frame_header = frame_decoder.GetFrameHeader();
     size_t max_passes = dparams.max_passes;
     size_t max_downsampling = std::max(
         dparams.max_downsampling >> (frame_header.dc_level * 3), size_t(1));
@@ -192,9 +192,18 @@ Status DecodeFrame(const DecompressParams& dparams,
       size_t e = b + frame_decoder.SectionSizes()[i];
       bytes_to_skip += e - b;
       size_t pos = reader->TotalBitsConsumed() / kBitsPerByte;
-      if (pos + e <= reader->TotalBytes()) {
-        auto br = make_unique<BitReader>(
-            Span<const uint8_t>(reader->FirstByte() + b + pos, e - b));
+      if (pos + (dparams.allow_more_progressive_steps &&
+                         (i == 0 ||
+                          frame_header.encoding == FrameEncoding::kModular)
+                     ? b
+                     : e) <=
+              reader->TotalBytes() ||
+          (i == 0 && dparams.allow_more_progressive_steps)) {
+        auto br = make_unique<BitReader>(Span<const uint8_t>(
+            reader->FirstByte() + b + pos,
+            (pos + b > reader->TotalBytes()
+                 ? 0
+                 : std::min(reader->TotalBytes() - pos - b, e - b))));
         section_info.emplace_back(FrameDecoder::SectionInfo{br.get(), i});
         section_closers.emplace_back(
             make_unique<BitReaderScopedCloser>(br.get(), &close_ok));
@@ -249,7 +258,23 @@ Status FrameDecoder::InitFrame(BitReader* JXL_RESTRICT br, ImageBundle* decoded,
   dec_state_->shared_storage.matrices = DequantMatrices();
 
   frame_header_.nonserialized_is_preview = is_preview;
-  JXL_RETURN_IF_ERROR(DecodeFrameHeader(br, &frame_header_));
+  size_t pos = br->TotalBitsConsumed() / kBitsPerByte;
+  Status have_frameheader =
+      br->TotalBytes() > pos && DecodeFrameHeader(br, &frame_header_);
+  JXL_RETURN_IF_ERROR(have_frameheader || allow_partial_frames);
+  if (!have_frameheader) {
+    if (dec_state_->shared_storage.dc_frames[0].xsize() > 0) {
+      // If we have a (partial) DC frame available, but we don't have the next
+      // frame header (so allow_partial_frames is true), then we'll assume the
+      // next frame uses that DC frame (which may not be true, e.g. there might
+      // first be a ReferenceOnly patch frame, but it's reasonable to assume
+      // that the DC frame is a good progressive preview)
+      frame_header_.flags |= FrameHeader::kUseDcFrame;
+      frame_header_.encoding = FrameEncoding::kVarDCT;
+      frame_header_.dc_level = 0;
+    } else
+      return JXL_FAILURE("Couldn't read frame header");
+  }
   frame_dim_ = frame_header_.ToFrameDimensions();
 
   const size_t num_passes = frame_header_.passes.num_passes;
@@ -271,7 +296,8 @@ Status FrameDecoder::InitFrame(BitReader* JXL_RESTRICT br, ImageBundle* decoded,
   const size_t toc_entries = NumTocEntries(num_groups, frame_dim_.num_dc_groups,
                                            num_passes, has_ac_global);
   JXL_RETURN_IF_ERROR(ReadGroupOffsets(toc_entries, br, &section_offsets_,
-                                       &section_sizes_, &groups_total_size));
+                                       &section_sizes_, &groups_total_size) ||
+                      allow_partial_frames);
 
   JXL_DASSERT((br->TotalBitsConsumed() % kBitsPerByte) == 0);
   const size_t group_codes_begin = br->TotalBitsConsumed() / kBitsPerByte;
@@ -371,11 +397,14 @@ Status FrameDecoder::ProcessDCGlobal(BitReader* br) {
   if (shared.frame_header.flags & FrameHeader::kNoise) {
     JXL_RETURN_IF_ERROR(DecodeNoise(br, &shared.image_features.noise_params));
   }
+  if (!allow_partial_dc_global_ ||
+      br->TotalBitsConsumed() < br->TotalBytes() * kBitsPerByte) {
+    JXL_RETURN_IF_ERROR(dec_state_->shared_storage.matrices.DecodeDC(br));
 
-  JXL_RETURN_IF_ERROR(dec_state_->shared_storage.matrices.DecodeDC(br));
-  if (frame_header_.encoding == FrameEncoding::kVarDCT) {
-    JXL_RETURN_IF_ERROR(
-        jxl::DecodeGlobalDCInfo(br, decoded_->IsJPEG(), dec_state_, pool_));
+    if (frame_header_.encoding == FrameEncoding::kVarDCT) {
+      JXL_RETURN_IF_ERROR(
+          jxl::DecodeGlobalDCInfo(br, decoded_->IsJPEG(), dec_state_, pool_));
+    }
   }
   // Splines' draw cache uses the color correlation map.
   if (shared.frame_header.flags & FrameHeader::kSplines) {
@@ -406,7 +435,7 @@ Status FrameDecoder::ProcessDCGroup(size_t dc_group_id, BitReader* br) {
                    frame_dim_.dc_group_dim, frame_dim_.dc_group_dim);
   JXL_RETURN_IF_ERROR(modular_frame_decoder_.DecodeGroup(
       mrect, br, 3, 1000, ModularStreamId::ModularDC(dc_group_id),
-      /*zerofill=*/false, nullptr, nullptr));
+      /*zerofill=*/false, nullptr, nullptr, allow_partial_frames_));
   if (frame_header_.encoding == FrameEncoding::kVarDCT) {
     JXL_RETURN_IF_ERROR(
         modular_frame_decoder_.DecodeAcMetadata(dc_group_id, br, dec_state_));
@@ -608,13 +637,13 @@ Status FrameDecoder::ProcessACGroup(size_t ac_group_id,
       JXL_RETURN_IF_ERROR(modular_frame_decoder_.DecodeGroup(
           mrect, br[i - decoded_passes_per_ac_group_[ac_group_id]], minShift,
           maxShift, ModularStreamId::ModularAC(ac_group_id, i),
-          /*zerofill=*/false, dec_state_, decoded_));
+          /*zerofill=*/false, dec_state_, decoded_, allow_partial_frames_));
     } else if (i >= decoded_passes_per_ac_group_[ac_group_id] + num_passes &&
                force_draw) {
       JXL_RETURN_IF_ERROR(modular_frame_decoder_.DecodeGroup(
           mrect, nullptr, minShift, maxShift,
           ModularStreamId::ModularAC(ac_group_id, i), /*zerofill=*/true,
-          dec_state_, decoded_));
+          dec_state_, decoded_, allow_partial_frames_));
     }
   }
   decoded_passes_per_ac_group_[ac_group_id] += num_passes;

--- a/lib/jxl/dec_modular.cc
+++ b/lib/jxl/dec_modular.cc
@@ -163,13 +163,17 @@ Status ModularFrameDecoder::DecodeGlobalInfo(BitReader* reader,
   if (!do_color) nb_chans = 0;
   size_t nb_extra = metadata.extra_channel_info.size();
   bool has_tree = reader->ReadBits(1);
-  if (has_tree) {
-    size_t tree_size_limit = std::min(
-        static_cast<size_t>(1 << 22),
-        1024 + frame_dim.xsize * frame_dim.ysize * (nb_chans + nb_extra) / 16);
-    JXL_RETURN_IF_ERROR(DecodeTree(reader, &tree, tree_size_limit));
-    JXL_RETURN_IF_ERROR(
-        DecodeHistograms(reader, (tree.size() + 1) / 2, &code, &context_map));
+  if (!allow_truncated_group ||
+      reader->TotalBitsConsumed() < reader->TotalBytes() * kBitsPerByte) {
+    if (has_tree) {
+      size_t tree_size_limit =
+          std::min(static_cast<size_t>(1 << 22),
+                   1024 + frame_dim.xsize * frame_dim.ysize *
+                              (nb_chans + nb_extra) / 16);
+      JXL_RETURN_IF_ERROR(DecodeTree(reader, &tree, tree_size_limit));
+      JXL_RETURN_IF_ERROR(
+          DecodeHistograms(reader, (tree.size() + 1) / 2, &code, &context_map));
+    }
   }
 
   bool fp = metadata.bit_depth.floating_point_sample;
@@ -257,12 +261,10 @@ void ModularFrameDecoder::MaybeDropFullImage() {
   }
 }
 
-Status ModularFrameDecoder::DecodeGroup(const Rect& rect, BitReader* reader,
-                                        int minShift, int maxShift,
-                                        const ModularStreamId& stream,
-                                        bool zerofill,
-                                        PassesDecoderState* dec_state,
-                                        ImageBundle* output) {
+Status ModularFrameDecoder::DecodeGroup(
+    const Rect& rect, BitReader* reader, int minShift, int maxShift,
+    const ModularStreamId& stream, bool zerofill, PassesDecoderState* dec_state,
+    ImageBundle* output, bool allow_truncated) {
   JXL_DASSERT(stream.kind == ModularStreamId::kModularDC ||
               stream.kind == ModularStreamId::kModularAC);
   const size_t xsize = rect.xsize();
@@ -302,9 +304,11 @@ Status ModularFrameDecoder::DecodeGroup(const Rect& rect, BitReader* reader,
   if (gi.channel.empty()) return true;
   ModularOptions options;
   if (!zerofill) {
-    if (!ModularGenericDecompress(
-            reader, gi, /*header=*/nullptr, stream.ID(frame_dim), &options,
-            /*undo_transforms=*/true, &tree, &code, &context_map)) {
+    if (!ModularGenericDecompress(reader, gi, /*header=*/nullptr,
+                                  stream.ID(frame_dim), &options,
+                                  /*undo_transforms=*/true, &tree, &code,
+                                  &context_map, allow_truncated) &&
+        !allow_truncated) {
       return JXL_FAILURE("Failed to decode modular group");
     }
   }

--- a/lib/jxl/dec_modular.h
+++ b/lib/jxl/dec_modular.h
@@ -91,7 +91,8 @@ class ModularFrameDecoder {
                           bool allow_truncated_group);
   Status DecodeGroup(const Rect& rect, BitReader* reader, int minShift,
                      int maxShift, const ModularStreamId& stream, bool zerofill,
-                     PassesDecoderState* dec_state, ImageBundle* output);
+                     PassesDecoderState* dec_state, ImageBundle* output,
+                     bool allow_truncated);
   // Decodes a VarDCT DC group (`group_id`) from the given `reader`.
   Status DecodeVarDCTDC(size_t group_id, BitReader* reader,
                         PassesDecoderState* dec_state);

--- a/lib/jxl/quant_weights.cc
+++ b/lib/jxl/quant_weights.cc
@@ -468,6 +468,7 @@ Status DequantMatrices::Decode(BitReader* br,
 
 Status DequantMatrices::DecodeDC(BitReader* br) {
   bool all_default = br->ReadBits(1);
+  if (!br->AllReadsWithinBounds()) return JXL_FAILURE("EOS during DecodeDC");
   if (!all_default) {
     for (size_t c = 0; c < 3; c++) {
       JXL_RETURN_IF_ERROR(F16Coder::Read(br, &dc_quant_[c]));


### PR DESCRIPTION
Progressive decoding (`djxl --allow_partial_files --allow_more_progressive_steps`) was a bit broken:

- progressive modular didn't work anymore
- DC frames were only shown when the frame header of the main frame was available (which kind of defeats the purpose of progressive DC)

This makes things work better again in `djxl`. ~~However, I only tested things with `djxl`, which only has to do one 'paint'. This PR may break things in the API, where multiple paints can be done as the bitstream gets loaded. For testing that, it would be useful to have a version of `decode_oneshot` that emulates what happens if a bitstream becomes available in X kb chunks, writing each of the intermediate progressive steps to output images.~~

Things were meanwhile fixed in the API: https://github.com/libjxl/libjxl/pull/607
Also, a program to do progressive decoding via the API is here: https://github.com/libjxl/libjxl/pull/606