### PR TITLE
Fix transform data parsing in API

### DIFF
--- a/lib/jxl/decode.cc
+++ b/lib/jxl/decode.cc
@@ -822,6 +822,8 @@ JxlDecoderStatus JxlDecoderReadAllHeaders(JxlDecoder* dec, const uint8_t* in,
     ImageMetadata dummy_metadata;
     JXL_API_RETURN_IF_ERROR(ReadBundle(span, reader.get(), &dummy_metadata));
 
+    dec->metadata.transform_data.nonserialized_xyb_encoded =
+        dec->metadata.m.xyb_encoded;
     JXL_API_RETURN_IF_ERROR(
         ReadBundle(span, reader.get(), &dec->metadata.transform_data));
   }


### PR DESCRIPTION
The xyb_encoded flag must be set on the transform data before parsing

This fixes the opsin_inverse case in issue https://github.com/libjxl/libjxl/issues/584