### PR TITLE
Fix reading other than regular files in file_io.h

### DIFF
--- a/lib/jxl/base/file_io.h
+++ b/lib/jxl/base/file_io.h
@@ -11,7 +11,9 @@
 #include <stdio.h>
 #include <sys/stat.h>
 
+#include <list>
 #include <string>
+#include <vector>
 
 #include "lib/jxl/base/compiler_specific.h"
 #include "lib/jxl/base/padded_bytes.h"
@@ -36,10 +38,24 @@ class FileWrapper {
 
   explicit FileWrapper(const std::string& pathname, const char* mode)
       : file_(pathname == "-" ? (mode[0] == 'r' ? stdin : stdout)
-                              : fopen(pathname.c_str(), mode)) {}
+                              : fopen(pathname.c_str(), mode)),
+        close_on_delete_(pathname != "-") {
+#ifdef _WIN32
+    struct __stat64 s = {};
+    const int err = _stat64(pathname.c_str(), &s);
+    const bool is_file = (s.st_mode & S_IFREG) != 0;
+#else
+    struct stat s = {};
+    const int err = stat(pathname.c_str(), &s);
+    const bool is_file = S_ISREG(s.st_mode);
+#endif
+    if (err == 0 && is_file) {
+      size_ = s.st_size;
+    }
+  }
 
   ~FileWrapper() {
-    if (file_ != nullptr) {
+    if (file_ != nullptr && close_on_delete_) {
       const int err = fclose(file_);
       JXL_CHECK(err == 0);
     }
@@ -49,55 +65,66 @@ class FileWrapper {
   // NOLINTNEXTLINE(google-explicit-constructor)
   operator FILE*() const { return file_; }
 
+  int64_t size() { return size_; }
+
  private:
   FILE* const file_;
+  bool close_on_delete_ = true;
+  int64_t size_ = -1;
 };
 
 template <typename ContainerType>
 static inline Status ReadFile(const std::string& pathname,
                               ContainerType* JXL_RESTRICT bytes) {
-  // Special case for stdin
-  if (pathname == "-") {
-    int byte;
-    bytes->clear();
-    while (true) {
-      byte = getchar();
-      if (byte == EOF) break;
-      bytes->push_back(byte);
-    }
-    return true;
-  }
   FileWrapper f(pathname, "rb");
   if (f == nullptr) return JXL_FAILURE("Failed to open file for reading");
 
-    // Ensure it is a regular file
-#ifdef _WIN32
-  struct __stat64 s = {};
-  const int err = _stat64(pathname.c_str(), &s);
-  const bool is_file = (s.st_mode & S_IFREG) != 0;
-#else
-  struct stat s = {};
-  const int err = stat(pathname.c_str(), &s);
-  const bool is_file = S_ISREG(s.st_mode);
-#endif
-  if (err != 0) return JXL_FAILURE("Failed to obtain file status");
-  if (!is_file) return JXL_FAILURE("Not a file");
-
   // Get size of file in bytes
-  const int64_t size = s.st_size;
-  if (size <= 0) return JXL_FAILURE("Empty or invalid file size");
-  bytes->resize(static_cast<size_t>(size));
+  const int64_t size = f.size();
+  if (size < 0) {
+    // Size is unknown, loop reading chunks until EOF.
+    bytes->clear();
+    std::list<std::vector<uint8_t>> chunks;
 
-  size_t pos = 0;
-  while (pos < bytes->size()) {
-    // Needed in case ContainerType is std::string, whose data() is const.
-    char* bytes_writable = reinterpret_cast<char*>(&(*bytes)[0]);
-    const size_t bytes_read =
-        fread(bytes_writable + pos, 1, bytes->size() - pos, f);
-    if (bytes_read == 0) return JXL_FAILURE("Failed to read");
-    pos += bytes_read;
+    size_t total_size = 0;
+    while (true) {
+      std::vector<uint8_t> chunk(16 * 1024);
+      const size_t bytes_read = fread(chunk.data(), 1, chunk.size(), f);
+      if (ferror(f) || bytes_read > chunk.size()) {
+        return JXL_FAILURE("Error reading %s", pathname.c_str());
+      }
+
+      chunk.resize(bytes_read);
+      total_size += bytes_read;
+      if (bytes_read != 0) {
+        chunks.emplace_back(std::move(chunk));
+      }
+      if (feof(f)) {
+        break;
+      }
+    }
+    bytes->resize(total_size);
+    size_t pos = 0;
+    for (const auto& chunk : chunks) {
+      // Needed in case ContainerType is std::string, whose data() is const.
+      char* bytes_writable = reinterpret_cast<char*>(&(*bytes)[0]);
+      memcpy(bytes_writable + pos, chunk.data(), chunk.size());
+      pos += chunk.size();
+    }
+  } else {
+    // Size is known, read the file directly.
+    bytes->resize(static_cast<size_t>(size));
+    size_t pos = 0;
+    while (pos < bytes->size()) {
+      // Needed in case ContainerType is std::string, whose data() is const.
+      char* bytes_writable = reinterpret_cast<char*>(&(*bytes)[0]);
+      const size_t bytes_read =
+          fread(bytes_writable + pos, 1, bytes->size() - pos, f);
+      if (bytes_read == 0) return JXL_FAILURE("Failed to read");
+      pos += bytes_read;
+    }
+    JXL_ASSERT(pos == bytes->size());
   }
-  JXL_ASSERT(pos == bytes->size());
   return true;
 }
 


### PR DESCRIPTION
Reading from regular files is simple because we can obtain the size of
the file first and then read the whole file to a buffer at once, but
when the input is given as a pipe (like in `cat file | cjxl - foo.jxl`)
the size is unknown. We had a special case for reading from "-" one byte
at a time, which is unnecessarily slow and didn't cover all cases.

This patch uses a list of 16 KiB chunks when reading from a file whose
size is unknown. This includes both stdin and named pipes.

Fixes #591