### PR TITLE
do not set default squeeze params in InvSqueeze

### DIFF
--- a/lib/jxl/jxl_test.cc
+++ b/lib/jxl/jxl_test.cc
@@ -77,7 +77,7 @@ TEST(JxlTest, HeaderSize) {
     io.Main().SetAlpha(std::move(alpha), /*alpha_is_premultiplied=*/false);
     AuxOut aux_out;
     Roundtrip(&io, cparams, dparams, pool, &io2, &aux_out);
-    EXPECT_LE(aux_out.layers[kLayerHeader].total_bits, 57u);
+    EXPECT_LE(aux_out.layers[kLayerHeader].total_bits, 46u);
   }
 }
 

--- a/lib/jxl/modular/transform/enc_squeeze.cc
+++ b/lib/jxl/modular/transform/enc_squeeze.cc
@@ -112,7 +112,8 @@ Status FwdSqueeze(Image &input, std::vector<SqueezeParams> parameters,
   if (parameters.empty()) {
     DefaultSqueezeParameters(&parameters, input);
   }
-
+  // if nothing to do, don't do squeeze
+  if (parameters.empty()) return false;
   for (size_t i = 0; i < parameters.size(); i++) {
     JXL_RETURN_IF_ERROR(
         CheckMetaSqueezeParams(parameters[i], input.channel.size()));

--- a/lib/jxl/modular/transform/squeeze.cc
+++ b/lib/jxl/modular/transform/squeeze.cc
@@ -282,10 +282,6 @@ Status MetaSqueeze(Image &image, std::vector<SqueezeParams> *parameters) {
 
 Status InvSqueeze(Image &input, std::vector<SqueezeParams> parameters,
                   ThreadPool *pool) {
-  if (parameters.empty()) {
-    DefaultSqueezeParameters(&parameters, input);
-  }
-
   for (int i = parameters.size() - 1; i >= 0; i--) {
     JXL_RETURN_IF_ERROR(
         CheckMetaSqueezeParams(parameters[i], input.channel.size()));


### PR DESCRIPTION
The normal decode flow is:
- input image has N channels
- it does Squeeze with default (empty) parameters
- at header decode, MetaSqueeze is called which will fill in the Squeeze params with default values, to get O(N log N) channels
- after channel decode, InvSqueeze is called which undoes the Squeezes (it now has actual parameters, since MetaSqueeze replaced the empty params with default params)

So there is no reason to set default squeeze params in InvSqueeze — if the params are still empty at that point, it's a bug.