### PR TITLE
silently fail on non-JPEGs

### DIFF
--- a/lib/extras/codec_jpg.cc
+++ b/lib/extras/codec_jpg.cc
@@ -239,6 +239,7 @@ void MyOutputMessage(j_common_ptr cinfo) {
 Status DecodeImageJPGCoefficients(Span<const uint8_t> bytes, CodecInOut* io) {
   // Use brunsli JPEG decoder to read quantized coefficients.
   if (!jpeg::DecodeImageJPG(bytes, io)) {
+    if (!IsJPG(bytes)) return false;
     fprintf(stderr, "Corrupt or CMYK JPEG.\n");
     return false;
   }


### PR DESCRIPTION
When calling `cjxl` on e.g. a broken GIF or on an OpenEXR file, it will say it's a `Corrupt or CMYK JPEG`. This fixes that and only shows that error message when it's actually a JPEG.