### PR TITLE
allow gif with out-of-bounds bg color

### DIFF
--- a/lib/extras/codec_gif.cc
+++ b/lib/extras/codec_gif.cc
@@ -140,12 +140,10 @@ Status DecodeImageGIF(Span<const uint8_t> bytes, const ColorHints& color_hints,
   io->SetSize(gif->SWidth, gif->SHeight);
   ImageF alpha(gif->SWidth, gif->SHeight);
   GifColorType background_color;
-  if (gif->SColorMap == nullptr) {
+  if (gif->SColorMap == nullptr ||
+      gif->SBackGroundColor >= gif->SColorMap->ColorCount) {
     background_color = {0, 0, 0};
   } else {
-    if (gif->SBackGroundColor >= gif->SColorMap->ColorCount) {
-      return JXL_FAILURE("GIF specifies out-of-bounds background color");
-    }
     background_color = gif->SColorMap->Colors[gif->SBackGroundColor];
   }
   FillPlane<float>(background_color.Red, &canvas.Plane(0));


### PR DESCRIPTION
Apparently there are GIF images like this one:
https://cdn.discordapp.com/attachments/804324493420920833/888295777821130792/patrick.gif

that have an out-of-bounds background color. The GIF spec doesn't say what should be done if that happens. I suppose it only makes a difference anyway if there is any visible background, which often isn't the case (since the frames have the same size as the canvas).
Instead of erroring out, we can just define the background color to be black in this case and call it a day. All the viewers that I tried don't make a fuss about it, so it's probably best if cjxl also doesn't.