### PR TITLE
API: remove duplicated `JxlBasicInfo` definition.

### DIFF
--- a/lib/include/jxl/codestream_header.h
+++ b/lib/include/jxl/codestream_header.h
@@ -92,7 +92,7 @@ typedef struct {
 /** Basic image information. This information is available from the file
  * signature and first part of the codestream header.
  */
-typedef struct JxlBasicInfo {
+typedef struct {
   /* TODO(lode): need additional fields for (transcoded) JPEG? For reusable
    * fields orientation must be read from Exif APP1. For has_icc_profile: must
    * look up where ICC profile is guaranteed to be in a JPEG file to be able to


### PR DESCRIPTION
JxlBasicInfo was defined both as a struct and as a typedef:

```
typedef struct JxlBasicInfo {
...
} JxlBasicInfo;
```

Like with all other types we do the typedef so `JxlBasicInfo` can be
used as a type directly in C, so naming the struct is not necesary and
actually causes the JxlBasicInfo name to have two different meanings.