### PR TITLE
Generate readthedocs.io sphinx documentation for the C API reference.

### DIFF
--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -100,6 +100,11 @@ jobs:
       with:
         submodules: true
         fetch-depth: 2
+    - name: Sphinx dependencies
+      # Dependencies for sphinx HTML documentation
+      if: matrix.name == 'release'
+      run: |
+        pip3 install -r doc/sphinx/requirements.txt
     - name: Git environment
       id: git-env
       run: |
@@ -168,6 +173,10 @@ jobs:
     - name: Test runtime stats
       run: |
         sort build/Testing/Temporary/CTestCostData.txt -k 3 -n | tail -n 20 || true
+    - name: Build HTML documentation (sphinx/readthetdocs)
+      if: matrix.name == 'release'
+      run: |
+        cmake --build build -- rtd-html
     - name: Coverage report
       if: github.event_name == 'push' && matrix.name == 'coverage'
       run: |

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,17 @@
+# Copyright (c) the JPEG XL Project Authors. All rights reserved.
+#
+# Use of this source code is governed by a BSD-style
+# license that can be found in the LICENSE file.
+#
+# readthedocs.io configuration file. See:
+#   https://docs.readthedocs.io/en/stable/config-file/v2.html
+
+version: 2
+
+sphinx:
+   configuration: doc/sphinx/conf.py
+
+python:
+   version: "3.7"
+   install:
+   - requirements: doc/sphinx/requirements.txt

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -308,15 +308,37 @@ endif() # BUILD_TESTING
 find_package(Doxygen)
 if(DOXYGEN_FOUND)
 set(DOXYGEN_GENERATE_HTML "YES")
-set(DOXYGEN_GENERATE_XML "NO")
-set(DOXYGEN_STRIP_FROM_PATH "${CMAKE_CURRENT_SOURCE_DIR}/include")
+set(DOXYGEN_GENERATE_XML "YES")
+set(DOXYGEN_STRIP_FROM_PATH "${CMAKE_CURRENT_SOURCE_DIR}/lib/include")
 set(DOXYGEN_USE_MDFILE_AS_MAINPAGE "README.md")
 set(DOXYGEN_WARN_AS_ERROR "YES")
+set(DOXYGEN_QUIET "YES")
 doxygen_add_docs(doc
-  "${CMAKE_CURRENT_SOURCE_DIR}/lib/include/jxl"
+  "${CMAKE_CURRENT_SOURCE_DIR}/lib/include"
   "${CMAKE_CURRENT_SOURCE_DIR}/doc/api.txt"
   WORKING_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}"
   COMMENT "Generating C API documentation")
+
+# Add sphinx doc build step for readthedocs.io (requires doxygen too).
+find_program(SPHINX_BUILD_PROGRAM sphinx-build)
+if(SPHINX_BUILD_PROGRAM)
+  add_custom_command(
+    OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/rtd/nonexistent"
+    COMMENT "Generating readthedocs.io output on ${CMAKE_CURRENT_BINARY_DIR}/rtd"
+    COMMAND ${SPHINX_BUILD_PROGRAM} -q -W -b html -j auto
+      ${CMAKE_SOURCE_DIR}/doc/sphinx
+      ${CMAKE_CURRENT_BINARY_DIR}/rtd
+    DEPENDS doc
+  )
+  # This command runs the documentation generation every time since the output
+  # target file doesn't exist.
+  add_custom_target(rtd-html
+    DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/rtd/nonexistent
+  )
+else() # SPHINX_BUILD_PROGRAM\
+  message(WARNING "sphinx-build not found, skipping rtd documentation")
+endif() # SPHINX_BUILD_PROGRAM
+
 else()
 # Create a "doc" target for compatibility since "doc" is not otherwise added to
 # the build when doxygen is not installed.

--- a/doc/api.txt
+++ b/doc/api.txt
@@ -8,7 +8,22 @@
  */
 
 /**
-@defgroup jpegxl_dec JPEG XL Decoder library (jpegxl_dec)
+@defgroup libjxl JPEG XL library (libjxl)
+@brief The main JPEG XL decoder / encoder library.
 
-@defgroup jpegxl_threads JPEG XL Threads API helper library (jpegxl_threads)
+@addtogroup libjxl
+@{
+
+@defgroup libjxl_decoder JPEG XL Decoder
+
+@defgroup libjxl_encoder JPEG XL Encoder
+
+@defgroup libjxl_common JPEG XL common definitions
+
+@defgroup libjxl_butteraugli Butteraugli metric
+
+@}
+
+@defgroup libjxl_threads JPEG XL Multi-thread library (libjxl_threads)
+@brief Additional multi-threaded implementations for the parallel runner.
 */

--- a/doc/sphinx/api.rst
+++ b/doc/sphinx/api.rst
@@ -1,0 +1,15 @@
+API reference
+=============
+
+``libjxl`` exposes a C API for encoding and decoding JPEG XL files with some
+C++ header-only helpers for C++ users.
+
+.. toctree::
+   :caption: API REFERENCE
+   :maxdepth: 2
+
+   api_decoder
+   api_encoder
+   api_common
+   api_butteraugli
+   api_threads

--- a/doc/sphinx/api_butteraugli.rst
+++ b/doc/sphinx/api_butteraugli.rst
@@ -1,0 +1,6 @@
+Butteraugli API - ``jxl/butteraugli.h``
+=======================================
+
+.. doxygengroup:: libjxl_butteraugli
+   :members:
+   :private-members:

--- a/doc/sphinx/api_common.rst
+++ b/doc/sphinx/api_common.rst
@@ -1,0 +1,6 @@
+Common API concepts
+===================
+
+.. doxygengroup:: libjxl_common
+   :members:
+   :private-members:

--- a/doc/sphinx/api_decoder.rst
+++ b/doc/sphinx/api_decoder.rst
@@ -1,0 +1,6 @@
+Decoder API - ``jxl/decode.h``
+==============================
+
+.. doxygengroup:: libjxl_decoder
+   :members:
+   :private-members:

--- a/doc/sphinx/api_encoder.rst
+++ b/doc/sphinx/api_encoder.rst
@@ -1,0 +1,6 @@
+Encoder API - ``jxl/encode.h``
+==============================
+
+.. doxygengroup:: libjxl_encoder
+   :members:
+   :private-members:

--- a/doc/sphinx/api_threads.rst
+++ b/doc/sphinx/api_threads.rst
@@ -1,0 +1,6 @@
+Multi-threaded Encoder/Decoder
+==============================
+
+.. doxygengroup:: libjxl_threads
+   :members:
+   :private-members:

--- a/doc/sphinx/conf.py
+++ b/doc/sphinx/conf.py
@@ -1,0 +1,108 @@
+# Copyright (c) the JPEG XL Project Authors. All rights reserved.
+#
+# Use of this source code is governed by a BSD-style
+# license that can be found in the LICENSE file.
+
+# Configuration file for the Sphinx documentation builder.
+#
+# See https://www.sphinx-doc.org/en/master/usage/configuration.html
+
+import os
+import re
+import subprocess
+
+def GetVersion():
+    """Function to get the version of the current code."""
+    with open(os.path.join(
+            os.path.dirname(__file__), '../../lib/CMakeLists.txt'), 'r') as f:
+        cmakevars = {}
+        for line in f:
+            m = re.match(r'set\(JPEGXL_([A-Z]+)_VERSION ([^\)]+)\)', line)
+            if m:
+                cmakevars[m.group(1)] = m.group(2)
+    return '%s.%s.%s' % (cmakevars['MAJOR'], cmakevars['MINOR'], cmakevars['PATCH'])
+
+def ConfigProject(app, config):
+    # Configure the doxygen xml directory as the "xml" directory next to the
+    # sphinx output directory. Doxygen generates by default the xml files in a
+    # "xml" sub-directory of the OUTPUT_DIRECTORY.
+    build_dir = os.path.dirname(app.outdir)
+    xml_dir = os.path.join(build_dir, 'xml')
+    config.breathe_projects['libjxl'] = xml_dir
+
+    # Read the docs build environment doesn't run our cmake script so instead we
+    # need to run doxygen manually here.
+    if os.environ.get('READTHEDOCS', None) != 'True':
+        return
+    root_dir = os.path.realpath(os.path.join(app.srcdir, '../../'))
+    doxyfile = os.path.join(build_dir, 'Doxyfile-rtd.doc')
+    with open(doxyfile, 'w') as f:
+        f.write(f"""
+FILE_PATTERNS          = *.c *.h
+GENERATE_HTML          = NO
+GENERATE_LATEX         = NO
+GENERATE_XML           = YES
+INPUT                  = lib/include doc/api.txt
+OUTPUT_DIRECTORY       = {build_dir}
+PROJECT_NAME           = LIBJXL
+QUIET                  = YES
+RECURSIVE              = YES
+STRIP_FROM_PATH        = lib/include
+WARN_AS_ERROR          = YES
+""")
+    subprocess.check_call(['doxygen', doxyfile], cwd=root_dir)
+
+def setup(app):
+    # Generate doxygen XML on init when running from Read the docs.
+    app.connect("config-inited", ConfigProject)
+
+### Project information
+
+project = 'libjxl'
+project_copyright = 'JPEG XL Project Authors'
+author = 'JPEG XL Project Authors'
+version = GetVersion()
+
+### General configuration
+
+extensions = [
+    # For integration with doxygen documentation.
+    'breathe',
+    # sphinx readthedocs theme.
+    'sphinx_rtd_theme',
+]
+
+breathe_default_project = 'libjxl'
+breathe_projects = {}
+
+
+# All the API is in C, except those files that end with cxx.h.
+breathe_domain_by_extension = {'h': 'cpp'}
+breathe_domain_by_file_pattern = {
+    '*cxx.h': 'cpp',
+}
+breathe_implementation_filename_extensions = ['.cc']
+
+# These are defined at build time by cmake.
+c_id_attributes = [
+    'JXL_EXPORT',
+    'JXL_DEPRECATED',
+    'JXL_THREADS_EXPORT',
+]
+cpp_id_attributes = c_id_attributes
+
+
+breathe_projects_source = {
+    'libjxl' : ('../../', [
+        'doc/api.txt',
+        'lib/include/jxl',
+    ])
+}
+
+# Recognized suffixes.
+source_suffix = ['.rst', '.md']
+
+### Options for HTML output
+
+# Use the readthedocs.io theme when generating the HTML output.
+html_theme = 'sphinx_rtd_theme'

--- a/doc/sphinx/index.rst
+++ b/doc/sphinx/index.rst
@@ -1,0 +1,18 @@
+.. libjxl sphinx documentation entrypoint
+
+JPEG XL image format reference implementation
+=============================================
+
+.. toctree::
+   :maxdepth: 3
+   :caption: Contents:
+
+   api
+
+
+Indices and tables
+==================
+
+* :ref:`genindex`
+* :ref:`search`
+

--- a/doc/sphinx/requirements.txt
+++ b/doc/sphinx/requirements.txt
@@ -1,0 +1,3 @@
+breathe
+sphinx
+sphinx-rtd-theme

--- a/lib/include/jxl/butteraugli.h
+++ b/lib/include/jxl/butteraugli.h
@@ -4,7 +4,9 @@
  * license that can be found in the LICENSE file.
  */
 
-/** @file butteraugli.h
+/** @addtogroup libjxl_butteraugli
+ * @{
+ * @file butteraugli.h
  * @brief Butteraugli API for JPEG XL.
  */
 
@@ -154,3 +156,5 @@ JXL_EXPORT void JxlButteraugliResultGetDistmap(
 #endif
 
 #endif /* JXL_BUTTERAUGLI_H_ */
+
+/** @}*/

--- a/lib/include/jxl/butteraugli_cxx.h
+++ b/lib/include/jxl/butteraugli_cxx.h
@@ -3,6 +3,9 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
+/// @addtogroup libjxl_butteraugli
+/// @{
+///
 /// @file butteraugli_cxx.h
 /// @brief C++ header-only helper for @ref butteraugli.h.
 ///
@@ -53,3 +56,5 @@ typedef std::unique_ptr<JxlButteraugliResult, JxlButteraugliResultDestroyStruct>
     JxlButteraugliResultPtr;
 
 #endif  // JXL_BUTTERAUGLI_CXX_H_
+
+/// @}

--- a/lib/include/jxl/codestream_header.h
+++ b/lib/include/jxl/codestream_header.h
@@ -4,7 +4,9 @@
  * license that can be found in the LICENSE file.
  */
 
-/** @file codestream_header.h
+/** @addtogroup libjxl_common
+ * @{
+ * @file codestream_header.h
  * @brief Definitions of structs and enums for the metadata from the JPEG XL
  * codestream headers (signature, metadata, preview dimensions, ...), excluding
  * color encoding which is in color_encoding.h.
@@ -319,3 +321,5 @@ typedef struct {
 #endif
 
 #endif /* JXL_CODESTREAM_HEADER_H_ */
+
+/** @}*/

--- a/lib/include/jxl/color_encoding.h
+++ b/lib/include/jxl/color_encoding.h
@@ -4,7 +4,9 @@
  * license that can be found in the LICENSE file.
  */
 
-/** @file color_encoding.h
+/** @addtogroup libjxl_common
+ * @{
+ * @file color_encoding.h
  * @brief Color Encoding definitions used by JPEG XL.
  * All CIE units are for the standard 1931 2 degree observer.
  */
@@ -143,3 +145,5 @@ typedef struct {
 #endif
 
 #endif /* JXL_COLOR_ENCODING_H_ */
+
+/** @}*/

--- a/lib/include/jxl/decode.h
+++ b/lib/include/jxl/decode.h
@@ -4,7 +4,9 @@
  * license that can be found in the LICENSE file.
  */
 
-/** @file decode.h
+/** @addtogroup libjxl_decoder
+ * @{
+ * @file decode.h
  * @brief Decoding API for JPEG XL.
  */
 
@@ -936,3 +938,5 @@ JXL_EXPORT JxlDecoderStatus JxlDecoderFlushImage(JxlDecoder* dec);
 #endif
 
 #endif /* JXL_DECODE_H_ */
+
+/** @}*/

--- a/lib/include/jxl/decode_cxx.h
+++ b/lib/include/jxl/decode_cxx.h
@@ -3,6 +3,9 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
+/// @addtogroup libjxl_decoder
+/// @{
+///
 /// @file decode_cxx.h
 /// @brief C++ header-only helper for @ref decode.h.
 ///
@@ -50,3 +53,5 @@ static inline JxlDecoderPtr JxlDecoderMake(
 }
 
 #endif  // JXL_DECODE_CXX_H_
+
+/// @}

--- a/lib/include/jxl/encode.h
+++ b/lib/include/jxl/encode.h
@@ -4,7 +4,9 @@
  * license that can be found in the LICENSE file.
  */
 
-/** @file encode.h
+/** @addtogroup libjxl_encoder
+ * @{
+ * @file encode.h
  * @brief Encoding API for JPEG XL.
  */
 
@@ -390,3 +392,5 @@ JXL_EXPORT void JxlColorEncodingSetToLinearSRGB(
 #endif
 
 #endif /* JXL_ENCODE_H_ */
+
+/** @}*/

--- a/lib/include/jxl/encode_cxx.h
+++ b/lib/include/jxl/encode_cxx.h
@@ -3,6 +3,9 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
+/// @addtogroup libjxl_encoder
+///@{
+///
 /// @file encode_cxx.h
 /// @brief C++ header-only helper for @ref encode.h.
 ///
@@ -50,3 +53,5 @@ static inline JxlEncoderPtr JxlEncoderMake(
 }
 
 #endif  // JXL_ENCODE_CXX_H_
+
+/// @}

--- a/lib/include/jxl/memory_manager.h
+++ b/lib/include/jxl/memory_manager.h
@@ -4,7 +4,9 @@
  * license that can be found in the LICENSE file.
  */
 
-/** @file memory_manager.h
+/** @addtogroup libjxl_common
+ * @{
+ * @file memory_manager.h
  * @brief Abstraction functions used by JPEG XL to allocate memory.
  */
 
@@ -65,3 +67,5 @@ typedef struct JxlMemoryManagerStruct {
 #endif
 
 #endif /* JXL_MEMORY_MANAGER_H_ */
+
+/** @}*/

--- a/lib/include/jxl/parallel_runner.h
+++ b/lib/include/jxl/parallel_runner.h
@@ -4,6 +4,9 @@
  * license that can be found in the LICENSE file.
  */
 
+/** @addtogroup libjxl_common
+ *  @{
+ */
 /**
  * @file parallel_runner.h
  */
@@ -149,3 +152,5 @@ typedef JxlParallelRetCode (*JxlParallelRunner)(
 #endif
 
 #endif /* JXL_PARALLEL_RUNNER_H_ */
+
+/** @}*/

--- a/lib/include/jxl/resizable_parallel_runner.h
+++ b/lib/include/jxl/resizable_parallel_runner.h
@@ -4,7 +4,9 @@
  * license that can be found in the LICENSE file.
  */
 
-/** @file resizable_parallel_runner.h
+/** @addtogroup libjxl_threads
+ * @{
+ * @file resizable_parallel_runner.h
  * @brief implementation using std::thread of a resizeable ::JxlParallelRunner.
  */
 
@@ -73,3 +75,5 @@ JXL_THREADS_EXPORT void JxlResizableParallelRunnerDestroy(void* runner_opaque);
 #endif
 
 #endif /* JXL_RESIZABLE_PARALLEL_RUNNER_H_ */
+
+/** @}*/

--- a/lib/include/jxl/resizable_parallel_runner_cxx.h
+++ b/lib/include/jxl/resizable_parallel_runner_cxx.h
@@ -3,7 +3,11 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
+/// @addtogroup libjxl_threads
+/// @{
+///
 /// @file resizable_parallel_runner_cxx.h
+/// @ingroup libjxl_threads
 /// @brief C++ header-only helper for @ref resizable_parallel_runner.h.
 ///
 /// There's no binary library associated with the header since this is a header
@@ -46,7 +50,6 @@ typedef std::unique_ptr<void, JxlResizableParallelRunnerDestroyStruct>
 ///
 /// @param memory_manager custom allocator function. It may be NULL. The memory
 ///        manager will be copied internally.
-/// @param num_worker_threads the number of worker threads to create.
 /// @return a @c NULL JxlResizableParallelRunnerPtr if the instance can not be
 /// allocated or initialized
 /// @return initialized JxlResizableParallelRunnerPtr instance otherwise.
@@ -57,3 +60,5 @@ static inline JxlResizableParallelRunnerPtr JxlResizableParallelRunnerMake(
 }
 
 #endif  // JXL_RESIZABLE_PARALLEL_RUNNER_CXX_H_
+
+/// @}

--- a/lib/include/jxl/thread_parallel_runner.h
+++ b/lib/include/jxl/thread_parallel_runner.h
@@ -4,7 +4,9 @@
  * license that can be found in the LICENSE file.
  */
 
-/** @file thread_parallel_runner.h
+/** @addtogroup libjxl_threads
+ * @{
+ * @file thread_parallel_runner.h
  * @brief implementation using std::thread of a ::JxlParallelRunner.
  */
 
@@ -67,3 +69,5 @@ JXL_THREADS_EXPORT size_t JxlThreadParallelRunnerDefaultNumWorkerThreads();
 #endif
 
 #endif /* JXL_THREAD_PARALLEL_RUNNER_H_ */
+
+/** @}*/

--- a/lib/include/jxl/thread_parallel_runner_cxx.h
+++ b/lib/include/jxl/thread_parallel_runner_cxx.h
@@ -3,6 +3,9 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
+/// @addtogroup libjxl_threads
+/// @{
+///
 /// @file thread_parallel_runner_cxx.h
 /// @brief C++ header-only helper for @ref thread_parallel_runner.h.
 ///
@@ -57,3 +60,5 @@ static inline JxlThreadParallelRunnerPtr JxlThreadParallelRunnerMake(
 }
 
 #endif  // JXL_THREAD_PARALLEL_RUNNER_CXX_H_
+
+/// @}

--- a/lib/include/jxl/types.h
+++ b/lib/include/jxl/types.h
@@ -4,7 +4,9 @@
  * license that can be found in the LICENSE file.
  */
 
-/** @file types.h
+/** @addtogroup libjxl_common
+ * @{
+ * @file types.h
  * @brief Data types for the JPEG XL API, for both encoding and decoding.
  */
 
@@ -114,3 +116,5 @@ typedef struct {
 #endif
 
 #endif /* JXL_TYPES_H_ */
+
+/** @}*/


### PR DESCRIPTION
This is first step to generate the library API documentation in HTML
format for publication in readthedocs.io. At the moment only the
reference documentation is included (functions, symbols, enums, etc and
their definition) but no other introductory documentation.

Split things a bit between encoder, decoder, common structs, butteraugli
and threads for easier navigation of the documentation.

HTML pages are not automatically build with cmake on local builds, but
can be triggered locally with `ninja -C rtd-html`.

PR pipelines now check that `rtd-html` builds without errors and
readthedocs.io automatically triggers a build of the documentation
whenever we push to main.