### PR TITLE
Improve penalty heuristic for palette delta selection.

### DIFF
--- a/lib/jxl/modular/transform/enc_palette.cc
+++ b/lib/jxl/modular/transform/enc_palette.cc
@@ -411,8 +411,12 @@ Status FwdPaletteIteration(Image &input, uint32_t begin_c, uint32_t end_c,
           float index_penalty = 0;
           if (index == -1) {
             index_penalty = -124;
+          } else if (index < 0) {
+            index_penalty = -2 * index;
+          } else if (index < static_cast<int>(nb_deltas)) {
+            index_penalty = 250;
           } else if (index < static_cast<int>(nb_colors)) {
-            index_penalty = 2 * std::abs(index);
+            index_penalty = 150;
           } else if (index < static_cast<int>(nb_colors) +
                                  palette_internal::kLargeCubeOffset) {
             index_penalty = 70;


### PR DESCRIPTION
BEFORE:

tools/benchmark_xl --input='jyrki31/*.png' --codec=jxl:m:p0:lp:P0:9 --save_decompressed  --error_pnorm=1 
benchmark_xl v0.7.0 c4df527 [AVX2,SSE4,Scalar]
6 cores, 62 tasks, 6 threads, 0 inner threads
```
Encoding            kPixels    Bytes          BPP  E MP/s  D MP/s     Max norm        pnorm       BPP*pnorm   Bugs
------------------------------------------------------------------------------------------------------------------
jxl:m:p0:lp:P0:9      16460  5362973    2.6065227   0.076   9.016   6.48264694   0.52997204  1.381384171235      0
Aggregate:            16460  5362973    2.6065227   0.076   9.016   6.48264694   0.52997204  1.381384171235      0
```

AFTER:

tools/benchmark_xl --input='jyrki31/*.png' --codec=jxl:m:p0:lp:P0:9 --save_decompressed  --error_pnorm=1 
benchmark_xl v0.7.0 c4df527 [AVX2,SSE4,Scalar]
6 cores, 62 tasks, 6 threads, 0 inner threads
```
Encoding            kPixels    Bytes          BPP  E MP/s  D MP/s     Max norm        pnorm       BPP*pnorm   Bugs
------------------------------------------------------------------------------------------------------------------
jxl:m:p0:lp:P0:9      16460  5360228    2.6051886   0.076   9.035   6.10237932   0.52988365  1.380446851345      0
Aggregate:            16460  5360228    2.6051886   0.076   9.035   6.10237932   0.52988365  1.380446851345      0
```

