### PR TITLE
Move .y4m parser to a test-only file.

### DIFF
--- a/lib/jxl/codec_y4m_testonly.cc
+++ b/lib/jxl/codec_y4m_testonly.cc
@@ -1,0 +1,202 @@
+// Copyright (c) the JPEG XL Project Authors. All rights reserved.
+//
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+#include "lib/jxl/codec_y4m_testonly.h"
+
+#include <stddef.h>
+
+namespace jxl {
+namespace test {
+
+struct HeaderY4M {
+  size_t xsize;
+  size_t ysize;
+  size_t bits_per_sample;
+  int is_yuv;  // Y4M: where 1 = 444, 2 = 422, 3 = 420
+};
+
+// Decode Y4M images.
+class Y4MParser {
+ public:
+  explicit Y4MParser(const Span<const uint8_t> bytes)
+      : pos_(bytes.data()), end_(pos_ + bytes.size()) {}
+
+  // TODO(jon): support multi-frame y4m
+  Status ParseHeader(HeaderY4M* header, const uint8_t** pos) {
+    JXL_RETURN_IF_ERROR(ExpectString("YUV4MPEG2", 9));
+    header->is_yuv = 3;
+    // TODO(jon): check if 4:2:0 is indeed the default
+    header->bits_per_sample = 8;
+    // TODO(jon): check if there's a y4m convention for higher bit depths
+    while (pos_ < end_) {
+      char next = 0;
+      JXL_RETURN_IF_ERROR(ReadChar(&next));
+      if (next == 0x0A) break;
+      if (next != ' ') continue;
+      char field = 0;
+      JXL_RETURN_IF_ERROR(ReadChar(&field));
+      switch (field) {
+        case 'W':
+          JXL_RETURN_IF_ERROR(ParseUnsigned(&header->xsize));
+          break;
+        case 'H':
+          JXL_RETURN_IF_ERROR(ParseUnsigned(&header->ysize));
+          break;
+        case 'I':
+          JXL_RETURN_IF_ERROR(ReadChar(&next));
+          if (next != 'p') {
+            return JXL_FAILURE(
+                "Y4M: only progressive (no frame interlacing) allowed");
+          }
+          break;
+        case 'C': {
+          char c1 = 0;
+          JXL_RETURN_IF_ERROR(ReadChar(&c1));
+          char c2 = 0;
+          JXL_RETURN_IF_ERROR(ReadChar(&c2));
+          char c3 = 0;
+          JXL_RETURN_IF_ERROR(ReadChar(&c3));
+          if (c1 != '4') return JXL_FAILURE("Y4M: invalid C param");
+          if (c2 == '4') {
+            if (c3 != '4') return JXL_FAILURE("Y4M: invalid C param");
+            header->is_yuv = 1;  // 444
+          } else if (c2 == '2') {
+            if (c3 == '2') {
+              header->is_yuv = 2;  // 422
+            } else if (c3 == '0') {
+              header->is_yuv = 3;  // 420
+            } else {
+              return JXL_FAILURE("Y4M: invalid C param");
+            }
+          } else {
+            return JXL_FAILURE("Y4M: invalid C param");
+          }
+        }
+          [[fallthrough]];
+          // no break: fallthrough because this field can have values like
+          // "C420jpeg" (we are ignoring the chroma sample location and treat
+          // everything like C420jpeg)
+        case 'F':  // Framerate in fps as numerator:denominator
+                   // TODO(jon): actually read this and set corresponding jxl
+                   // metadata
+        case 'A':  // Pixel aspect ratio (ignoring it, could perhaps adjust
+                   // intrinsic dimensions based on this?)
+        case 'X':  // Comment, ignore
+          // ignore the field value and go to next one
+          while (pos_ < end_) {
+            if (pos_[0] == ' ' || pos_[0] == 0x0A) break;
+            pos_++;
+          }
+          break;
+        default:
+          return JXL_FAILURE("Y4M: parse error");
+      }
+    }
+    JXL_RETURN_IF_ERROR(ExpectString("FRAME", 5));
+    while (true) {
+      char next = 0;
+      JXL_RETURN_IF_ERROR(ReadChar(&next));
+      if (next == 0x0A) {
+        *pos = pos_;
+        return true;
+      }
+    }
+  }
+
+ private:
+  Status ExpectString(const char* str, size_t len) {
+    // Unlikely to happen.
+    if (pos_ + len < pos_) return JXL_FAILURE("Y4M: overflow");
+
+    if (pos_ + len > end_ || strncmp(str, (const char*)pos_, len) != 0) {
+      return JXL_FAILURE("Y4M: expected %s", str);
+    }
+    pos_ += len;
+    return true;
+  }
+
+  Status ReadChar(char* out) {
+    // Unlikely to happen.
+    if (pos_ + 1 < pos_) return JXL_FAILURE("Y4M: overflow");
+
+    if (pos_ >= end_) {
+      return JXL_FAILURE("Y4M: unexpected end of input");
+    }
+    *out = *pos_;
+    pos_++;
+    return true;
+  }
+
+  static bool IsDigit(const uint8_t c) { return '0' <= c && c <= '9'; }
+
+  Status ParseUnsigned(size_t* number) {
+    if (pos_ == end_) return JXL_FAILURE("PNM: reached end before number");
+    if (!IsDigit(*pos_)) return JXL_FAILURE("PNM: expected unsigned number");
+
+    *number = 0;
+    while (pos_ < end_ && *pos_ >= '0' && *pos_ <= '9') {
+      *number *= 10;
+      *number += *pos_ - '0';
+      ++pos_;
+    }
+
+    return true;
+  }
+
+  const uint8_t* pos_;
+  const uint8_t* const end_;
+};
+
+Status DecodeImageY4M(const Span<const uint8_t> bytes, CodecInOut* io) {
+  Y4MParser parser(bytes);
+  HeaderY4M header = {};
+  const uint8_t* pos = nullptr;
+  JXL_RETURN_IF_ERROR(parser.ParseHeader(&header, &pos));
+
+  Image3F yuvdata(header.xsize, header.ysize);
+  ImageBundle bundle(&io->metadata.m);
+  const int hshift[3][3] = {{0, 0, 0}, {0, 1, 1}, {0, 1, 1}};
+  const int vshift[3][3] = {{0, 0, 0}, {0, 0, 0}, {0, 1, 1}};
+
+  for (size_t c = 0; c < 3; c++) {
+    for (size_t y = 0; y < header.ysize >> vshift[header.is_yuv - 1][c]; ++y) {
+      float* const JXL_RESTRICT row = yuvdata.PlaneRow((c == 2 ? 2 : 1 - c), y);
+      if (pos + (header.xsize >> hshift[header.is_yuv - 1][c]) >
+          bytes.data() + bytes.size())
+        return JXL_FAILURE("Not enough image data");
+      for (size_t x = 0; x < header.xsize >> hshift[header.is_yuv - 1][c];
+           ++x) {
+        row[x] = (1.f / 255.f) * ((*pos++) - 128.f);
+      }
+    }
+  }
+  bundle.SetFromImage(std::move(yuvdata), io->metadata.m.color_encoding);
+  bundle.color_transform = ColorTransform::kYCbCr;
+
+  YCbCrChromaSubsampling subsampling;
+  uint8_t cssh[3] = {
+      2, static_cast<uint8_t>(hshift[header.is_yuv - 1][1] ? 1 : 2),
+      static_cast<uint8_t>(hshift[header.is_yuv - 1][2] ? 1 : 2)};
+  uint8_t cssv[3] = {
+      2, static_cast<uint8_t>(vshift[header.is_yuv - 1][1] ? 1 : 2),
+      static_cast<uint8_t>(vshift[header.is_yuv - 1][2] ? 1 : 2)};
+
+  JXL_RETURN_IF_ERROR(subsampling.Set(cssh, cssv));
+  bundle.chroma_subsampling = subsampling;
+  io->Main() = std::move(bundle);
+
+  JXL_RETURN_IF_ERROR(io->metadata.m.color_encoding.SetSRGB(ColorSpace::kRGB));
+  io->metadata.m.SetUintSamples(header.bits_per_sample);
+  io->metadata.m.SetAlphaBits(0);
+  io->dec_pixels = header.xsize * header.ysize;
+
+  io->metadata.m.bit_depth.bits_per_sample = io->Main().DetectRealBitdepth();
+  io->SetSize(header.xsize, header.ysize);
+  SetIntensityTarget(io);
+  return true;
+}
+
+}  // namespace test
+}  // namespace jxl

--- a/lib/jxl/codec_y4m_testonly.h
+++ b/lib/jxl/codec_y4m_testonly.h
@@ -1,0 +1,18 @@
+// Copyright (c) the JPEG XL Project Authors. All rights reserved.
+//
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+#include <stdint.h>
+
+#include "lib/jxl/base/padded_bytes.h"
+#include "lib/jxl/base/status.h"
+#include "lib/jxl/codec_in_out.h"
+
+namespace jxl {
+namespace test {
+
+Status DecodeImageY4M(const Span<const uint8_t> bytes, CodecInOut* io);
+
+}  // namespace test
+}  // namespace jxl

--- a/lib/jxl/jxl_test.cc
+++ b/lib/jxl/jxl_test.cc
@@ -21,6 +21,7 @@
 #include "lib/jxl/base/padded_bytes.h"
 #include "lib/jxl/base/thread_pool_internal.h"
 #include "lib/jxl/codec_in_out.h"
+#include "lib/jxl/codec_y4m_testonly.h"
 #include "lib/jxl/color_encoding_internal.h"
 #include "lib/jxl/color_management.h"
 #include "lib/jxl/dec_file.h"
@@ -1181,7 +1182,7 @@ TEST(JxlTest, RoundtripYCbCr420) {
   const PaddedBytes yuv420 =
       ReadTestData("imagecompression.info/flower_foveon.png.ffmpeg.y4m");
   CodecInOut io2;
-  ASSERT_TRUE(SetFromBytes(Span<const uint8_t>(yuv420), &io2, pool));
+  ASSERT_TRUE(test::DecodeImageY4M(Span<const uint8_t>(yuv420), &io2));
 
   CompressParams cparams = CParamsForLossless();
   cparams.speed_tier = SpeedTier::kThunder;

--- a/lib/jxl_tests.cmake
+++ b/lib/jxl_tests.cmake
@@ -69,6 +69,8 @@ set(TEST_FILES
 
 # Test-only library code.
 set(TESTLIB_FILES
+  jxl/codec_y4m_testonly.cc
+  jxl/codec_y4m_testonly.h
   jxl/dct_for_test.h
   jxl/dec_transforms_testonly.cc
   jxl/dec_transforms_testonly.h
@@ -90,7 +92,7 @@ target_compile_definitions(jxl_testlib-static PUBLIC
 target_include_directories(jxl_testlib-static PUBLIC
   "${PROJECT_SOURCE_DIR}"
 )
-target_link_libraries(jxl_testlib-static hwy)
+target_link_libraries(jxl_testlib-static hwy jxl-static)
 
 # Individual test binaries:
 file(MAKE_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/tests)

--- a/lib/lib.gni
+++ b/lib/lib.gni
@@ -383,6 +383,8 @@ libjxl_tests_sources = [
 
 # Test-only library code.
 libjxl_testlib_sources = [
+    "jxl/codec_y4m_testonly.cc",
+    "jxl/codec_y4m_testonly.h",
     "jxl/dct_for_test.h",
     "jxl/dec_transforms_testonly.cc",
     "jxl/dec_transforms_testonly.h",


### PR DESCRIPTION
The external API currently doesn't support encoding subsampled YUV
frames, so we can't support this mode in cjxl. This patch moves the .y4m
parsing to another test-only file that is used by jxl_test.cc so we can
continue to run the roundtrip test (which upsamples the data). This
removes the possibility to encode .y4m images in the cjxl tool.