### PR TITLE
add custom squeeze encode option (just for testing atm)

### DIFF
--- a/lib/jxl/enc_modular.cc
+++ b/lib/jxl/enc_modular.cc
@@ -680,8 +680,9 @@ Status ModularFrameEncoder::ComputeEncodingData(
   }
 
   if (cparams.responsive && !gi.channel.empty()) {
-    do_transform(gi, Transform(TransformId::kSqueeze), weighted::Header(),
-                 pool);  // use default squeezing
+    Transform t(TransformId::kSqueeze);
+    t.squeezes = cparams.squeezes;
+    do_transform(gi, t, weighted::Header(), pool);
   }
 
   std::vector<uint32_t> quants;

--- a/lib/jxl/enc_params.h
+++ b/lib/jxl/enc_params.h
@@ -17,6 +17,7 @@
 #include "lib/jxl/butteraugli/butteraugli.h"
 #include "lib/jxl/frame_header.h"
 #include "lib/jxl/modular/options.h"
+#include "lib/jxl/modular/transform/transform.h"
 
 namespace jxl {
 
@@ -215,6 +216,8 @@ struct CompressParams {
   // modular mode options below
   ModularOptions options;
   int responsive = -1;
+  // empty for default squeeze
+  std::vector<SqueezeParams> squeezes;
   // A pair of <quality, cquality>.
   std::pair<float, float> quality_pair{100.f, 100.f};
   int colorspace = -1;


### PR DESCRIPTION
Currently the encoder always uses the default squeeze parameters.

This adds an encode option (only in cparams, not exposed in cjxl or api) to use custom squeeze parameters instead.

At the moment, it just does some random fixed custom squeeze, just for testing (improving code coverage a bit, checking that things roundtrip also with custom params). Perhaps at some point alternatives to the default squeeze params can be explored, e.g. to achieve better trade-offs between density and progressiveness.