### PR TITLE
fuzzer: integer overflow in MA decoding

### DIFF
--- a/lib/jxl/modular/encoding/dec_ma.cc
+++ b/lib/jxl/modular/encoding/dec_ma.cc
@@ -44,12 +44,9 @@ Status DecodeTree(BitReader *br, ANSSymbolReader *reader,
       return JXL_FAILURE("Tree is too large");
     }
     to_decode--;
-    int property = static_cast<int>(reader->ReadHybridUint(kPropertyContext, br,
-                                                           context_map)) -
-                   1;
-    if (property < -1 || property >= 256) {
-      return JXL_FAILURE("Invalid tree property value");
-    }
+    uint32_t prop1 = reader->ReadHybridUint(kPropertyContext, br, context_map);
+    if (prop1 > 256) return JXL_FAILURE("Invalid tree property value");
+    int property = prop1 - 1;
     if (property == -1) {
       size_t predictor =
           reader->ReadHybridUint(kPredictorContext, br, context_map);


### PR DESCRIPTION

Should fix a fuzzer-found integer overflow when a corrupt MA tree has a wildly out-of-range property value.