### PR TITLE
Remove Fields::Name() strings from non-debug builds.

### DIFF
--- a/lib/jxl/color_encoding_internal.h
+++ b/lib/jxl/color_encoding_internal.h
@@ -140,7 +140,7 @@ struct PrimariesCIExy {
 // Serializable form of CIExy.
 struct Customxy : public Fields {
   Customxy();
-  const char* Name() const override { return "Customxy"; }
+  JXL_FIELDS_NAME(Customxy)
 
   Status VisitFields(Visitor* JXL_RESTRICT visitor) override;
 
@@ -154,7 +154,7 @@ struct Customxy : public Fields {
 
 struct CustomTransferFunction : public Fields {
   CustomTransferFunction();
-  const char* Name() const override { return "CustomTransferFunction"; }
+  JXL_FIELDS_NAME(CustomTransferFunction)
 
   // Sets fields and returns true if nonserialized_color_space has an implicit
   // transfer function, otherwise leaves fields unchanged and returns false.
@@ -229,7 +229,7 @@ struct CustomTransferFunction : public Fields {
 // known color space. Stored in Metadata. Thread-compatible.
 struct ColorEncoding : public Fields {
   ColorEncoding();
-  const char* Name() const override { return "ColorEncoding"; }
+  JXL_FIELDS_NAME(ColorEncoding)
 
   // Returns ready-to-use color encodings (initialized on-demand).
   static const ColorEncoding& SRGB(bool is_gray = false);

--- a/lib/jxl/dec_ans.h
+++ b/lib/jxl/dec_ans.h
@@ -99,7 +99,7 @@ struct HybridUintConfig {
 
 struct LZ77Params : public Fields {
   LZ77Params();
-  const char* Name() const override { return "LZ77Params"; }
+  JXL_FIELDS_NAME(LZ77Params)
   Status VisitFields(Visitor* JXL_RESTRICT visitor) override;
   bool enabled;
 

--- a/lib/jxl/field_encodings.h
+++ b/lib/jxl/field_encodings.h
@@ -19,11 +19,22 @@
 
 namespace jxl {
 
+// Macro to define the Fields' derived class Name when compiling with debug
+// names.
+#if JXL_IS_DEBUG_BUILD
+#define JXL_FIELDS_NAME(X) \
+  const char* Name() const override { return #X; }
+#else
+#define JXL_FIELDS_NAME(X)
+#endif  // JXL_IS_DEBUG_BUILD
+
 class Visitor;
 class Fields {
  public:
   virtual ~Fields() = default;
+#if JXL_IS_DEBUG_BUILD
   virtual const char* Name() const = 0;
+#endif  // JXL_IS_DEBUG_BUILD
   virtual Status VisitFields(Visitor* JXL_RESTRICT visitor) = 0;
 };
 

--- a/lib/jxl/fields.cc
+++ b/lib/jxl/fields.cc
@@ -71,7 +71,9 @@ class VisitorBase : public Visitor {
   Status Visit(Fields* fields, const char* visitor_name) override {
     fputs(visitor_name, stdout);  // No newline; no effect if empty
     if (print_bundles_) {
+#if JXL_IS_DEBUG_BUILD
       Trace("%s\n", print_bundles_ ? fields->Name() : "");
+#endif  // JXL_IS_DEBUG_BUILD
     }
 
     depth_ += 1;

--- a/lib/jxl/fields_test.cc
+++ b/lib/jxl/fields_test.cc
@@ -289,7 +289,7 @@ TEST(FieldsTest, TestOutOfRange) {
 
 struct OldBundle : public Fields {
   OldBundle() { Bundle::Init(this); }
-  const char* Name() const override { return "OldBundle"; }
+  JXL_FIELDS_NAME(OldBundle)
 
   Status VisitFields(Visitor* JXL_RESTRICT visitor) override {
     JXL_QUIET_RETURN_IF_ERROR(
@@ -310,7 +310,7 @@ struct OldBundle : public Fields {
 
 struct NewBundle : public Fields {
   NewBundle() { Bundle::Init(this); }
-  const char* Name() const override { return "NewBundle"; }
+  JXL_FIELDS_NAME(NewBundle)
 
   Status VisitFields(Visitor* JXL_RESTRICT visitor) override {
     JXL_QUIET_RETURN_IF_ERROR(

--- a/lib/jxl/frame_header.h
+++ b/lib/jxl/frame_header.h
@@ -76,7 +76,7 @@ inline std::array<int, 3> JpegOrder(ColorTransform ct, bool is_gray) {
 
 struct YCbCrChromaSubsampling : public Fields {
   YCbCrChromaSubsampling();
-  const char* Name() const override { return "YCbCrChromaSubsampling"; }
+  JXL_FIELDS_NAME(YCbCrChromaSubsampling)
   size_t HShift(size_t c) const { return maxhs_ - kHShift[channel_mode_[c]]; }
   size_t VShift(size_t c) const { return maxvs_ - kVShift[channel_mode_[c]]; }
 
@@ -208,7 +208,7 @@ enum class BlendMode {
 
 struct BlendingInfo : public Fields {
   BlendingInfo();
-  const char* Name() const override { return "BlendingInfo"; }
+  JXL_FIELDS_NAME(BlendingInfo)
   Status VisitFields(Visitor* JXL_RESTRICT visitor) override;
   BlendMode mode;
   // Which extra channel to use as alpha channel for blending, only encoded
@@ -238,7 +238,7 @@ struct FrameSize {
 // AnimationFrame defines duration of animation frames.
 struct AnimationFrame : public Fields {
   explicit AnimationFrame(const CodecMetadata* metadata);
-  const char* Name() const override { return "AnimationFrame"; }
+  JXL_FIELDS_NAME(AnimationFrame)
 
   Status VisitFields(Visitor* JXL_RESTRICT visitor) override;
 
@@ -256,7 +256,7 @@ struct AnimationFrame : public Fields {
 // For decoding to lower resolutions. Only used for kRegular frames.
 struct Passes : public Fields {
   Passes();
-  const char* Name() const override { return "Passes"; }
+  JXL_FIELDS_NAME(Passes)
 
   Status VisitFields(Visitor* JXL_RESTRICT visitor) override;
 
@@ -338,7 +338,7 @@ struct FrameHeader : public Fields {
   };
 
   explicit FrameHeader(const CodecMetadata* metadata);
-  const char* Name() const override { return "FrameHeader"; }
+  JXL_FIELDS_NAME(FrameHeader)
 
   Status VisitFields(Visitor* JXL_RESTRICT visitor) override;
 

--- a/lib/jxl/headers.h
+++ b/lib/jxl/headers.h
@@ -34,7 +34,7 @@ class SizeHeader : public Fields {
   static constexpr size_t kMaxBits = 78;
 
   SizeHeader();
-  const char* Name() const override { return "SizeHeader"; }
+  JXL_FIELDS_NAME(SizeHeader)
 
   Status VisitFields(Visitor* JXL_RESTRICT visitor) override;
 
@@ -60,7 +60,7 @@ class SizeHeader : public Fields {
 class PreviewHeader : public Fields {
  public:
   PreviewHeader();
-  const char* Name() const override { return "PreviewHeader"; }
+  JXL_FIELDS_NAME(PreviewHeader)
 
   Status VisitFields(Visitor* JXL_RESTRICT visitor) override;
 
@@ -82,7 +82,7 @@ class PreviewHeader : public Fields {
 
 struct AnimationHeader : public Fields {
   AnimationHeader();
-  const char* Name() const override { return "AnimationHeader"; }
+  JXL_FIELDS_NAME(AnimationHeader)
 
   Status VisitFields(Visitor* JXL_RESTRICT visitor) override;
 

--- a/lib/jxl/image_metadata.h
+++ b/lib/jxl/image_metadata.h
@@ -71,7 +71,7 @@ static inline constexpr uint64_t EnumBits(ExtraChannel /*unused*/) {
 // Used in ImageMetadata and ExtraChannelInfo.
 struct BitDepth : public Fields {
   BitDepth();
-  const char* Name() const override { return "BitDepth"; }
+  JXL_FIELDS_NAME(BitDepth)
 
   Status VisitFields(Visitor* JXL_RESTRICT visitor) override;
 
@@ -99,7 +99,7 @@ struct BitDepth : public Fields {
 // Describes one extra channel.
 struct ExtraChannelInfo : public Fields {
   ExtraChannelInfo();
-  const char* Name() const override { return "ExtraChannelInfo"; }
+  JXL_FIELDS_NAME(ExtraChannelInfo)
 
   Status VisitFields(Visitor* JXL_RESTRICT visitor) override;
 
@@ -119,7 +119,7 @@ struct ExtraChannelInfo : public Fields {
 
 struct OpsinInverseMatrix : public Fields {
   OpsinInverseMatrix();
-  const char* Name() const override { return "OpsinInverseMatrix"; }
+  JXL_FIELDS_NAME(OpsinInverseMatrix)
 
   Status VisitFields(Visitor* JXL_RESTRICT visitor) override;
 
@@ -133,7 +133,7 @@ struct OpsinInverseMatrix : public Fields {
 // Information useful for mapping HDR images to lower dynamic range displays.
 struct ToneMapping : public Fields {
   ToneMapping();
-  const char* Name() const override { return "ToneMapping"; }
+  JXL_FIELDS_NAME(ToneMapping)
 
   Status VisitFields(Visitor* JXL_RESTRICT visitor) override;
 
@@ -163,7 +163,7 @@ struct ToneMapping : public Fields {
 // upsampling.
 struct CustomTransformData : public Fields {
   CustomTransformData();
-  const char* Name() const override { return "CustomTransformData"; }
+  JXL_FIELDS_NAME(CustomTransformData)
 
   Status VisitFields(Visitor* JXL_RESTRICT visitor) override;
 
@@ -185,7 +185,7 @@ struct CustomTransformData : public Fields {
 // re-create an equivalent image without user input.
 struct ImageMetadata : public Fields {
   ImageMetadata();
-  const char* Name() const override { return "ImageMetadata"; }
+  JXL_FIELDS_NAME(ImageMetadata)
 
   Status VisitFields(Visitor* JXL_RESTRICT visitor) override;
 

--- a/lib/jxl/jpeg/jpeg_data.h
+++ b/lib/jxl/jpeg/jpeg_data.h
@@ -216,7 +216,7 @@ struct JPEGData : public Fields {
         error(JPEGReadError::OK),
         has_zero_padding_bit(false) {}
 
-  const char* Name() const override { return "JPEGData"; }
+  JXL_FIELDS_NAME(JPEGData)
 #if JPEGXL_ENABLE_TRANSCODE_JPEG
   // Doesn't serialize everything - skips brotli-encoded data and what is
   // already encoded in the codestream.

--- a/lib/jxl/loop_filter.h
+++ b/lib/jxl/loop_filter.h
@@ -22,7 +22,7 @@ namespace jxl {
 
 struct LoopFilter : public Fields {
   LoopFilter();
-  const char* Name() const override { return "LoopFilter"; }
+  JXL_FIELDS_NAME(LoopFilter)
 
   Status VisitFields(Visitor* JXL_RESTRICT visitor) override;
 

--- a/lib/jxl/modular/encoding/context_predict.h
+++ b/lib/jxl/modular/encoding/context_predict.h
@@ -22,7 +22,7 @@ constexpr static int64_t kPredictionRound = ((1 << kPredExtraBits) >> 1) - 1;
 constexpr static size_t kNumProperties = 1;
 
 struct Header : public Fields {
-  const char *Name() const override { return "WeightedPredictorHeader"; }
+  JXL_FIELDS_NAME(WeightedPredictorHeader)
   // TODO(janwas): move to cc file, avoid including fields.h.
   Header() { Bundle::Init(this); }
 

--- a/lib/jxl/modular/encoding/encoding.h
+++ b/lib/jxl/modular/encoding/encoding.h
@@ -27,7 +27,7 @@ constexpr int32_t kPropRangeFast = 512;
 struct GroupHeader : public Fields {
   GroupHeader();
 
-  const char *Name() const override { return "GroupHeader"; }
+  JXL_FIELDS_NAME(GroupHeader)
 
   Status VisitFields(Visitor *JXL_RESTRICT visitor) override {
     JXL_QUIET_RETURN_IF_ERROR(visitor->Bool(false, &use_global_tree));

--- a/lib/jxl/modular/modular_image.cc
+++ b/lib/jxl/modular/modular_image.cc
@@ -16,14 +16,14 @@ void Image::undo_transforms(const weighted::Header &wp_header, int keep,
   if (keep == -2) return;
   while ((int)transform.size() > keep && transform.size() > 0) {
     Transform t = transform.back();
-    JXL_DEBUG_V(4, "Undoing transform %s", t.Name());
+    JXL_DEBUG_V(4, "Undoing transform");
     Status result = t.Inverse(*this, wp_header, pool);
     if (result == false) {
-      JXL_NOTIFY_ERROR("Error while undoing transform %s.", t.Name());
+      JXL_NOTIFY_ERROR("Error while undoing transform.");
       error = true;
       return;
     }
-    JXL_DEBUG_V(8, "Undoing transform %s: done", t.Name());
+    JXL_DEBUG_V(8, "Undoing transform: done");
     transform.pop_back();
   }
   if (!keep && bitdepth < 32) {

--- a/lib/jxl/modular/transform/transform.h
+++ b/lib/jxl/modular/transform/transform.h
@@ -32,7 +32,7 @@ enum class TransformId : uint32_t {
 };
 
 struct SqueezeParams : public Fields {
-  const char *Name() const override { return "SqueezeParams"; }
+  JXL_FIELDS_NAME(SqueezeParams)
   bool horizontal;
   bool in_place;
   uint32_t begin_c;
@@ -129,7 +129,7 @@ class Transform : public Fields {
     return true;
   }
 
-  const char *Name() const override { return "Transform"; }
+  JXL_FIELDS_NAME(Transform)
 
   Status Inverse(Image &input, const weighted::Header &wp_header,
                  ThreadPool *pool = nullptr);

--- a/lib/jxl/quantizer.h
+++ b/lib/jxl/quantizer.h
@@ -165,7 +165,7 @@ class Quantizer {
 
 struct QuantizerParams : public Fields {
   QuantizerParams() { Bundle::Init(this); }
-  const char* Name() const override { return "QuantizerParams"; }
+  JXL_FIELDS_NAME(QuantizerParams)
 
   Status VisitFields(Visitor* JXL_RESTRICT visitor) override;
 


### PR DESCRIPTION
The const string returned by Name() ends up in the library and it is
only used in debug builds when Fields tracing is enabled. This patch
removes the Name() virtual method and replaces it with an empty string
in non-debug build so these strings don't end up in the library.