### PR TITLE
deduplicate PrintTree and move enc-only debug stuff to a new file

### DIFF
--- a/lib/jxl.cmake
+++ b/lib/jxl.cmake
@@ -283,6 +283,8 @@ set(JPEGXL_INTERNAL_SOURCES_ENC
   jxl/jpeg/enc_jpeg_huffman_decode.cc
   jxl/jpeg/enc_jpeg_huffman_decode.h
   jxl/linalg.cc
+  jxl/modular/encoding/enc_debug_tree.cc
+  jxl/modular/encoding/enc_debug_tree.h
   jxl/modular/encoding/enc_encoding.cc
   jxl/modular/encoding/enc_encoding.h
   jxl/modular/encoding/enc_ma.cc

--- a/lib/jxl/enc_modular.cc
+++ b/lib/jxl/enc_modular.cc
@@ -28,6 +28,7 @@
 #include "lib/jxl/frame_header.h"
 #include "lib/jxl/gaborish.h"
 #include "lib/jxl/modular/encoding/context_predict.h"
+#include "lib/jxl/modular/encoding/enc_debug_tree.h"
 #include "lib/jxl/modular/encoding/enc_encoding.h"
 #include "lib/jxl/modular/encoding/encoding.h"
 #include "lib/jxl/modular/encoding/ma_common.h"

--- a/lib/jxl/modular/encoding/context_predict.h
+++ b/lib/jxl/modular/encoding/context_predict.h
@@ -398,46 +398,6 @@ struct PredictionResult {
   int32_t multiplier;
 };
 
-inline std::string PropertyName(size_t i) {
-  static_assert(kNumNonrefProperties == 16, "Update this function");
-  switch (i) {
-    case 0:
-      return "c";
-    case 1:
-      return "g";
-    case 2:
-      return "y";
-    case 3:
-      return "x";
-    case 4:
-      return "|N|";
-    case 5:
-      return "|W|";
-    case 6:
-      return "N";
-    case 7:
-      return "W";
-    case 8:
-      return "W-WW-NW+NWW";
-    case 9:
-      return "W+N-NW";
-    case 10:
-      return "W-NW";
-    case 11:
-      return "NW-N";
-    case 12:
-      return "N-NE";
-    case 13:
-      return "N-NN";
-    case 14:
-      return "W-WW";
-    case 15:
-      return "WGH";
-    default:
-      return "ch[" + ToString(15 - (int)i) + "]";
-  }
-}
-
 inline void InitPropsRow(
     Properties *p,
     const std::array<pixel_type, kNumStaticProperties> &static_props,

--- a/lib/jxl/modular/encoding/enc_debug_tree.cc
+++ b/lib/jxl/modular/encoding/enc_debug_tree.cc
@@ -1,0 +1,127 @@
+// Copyright (c) the JPEG XL Project Authors. All rights reserved.
+//
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+#include "lib/jxl/modular/encoding/enc_debug_tree.h"
+
+#include <stdint.h>
+#include <stdlib.h>
+
+#include "lib/jxl/base/os_macros.h"
+#include "lib/jxl/base/status.h"
+#include "lib/jxl/modular/encoding/context_predict.h"
+#include "lib/jxl/modular/encoding/dec_ma.h"
+#include "lib/jxl/modular/options.h"
+
+#if JXL_OS_IOS
+#define JXL_ENABLE_DOT 0
+#else
+#define JXL_ENABLE_DOT 1  // iOS lacks C89 system()
+#endif
+
+namespace jxl {
+
+namespace {
+
+inline const char *PredictorName(Predictor p) {
+  switch (p) {
+    case Predictor::Zero:
+      return "Zero";
+    case Predictor::Left:
+      return "Left";
+    case Predictor::Top:
+      return "Top";
+    case Predictor::Average0:
+      return "Avg0";
+    case Predictor::Average1:
+      return "Avg1";
+    case Predictor::Average2:
+      return "Avg2";
+    case Predictor::Average3:
+      return "Avg3";
+    case Predictor::Average4:
+      return "Avg4";
+    case Predictor::Select:
+      return "Sel";
+    case Predictor::Gradient:
+      return "Grd";
+    case Predictor::Weighted:
+      return "Wgh";
+    case Predictor::TopLeft:
+      return "TopL";
+    case Predictor::TopRight:
+      return "TopR";
+    case Predictor::LeftLeft:
+      return "LL";
+    default:
+      return "INVALID";
+  };
+}
+
+inline std::string PropertyName(size_t i) {
+  static_assert(kNumNonrefProperties == 16, "Update this function");
+  switch (i) {
+    case 0:
+      return "c";
+    case 1:
+      return "g";
+    case 2:
+      return "y";
+    case 3:
+      return "x";
+    case 4:
+      return "|N|";
+    case 5:
+      return "|W|";
+    case 6:
+      return "N";
+    case 7:
+      return "W";
+    case 8:
+      return "W-WW-NW+NWW";
+    case 9:
+      return "W+N-NW";
+    case 10:
+      return "W-NW";
+    case 11:
+      return "NW-N";
+    case 12:
+      return "N-NE";
+    case 13:
+      return "N-NN";
+    case 14:
+      return "W-WW";
+    case 15:
+      return "WGH";
+    default:
+      return "ch[" + ToString(15 - (int)i) + "]";
+  }
+}
+
+}  // namespace
+
+void PrintTree(const Tree &tree, const std::string &path) {
+  FILE *f = fopen((path + ".dot").c_str(), "w");
+  fprintf(f, "graph{\n");
+  for (size_t cur = 0; cur < tree.size(); cur++) {
+    if (tree[cur].property < 0) {
+      fprintf(f, "n%05zu [label=\"%s%+" PRId64 " (x%u)\"];\n", cur,
+              PredictorName(tree[cur].predictor), tree[cur].predictor_offset,
+              tree[cur].multiplier);
+    } else {
+      fprintf(f, "n%05zu [label=\"%s>%d\"];\n", cur,
+              PropertyName(tree[cur].property).c_str(), tree[cur].splitval);
+      fprintf(f, "n%05zu -- n%05d;\n", cur, tree[cur].lchild);
+      fprintf(f, "n%05zu -- n%05d;\n", cur, tree[cur].rchild);
+    }
+  }
+  fprintf(f, "}\n");
+  fclose(f);
+#if JXL_ENABLE_DOT
+  JXL_ASSERT(
+      system(("dot " + path + ".dot -T svg -o " + path + ".svg").c_str()) == 0);
+#endif
+}
+
+}  // namespace jxl

--- a/lib/jxl/modular/encoding/enc_debug_tree.h
+++ b/lib/jxl/modular/encoding/enc_debug_tree.h
@@ -1,0 +1,23 @@
+// Copyright (c) the JPEG XL Project Authors. All rights reserved.
+//
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+#ifndef LIB_JXL_MODULAR_ENCODING_ENC_DEBUG_TREE_H_
+#define LIB_JXL_MODULAR_ENCODING_ENC_DEBUG_TREE_H_
+
+#include <stddef.h>
+#include <stdint.h>
+
+#include <vector>
+
+#include "lib/jxl/modular/encoding/dec_ma.h"
+#include "lib/jxl/modular/options.h"
+
+namespace jxl {
+
+void PrintTree(const Tree &tree, const std::string &path);
+
+}  // namespace jxl
+
+#endif  // LIB_JXL_MODULAR_ENCODING_ENC_DEBUG_TREE_H_

--- a/lib/jxl/modular/encoding/enc_encoding.h
+++ b/lib/jxl/modular/encoding/enc_encoding.h
@@ -28,7 +28,6 @@
 
 namespace jxl {
 
-void PrintTree(const Tree &tree, const std::string &path);
 Tree LearnTree(TreeSamples &&tree_samples, size_t total_pixels,
                const ModularOptions &options,
                const std::vector<ModularMultiplierInfo> &multiplier_info = {},

--- a/lib/jxl/modular/options.h
+++ b/lib/jxl/modular/options.h
@@ -37,65 +37,6 @@ enum class Predictor : uint32_t {
       15,  // Find the best decision tree for predictors/predictor per row
 };
 
-inline const char* PredictorName(Predictor p) {
-  switch (p) {
-    case Predictor::Zero:
-      return "Zero";
-    case Predictor::Left:
-      return "Left";
-    case Predictor::Top:
-      return "Top";
-    case Predictor::Average0:
-      return "Avg0";
-    case Predictor::Average1:
-      return "Avg1";
-    case Predictor::Average2:
-      return "Avg2";
-    case Predictor::Average3:
-      return "Avg3";
-    case Predictor::Average4:
-      return "Avg4";
-    case Predictor::Select:
-      return "Sel";
-    case Predictor::Gradient:
-      return "Grd";
-    case Predictor::Weighted:
-      return "Wgh";
-    case Predictor::TopLeft:
-      return "TopL";
-    case Predictor::TopRight:
-      return "TopR";
-    case Predictor::LeftLeft:
-      return "LL";
-    default:
-      return "INVALID";
-  };
-}
-
-inline std::array<uint8_t, 3> PredictorColor(Predictor p) {
-  switch (p) {
-    case Predictor::Zero:
-      return {{0, 0, 0}};
-    case Predictor::Left:
-      return {{255, 0, 0}};
-    case Predictor::Top:
-      return {{0, 255, 0}};
-    case Predictor::Average0:
-      return {{0, 0, 255}};
-    case Predictor::Average4:
-      return {{192, 128, 128}};
-    case Predictor::Select:
-      return {{255, 255, 0}};
-    case Predictor::Gradient:
-      return {{255, 0, 255}};
-    case Predictor::Weighted:
-      return {{0, 255, 255}};
-      // TODO
-    default:
-      return {{255, 255, 255}};
-  };
-}
-
 constexpr size_t kNumModularPredictors = static_cast<size_t>(Predictor::Best);
 
 static constexpr ssize_t kNumStaticProperties = 2;  // channel, group_id.

--- a/lib/lib.gni
+++ b/lib/lib.gni
@@ -298,6 +298,8 @@ libjxl_enc_sources = [
     "jxl/jpeg/enc_jpeg_huffman_decode.cc",
     "jxl/jpeg/enc_jpeg_huffman_decode.h",
     "jxl/linalg.cc",
+    "jxl/modular/encoding/enc_debug_tree.cc",
+    "jxl/modular/encoding/enc_debug_tree.h",
     "jxl/modular/encoding/enc_encoding.cc",
     "jxl/modular/encoding/enc_encoding.h",
     "jxl/modular/encoding/enc_ma.cc",

--- a/tools/jxl_from_tree.cc
+++ b/tools/jxl_from_tree.cc
@@ -16,6 +16,7 @@
 #include "lib/jxl/enc_frame.h"
 #include "lib/jxl/enc_heuristics.h"
 #include "lib/jxl/modular/encoding/context_predict.h"
+#include "lib/jxl/modular/encoding/enc_debug_tree.h"
 #include "lib/jxl/modular/encoding/enc_ma.h"
 #include "lib/jxl/modular/encoding/encoding.h"
 #include "lib/jxl/splines.h"
@@ -351,29 +352,6 @@ bool ParseNode(F& tok, Tree& tree, SplineData& spline_data,
   JXL_RETURN_IF_ERROR(
       ParseNode(tok, tree, spline_data, cparams, W, H, io, have_next, x0, y0));
   return true;
-}
-
-void PrintTree(const Tree& tree, const std::string& path) {
-  FILE* f = fopen((path + ".dot").c_str(), "w");
-  fprintf(f, "digraph{\n");
-  for (size_t cur = 0; cur < tree.size(); cur++) {
-    if (tree[cur].property < 0) {
-      fprintf(f, "n%05zu [label=\"%s%+lld\"];\n", cur,
-              PredictorName(tree[cur].predictor),
-              static_cast<long long>(tree[cur].predictor_offset));
-    } else {
-      fprintf(f, "n%05zu [label=\"%s>%d\"];\n", cur,
-              PropertyName(tree[cur].property).c_str(), tree[cur].splitval);
-      fprintf(f, "n%05zu -> n%05d [style=dashed];\n", cur, tree[cur].rchild);
-      fprintf(f, "n%05zu -> n%05d;\n", cur, tree[cur].lchild);
-    }
-  }
-  fprintf(f, "}\n");
-  fclose(f);
-  std::string command = "dot " + path + ".dot -T png -o " + path + ".png";
-  if (system(command.c_str()) != 0) {
-    JXL_ABORT("Command failed: %s", command.c_str());
-  }
 }
 
 class Heuristics : public DefaultEncoderHeuristics {


### PR DESCRIPTION

PrintTree was duplicated in jxl_from_tree.cc, and some debug stuff that is only used in the encoder was in common files. This moves things around to make more sense.