### PR TITLE
Keep parallel runner on decoder rewind

### DIFF
--- a/lib/include/jxl/decode.h
+++ b/lib/include/jxl/decode.h
@@ -282,11 +282,11 @@ typedef enum {
  * the beginning of the file and the decoder will emit events from the beginning
  * again. When rewinding (as opposed to JxlDecoderReset), the decoder can keep
  * state about the image, which it can use to skip to a requested frame more
- * efficiently with JxlDecoderSkipFrames. After rewind,
- * JxlDecoderSubscribeEvents can be used again, and it is feasible to leave out
- * events that were already handled before, such as JXL_DEC_BASIC_INFO and
- * JXL_DEC_COLOR_ENCODING, since they will provide the same information as
- * before.
+ * efficiently with JxlDecoderSkipFrames. Settings such as parallel runner or
+ * subscribed events are kept. After rewind, JxlDecoderSubscribeEvents can be
+ * used again, and it is feasible to leave out events that were already handled
+ * before, such as JXL_DEC_BASIC_INFO and JXL_DEC_COLOR_ENCODING, since they
+ * will provide the same information as before.
  * @param dec decoder object
  */
 JXL_EXPORT void JxlDecoderRewind(JxlDecoder* dec);


### PR DESCRIPTION
The decoder should not reset the parallel runner when using rewind, only
when using reset.

Improved the way code between rewind and reset is shared.

In addition, changed the behavior of JxlDecoderSetParallelRunner to
match the documentation: the documentation says "may only set before
starting decoding", while the implementation instead allowed setting at
any time, but only once. Now it allows setting it before decoding, after
reset, and after rewind. It's not required to do so after rewind since
it keeps it now.

This addresses https://github.com/libjxl/libjxl/issues/624, by changing
the behavior rather than the documentation