### PR TITLE
allow changing predictor used in delta palette

### DIFF
--- a/lib/jxl/enc_modular.h
+++ b/lib/jxl/enc_modular.h
@@ -85,6 +85,7 @@ class ModularFrameEncoder {
   std::vector<ModularMultiplierInfo> multiplier_info;
   std::vector<std::vector<uint32_t>> gi_channel;
   std::vector<size_t> image_widths;
+  Predictor delta_pred = Predictor::Average4;
 };
 
 }  // namespace jxl

--- a/lib/jxl/modular_test.cc
+++ b/lib/jxl/modular_test.cc
@@ -130,6 +130,33 @@ TEST(ModularTest, RoundtripLossyDeltaPalette) {
                                 /*distmap=*/nullptr, pool),
             1.5);
 }
+TEST(ModularTest, RoundtripLossyDeltaPaletteWP) {
+  ThreadPool* pool = nullptr;
+  const PaddedBytes orig =
+      ReadTestData("wesaturate/500px/u76c0g_bliznaca_srgb8.png");
+  CompressParams cparams;
+  cparams.modular_mode = true;
+  cparams.color_transform = jxl::ColorTransform::kNone;
+  cparams.lossy_palette = true;
+  cparams.palette_colors = 0;
+  cparams.options.predictor = jxl::Predictor::Weighted;
+
+  DecompressParams dparams;
+
+  CodecInOut io_out;
+  size_t compressed_size;
+
+  CodecInOut io;
+  ASSERT_TRUE(SetFromBytes(Span<const uint8_t>(orig), &io, pool));
+  io.ShrinkTo(300, 100);
+
+  compressed_size = Roundtrip(&io, cparams, dparams, pool, &io_out);
+  EXPECT_LE(compressed_size, 7000u);
+  cparams.ba_params.intensity_target = 80.0f;
+  EXPECT_LE(ButteraugliDistance(io, io_out, cparams.ba_params,
+                                /*distmap=*/nullptr, pool),
+            10.0);
+}
 
 TEST(ModularTest, RoundtripLossy) {
   ThreadPool* pool = nullptr;


### PR DESCRIPTION

Currently, the predictor used for delta palette (`cjxl --lossy-palette`) is hardcoded to `Average4` (which is the one that works best). This changes that to use that one by default, but allows changing it by setting `-P`. The predictor used to encode the indices themselves is now hardcoded to `Zero`, which is the one that should work best.

Before: (the predictor choice affects how the indices are encoded, not the predictor used in delta-palette)
```
bees.png
Encoding          kPixels    Bytes          BPP  E MP/s  D MP/s     Max norm        pnorm       BPP*pnorm   Bugs
----------------------------------------------------------------------------------------------------------------
jxl:m:lp:p0           114    37800    2.6398492   0.084   7.107   1.32610476   0.63799224  1.684203267014      0
jxl:m:lp:p0:P0        114    36055    2.5179831   0.085   7.566   1.32610476   0.63799224  1.606453671751      0
jxl:m:lp:p0:P3        114    37938    2.6494867   0.085   7.352   1.32610476   0.63799224  1.690351945608      0
jxl:m:lp:p0:P5        114    37709    2.6334940   0.085   7.183   1.32610476   0.63799224  1.680148703593      0
jxl:m:lp:p0:P6        114    44107    3.0803129   0.087   7.785   1.32610476   0.63799224  1.965215701010      0
Aggregate:            114    38628    2.6976411   0.085   7.394   1.32610476   0.63799224  1.721074060306      0
```

After: (the predictor choice determines what is used in delta-palette)
```
bees.png
Encoding          kPixels    Bytes          BPP  E MP/s  D MP/s     Max norm        pnorm       BPP*pnorm   Bugs
----------------------------------------------------------------------------------------------------------------
jxl:m:lp:p0           114    36055    2.5179831   0.088   6.455   1.32610476   0.63799224  1.606453671751      0
jxl:m:lp:p0:P0        114    89544    6.2535093   0.079   5.307   7.13514614   3.36888807 21.067372977656      0
jxl:m:lp:p0:P3        114    39080    2.7292409   0.088   6.271   1.52486873   0.68404738  1.866930078909      0
jxl:m:lp:p0:P5        114    44648    3.1180948   0.087   6.474   1.34442711   0.68350368  2.131229294410      0
jxl:m:lp:p0:P6        114    36474    2.5472449   0.085   5.137  16.08805084   6.04508743 15.398318252508      0
Aggregate:            114    45978    3.2109660   0.086   5.899   3.15392071   1.43451906  4.606191845894      0
```

As expected, the other predictors are worse than Average4, and in particular the Weighted Predictor (P6) works very poorly with the current encoder for delta-palette - there might be an encoder bug there, or maybe that predictor just leads to bad error accumulation - the images look bad but not completely buggy.

Also gets rid of a specialized codepath for the Gradient predictor in delta-palette, which was unreachable before (since that predictor was never used), and is not worth specializing for (since Gradient is not a good predictor for delta-palette; something that averages values works better).

Finally a test is added for the case of the Weighted predictor, which has a separate code path that wasn't covered by tests yet. Note that the BA distance is quite high in this case, so it might be worth investigating if there's an encoder bug in that case.