### PR TITLE
fix and (better) test progressive decode

### DIFF
--- a/lib/jxl/adaptive_reconstruction_test.cc
+++ b/lib/jxl/adaptive_reconstruction_test.cc
@@ -152,7 +152,7 @@ void EnsureUnchanged(const float background, const float foreground,
     // input image.
     JXL_CHECK(FinalizeFrameDecoding(&out, &state, /*pool=*/nullptr,
                                     /*force_fir=*/true,
-                                    /*skip_blending=*/true));
+                                    /*skip_blending=*/true, /*move_ec=*/true));
 
 #if JXL_HIGH_PRECISION
     VerifyRelativeError(in, *out.color(), 1E-3, 1E-4);

--- a/lib/jxl/dec_frame.cc
+++ b/lib/jxl/dec_frame.cc
@@ -826,7 +826,8 @@ Status FrameDecoder::Flush() {
       dec_state_, pool_, decoded_, is_finalized_));
   JXL_RETURN_IF_ERROR(FinalizeFrameDecoding(decoded_, dec_state_, pool_,
                                             /*force_fir=*/false,
-                                            /*skip_blending=*/false));
+                                            /*skip_blending=*/false,
+                                            /*move_ec=*/is_finalized_));
 
   num_renders_++;
   return true;

--- a/lib/jxl/dec_reconstruct.cc
+++ b/lib/jxl/dec_reconstruct.cc
@@ -1081,7 +1081,7 @@ Status FinalizeImageRect(
 
 Status FinalizeFrameDecoding(ImageBundle* decoded,
                              PassesDecoderState* dec_state, ThreadPool* pool,
-                             bool force_fir, bool skip_blending) {
+                             bool force_fir, bool skip_blending, bool move_ec) {
   const FrameHeader& frame_header = dec_state->shared->frame_header;
   const FrameDimensions& frame_dim = dec_state->shared->frame_dim;
 
@@ -1106,7 +1106,11 @@ Status FinalizeFrameDecoding(ImageBundle* decoded,
       const ImageMetadata& metadata = frame_header.nonserialized_metadata->m;
       for (size_t i = 0; i < metadata.num_extra_channels; i++) {
         if (frame_header.extra_channel_upsampling[i] == 1) {
-          ecs.push_back(std::move(dec_state->extra_channels[i]));
+          if (move_ec) {
+            ecs.push_back(std::move(dec_state->extra_channels[i]));
+          } else {
+            ecs.push_back(CopyImage(dec_state->extra_channels[i]));
+          }
         } else {
           ecs.emplace_back(frame_dim.xsize_upsampled_padded,
                            frame_dim.ysize_upsampled_padded);

--- a/lib/jxl/dec_reconstruct.h
+++ b/lib/jxl/dec_reconstruct.h
@@ -34,7 +34,7 @@ namespace jxl {
 // those use cases where this is needed.
 Status FinalizeFrameDecoding(ImageBundle* JXL_RESTRICT decoded,
                              PassesDecoderState* dec_state, ThreadPool* pool,
-                             bool force_fir, bool skip_blending);
+                             bool force_fir, bool skip_blending, bool move_ec);
 
 // Renders the `frame_rect` portion of the final image to `output_image`
 // (unless the frame is upsampled - in which case, `frame_rect` is scaled

--- a/lib/jxl/decode.cc
+++ b/lib/jxl/decode.cc
@@ -2026,7 +2026,7 @@ JxlDecoderStatus JxlDecoderFlushImage(JxlDecoder* dec) {
   dec->ib->ShrinkTo(dec->metadata.size.xsize(), dec->metadata.size.ysize());
   JxlDecoderStatus status = jxl::ConvertImageInternal(
       dec, *dec->ib, dec->image_out_format,
-      /*want_extra_channel=*/dec->metadata.m.num_extra_channels > 0,
+      /*want_extra_channel=*/false,
       /*extra_channel_index=*/0, dec->image_out_buffer, dec->image_out_size,
       /*out_callback=*/nullptr, /*out_opaque=*/nullptr);
   dec->ib->ShrinkTo(xsize, ysize);

--- a/lib/jxl/enc_adaptive_quantization.cc
+++ b/lib/jxl/enc_adaptive_quantization.cc
@@ -1107,7 +1107,8 @@ ImageBundle RoundtripImage(const Image3F& opsin, PassesEncoderState* enc_state,
   // Fine to do a JXL_ASSERT instead of error handling, since this only happens
   // on the encoder side where we can't be fed with invalid data.
   JXL_CHECK(FinalizeFrameDecoding(&decoded, dec_state.get(), pool,
-                                  /*force_fir=*/false, /*skip_blending=*/true));
+                                  /*force_fir=*/false, /*skip_blending=*/true,
+                                  /*move_ec=*/true));
   // Ensure we don't create any new special frames.
   enc_state->special_frames.resize(num_special_frames);
 

--- a/tools/epf.cc
+++ b/tools/epf.cc
@@ -61,7 +61,7 @@ jxl::Status RunEPF(uint32_t epf_iters, const float distance,
   // Call with `force_fir` set to true to force to apply filters to all of the
   // input image.
   JXL_CHECK(FinalizeFrameDecoding(&io->Main(), &state, pool, /*force_fir=*/true,
-                                  /*skip_blending=*/true));
+                                  /*skip_blending=*/true, /*move_ec=*/true));
   JXL_RETURN_IF_ERROR(io->TransformTo(original_color_encoding, pool));
   return true;
 }


### PR DESCRIPTION
There was still a bug in progressive decoding: extra channels would be moved from the dec_state at the first flush, causing segfault (unallocated buffer) at the next/final flush. That causes trouble e.g. in case of images with alpha.

Added tests for the cases of VarDCT + Modular alpha and lossless RGBA, to check that progressive decode works in these cases (no crashes), and do a crude check of the pixel values (check that most pixels are close to what they should be, i.e. there is an actual progressive preview and not just a black image).