### PR TITLE
Allow passing alpha channel to an ImageBundle without alpha.

### DIFF
--- a/lib/jxl/enc_external_image_test.cc
+++ b/lib/jxl/enc_external_image_test.cc
@@ -45,5 +45,25 @@ TEST(ExternalImageTest, InvalidSize) {
 }
 #endif
 
+TEST(ExternalImageTest, AlphaMissing) {
+  ImageMetadata im;
+  im.SetAlphaBits(0);  // No alpha
+  ImageBundle ib(&im);
+
+  const size_t xsize = 10;
+  const size_t ysize = 20;
+  const uint8_t buf[xsize * ysize * 4] = {};
+
+  // has_alpha is true but the ImageBundle has no alpha. Alpha channel should
+  // be ignored.
+  EXPECT_TRUE(ConvertFromExternal(
+      Span<const uint8_t>(buf, sizeof(buf)), xsize, ysize,
+      /*c_current=*/ColorEncoding::SRGB(),
+      /*has_alpha=*/true, /*alpha_is_premultiplied=*/false,
+      /*bits_per_sample=*/8, JXL_BIG_ENDIAN,
+      /*flipped_y=*/false, nullptr, &ib, /*float_in=*/false));
+  EXPECT_FALSE(ib.HasAlpha());
+}
+
 }  // namespace
 }  // namespace jxl


### PR DESCRIPTION
When de-interleaving a RGBA or GA image to an ImageBundle object that
doesn't have an alpha channel the code was crashing. This patch ignores
the alpha channel in that case. This should help with situations like
issue #513 where passing RGBX data to an RGB image.