### PR TITLE
Move the check for JPG files earlier.

### DIFF
--- a/lib/extras/codec_jpg.cc
+++ b/lib/extras/codec_jpg.cc
@@ -237,9 +237,9 @@ void MyOutputMessage(j_common_ptr cinfo) {
 #endif  // JPEGXL_ENABLE_JPEG
 
 Status DecodeImageJPGCoefficients(Span<const uint8_t> bytes, CodecInOut* io) {
+  if (!IsJPG(bytes)) return false;
   // Use brunsli JPEG decoder to read quantized coefficients.
   if (!jpeg::DecodeImageJPG(bytes, io)) {
-    if (!IsJPG(bytes)) return false;
     fprintf(stderr, "Corrupt or CMYK JPEG.\n");
     return false;
   }


### PR DESCRIPTION
jpeg::DecodeImageJPG() can return an error after modifying the
CodecInOut on invalid JPEG files (or non-JPEG files). This causes codecs
running after the call to DecodeImageJPGCoefficients() to fail to decode
unless -j is passed to cjxl. This solves the issue at least for valid
JPEG files and files that not start with a JPEG header. File that look
like a JPEG might trigger an error but those shouldn't be parsed by any
other codec on the chain.

This is not an issue when calling jpeg::DecodeImageJPG() from the API
because the CodecInOut is not reused afterwards.