### PR TITLE
cleanup undo_transforms

### DIFF
--- a/lib/jxl/dec_modular.cc
+++ b/lib/jxl/dec_modular.cc
@@ -218,7 +218,7 @@ Status ModularFrameDecoder::DecodeGlobalInfo(BitReader* reader,
   Status dec_status = ModularGenericDecompress(
       reader, gi, &global_header, ModularStreamId::Global().ID(frame_dim),
       &options,
-      /*undo_transforms=*/-2, &tree, &code, &context_map,
+      /*undo_transforms=*/false, &tree, &code, &context_map,
       allow_truncated_group);
   if (!allow_truncated_group) JXL_RETURN_IF_ERROR(dec_status);
   if (dec_status.IsFatalError()) {
@@ -302,7 +302,7 @@ Status ModularFrameDecoder::DecodeGroup(const Rect& rect, BitReader* reader,
   if (!zerofill) {
     if (!ModularGenericDecompress(
             reader, gi, /*header=*/nullptr, stream.ID(frame_dim), &options,
-            /*undo_transforms=*/-1, &tree, &code, &context_map)) {
+            /*undo_transforms=*/true, &tree, &code, &context_map)) {
       return JXL_FAILURE("Failed to decode modular group");
     }
   }
@@ -355,7 +355,7 @@ Status ModularFrameDecoder::DecodeVarDCTDC(size_t group_id, BitReader* reader,
   }
   if (!ModularGenericDecompress(
           reader, image, /*header=*/nullptr, stream_id, &options,
-          /*undo_transforms=*/-1, &tree, &code, &context_map)) {
+          /*undo_transforms=*/true, &tree, &code, &context_map)) {
     return JXL_FAILURE("Failed to decode modular DC group");
   }
   DequantDC(r, &dec_state->shared_storage.dc_storage,
@@ -384,7 +384,7 @@ Status ModularFrameDecoder::DecodeAcMetadata(size_t group_id, BitReader* reader,
   ModularOptions options;
   if (!ModularGenericDecompress(
           reader, image, /*header=*/nullptr, stream_id, &options,
-          /*undo_transforms=*/-1, &tree, &code, &context_map)) {
+          /*undo_transforms=*/true, &tree, &code, &context_map)) {
     return JXL_FAILURE("Failed to decode AC metadata");
   }
   ConvertPlaneAndClamp(Rect(image.channel[0].plane), image.channel[0].plane, cr,
@@ -603,7 +603,7 @@ Status ModularFrameDecoder::FinalizeDecoding(PassesDecoderState* dec_state,
   if (xsize * ysize < frame_dim.group_dim * frame_dim.group_dim) pool = nullptr;
 
   // Undo the global transforms
-  gi.undo_transforms(global_header.wp_header, -1, pool);
+  gi.undo_transforms(global_header.wp_header, pool);
   if (gi.error) return JXL_FAILURE("Undoing transforms failed");
 
   auto& decoded = dec_state->decoded;
@@ -631,12 +631,12 @@ Status ModularFrameDecoder::DecodeQuantTable(
     JXL_RETURN_IF_ERROR(ModularGenericDecompress(
         br, image, /*header=*/nullptr,
         ModularStreamId::QuantTable(idx).ID(modular_frame_decoder->frame_dim),
-        &options, /*undo_transforms=*/-1, &modular_frame_decoder->tree,
+        &options, /*undo_transforms=*/true, &modular_frame_decoder->tree,
         &modular_frame_decoder->code, &modular_frame_decoder->context_map));
   } else {
     JXL_RETURN_IF_ERROR(ModularGenericDecompress(br, image, /*header=*/nullptr,
                                                  0, &options,
-                                                 /*undo_transforms=*/-1));
+                                                 /*undo_transforms=*/true));
   }
   if (!encoding->qraw.qtable) {
     encoding->qraw.qtable = new std::vector<int>();

--- a/lib/jxl/modular/encoding/encoding.cc
+++ b/lib/jxl/modular/encoding/encoding.cc
@@ -490,7 +490,7 @@ Status ModularDecode(BitReader *br, Image &image, GroupHeader &header,
 
 Status ModularGenericDecompress(BitReader *br, Image &image,
                                 GroupHeader *header, size_t group_id,
-                                ModularOptions *options, int undo_transforms,
+                                ModularOptions *options, bool undo_transforms,
                                 const Tree *tree, const ANSCode *code,
                                 const std::vector<uint8_t> *ctx_map,
                                 bool allow_truncated_group) {
@@ -506,7 +506,7 @@ Status ModularGenericDecompress(BitReader *br, Image &image,
                                   code, ctx_map, allow_truncated_group);
   if (!allow_truncated_group) JXL_RETURN_IF_ERROR(dec_status);
   if (dec_status.IsFatalError()) return dec_status;
-  image.undo_transforms(header->wp_header, undo_transforms);
+  if (undo_transforms) image.undo_transforms(header->wp_header);
   if (image.error) return JXL_FAILURE("Corrupt file. Aborting.");
   size_t bit_pos = br->TotalBitsConsumed();
   JXL_DEBUG_V(4, "Modular-decoded a %zux%zu nbchans=%zu image from %zu bytes",
@@ -516,7 +516,7 @@ Status ModularGenericDecompress(BitReader *br, Image &image,
 #ifdef JXL_ENABLE_ASSERT
   // Check that after applying all transforms we are back to the requested image
   // sizes, otherwise there's a programming error with the transformations.
-  if (undo_transforms == -1 || undo_transforms == 0) {
+  if (undo_transforms) {
     JXL_ASSERT(image.channel.size() == req_sizes.size());
     for (size_t c = 0; c < req_sizes.size(); c++) {
       JXL_ASSERT(req_sizes[c].first == image.channel[c].w);

--- a/lib/jxl/modular/encoding/encoding.h
+++ b/lib/jxl/modular/encoding/encoding.h
@@ -122,15 +122,10 @@ bool TreeToLookupTable(const FlatTree &tree,
 Status ValidateChannelDimensions(const Image &image,
                                  const ModularOptions &options);
 
-// undo_transforms == N > 0: undo all transforms except the first N
-//                           (e.g. to represent YCbCr420 losslessly)
-// undo_transforms == 0: undo all transforms
-// undo_transforms == -1: undo all transforms but don't clamp to range
-// undo_transforms == -2: don't undo any transform
 Status ModularGenericDecompress(BitReader *br, Image &image,
                                 GroupHeader *header, size_t group_id,
                                 ModularOptions *options,
-                                int undo_transforms = -1,
+                                bool undo_transforms = true,
                                 const Tree *tree = nullptr,
                                 const ANSCode *code = nullptr,
                                 const std::vector<uint8_t> *ctx_map = nullptr,

--- a/lib/jxl/modular/modular_image.cc
+++ b/lib/jxl/modular/modular_image.cc
@@ -11,10 +11,9 @@
 
 namespace jxl {
 
-void Image::undo_transforms(const weighted::Header &wp_header, int keep,
+void Image::undo_transforms(const weighted::Header &wp_header,
                             jxl::ThreadPool *pool) {
-  if (keep == -2) return;
-  while ((int)transform.size() > keep && transform.size() > 0) {
+  while (transform.size() > 0) {
     Transform t = transform.back();
     JXL_DEBUG_V(4, "Undoing transform");
     Status result = t.Inverse(*this, wp_header, pool);
@@ -25,19 +24,6 @@ void Image::undo_transforms(const weighted::Header &wp_header, int keep,
     }
     JXL_DEBUG_V(8, "Undoing transform: done");
     transform.pop_back();
-  }
-  if (!keep && bitdepth < 32) {
-    // clamp the values to the valid range (lossy compression can produce values
-    // outside the range)
-    pixel_type maxval = (1u << bitdepth) - 1;
-    for (size_t i = 0; i < channel.size(); i++) {
-      for (size_t y = 0; y < channel[i].h; y++) {
-        pixel_type *JXL_RESTRICT p = channel[i].plane.Row(y);
-        for (size_t x = 0; x < channel[i].w; x++, p++) {
-          *p = Clamp1(*p, 0, maxval);
-        }
-      }
-    }
   }
 }
 

--- a/lib/jxl/modular/modular_image.h
+++ b/lib/jxl/modular/modular_image.h
@@ -99,8 +99,7 @@ class Image {
 
   Image clone();
 
-  // undo all except the first 'keep' transforms
-  void undo_transforms(const weighted::Header& wp_header, int keep = 0,
+  void undo_transforms(const weighted::Header& wp_header,
                        jxl::ThreadPool* pool = nullptr);
 };
 

--- a/tools/transforms_fuzzer.cc
+++ b/tools/transforms_fuzzer.cc
@@ -113,7 +113,7 @@ int TestOneInput(const uint8_t* data, size_t size) {
     FillChannel(image.channel[i], rng);
   }
 
-  image.undo_transforms(w_header, /*keep=*/-1);
+  image.undo_transforms(w_header);
 
   AssertEq(image.error, false);
   AssertEq<size_t>(image.nb_meta_channels, 0);


### PR DESCRIPTION
There was some dead code in `modular_image.cc`:

- Back in FUIF days, it used to be useful to not undo all transforms, but that was because e.g. YCbCr and DCT were transforms too (remember, FUIF could also do lossless jpeg recompression, though it wasn't as good at it as jxl is now), so there were cases when you wanted to keep those. This option (`keep > 0`) has never been used in the jxl decoder though.
- undo_transform used to also clamp values to their valid range (`keep == 0`), but we never used that option either, since clamping is done elsewhere now (much later) and it is undesirable to do it too early.
- so that left only two options that were actually used: `keep == -1` (undo all transforms and don't clamp) and `keep == -2` (don't undo any transform). 

Cleaned things up a bit to remove the `keep` argument from `undo_transforms()` and to have a simple self-documenting boolean in `ModularGenericDecompress()` instead of the weird argument that was always -1 or -2.