### PR TITLE
Remove unused ImageBundle::depth().

### DIFF
--- a/lib/jxl/image_bundle.cc
+++ b/lib/jxl/image_bundle.cc
@@ -92,14 +92,6 @@ ImageF* ImageBundle::alpha() {
   return &extra_channels_[ec];
 }
 
-const ImageF& ImageBundle::depth() const {
-  JXL_ASSERT(HasDepth());
-  const size_t ec = metadata_->Find(ExtraChannel::kDepth) -
-                    metadata_->extra_channel_info.data();
-  JXL_ASSERT(ec < extra_channels_.size());
-  return extra_channels_[ec];
-}
-
 void ImageBundle::SetAlpha(ImageF&& alpha, bool alpha_is_premultiplied) {
   const ExtraChannelInfo* eci = metadata_->Find(ExtraChannel::kAlpha);
   // Must call SetAlphaBits first, otherwise we don't know which channel index

--- a/lib/jxl/image_bundle.h
+++ b/lib/jxl/image_bundle.h
@@ -179,12 +179,6 @@ class ImageBundle {
   const ImageF& alpha() const;
   ImageF* alpha();
 
-  // -- DEPTH
-  bool HasDepth() const {
-    return metadata_->Find(ExtraChannel::kDepth) != nullptr;
-  }
-  const ImageF& depth() const;
-
   // -- EXTRA CHANNELS
 
   // Extra channels of unknown interpretation (e.g. spot colors).


### PR DESCRIPTION
The specific depth channel is never used in our code and it won't be
different than any other extra channel so it doesn't need special
treatment.