### PR TITLE
Remove unused jxl::Divider()

### DIFF
--- a/lib/jxl/base/data_parallel.h
+++ b/lib/jxl/base/data_parallel.h
@@ -119,37 +119,6 @@ bool RunOnPool(ThreadPool* pool, const uint32_t begin, const uint32_t end,
   return ret;
 }
 
-// Accelerates multiple unsigned 32-bit divisions with the same divisor by
-// precomputing a multiplier. This is useful for splitting a contiguous range of
-// indices (the task index) into 2D indices. Exhaustively tested on dividends
-// up to 4M with non-power of two divisors up to 2K.
-class Divider {
- public:
-  // "d" is the divisor (what to divide by).
-  explicit Divider(const uint32_t d) : shift_(FloorLog2Nonzero(d)) {
-    // Power of two divisors (including 1) are not supported because it is more
-    // efficient to special-case them at a higher level.
-    JXL_ASSERT((d & (d - 1)) != 0);
-
-    // ceil_log2 = floor_log2 + 1 because we ruled out powers of two above.
-    const uint64_t next_pow2 = 1ULL << (shift_ + 1);
-
-    mul_ = ((next_pow2 - d) << 32) / d + 1;
-  }
-
-  // "n" is the numerator (what is being divided).
-  inline uint32_t operator()(const uint32_t n) const {
-    // Algorithm from "Division by Invariant Integers using Multiplication".
-    // Its "sh1" is hardcoded to 1 because we don't need to handle d=1.
-    const uint32_t hi = (uint64_t(mul_) * n) >> 32;
-    return (hi + ((n - hi) >> 1)) >> shift_;
-  }
-
- private:
-  uint32_t mul_;
-  const int shift_;
-};
-
 }  // namespace jxl
 
 #endif  // LIB_JXL_BASE_DATA_PARALLEL_H_

--- a/lib/jxl/data_parallel_test.cc
+++ b/lib/jxl/data_parallel_test.cc
@@ -86,26 +86,4 @@ TEST_F(DataParallelTest, RunnerNotCalledOnEmptyRange) {
   EXPECT_EQ(0, runner_called_);
 }
 
-// The TestDivider is slow when compiled in debug mode.
-TEST_F(DataParallelTest, JXL_SLOW_TEST(TestDivider)) {
-  jxl::ThreadPoolInternal pool(8);
-  // 1, 2 are powers of two.
-  pool.Run(3, 2 * 1024, ThreadPool::SkipInit(),
-           [](const int d, const int thread) {
-             // powers of two are not supported.
-             if ((d & (d - 1)) == 0) return;
-
-             const Divider div(d);
-#ifdef NDEBUG
-             const int max_dividend = 4 * 1024 * 1024;
-#else
-             const int max_dividend = 2 * 1024 + 1;
-#endif
-             for (int x = 0; x < max_dividend; ++x) {
-               const int q = div(x);
-               ASSERT_EQ(x / d, q) << x << "/" << d;
-             }
-           });
-}
-
 }  // namespace jxl


### PR DESCRIPTION
The `class Divider` implemented a unsigned 32-bit division that
accelerated dividing by the same divisor multiple times. This could be
of use in a libjxl_threads implementation (and that's why it was in
data_parallel.h) but this would be out of the scope of libjxl and it
hasn't been used in a long a time.