### PR TITLE
Allow setting more boxes after decoder finished

### DIFF
--- a/lib/include/jxl/decode.h
+++ b/lib/include/jxl/decode.h
@@ -422,7 +422,15 @@ JxlDecoderSetKeepOrientation(JxlDecoder* dec, JXL_BOOL keep_orientation);
  * requires more JxlDecoderProcessInput calls to continue.
  *
  * @param dec decoder object
- * @return JXL_DEC_SUCCESS when decoding finished and all events handled.
+ * @return JXL_DEC_SUCCESS when decoding finished and all events handled. If you
+ * still have more unprocessed input data anyway, then you can still continue
+ * by using JxlDecoderSetInput and calling JxlDecoderProcessInput again, similar
+ * to handling JXL_DEC_NEED_MORE_INPUT. JXL_DEC_SUCCESS can occur instead of
+ * JXL_DEC_NEED_MORE_INPUT when, for example, the input data ended right at
+ * the boundary of a box of the container format, all essential codestream boxes
+ * were already decoded, but extra metadata boxes are still present in the next
+ * data. JxlDecoderProcessInput cannot return success if all codestream boxes
+ * have not been seen yet.
  * @return JXL_DEC_ERROR when decoding failed, e.g. invalid codestream.
  * TODO(lode) document the input data mechanism
  * @return JXL_DEC_NEED_MORE_INPUT more input data is necessary.


### PR DESCRIPTION
The box based container format doesn't indicate which box is the last
(having an unbounded size last box is possible but not required), so the
decoder cannot know for sure when the file finished.

If there would be metadata boxes after codestream boxes, the decoder
could return JXL_DEC_SUCCESS when it decoded all codestream boxes and
the user input happened to end exactly at the last codestream box
boundary.

The API did not allow calling JxlDecoderProcessInput again after it
returned success, so it would be impossible to decode those further
metadata boxes.

This MR changes that by allowing to call JxlDecoderSetInput and then
process the further input again.

It will still give errors when calling JxlDecoderProcessInput without
setting any new input, and also when it's not the container format, or a
codestream box is encountered even though all codestream boxes were already
decoded.