### PR TITLE
add option for simplified ssimulacra

### DIFF
--- a/tools/ssimulacra.cc
+++ b/tools/ssimulacra.cc
@@ -235,11 +235,13 @@ double Ssimulacra::Score() const {
       ssim += kMinScaleWeights[scale][c] * scales[scale].min_ssim[c];
       ssim_max += kMinScaleWeights[scale][c];
     }
-    ssim += kEdgeWeight[c] * avg_edgediff[c];
-    ssim_max += kEdgeWeight[c];
-    ssim += kGridWeight[c] *
-            (row_p2[0][c] + row_p2[1][c] + col_p2[0][c] + col_p2[1][c]);
-    ssim_max += 4.0 * kGridWeight[c];
+    if (!simple) {
+      ssim += kEdgeWeight[c] * avg_edgediff[c];
+      ssim_max += kEdgeWeight[c];
+      ssim += kGridWeight[c] *
+              (row_p2[0][c] + row_p2[1][c] + col_p2[0][c] + col_p2[1][c]);
+      ssim_max += 4.0 * kGridWeight[c];
+    }
   }
   double dssim = ssim_max / ssim - 1.0;
   return std::min(1.0, std::max(0.0, dssim));
@@ -255,7 +257,7 @@ void Ssimulacra::PrintDetails() const {
   for (size_t s = 0; s < scales.size(); ++s) {
     PrintItem("avg ssim", s, scales[s].avg_ssim, &kScaleWeights[s][0]);
     PrintItem("min ssim", s, scales[s].min_ssim, &kMinScaleWeights[s][0]);
-    if (s == 0) {
+    if (s == 0 && !simple) {
       PrintItem("avg edif", s, avg_edgediff, kEdgeWeight);
       PrintItem("rp2 ssim", s, &row_p2[0][0], kGridWeight);
       PrintItem("cp2 ssim", s, &col_p2[0][0], kGridWeight);
@@ -265,9 +267,11 @@ void Ssimulacra::PrintDetails() const {
   }
 }
 
-Ssimulacra ComputeDiff(const Image3F& orig, const Image3F& distorted) {
+Ssimulacra ComputeDiff(const Image3F& orig, const Image3F& distorted,
+                       bool simple) {
   Ssimulacra ssimulacra;
 
+  ssimulacra.simple = simple;
   Image3F img1 = Rgb2Lab(orig);
   Image3F img2 = Rgb2Lab(distorted);
 
@@ -308,7 +312,7 @@ Ssimulacra ComputeDiff(const Image3F& orig, const Image3F& distorted) {
     }
     ssimulacra.scales.push_back(sscale);
 
-    if (scale == 0) {
+    if (scale == 0 && !simple) {
       Image3F* edgediff = &sigma1_sq;  // reuse
       EdgeDiffMap(img1, mu1, img2, mu2, edgediff, ssimulacra.avg_edgediff);
       for (size_t c = 0; c < 3; c++) {

--- a/tools/ssimulacra.h
+++ b/tools/ssimulacra.h
@@ -22,12 +22,14 @@ struct Ssimulacra {
   double avg_edgediff[3];
   double row_p2[2][3];
   double col_p2[2][3];
+  bool simple;
 
   double Score() const;
   void PrintDetails() const;
 };
 
-Ssimulacra ComputeDiff(const jxl::Image3F& orig, const jxl::Image3F& distorted);
+Ssimulacra ComputeDiff(const jxl::Image3F& orig, const jxl::Image3F& distorted,
+                       bool simple);
 
 }  // namespace ssimulacra
 

--- a/tools/ssimulacra_main.cc
+++ b/tools/ssimulacra_main.cc
@@ -13,18 +13,22 @@ namespace ssimulacra {
 namespace {
 
 int PrintUsage(char** argv) {
-  fprintf(stderr, "Usage: %s [-v] orig.png distorted.png\n", argv[0]);
+  fprintf(stderr, "Usage: %s [-v] [-s] orig.png distorted.png\n", argv[0]);
   return 1;
 }
 
 int Run(int argc, char** argv) {
   if (argc < 2) return PrintUsage(argv);
 
-  bool verbose = false;
+  bool verbose = false, simple = false;
   int input_arg = 1;
-  if (argv[1][0] == '-' && argv[1][1] == 'v') {
+  if (!strcmp(argv[input_arg], "-v")) {
     verbose = true;
-    input_arg = 2;
+    input_arg++;
+  }
+  if (!strcmp(argv[input_arg], "-s")) {
+    simple = true;
+    input_arg++;
   }
   if (argc < input_arg + 2) return PrintUsage(argv);
 
@@ -46,7 +50,8 @@ int Run(int argc, char** argv) {
     return 1;
   }
 
-  Ssimulacra ssimulacra = ComputeDiff(*io1.Main().color(), *io2.Main().color());
+  Ssimulacra ssimulacra =
+      ComputeDiff(*io1.Main().color(), *io2.Main().color(), simple);
 
   if (verbose) {
     ssimulacra.PrintDetails();


### PR DESCRIPTION
Adds an option `-s` to `ssimulacra_main` to skip the edge/grid penalties, so it's basically just L*a*b* MS-SSIM with pooling being a weighted sum of the mean error and the max error.