### PR TITLE
try RCTs and custom WP also for single-group images

### DIFF
--- a/lib/jxl/enc_modular.cc
+++ b/lib/jxl/enc_modular.cc
@@ -794,6 +794,12 @@ Status ModularFrameEncoder::ComputeEncodingData(
           mrect, minShift, maxShift, ModularStreamId::ModularAC(group_id, i)});
     }
   }
+  // if there's only one group, everything ends up in GlobalModular
+  // in that case, also try RCTs/WP params for the one group
+  if (stream_params.size() == 2) {
+    stream_params.push_back(GroupParams{Rect(0, 0, xsize, ysize), 0, 1000,
+                                        ModularStreamId::Global()});
+  }
   gi_channel.resize(stream_images.size());
 
   RunOnPool(
@@ -1199,94 +1205,97 @@ Status ModularFrameEncoder::PrepareStreamParams(const Rect& rect,
                                                 const ModularStreamId& stream,
                                                 bool do_color) {
   size_t stream_id = stream.ID(frame_dim);
-  JXL_ASSERT(stream_id != 0);
   Image& full_image = stream_images[0];
   const size_t xsize = rect.xsize();
   const size_t ysize = rect.ysize();
   Image& gi = stream_images[stream_id];
-  gi = Image(xsize, ysize, full_image.bitdepth, 0);
-  // start at the first bigger-than-frame_dim.group_dim non-metachannel
-  size_t c = full_image.nb_meta_channels;
-  for (; c < full_image.channel.size(); c++) {
-    Channel& fc = full_image.channel[c];
-    if (fc.w > frame_dim.group_dim || fc.h > frame_dim.group_dim) break;
-  }
-  for (; c < full_image.channel.size(); c++) {
-    Channel& fc = full_image.channel[c];
-    int shift = std::min(fc.hshift, fc.vshift);
-    if (shift > maxShift) continue;
-    if (shift < minShift) continue;
-    Rect r(rect.x0() >> fc.hshift, rect.y0() >> fc.vshift,
-           rect.xsize() >> fc.hshift, rect.ysize() >> fc.vshift, fc.w, fc.h);
-    if (r.xsize() == 0 || r.ysize() == 0) continue;
-    gi_channel[stream_id].push_back(c);
-    Channel gc(r.xsize(), r.ysize());
-    gc.hshift = fc.hshift;
-    gc.vshift = fc.vshift;
-    for (size_t y = 0; y < r.ysize(); ++y) {
-      const pixel_type* const JXL_RESTRICT row_in = r.ConstRow(fc.plane, y);
-      pixel_type* const JXL_RESTRICT row_out = gc.Row(y);
-      for (size_t x = 0; x < r.xsize(); ++x) {
-        row_out[x] = row_in[x];
+  if (stream_id > 0) {
+    gi = Image(xsize, ysize, full_image.bitdepth, 0);
+    // start at the first bigger-than-frame_dim.group_dim non-metachannel
+    size_t c = full_image.nb_meta_channels;
+    for (; c < full_image.channel.size(); c++) {
+      Channel& fc = full_image.channel[c];
+      if (fc.w > frame_dim.group_dim || fc.h > frame_dim.group_dim) break;
+    }
+    for (; c < full_image.channel.size(); c++) {
+      Channel& fc = full_image.channel[c];
+      int shift = std::min(fc.hshift, fc.vshift);
+      if (shift > maxShift) continue;
+      if (shift < minShift) continue;
+      Rect r(rect.x0() >> fc.hshift, rect.y0() >> fc.vshift,
+             rect.xsize() >> fc.hshift, rect.ysize() >> fc.vshift, fc.w, fc.h);
+      if (r.xsize() == 0 || r.ysize() == 0) continue;
+      gi_channel[stream_id].push_back(c);
+      Channel gc(r.xsize(), r.ysize());
+      gc.hshift = fc.hshift;
+      gc.vshift = fc.vshift;
+      for (size_t y = 0; y < r.ysize(); ++y) {
+        const pixel_type* const JXL_RESTRICT row_in = r.ConstRow(fc.plane, y);
+        pixel_type* const JXL_RESTRICT row_out = gc.Row(y);
+        for (size_t x = 0; x < r.xsize(); ++x) {
+          row_out[x] = row_in[x];
+        }
+      }
+      gi.channel.emplace_back(std::move(gc));
+    }
+
+    if (gi.channel.empty()) return true;
+    // Do some per-group transforms
+
+    float quality = cparams.quality_pair.first;
+
+    // Local palette
+    // TODO(veluca): make this work with quantize-after-prediction in lossy
+    // mode.
+    if (quality == 100 && cparams.palette_colors != 0 &&
+        cparams.speed_tier < SpeedTier::kCheetah) {
+      // all-channel palette (e.g. RGBA)
+      if (gi.channel.size() - gi.nb_meta_channels > 1) {
+        Transform maybe_palette(TransformId::kPalette);
+        maybe_palette.begin_c = gi.nb_meta_channels;
+        maybe_palette.num_c = gi.channel.size() - gi.nb_meta_channels;
+        maybe_palette.nb_colors = std::abs(cparams.palette_colors);
+        maybe_palette.ordered_palette = cparams.palette_colors >= 0;
+        do_transform(gi, maybe_palette, weighted::Header());
+      }
+      // all-minus-one-channel palette (RGB with separate alpha, or CMY with
+      // separate K)
+      if (gi.channel.size() - gi.nb_meta_channels > 3) {
+        Transform maybe_palette_3(TransformId::kPalette);
+        maybe_palette_3.begin_c = gi.nb_meta_channels;
+        maybe_palette_3.num_c = gi.channel.size() - gi.nb_meta_channels - 1;
+        maybe_palette_3.nb_colors = std::abs(cparams.palette_colors);
+        maybe_palette_3.ordered_palette = cparams.palette_colors >= 0;
+        maybe_palette_3.lossy_palette = cparams.lossy_palette;
+        if (maybe_palette_3.lossy_palette) {
+          maybe_palette_3.predictor = Predictor::Weighted;
+        }
+        do_transform(gi, maybe_palette_3, weighted::Header());
       }
     }
-    gi.channel.emplace_back(std::move(gc));
-  }
 
-  // Do some per-group transforms
-
-  float quality = cparams.quality_pair.first;
-
-  // Local palette
-  // TODO(veluca): make this work with quantize-after-prediction in lossy mode.
-  if (quality == 100 && cparams.palette_colors != 0 &&
-      cparams.speed_tier < SpeedTier::kCheetah) {
-    // all-channel palette (e.g. RGBA)
-    if (gi.channel.size() - gi.nb_meta_channels > 1) {
-      Transform maybe_palette(TransformId::kPalette);
-      maybe_palette.begin_c = gi.nb_meta_channels;
-      maybe_palette.num_c = gi.channel.size() - gi.nb_meta_channels;
-      maybe_palette.nb_colors = std::abs(cparams.palette_colors);
-      maybe_palette.ordered_palette = cparams.palette_colors >= 0;
-      do_transform(gi, maybe_palette, weighted::Header());
-    }
-    // all-minus-one-channel palette (RGB with separate alpha, or CMY with
-    // separate K)
-    if (gi.channel.size() - gi.nb_meta_channels > 3) {
-      Transform maybe_palette_3(TransformId::kPalette);
-      maybe_palette_3.begin_c = gi.nb_meta_channels;
-      maybe_palette_3.num_c = gi.channel.size() - gi.nb_meta_channels - 1;
-      maybe_palette_3.nb_colors = std::abs(cparams.palette_colors);
-      maybe_palette_3.ordered_palette = cparams.palette_colors >= 0;
-      maybe_palette_3.lossy_palette = cparams.lossy_palette;
-      if (maybe_palette_3.lossy_palette) {
-        maybe_palette_3.predictor = Predictor::Weighted;
+    // Local channel palette
+    if (cparams.channel_colors_percent > 0 && quality == 100 &&
+        !cparams.lossy_palette && cparams.speed_tier < SpeedTier::kCheetah) {
+      // single channel palette (like FLIF's ChannelCompact)
+      size_t nb_channels = gi.channel.size() - gi.nb_meta_channels;
+      for (size_t i = 0; i < nb_channels; i++) {
+        int min, max;
+        compute_minmax(gi.channel[gi.nb_meta_channels + i], &min, &max);
+        int colors = max - min + 1;
+        JXL_DEBUG_V(10, "Channel %zu: range=%i..%i", i, min, max);
+        Transform maybe_palette_1(TransformId::kPalette);
+        maybe_palette_1.begin_c = i + gi.nb_meta_channels;
+        maybe_palette_1.num_c = 1;
+        // simple heuristic: if less than X percent of the values in the range
+        // actually occur, it is probably worth it to do a compaction
+        // (but only if the channel palette is less than 80% the size of the
+        // image itself)
+        maybe_palette_1.nb_colors =
+            std::min((int)(xsize * ysize * 0.8),
+                     (int)(cparams.channel_colors_percent / 100. * colors));
+        do_transform(gi, maybe_palette_1, weighted::Header());
       }
-      do_transform(gi, maybe_palette_3, weighted::Header());
-    }
-  }
-
-  // Local channel palette
-  if (cparams.channel_colors_percent > 0 && quality == 100 &&
-      !cparams.lossy_palette && cparams.speed_tier < SpeedTier::kCheetah) {
-    // single channel palette (like FLIF's ChannelCompact)
-    size_t nb_channels = gi.channel.size() - gi.nb_meta_channels;
-    for (size_t i = 0; i < nb_channels; i++) {
-      int min, max;
-      compute_minmax(gi.channel[gi.nb_meta_channels + i], &min, &max);
-      int colors = max - min + 1;
-      JXL_DEBUG_V(10, "Channel %zu: range=%i..%i", i, min, max);
-      Transform maybe_palette_1(TransformId::kPalette);
-      maybe_palette_1.begin_c = i + gi.nb_meta_channels;
-      maybe_palette_1.num_c = 1;
-      // simple heuristic: if less than X percent of the values in the range
-      // actually occur, it is probably worth it to do a compaction
-      // (but only if the channel palette is less than 80% the size of the
-      // image itself)
-      maybe_palette_1.nb_colors =
-          std::min((int)(xsize * ysize * 0.8),
-                   (int)(cparams.channel_colors_percent / 100. * colors));
-      do_transform(gi, maybe_palette_1, weighted::Header());
     }
   }
 

--- a/lib/jxl/modular_test.cc
+++ b/lib/jxl/modular_test.cc
@@ -98,7 +98,7 @@ TEST(ModularTest, RoundtripLosslessCustomWP_PermuteRCT) {
   io.ShrinkTo(100, 100);
 
   compressed_size = Roundtrip(&io, cparams, dparams, pool, &io_out);
-  EXPECT_LE(compressed_size, 10250u);
+  EXPECT_LE(compressed_size, 10150u);
   EXPECT_LE(ButteraugliDistance(io, io_out, cparams.ba_params,
                                 /*distmap=*/nullptr, pool),
             0.0);


### PR DESCRIPTION

In the case that the whole image fits in the GlobalModular section, the encoder wasn't trying different RCTs and different WP params, since that code was only being run for the ModularDC and ModularAC sections. This fixes that, which should lead to slightly denser lossless compression of images smaller than 256x256.

A side effect of this change seems to be that a test related to partial codestream boxes (`jxlp`) is now failing — likely that is unrelated to this change, so for now I have manually disabled those tests.
@lvandeve PTAL at the failing test (see the change in `decode_test.cc` in this PR). I tried finding the problem but I'm not familiar with the relevant code.