### PR TITLE
fix case where the global modular image is used after all

### DIFF
--- a/lib/jxl/dec_modular.cc
+++ b/lib/jxl/dec_modular.cc
@@ -604,6 +604,9 @@ Status ModularFrameDecoder::FinalizeDecoding(PassesDecoderState* dec_state,
 
   // Undo the global transforms
   gi.undo_transforms(global_header.wp_header, pool);
+  for (auto t : global_transform) {
+    JXL_RETURN_IF_ERROR(t.Inverse(gi, global_header.wp_header));
+  }
   if (gi.error) return JXL_FAILURE("Undoing transforms failed");
 
   auto& decoded = dec_state->decoded;


### PR DESCRIPTION
Fixes https://github.com/libjxl/libjxl/issues/650

In the case where there's only a global RCT, there's an optimization that skips the global modular image and does the transform undo at the group level, directly copying decoded groups to the output buffer.
This optimization is only implemented for the full float output buffer case, not for the 8-bit output case or the pixel callback. This caused buggy behavior when the global transform was moved out of the global modular image, but `use_full_image` was still true.