### PR TITLE
fix allocation not being done before use in some cases

### DIFF
--- a/lib/jxl/dec_frame.h
+++ b/lib/jxl/dec_frame.h
@@ -263,6 +263,7 @@ class FrameDecoder {
   bool finalized_dc_ = true;
   bool is_finalized_ = true;
   size_t num_renders_ = 0;
+  bool allocated_ = false;
 
   std::vector<GroupDecCache> group_dec_caches_;
 

--- a/lib/jxl/dec_group.cc
+++ b/lib/jxl/dec_group.cc
@@ -715,6 +715,7 @@ Status DecodeGroup(BitReader* JXL_RESTRICT* JXL_RESTRICT readers,
                       PassesDecoderState::kGroupDataYBorder, dst_rect.xsize(),
                       dst_rect.ysize());
     }
+    JXL_ASSERT(dst_rect.IsInside(*upsampling_dst));
     dec_state->upsamplers[2].UpsampleRect(
         dec_state->filter_input_storage[thread], copy_rect, upsampling_dst,
         dst_rect,


### PR DESCRIPTION
In some cases (progressive rendering with a flush at an unfortunate moment), the allocations done in InitForAC() were not yet done when they are already expected to be done to be able to render partial images, causing segfault. I think this could happen when DC is available but ACGlobal not yet, or something like that. This fixes that.

In general, we probably need to revisit what is allocated where and by whom, because the current situation of `FrameDecoder.decoded_` and `PassesDecoderState.decoded` both being used is quite confusing and probably unnecessary.