### PR TITLE
remove uint24

### DIFF
--- a/lib/jxl/base/byte_order.h
+++ b/lib/jxl/base/byte_order.h
@@ -56,20 +56,6 @@ static JXL_INLINE uint32_t LoadLE16(const uint8_t* p) {
   return (byte1 << 8) | byte0;
 }
 
-static JXL_INLINE uint32_t LoadBE24(const uint8_t* p) {
-  const uint32_t byte2 = p[0];
-  const uint32_t byte1 = p[1];
-  const uint32_t byte0 = p[2];
-  return (byte2 << 16) | (byte1 << 8) | byte0;
-}
-
-static JXL_INLINE uint32_t LoadLE24(const uint8_t* p) {
-  const uint32_t byte0 = p[0];
-  const uint32_t byte1 = p[1];
-  const uint32_t byte2 = p[2];
-  return (byte2 << 16) | (byte1 << 8) | byte0;
-}
-
 static JXL_INLINE uint32_t LoadBE32(const uint8_t* p) {
 #if JXL_BYTE_ORDER_LITTLE
   uint32_t big;
@@ -151,18 +137,6 @@ static JXL_INLINE void StoreLE16(const uint32_t native, uint8_t* p) {
   p[0] = native & 0xFF;
 }
 
-static JXL_INLINE void StoreBE24(const uint32_t native, uint8_t* p) {
-  p[0] = (native >> 16) & 0xFF;
-  p[1] = (native >> 8) & 0xFF;
-  p[2] = native & 0xFF;
-}
-
-static JXL_INLINE void StoreLE24(const uint32_t native, uint8_t* p) {
-  p[2] = (native >> 24) & 0xFF;
-  p[1] = (native >> 8) & 0xFF;
-  p[0] = native & 0xFF;
-}
-
 static JXL_INLINE void StoreBE32(const uint32_t native, uint8_t* p) {
 #if JXL_BYTE_ORDER_LITTLE
   const uint32_t big = JXL_BSWAP32(native);
@@ -238,15 +212,6 @@ static JXL_INLINE void Store16(OrderLE /*tag*/, const uint32_t native,
   return StoreLE16(native, p);
 }
 
-static JXL_INLINE void Store24(OrderBE /*tag*/, const uint32_t native,
-                               uint8_t* p) {
-  return StoreBE24(native, p);
-}
-
-static JXL_INLINE void Store24(OrderLE /*tag*/, const uint32_t native,
-                               uint8_t* p) {
-  return StoreLE24(native, p);
-}
 static JXL_INLINE void Store32(OrderBE /*tag*/, const uint32_t native,
                                uint8_t* p) {
   return StoreBE32(native, p);
@@ -265,13 +230,6 @@ static JXL_INLINE uint32_t Load16(OrderLE /*tag*/, const uint8_t* p) {
   return LoadLE16(p);
 }
 
-static JXL_INLINE uint32_t Load24(OrderBE /*tag*/, const uint8_t* p) {
-  return LoadBE24(p);
-}
-
-static JXL_INLINE uint32_t Load24(OrderLE /*tag*/, const uint8_t* p) {
-  return LoadLE24(p);
-}
 static JXL_INLINE uint32_t Load32(OrderBE /*tag*/, const uint8_t* p) {
   return LoadBE32(p);
 }

--- a/lib/jxl/dec_external_image.cc
+++ b/lib/jxl/dec_external_image.cc
@@ -282,6 +282,9 @@ Status ConvertChannelsToExternal(const ImageF* channels[], size_t num_channels,
   if (bits_per_sample == 1) {
     return JXL_FAILURE("packed 1-bit per sample is not yet supported");
   }
+  if (bits_per_sample > 16 && bits_per_sample < 32) {
+    return JXL_FAILURE("not supported, try bits_per_sample=32");
+  }
 
   // bytes_per_channel and is only valid for bits_per_sample > 1.
   const size_t bytes_per_channel = DivCeil(bits_per_sample, jxl::kBitsPerByte);
@@ -449,12 +452,6 @@ Status ConvertChannelsToExternal(const ImageF* channels[], size_t num_channels,
               StoreUintRow<StoreLE16>(row_u32, num_channels, xsize, 2, row_out);
             } else {
               StoreUintRow<StoreBE16>(row_u32, num_channels, xsize, 2, row_out);
-            }
-          } else if (bits_per_sample <= 24) {
-            if (little_endian) {
-              StoreUintRow<StoreLE24>(row_u32, num_channels, xsize, 3, row_out);
-            } else {
-              StoreUintRow<StoreBE24>(row_u32, num_channels, xsize, 3, row_out);
             }
           } else {
             if (little_endian) {

--- a/lib/jxl/enc_external_image.cc
+++ b/lib/jxl/enc_external_image.cc
@@ -107,6 +107,9 @@ Status ConvertFromExternal(Span<const uint8_t> bytes, size_t xsize,
   // bits_per_sample > 1.
   const size_t bytes_per_channel = DivCeil(bits_per_sample, jxl::kBitsPerByte);
   const size_t bytes_per_pixel = channels * bytes_per_channel;
+  if (bits_per_sample > 16 && bits_per_sample < 32) {
+    return JXL_FAILURE("not supported, try bits_per_sample=32");
+  }
 
   const size_t row_size = xsize * bytes_per_pixel;
   if (ysize && bytes.size() / ysize < row_size) {
@@ -182,14 +185,6 @@ Status ConvertFromExternal(Span<const uint8_t> bytes, size_t xsize,
                                        bytes_per_pixel);
               } else {
                 LoadFloatRow<LoadBE16>(row_out, in + i, mul, xsize,
-                                       bytes_per_pixel);
-              }
-            } else if (bits_per_sample <= 24) {
-              if (little_endian) {
-                LoadFloatRow<LoadLE24>(row_out, in + i, mul, xsize,
-                                       bytes_per_pixel);
-              } else {
-                LoadFloatRow<LoadBE24>(row_out, in + i, mul, xsize,
                                        bytes_per_pixel);
               }
             } else {
@@ -271,14 +266,6 @@ Status ConvertFromExternal(Span<const uint8_t> bytes, size_t xsize,
                                        bytes_per_pixel);
               } else {
                 LoadFloatRow<LoadBE16>(row_out, in + i, mul, xsize,
-                                       bytes_per_pixel);
-              }
-            } else if (bits_per_sample <= 24) {
-              if (little_endian) {
-                LoadFloatRow<LoadLE24>(row_out, in + i, mul, xsize,
-                                       bytes_per_pixel);
-              } else {
-                LoadFloatRow<LoadBE24>(row_out, in + i, mul, xsize,
                                        bytes_per_pixel);
               }
             } else {


### PR DESCRIPTION

We have code to handle (big-endian and little-endian) uint24 buffers. Nobody will use that — you can use 32-bit if you need more than 16-bit, but handling 24-bit data will be inconvenient for anyone and we will not have it in the api either (also now the code does what the documentation says it does: bits_per_sample has to be 8, 16 or 32.