### PR TITLE
drop ==, != from dec_params.h

### DIFF
--- a/lib/jxl/dec_params.h
+++ b/lib/jxl/dec_params.h
@@ -42,19 +42,6 @@ struct DecompressParams {
   bool allow_partial_files = false;
   // Allow even more progression.
   bool allow_more_progressive_steps = false;
-
-  bool operator==(const DecompressParams other) const {
-    return check_decompressed_size == other.check_decompressed_size &&
-           keep_dct == other.keep_dct &&
-           render_spotcolors == other.render_spotcolors &&
-           preview == other.preview && max_passes == other.max_passes &&
-           max_downsampling == other.max_downsampling &&
-           allow_partial_files == other.allow_partial_files &&
-           allow_more_progressive_steps == other.allow_more_progressive_steps;
-  }
-  bool operator!=(const DecompressParams& other) const {
-    return !(*this == other);
-  }
 };
 
 }  // namespace jxl

--- a/tools/benchmark/benchmark_codec_jxl.cc
+++ b/tools/benchmark/benchmark_codec_jxl.cc
@@ -266,7 +266,8 @@ class JxlCodec : public ImageCodec {
                     ThreadPoolInternal* pool, CodecInOut* io,
                     jpegxl::tools::SpeedStats* speed_stats) override {
     io->frames.clear();
-    if (dparams_ != DecompressParams{}) {
+    if (dparams_.max_passes != DecompressParams().max_passes ||
+        dparams_.max_downsampling != DecompressParams().max_downsampling) {
       // Must use the C++ API to honor non-default dparams.
       if (uint8_) {
         return JXL_FAILURE(


### PR DESCRIPTION

The comparison operators for dec_params were only used in one spot in benchmark_xl, no need to have that in libjxl itself.