### PR TITLE
Update SOVERSION to reflect v0.6 API/ABI changes.

### DIFF
--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -9,8 +9,19 @@ set(JPEGXL_PATCH_VERSION 0)
 set(JPEGXL_LIBRARY_VERSION
     "${JPEGXL_MAJOR_VERSION}.${JPEGXL_MINOR_VERSION}.${JPEGXL_PATCH_VERSION}")
 
-# This the library API compatibility version.
+# This is the library API/ABI compatibility version. Changing this value makes
+# the shared library incompatible with previous version. A program linked
+# against this shared library SOVERSION will not run with an older SOVERSION.
+# It is important to update this value when making incompatible API/ABI changes
+# so that programs that depend on libjxl can update their dependencies. Semantic
+# versioning allows 0.y.z to have incompatible changes in minor versions.
+set(JPEGXL_SO_MINOR_VERSION 6)
+if (JPEGXL_MAJOR_VERSION EQUAL 0)
+set(JPEGXL_LIBRARY_SOVERSION
+    "${JPEGXL_MAJOR_VERSION}.${JPEGXL_SO_MINOR_VERSION}")
+else()
 set(JPEGXL_LIBRARY_SOVERSION "${JPEGXL_MAJOR_VERSION}")
+endif()
 
 
 # List of warning and feature flags for our library and tests.


### PR DESCRIPTION
0.y.z version can have API/ABI changes during development but we should
mark those in the shared library SOVERSION. This uses MAJOR.MINOR for
major version 0, and just MAJOR for version after 1.0.