### PR TITLE
don't report coverage of debug-printing code

### DIFF
--- a/ci.sh
+++ b/ci.sh
@@ -558,6 +558,7 @@ cmd_coverage_report() {
     --filter '.*jxl/.*'
     --exclude '.*_test.cc'
     --exclude '.*_testonly..*'
+    --exclude '.*_debug.*'
     --exclude '.*test_utils..*'
     --object-directory "${real_build_dir}"
   )

--- a/lib/jxl/aux_out.cc
+++ b/lib/jxl/aux_out.cc
@@ -59,23 +59,6 @@ void AuxOut::Print(size_t num_inputs) const {
   }
 }
 
-void AuxOut::DumpCoeffImage(const char* label,
-                            const Image3S& coeff_image) const {
-  JXL_ASSERT(coeff_image.xsize() % 64 == 0);
-  Image3S reshuffled(coeff_image.xsize() / 8, coeff_image.ysize() * 8);
-  for (size_t c = 0; c < 3; c++) {
-    for (size_t y = 0; y < coeff_image.ysize(); y++) {
-      for (size_t x = 0; x < coeff_image.xsize(); x += 64) {
-        for (size_t i = 0; i < 64; i++) {
-          reshuffled.PlaneRow(c, 8 * y + i / 8)[x / 8 + i % 8] =
-              coeff_image.PlaneRow(c, y)[x + i];
-        }
-      }
-    }
-  }
-  DumpImage(label, reshuffled);
-}
-
 void ReclaimAndCharge(BitWriter* JXL_RESTRICT writer,
                       BitWriter::Allotment* JXL_RESTRICT allotment,
                       size_t layer, AuxOut* JXL_RESTRICT aux_out) {

--- a/lib/jxl/aux_out.h
+++ b/lib/jxl/aux_out.h
@@ -251,12 +251,6 @@ struct AuxOut {
     DumpImage(label, normalized);
   }
 
-  // This dumps coefficients as a 16-bit PNG with coefficients of a block placed
-  // in the area that would contain that block in a normal image. To view the
-  // resulting image manually, rescale intensities by using:
-  // $ convert -auto-level IMAGE.PNG - | display -
-  void DumpCoeffImage(const char* label, const Image3S& coeff_image) const;
-
   void SetInspectorImage3F(const jxl::InspectorImage3F& inspector) {
     inspector_image3f_ = inspector;
   }


### PR DESCRIPTION
No need to have files in the coverage report that only contain verbose debug printing functions.

Also remove an unused function from `aux_out.cc`.