### PR TITLE
Special-case 16-bit "Gaborish only" path for ARM.

### DIFF
--- a/lib/jxl.cmake
+++ b/lib/jxl.cmake
@@ -67,6 +67,8 @@ set(JPEGXL_INTERNAL_SOURCES_DEC
   jxl/dct_scales.cc
   jxl/dct_scales.h
   jxl/dct_util.h
+  jxl/dec_16bit_reconstruct.cc
+  jxl/dec_16bit_reconstruct.h
   jxl/dec_ans.cc
   jxl/dec_ans.h
   jxl/dec_bit_reader.h

--- a/lib/jxl/dec_16bit_reconstruct.cc
+++ b/lib/jxl/dec_16bit_reconstruct.cc
@@ -1,0 +1,129 @@
+// Copyright (c) the JPEG XL Project Authors. All rights reserved.
+//
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+#include "lib/jxl/dec_16bit_reconstruct.h"
+
+#undef HWY_TARGET_INCLUDE
+#define HWY_TARGET_INCLUDE "lib/jxl/dec_16bit_reconstruct.cc"
+#include <hwy/foreach_target.h>
+#include <hwy/highway.h>
+
+#include "lib/jxl/dec_xyb-inl.h"
+
+HWY_BEFORE_NAMESPACE();
+namespace jxl {
+namespace HWY_NAMESPACE {
+void FinalizeImageRect16(Image3F* input_image, const Rect& input_rect,
+                         ImageF* alpha, const Rect& alpha_rect,
+                         PassesDecoderState* dec_state, size_t thread,
+                         const Rect& frame_rect) {
+  // This function is very NEON-specific. As such, it uses intrinsics directly.
+#if HWY_TARGET == HWY_NEON
+  // WARNING: doing fixed point arithmetic correctly is very complicated.
+  // Changes to this function should be thoroughly tested.
+  JXL_ASSERT(SameSize(input_rect, frame_rect));
+  if (alpha) JXL_ASSERT(SameSize(alpha_rect, input_rect));
+
+  const FrameDimensions& frame_dim = dec_state->shared->frame_dim;
+
+  ImageS& storage = dec_state->fixpoint_buffer[thread];
+
+  size_t x0 = frame_rect.x0();
+  size_t x1 = std::min(x0 + frame_rect.xsize(), frame_dim.xsize_upsampled);
+  size_t xs = x1 - x0;
+
+  int16_t* xyba[4] = {};
+  xyba[0] = storage.Row(9);
+  xyba[1] = storage.Row(10);
+  xyba[2] = storage.Row(11);
+  if (alpha) xyba[3] = storage.Row(12);
+
+  for (size_t y = 0; y < frame_rect.ysize() + 2 &&
+                     y + frame_rect.y0() < frame_dim.ysize_upsampled + 2;
+       y++) {
+    // Mirroring
+    size_t yfrom =
+        y + frame_rect.y0() == 0
+            ? 0
+            : (y + frame_rect.y0() == frame_dim.ysize_upsampled + 1 ? y - 2
+                                                                    : y - 1);
+
+    ConvertToFixpoint<18>(input_rect.ConstPlaneRow(*input_image, 0, yfrom) - 1,
+                          storage.Row(0 + (y % 3)), xs + 2);
+    ConvertToFixpoint<15>(input_rect.ConstPlaneRow(*input_image, 1, yfrom) - 1,
+                          storage.Row(3 + (y % 3)), xs + 2);
+    ConvertToFixpoint<15>(input_rect.ConstPlaneRow(*input_image, 2, yfrom) - 1,
+                          storage.Row(6 + (y % 3)), xs + 2);
+
+    // x mirroring
+    if (x0 == 0) {
+      for (size_t c : {0, 1, 2}) {
+        storage.Row(c * 3 + (y % 3))[0] = storage.Row(c * 3 + (y % 3))[1];
+      }
+    }
+    if (x1 == frame_dim.xsize_upsampled && frame_dim.xsize_upsampled % 8 == 0) {
+      for (size_t c : {0, 1, 2}) {
+        storage.Row(c * 3 + (y % 3))[xs + 1] = storage.Row(c * 3 + (y % 3))[xs];
+      }
+    }
+
+    if (y < 2) continue;
+
+    // Apply Gaborish
+    for (size_t c : {0, 1, 2}) {
+      int16_t* row_top = storage.Row(c * 3 + ((y - 2) % 3)) + 1;
+      int16_t* row_mid = storage.Row(c * 3 + ((y - 1) % 3)) + 1;
+      int16_t* row_bot = storage.Row(c * 3 + ((y - 0) % 3)) + 1;
+      for (size_t x = 0; x < xs; x += 8) {
+        int16x8_t p01 = vld1q_s16(row_top + x);
+        int16x8_t p00 = vld1q_s16(row_top + x - 1);
+        int16x8_t p02 = vld1q_s16(row_top + x + 1);
+        int16x8_t p11 = vld1q_s16(row_mid + x);
+        int16x8_t p10 = vld1q_s16(row_mid + x - 1);
+        int16x8_t p12 = vld1q_s16(row_mid + x + 1);
+        int16x8_t p21 = vld1q_s16(row_bot + x);
+        int16x8_t p20 = vld1q_s16(row_bot + x - 1);
+        int16x8_t p22 = vld1q_s16(row_bot + x + 1);
+
+        int16x8_t sum0 = vqrdmulhq_n_s16(p11, 19211);  // 0.586279
+        int16x8_t sum1pre =
+            vhaddq_s16(vhaddq_s16(p01, p21), vhaddq_s16(p10, p12));
+        int16x8_t sum1 = vqrdmulhq_n_s16(sum1pre, 8850);  // 0.067521 * 4
+        int16x8_t sum2pre =
+            vhaddq_s16(vhaddq_s16(p00, p22), vhaddq_s16(p02, p20));
+        int16x8_t sum2 = vqrdmulhq_n_s16(sum2pre, 4707);  // 0.035909 * 4
+
+        int16x8_t out = vaddq_s16(sum0, vaddq_s16(sum1, sum2));
+        vst1q_s16(xyba[c] + x, out);
+      }
+    }
+
+    if (alpha)
+      ConvertToFixpoint<8>(alpha_rect.ConstRow(*alpha, y), xyba[3], xs);
+    uint8_t* out = dec_state->rgb_output +
+                   dec_state->rgb_stride * (frame_rect.y0() + y - 2) +
+                   x0 * (dec_state->rgb_output_is_rgba ? 4 : 3);
+    FastXYBTosRGB8Impl(const_cast<const int16_t**>(xyba), out, xs, !!alpha);
+  }
+#else
+  JXL_ABORT("Unreachable");
+#endif
+}
+}  // namespace HWY_NAMESPACE
+}  // namespace jxl
+HWY_AFTER_NAMESPACE();
+
+#if HWY_ONCE
+namespace jxl {
+HWY_EXPORT(FinalizeImageRect16);
+void FinalizeImageRect16(Image3F* input_image, const Rect& input_rect,
+                         ImageF* alpha, const Rect& alpha_rect,
+                         PassesDecoderState* dec_state, size_t thread,
+                         const Rect& frame_rect) {
+  HWY_DYNAMIC_DISPATCH(FinalizeImageRect16)
+  (input_image, input_rect, alpha, alpha_rect, dec_state, thread, frame_rect);
+}
+}  // namespace jxl
+#endif

--- a/lib/jxl/dec_16bit_reconstruct.h
+++ b/lib/jxl/dec_16bit_reconstruct.h
@@ -1,0 +1,13 @@
+// Copyright (c) the JPEG XL Project Authors. All rights reserved.
+//
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+#include "lib/jxl/dec_cache.h"
+
+namespace jxl {
+void FinalizeImageRect16(Image3F* input_image, const Rect& input_rect,
+                         ImageF* alpha, const Rect& alpha_rect,
+                         PassesDecoderState* dec_state, size_t thread,
+                         const Rect& frame_rect);
+}

--- a/lib/jxl/dec_cache.h
+++ b/lib/jxl/dec_cache.h
@@ -86,6 +86,9 @@ struct PassesDecoderState {
   // One row per thread
   std::vector<std::vector<float>> pixel_callback_rows;
 
+  // Buffer for 16bit fixpoint fastpath.
+  std::vector<ImageS> fixpoint_srgb_buffer;
+
   // Seed for noise, to have different noise per-frame.
   size_t noise_seed = 0;
 
@@ -203,6 +206,12 @@ struct PassesDecoderState {
                                        kGroupDim + 2 * kGroupDataYBorder);
         ycbcr_out_images.emplace_back(kGroupDim + 2 * kGroupDataXBorder,
                                       kGroupDim + 2 * kGroupDataYBorder);
+      }
+    }
+    if (fast_xyb_srgb8_conversion) {
+      for (size_t _ = fixpoint_srgb_buffer.size(); _ < num_threads; _++) {
+        fixpoint_srgb_buffer.emplace_back(
+            ImageS(kApplyImageFeaturesTileDim * 8, 4));
       }
     }
     if (rgb_output || pixel_callback) {

--- a/lib/jxl/dec_frame.h
+++ b/lib/jxl/dec_frame.h
@@ -156,7 +156,21 @@ class FrameDecoder {
     if (decoded_->metadata()->xyb_encoded &&
         dec_state_->output_encoding_info.color_encoding.IsSRGB() &&
         dec_state_->output_encoding_info.all_default_opsin &&
-        HasFastXYBTosRGB8() && frame_header_.needs_color_transform()) {
+        HasFastXYBTosRGB8() && frame_header_.needs_color_transform() &&
+        ((frame_header_.flags & (FrameHeader::kPatches | FrameHeader::kSplines |
+                                 FrameHeader::kNoise)) == 0) &&
+        frame_header_.upsampling == 1 && frame_header_.loop_filter.gab &&
+        !frame_header_.loop_filter.gab_custom &&
+        frame_header_.loop_filter.epf_iters == 0 &&
+        (decoded_->metadata()->num_extra_channels == 0 ||
+         (decoded_->metadata()->num_extra_channels == 1 &&
+          decoded_->metadata()->extra_channel_info[0].type ==
+              ExtraChannel::kAlpha))) {
+      dec_state_->use_16bit_dec_reconstruct = true;
+    } else if (decoded_->metadata()->xyb_encoded &&
+               dec_state_->output_encoding_info.color_encoding.IsSRGB() &&
+               dec_state_->output_encoding_info.all_default_opsin &&
+               HasFastXYBTosRGB8() && frame_header_.needs_color_transform()) {
       dec_state_->fast_xyb_srgb8_conversion = true;
     }
 #endif

--- a/lib/jxl/dec_reconstruct.cc
+++ b/lib/jxl/dec_reconstruct.cc
@@ -8,6 +8,7 @@
 #include <atomic>
 #include <utility>
 
+#include "lib/jxl/dec_16bit_reconstruct.h"
 #include "lib/jxl/filters.h"
 #include "lib/jxl/image_ops.h"
 
@@ -579,6 +580,15 @@ Status FinalizeImageRect(
     const std::vector<std::pair<ImageF*, Rect>>& extra_channels,
     PassesDecoderState* dec_state, size_t thread,
     ImageBundle* JXL_RESTRICT output_image, const Rect& frame_rect) {
+  if (dec_state->use_16bit_dec_reconstruct) {
+    FinalizeImageRect16(
+        input_image, input_rect,
+        extra_channels.empty() ? nullptr : extra_channels[0].first,
+        extra_channels.empty() ? Rect() : extra_channels[0].second, dec_state,
+        thread, frame_rect);
+    return true;
+  }
+
   const ImageFeatures& image_features = dec_state->shared->image_features;
   const FrameHeader& frame_header = dec_state->shared->frame_header;
   const ImageMetadata& metadata = frame_header.nonserialized_metadata->m;

--- a/lib/jxl/dec_xyb-inl.h
+++ b/lib/jxl/dec_xyb-inl.h
@@ -86,10 +86,34 @@ static inline HWY_MAYBE_UNUSED bool HasFastXYBTosRGB8() {
 #endif
 }
 
-static inline HWY_MAYBE_UNUSED void FastXYBTosRGB8(
-    const Image3F& input, const Rect& input_rect, const Rect& output_buf_rect,
-    const ImageF* alpha, const Rect& alpha_rect, bool is_rgba,
-    uint8_t* JXL_RESTRICT output_buf, size_t xsize, size_t output_stride) {
+template <size_t shift>
+static inline HWY_MAYBE_UNUSED void ConvertToFixpoint(const float* in,
+                                                      int16_t* out,
+                                                      size_t xsize) {
+#if HWY_TARGET == HWY_NEON
+  for (size_t x = 0; x < xsize; x += 8) {
+    // TODO(veluca): consider different approaches here, like vld1q_f32_x2.
+    float32x4_t flt_left = vld1q_f32(in + x);
+    int16x4_t int16_left = vqmovn_s32(vcvtq_n_s32_f32(flt_left, shift));
+    float32x4_t flt_right = vld1q_f32(in + x + (x + 4 < xsize ? 4 : 0));
+    int16x4_t int16_right = vqmovn_s32(vcvtq_n_s32_f32(flt_right, shift));
+    vst1q_s16(out + x, vcombine_s16(int16_left, int16_right));
+  }
+#else
+  (void)in;
+  (void)out;
+  (void)xsize;
+  JXL_ABORT("Unreachable");
+#endif
+}
+
+// Requires input data to be in 16-bit fixpoint format, with 15 bits after the
+// decimal point, except for the x (0) channel, which should have "18" bits
+// after the decimal point (i.e. x * 8 should have 15 bit after the decimal
+// point).
+static inline HWY_MAYBE_UNUSED void FastXYBTosRGB8Impl(
+    const int16_t* JXL_RESTRICT rgb[4], uint8_t* output, size_t xsize,
+    bool is_rgba) {
   // This function is very NEON-specific. As such, it uses intrinsics directly.
 #if HWY_TARGET == HWY_NEON
   // WARNING: doing fixed point arithmetic correctly is very complicated.
@@ -173,173 +197,142 @@ static inline HWY_MAYBE_UNUSED void FastXYBTosRGB8(
     // > 0.0031308f (note that v16 has 13 mantissa bits)
     return vbslq_s16(vcgeq_s16(v16, vdupq_n_s16(26)), v16_pow, v16_linear);
   };
-  for (size_t y = 0; y < output_buf_rect.ysize(); y++) {
-    const float* JXL_RESTRICT row_in_x = input_rect.ConstPlaneRow(input, 0, y);
-    const float* JXL_RESTRICT row_in_y = input_rect.ConstPlaneRow(input, 1, y);
-    const float* JXL_RESTRICT row_in_b = input_rect.ConstPlaneRow(input, 2, y);
-    const float* JXL_RESTRICT row_in_a =
-        alpha == nullptr ? nullptr : alpha_rect.ConstRow(*alpha, y);
-    size_t cnt = !is_rgba ? 3 : 4;
-    size_t base_ptr =
-        (y + output_buf_rect.y0()) * output_stride + output_buf_rect.x0() * cnt;
-    for (size_t x = 0; x < output_buf_rect.xsize(); x += 8) {
-      // Normal ranges for xyb for in-gamut sRGB colors:
-      // x: -0.015386 0.028100
-      // y: 0.000000 0.845308
-      // b: 0.000000 0.845308
+  for (size_t x = 0; x < xsize; x += 8) {
+    // Normal ranges for xyb for in-gamut sRGB colors:
+    // x: -0.015386 0.028100
+    // y: 0.000000 0.845308
+    // b: 0.000000 0.845308
 
-      // We actually want x * 8 to have some extra precision.
-      // TODO(veluca): consider different approaches here, like vld1q_f32_x2.
-      float32x4_t opsin_x_left = vld1q_f32(row_in_x + x);
-      int16x4_t opsin_x16_times8_left =
-          vqmovn_s32(vcvtq_n_s32_f32(opsin_x_left, 18));
-      float32x4_t opsin_x_right =
-          vld1q_f32(row_in_x + x + (x + 4 < output_buf_rect.xsize() ? 4 : 0));
-      int16x4_t opsin_x16_times8_right =
-          vqmovn_s32(vcvtq_n_s32_f32(opsin_x_right, 18));
-      int16x8_t opsin_x16_times8 =
-          vcombine_s16(opsin_x16_times8_left, opsin_x16_times8_right);
+    int16x8_t opsin_x16_times8 = vld1q_s16(rgb[0] + x);
+    int16x8_t opsin_y16 = vld1q_s16(rgb[1] + x);
+    int16x8_t opsin_b16 = vld1q_s16(rgb[2] + x);
 
-      float32x4_t opsin_y_left = vld1q_f32(row_in_y + x);
-      int16x4_t opsin_y16_left = vqmovn_s32(vcvtq_n_s32_f32(opsin_y_left, 15));
-      float32x4_t opsin_y_right =
-          vld1q_f32(row_in_y + x + (x + 4 < output_buf_rect.xsize() ? 4 : 0));
-      int16x4_t opsin_y16_right =
-          vqmovn_s32(vcvtq_n_s32_f32(opsin_y_right, 15));
-      int16x8_t opsin_y16 = vcombine_s16(opsin_y16_left, opsin_y16_right);
+    int16x8_t neg_bias16 = vdupq_n_s16(-124);        // -0.0037930732552754493
+    int16x8_t neg_bias_cbrt16 = vdupq_n_s16(-5110);  // -0.155954201
+    int16x8_t neg_bias_half16 = vdupq_n_s16(-62);
 
-      float32x4_t opsin_b_left = vld1q_f32(row_in_b + x);
-      int16x4_t opsin_b16_left = vqmovn_s32(vcvtq_n_s32_f32(opsin_b_left, 15));
-      float32x4_t opsin_b_right =
-          vld1q_f32(row_in_b + x + (x + 4 < output_buf_rect.xsize() ? 4 : 0));
-      int16x4_t opsin_b16_right =
-          vqmovn_s32(vcvtq_n_s32_f32(opsin_b_right, 15));
-      int16x8_t opsin_b16 = vcombine_s16(opsin_b16_left, opsin_b16_right);
+    // Color space: XYB -> RGB
+    // Compute ((y+x-bias_cbrt)^3-(y-x-bias_cbrt)^3)/2,
+    // ((y+x-bias_cbrt)^3+(y-x-bias_cbrt)^3)/2+bias, (b-bias_cbrt)^3+bias.
+    // Note that ignoring x2 in the formulas below (as x << y) results in
+    // errors of at least 3 in the final sRGB values.
+    int16x8_t opsin_yp16 = vqsubq_s16(opsin_y16, neg_bias_cbrt16);
+    int16x8_t ysq16 = vqrdmulhq_s16(opsin_yp16, opsin_yp16);
+    int16x8_t twentyfourx16 = vmulq_n_s16(opsin_x16_times8, 3);
+    int16x8_t twentyfourxy16 = vqrdmulhq_s16(opsin_yp16, twentyfourx16);
+    int16x8_t threexsq16 =
+        vrshrq_n_s16(vqrdmulhq_s16(opsin_x16_times8, twentyfourx16), 6);
 
-      int16x8_t neg_bias16 = vdupq_n_s16(-124);        // -0.0037930732552754493
-      int16x8_t neg_bias_cbrt16 = vdupq_n_s16(-5110);  // -0.155954201
-      int16x8_t neg_bias_half16 = vdupq_n_s16(-62);
+    // We can ignore x^3 here. Note that this is multiplied by 8.
+    int16x8_t mixed_rmg16 = vqrdmulhq_s16(twentyfourxy16, opsin_yp16);
 
-      // Color space: XYB -> RGB
-      // Compute ((y+x-bias_cbrt)^3-(y-x-bias_cbrt)^3)/2,
-      // ((y+x-bias_cbrt)^3+(y-x-bias_cbrt)^3)/2+bias, (b-bias_cbrt)^3+bias.
-      // Note that ignoring x2 in the formulas below (as x << y) results in
-      // errors of at least 3 in the final sRGB values.
-      int16x8_t opsin_yp16 = vqsubq_s16(opsin_y16, neg_bias_cbrt16);
-      int16x8_t ysq16 = vqrdmulhq_s16(opsin_yp16, opsin_yp16);
-      int16x8_t twentyfourx16 = vmulq_n_s16(opsin_x16_times8, 3);
-      int16x8_t twentyfourxy16 = vqrdmulhq_s16(opsin_yp16, twentyfourx16);
-      int16x8_t threexsq16 =
-          vrshrq_n_s16(vqrdmulhq_s16(opsin_x16_times8, twentyfourx16), 6);
+    int16x8_t mixed_rpg_sos_half = vhaddq_s16(ysq16, threexsq16);
+    int16x8_t mixed_rpg16 = vhaddq_s16(
+        vqrdmulhq_s16(opsin_yp16, mixed_rpg_sos_half), neg_bias_half16);
 
-      // We can ignore x^3 here. Note that this is multiplied by 8.
-      int16x8_t mixed_rmg16 = vqrdmulhq_s16(twentyfourxy16, opsin_yp16);
+    int16x8_t gamma_b16 = vqsubq_s16(opsin_b16, neg_bias_cbrt16);
+    int16x8_t gamma_bsq16 = vqrdmulhq_s16(gamma_b16, gamma_b16);
+    int16x8_t gamma_bcb16 = vqrdmulhq_s16(gamma_bsq16, gamma_b16);
+    int16x8_t mixed_b16 = vqaddq_s16(gamma_bcb16, neg_bias16);
+    // mixed_rpg and mixed_b are in 0-1 range.
+    // mixed_rmg has a smaller range (-0.035 to 0.035 for valid sRGB). Note
+    // that at this point it is already multiplied by 8.
 
-      int16x8_t mixed_rpg_sos_half = vhaddq_s16(ysq16, threexsq16);
-      int16x8_t mixed_rpg16 = vhaddq_s16(
-          vqrdmulhq_s16(opsin_yp16, mixed_rpg_sos_half), neg_bias_half16);
+    // We multiply all the mixed values by 1/4 (i.e. shift them to 13-bit
+    // fixed point) to ensure intermediate quantities are in range. Note that
+    // r-g is not shifted, and was x8 before here; this corresponds to a x32
+    // overall multiplicative factor and ensures that all the matrix constants
+    // are in 0-1 range.
+    // Similarly, mixed_rpg16 is already multiplied by 1/4 because of the two
+    // vhadd + using neg_bias_half.
+    mixed_b16 = vshrq_n_s16(mixed_b16, 2);
 
-      int16x8_t gamma_b16 = vqsubq_s16(opsin_b16, neg_bias_cbrt16);
-      int16x8_t gamma_bsq16 = vqrdmulhq_s16(gamma_b16, gamma_b16);
-      int16x8_t gamma_bcb16 = vqrdmulhq_s16(gamma_bsq16, gamma_b16);
-      int16x8_t mixed_b16 = vqaddq_s16(gamma_bcb16, neg_bias16);
-      // mixed_rpg and mixed_b are in 0-1 range.
-      // mixed_rmg has a smaller range (-0.035 to 0.035 for valid sRGB). Note
-      // that at this point it is already multiplied by 8.
+    // Unmix (multiply by 3x3 inverse_matrix)
+    // For increased precision, we use a matrix for converting from
+    // ((mixed_r - mixed_g)/2, (mixed_r + mixed_g)/2, mixed_b) to rgb. This
+    // avoids cancellation effects when computing (y+x)^3-(y-x)^3.
+    // We compute mixed_rpg - mixed_b because the (1+c)*mixed_rpg - c *
+    // mixed_b pattern is repeated frequently in the code below. This allows
+    // us to save a multiply per channel, and removes the presence of
+    // some constants above 1. Moreover, mixed_rmg - mixed_b is in (-1, 1)
+    // range, so the subtraction is safe.
+    // All the magic-looking constants here are derived by computing the
+    // inverse opsin matrix for the transformation modified as described
+    // above.
 
-      // We multiply all the mixed values by 1/4 (i.e. shift them to 13-bit
-      // fixed point) to ensure intermediate quantities are in range. Note that
-      // r-g is not shifted, and was x8 before here; this corresponds to a x32
-      // overall multiplicative factor and ensures that all the matrix constants
-      // are in 0-1 range.
-      // Similarly, mixed_rpg16 is already multiplied by 1/4 because of the two
-      // vhadd + using neg_bias_half.
-      mixed_b16 = vshrq_n_s16(mixed_b16, 2);
+    // Precomputation common to multiple color values.
+    int16x8_t mixed_rpgmb16 = vqsubq_s16(mixed_rpg16, mixed_b16);
+    int16x8_t mixed_rpgmb_times_016 = vqrdmulhq_n_s16(mixed_rpgmb16, 5394);
+    int16x8_t mixed_rg16 = vqaddq_s16(mixed_rpgmb_times_016, mixed_rpg16);
 
-      // Unmix (multiply by 3x3 inverse_matrix)
-      // For increased precision, we use a matrix for converting from
-      // ((mixed_r - mixed_g)/2, (mixed_r + mixed_g)/2, mixed_b) to rgb. This
-      // avoids cancellation effects when computing (y+x)^3-(y-x)^3.
-      // We compute mixed_rpg - mixed_b because the (1+c)*mixed_rpg - c *
-      // mixed_b pattern is repeated frequently in the code below. This allows
-      // us to save a multiply per channel, and removes the presence of
-      // some constants above 1. Moreover, mixed_rmg - mixed_b is in (-1, 1)
-      // range, so the subtraction is safe.
-      // All the magic-looking constants here are derived by computing the
-      // inverse opsin matrix for the transformation modified as described
-      // above.
+    // R
+    int16x8_t linear_r16 =
+        vqaddq_s16(mixed_rg16, vqrdmulhq_n_s16(mixed_rmg16, 21400));
 
-      // Precomputation common to multiple color values.
-      int16x8_t mixed_rpgmb16 = vqsubq_s16(mixed_rpg16, mixed_b16);
-      int16x8_t mixed_rpgmb_times_016 = vqrdmulhq_n_s16(mixed_rpgmb16, 5394);
-      int16x8_t mixed_rg16 = vqaddq_s16(mixed_rpgmb_times_016, mixed_rpg16);
+    // G
+    int16x8_t linear_g16 =
+        vqaddq_s16(mixed_rg16, vqrdmulhq_n_s16(mixed_rmg16, -7857));
 
-      // R
-      int16x8_t linear_r16 =
-          vqaddq_s16(mixed_rg16, vqrdmulhq_n_s16(mixed_rmg16, 21400));
+    // B
+    int16x8_t linear_b16 = vqrdmulhq_n_s16(mixed_rpgmb16, -30996);
+    linear_b16 = vqaddq_s16(linear_b16, mixed_b16);
+    linear_b16 = vqaddq_s16(linear_b16, vqrdmulhq_n_s16(mixed_rmg16, -6525));
 
-      // G
-      int16x8_t linear_g16 =
-          vqaddq_s16(mixed_rg16, vqrdmulhq_n_s16(mixed_rmg16, -7857));
+    // Apply SRGB transfer function.
+    int16x8_t r = srgb_tf(linear_r16);
+    int16x8_t g = srgb_tf(linear_g16);
+    int16x8_t b = srgb_tf(linear_b16);
 
-      // B
-      int16x8_t linear_b16 = vqrdmulhq_n_s16(mixed_rpgmb16, -30996);
-      linear_b16 = vqaddq_s16(linear_b16, mixed_b16);
-      linear_b16 = vqaddq_s16(linear_b16, vqrdmulhq_n_s16(mixed_rmg16, -6525));
+    uint8x8_t r8 =
+        vqmovun_s16(vrshrq_n_s16(vsubq_s16(r, vshrq_n_s16(r, 8)), 6));
+    uint8x8_t g8 =
+        vqmovun_s16(vrshrq_n_s16(vsubq_s16(g, vshrq_n_s16(g, 8)), 6));
+    uint8x8_t b8 =
+        vqmovun_s16(vrshrq_n_s16(vsubq_s16(b, vshrq_n_s16(b, 8)), 6));
 
-      // Apply SRGB transfer function.
-      int16x8_t r = srgb_tf(linear_r16);
-      int16x8_t g = srgb_tf(linear_g16);
-      int16x8_t b = srgb_tf(linear_b16);
-
-      uint8x8_t r8 =
-          vqmovun_s16(vrshrq_n_s16(vsubq_s16(r, vshrq_n_s16(r, 8)), 6));
-      uint8x8_t g8 =
-          vqmovun_s16(vrshrq_n_s16(vsubq_s16(g, vshrq_n_s16(g, 8)), 6));
-      uint8x8_t b8 =
-          vqmovun_s16(vrshrq_n_s16(vsubq_s16(b, vshrq_n_s16(b, 8)), 6));
-
-      size_t n = output_buf_rect.xsize() - x;
-      if (is_rgba) {
-        float32x4_t a_f32_left =
-            row_in_a ? vld1q_f32(row_in_a + x) : vdupq_n_f32(1.0f);
-        float32x4_t a_f32_right =
-            row_in_a ? vld1q_f32(row_in_a + x +
-                                 (x + 4 < output_buf_rect.xsize() ? 4 : 0))
-                     : vdupq_n_f32(1.0f);
-        int16x4_t a16_left = vqmovn_s32(vcvtq_n_s32_f32(a_f32_left, 8));
-        int16x4_t a16_right = vqmovn_s32(vcvtq_n_s32_f32(a_f32_right, 8));
-        uint8x8_t a8 = vqmovun_s16(vcombine_s16(a16_left, a16_right));
-        uint8_t* buf = output_buf + base_ptr + 4 * x;
-        uint8x8x4_t data = {r8, g8, b8, a8};
-        if (n >= 8) {
-          vst4_u8(buf, data);
-        } else {
-          uint8_t tmp[8 * 4];
-          vst4_u8(tmp, data);
-          memcpy(buf, tmp, n * 4);
-        }
+    size_t n = xsize - x;
+    if (is_rgba) {
+      uint8x8_t a8 =
+          rgb[3] ? vqmovun_s16(vld1q_s16(rgb[3] + x)) : vdup_n_u8(255);
+      uint8_t* buf = output + 4 * x;
+      uint8x8x4_t data = {r8, g8, b8, a8};
+      if (n >= 8) {
+        vst4_u8(buf, data);
       } else {
-        uint8_t* buf = output_buf + base_ptr + 3 * x;
-        uint8x8x3_t data = {r8, g8, b8};
-        if (n >= 8) {
-          vst3_u8(buf, data);
-        } else {
-          uint8_t tmp[8 * 3];
-          vst3_u8(tmp, data);
-          memcpy(buf, tmp, n * 3);
-        }
+        uint8_t tmp[8 * 4];
+        vst4_u8(tmp, data);
+        memcpy(buf, tmp, n * 4);
+      }
+    } else {
+      uint8_t* buf = output + 3 * x;
+      uint8x8x3_t data = {r8, g8, b8};
+      if (n >= 8) {
+        vst3_u8(buf, data);
+      } else {
+        uint8_t tmp[8 * 3];
+        vst3_u8(tmp, data);
+        memcpy(buf, tmp, n * 3);
       }
     }
   }
 #else
-  (void)input;
-  (void)input_rect;
-  (void)output_buf_rect;
-  (void)output_buf;
+  (void)rgb;
+  (void)is_rgba;
+  (void)output;
   (void)xsize;
   JXL_ABORT("Unreachable");
 #endif
+}
+
+static inline HWY_MAYBE_UNUSED void FastXYBTosRGB8(
+    const float* JXL_RESTRICT rgb[4], uint8_t* output, size_t xsize,
+    bool is_rgba, int16_t* JXL_RESTRICT rgb16[4]) {
+  ConvertToFixpoint<18>(rgb[0], rgb16[0], xsize);
+  ConvertToFixpoint<15>(rgb[1], rgb16[1], xsize);
+  ConvertToFixpoint<15>(rgb[2], rgb16[2], xsize);
+  if (rgb[3]) ConvertToFixpoint<8>(rgb[3], rgb16[3], xsize);
+  FastXYBTosRGB8Impl(const_cast<const int16_t**>(rgb16), output, xsize,
+                     is_rgba);
 }
 
 }  // namespace

--- a/lib/jxl/dec_xyb.cc
+++ b/lib/jxl/dec_xyb.cc
@@ -182,14 +182,11 @@ HWY_EXPORT(HasFastXYBTosRGB8);
 bool HasFastXYBTosRGB8() { return HWY_DYNAMIC_DISPATCH(HasFastXYBTosRGB8)(); }
 
 HWY_EXPORT(FastXYBTosRGB8);
-void FastXYBTosRGB8(const Image3F& input, const Rect& input_rect,
-                    const Rect& output_buf_rect, const ImageF* alpha,
-                    const Rect& alpha_rect, bool is_rgba,
-                    uint8_t* JXL_RESTRICT output_buf, size_t xsize,
-                    size_t output_stride) {
-  return HWY_DYNAMIC_DISPATCH(FastXYBTosRGB8)(
-      input, input_rect, output_buf_rect, alpha, alpha_rect, is_rgba,
-      output_buf, xsize, output_stride);
+void FastXYBTosRGB8(const float* JXL_RESTRICT data[4], uint8_t* output,
+                    size_t xsize, bool is_rgba,
+                    int16_t* JXL_RESTRICT data16[4]) {
+  return HWY_DYNAMIC_DISPATCH(FastXYBTosRGB8)(data, output, xsize, is_rgba,
+                                              data16);
 }
 
 void OpsinParams::Init(float intensity_target) {

--- a/lib/jxl/dec_xyb.h
+++ b/lib/jxl/dec_xyb.h
@@ -60,11 +60,9 @@ void OpsinToLinear(const Image3F& opsin, const Rect& rect, ThreadPool* pool,
 void YcbcrToRgb(const Image3F& ycbcr, Image3F* rgb, const Rect& rect);
 
 bool HasFastXYBTosRGB8();
-void FastXYBTosRGB8(const Image3F& input, const Rect& input_rect,
-                    const Rect& output_buf_rect, const ImageF* alpha,
-                    const Rect& alpha_rect, bool is_rgba,
-                    uint8_t* JXL_RESTRICT output_buf, size_t xsize,
-                    size_t output_stride);
+void FastXYBTosRGB8(const float* JXL_RESTRICT data[4], uint8_t* output,
+                    size_t xsize, bool is_rgba,
+                    int16_t* JXL_RESTRICT data16[4]);
 
 }  // namespace jxl
 

--- a/lib/lib.gni
+++ b/lib/lib.gni
@@ -84,6 +84,8 @@ libjxl_dec_sources = [
     "jxl/dct_scales.cc",
     "jxl/dct_scales.h",
     "jxl/dct_util.h",
+    "jxl/dec_16bit_reconstruct.cc",
+    "jxl/dec_16bit_reconstruct.h",
     "jxl/dec_ans.cc",
     "jxl/dec_ans.h",
     "jxl/dec_bit_reader.h",


### PR DESCRIPTION
About 10% speedup of faster_decoding=3 case. It may be possible to
recover some extra performance by reducing the total amount of border
storage.

```
faster decoding 4: geomean: 22.0309 MP/s [21.1923, 22.2131]
before: geomean: 16.3272 MP/s [16.1619, 16.4523]
skip gaborish: geomean: 19.7544 MP/s [19.6237, 19.9077]
after: geomean: 18.2605 MP/s [18.1625, 18.3798]

float output, bpp*pnorm: 0.843556372436
uint8 output before, bpp*pnorm: 0.853447943526
uint8 output after, bpp*pnorm: 0.853247854260
```



Based on https://github.com/libjxl/libjxl/pull/670