### PR TITLE
cleanup image_bundle and enc_image_bundle

### DIFF
--- a/lib/extras/codec_exr.cc
+++ b/lib/extras/codec_exr.cc
@@ -15,6 +15,7 @@
 #include "lib/jxl/alpha.h"
 #include "lib/jxl/color_encoding_internal.h"
 #include "lib/jxl/color_management.h"
+#include "lib/jxl/enc_image_bundle.h"
 
 namespace jxl {
 namespace extras {

--- a/lib/extras/codec_jpg.cc
+++ b/lib/extras/codec_jpg.cc
@@ -27,6 +27,7 @@
 #include "lib/jxl/color_encoding_internal.h"
 #include "lib/jxl/color_management.h"
 #include "lib/jxl/common.h"
+#include "lib/jxl/enc_image_bundle.h"
 #include "lib/jxl/image.h"
 #include "lib/jxl/image_bundle.h"
 #include "lib/jxl/image_ops.h"

--- a/lib/extras/codec_pgx.cc
+++ b/lib/extras/codec_pgx.cc
@@ -21,6 +21,7 @@
 #include "lib/jxl/color_management.h"
 #include "lib/jxl/dec_external_image.h"
 #include "lib/jxl/enc_external_image.h"
+#include "lib/jxl/enc_image_bundle.h"
 #include "lib/jxl/fields.h"  // AllDefault
 #include "lib/jxl/image.h"
 #include "lib/jxl/image_bundle.h"

--- a/lib/extras/codec_png.cc
+++ b/lib/extras/codec_png.cc
@@ -26,6 +26,7 @@
 #include "lib/jxl/common.h"
 #include "lib/jxl/dec_external_image.h"
 #include "lib/jxl/enc_external_image.h"
+#include "lib/jxl/enc_image_bundle.h"
 #include "lib/jxl/image.h"
 #include "lib/jxl/image_bundle.h"
 #include "lib/jxl/luminance.h"

--- a/lib/extras/codec_pnm.cc
+++ b/lib/extras/codec_pnm.cc
@@ -22,6 +22,7 @@
 #include "lib/jxl/color_management.h"
 #include "lib/jxl/dec_external_image.h"
 #include "lib/jxl/enc_external_image.h"
+#include "lib/jxl/enc_image_bundle.h"
 #include "lib/jxl/fields.h"  // AllDefault
 #include "lib/jxl/image.h"
 #include "lib/jxl/image_bundle.h"

--- a/lib/jxl/enc_butteraugli_comparator.cc
+++ b/lib/jxl/enc_butteraugli_comparator.cc
@@ -9,6 +9,7 @@
 #include <vector>
 
 #include "lib/jxl/color_management.h"
+#include "lib/jxl/enc_image_bundle.h"
 
 namespace jxl {
 

--- a/lib/jxl/enc_comparator.cc
+++ b/lib/jxl/enc_comparator.cc
@@ -14,6 +14,7 @@
 #include "lib/jxl/base/profiler.h"
 #include "lib/jxl/color_management.h"
 #include "lib/jxl/enc_gamma_correct.h"
+#include "lib/jxl/enc_image_bundle.h"
 
 namespace jxl {
 namespace {

--- a/lib/jxl/enc_image_bundle.cc
+++ b/lib/jxl/enc_image_bundle.cc
@@ -23,14 +23,10 @@ namespace jxl {
 namespace {
 
 // Copies ib:rect, converts, and copies into out.
-template <typename T>
 Status CopyToT(const ImageMetadata* metadata, const ImageBundle* ib,
                const Rect& rect, const ColorEncoding& c_desired,
-               ThreadPool* pool, Image3<T>* out) {
+               ThreadPool* pool, Image3F* out) {
   PROFILER_FUNC;
-  static_assert(
-      std::is_same<T, float>::value || std::numeric_limits<T>::min() == 0,
-      "CopyToT implemented only for float and unsigned types");
   ColorSpaceTransform c_transform;
   // Changing IsGray is probably a bug.
   JXL_CHECK(ib->IsGray() == c_desired.IsGray());
@@ -40,7 +36,7 @@ Status CopyToT(const ImageMetadata* metadata, const ImageBundle* ib,
   bool is_gray = ib->IsGray();
 #endif
   if (out->xsize() < rect.xsize() || out->ysize() < rect.ysize()) {
-    *out = Image3<T>(rect.xsize(), rect.ysize());
+    *out = Image3F(rect.xsize(), rect.ysize());
   } else {
     out->ShrinkTo(rect.xsize(), rect.ysize());
   }
@@ -72,43 +68,21 @@ Status CopyToT(const ImageMetadata* metadata, const ImageBundle* ib,
         }
         float* JXL_RESTRICT dst_buf = c_transform.BufDst(thread);
         DoColorSpaceTransform(&c_transform, thread, src_buf, dst_buf);
-        T* JXL_RESTRICT row_out0 = out->PlaneRow(0, y);
-        T* JXL_RESTRICT row_out1 = out->PlaneRow(1, y);
-        T* JXL_RESTRICT row_out2 = out->PlaneRow(2, y);
+        float* JXL_RESTRICT row_out0 = out->PlaneRow(0, y);
+        float* JXL_RESTRICT row_out1 = out->PlaneRow(1, y);
+        float* JXL_RESTRICT row_out2 = out->PlaneRow(2, y);
         // De-interleave output and convert type.
-        if (std::is_same<float, T>::value) {  // deinterleave to float.
-          if (is_gray) {
-            for (size_t x = 0; x < rect.xsize(); x++) {
-              row_out0[x] = dst_buf[x];
-              row_out1[x] = dst_buf[x];
-              row_out2[x] = dst_buf[x];
-            }
-          } else {
-            for (size_t x = 0; x < rect.xsize(); x++) {
-              row_out0[x] = dst_buf[3 * x + 0];
-              row_out1[x] = dst_buf[3 * x + 1];
-              row_out2[x] = dst_buf[3 * x + 2];
-            }
+        if (is_gray) {
+          for (size_t x = 0; x < rect.xsize(); x++) {
+            row_out0[x] = dst_buf[x];
+            row_out1[x] = dst_buf[x];
+            row_out2[x] = dst_buf[x];
           }
         } else {
-          // Convert to T, doing clamping.
-          float max = std::numeric_limits<T>::max();
-          auto cvt = [max](float in) {
-            float v = std::max(0.0f, std::min(max, in * max));
-            return static_cast<T>(v < 0 ? v - 0.5f : v + 0.5f);
-          };
-          if (is_gray) {
-            for (size_t x = 0; x < rect.xsize(); x++) {
-              row_out0[x] = cvt(dst_buf[x]);
-              row_out1[x] = cvt(dst_buf[x]);
-              row_out2[x] = cvt(dst_buf[x]);
-            }
-          } else {
-            for (size_t x = 0; x < rect.xsize(); x++) {
-              row_out0[x] = cvt(dst_buf[3 * x + 0]);
-              row_out1[x] = cvt(dst_buf[3 * x + 1]);
-              row_out2[x] = cvt(dst_buf[3 * x + 2]);
-            }
+          for (size_t x = 0; x < rect.xsize(); x++) {
+            row_out0[x] = dst_buf[3 * x + 0];
+            row_out1[x] = dst_buf[3 * x + 1];
+            row_out2[x] = dst_buf[3 * x + 2];
           }
         }
       },
@@ -125,21 +99,10 @@ Status ImageBundle::TransformTo(const ColorEncoding& c_desired,
   c_current_ = c_desired;
   return true;
 }
-
-Status ImageBundle::CopyTo(const Rect& rect, const ColorEncoding& c_desired,
-                           Image3B* out, ThreadPool* pool) const {
-  return CopyToT(metadata_, this, rect, c_desired, pool, out);
-}
 Status ImageBundle::CopyTo(const Rect& rect, const ColorEncoding& c_desired,
                            Image3F* out, ThreadPool* pool) const {
   return CopyToT(metadata_, this, rect, c_desired, pool, out);
 }
-
-Status ImageBundle::CopyToSRGB(const Rect& rect, Image3B* out,
-                               ThreadPool* pool) const {
-  return CopyTo(rect, ColorEncoding::SRGB(IsGray()), out, pool);
-}
-
 Status TransformIfNeeded(const ImageBundle& in, const ColorEncoding& c_desired,
                          ThreadPool* pool, ImageBundle* store,
                          const ImageBundle** out) {

--- a/lib/jxl/enc_xyb.cc
+++ b/lib/jxl/enc_xyb.cc
@@ -21,6 +21,7 @@
 #include "lib/jxl/color_encoding_internal.h"
 #include "lib/jxl/color_management.h"
 #include "lib/jxl/enc_bit_writer.h"
+#include "lib/jxl/enc_image_bundle.h"
 #include "lib/jxl/fields.h"
 #include "lib/jxl/image_bundle.h"
 #include "lib/jxl/image_ops.h"

--- a/lib/jxl/image_bundle.h
+++ b/lib/jxl/image_bundle.h
@@ -151,12 +151,8 @@ class ImageBundle {
   Status TransformTo(const ColorEncoding& c_desired,
                      ThreadPool* pool = nullptr);
   // Copies this:rect, converts to c_desired, and allocates+fills out.
-  Status CopyTo(const Rect& rect, const ColorEncoding& c_desired, Image3B* out,
-                ThreadPool* pool = nullptr) const;
   Status CopyTo(const Rect& rect, const ColorEncoding& c_desired, Image3F* out,
                 ThreadPool* pool = nullptr) const;
-  Status CopyToSRGB(const Rect& rect, Image3B* out,
-                    ThreadPool* pool = nullptr) const;
 
   // Detect 'real' bit depth, which can be lower than nominal bit depth
   // (this is common in PNG), returns 'real' bit depth
@@ -241,16 +237,6 @@ class ImageBundle {
   // How many bytes of the input were actually read.
   size_t decoded_bytes_ = 0;
 };
-
-// Does color transformation from in.c_current() to c_desired if the color
-// encodings are different, or nothing if they are already the same.
-// If color transformation is done, stores the transformed values into store and
-// sets the out pointer to store, else leaves store untouched and sets the out
-// pointer to &in.
-// Returns false if color transform fails.
-Status TransformIfNeeded(const ImageBundle& in, const ColorEncoding& c_desired,
-                         ThreadPool* pool, ImageBundle* store,
-                         const ImageBundle** out);
 
 }  // namespace jxl
 


### PR DESCRIPTION
The `CopyToSRGB()` function (and the associated code in CopyTtoT to convert to uint8) in `image_bundle.h` / `enc_image_bundle.cc` was only used by the webp codec in `benchmark_xl`. Cleaning some things up to reduce code duplication and unnecessary clutter in the lib/jxl code.