### PR TITLE
remove debug printing instrumentation on header fields

### DIFF
--- a/lib/jxl/fields.cc
+++ b/lib/jxl/fields.cc
@@ -62,20 +62,12 @@ class ExtensionStates {
 
 class VisitorBase : public Visitor {
  public:
-  explicit VisitorBase(bool print_bundles = false)
-      : print_bundles_(print_bundles) {}
+  explicit VisitorBase() {}
   ~VisitorBase() override { JXL_ASSERT(depth_ == 0); }
 
-  // This is the only call site of Fields::VisitFields. Adds tracing and
-  // ensures EndExtensions was called.
-  Status Visit(Fields* fields, const char* visitor_name) override {
-    fputs(visitor_name, stdout);  // No newline; no effect if empty
-    if (print_bundles_) {
-#if JXL_IS_DEBUG_BUILD
-      Trace("%s\n", print_bundles_ ? fields->Name() : "");
-#endif  // JXL_IS_DEBUG_BUILD
-    }
-
+  // This is the only call site of Fields::VisitFields.
+  // Ensures EndExtensions was called.
+  Status Visit(Fields* fields) override {
     depth_ += 1;
     JXL_ASSERT(depth_ <= Bundle::kMaxExtensions);
     extension_states_.Push();
@@ -101,9 +93,7 @@ class VisitorBase : public Visitor {
   // For visitors accepting a const Visitor, need to const-cast so we can call
   // the non-const Visitor::VisitFields. NOTE: C is not modified except the
   // `all_default` field by CanEncodeVisitor.
-  Status VisitConst(const Fields& t, const char* message) {
-    return Visit(const_cast<Fields*>(&t), message);
-  }
+  Status VisitConst(const Fields& t) { return Visit(const_cast<Fields*>(&t)); }
 
   // Derived types (overridden by InitVisitor because it is unsafe to read
   // from *value there)
@@ -135,23 +125,9 @@ class VisitorBase : public Visitor {
     return true;
   }
 
- protected:
-  // Prints indentation, <format>.
-  JXL_FORMAT(2, 3)  // 1-based plus one because member function
-  void Trace(const char* format, ...) const {
-    // Indentation.
-    printf("%*s", static_cast<int>(2 * depth_), "");
-
-    va_list args;
-    va_start(args, format);
-    vfprintf(stdout, format, args);
-    va_end(args);
-  }
-
  private:
-  size_t depth_ = 0;  // for indentation.
+  size_t depth_ = 0;  // to check nesting
   ExtensionStates extension_states_;
-  const bool print_bundles_;
 };
 
 struct InitVisitor : public VisitorBase {
@@ -198,8 +174,6 @@ struct InitVisitor : public VisitorBase {
     // Bundle::Init for their fields).
     return true;
   }
-
-  const char* VisitorName() override { return "InitVisitor"; }
 };
 
 // Similar to InitVisitor, but also initializes nested fields.
@@ -241,51 +215,31 @@ struct SetDefaultVisitor : public VisitorBase {
     JXL_RETURN_IF_ERROR(Bool(true, all_default));
     return false;
   }
-
-  const char* VisitorName() override { return "SetDefaultVisitor"; }
 };
 
 class AllDefaultVisitor : public VisitorBase {
  public:
-  explicit AllDefaultVisitor(bool print_all_default)
-      : VisitorBase(print_all_default), print_all_default_(print_all_default) {}
+  explicit AllDefaultVisitor() : VisitorBase() {}
 
   Status Bits(const size_t bits, const uint32_t default_value,
               uint32_t* JXL_RESTRICT value) override {
-    if (print_all_default_) {
-      Trace("  u(%zu) = %u, default %u\n", bits, *value, default_value);
-    }
-
     all_default_ &= *value == default_value;
     return true;
   }
 
   Status U32(const U32Enc /*unused*/, const uint32_t default_value,
              uint32_t* JXL_RESTRICT value) override {
-    if (print_all_default_) {
-      Trace("  U32 = %u, default %u\n", *value, default_value);
-    }
-
     all_default_ &= *value == default_value;
     return true;
   }
 
   Status U64(const uint64_t default_value,
              uint64_t* JXL_RESTRICT value) override {
-    if (print_all_default_) {
-      Trace("  U64 = %" PRIu64 ", default %" PRIu64 "\n", *value,
-            default_value);
-    }
-
     all_default_ &= *value == default_value;
     return true;
   }
 
   Status F16(const float default_value, float* JXL_RESTRICT value) override {
-    if (print_all_default_) {
-      Trace("  F16 = %.6f, default %.6f\n", static_cast<double>(*value),
-            static_cast<double>(default_value));
-    }
     all_default_ &= std::abs(*value - default_value) < 1E-6f;
     return true;
   }
@@ -298,17 +252,13 @@ class AllDefaultVisitor : public VisitorBase {
 
   bool AllDefault() const { return all_default_; }
 
-  const char* VisitorName() override { return "AllDefaultVisitor"; }
-
  private:
-  const bool print_all_default_;
   bool all_default_ = true;
 };
 
 class ReadVisitor : public VisitorBase {
  public:
-  ReadVisitor(BitReader* reader, bool print_read)
-      : VisitorBase(print_read), print_read_(print_read), reader_(reader) {}
+  ReadVisitor(BitReader* reader) : VisitorBase(), reader_(reader) {}
 
   Status Bits(const size_t bits, const uint32_t /*default_value*/,
               uint32_t* JXL_RESTRICT value) override {
@@ -317,7 +267,6 @@ class ReadVisitor : public VisitorBase {
       return JXL_STATUS(StatusCode::kNotEnoughBytes,
                         "Not enough bytes for header");
     }
-    if (print_read_) Trace("  u(%zu) = %u\n", bits, *value);
     return true;
   }
 
@@ -328,7 +277,6 @@ class ReadVisitor : public VisitorBase {
       return JXL_STATUS(StatusCode::kNotEnoughBytes,
                         "Not enough bytes for header");
     }
-    if (print_read_) Trace("  U32 = %u\n", *value);
     return true;
   }
 
@@ -339,7 +287,6 @@ class ReadVisitor : public VisitorBase {
       return JXL_STATUS(StatusCode::kNotEnoughBytes,
                         "Not enough bytes for header");
     }
-    if (print_read_) Trace("  U64 = %" PRIu64 "\n", *value);
     return true;
   }
 
@@ -350,7 +297,6 @@ class ReadVisitor : public VisitorBase {
       return JXL_STATUS(StatusCode::kNotEnoughBytes,
                         "Not enough bytes for header");
     }
-    if (print_read_) Trace("  F16 = %f\n", static_cast<double>(*value));
     return true;
   }
 
@@ -419,11 +365,7 @@ class ReadVisitor : public VisitorBase {
 
   Status OK() const { return ok_; }
 
-  const char* VisitorName() override { return "ReadVisitor"; }
-
  private:
-  const bool print_read_;
-
   // Whether any error other than not enough bytes occurred.
   bool ok_ = true;
 
@@ -481,22 +423,18 @@ class MaxBitsVisitor : public VisitorBase {
 
   size_t MaxBits() const { return max_bits_; }
 
-  const char* VisitorName() override { return "MaxBitsVisitor"; }
-
  private:
   size_t max_bits_ = 0;
 };
 
 class CanEncodeVisitor : public VisitorBase {
  public:
-  explicit CanEncodeVisitor(bool print_sizes)
-      : VisitorBase(print_sizes), print_sizes_(print_sizes) {}
+  explicit CanEncodeVisitor() : VisitorBase() {}
 
   Status Bits(const size_t bits, const uint32_t /*default_value*/,
               uint32_t* JXL_RESTRICT value) override {
     size_t encoded_bits = 0;
     ok_ &= BitsCoder::CanEncode(bits, *value, &encoded_bits);
-    if (print_sizes_) Trace("u(%zu) = %u\n", bits, *value);
     encoded_bits_ += encoded_bits;
     return true;
   }
@@ -505,7 +443,6 @@ class CanEncodeVisitor : public VisitorBase {
              uint32_t* JXL_RESTRICT value) override {
     size_t encoded_bits = 0;
     ok_ &= U32Coder::CanEncode(enc, *value, &encoded_bits);
-    if (print_sizes_) Trace("U32(%zu) = %u\n", encoded_bits, *value);
     encoded_bits_ += encoded_bits;
     return true;
   }
@@ -514,9 +451,6 @@ class CanEncodeVisitor : public VisitorBase {
              uint64_t* JXL_RESTRICT value) override {
     size_t encoded_bits = 0;
     ok_ &= U64Coder::CanEncode(*value, &encoded_bits);
-    if (print_sizes_) {
-      Trace("U64(%zu) = %" PRIu64 "\n", encoded_bits, *value);
-    }
     encoded_bits_ += encoded_bits;
     return true;
   }
@@ -525,9 +459,6 @@ class CanEncodeVisitor : public VisitorBase {
              float* JXL_RESTRICT value) override {
     size_t encoded_bits = 0;
     ok_ &= F16Coder::CanEncode(*value, &encoded_bits);
-    if (print_sizes_) {
-      Trace("F16(%zu) = %.6f\n", encoded_bits, static_cast<double>(*value));
-    }
     encoded_bits_ += encoded_bits;
     return true;
   }
@@ -577,10 +508,7 @@ class CanEncodeVisitor : public VisitorBase {
     return true;
   }
 
-  const char* VisitorName() override { return "CanEncodeVisitor"; }
-
  private:
-  const bool print_sizes_;
   bool ok_ = true;
   size_t encoded_bits_ = 0;
   uint64_t extensions_ = 0;
@@ -640,8 +568,6 @@ class WriteVisitor : public VisitorBase {
 
   Status OK() const { return ok_; }
 
-  const char* VisitorName() override { return "WriteVisitor"; }
-
  private:
   const size_t extension_bits_;
   BitWriter* JXL_RESTRICT writer_;
@@ -652,25 +578,21 @@ class WriteVisitor : public VisitorBase {
 
 void Bundle::Init(Fields* fields) {
   InitVisitor visitor;
-  if (!visitor.Visit(fields, PrintVisitors() ? "-- Init\n" : "")) {
+  if (!visitor.Visit(fields)) {
     JXL_ABORT("Init should never fail");
   }
 }
 void Bundle::SetDefault(Fields* fields) {
   SetDefaultVisitor visitor;
-  if (!visitor.Visit(fields, PrintVisitors() ? "-- SetDefault\n" : "")) {
+  if (!visitor.Visit(fields)) {
     JXL_ABORT("SetDefault should never fail");
   }
 }
 bool Bundle::AllDefault(const Fields& fields) {
-  AllDefaultVisitor visitor(/*print_all_default=*/PrintAllDefault());
-  const char* name =
-      (PrintVisitors() || PrintAllDefault()) ? "[[AllDefault\n" : "";
-  if (!visitor.VisitConst(fields, name)) {
+  AllDefaultVisitor visitor;
+  if (!visitor.VisitConst(fields)) {
     JXL_ABORT("AllDefault should never fail");
   }
-
-  if (PrintAllDefault()) printf("  %d]]\n", visitor.AllDefault());
   return visitor.AllDefault();
 }
 size_t Bundle::MaxBits(const Fields& fields) {
@@ -680,28 +602,25 @@ size_t Bundle::MaxBits(const Fields& fields) {
 #else
   (void)
 #endif  // JXL_ENABLE_ASSERT
-      visitor.VisitConst(fields, PrintVisitors() ? "-- MaxBits\n" : "");
+      visitor.VisitConst(fields);
   JXL_ASSERT(ret);
   return visitor.MaxBits();
 }
 Status Bundle::CanEncode(const Fields& fields, size_t* extension_bits,
                          size_t* total_bits) {
-  CanEncodeVisitor visitor(/*print_sizes=*/PrintSizes());
-  const char* name = (PrintVisitors() || PrintSizes()) ? "[[CanEncode\n" : "";
-  JXL_QUIET_RETURN_IF_ERROR(visitor.VisitConst(fields, name));
+  CanEncodeVisitor visitor;
+  JXL_QUIET_RETURN_IF_ERROR(visitor.VisitConst(fields));
   JXL_QUIET_RETURN_IF_ERROR(visitor.GetSizes(extension_bits, total_bits));
-  if (PrintSizes()) printf("  %zu]]\n", *total_bits);
   return true;
 }
 Status Bundle::Read(BitReader* reader, Fields* fields) {
-  ReadVisitor visitor(reader, /*print_read=*/PrintRead());
-  JXL_RETURN_IF_ERROR(
-      visitor.Visit(fields, PrintVisitors() ? "-- Read\n" : ""));
+  ReadVisitor visitor(reader);
+  JXL_RETURN_IF_ERROR(visitor.Visit(fields));
   return visitor.OK();
 }
 bool Bundle::CanRead(BitReader* reader, Fields* fields) {
-  ReadVisitor visitor(reader, /*print_read=*/PrintRead());
-  Status status = visitor.Visit(fields, PrintVisitors() ? "-- Read\n" : "");
+  ReadVisitor visitor(reader);
+  Status status = visitor.Visit(fields);
   // We are only checking here whether there are enough bytes. We still return
   // true for other errors because it means there are enough bytes to determine
   // there's an error. Use Read() to determine which error it is.
@@ -714,8 +633,7 @@ Status Bundle::Write(const Fields& fields, BitWriter* writer, size_t layer,
 
   BitWriter::Allotment allotment(writer, total_bits);
   WriteVisitor visitor(extension_bits, writer);
-  JXL_RETURN_IF_ERROR(
-      visitor.VisitConst(fields, PrintVisitors() ? "-- Write\n" : ""));
+  JXL_RETURN_IF_ERROR(visitor.VisitConst(fields));
   JXL_RETURN_IF_ERROR(visitor.OK());
   ReclaimAndCharge(writer, &allotment, layer, aux_out);
   return true;

--- a/lib/jxl/fields.h
+++ b/lib/jxl/fields.h
@@ -181,15 +181,6 @@ class Bundle {
  public:
   static constexpr size_t kMaxExtensions = 64;  // bits in u64
 
-  // Print the type of each visitor called.
-  static constexpr bool PrintVisitors() { return false; }
-  // Print default value for each field and AllDefault result.
-  static constexpr bool PrintAllDefault() { return false; }
-  // Print values decoded for each field in Read.
-  static constexpr bool PrintRead() { return false; }
-  // Print size for each field and CanEncode total_bits.
-  static constexpr bool PrintSizes() { return false; }
-
   // Initializes fields to the default values. It is not recursive to nested
   // fields, this function is intended to be called in the constructors so
   // each nested field will already Init itself.
@@ -235,7 +226,7 @@ class Bundle {
 class Visitor {
  public:
   virtual ~Visitor() = default;
-  virtual Status Visit(Fields* fields, const char* visitor_name) = 0;
+  virtual Status Visit(Fields* fields) = 0;
 
   virtual Status Bool(bool default_value, bool* JXL_RESTRICT value) = 0;
   virtual Status U32(U32Enc, uint32_t, uint32_t*) = 0;
@@ -283,16 +274,13 @@ class Visitor {
 
   // Returns the result of visiting a nested Bundle.
   // Overridden by InitVisitor.
-  virtual Status VisitNested(Fields* fields) { return Visit(fields, ""); }
+  virtual Status VisitNested(Fields* fields) { return Visit(fields); }
 
   // Overridden by ReadVisitor. Enables dynamically-sized fields.
   virtual bool IsReading() const { return false; }
 
   virtual Status BeginExtensions(uint64_t* JXL_RESTRICT extensions) = 0;
   virtual Status EndExtensions() = 0;
-
-  // For debugging
-  virtual const char* VisitorName() = 0;
 };
 
 }  // namespace jxl


### PR DESCRIPTION
I don't think we still need these — and if we do, it currently requires manually enabling printing by editing the code anyway, so you can just as well just fetch a version of `fields.*` from before this commit.

Not all the printed strings are detected by the compiler to be in unreachable code, so they did end up in the binary. So this is a (very minor) binary size improvement.

This instrumentation was useful when debugging the (quite complicated) header field mechanism with its various visitors, but I think it's safe to say that it now just works and we don't need the debug instrumentation anymore.