### PR TITLE
Remove sys/platform/ppc.h include.

### DIFF
--- a/tools/cpu/cpu.cc
+++ b/tools/cpu/cpu.cc
@@ -18,10 +18,6 @@
 #endif
 #endif
 
-#if JXL_ARCH_PPC
-#include <sys/platform/ppc.h>  // __ppc_get_timebase_freq
-#endif
-
 #if JXL_ARCH_ARM
 #include <unistd.h>  // sysconf
 #endif


### PR DESCRIPTION
According to the comment this include was used for
`__ppc_get_timebase_freq` at some point in this file but nowadays that
function is not there, so we can remove the include. Fixes #677.