### PR TITLE
tweaks to lossless jpeg recompression

### DIFF
--- a/lib/jxl/enc_cache.cc
+++ b/lib/jxl/enc_cache.cc
@@ -165,7 +165,7 @@ void InitializePassesEncoder(const Image3F& opsin, ThreadPool* pool,
           dc, group_index,
           enc_state->cparams.butteraugli_distance >= 2.0f &&
               enc_state->cparams.speed_tier < SpeedTier::kFalcon,
-          enc_state);
+          enc_state, /*jpeg_transcode=*/true);
     };
     RunOnPool(pool, 0, shared.frame_dim.num_dc_groups, ThreadPool::SkipInit(),
               compute_dc_coeffs, "Compute DC coeffs");

--- a/lib/jxl/enc_modular.h
+++ b/lib/jxl/enc_modular.h
@@ -42,7 +42,7 @@ class ModularFrameEncoder {
   // `nl_dc` decides whether to apply a near-lossless processing to the DC or
   // not.
   void AddVarDCTDC(const Image3F& dc, size_t group_index, bool nl_dc,
-                   PassesEncoderState* enc_state);
+                   PassesEncoderState* enc_state, bool jpeg_transcode);
   // Creates a modular image for the AC metadata of the given group
   // (`group_index`).
   void AddACMetadata(size_t group_index, bool jpeg_transcode,


### PR DESCRIPTION
Some small tweaks to the lossless jpeg recompression encoder choices:
- slightly adjust AC context model (use fewer contexts for smaller images)
- allow more effort to be spent on DC at -e 8, -e 9
- don't call ClusterGroups() at -e 9, it makes -e 9 extremely slow for little benefit

Tested on a corpus of the (large) CTC images + jyrki's testset (of mostly smaller images), converted to jpeg with imagemagick -quality 70 and 90. Times and sizes are totals for the whole set. Speed was not measured very accurately, but it gives an idea.

At q70:

| effort | size before | size after | time before | time after |
|-------|------------|-----------|----------|--------|
| e3 | 7,464,028 | 7,460,659  | 2.4s | 2.4s | 
| e7 | 7,460,245 | 7,456,938 | 2.5s | 2.5s |
| e8 | 7,449,599 | 7,434,265  | 4.0s | 5.1s |
| e9 | 7,449,426 | 7,430,898 | 4m39s | 22.7s |

At q90:

| effort | size before | size after | time before | time after |
|-------|------------|-----------|----------|--------|
| e3 | 17,737,365 | 17,719,048 | 4.8s | 4.6s | 
| e7 | 17,719,499 | 17,702,678 | 4.9s | 4.9s |
| e8 | 17,679,099 | 17,636,227  | 7.9s | 10.7s |
| e9 | 17,675,316 | 17,632,400 | 11m36s | 1m6s |

Some per-image statistics to indicate how consistent the results are:
At default speed (e7), for q70, the worst case was 0.34% larger (after this change compared to before this change), the best case was 0.73% smaller, and the median case was 0.2% smaller. For q90, the worst case was 0.02% larger, the best case was 0.81% smaller, and the median case was 0.43% smaller.

At slowest speed (e9), which becomes about 10x faster with this change, for q70, the worst case was 0.27% larger, the best case was 1.48% smaller, and the median case was 0.35% smaller. At q90, the worst case was 0.08% larger, the best case 1.49% smaller, and the median case 0.6% smaller.