### PR TITLE
silly copy/paste error

### DIFF
--- a/lib/jxl/enc_cache.cc
+++ b/lib/jxl/enc_cache.cc
@@ -165,7 +165,7 @@ void InitializePassesEncoder(const Image3F& opsin, ThreadPool* pool,
           dc, group_index,
           enc_state->cparams.butteraugli_distance >= 2.0f &&
               enc_state->cparams.speed_tier < SpeedTier::kFalcon,
-          enc_state, /*jpeg_transcode=*/true);
+          enc_state, /*jpeg_transcode=*/false);
     };
     RunOnPool(pool, 0, shared.frame_dim.num_dc_groups, ThreadPool::SkipInit(),
               compute_dc_coeffs, "Compute DC coeffs");


### PR DESCRIPTION
`true` is not the same thing as `false`, as I noticed minutes after merging https://github.com/libjxl/libjxl/pull/679

Sorry about that.