### PR TITLE
DC tweaks

### DIFF
--- a/lib/jxl/enc_cache.cc
+++ b/lib/jxl/enc_cache.cc
@@ -163,7 +163,7 @@ void InitializePassesEncoder(const Image3F& opsin, ThreadPool* pool,
     auto compute_dc_coeffs = [&](int group_index, int /* thread */) {
       modular_frame_encoder->AddVarDCTDC(
           dc, group_index,
-          enc_state->cparams.butteraugli_distance >= 2.0f &&
+          enc_state->cparams.butteraugli_distance >= 2.5f &&
               enc_state->cparams.speed_tier < SpeedTier::kFalcon,
           enc_state, /*jpeg_transcode=*/false);
     };

--- a/lib/jxl/enc_modular.cc
+++ b/lib/jxl/enc_modular.cc
@@ -1384,6 +1384,7 @@ Status ModularFrameEncoder::PrepareStreamParams(const Rect& rect,
   return true;
 }
 
+constexpr float q_deadzone = 0.666f;
 int QuantizeWP(const int32_t* qrow, size_t onerow, size_t c, size_t x, size_t y,
                size_t w, weighted::State* wp_state, float value,
                float inv_factor) {
@@ -1391,6 +1392,7 @@ int QuantizeWP(const int32_t* qrow, size_t onerow, size_t c, size_t x, size_t y,
   PredictionResult pred =
       PredictNoTreeWP(w, qrow + x, onerow, x, y, Predictor::Weighted, wp_state);
   svalue -= pred.guess;
+  if (svalue > -q_deadzone && svalue < q_deadzone) svalue = 0;
   int residual = roundf(svalue);
   if (residual > 2 || residual < -2) residual = roundf(svalue * 0.5) * 2;
   return residual + pred.guess;
@@ -1402,6 +1404,7 @@ int QuantizeGradient(const int32_t* qrow, size_t onerow, size_t c, size_t x,
   PredictionResult pred =
       PredictNoTreeNoWP(w, qrow + x, onerow, x, y, Predictor::Gradient);
   svalue -= pred.guess;
+  if (svalue > -q_deadzone && svalue < q_deadzone) svalue = 0;
   int residual = roundf(svalue);
   if (residual > 2 || residual < -2) residual = roundf(svalue * 0.5) * 2;
   return residual + pred.guess;
@@ -1421,7 +1424,7 @@ void ModularFrameEncoder::AddVarDCTDC(const Image3F& dc, size_t group_index,
   if (cparams.speed_tier >= SpeedTier::kSquirrel) {
     stream_options[stream_id].tree_kind = ModularOptions::TreeKind::kWPFixedDC;
   }
-  if (cparams.speed_tier < SpeedTier::kSquirrel && jpeg_transcode) {
+  if (cparams.speed_tier < SpeedTier::kSquirrel && !nl_dc) {
     stream_options[stream_id].predictor =
         (cparams.speed_tier < SpeedTier::kKitten ? Predictor::Variable
                                                  : Predictor::Best);


### PR DESCRIPTION
Changes some things in the way VarDCT DC gets encoded in the usual (no DC frame) case.

- Modifies the threshold at which extralevels=1 ('near-lossless') DC is done instead of extralevels=0 from d>=2.0 to d>=2.5
- Introduces mild deadzone quantization in the extralevels approach (round -2/3 .. 2/3 residuals to zero instead of -1/2 .. 1/2)
- Allows arbitrary predictors and MA trees in the -e 8 and -e 9 case (only for d < 2.5 and when faster_decoding==0), causing slower enc/dec but somewhat better density

This results in about 0.5% better BPP*pnorm and about 1% lower bpp.

I looked at a few images manually (mostly at d2, where pnorm tends to go up a bit) and couldn't spot any issues (couldn't see any difference between images before and after these changes), but it would be good if a few experienced quality checkers like @jyrkialakuijala and @veluca93 could take a look at some images before and after this PR.


Before (on CTC images + jyrki's testset + maybe one or two other random images that happened to be in my test dir):
```
Encoding                        kPixels    Bytes          BPP  E MP/s  D MP/s     Max norm        pnorm       BPP*pnorm   Bugs
------------------------------------------------------------------------------------------------------------------------------
jxl:d0.5:8                        57482 18263763    2.5418209   0.547  27.489   1.22900844   0.34877706  0.886528829665      0
jxl:d0.5:9                        57482 18496145    2.5741622   0.067  27.115   0.92398560   0.34085196  0.877408231456      0
jxl:d0.7:8                        57482 14381068    2.0014550   0.543  27.190   1.72039413   0.46435144  0.929378504606      0
jxl:d0.7:9                        57482 14484573    2.0158601   0.083  27.389   1.37767184   0.45774085  0.922741500108      0
jxl:d1:8                          57482 11009402    1.5322104   0.556  29.142   2.79407597   0.62491593  0.957502707665      0
jxl:d1:9                          57482 11056123    1.5387127   0.110  28.819   1.74976742   0.61783670  0.950673203613      0
jxl:d1.5:8                        57482  8072319    1.1234481   0.565  28.838   3.38287067   0.85383911  0.959243898342      0
jxl:d1.5:9                        57482  8085457    1.1252765   0.144  28.823   2.61590171   0.84945329  0.955869843009      0
jxl:d2:6                          57482  7036825    0.9793354  14.372  29.551   8.00096035   1.03067219  1.009373720127      0
jxl:d2:6:faster_decoding=3        57482  7179421    0.9991809  18.509  36.688   8.02611542   1.03782556  1.036975438798      0
jxl:d2                            57482  7025337    0.9777365   6.626  29.310   8.18064690   1.02123190  0.998495747657      0
jxl:d2:8                          57482  6548377    0.9113566   0.564  29.609   5.99368095   1.05789856  0.964122874153      0
jxl:d2:9                          57482  6551940    0.9118525   0.191  29.454   2.45867181   1.04690054  0.954618885348      0
jxl:d2.5:6                        57482  5965166    0.8301895  14.862  29.908  11.54874897   1.21477317  1.008491890688      0
jxl:d2.5:6:faster_decoding=3      57482  6081678    0.8464048  19.007  37.328  11.44617748   1.22371579  1.035758899191      0
jxl:d2.5                          57482  5950986    0.8282160   6.664  29.167   7.46087646   1.17694860  0.974767655090      0
jxl:d3:6                          57482  5204884    0.7243788  15.074  29.888  10.20740032   1.36510175  0.988850792394      0
jxl:d3:6:faster_decoding=3        57482  5293899    0.7367673  19.319  37.960   8.95996094   1.37357728  1.012006812160      0
jxl:d3                            57482  5193751    0.7228294   6.191  29.356  10.90374947   1.34876411  0.974926358043      0
jxl:d4:6                          57482  4229125    0.5885796  15.518  19.503  11.25011444   1.66345190  0.979073858999      0
jxl:d4:6:faster_decoding=3        57482  4296815    0.5980002  19.679  39.592  11.08001709   1.68226441  1.005994484285      0
jxl:d4                            57482  4221459    0.5875127   6.378  19.473  11.15707970   1.64387580  0.965797915919      0
jxl:d5                            57482  3450679    0.4802410   5.924  18.175  10.13587284   1.90777165  0.916190191567      0
Aggregate:                        57482  7290006    1.0145713   2.180  28.618   5.01028703   0.95324430  0.967134347427      0
```

After:
```
Encoding                        kPixels    Bytes          BPP  E MP/s  D MP/s     Max norm        pnorm       BPP*pnorm   Bugs
------------------------------------------------------------------------------------------------------------------------------
jxl:d0.5:8                        57482 18234606    2.5377631   0.480  24.385   1.22900844   0.34877706  0.885113539668      0
jxl:d0.5:9                        57482 18463063    2.5695581   0.061  24.654   0.92398560   0.34085196  0.875838908816      0
jxl:d0.7:8                        57482 14352802    1.9975211   0.452  23.194   1.72039413   0.46435144  0.927551810454      0
jxl:d0.7:9                        57482 14451808    2.0113001   0.072  23.252   1.37767184   0.45774085  0.920654201763      0
jxl:d1:8                          57482 10989078    1.5293819   0.488  25.874   2.79407597   0.62491593  0.955735101665      0
jxl:d1:9                          57482 11024140    1.5342616   0.097  25.312   1.74976742   0.61783670  0.947923109292      0
jxl:d1.5:8                        57482  8052560    1.1206982   0.493  26.036   3.38287067   0.85383911  0.956895911327      0
jxl:d1.5:9                        57482  8052626    1.1207073   0.126  25.724   2.61590171   0.84945329  0.951988533293      0
jxl:d2:6                          57482  6894964    0.9595922  14.219  27.864   7.95051956   1.05405872  1.011466478849      0
jxl:d2:6:faster_decoding=3        57482  7029215    0.9782763  18.276  32.720   7.95051956   1.06089165  1.037845110374      0
jxl:d2                            57482  6883802    0.9580387   6.137  26.987   8.09981728   1.03256587  0.989238074795      0
jxl:d2:8                          57482  6383066    0.8883498   0.491  25.194   5.85797405   1.06650842  0.947432564842      0
jxl:d2:9                          57482  6371467    0.8867356   0.171  26.494   2.49288702   1.05705576  0.937328933867      0
jxl:d2.5:6                        57482  5925893    0.8247237  13.999  28.176  11.27026463   1.21401802  1.001229471294      0
jxl:d2.5:6:faster_decoding=3      57482  6041676    0.8408376  17.756  34.661  11.73111916   1.22773796  1.032328222472      0
jxl:d2.5                          57482  5911605    0.8227352   6.089  27.600   7.07468653   1.17908757  0.970076886439      0
jxl:d3:6                          57482  5163757    0.7186551  13.987  27.348  10.65434074   1.37103860  0.985303817676      0
jxl:d3:6:faster_decoding=3        57482  5250805    0.7307698  17.446  34.743   8.96774292   1.37689012  1.006189682437      0
jxl:d3                            57482  5152039    0.7170242   5.596  26.733  11.10146141   1.35333575  0.970374515985      0
jxl:d4:6                          57482  4183935    0.5822904  13.967  18.165  10.58452320   1.66447547  0.969208051724      0
jxl:d4:6:faster_decoding=3        57482  4249118    0.5913621  18.463  35.927  11.20845604   1.68713234  0.997706100746      0
jxl:d4                            57482  4176283    0.5812254   5.586  18.054  10.92675591   1.64723124  0.957412683236      0
jxl:d5                            57482  3450679    0.4802410   5.261  16.157  10.13587284   1.90777165  0.916190191567      0
Aggregate:                        57482  7223458    1.0053096   1.968  25.842   4.98933214   0.95712179  0.962203711470      0
```

