### PR TITLE
AC block ctx tweaks

### DIFF
--- a/lib/jxl/enc_cache.cc
+++ b/lib/jxl/enc_cache.cc
@@ -163,7 +163,7 @@ void InitializePassesEncoder(const Image3F& opsin, ThreadPool* pool,
     auto compute_dc_coeffs = [&](int group_index, int /* thread */) {
       modular_frame_encoder->AddVarDCTDC(
           dc, group_index,
-          enc_state->cparams.butteraugli_distance >= 2.0f &&
+          enc_state->cparams.butteraugli_distance >= 2.5f &&
               enc_state->cparams.speed_tier < SpeedTier::kFalcon,
           enc_state, /*jpeg_transcode=*/false);
     };

--- a/lib/jxl/enc_heuristics.cc
+++ b/lib/jxl/enc_heuristics.cc
@@ -125,8 +125,9 @@ void FindBestBlockEntropyModel(PassesEncoderState& enc_state) {
   std::vector<uint8_t> remap((qft.size() + 1) * kNumOrders);
   std::iota(remap.begin(), remap.end(), 0);
   std::vector<uint8_t> clusters(remap);
-  size_t nb_clusters = Clamp1((int)(tot / size_for_ctx_model / 2), 4, 8);
-  // This is O(n^2 log n), but n <= 14.
+  size_t nb_clusters = Clamp1((int)(tot / size_for_ctx_model / 2), 2, 9);
+  size_t nb_clusters_chroma = Clamp1((int)(tot / size_for_ctx_model / 3), 1, 5);
+  // This is O(n^2 log n), but n is small.
   while (clusters.size() > nb_clusters) {
     std::sort(clusters.begin(), clusters.end(),
               [&](int a, int b) { return counts[a] > counts[b]; });
@@ -153,8 +154,11 @@ void FindBestBlockEntropyModel(PassesEncoderState& enc_state) {
   auto& ctx_map = enc_state.shared.block_ctx_map.ctx_map;
   ctx_map = remap;
   ctx_map.resize(remap.size() * 3);
+  // for chroma, only use up to nb_clusters_chroma separate block contexts
+  // (those for the biggest clusters)
   for (size_t i = remap.size(); i < remap.size() * 3; i++) {
-    ctx_map[i] = remap[i % remap.size()] + num;
+    ctx_map[i] = num + Clamp1((int)remap[i % remap.size()], 0,
+                              (int)nb_clusters_chroma - 1);
   }
   enc_state.shared.block_ctx_map.num_ctxs =
       *std::max_element(ctx_map.begin(), ctx_map.end()) + 1;

--- a/lib/jxl/enc_modular.cc
+++ b/lib/jxl/enc_modular.cc
@@ -1384,6 +1384,7 @@ Status ModularFrameEncoder::PrepareStreamParams(const Rect& rect,
   return true;
 }
 
+constexpr float q_deadzone = 0.666f;
 int QuantizeWP(const int32_t* qrow, size_t onerow, size_t c, size_t x, size_t y,
                size_t w, weighted::State* wp_state, float value,
                float inv_factor) {
@@ -1391,6 +1392,7 @@ int QuantizeWP(const int32_t* qrow, size_t onerow, size_t c, size_t x, size_t y,
   PredictionResult pred =
       PredictNoTreeWP(w, qrow + x, onerow, x, y, Predictor::Weighted, wp_state);
   svalue -= pred.guess;
+  if (svalue > -q_deadzone && svalue < q_deadzone) svalue = 0;
   int residual = roundf(svalue);
   if (residual > 2 || residual < -2) residual = roundf(svalue * 0.5) * 2;
   return residual + pred.guess;
@@ -1402,6 +1404,7 @@ int QuantizeGradient(const int32_t* qrow, size_t onerow, size_t c, size_t x,
   PredictionResult pred =
       PredictNoTreeNoWP(w, qrow + x, onerow, x, y, Predictor::Gradient);
   svalue -= pred.guess;
+  if (svalue > -q_deadzone && svalue < q_deadzone) svalue = 0;
   int residual = roundf(svalue);
   if (residual > 2 || residual < -2) residual = roundf(svalue * 0.5) * 2;
   return residual + pred.guess;
@@ -1421,7 +1424,7 @@ void ModularFrameEncoder::AddVarDCTDC(const Image3F& dc, size_t group_index,
   if (cparams.speed_tier >= SpeedTier::kSquirrel) {
     stream_options[stream_id].tree_kind = ModularOptions::TreeKind::kWPFixedDC;
   }
-  if (cparams.speed_tier < SpeedTier::kSquirrel && jpeg_transcode) {
+  if (cparams.speed_tier < SpeedTier::kSquirrel && !nl_dc) {
     stream_options[stream_id].predictor =
         (cparams.speed_tier < SpeedTier::kKitten ? Predictor::Variable
                                                  : Predictor::Best);


### PR DESCRIPTION
Slight density improvement by tweaking the AC block_ctx heuristics to potentially use one more luma block context and to use fewer chroma block contexts. Entropy coding change only, no impact on quality.

~0.13% improvement in bpp*pnorm at wombat speed, ~0.16% improvement at kitten speed.

Before:
```
Encoding      kPixels    Bytes          BPP  E MP/s  D MP/s     Max norm        pnorm       BPP*pnorm   Bugs
------------------------------------------------------------------------------------------------------------
jxl:d0.5:6      13270  4148974    2.5011808   3.833  25.017   1.40471935   0.39751908  0.994267082827      0
jxl:d1:6        13270  2673109    1.6114656   4.181  26.931   1.78735065   0.62486282  1.006944939222      0
jxl:d2:6        13270  1652861    0.9964160   4.229  25.503   3.08057809   1.00276867  0.999174770654      0
jxl:d3:6        13270  1239422    0.7471771   4.304  25.090   3.84514308   1.31766203  0.984526936213      0
jxl:d4:6        13270  1000128    0.6029204   4.192  15.051   5.31905365   1.60527906  0.967855444002      0
jxl:d6:6        13270   718936    0.4334057   4.266  14.360   7.45280504   2.14149141  0.928134544310      0
jxl:d8:6        13270   572614    0.3451965   4.196  14.010   9.50879097   2.61006500  0.900985195516      0
Aggregate:      13270  1376313    0.8297010   4.169  20.056   3.78893924   1.16683482  0.968124009829      0
```

After:
```
Encoding      kPixels    Bytes          BPP  E MP/s  D MP/s     Max norm        pnorm       BPP*pnorm   Bugs
------------------------------------------------------------------------------------------------------------
jxl:d0.5:6      13270  4145352    2.4989973   3.992  27.402   1.40471935   0.39751908  0.993399100677      0
jxl:d1:6        13270  2669631    1.6093689   4.311  27.699   1.78735065   0.62486282  1.005634796426      0
jxl:d2:6        13270  1650662    0.9950904   4.512  26.426   3.08057809   1.00276867  0.997845448152      0
jxl:d3:6        13270  1237692    0.7461342   4.376  25.946   3.84514308   1.31766203  0.983152721781      0
jxl:d4:6        13270   998583    0.6019890   4.337  14.965   5.31905365   1.60527906  0.966360298719      0
jxl:d6:6        13270   717511    0.4325466   4.307  14.832   7.45280504   2.14149141  0.926294892762      0
jxl:d8:6        13270   572284    0.3449975   4.331  14.468   9.50879097   2.61006500  0.900465953733      0
Aggregate:      13270  1374543    0.8286337   4.307  20.777   3.78893924   1.16683482  0.966878705111      0
```

Before:
```
Encoding      kPixels    Bytes          BPP  E MP/s  D MP/s     Max norm        pnorm       BPP*pnorm   Bugs
------------------------------------------------------------------------------------------------------------
jxl:d0.5:8      13270  4372401    2.6358722   0.428  22.632   0.82337618   0.35225850  0.928508392534      0
jxl:d1:8        13270  2621824    1.5805488   0.436  23.268   1.47186911   0.61985069  0.979704258312      0
jxl:d2:8        13270  1548518    0.9335136   0.448  23.338   2.68204546   1.04558914  0.976071637065      0
jxl:d3:8        13270  1145436    0.6905183   0.448  23.596   3.82011271   1.39642941  0.964260077893      0
jxl:d4:8        13270   912144    0.5498798   0.435  14.021   4.91579628   1.72018522  0.945895126890      0
jxl:d6:8        13270   644420    0.3884842   0.408  13.321   7.04024458   2.30491263  0.895422181020      0
jxl:d8:8        13270   513887    0.3097933   0.408  12.527   9.20119476   2.83191734  0.877308977184      0
Aggregate:      13270  1296032    0.7813042   0.430  18.266   3.26484250   1.19983034  0.937432523503      0
```

After:
```
Encoding      kPixels    Bytes          BPP  E MP/s  D MP/s     Max norm        pnorm       BPP*pnorm   Bugs
------------------------------------------------------------------------------------------------------------
jxl:d0.5:8      13270  4370248    2.6345743   0.485  24.441   0.82337618   0.35225850  0.928051188684      0
jxl:d1:8        13270  2617319    1.5778330   0.500  26.102   1.47186911   0.61985069  0.978020862446      0
jxl:d2:8        13270  1545126    0.9314687   0.510  26.418   2.68204546   1.04558914  0.973933570221      0
jxl:d3:8        13270  1143533    0.6893711   0.516  27.367   3.82011271   1.39642941  0.962658079241      0
jxl:d4:8        13270   910118    0.5486585   0.498  15.802   4.91579628   1.72018522  0.943794160894      0
jxl:d6:8        13270   643386    0.3878609   0.465  14.571   7.04024458   2.30491263  0.893985437072      0
jxl:d8:8        13270   513104    0.3093213   0.455  14.185   9.20119476   2.83191734  0.875972237922      0
Aggregate:      13270  1293919    0.7800304   0.489  20.471   3.26484250   1.19983034  0.935904121505      0
```
