### PR TITLE
AC quantization deadzone tweaks

### DIFF
--- a/lib/jxl/enc_cache.cc
+++ b/lib/jxl/enc_cache.cc
@@ -163,7 +163,7 @@ void InitializePassesEncoder(const Image3F& opsin, ThreadPool* pool,
     auto compute_dc_coeffs = [&](int group_index, int /* thread */) {
       modular_frame_encoder->AddVarDCTDC(
           dc, group_index,
-          enc_state->cparams.butteraugli_distance >= 2.0f &&
+          enc_state->cparams.butteraugli_distance >= 2.5f &&
               enc_state->cparams.speed_tier < SpeedTier::kFalcon,
           enc_state, /*jpeg_transcode=*/false);
     };

--- a/lib/jxl/enc_group.cc
+++ b/lib/jxl/enc_group.cc
@@ -42,10 +42,10 @@ void QuantizeBlockAC(const Quantizer& quantizer, const bool error_diffusion,
   const float* JXL_RESTRICT qm = quantizer.InvDequantMatrix(quant_kind, c);
   const float qac = quantizer.Scale() * quant;
   // Not SIMD-fied for now.
-  float thres[4] = {0.5f, 0.6f, 0.6f, 0.65f};
+  float thres[4] = {0.6f, 0.633f, 0.666f, 0.7f};
   if (c != 1) {
-    for (int i = 1; i < 4; ++i) {
-      thres[i] = 0.75f;
+    for (int i = 0; i < 4; ++i) {
+      thres[i] += 0.07f;
     }
   }
 

--- a/lib/jxl/enc_heuristics.cc
+++ b/lib/jxl/enc_heuristics.cc
@@ -125,8 +125,9 @@ void FindBestBlockEntropyModel(PassesEncoderState& enc_state) {
   std::vector<uint8_t> remap((qft.size() + 1) * kNumOrders);
   std::iota(remap.begin(), remap.end(), 0);
   std::vector<uint8_t> clusters(remap);
-  size_t nb_clusters = Clamp1((int)(tot / size_for_ctx_model / 2), 4, 8);
-  // This is O(n^2 log n), but n <= 14.
+  size_t nb_clusters = Clamp1((int)(tot / size_for_ctx_model / 2), 2, 9);
+  size_t nb_clusters_chroma = Clamp1((int)(tot / size_for_ctx_model / 3), 1, 5);
+  // This is O(n^2 log n), but n is small.
   while (clusters.size() > nb_clusters) {
     std::sort(clusters.begin(), clusters.end(),
               [&](int a, int b) { return counts[a] > counts[b]; });
@@ -153,8 +154,11 @@ void FindBestBlockEntropyModel(PassesEncoderState& enc_state) {
   auto& ctx_map = enc_state.shared.block_ctx_map.ctx_map;
   ctx_map = remap;
   ctx_map.resize(remap.size() * 3);
+  // for chroma, only use up to nb_clusters_chroma separate block contexts
+  // (those for the biggest clusters)
   for (size_t i = remap.size(); i < remap.size() * 3; i++) {
-    ctx_map[i] = remap[i % remap.size()] + num;
+    ctx_map[i] = num + Clamp1((int)remap[i % remap.size()], 0,
+                              (int)nb_clusters_chroma - 1);
   }
   enc_state.shared.block_ctx_map.num_ctxs =
       *std::max_element(ctx_map.begin(), ctx_map.end()) + 1;

--- a/lib/jxl/enc_modular.cc
+++ b/lib/jxl/enc_modular.cc
@@ -1384,6 +1384,7 @@ Status ModularFrameEncoder::PrepareStreamParams(const Rect& rect,
   return true;
 }
 
+constexpr float q_deadzone = 0.666f;
 int QuantizeWP(const int32_t* qrow, size_t onerow, size_t c, size_t x, size_t y,
                size_t w, weighted::State* wp_state, float value,
                float inv_factor) {
@@ -1391,6 +1392,7 @@ int QuantizeWP(const int32_t* qrow, size_t onerow, size_t c, size_t x, size_t y,
   PredictionResult pred =
       PredictNoTreeWP(w, qrow + x, onerow, x, y, Predictor::Weighted, wp_state);
   svalue -= pred.guess;
+  if (svalue > -q_deadzone && svalue < q_deadzone) svalue = 0;
   int residual = roundf(svalue);
   if (residual > 2 || residual < -2) residual = roundf(svalue * 0.5) * 2;
   return residual + pred.guess;
@@ -1402,6 +1404,7 @@ int QuantizeGradient(const int32_t* qrow, size_t onerow, size_t c, size_t x,
   PredictionResult pred =
       PredictNoTreeNoWP(w, qrow + x, onerow, x, y, Predictor::Gradient);
   svalue -= pred.guess;
+  if (svalue > -q_deadzone && svalue < q_deadzone) svalue = 0;
   int residual = roundf(svalue);
   if (residual > 2 || residual < -2) residual = roundf(svalue * 0.5) * 2;
   return residual + pred.guess;
@@ -1421,7 +1424,7 @@ void ModularFrameEncoder::AddVarDCTDC(const Image3F& dc, size_t group_index,
   if (cparams.speed_tier >= SpeedTier::kSquirrel) {
     stream_options[stream_id].tree_kind = ModularOptions::TreeKind::kWPFixedDC;
   }
-  if (cparams.speed_tier < SpeedTier::kSquirrel && jpeg_transcode) {
+  if (cparams.speed_tier < SpeedTier::kSquirrel && !nl_dc) {
     stream_options[stream_id].predictor =
         (cparams.speed_tier < SpeedTier::kKitten ? Predictor::Variable
                                                  : Predictor::Best);


### PR DESCRIPTION
(builds on top of #688 and #684, comparison is done w.r.t. those PRs merged; will rebase this one if those land)

Adjusts the thresholds for deadzone quantization in AC. This does have impact on quality and density. Generally speaking, the effect is small or not noticeable at low distance; at higher distance, this change results in somewhat more blurring/smoothing and less ringing and visible DCT base patterns — in particular in slow gradient slightly noisy backgrounds, at d4 and higher, there currently tend to be low-contrast visible base patterns, which improve with this change.

Did manual viewing at d2, d3, d4 and d8. To me, it doesn't look like an actual quality regression, despite Butteraugli pnorm generally getting worse. At d2, the visual difference is very small and I cannot really say which is best (before or after). At d4 and d8, there is a clearer visual difference, but I personally typically prefer the after — the main differences are the 'before' image looking like it is 'trying to preserve detail' but doing it in an ugly way (showing a DCT base pattern that looks more like an artifact than image detail), while in the 'after' image, things are a bit smoother. At those low bitrates, when fidelity is low anyway, I personally prefer the smoother option. In some cases, at low distance, it does go in the direction of AVIF-style oversmoothing (especially at the faster speeds where there are no adaptive quant iterations to detect and fix it), but generally I think it's a (small) quality improvement, rather than a regression.

At wombat speed, this is a 0.6% improvement in bpp*pnorm, a 5.6% improvement in density.
At default speed, it's a 0.6% improvement in bpp*pnorm, a 5.3% improvement in density.
At kitten speed, it's a 0.58% improvement in bpp*pnorm, a 4.3% improvement in density.

More opinions are needed, in particular it would be good if @jyrkialakuijala and @lvandeve can take a look at this, but of course others are welcome to give their opinion too. This is a rather big change in terms of visual results, so we need to be careful not to make any fidelity regressions. In my opinion, there is no significant regression and it's just a ~5% density win. But obviously a change like this requires more than just one opinion :)

Some benchmark results on the jyrki testset:

Wombat, before:
```
Encoding      kPixels    Bytes          BPP  E MP/s  D MP/s     Max norm        pnorm       BPP*pnorm   Bugs
------------------------------------------------------------------------------------------------------------
jxl:d0.5:6      13270  4145352    2.4989973   4.082  27.755   1.40471935   0.39751908  0.993399100677      0
jxl:d1:6        13270  2669631    1.6093689   4.177  25.530   1.78735065   0.62486282  1.005634796426      0
jxl:d2:6        13270  1650662    0.9950904   4.319  25.706   3.08057809   1.00276867  0.997845448152      0
jxl:d3:6        13270  1237692    0.7461342   4.357  26.110   3.84514308   1.31766203  0.983152721781      0
jxl:d4:6        13270   998583    0.6019890   4.448  15.117   5.31905365   1.60527906  0.966360298719      0
jxl:d6:6        13270   717511    0.4325466   4.495  15.890   7.45280504   2.14149141  0.926294892762      0
jxl:d8:6        13270   572284    0.3449975   4.519  14.834   9.50879097   2.61006500  0.900465953733      0
Aggregate:      13270  1374543    0.8286337   4.340  20.818   3.78893924   1.16683482  0.966878705111      0
```

Wombat, after:
```
Encoding      kPixels    Bytes          BPP  E MP/s  D MP/s     Max norm        pnorm       BPP*pnorm   Bugs
------------------------------------------------------------------------------------------------------------
jxl:d0.5:6      13270  3982798    2.4010027   3.994  26.629   1.45580149   0.41135961  0.987675544053      0
jxl:d1:6        13270  2546790    1.5353150   4.169  26.394   1.98144031   0.64856314  0.995748750675      0
jxl:d2:6        13270  1561765    0.9414994   4.290  25.051   3.26107335   1.04517436  0.984031048638      0
jxl:d3:6        13270  1166470    0.7031985   4.365  26.705   4.16321659   1.37921386  0.969861132669      0
jxl:d4:6        13270   938386    0.5656996   4.306  14.621   6.14720535   1.70341056  0.963618709715      0
jxl:d6:6        13270   670190    0.4040195   4.248  14.575   8.18618488   2.28411476  0.922826874517      0
jxl:d8:6        13270   534728    0.3223571   4.185  13.744  10.35805321   2.81415429  0.907162730965      0
Aggregate:      13270  1298197    0.7826089   4.221  20.210   4.12763653   1.22799631  0.961040896535      0
```


Default speed, before:
```
Encoding      kPixels    Bytes          BPP  E MP/s  D MP/s     Max norm        pnorm       BPP*pnorm   Bugs
------------------------------------------------------------------------------------------------------------
jxl:d0.5        13270  4149533    2.5015178   2.676  24.448   1.26147425   0.39095048  0.977969580024      0
jxl:d1          13270  2678938    1.6149796   2.921  25.692   1.78285432   0.61857257  0.998982057118      0
jxl:d2          13270  1656707    0.9987346   3.033  23.107   3.14321733   1.00033337  0.999067509763      0
jxl:d3          13270  1245691    0.7509564   2.941  26.388   3.81969762   1.30922044  0.983167407819      0
jxl:d4          13270  1006160    0.6065567   2.753  14.131   5.86349869   1.59430804  0.967038255837      0
jxl:d6          13270   725042    0.4370866   2.848  14.157   7.62232113   2.12312500  0.927989578498      0
jxl:d8          13270   579813    0.3495363   2.823  14.041   9.35824680   2.58072979  0.902058812963      0
Aggregate:      13270  1383537    0.8340561   2.854  19.510   3.79294549   1.15647749  0.964567048624      0
```

Default speed, after:
```
Encoding      kPixels    Bytes          BPP  E MP/s  D MP/s     Max norm        pnorm       BPP*pnorm   Bugs
------------------------------------------------------------------------------------------------------------
jxl:d0.5        13270  3995332    2.4085587   2.792  27.767   1.47424960   0.40440556  0.974034540204      0
jxl:d1          13270  2562972    1.5450703   3.147  29.278   2.17064810   0.64074132  0.989990347902      0
jxl:d2          13270  1571550    0.9473982   3.233  27.284   3.08977270   1.03935205  0.984680302582      0
jxl:d3          13270  1177061    0.7095832   2.907  27.047   4.11304808   1.36756478  0.970401026422      0
jxl:d4          13270   948376    0.5717220   2.968  14.993   6.08318663   1.68524611  0.963492320451      0
jxl:d6          13270   679659    0.4097278   2.948  14.597   7.49222660   2.25038216  0.922044151513      0
jxl:d8          13270   542870    0.3272655   2.966  14.697   9.93046474   2.77931491  0.909573855798      0
Aggregate:      13270  1310212    0.7898525   2.991  21.208   4.06705775   1.21381512  0.958734900330      0
```

Kitten, before:
```
Encoding      kPixels    Bytes          BPP  E MP/s  D MP/s     Max norm        pnorm       BPP*pnorm   Bugs
------------------------------------------------------------------------------------------------------------
jxl:d0.5:8      13270  4370248    2.6345743   0.445  23.682   0.82337618   0.35225850  0.928051188684      0
jxl:d1:8        13270  2617319    1.5778330   0.470  25.723   1.47186911   0.61985069  0.978020862446      0
jxl:d2:8        13270  1545126    0.9314687   0.462  24.071   2.68204546   1.04558914  0.973933570221      0
jxl:d3:8        13270  1143533    0.6893711   0.473  24.885   3.82011271   1.39642941  0.962658079241      0
jxl:d4:8        13270   910118    0.5486585   0.450  14.419   4.91579628   1.72018522  0.943794160894      0
jxl:d6:8        13270   643386    0.3878609   0.432  14.467   7.04024458   2.30491263  0.893985437072      0
jxl:d8:8        13270   513104    0.3093213   0.424  12.890   9.20119476   2.83191734  0.875972237922      0
Aggregate:      13270  1293919    0.7800304   0.451  19.255   3.26484250   1.19983034  0.935904121505      0
```

Kitten, after:
```
Encoding      kPixels    Bytes          BPP  E MP/s  D MP/s     Max norm        pnorm       BPP*pnorm   Bugs
------------------------------------------------------------------------------------------------------------
jxl:d0.5:8      13270  4281346    2.5809803   0.425  22.528   0.91246235   0.35676132  0.920793945798      0
jxl:d1:8        13270  2531251    1.5259475   0.433  23.908   1.57006633   0.63309290  0.966066503164      0
jxl:d2:8        13270  1477849    0.8909112   0.444  23.101   2.63382649   1.07774547  0.960175542597      0
jxl:d3:8        13270  1088666    0.6562949   0.448  23.128   3.77840018   1.44943079  0.951254035630      0
jxl:d4:8        13270   865451    0.5217313   0.436  14.198   5.32216167   1.80119913  0.939741879537      0
jxl:d6:8        13270   609208    0.3672569   0.403  13.059   7.76726770   2.43077285  0.892718108522      0
jxl:d8:8        13270   486099    0.2930415   0.398  12.492  10.06349468   3.02403739  0.886168388916      0
Aggregate:      13270  1238460    0.7465970   0.426  18.220   3.45954539   1.24633853  0.930512600913      0
```
