### PR TITLE
Tiny fix: match StartBox in no-transcode version

### DIFF
--- a/lib/jxl/decode_to_jpeg.h
+++ b/lib/jxl/decode_to_jpeg.h
@@ -153,7 +153,7 @@ class JxlToJpegDecoder {
   }
   size_t ReleaseOutputBuffer() { return 0; }
 
-  void StartBox(uint64_t /* box_size */, size_t /* contents_size */) {}
+  void StartBox(bool /* box_until_eof */, size_t /* contents_size */) {}
 
   JxlDecoderStatus Process(const uint8_t** next_in, size_t* avail_in) {
     return JXL_DEC_ERROR;


### PR DESCRIPTION
Make the function signatures in JPEGXL_ENABLE_TRANSCODE_JPEG and
no-JPEGXL_ENABLE_TRANSCODE_JPEG versions of the code match