### PR TITLE
return early (before init/allocation) if no actual decode will happen

### DIFF
--- a/lib/jxl/dec_frame.cc
+++ b/lib/jxl/dec_frame.cc
@@ -148,7 +148,8 @@ Status DecodeFrame(const DecompressParams& dparams,
 
   JXL_RETURN_IF_ERROR(frame_decoder.InitFrame(
       reader, decoded, is_preview, dparams.allow_partial_files,
-      dparams.allow_partial_files && dparams.allow_more_progressive_steps));
+      dparams.allow_partial_files && dparams.allow_more_progressive_steps,
+      true));
 
   // Handling of progressive decoding.
   {
@@ -234,7 +235,8 @@ Status DecodeFrame(const DecompressParams& dparams,
 
 Status FrameDecoder::InitFrame(BitReader* JXL_RESTRICT br, ImageBundle* decoded,
                                bool is_preview, bool allow_partial_frames,
-                               bool allow_partial_dc_global) {
+                               bool allow_partial_dc_global,
+                               bool output_needed) {
   PROFILER_FUNC;
   decoded_ = decoded;
   JXL_ASSERT(is_finalized_);
@@ -286,6 +288,8 @@ Status FrameDecoder::InitFrame(BitReader* JXL_RESTRICT br, ImageBundle* decoded,
         "Non-444 chroma subsampling is not allowed when adaptive DC "
         "smoothing is enabled");
   }
+
+  if (!output_needed) return true;
   JXL_RETURN_IF_ERROR(
       InitializePassesSharedState(frame_header_, &dec_state_->shared_storage));
   JXL_RETURN_IF_ERROR(dec_state_->Init());

--- a/lib/jxl/dec_frame.h
+++ b/lib/jxl/dec_frame.h
@@ -71,7 +71,7 @@ class FrameDecoder {
   // on callers.
   Status InitFrame(BitReader* JXL_RESTRICT br, ImageBundle* decoded,
                    bool is_preview, bool allow_partial_frames,
-                   bool allow_partial_dc_global);
+                   bool allow_partial_dc_global, bool output_needed);
 
   struct SectionInfo {
     BitReader* JXL_RESTRICT br;

--- a/lib/jxl/decode.cc
+++ b/lib/jxl/decode.cc
@@ -1260,7 +1260,8 @@ JxlDecoderStatus JxlDecoderProcessCodestream(JxlDecoder* dec, const uint8_t* in,
 
       jxl::Status status = dec->frame_dec->InitFrame(
           reader.get(), dec->ib.get(), /*is_preview=*/false,
-          /*allow_partial_frames=*/true, /*allow_partial_dc_global=*/false);
+          /*allow_partial_frames=*/true, /*allow_partial_dc_global=*/false,
+          /*output_needed=*/dec->events_wanted & JXL_DEC_FULL_IMAGE);
       if (!status) JXL_API_RETURN_IF_ERROR(status);
 
       size_t sections_begin =


### PR DESCRIPTION
When no actual decode will happen, just parsing of frameheader/TOC, there is no need to actually initialize things and allocate internal stuff that will be used during decode. Also it's not a good idea to check things like the presence of DC frames since they will not have been decoded either, but that's OK since the frame itself will not be decoded. So just return early (after reading the frameheader and TOC, but before the actual frame decoder initialization).

This fixes https://github.com/libjxl/libjxl/issues/699 and somewhat reduces the memory footprint of `jxlinfo` and other applications that just want to get info about frames without doing actual decode.
