### PR TITLE
adjust MA tree size limits

### DIFF
--- a/lib/jxl/dec_modular.cc
+++ b/lib/jxl/dec_modular.cc
@@ -159,17 +159,18 @@ Status ModularFrameDecoder::DecodeGlobalInfo(BitReader* reader,
   if (is_gray && frame_header.color_transform == ColorTransform::kNone) {
     nb_chans = 1;
   }
+  do_color = decode_color;
+  if (!do_color) nb_chans = 0;
+  size_t nb_extra = metadata.extra_channel_info.size();
   bool has_tree = reader->ReadBits(1);
   if (has_tree) {
-    size_t tree_size_limit =
-        1024 + frame_dim.xsize * frame_dim.ysize * nb_chans / 16;
+    size_t tree_size_limit = std::min(
+        static_cast<size_t>(1 << 22),
+        1024 + frame_dim.xsize * frame_dim.ysize * (nb_chans + nb_extra) / 16);
     JXL_RETURN_IF_ERROR(DecodeTree(reader, &tree, tree_size_limit));
     JXL_RETURN_IF_ERROR(
         DecodeHistograms(reader, (tree.size() + 1) / 2, &code, &context_map));
   }
-  do_color = decode_color;
-  if (!do_color) nb_chans = 0;
-  size_t nb_extra = metadata.extra_channel_info.size();
 
   bool fp = metadata.bit_depth.floating_point_sample;
 

--- a/lib/jxl/modular/encoding/encoding.cc
+++ b/lib/jxl/modular/encoding/encoding.cc
@@ -447,7 +447,7 @@ Status ModularDecode(BitReader *br, Image &image, GroupHeader &header,
       max_tree_size += pixels;
       if (max_tree_size < pixels) return JXL_FAILURE("Tree size overflow");
     }
-
+    max_tree_size = std::min(static_cast<size_t>(1 << 20), max_tree_size);
     JXL_RETURN_IF_ERROR(DecodeTree(br, &tree_storage, max_tree_size));
     JXL_RETURN_IF_ERROR(DecodeHistograms(br, (tree_storage.size() + 1) / 2,
                                          &code_storage, &context_map_storage));


### PR DESCRIPTION
The global MA tree limit was computed without taking extra channels into account. Also added a hard cap of 1<<22 for global trees and 1<<20 for local ones.