### PR TITLE
fix std::fmin compilation issue

### DIFF
--- a/plugins/gimp/file-jxl-save.cc
+++ b/plugins/gimp/file-jxl-save.cc
@@ -5,6 +5,8 @@
 
 #include "plugins/gimp/file-jxl-save.h"
 
+#include <cmath>
+
 #include "gobject/gsignal.h"
 
 #define PLUG_IN_BINARY "file-jxl"


### PR DESCRIPTION
When building with msan I get compiler errors about std::fmin, including
cmath fixes it. Likely this is platform dependent since I don't get it
without msan, and the continuous integration doesn't seem to get the
error with msan either.