### PR TITLE
Fix gbench build in Docker

### DIFF
--- a/lib/jxl/gauss_blur_gbench.cc
+++ b/lib/jxl/gauss_blur_gbench.cc
@@ -9,7 +9,6 @@
 #include "lib/jxl/convolve.h"
 #include "lib/jxl/gauss_blur.h"
 #include "lib/jxl/image_ops.h"
-#include "lib/jxl/image_test_utils.h"
 
 namespace jxl {
 namespace {


### PR DESCRIPTION
gtest is not a dependency of gbench and it doesn't seem that we need it.