### PR TITLE
Windows: fix build with MSYS2

### DIFF
--- a/third_party/skcms.cmake
+++ b/third_party/skcms.cmake
@@ -35,7 +35,7 @@ if(JPEGXL_BUNDLE_SKCMS)
       PRIVATE /FI${CMAKE_CURRENT_SOURCE_DIR}/../lib/jxl/enc_jxl_skcms.h)
   else()
     target_compile_options(skcms-obj
-      PRIVATE -include${CMAKE_CURRENT_SOURCE_DIR}/../lib/jxl/enc_jxl_skcms.h)
+      PRIVATE -include ${CMAKE_CURRENT_SOURCE_DIR}/../lib/jxl/enc_jxl_skcms.h)
   endif()
 endif()
 


### PR DESCRIPTION
Without patch:

```
[ 73%] Building CXX object third_party/CMakeFiles/skcms-obj.dir/skcms/skcms.cc.obj
cc1plus.exe: fatal error: E:E:/Documents/programmes_x64/msys2/Documents/programmes_x64/msys2/home/vtorri/gitroot_64/libjxl_vtorri/third_party/../lib/jxl/enc_jxl_skcms.h: Invalid argument
compilation terminated.
make[2]: *** [third_party/CMakeFiles/skcms-obj.dir/build.make:77: third_party/CMakeFiles/skcms-obj.dir/skcms/skcms.cc.obj] Error 1
```

and path begins with "E:E:/"
