### PR TITLE
Use PRIuS/PRIdS macros to printf size_t/ssize_t.

### DIFF
--- a/bash_test.sh
+++ b/bash_test.sh
@@ -84,6 +84,17 @@ test_copyright() {
   return ${ret}
 }
 
+# Check that we don't use "%zu" or "%zd" in format string for size_t.
+test_printf_size_t() {
+  if grep -n -E '%[0-9]*z[udx]' \
+      $(git ls-files | grep -E '(\.c|\.cc|\.cpp|\.h)$'); then
+    echo "Don't use '%zu' or '%zd' in a format string, instead use " \
+      "'%\" PRIuS \"' or '%\" PRIdS \"'." >&2
+    return 1
+  fi
+  return 0
+}
+
 # Check that "dec_" code doesn't depend on "enc_" headers.
 test_dec_enc_deps() {
   local ret=0

--- a/examples/decode_oneshot.cc
+++ b/examples/decode_oneshot.cc
@@ -7,6 +7,7 @@
 // available at once). The example outputs the pixels and color information to a
 // floating point image and an ICC profile on disk.
 
+#include <inttypes.h>
 #include <limits.h>
 #include <stdint.h>
 #include <stdio.h>
@@ -96,8 +97,9 @@ bool DecodeJpegXlOneShot(const uint8_t* jxl, size_t size,
         return false;
       }
       if (buffer_size != *xsize * *ysize * 16) {
-        fprintf(stderr, "Invalid out buffer size %zu %zu\n", buffer_size,
-                *xsize * *ysize * 16);
+        fprintf(stderr, "Invalid out buffer size %" PRIu64 " %" PRIu64 "\n",
+                static_cast<uint64_t>(buffer_size),
+                static_cast<uint64_t>(*xsize * *ysize * 16));
         return false;
       }
       pixels->resize(*xsize * *ysize * 4);

--- a/examples/jxlinfo.c
+++ b/examples/jxlinfo.c
@@ -5,6 +5,8 @@
 
 // This example prints information from the main codestream header.
 
+#include <inttypes.h>
+#include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -232,7 +234,7 @@ int PrintBasicInfo(FILE* file) {
           fprintf(stderr, "JxlDecoderGetICCProfileSize failed\n");
           continue;
         }
-        printf("  ICC profile size: %zu\n", profile_size);
+        printf("  ICC profile size: %" PRIu64 "\n", (uint64_t)profile_size);
         if (profile_size < 132) {
           fprintf(stderr, "ICC profile too small\n");
           continue;
@@ -284,8 +286,8 @@ int PrintBasicInfo(FILE* file) {
       uint64_t size;
       JxlDecoderGetBoxType(dec, type, JXL_FALSE);
       JxlDecoderGetBoxSizeRaw(dec, &size);
-      printf("box: type: \"%c%c%c%c\" size: %zu\n", type[0], type[1], type[2],
-             type[3], (size_t)size);
+      printf("box: type: \"%c%c%c%c\" size: %" PRIu64 "\n", type[0], type[1],
+             type[2], type[3], (uint64_t)size);
     } else {
       fprintf(stderr, "Unexpected decoder status\n");
       break;

--- a/lib/extras/codec_pgx.cc
+++ b/lib/extras/codec_pgx.cc
@@ -173,7 +173,8 @@ Status EncodeHeader(const ImageBundle& ib, const size_t bits_per_sample,
   }
 
   // Use ML (Big Endian), LM may not be well supported by all decoders.
-  *chars_written = snprintf(header, kMaxHeaderSize, "PG ML + %zu %zu %zu\n",
+  *chars_written = snprintf(header, kMaxHeaderSize,
+                            "PG ML + %" PRIuS " %" PRIuS " %" PRIuS "\n",
                             bits_per_sample, ib.xsize(), ib.ysize());
   JXL_RETURN_IF_ERROR(static_cast<unsigned int>(*chars_written) <
                       kMaxHeaderSize);

--- a/lib/extras/codec_png.cc
+++ b/lib/extras/codec_png.cc
@@ -69,7 +69,8 @@ class BlobsReaderPNG {
       }
       if (type == "exif") {
         if (!metadata->exif.empty()) {
-          JXL_WARNING("overwriting EXIF (%zu bytes) with base16 (%zu bytes)",
+          JXL_WARNING("overwriting EXIF (%" PRIuS " bytes) with base16 (%" PRIuS
+                      " bytes)",
                       metadata->exif.size(), bytes.size());
         }
         metadata->exif = std::move(bytes);
@@ -79,14 +80,15 @@ class BlobsReaderPNG {
         // TODO (jon): Deal with 8bim in some way
       } else if (type == "xmp") {
         if (!metadata->xmp.empty()) {
-          JXL_WARNING("overwriting XMP (%zu bytes) with base16 (%zu bytes)",
+          JXL_WARNING("overwriting XMP (%" PRIuS " bytes) with base16 (%" PRIuS
+                      " bytes)",
                       metadata->xmp.size(), bytes.size());
         }
         metadata->xmp = std::move(bytes);
       } else {
-        JXL_WARNING(
-            "Unknown type in 'Raw format type' text chunk: %s: %zu bytes",
-            type.c_str(), bytes.size());
+        JXL_WARNING("Unknown type in 'Raw format type' text chunk: %s: %" PRIuS
+                    " bytes",
+                    type.c_str(), bytes.size());
       }
     }
 
@@ -234,7 +236,8 @@ class BlobsWriterPNG {
     snprintf(key, sizeof(key), "Raw profile type %s", type.c_str());
 
     char header[30];
-    snprintf(header, sizeof(header), "\n%s\n%8zu", type.c_str(), bytes.size());
+    snprintf(header, sizeof(header), "\n%s\n%8" PRIuS, type.c_str(),
+             bytes.size());
 
     const std::string& encoded = std::string(header) + base16;
     if (lodepng_add_text(info, key, encoded.c_str()) != 0) {

--- a/lib/extras/codec_pnm.cc
+++ b/lib/extras/codec_pnm.cc
@@ -258,16 +258,17 @@ Status EncodeHeader(const ImageBundle& ib, const size_t bits_per_sample,
     const char type = ib.IsGray() ? 'f' : 'F';
     const double scale = little_endian ? -1.0 : 1.0;
     *chars_written =
-        snprintf(header, kMaxHeaderSize, "P%c\n%zu %zu\n%.1f\n", type,
-                 ib.oriented_xsize(), ib.oriented_ysize(), scale);
+        snprintf(header, kMaxHeaderSize, "P%c\n%" PRIuS " %" PRIuS "\n%.1f\n",
+                 type, ib.oriented_xsize(), ib.oriented_ysize(), scale);
     JXL_RETURN_IF_ERROR(static_cast<unsigned int>(*chars_written) <
                         kMaxHeaderSize);
   } else if (bits_per_sample == 1) {  // PBM
     if (!ib.IsGray()) {
       return JXL_FAILURE("Cannot encode color as PBM");
     }
-    *chars_written = snprintf(header, kMaxHeaderSize, "P4\n%zu %zu\n",
-                              ib.oriented_xsize(), ib.oriented_ysize());
+    *chars_written =
+        snprintf(header, kMaxHeaderSize, "P4\n%" PRIuS " %" PRIuS "\n",
+                 ib.oriented_xsize(), ib.oriented_ysize());
     JXL_RETURN_IF_ERROR(static_cast<unsigned int>(*chars_written) <
                         kMaxHeaderSize);
   } else {  // PGM/PPM
@@ -275,8 +276,8 @@ Status EncodeHeader(const ImageBundle& ib, const size_t bits_per_sample,
     if (max_val >= 65536) return JXL_FAILURE("PNM cannot have > 16 bits");
     const char type = ib.IsGray() ? '5' : '6';
     *chars_written =
-        snprintf(header, kMaxHeaderSize, "P%c\n%zu %zu\n%u\n", type,
-                 ib.oriented_xsize(), ib.oriented_ysize(), max_val);
+        snprintf(header, kMaxHeaderSize, "P%c\n%" PRIuS " %" PRIuS "\n%u\n",
+                 type, ib.oriented_xsize(), ib.oriented_ysize(), max_val);
     JXL_RETURN_IF_ERROR(static_cast<unsigned int>(*chars_written) <
                         kMaxHeaderSize);
   }

--- a/lib/extras/codec_psd.cc
+++ b/lib/extras/codec_psd.cc
@@ -79,7 +79,7 @@ Status decode_layer(const uint8_t*& pos, const uint8_t* maxpos,
   for (int c = 0; c < nb_channels; c++) {
     // skip nop byte padding
     while (pos < maxpos && *pos == 128) pos++;
-    JXL_DEBUG_V(PSD_VERBOSITY, "Channel %i (pos %zu)", c, (size_t)pos);
+    JXL_DEBUG_V(PSD_VERBOSITY, "Channel %i (pos %" PRIuS ")", c, (size_t)pos);
     // Merged image stores all channels together (same compression method)
     // Layers store channel per channel
     if (is_layer || c == 0) {
@@ -246,7 +246,7 @@ Status DecodeImagePSD(const Span<const uint8_t> bytes,
     pos += namelength;
     if (!(namelength & 1)) pos++;  // padding to even length
     size_t blocklength = get_be_int(4, pos, maxpos);
-    // JXL_DEBUG_V(PSD_VERBOSITY, "block id: %i | block length: %zu",id,
+    // JXL_DEBUG_V(PSD_VERBOSITY, "block id: %i | block length: %" PRIuS,id,
     // blocklength);
     if (pos > maxpos) return JXL_FAILURE("PSD: Unexpected end of file");
     if (id == 1039) {  // ICC profile
@@ -275,8 +275,8 @@ Status DecodeImagePSD(const Span<const uint8_t> bytes,
             "PSD: expected DisplayInfo version 1, got version %i", version);
       }
       int spotcolorcount = nb_channels - colormodel;
-      JXL_DEBUG_V(PSD_VERBOSITY, "Reading %i spot colors. %zu", spotcolorcount,
-                  blocklength);
+      JXL_DEBUG_V(PSD_VERBOSITY, "Reading %i spot colors. %" PRIuS,
+                  spotcolorcount, blocklength);
       for (int k = 0; k < spotcolorcount; k++) {
         int colorspace = get_be_int(2, pos, maxpos);
         if ((colormodel == 3 && colorspace != 0) ||
@@ -324,7 +324,7 @@ Status DecodeImagePSD(const Span<const uint8_t> bytes,
   if (after_layers_pos < pos) return JXL_FAILURE("PSD: invalid layer length");
   if (layerlength) {
     pos += 4 * version;  // don't care about layerinfolength
-    JXL_DEBUG_V(PSD_VERBOSITY, "Layer section length: %zu", layerlength);
+    JXL_DEBUG_V(PSD_VERBOSITY, "Layer section length: %" PRIuS, layerlength);
     int layercount = static_cast<int16_t>(get_be_int(2, pos, maxpos));
     JXL_DEBUG_V(PSD_VERBOSITY, "Layer count: %i", layercount);
     io->frames.clear();
@@ -342,7 +342,7 @@ Status DecodeImagePSD(const Span<const uint8_t> bytes,
         const uint8_t* tpos = pos;
         pos += 4;
         size_t blocklength = get_be_int(4 * version, pos, maxpos);
-        JXL_DEBUG_V(PSD_VERBOSITY, "Length=%zu", blocklength);
+        JXL_DEBUG_V(PSD_VERBOSITY, "Length=%" PRIuS, blocklength);
         if (blocklength > 0) {
           if (pos >= maxpos) return JXL_FAILURE("PSD: Unexpected end of file");
           size_t delta = maxpos - pos;
@@ -433,7 +433,8 @@ Status DecodeImagePSD(const Span<const uint8_t> bytes,
       layer.origin.x0 = get_be_int(4, pos, maxpos);
       size_t height = get_be_int(4, pos, maxpos) - layer.origin.y0;
       size_t width = get_be_int(4, pos, maxpos) - layer.origin.x0;
-      JXL_DEBUG_V(PSD_VERBOSITY, "Layer %i: %zu x %zu at origin (%i, %i)", l,
+      JXL_DEBUG_V(PSD_VERBOSITY,
+                  "Layer %i: %" PRIuS " x %" PRIuS " at origin (%i, %i)", l,
                   width, height, layer.origin.x0, layer.origin.y0);
       int nb_chs = get_be_int(2, pos, maxpos);
       JXL_DEBUG_V(PSD_VERBOSITY, "  channels: %i", nb_chs);
@@ -480,7 +481,7 @@ Status DecodeImagePSD(const Span<const uint8_t> bytes,
         }
       }
       size_t extradata = get_be_int(4, pos, maxpos);
-      JXL_DEBUG_V(PSD_VERBOSITY, "  extradata: %zu bytes", extradata);
+      JXL_DEBUG_V(PSD_VERBOSITY, "  extradata: %" PRIuS " bytes", extradata);
       const uint8_t* after_extra = pos + extradata;
       // TODO: deal with non-empty layer masks
       pos += get_be_int(4, pos, maxpos);  // skip layer mask data
@@ -532,7 +533,7 @@ Status DecodeImagePSD(const Span<const uint8_t> bytes,
       if (!is_real_layer[l]) continue;
       pos = bpos + layer_offsets[l];
       if (pos < bpos) return JXL_FAILURE("PSD: invalid layer offset");
-      JXL_DEBUG_V(PSD_VERBOSITY, "At position %i (%zu)",
+      JXL_DEBUG_V(PSD_VERBOSITY, "At position %i (%" PRIuS ")",
                   (int)(pos - bytes.data()), (size_t)pos);
       ImageBundle& layer = io->frames[il++];
       std::vector<int>& chan_id = layer_chan_id[l];

--- a/lib/extras/codec_test.cc
+++ b/lib/extras/codec_test.cc
@@ -74,7 +74,7 @@ void TestRoundTrip(Codec codec, const size_t xsize, const size_t ysize,
   // Our EXR codec always uses 16-bit premultiplied alpha, does not support
   // grayscale, and somehow does not have sufficient precision for this test.
   if (codec == Codec::kEXR) return;
-  printf("Codec %s bps:%zu gr:%d al:%d\n",
+  printf("Codec %s bps:%" PRIuS " gr:%d al:%d\n",
          ExtensionFromCodec(codec, is_gray, bits_per_sample).c_str(),
          bits_per_sample, is_gray, add_alpha);
 

--- a/lib/jxl/aux_out.cc
+++ b/lib/jxl/aux_out.cc
@@ -52,8 +52,9 @@ void AuxOut::Print(size_t num_inputs) const {
   size_t total_positions = 0;
   if (total_blocks != 0 && total_positions != 0) {
     printf("\n\t\t  Blocks\t\tPositions\t\t\tBlocks/Position\n");
-    printf(" Total:\t\t    %7zu\t\t     %7zu \t\t\t%10f%%\n\n", total_blocks,
-           total_positions, 100.0 * total_blocks / total_positions);
+    printf(" Total:\t\t    %7" PRIuS "\t\t     %7" PRIuS " \t\t\t%10f%%\n\n",
+           total_blocks, total_positions,
+           100.0 * total_blocks / total_positions);
   }
 }
 
@@ -81,7 +82,7 @@ void ReclaimAndCharge(BitWriter* JXL_RESTRICT writer,
   allotment->PrivateReclaim(writer, &used_bits, &unused_bits);
 
 #if 0
-  printf("Layer %s bits: max %zu used %zu unused %zu\n", LayerName(layer),
+  printf("Layer %s bits: max %" PRIuS " used %" PRIuS " unused %" PRIuS "\n", LayerName(layer),
          allotment->MaxBits(), used_bits, unused_bits);
 #endif
 

--- a/lib/jxl/aux_out.h
+++ b/lib/jxl/aux_out.h
@@ -103,7 +103,7 @@ static inline const char* LayerName(size_t layer) {
     case kLayerExtraChannels:
       return "extra channels";
     default:
-      JXL_ABORT("Invalid layer %zu\n", layer);
+      JXL_ABORT("Invalid layer %" PRIuS "\n", layer);
   }
 }
 
@@ -119,9 +119,10 @@ struct AuxOut {
       clustered_entropy += victim.clustered_entropy;
     }
     void Print(size_t num_inputs) const {
-      printf("%10zd", total_bits);
+      printf("%10" PRIdS, total_bits);
       if (histogram_bits != 0) {
-        printf("   [c/i:%6.2f | hst:%8zd | ex:%8zd | h+c+e:%12.3f",
+        printf("   [c/i:%6.2f | hst:%8" PRIdS " | ex:%8" PRIdS
+               " | h+c+e:%12.3f",
                num_clustered_histograms * 1.0 / num_inputs, histogram_bits >> 3,
                extra_bits >> 3,
                (histogram_bits + clustered_entropy + extra_bits) / 8.0);

--- a/lib/jxl/base/cache_aligned.cc
+++ b/lib/jxl/base/cache_aligned.cc
@@ -21,6 +21,7 @@
 #include <limits>
 
 #include "lib/jxl/base/status.h"
+#include "lib/jxl/common.h"
 
 namespace jxl {
 namespace {
@@ -46,9 +47,10 @@ constexpr size_t CacheAligned::kAlignment;
 constexpr size_t CacheAligned::kAlias;
 
 void CacheAligned::PrintStats() {
-  fprintf(stderr, "Allocations: %zu (max bytes in use: %E)\n",
-          size_t(num_allocations.load(std::memory_order_relaxed)),
-          double(max_bytes_in_use.load(std::memory_order_relaxed)));
+  fprintf(
+      stderr, "Allocations: %" PRIuS " (max bytes in use: %E)\n",
+      static_cast<size_t>(num_allocations.load(std::memory_order_relaxed)),
+      static_cast<double>(max_bytes_in_use.load(std::memory_order_relaxed)));
 }
 
 size_t CacheAligned::NextOffset() {

--- a/lib/jxl/blending.cc
+++ b/lib/jxl/blending.cc
@@ -160,7 +160,8 @@ Status ImageBlender::PrepareBlending(
 
   if (bg.xsize() < image_xsize || bg.ysize() < image_ysize ||
       bg.origin.x0 != 0 || bg.origin.y0 != 0) {
-    return JXL_FAILURE("Trying to use a %zux%zu crop as a background",
+    return JXL_FAILURE("Trying to use a %" PRIuS "x%" PRIuS
+                       " crop as a background",
                        bg.xsize(), bg.ysize());
   }
   if (state.metadata->m.xyb_encoded) {
@@ -170,15 +171,16 @@ Status ImageBlender::PrepareBlending(
   }
 
   if (!overlap_.IsInside(Rect(0, 0, foreground_xsize, foreground_ysize))) {
-    return JXL_FAILURE("Trying to use a %zux%zu crop as a foreground",
+    return JXL_FAILURE("Trying to use a %" PRIuS "x%" PRIuS
+                       " crop as a foreground",
                        foreground_xsize, foreground_ysize);
   }
 
   if (!cropbox_.IsInside(bg)) {
-    return JXL_FAILURE(
-        "Trying blend %zux%zu to (%zu,%zu), but background is %zux%zu",
-        cropbox_.xsize(), cropbox_.ysize(), cropbox_.x0(), cropbox_.y0(),
-        bg.xsize(), bg.ysize());
+    return JXL_FAILURE("Trying blend %" PRIuS "x%" PRIuS " to (%" PRIuS
+                       ",%" PRIuS "), but background is %" PRIuS "x%" PRIuS,
+                       cropbox_.xsize(), cropbox_.ysize(), cropbox_.x0(),
+                       cropbox_.y0(), bg.xsize(), bg.ysize());
   }
 
   Rect frame_rects_storage[4], output_rects_storage[4];
@@ -209,8 +211,11 @@ Status ImageBlender::PrepareBlending(
           src.extra_channels()[i].ysize() < image_ysize || src.origin.x0 != 0 ||
           src.origin.y0 != 0) {
         return JXL_FAILURE(
-            "Invalid size %zux%zu or origin %+d%+d for extra channel %zu of "
-            "reference frame %zu, expected at least %zux%zu+0+0",
+            "Invalid size %" PRIuS "x%" PRIuS
+            " or origin %+d%+d for extra channel %" PRIuS
+            " of "
+            "reference frame %" PRIuS ", expected at least %" PRIuS "x%" PRIuS
+            "+0+0",
             src.extra_channels()[i].xsize(), src.extra_channels()[i].ysize(),
             static_cast<int>(src.origin.x0), static_cast<int>(src.origin.y0), i,
             static_cast<size_t>(eci.source), image_xsize, image_ysize);

--- a/lib/jxl/butteraugli/butteraugli.cc
+++ b/lib/jxl/butteraugli/butteraugli.cc
@@ -191,7 +191,7 @@ void ConvolutionWithTranspose(const ImageF& in,
       break;
     }
     default:
-      printf("Warning: Unexpected kernel size! %zu\n", len);
+      printf("Warning: Unexpected kernel size! %" PRIuS "\n", len);
       for (size_t y = 0; y < in.ysize(); ++y) {
         const float* BUTTERAUGLI_RESTRICT row_in = in.Row(y);
         for (size_t x = border1; x < border2; ++x) {
@@ -1499,8 +1499,9 @@ static inline void CheckImage(const ImageF& image, const char* name) {
     const float* BUTTERAUGLI_RESTRICT row = image.Row(y);
     for (size_t x = 0; x < image.xsize(); ++x) {
       if (IsNan(row[x])) {
-        printf("NAN: Image %s @ %zu,%zu (of %zu,%zu)\n", name, x, y,
-               image.xsize(), image.ysize());
+        printf("NAN: Image %s @ %" PRIuS ",%" PRIuS " (of %" PRIuS ",%" PRIuS
+               ")\n",
+               name, x, y, image.xsize(), image.ysize());
         exit(1);
       }
     }

--- a/lib/jxl/coeff_order_test.cc
+++ b/lib/jxl/coeff_order_test.cc
@@ -77,7 +77,7 @@ void TestPermutation(Permutation kind, size_t len) {
       EXPECT_EQ(perm[idx], out[idx]);
     }
   }
-  printf("Encoded size: %zu\n", size);
+  printf("Encoded size: %" PRIuS "\n", size);
 }
 
 TEST(CoeffOrderTest, IdentitySmall) { TestPermutation(kIdentity, 256); }

--- a/lib/jxl/common.h
+++ b/lib/jxl/common.h
@@ -27,6 +27,27 @@
 #define JPEGXL_ENABLE_TRANSCODE_JPEG 1
 #endif  // JPEGXL_ENABLE_TRANSCODE_JPEG
 
+// PRIuS and PRIdS macros to print size_t and ssize_t respectively.
+#if !defined(PRIdS)
+#if defined(_WIN64)
+#define PRIdS "lld"
+#elif defined(_WIN32)
+#define PRIdS "d"
+#else
+#define PRIdS "zd"
+#endif
+#endif  // PRIdS
+
+#if !defined(PRIuS)
+#if defined(_WIN64)
+#define PRIuS "llu"
+#elif defined(_WIN32)
+#define PRIuS "u"
+#else
+#define PRIuS "zu"
+#endif
+#endif  // PRIuS
+
 namespace jxl {
 // Some enums and typedefs used by more than one header file.
 

--- a/lib/jxl/convolve_test.cc
+++ b/lib/jxl/convolve_test.cc
@@ -145,7 +145,8 @@ void TestConvolve() {
              ThreadPoolInternal pool3(3);
              for (size_t ysize = kConvolveMaxRadius; ysize < 16; ++ysize) {
                JXL_DEBUG(JXL_DEBUG_CONVOLVE,
-                         "%zu x %zu (target %d)===============================",
+                         "%" PRIuS " x %" PRIuS
+                         " (target %d)===============================",
                          xsize, ysize, HWY_TARGET);
 
                JXL_DEBUG(JXL_DEBUG_CONVOLVE, "Sym3------------------");

--- a/lib/jxl/dec_ans.cc
+++ b/lib/jxl/dec_ans.cc
@@ -207,9 +207,9 @@ Status DecodeANSCodes(const size_t num_histograms,
             return JXL_STATUS(StatusCode::kNotEnoughBytes,
                               "Not enough bytes for huffman code");
           }
-          return JXL_FAILURE(
-              "Invalid huffman tree number %zu, alphabet size %u", c,
-              alphabet_sizes[c]);
+          return JXL_FAILURE("Invalid huffman tree number %" PRIuS
+                             ", alphabet size %u",
+                             c, alphabet_sizes[c]);
         }
       } else {
         // 0-bit codes does not require extension tables.
@@ -235,7 +235,7 @@ Status DecodeANSCodes(const size_t num_histograms,
         return JXL_FAILURE("Invalid histogram bitstream.");
       }
       if (counts.size() > max_alphabet_size) {
-        return JXL_FAILURE("Alphabet size is too long: %zu", counts.size());
+        return JXL_FAILURE("Alphabet size is too long: %" PRIuS, counts.size());
       }
       while (!counts.empty() && counts.back() == 0) {
         counts.pop_back();
@@ -366,7 +366,8 @@ Status DecodeHistograms(BitReader* br, size_t num_contexts, ANSCode* code,
   // decoding. There's no benefit to doing that, though.
   if (!code->lz77.enabled && code->max_num_bits > 32) {
     // Just emit a warning as there are many opportunities for false positives.
-    JXL_WARNING("Histogram can represent numbers that are too large: %zu\n",
+    JXL_WARNING("Histogram can represent numbers that are too large: %" PRIuS
+                "\n",
                 code->max_num_bits);
   }
   return true;

--- a/lib/jxl/dec_external_image.cc
+++ b/lib/jxl/dec_external_image.cc
@@ -316,9 +316,9 @@ Status ConvertChannelsToExternal(const ImageF* channels[], size_t num_channels,
   size_t ysize = channels[0]->ysize();
 
   if (stride < bytes_per_pixel * xsize) {
-    return JXL_FAILURE(
-        "stride is smaller than scanline width in bytes: %zu vs %zu", stride,
-        bytes_per_pixel * xsize);
+    return JXL_FAILURE("stride is smaller than scanline width in bytes: %" PRIuS
+                       " vs %" PRIuS,
+                       stride, bytes_per_pixel * xsize);
   }
 
   const bool little_endian =

--- a/lib/jxl/dec_frame.cc
+++ b/lib/jxl/dec_frame.cc
@@ -221,8 +221,8 @@ Status DecodeFrame(const DecompressParams& dparams,
       if (dparams.max_downsampling > 1 && s == FrameDecoder::kSkipped) {
         continue;
       }
-      return JXL_FAILURE("Invalid section %zu status: %d", section_info[i].id,
-                         s);
+      return JXL_FAILURE("Invalid section %" PRIuS " status: %d",
+                         section_info[i].id, s);
     }
   }
 
@@ -958,8 +958,10 @@ Status FrameDecoder::FinalizeFrame() {
       if (reference_frame.frame->xsize() < metadata->xsize() ||
           reference_frame.frame->ysize() < metadata->ysize()) {
         return JXL_FAILURE(
-            "trying to save a reference frame that is too small: %zux%zu "
-            "instead of %zux%zu",
+            "trying to save a reference frame that is too small: %" PRIuS
+            "x%" PRIuS
+            " "
+            "instead of %" PRIuS "x%" PRIuS,
             reference_frame.frame->xsize(), reference_frame.frame->ysize(),
             metadata->xsize(), metadata->ysize());
       }

--- a/lib/jxl/dec_group.cc
+++ b/lib/jxl/dec_group.cc
@@ -521,8 +521,9 @@ Status DecodeACVarBlock(size_t ctx_offset, size_t log2_covered_blocks,
       nzeros -= prev;
     }
     if (JXL_UNLIKELY(nzeros != 0)) {
-      return JXL_FAILURE(
-          "Invalid AC: nzeros not 0. Block (%zu, %zu), channel %zu", bx, by, c);
+      return JXL_FAILURE("Invalid AC: nzeros not 0. Block (%" PRIuS ", %" PRIuS
+                         "), channel %" PRIuS,
+                         bx, by, c);
     }
   }
   return true;

--- a/lib/jxl/dec_modular.cc
+++ b/lib/jxl/dec_modular.cc
@@ -497,10 +497,11 @@ Status ModularFrameDecoder::ModularImageToDecodedRect(
              DivCeil(decoded.xsize(), 1 << ch_in.hshift),
              DivCeil(decoded.ysize(), 1 << ch_in.vshift));
       if (r.ysize() != ch_in.h || r.xsize() != ch_in.w) {
-        return JXL_FAILURE(
-            "Dimension mismatch: trying to fit a %zux%zu modular channel into "
-            "a %zux%zu rect",
-            ch_in.w, ch_in.h, r.xsize(), r.ysize());
+        return JXL_FAILURE("Dimension mismatch: trying to fit a %" PRIuS
+                           "x%" PRIuS
+                           " modular channel into "
+                           "a %" PRIuS "x%" PRIuS " rect",
+                           ch_in.w, ch_in.h, r.xsize(), r.ysize());
       }
       if (frame_header.color_transform == ColorTransform::kXYB && c == 2) {
         JXL_ASSERT(!fp);

--- a/lib/jxl/dec_patch_dictionary.cc
+++ b/lib/jxl/dec_patch_dictionary.cc
@@ -104,12 +104,14 @@ Status PatchDictionary::Decode(BitReader* br, size_t xsize, size_t ysize,
             positions_.back().y + UnpackSigned(read_num(kPatchOffsetContext));
       }
       if (pos.x + ref_pos.xsize > xsize) {
-        return JXL_FAILURE("Invalid patch x: at %zu + %zu > %zu", pos.x,
-                           ref_pos.xsize, xsize);
+        return JXL_FAILURE("Invalid patch x: at %" PRIuS " + %" PRIuS
+                           " > %" PRIuS,
+                           pos.x, ref_pos.xsize, xsize);
       }
       if (pos.y + ref_pos.ysize > ysize) {
-        return JXL_FAILURE("Invalid patch y: at %zu + %zu > %zu", pos.y,
-                           ref_pos.ysize, ysize);
+        return JXL_FAILURE("Invalid patch y: at %" PRIuS " + %" PRIuS
+                           " > %" PRIuS,
+                           pos.y, ref_pos.ysize, ysize);
       }
       for (size_t i = 0; i < shared_->metadata->m.extra_channel_info.size() + 1;
            i++) {

--- a/lib/jxl/enc_color_management.cc
+++ b/lib/jxl/enc_color_management.cc
@@ -310,7 +310,7 @@ Status CreateProfileXYZ(const cmsContext context,
 // IMPORTANT: icc must outlive profile.
 Status DecodeProfile(const PaddedBytes& icc, skcms_ICCProfile* const profile) {
   if (!skcms_Parse(icc.data(), icc.size(), profile)) {
-    return JXL_FAILURE("Failed to parse ICC profile with %zu bytes",
+    return JXL_FAILURE("Failed to parse ICC profile with %" PRIuS " bytes",
                        icc.size());
   }
   return true;
@@ -845,7 +845,8 @@ Status ColorSpaceTransform::Init(const ColorEncoding& c_src,
   const size_t channels_dst = c_dst.Channels();
   JXL_CHECK(channels_src == channels_dst);
 #if JXL_CMS_VERBOSE
-  printf("Channels: %zu; Threads: %zu\n", channels_src, num_threads);
+  printf("Channels: %" PRIuS "; Threads: %" PRIuS "\n", channels_src,
+         num_threads);
 #endif
 
 #if !JPEGXL_ENABLE_SKCMS

--- a/lib/jxl/enc_detect_dots.cc
+++ b/lib/jxl/enc_detect_dots.cc
@@ -320,7 +320,7 @@ std::vector<ConnectedComponent> FindCC(const ImageF& energy, double t_low,
           if (cc.score < minScore) continue;
           JXL_DEBUG(JXL_DEBUG_DOT_DETECT,
                     "cc mode: (%d,%d), max: %f, bgMean: %f bgVar: "
-                    "%f bound:(%zu,%zu,%zu,%zu)\n",
+                    "%f bound:(%" PRIuS ",%" PRIuS ",%" PRIuS ",%" PRIuS ")\n",
                     cc.mode.x, cc.mode.y, cc.maxEnergy, cc.meanEnergy,
                     cc.varEnergy, cc.bounds.x0(), cc.bounds.y0(),
                     cc.bounds.xsize(), cc.bounds.ysize());
@@ -415,7 +415,8 @@ GaussianEllipse FitGaussianFast(const ConnectedComponent& cc,
   std::array<double, 3> color{{0.0, 0.0, 0.0}};
   std::array<double, 3> bgColor{{0.0, 0.0, 0.0}};
 
-  JXL_DEBUG(JXL_DEBUG_DOT_DETECT, "%zu %zu %zu %zu\n", cc.bounds.x0(),
+  JXL_DEBUG(JXL_DEBUG_DOT_DETECT,
+            "%" PRIuS " %" PRIuS " %" PRIuS " %" PRIuS "\n", cc.bounds.x0(),
             cc.bounds.y0(), cc.bounds.xsize(), cc.bounds.ysize());
   for (int c = 0; c < 3; c++) {
     color[c] = img.ConstPlaneRow(c, cc.mode.y)[cc.mode.x] -
@@ -523,7 +524,7 @@ GaussianEllipse FitGaussian(const ConnectedComponent& cc, const ImageF& energy,
   JXL_DEBUG(JXL_DEBUG_DOT_DETECT,
             "Ellipse mu=(%lf,%lf) sigma=(%lf,%lf) angle=%lf "
             "intensity=(%lf,%lf,%lf) bg=(%lf,%lf,%lf) l2_loss=%lf "
-            "custom_loss=%lf, neg_pix=%zu, neg_v=(%lf,%lf,%lf)\n",
+            "custom_loss=%lf, neg_pix=%" PRIuS ", neg_v=(%lf,%lf,%lf)\n",
             ellipse.x, ellipse.y, ellipse.sigma_x, ellipse.sigma_y,
             ellipse.angle, ellipse.intensity[0], ellipse.intensity[1],
             ellipse.intensity[2], ellipse.bgColor[0], ellipse.bgColor[1],
@@ -601,7 +602,7 @@ std::vector<PatchInfo> DetectGaussianEllipses(
     }
   }
 #if JXL_DEBUG_DOT_DETECT
-  JXL_DEBUG(JXL_DEBUG_DOT_DETECT, "Candidates: %zu, Dots: %zu\n",
+  JXL_DEBUG(JXL_DEBUG_DOT_DETECT, "Candidates: %" PRIuS ", Dots: %" PRIuS "\n",
             components.size(), dots.size());
   ApplyGaussianEllipses(&smooth, dots, 1.0);
   aux.DumpXybImage("draw", smooth);

--- a/lib/jxl/enc_modular.cc
+++ b/lib/jxl/enc_modular.cc
@@ -610,7 +610,7 @@ Status ModularFrameEncoder::ComputeEncodingData(
       int min, max;
       compute_minmax(gi.channel[gi.nb_meta_channels + i], &min, &max);
       int64_t colors = max - min + 1;
-      JXL_DEBUG_V(10, "Channel %zu: range=%i..%i", i, min, max);
+      JXL_DEBUG_V(10, "Channel %" PRIuS ": range=%i..%i", i, min, max);
       Transform maybe_palette_1(TransformId::kPalette);
       maybe_palette_1.begin_c = i + gi.nb_meta_channels;
       maybe_palette_1.num_c = 1;
@@ -1283,7 +1283,7 @@ Status ModularFrameEncoder::PrepareStreamParams(const Rect& rect,
         int min, max;
         compute_minmax(gi.channel[gi.nb_meta_channels + i], &min, &max);
         int colors = max - min + 1;
-        JXL_DEBUG_V(10, "Channel %zu: range=%i..%i", i, min, max);
+        JXL_DEBUG_V(10, "Channel %" PRIuS ": range=%i..%i", i, min, max);
         Transform maybe_palette_1(TransformId::kPalette);
         maybe_palette_1.begin_c = i + gi.nb_meta_channels;
         maybe_palette_1.num_c = 1;

--- a/lib/jxl/fields.cc
+++ b/lib/jxl/fields.cc
@@ -353,7 +353,7 @@ class ReadVisitor : public VisitorBase {
     }
     const size_t remaining_bits = end - bits_read;
     if (remaining_bits != 0) {
-      JXL_WARNING("Skipping %zu-bit extension(s)", remaining_bits);
+      JXL_WARNING("Skipping %" PRIuS "-bit extension(s)", remaining_bits);
       reader_->SkipBits(remaining_bits);
       if (!reader_->AllReadsWithinBounds()) {
         return JXL_STATUS(StatusCode::kNotEnoughBytes,

--- a/lib/jxl/fields.h
+++ b/lib/jxl/fields.h
@@ -40,7 +40,7 @@ class BitsCoder {
                           size_t* JXL_RESTRICT encoded_bits) {
     *encoded_bits = bits;
     if (value >= (1ULL << bits)) {
-      return JXL_FAILURE("Value %u too large for %zu bits", value, bits);
+      return JXL_FAILURE("Value %u too large for %" PRIuS " bits", value, bits);
     }
     return true;
   }
@@ -53,8 +53,8 @@ class BitsCoder {
   static Status Write(const size_t bits, const uint32_t value,
                       BitWriter* JXL_RESTRICT writer) {
     if (value >= (1ULL << bits)) {
-      return JXL_FAILURE("Value %d too large to encode in %zu bits", value,
-                         bits);
+      return JXL_FAILURE("Value %d too large to encode in %" PRIuS " bits",
+                         value, bits);
     }
     writer->Write(bits, value);
     return true;

--- a/lib/jxl/frame_header.cc
+++ b/lib/jxl/frame_header.cc
@@ -345,7 +345,8 @@ Status FrameHeader::VisitFields(Visitor* JXL_RESTRICT visitor) {
            frame_size.ysize < nonserialized_metadata->ysize() ||
            frame_origin.x0 != 0 || frame_origin.y0 != 0)) {
         return JXL_FAILURE(
-            "non-patch reference frame with invalid crop: %zux%zu%+d%+d",
+            "non-patch reference frame with invalid crop: %" PRIuS "x%" PRIuS
+            "%+d%+d",
             static_cast<size_t>(frame_size.xsize),
             static_cast<size_t>(frame_size.ysize),
             static_cast<int>(frame_origin.x0),

--- a/lib/jxl/gauss_blur_test.cc
+++ b/lib/jxl/gauss_blur_test.cc
@@ -185,7 +185,8 @@ TEST(GaussBlurTest, DISABLED_SlowTestDirac1D) {
 
 void TestRandom(size_t xsize, size_t ysize, float min, float max, double sigma,
                 double max_l1, double max_rel) {
-  printf("%4zu x %4zu %4.1f %4.1f sigma %.1f\n", xsize, ysize, min, max, sigma);
+  printf("%4" PRIuS " x %4" PRIuS " %4.1f %4.1f sigma %.1f\n", xsize, ysize,
+         min, max, sigma);
   ImageF in(xsize, ysize);
   RandomFillImage(&in, min, max, 65537 + xsize * 129 + ysize);
   // FastGaussian/Convolve handle borders differently, so keep those pixels 0.
@@ -439,7 +440,7 @@ TEST(GaussBlurTest, TestSign) {
   {
     const std::vector<float> kernel =
         GaussianKernel(static_cast<int>(4 * sigma), static_cast<float>(sigma));
-    printf("old kernel size %zu\n", kernel.size());
+    printf("old kernel size %" PRIuS "\n", kernel.size());
     out_old = Convolve(in, kernel);
   }
 

--- a/lib/jxl/headers.cc
+++ b/lib/jxl/headers.cc
@@ -195,7 +195,8 @@ Status WriteSizeHeader(const SizeHeader& size, BitWriter* JXL_RESTRICT writer,
                        size_t layer, AuxOut* aux_out) {
   const size_t max_bits = Bundle::MaxBits(size);
   if (max_bits != SizeHeader::kMaxBits) {
-    JXL_ABORT("Please update SizeHeader::kMaxBits from %zu to %zu\n",
+    JXL_ABORT("Please update SizeHeader::kMaxBits from %" PRIuS " to %" PRIuS
+              "\n",
               SizeHeader::kMaxBits, max_bits);
   }
 

--- a/lib/jxl/image.h
+++ b/lib/jxl/image.h
@@ -18,6 +18,7 @@
 #include "lib/jxl/base/cache_aligned.h"
 #include "lib/jxl/base/compiler_specific.h"
 #include "lib/jxl/base/status.h"
+#include "lib/jxl/common.h"
 
 namespace jxl {
 
@@ -83,7 +84,7 @@ struct PlaneBase {
 #if defined(ADDRESS_SANITIZER) || defined(MEMORY_SANITIZER) || \
     defined(THREAD_SANITIZER)
     if (y >= ysize_) {
-      JXL_ABORT("Row(%zu) in (%u x %u) image\n", y, xsize_, ysize_);
+      JXL_ABORT("Row(%" PRIuS ") in (%u x %u) image\n", y, xsize_, ysize_);
     }
 #endif
 
@@ -415,8 +416,9 @@ class Image3 {
 #if defined(ADDRESS_SANITIZER) || defined(MEMORY_SANITIZER) || \
     defined(THREAD_SANITIZER)
     if (c >= kNumPlanes || y >= ysize()) {
-      JXL_ABORT("PlaneRow(%zu, %zu) in (%zu x %zu) image\n", c, y, xsize(),
-                ysize());
+      JXL_ABORT("PlaneRow(%" PRIuS ", %" PRIuS ") in (%" PRIuS " x %" PRIuS
+                ") image\n",
+                c, y, xsize(), ysize());
     }
 #endif
   }

--- a/lib/jxl/image_bundle.cc
+++ b/lib/jxl/image_bundle.cc
@@ -41,7 +41,7 @@ void ImageBundle::VerifyMetadata() const {
   JXL_CHECK(metadata_->color_encoding.IsGray() == IsGray());
 
   if (metadata_->HasAlpha() && alpha().xsize() == 0) {
-    JXL_ABORT("MD alpha_bits %u IB alpha %zu x %zu\n",
+    JXL_ABORT("MD alpha_bits %u IB alpha %" PRIuS " x %" PRIuS "\n",
               metadata_->GetAlphaBits(), alpha().xsize(), alpha().ysize());
   }
   const uint32_t alpha_bits = metadata_->GetAlphaBits();

--- a/lib/jxl/image_ops.h
+++ b/lib/jxl/image_ops.h
@@ -15,6 +15,7 @@
 
 #include "lib/jxl/base/profiler.h"
 #include "lib/jxl/base/status.h"
+#include "lib/jxl/common.h"
 #include "lib/jxl/image.h"
 
 namespace jxl {

--- a/lib/jxl/image_ops_test.cc
+++ b/lib/jxl/image_ops_test.cc
@@ -76,8 +76,9 @@ void TestFillImpl(Image3<T>* img, const char* layout) {
       T* JXL_RESTRICT row = img->PlaneRow(c, y);
       for (size_t x = 0; x < img->xsize(); ++x) {
         if (row[x] != T(1)) {
-          printf("Not 1 at c=%zu %zu, %zu (%zu x %zu) (%s)\n", c, x, y,
-                 img->xsize(), img->ysize(), layout);
+          printf("Not 1 at c=%" PRIuS " %" PRIuS ", %" PRIuS " (%" PRIuS
+                 " x %" PRIuS ") (%s)\n",
+                 c, x, y, img->xsize(), img->ysize(), layout);
           abort();
         }
         row[x] = T(2);
@@ -92,8 +93,9 @@ void TestFillImpl(Image3<T>* img, const char* layout) {
       T* JXL_RESTRICT row = img->PlaneRow(c, y);
       for (size_t x = 0; x < img->xsize(); ++x) {
         if (row[x] != T(0)) {
-          printf("Not 0 at c=%zu %zu, %zu (%zu x %zu) (%s)\n", c, x, y,
-                 img->xsize(), img->ysize(), layout);
+          printf("Not 0 at c=%" PRIuS " %" PRIuS ", %" PRIuS " (%" PRIuS
+                 " x %" PRIuS ") (%s)\n",
+                 c, x, y, img->xsize(), img->ysize(), layout);
           abort();
         }
         row[x] = T(3);

--- a/lib/jxl/image_test_utils.h
+++ b/lib/jxl/image_test_utils.h
@@ -14,6 +14,7 @@
 #include "gtest/gtest.h"
 #include "lib/jxl/base/compiler_specific.h"
 #include "lib/jxl/base/random.h"
+#include "lib/jxl/common.h"
 #include "lib/jxl/image.h"
 
 namespace jxl {
@@ -120,10 +121,11 @@ void VerifyRelativeError(const Plane<T>& expected, const Plane<T>& actual,
   if (any_bad) {
     // Never had a valid relative value, don't print it.
     if (max_relative < 0) {
-      fprintf(stderr, "c=%zu: max +/- %E exceeds +/- %.2E\n", c, max_l1,
+      fprintf(stderr, "c=%" PRIuS ": max +/- %E exceeds +/- %.2E\n", c, max_l1,
               threshold_l1);
     } else {
-      fprintf(stderr, "c=%zu: max +/- %E, x %E exceeds +/- %.2E, x %.2E\n", c,
+      fprintf(stderr,
+              "c=%" PRIuS ": max +/- %E, x %E exceeds +/- %.2E, x %.2E\n", c,
               max_l1, max_relative, threshold_l1, threshold_relative);
     }
     // Dump the expected image and actual image if the region is small enough.

--- a/lib/jxl/jpeg/enc_jpeg_data_reader.cc
+++ b/lib/jxl/jpeg/enc_jpeg_data_reader.cc
@@ -34,12 +34,13 @@ static const size_t kBrunsliMaxNumBlocks = 1ull << 24;
 
 // Macros for commonly used error conditions.
 
-#define JXL_JPEG_VERIFY_LEN(n)                                               \
-  if (*pos + (n) > len) {                                                    \
-    JXL_JPEG_DEBUG("Unexpected end of input: pos=%zu need=%d len=%zu", *pos, \
-                   static_cast<int>(n), len);                                \
-    jpg->error = JPEGReadError::UNEXPECTED_EOF;                              \
-    return false;                                                            \
+#define JXL_JPEG_VERIFY_LEN(n)                            \
+  if (*pos + (n) > len) {                                 \
+    JXL_JPEG_DEBUG("Unexpected end of input: pos=%" PRIuS \
+                   " need=%d len=%" PRIuS,                \
+                   *pos, static_cast<int>(n), len);       \
+    jpg->error = JPEGReadError::UNEXPECTED_EOF;           \
+    return false;                                         \
   }
 
 #define JXL_JPEG_VERIFY_INPUT(var, low, high, code)                \
@@ -49,21 +50,22 @@ static const size_t kBrunsliMaxNumBlocks = 1ull << 24;
     return false;                                                  \
   }
 
-#define JXL_JPEG_VERIFY_MARKER_END()                                 \
-  if (start_pos + marker_len != *pos) {                              \
-    JXL_JPEG_DEBUG("Invalid marker length: declared=%zu actual=%zu", \
-                   marker_len, (*pos - start_pos));                  \
-    jpg->error = JPEGReadError::WRONG_MARKER_SIZE;                   \
-    return false;                                                    \
+#define JXL_JPEG_VERIFY_MARKER_END()                         \
+  if (start_pos + marker_len != *pos) {                      \
+    JXL_JPEG_DEBUG("Invalid marker length: declared=%" PRIuS \
+                   " actual=%" PRIuS,                        \
+                   marker_len, (*pos - start_pos));          \
+    jpg->error = JPEGReadError::WRONG_MARKER_SIZE;           \
+    return false;                                            \
   }
 
-#define JXL_JPEG_EXPECT_MARKER()                                      \
-  if (pos + 2 > len || data[pos] != 0xff) {                           \
-    JXL_JPEG_DEBUG(                                                   \
-        "Marker byte (0xff) expected, found: 0x%.2x pos=%zu len=%zu", \
-        (pos < len ? data[pos] : 0), pos, len);                       \
-    jpg->error = JPEGReadError::MARKER_BYTE_NOT_FOUND;                \
-    return false;                                                     \
+#define JXL_JPEG_EXPECT_MARKER()                                            \
+  if (pos + 2 > len || data[pos] != 0xff) {                                 \
+    JXL_JPEG_DEBUG("Marker byte (0xff) expected, found: 0x%.2x pos=%" PRIuS \
+                   " len=%" PRIuS,                                          \
+                   (pos < len ? data[pos] : 0), pos, len);                  \
+    jpg->error = JPEGReadError::MARKER_BYTE_NOT_FOUND;                      \
+    return false;                                                           \
   }
 
 inline int ReadUint8(const uint8_t* data, size_t* pos) {
@@ -947,8 +949,9 @@ bool ProcessScan(const uint8_t* data, const size_t len,
     return false;
   }
   if (*pos > len) {
-    JXL_JPEG_DEBUG("Unexpected end of file during scan. pos=%zu len=%zu", *pos,
-                   len);
+    JXL_JPEG_DEBUG("Unexpected end of file during scan. pos=%" PRIuS
+                   " len=%" PRIuS,
+                   *pos, len);
     jpg->error = JPEGReadError::UNEXPECTED_EOF;
     return false;
   }
@@ -1092,8 +1095,8 @@ bool ReadJpeg(const uint8_t* data, const size_t len, JpegReadMode mode,
         }
         break;
       default:
-        JXL_JPEG_DEBUG("Unsupported marker: %d pos=%zu len=%zu", marker, pos,
-                       len);
+        JXL_JPEG_DEBUG("Unsupported marker: %d pos=%" PRIuS " len=%" PRIuS,
+                       marker, pos, len);
         jpg->error = JPEGReadError::UNSUPPORTED_MARKER;
         ok = false;
         break;

--- a/lib/jxl/jpeg/jpeg_data.cc
+++ b/lib/jxl/jpeg/jpeg_data.cc
@@ -66,12 +66,13 @@ Status JPEGData::VisitFields(Visitor* visitor) {
       JXL_RETURN_IF_ERROR(VisitMarker(&marker, visitor, &info));
       marker_order.push_back(marker);
       if (marker_order.size() > 16384) {
-        return JXL_FAILURE("Too many markers: %zu\n", marker_order.size());
+        return JXL_FAILURE("Too many markers: %" PRIuS "\n",
+                           marker_order.size());
       }
     } while (marker != 0xd9);
   } else {
     if (marker_order.size() > 16384) {
-      return JXL_FAILURE("Too many markers: %zu\n", marker_order.size());
+      return JXL_FAILURE("Too many markers: %" PRIuS "\n", marker_order.size());
     }
     for (size_t i = 0; i < marker_order.size(); i++) {
       JXL_RETURN_IF_ERROR(VisitMarker(&marker_order[i], visitor, &info));
@@ -110,7 +111,7 @@ Status JPEGData::VisitFields(Visitor* visitor) {
     JXL_RETURN_IF_ERROR(visitor->Bits(16, 0, &len));
     if (visitor->IsReading()) app.resize(len + 1);
     if (app.size() < 3) {
-      return JXL_FAILURE("Invalid marker size: %zu\n", app.size());
+      return JXL_FAILURE("Invalid marker size: %" PRIuS "\n", app.size());
     }
   }
   for (auto& com : com_data) {
@@ -118,7 +119,7 @@ Status JPEGData::VisitFields(Visitor* visitor) {
     JXL_RETURN_IF_ERROR(visitor->Bits(16, 0, &len));
     if (visitor->IsReading()) com.resize(len + 1);
     if (com.size() < 3) {
-      return JXL_FAILURE("Invalid marker size: %zu\n", com.size());
+      return JXL_FAILURE("Invalid marker size: %" PRIuS "\n", com.size());
     }
   }
 
@@ -189,15 +190,15 @@ Status JPEGData::VisitFields(Visitor* visitor) {
   for (size_t i = 0; i < components.size(); i++) {
     JXL_RETURN_IF_ERROR(visitor->Bits(2, 0, &components[i].quant_idx));
     if (components[i].quant_idx >= quant.size()) {
-      return JXL_FAILURE("Invalid quant table for component %zu: %u\n", i,
-                         components[i].quant_idx);
+      return JXL_FAILURE("Invalid quant table for component %" PRIuS ": %u\n",
+                         i, components[i].quant_idx);
     }
     used_tables |= 1U << components[i].quant_idx;
   }
   if (used_tables + 1 != 1U << quant.size()) {
-    return JXL_FAILURE(
-        "Not all quant tables are used (%zu tables, %zx used table mask)",
-        quant.size(), used_tables);
+    return JXL_FAILURE("Not all quant tables are used (%" PRIuS
+                       " tables, %" PRIx64 " used table mask)",
+                       quant.size(), static_cast<uint64_t>(used_tables));
   }
 
   uint32_t num_huff = huffman_code.size();
@@ -224,7 +225,7 @@ Status JPEGData::VisitFields(Visitor* visitor) {
       return JXL_FAILURE("Empty Huffman table");
     }
     if (num_symbols > hc.values.size()) {
-      return JXL_FAILURE("Huffman code too large (%zu)", num_symbols);
+      return JXL_FAILURE("Huffman code too large (%" PRIuS ")", num_symbols);
     }
     // Presence flags for 4 * 64 + 1 values.
     uint64_t value_slots[5] = {};
@@ -429,8 +430,9 @@ Status SetJPEGDataFromICC(const PaddedBytes& icc, jpeg::JPEGData* jpeg_data) {
     size_t len = jpeg_data->app_data[i].size() - 17;
     if (icc_pos + len > icc.size()) {
       return JXL_FAILURE(
-          "ICC length is less than APP markers: requested %zu more bytes, "
-          "%zu available",
+          "ICC length is less than APP markers: requested %" PRIuS
+          " more bytes, "
+          "%" PRIuS " available",
           len, icc.size() - icc_pos);
     }
     memcpy(&jpeg_data->app_data[i][17], icc.data() + icc_pos, len);

--- a/lib/jxl/jxl_test.cc
+++ b/lib/jxl/jxl_test.cc
@@ -133,7 +133,7 @@ TEST(JxlTest, RoundtripTinyFast) {
 
   CodecInOut io2;
   const size_t enc_bytes = Roundtrip(&io, cparams, dparams, pool, &io2);
-  printf("32x32 image size %zu bytes\n", enc_bytes);
+  printf("32x32 image size %" PRIuS " bytes\n", enc_bytes);
 }
 
 TEST(JxlTest, RoundtripSmallD1) {

--- a/lib/jxl/linalg.h
+++ b/lib/jxl/linalg.h
@@ -16,6 +16,7 @@
 
 #include "lib/jxl/base/compiler_specific.h"
 #include "lib/jxl/base/status.h"
+#include "lib/jxl/common.h"
 #include "lib/jxl/image.h"
 #include "lib/jxl/image_ops.h"
 

--- a/lib/jxl/modular/encoding/enc_debug_tree.cc
+++ b/lib/jxl/modular/encoding/enc_debug_tree.cc
@@ -106,14 +106,14 @@ void PrintTree(const Tree &tree, const std::string &path) {
   fprintf(f, "graph{\n");
   for (size_t cur = 0; cur < tree.size(); cur++) {
     if (tree[cur].property < 0) {
-      fprintf(f, "n%05zu [label=\"%s%+" PRId64 " (x%u)\"];\n", cur,
+      fprintf(f, "n%05" PRIuS " [label=\"%s%+" PRId64 " (x%u)\"];\n", cur,
               PredictorName(tree[cur].predictor), tree[cur].predictor_offset,
               tree[cur].multiplier);
     } else {
-      fprintf(f, "n%05zu [label=\"%s>%d\"];\n", cur,
+      fprintf(f, "n%05" PRIuS " [label=\"%s>%d\"];\n", cur,
               PropertyName(tree[cur].property).c_str(), tree[cur].splitval);
-      fprintf(f, "n%05zu -- n%05d;\n", cur, tree[cur].lchild);
-      fprintf(f, "n%05zu -- n%05d;\n", cur, tree[cur].rchild);
+      fprintf(f, "n%05" PRIuS " -- n%05d;\n", cur, tree[cur].lchild);
+      fprintf(f, "n%05" PRIuS " -- n%05d;\n", cur, tree[cur].rchild);
     }
   }
   fprintf(f, "}\n");

--- a/lib/jxl/modular/encoding/enc_encoding.cc
+++ b/lib/jxl/modular/encoding/enc_encoding.cc
@@ -71,7 +71,8 @@ void GatherTreeData(const Image &image, pixel_type chan, size_t group_id,
                     size_t *total_pixels) {
   const Channel &channel = image.channel[chan];
 
-  JXL_DEBUG_V(7, "Learning %zux%zu channel %d", channel.w, channel.h, chan);
+  JXL_DEBUG_V(7, "Learning %" PRIuS "x%" PRIuS " channel %d", channel.w,
+              channel.h, chan);
 
   std::array<pixel_type, kNumStaticProperties> static_props = {
       {chan, (int)group_id}};
@@ -171,7 +172,8 @@ Status EncodeModularChannelMAANS(const Image &image, pixel_type chan,
   if (kWantDebug) predictor_img = Image3F(channel.w, channel.h);
 
   JXL_DEBUG_V(6,
-              "Encoding %zux%zu channel %d, "
+              "Encoding %" PRIuS "x%" PRIuS
+              " channel %d, "
               "(shift=%i,%i)",
               channel.w, channel.h, chan, channel.hshift, channel.vshift);
 
@@ -184,7 +186,7 @@ Status EncodeModularChannelMAANS(const Image &image, pixel_type chan,
                              &is_wp_only, &is_gradient_only);
   Properties properties(num_props);
   MATreeLookup tree_lookup(tree);
-  JXL_DEBUG_V(3, "Encoding using a MA tree with %zu nodes", tree.size());
+  JXL_DEBUG_V(3, "Encoding using a MA tree with %" PRIuS " nodes", tree.size());
 
   // Check if this tree is a WP-only tree with a small enough property value
   // range.
@@ -381,8 +383,9 @@ Status ModularEncode(const Image &image, const ModularOptions &options,
                      size_t *width) {
   if (image.error) return JXL_FAILURE("Invalid image");
   size_t nb_channels = image.channel.size();
-  JXL_DEBUG_V(2, "Encoding %zu-channel, %i-bit, %zux%zu image.", nb_channels,
-              image.bitdepth, image.w, image.h);
+  JXL_DEBUG_V(
+      2, "Encoding %" PRIuS "-channel, %i-bit, %" PRIuS "x%" PRIuS " image.",
+      nb_channels, image.bitdepth, image.w, image.h);
 
   if (nb_channels < 1) {
     return true;  // is there any use for a zero-channel image?
@@ -530,10 +533,11 @@ Status ModularGenericCompress(Image &image, const ModularOptions &opts,
                                     header, tokens, width));
   bits = writer ? writer->BitsWritten() - bits : 0;
   if (writer) {
-    JXL_DEBUG_V(
-        4,
-        "Modular-encoded a %zux%zu bitdepth=%i nbchans=%zu image in %zu bytes",
-        image.w, image.h, image.bitdepth, image.channel.size(), bits / 8);
+    JXL_DEBUG_V(4,
+                "Modular-encoded a %" PRIuS "x%" PRIuS
+                " bitdepth=%i nbchans=%" PRIuS " image in %" PRIuS " bytes",
+                image.w, image.h, image.bitdepth, image.channel.size(),
+                bits / 8);
   }
   (void)bits;
   return true;

--- a/lib/jxl/modular/encoding/encoding.cc
+++ b/lib/jxl/modular/encoding/encoding.cc
@@ -154,7 +154,7 @@ Status DecodeModularChannelMAANS(BitReader *br, ANSSymbolReader *reader,
     }
   }
 
-  JXL_DEBUG_V(3, "Decoded MA tree with %zu nodes", tree.size());
+  JXL_DEBUG_V(3, "Decoded MA tree with %" PRIuS " nodes", tree.size());
 
   // MAANS decode
   const auto make_pixel = [](uint64_t v, pixel_type multiplier,
@@ -387,7 +387,7 @@ Status ModularDecode(BitReader *br, Image &image, GroupHeader &header,
 
   // decode transforms
   JXL_RETURN_IF_ERROR(Bundle::Read(br, &header));
-  JXL_DEBUG_V(3, "Image data underwent %zu transformations: ",
+  JXL_DEBUG_V(3, "Image data underwent %" PRIuS " transformations: ",
               header.transforms.size());
   image.transform = header.transforms;
   for (Transform &transform : image.transform) {
@@ -509,7 +509,9 @@ Status ModularGenericDecompress(BitReader *br, Image &image,
   if (undo_transforms) image.undo_transforms(header->wp_header);
   if (image.error) return JXL_FAILURE("Corrupt file. Aborting.");
   size_t bit_pos = br->TotalBitsConsumed();
-  JXL_DEBUG_V(4, "Modular-decoded a %zux%zu nbchans=%zu image from %zu bytes",
+  JXL_DEBUG_V(4,
+              "Modular-decoded a %" PRIuS "x%" PRIuS " nbchans=%" PRIuS
+              " image from %" PRIuS " bytes",
               image.w, image.h, image.channel.size(),
               (br->TotalBitsConsumed() - bit_pos) / 8);
   (void)bit_pos;

--- a/lib/jxl/modular/transform/squeeze.cc
+++ b/lib/jxl/modular/transform/squeeze.cc
@@ -33,7 +33,7 @@ void InvHSqueeze(Image &input, uint32_t c, uint32_t rc, ThreadPool *pool) {
   Channel chout(chin.w + chin_residual.w, chin.h, chin.hshift - 1, chin.vshift);
   JXL_DEBUG_V(4,
               "Undoing horizontal squeeze of channel %i using residuals in "
-              "channel %i (going from width %zu to %zu)",
+              "channel %i (going from width %" PRIuS " to %" PRIuS ")",
               c, rc, chin.w, chout.w);
 
   if (chin_residual.h == 0) {
@@ -100,7 +100,7 @@ void InvVSqueeze(Image &input, uint32_t c, uint32_t rc, ThreadPool *pool) {
   JXL_DEBUG_V(
       4,
       "Undoing vertical squeeze of channel %i using residuals in channel "
-      "%i (going from height %zu to %zu)",
+      "%i (going from height %" PRIuS " to %" PRIuS ")",
       c, rc, chin.h, chout.h);
 
   if (chin_residual.w == 0) {
@@ -164,7 +164,8 @@ void DefaultSqueezeParameters(std::vector<SqueezeParams> *parameters,
   parameters->clear();
   size_t w = image.channel[image.nb_meta_channels].w;
   size_t h = image.channel[image.nb_meta_channels].h;
-  JXL_DEBUG_V(7, "Default squeeze parameters for %zux%zu image: ", w, h);
+  JXL_DEBUG_V(
+      7, "Default squeeze parameters for %" PRIuS "x%" PRIuS " image: ", w, h);
 
   // do horizontal first on wide images; vertical first on tall images
   bool wide = (w > h);
@@ -173,7 +174,7 @@ void DefaultSqueezeParameters(std::vector<SqueezeParams> *parameters,
       image.channel[image.nb_meta_channels + 1].h == h) {
     // assume channels 1 and 2 are chroma, and can be squeezed first for 4:2:0
     // previews
-    JXL_DEBUG_V(7, "(4:2:0 chroma), %zux%zu image", w, h);
+    JXL_DEBUG_V(7, "(4:2:0 chroma), %" PRIuS "x%" PRIuS " image", w, h);
     SqueezeParams params;
     // horizontal chroma squeeze
     params.horizontal = true;
@@ -195,7 +196,7 @@ void DefaultSqueezeParameters(std::vector<SqueezeParams> *parameters,
       params.horizontal = false;
       parameters->push_back(params);
       h = (h + 1) / 2;
-      JXL_DEBUG_V(7, "Vertical (%zux%zu), ", w, h);
+      JXL_DEBUG_V(7, "Vertical (%" PRIuS "x%" PRIuS "), ", w, h);
     }
   }
   while (w > JXL_MAX_FIRST_PREVIEW_SIZE || h > JXL_MAX_FIRST_PREVIEW_SIZE) {
@@ -203,13 +204,13 @@ void DefaultSqueezeParameters(std::vector<SqueezeParams> *parameters,
       params.horizontal = true;
       parameters->push_back(params);
       w = (w + 1) / 2;
-      JXL_DEBUG_V(7, "Horizontal (%zux%zu), ", w, h);
+      JXL_DEBUG_V(7, "Horizontal (%" PRIuS "x%" PRIuS "), ", w, h);
     }
     if (h > JXL_MAX_FIRST_PREVIEW_SIZE) {
       params.horizontal = false;
       parameters->push_back(params);
       h = (h + 1) / 2;
-      JXL_DEBUG_V(7, "Vertical (%zux%zu), ", w, h);
+      JXL_DEBUG_V(7, "Vertical (%" PRIuS "x%" PRIuS "), ", w, h);
     }
   }
   JXL_DEBUG_V(7, "that's it");

--- a/lib/jxl/modular/transform/transform.cc
+++ b/lib/jxl/modular/transform/transform.cc
@@ -21,8 +21,8 @@ Transform::Transform(TransformId id) {
 
 Status Transform::Inverse(Image &input, const weighted::Header &wp_header,
                           ThreadPool *pool) {
-  JXL_DEBUG_V(6, "Input channels (%zu, %zu meta): ", input.channel.size(),
-              input.nb_meta_channels);
+  JXL_DEBUG_V(6, "Input channels (%" PRIuS ", %" PRIuS " meta): ",
+              input.channel.size(), input.nb_meta_channels);
   switch (id) {
     case TransformId::kRCT:
       return InvRCT(input, begin_c, rct_type, pool);
@@ -38,8 +38,8 @@ Status Transform::Inverse(Image &input, const weighted::Header &wp_header,
 }
 
 Status Transform::MetaApply(Image &input) {
-  JXL_DEBUG_V(6, "Input channels (%zu, %zu meta): ", input.channel.size(),
-              input.nb_meta_channels);
+  JXL_DEBUG_V(6, "Input channels (%" PRIuS ", %" PRIuS " meta): ",
+              input.channel.size(), input.nb_meta_channels);
   switch (id) {
     case TransformId::kRCT:
       JXL_DEBUG_V(2, "Transform: kRCT, rct_type=%" PRIu32, rct_type);
@@ -77,9 +77,9 @@ Status Transform::MetaApply(Image &input) {
 
 Status CheckEqualChannels(const Image &image, uint32_t c1, uint32_t c2) {
   if (c1 > image.channel.size() || c2 >= image.channel.size() || c2 < c1) {
-    return JXL_FAILURE(
-        "Invalid channel range: %u..%u (there are only %zu channels)", c1, c2,
-        image.channel.size());
+    return JXL_FAILURE("Invalid channel range: %u..%u (there are only %" PRIuS
+                       " channels)",
+                       c1, c2, image.channel.size());
   }
   if (c1 < image.nb_meta_channels && c2 >= image.nb_meta_channels) {
     return JXL_FAILURE("Invalid: transforming mix of meta and nonmeta");

--- a/lib/jxl/quant_weights.cc
+++ b/lib/jxl/quant_weights.cc
@@ -99,7 +99,7 @@ Status GetQuantWeights(
     size_t num_bands, float* out) {
   for (size_t c = 0; c < 3; c++) {
     if (print_mode) {
-      fprintf(stderr, "Channel %zu\n", c);
+      fprintf(stderr, "Channel %" PRIuS "\n", c);
     }
     float bands[DctQuantWeightParams::kMaxDistanceBands] = {
         distance_bands[c][0]};
@@ -122,7 +122,7 @@ Status GetQuantWeights(
           fprintf(stderr, "%15.12f, ", weight);
         }
         if (print_mode == 2) {
-          fprintf(stderr, "%zu %zu %15.12f\n", x, y, weight);
+          fprintf(stderr, "%" PRIuS " %" PRIuS " %15.12f\n", x, y, weight);
         }
         out[c * COLS * ROWS + y * COLS + x] = weight;
       }

--- a/lib/jxl/sanitizers.h
+++ b/lib/jxl/sanitizers.h
@@ -98,7 +98,8 @@ static JXL_INLINE JXL_MAYBE_UNUSED void PoisonImage(const Image3<T>& im) {
 template <typename T>
 static JXL_INLINE JXL_MAYBE_UNUSED void PrintImageUninitialized(
     const Plane<T>& im) {
-  fprintf(stderr, "Uninitialized regions for image of size %zux%zu:\n",
+  fprintf(stderr,
+          "Uninitialized regions for image of size %" PRIuS "x%" PRIuS ":\n",
           im.xsize(), im.ysize());
 
   // A segment of uninitialized pixels in a row, in the format [first, second).
@@ -137,15 +138,15 @@ static JXL_INLINE JXL_MAYBE_UNUSED void PrintImageUninitialized(
         return;
       }
       if (end_y - start_y_ > 1) {
-        fprintf(stderr, " y=[%zd, %zu):", start_y_, end_y);
+        fprintf(stderr, " y=[%" PRIdS ", %" PRIuS "):", start_y_, end_y);
       } else {
-        fprintf(stderr, " y=[%zd]:", start_y_);
+        fprintf(stderr, " y=[%" PRIdS "]:", start_y_);
       }
       for (const auto& seg : segments_) {
         if (seg.first + 1 == seg.second) {
-          fprintf(stderr, " [%zd]", seg.first);
+          fprintf(stderr, " [%" PRIdS "]", seg.first);
         } else {
-          fprintf(stderr, " [%zd, %zu)", seg.first, seg.second);
+          fprintf(stderr, " [%" PRIdS ", %" PRIuS ")", seg.first, seg.second);
         }
       }
       fprintf(stderr, "\n");
@@ -203,12 +204,15 @@ static JXL_INLINE JXL_MAYBE_UNUSED void CheckImageInitialized(
     intptr_t ret = __msan_test_shadow(row + r.x0(), sizeof(*row) * r.xsize());
     if (ret != -1) {
       JXL_DEBUG(1,
-                "Checking an image of %zu x %zu, rect x0=%zu, y0=%zu, "
-                "xsize=%zu, ysize=%zu",
+                "Checking an image of %" PRIuS " x %" PRIuS ", rect x0=%" PRIuS
+                ", y0=%" PRIuS
+                ", "
+                "xsize=%" PRIuS ", ysize=%" PRIuS,
                 im.xsize(), im.ysize(), r.x0(), r.y0(), r.xsize(), r.ysize());
       size_t x = ret / sizeof(*row);
-      JXL_DEBUG(1, "CheckImageInitialized failed at x=%zu, y=%zu: %s",
-                r.x0() + x, y, message ? message : "");
+      JXL_DEBUG(
+          1, "CheckImageInitialized failed at x=%" PRIuS ", y=%" PRIuS ": %s",
+          r.x0() + x, y, message ? message : "");
       PrintImageUninitialized(im);
     }
     // This will report an error if memory is not initialized.

--- a/lib/jxl/splines.cc
+++ b/lib/jxl/splines.cc
@@ -417,7 +417,7 @@ Status QuantizedSpline::Decode(const std::vector<uint8_t>& context_map,
       decoder->ReadHybridUint(kNumControlPointsContext, br, context_map);
   *total_num_control_points += num_control_points;
   if (*total_num_control_points > max_control_points) {
-    return JXL_FAILURE("Too many control points: %zu",
+    return JXL_FAILURE("Too many control points: %" PRIuS,
                        *total_num_control_points);
   }
   control_points_.resize(num_control_points);
@@ -462,7 +462,7 @@ Status Splines::Decode(jxl::BitReader* br, size_t num_pixels) {
   size_t max_control_points = std::min(
       kMaxNumControlPoints, num_pixels / kMaxNumControlPointsPerPixelRatio);
   if (num_splines > max_control_points) {
-    return JXL_FAILURE("Too many splines: %zu", num_splines);
+    return JXL_FAILURE("Too many splines: %" PRIuS, num_splines);
   }
   JXL_RETURN_IF_ERROR(DecodeAllStartingPoints(&starting_points_, br, &decoder,
                                               context_map, num_splines));
@@ -513,8 +513,8 @@ Status Splines::InitializeDrawCache(size_t image_xsize, size_t image_ysize,
     if (std::adjacent_find(spline.control_points.begin(),
                            spline.control_points.end()) !=
         spline.control_points.end()) {
-      return JXL_FAILURE("identical successive control points in spline %zu",
-                         i);
+      return JXL_FAILURE(
+          "identical successive control points in spline %" PRIuS, i);
     }
     std::vector<std::pair<Spline::Point, float>> points_to_draw;
     ForEachEquallySpacedPoint(

--- a/lib/jxl/splines_test.cc
+++ b/lib/jxl/splines_test.cc
@@ -193,7 +193,7 @@ TEST(SplinesTest, Serialization) {
   writer.ZeroPadToByte();
   const size_t bits_written = writer.BitsWritten();
 
-  printf("Wrote %zu bits of splines.\n", bits_written);
+  printf("Wrote %" PRIuS " bits of splines.\n", bits_written);
 
   BitReader reader(writer.GetSpan());
   Splines decoded_splines;

--- a/lib/profiler/profiler.cc
+++ b/lib/profiler/profiler.cc
@@ -432,7 +432,7 @@ void ThreadSpecific::ComputeOverhead() {
     std::sort(samples, samples + kNumSamples);
     self_overhead = samples[kNumSamples / 2];
 #if PROFILER_PRINT_OVERHEAD
-    printf("Overhead: %zu\n", self_overhead);
+    printf("Overhead: %" PRIuS "\n", self_overhead);
 #endif
     results_->SetSelfOverhead(self_overhead);
   }
@@ -468,7 +468,7 @@ void ThreadSpecific::ComputeOverhead() {
   std::sort(samples, samples + kNumSamples);
   const uint64_t child_overhead = samples[9 * kNumSamples / 10];
 #if PROFILER_PRINT_OVERHEAD
-  printf("Child overhead: %zu\n", child_overhead);
+  printf("Child overhead: %" PRIuS "\n", child_overhead);
 #endif
   results_->SetChildOverhead(child_overhead);
 }

--- a/tools/args.h
+++ b/tools/args.h
@@ -120,8 +120,10 @@ static inline bool ParsePredictor(const char* arg, jxl::Predictor* out) {
     return JXL_FAILURE("Args");
   }
   if (p >= jxl::kNumModularPredictors) {
-    fprintf(stderr, "Invalid predictor value %zu, must be less than %zu.\n", p,
-            jxl::kNumModularPredictors);
+    fprintf(stderr,
+            "Invalid predictor value %" PRIuS ", must be less than %" PRIuS
+            ".\n",
+            p, jxl::kNumModularPredictors);
     return JXL_FAILURE("Args");
   }
   *out = static_cast<jxl::Predictor>(p);

--- a/tools/benchmark/benchmark_stats.cc
+++ b/tools/benchmark/benchmark_stats.cc
@@ -253,12 +253,12 @@ static std::string PrintFormattedEntries(
     if (descriptors[i].type == TYPE_STRING) {
       value = values[i].s;
     } else if (descriptors[i].type == TYPE_SIZE) {
-      value = values[i].i ? StringPrintf("%zd", values[i].i) : "---";
+      value = values[i].i ? StringPrintf("%" PRIdS, values[i].i) : "---";
     } else if (descriptors[i].type == TYPE_POSITIVE_FLOAT) {
       value = FormatFloat(descriptors[i], values[i].f);
       value = FormatFloat(descriptors[i], values[i].f);
     } else if (descriptors[i].type == TYPE_COUNT) {
-      value = StringPrintf("%zd", values[i].i);
+      value = StringPrintf("%" PRIdS, values[i].i);
     }
 
     int numspaces = descriptors[i].width - value.size();

--- a/tools/benchmark/benchmark_xl.cc
+++ b/tools/benchmark/benchmark_xl.cc
@@ -177,7 +177,8 @@ void DoCompress(const std::string& filename, const CodecInOut& io,
     if (!Args()->silent_errors) {
       // Animated gifs not supported yet?
       fprintf(stderr,
-              "Frame sizes not equal, is this an animated gif? %s %s %zu %zu\n",
+              "Frame sizes not equal, is this an animated gif? %s %s %" PRIuS
+              " %" PRIuS "\n",
               codec_name.c_str(), name.c_str(), io.frames.size(),
               io2.frames.size());
     }
@@ -480,12 +481,12 @@ void WriteHtmlReport(const std::string& codec_desc,
       url_out = Base64Image(fname_out);
       url_heatmap = Base64Image(fname_heatmap);
     }
-    std::string number = StringPrintf("%zu", i);
+    std::string number = StringPrintf("%" PRIuS, i);
     const CodecInOut& image = *images[i];
     size_t xsize = image.frames.size() == 1 ? image.xsize() : 0;
     size_t ysize = image.frames.size() == 1 ? image.ysize() : 0;
-    std::string html_width = StringPrintf("%zupx", xsize);
-    std::string html_height = StringPrintf("%zupx", ysize);
+    std::string html_width = StringPrintf("%" PRIuS "px", xsize);
+    std::string html_height = StringPrintf("%" PRIuS "px", ysize);
     double bpp = tasks[i]->stats.total_compressed_size * 8.0 /
                  tasks[i]->stats.total_input_pixels;
     double pnorm =
@@ -614,7 +615,8 @@ struct StatPrinter {
     const double dec_mps =
         t.stats.total_input_pixels / (1000000.0 * t.stats.total_time_decode);
     if (Args()->print_details_csv) {
-      printf("%s,%s,%zd,%zd,%zd,%.8f,%.8f,%.8f,%.8f,%.8f,%.8f,%.8f,%.8f",
+      printf("%s,%s,%" PRIdS ",%" PRIdS ",%" PRIdS
+             ",%.8f,%.8f,%.8f,%.8f,%.8f,%.8f,%.8f,%.8f",
              (*methods_)[t.idx_method].c_str(),
              FileBaseName((*fnames_)[t.idx_image]).c_str(),
              t.stats.total_errors, t.stats.total_compressed_size, pixels,
@@ -636,8 +638,8 @@ struct StatPrinter {
         printf(" ");
       }
       printf(
-          "error:%zd    size:%8zd    pixels:%9zd    enc_speed:%8.8f"
-          "    dec_speed:%8.8f    bpp:%10.8f    dist:%10.8f"
+          "error:%" PRIdS "    size:%8" PRIdS "    pixels:%9" PRIdS
+          "    enc_speed:%8.8f    dec_speed:%8.8f    bpp:%10.8f    dist:%10.8f"
           "    psnr:%10.8f    p:%10.8f    bppp:%10.8f    qabpp:%10.8f ",
           t.stats.total_errors, t.stats.total_compressed_size, pixels, enc_mps,
           dec_mps, comp_bpp, t.stats.max_distance, psnr, p_norm, bpp_p_norm,
@@ -823,10 +825,11 @@ class Benchmark {
     pool->RunOnEachThread([&](int /*task*/, const int thread) {
       const size_t index = *next_index + static_cast<size_t>(thread);
       if (index < cpus.size()) {
-        // printf("pin pool %p thread %3d to index %3zu = cpu %3d\n",
+        // printf("pin pool %p thread %3d to index %3" PRIuS " = cpu %3d\n",
         //        static_cast<void*>(pool), thread, index, cpus[index]);
         if (!jpegxl::tools::cpu::PinThreadToCPU(cpus[index])) {
-          fprintf(stderr, "WARNING: failed to pin thread %d, next %zu.\n",
+          fprintf(stderr,
+                  "WARNING: failed to pin thread %d, next %" PRIuS ".\n",
                   thread, *next_index);
         }
       }
@@ -904,7 +907,8 @@ class Benchmark {
                                    const std::string& sample_tmp_dir,
                                    int num_samples, size_t size) {
     JXL_CHECK(!sample_tmp_dir.empty());
-    fprintf(stderr, "Creating samples of %zux%zu tiles...\n", size, size);
+    fprintf(stderr, "Creating samples of %" PRIuS "x%" PRIuS " tiles...\n",
+            size, size);
     StringVec fnames_out;
     std::vector<Image3F> images;
     std::vector<size_t> offsets;

--- a/tools/box/box_list_main.cc
+++ b/tools/box/box_list_main.cc
@@ -28,18 +28,19 @@ int RunMain(int argc, const char* argv[]) {
 
   jxl::PaddedBytes compressed;
   if (!jxl::ReadFile(argv[1], &compressed)) return 1;
-  fprintf(stderr, "Read %zu compressed bytes\n", compressed.size());
+  fprintf(stderr, "Read %" PRIuS " compressed bytes\n", compressed.size());
 
   const uint8_t* in = compressed.data();
   size_t available_in = compressed.size();
 
-  fprintf(stderr, "File size: %zu\n", compressed.size());
+  fprintf(stderr, "File size: %" PRIuS "\n", compressed.size());
 
   while (available_in != 0) {
     const uint8_t* start = in;
     Box box;
     if (!ParseBoxHeader(&in, &available_in, &box)) {
-      fprintf(stderr, "Failed at %zu\n", compressed.size() - available_in);
+      fprintf(stderr, "Failed at %" PRIuS "\n",
+              compressed.size() - available_in);
       break;
     }
 
@@ -55,8 +56,8 @@ int RunMain(int argc, const char* argv[]) {
       }
     }
 
-    printf("box: \"%.4s\" box_size:%zu data_size:%zu", box.type, box_size,
-           data_size);
+    printf("box: \"%.4s\" box_size:%" PRIuS " data_size:%" PRIuS, box.type,
+           box_size, data_size);
     if (!memcmp("uuid", box.type, 4)) {
       printf(" -- extended type:\"%.16s\"", box.extended_type);
     }
@@ -67,9 +68,9 @@ int RunMain(int argc, const char* argv[]) {
     printf("\n");
 
     if (data_size > available_in) {
-      fprintf(stderr, "Unexpected end of file %zu %zu %zu\n",
-              static_cast<size_t>(box.data_size), available_in,
-              compressed.size());
+      fprintf(
+          stderr, "Unexpected end of file %" PRIuS " %" PRIuS " %" PRIuS "\n",
+          static_cast<size_t>(box.data_size), available_in, compressed.size());
       break;
     }
 

--- a/tools/butteraugli_main.cc
+++ b/tools/butteraugli_main.cc
@@ -65,11 +65,13 @@ Status RunButteraugli(const char* pathname1, const char* pathname2,
   }
 
   if (io1.xsize() != io2.xsize()) {
-    fprintf(stderr, "Width mismatch: %zu %zu\n", io1.xsize(), io2.xsize());
+    fprintf(stderr, "Width mismatch: %" PRIuS " %" PRIuS "\n", io1.xsize(),
+            io2.xsize());
     return false;
   }
   if (io1.ysize() != io2.ysize()) {
-    fprintf(stderr, "Height mismatch: %zu %zu\n", io1.ysize(), io2.ysize());
+    fprintf(stderr, "Height mismatch: %" PRIuS " %" PRIuS "\n", io1.ysize(),
+            io2.ysize());
     return false;
   }
 

--- a/tools/cjxl.cc
+++ b/tools/cjxl.cc
@@ -119,7 +119,7 @@ void SetModularQualityForBitrate(jxl::ThreadPoolInternal* pool,
           quality);
       break;
     }
-    printf("Quality %.2f yields %6zu bytes, %.3f bpp.\n", quality,
+    printf("Quality %.2f yields %6" PRIuS " bytes, %.3f bpp.\n", quality,
            candidate.size(), candidate.size() * 8.0 / pixels);
     const double ratio = static_cast<double>(candidate.size()) / target_size;
     const double loss = std::abs(1.0 - ratio);
@@ -194,8 +194,8 @@ void SetParametersForSizeOrBitrate(jxl::ThreadPoolInternal* pool,
           best_dist);
       break;
     }
-    printf("Butteraugli distance %.3f yields %6zu bytes, %.3f bpp.\n", dist,
-           candidate.size(), candidate.size() * 8.0 / pixels);
+    printf("Butteraugli distance %.3f yields %6" PRIuS " bytes, %.3f bpp.\n",
+           dist, candidate.size(), candidate.size() * 8.0 / pixels);
     const double ratio = static_cast<double>(candidate.size()) / target_size;
     const double loss = std::max(ratio, 1.0 / std::max(ratio, 1e-30));
     if (best_loss > loss) {
@@ -248,7 +248,8 @@ void PrintMode(jxl::ThreadPoolInternal* pool, const jxl::CodecInOut& io,
   const char* speed = SpeedTierName(args.params.speed_tier);
   const std::string quality = QualityFromArgs(args);
   fprintf(stderr,
-          "Read %zux%zu image, %.1f MP/s\n"
+          "Read %" PRIuS "x%" PRIuS
+          " image, %.1f MP/s\n"
           "Encoding [%s%s, %s, %s",
           io.xsize(), io.ysize(), decode_mps,
           (args.use_container ? "Container | " : ""), mode, quality.c_str(),
@@ -256,13 +257,13 @@ void PrintMode(jxl::ThreadPoolInternal* pool, const jxl::CodecInOut& io,
   if (args.use_container) {
     if (args.jpeg_transcode) fprintf(stderr, " | JPEG reconstruction data");
     if (!io.blobs.exif.empty())
-      fprintf(stderr, " | %zu-byte Exif", io.blobs.exif.size());
+      fprintf(stderr, " | %" PRIuS "-byte Exif", io.blobs.exif.size());
     if (!io.blobs.xmp.empty())
-      fprintf(stderr, " | %zu-byte XMP", io.blobs.xmp.size());
+      fprintf(stderr, " | %" PRIuS "-byte XMP", io.blobs.xmp.size());
     if (!io.blobs.jumbf.empty())
-      fprintf(stderr, " | %zu-byte JUMBF", io.blobs.jumbf.size());
+      fprintf(stderr, " | %" PRIuS "-byte JUMBF", io.blobs.jumbf.size());
   }
-  fprintf(stderr, "], %zu threads.\n", pool->NumWorkerThreads());
+  fprintf(stderr, "], %" PRIuS " threads.\n", pool->NumWorkerThreads());
 }
 
 }  // namespace
@@ -835,7 +836,7 @@ jxl::Status CompressJxl(jxl::CodecInOut& io, double decode_mps,
   if (print_stats) {
     const double bpp =
         static_cast<double>(compressed->size() * jxl::kBitsPerByte) / pixels;
-    fprintf(stderr, "Compressed to %zu bytes (%.3f bpp%s).\n",
+    fprintf(stderr, "Compressed to %" PRIuS " bytes (%.3f bpp%s).\n",
             compressed->size(), bpp / io.frames.size(),
             io.frames.size() == 1 ? "" : "/frame");
     JXL_CHECK(stats.Print(args.num_threads));

--- a/tools/djxl.cc
+++ b/tools/djxl.cc
@@ -310,7 +310,9 @@ jxl::Status WriteJxlOutput(const DecompressArgs& args, const char* file_out,
                base.c_str(), digits, i, extension);
       if (!EncodeToFile(frame_io, c_out, bits_per_sample,
                         output_filename.data(), pool)) {
-        fprintf(stderr, "Failed to write decoded image for frame %zu/%zu.\n",
+        fprintf(stderr,
+                "Failed to write decoded image for frame %" PRIuS "/%" PRIuS
+                ".\n",
                 i + 1, io.frames.size());
       }
     }

--- a/tools/djxl_main.cc
+++ b/tools/djxl_main.cc
@@ -72,7 +72,7 @@ int DecompressMain(int argc, const char* argv[]) {
     return 1;
   }
   if (!args.quiet) {
-    fprintf(stderr, "Read %zu compressed bytes.\n", compressed.size());
+    fprintf(stderr, "Read %" PRIuS " compressed bytes.\n", compressed.size());
   }
 
   // If the file uses the box format container, unpack the boxes into
@@ -105,7 +105,7 @@ int DecompressMain(int argc, const char* argv[]) {
     // 1.1-1.2x speedup (36 cores) from pinning.
     if (thread < cpus.size()) {
       if (!jpegxl::tools::cpu::PinThreadToCPU(cpus[thread])) {
-        fprintf(stderr, "WARNING: failed to pin thread %zu.\n", thread);
+        fprintf(stderr, "WARNING: failed to pin thread %" PRIuS ".\n", thread);
       }
     }
   });
@@ -187,7 +187,7 @@ int DecompressMain(int argc, const char* argv[]) {
     }
 
     if (args.print_read_bytes) {
-      fprintf(stderr, "Decoded bytes: %zu\n", io.Main().decoded_bytes());
+      fprintf(stderr, "Decoded bytes: %" PRIuS "\n", io.Main().decoded_bytes());
     }
   }
 

--- a/tools/epf_main.cc
+++ b/tools/epf_main.cc
@@ -43,7 +43,8 @@ int main(int argc, const char** argv) {
     return EXIT_FAILURE;
   }
   if (!epf_iters || epf_iters > 3) {
-    fprintf(stderr, "epf_iters value (%zu) is out of range, must be 1..3.\n",
+    fprintf(stderr,
+            "epf_iters value (%" PRIuS ") is out of range, must be 1..3.\n",
             epf_iters);
     return EXIT_FAILURE;
   }

--- a/tools/speed_stats.cc
+++ b/tools/speed_stats.cc
@@ -12,6 +12,8 @@
 #include <algorithm>
 #include <string>
 
+#include "lib/jxl/common.h"
+
 namespace jpegxl {
 namespace tools {
 
@@ -102,9 +104,11 @@ jxl::Status SpeedStats::Print(size_t worker_threads) {
     snprintf(variability, sizeof(variability), " (var %.2f)", s.variability);
   }
 
-  fprintf(stderr, "%zu x %zu%s%s%s, %zu reps, %zu threads.\n", xsize_, ysize_,
-          mps_stats.c_str(), mbs_stats.c_str(), variability, elapsed_.size(),
-          worker_threads);
+  fprintf(stderr,
+          "%" PRIuS " x %" PRIuS "%s%s%s, %" PRIuS " reps, %" PRIuS
+          " threads.\n",
+          xsize_, ysize_, mps_stats.c_str(), mbs_stats.c_str(), variability,
+          elapsed_.size(), worker_threads);
   return true;
 }
 

--- a/tools/xyb_range.cc
+++ b/tools/xyb_range.cc
@@ -63,11 +63,11 @@ void PrintXybRange() {
         }
       }
     }
-    printf(
-        "Opsin image plane %zu range: [%8.4f, %8.4f] "
-        "center: %.12f, range: %.12f (RGBmin=%06x, RGBmax=%06x)\n",
-        c, minval, maxval, 0.5 * (minval + maxval), 0.5 * (maxval - minval),
-        rgb_min, rgb_max);
+    printf("Opsin image plane %" PRIuS
+           " range: [%8.4f, %8.4f] "
+           "center: %.12f, range: %.12f (RGBmin=%06x, RGBmax=%06x)\n",
+           c, minval, maxval, 0.5 * (minval + maxval), 0.5 * (maxval - minval),
+           rgb_min, rgb_max);
     // Ensure our constants are at least as wide as those obtained from sRGB.
   }
 }


### PR DESCRIPTION
PRIuS is defined to either "zu" or "Iu" depending on the platform
allowing to print size_t values in MSYS2. This macro is meant to be used
similarly to PRIu32, so that the "%" is not part of the macro allowing
expressions like `"%3" PRIuS` instead of `"%3zu"`. Similarly, `PRIdS` is
used for ssize_t.

This patch replaces all the occurrences and adds a test to bash_test.sh.

Fixes #718.