### PR TITLE
Support exif/xmp boxes in API JPEG1 reconstruction

### DIFF
--- a/lib/jxl/decode_to_jpeg.cc
+++ b/lib/jxl/decode_to_jpeg.cc
@@ -72,6 +72,60 @@ JxlDecoderStatus JxlToJpegDecoder::Process(const uint8_t** next_in,
   return JXL_DEC_NEED_MORE_INPUT;
 }
 
+size_t JxlToJpegDecoder::NumExifMarkers(const jpeg::JPEGData& jpeg_data) {
+  size_t num = 0;
+  for (size_t i = 0; i < jpeg_data.app_data.size(); ++i) {
+    if (jpeg_data.app_marker_type[i] == jxl::jpeg::AppMarkerType::kExif) {
+      num++;
+    }
+  }
+  return num;
+}
+
+size_t JxlToJpegDecoder::NumXmpMarkers(const jpeg::JPEGData& jpeg_data) {
+  size_t num = 0;
+  for (size_t i = 0; i < jpeg_data.app_data.size(); ++i) {
+    if (jpeg_data.app_marker_type[i] == jxl::jpeg::AppMarkerType::kXMP) {
+      num++;
+    }
+  }
+  return num;
+}
+
+JxlDecoderStatus JxlToJpegDecoder::SetExif(const uint8_t* data, size_t size,
+                                           jpeg::JPEGData* jpeg_data) {
+  for (size_t i = 0; i < jpeg_data->app_data.size(); ++i) {
+    if (jpeg_data->app_marker_type[i] == jxl::jpeg::AppMarkerType::kExif) {
+      if (jpeg_data->app_data[i].size() != size + 9 - 4) return JXL_DEC_ERROR;
+      // The first 9 bytes are used for JPEG marker header.
+      jpeg_data->app_data[i][0] = 0xE1;
+      // The second and third byte are already filled in correctly
+      memcpy(jpeg_data->app_data[i].data() + 3, jpeg::kExifTag,
+             sizeof(jpeg::kExifTag));
+      // The first 4
+      memcpy(jpeg_data->app_data[i].data() + 9, data + 4, size - 4);
+      return JXL_DEC_SUCCESS;
+    }
+  }
+  return JXL_DEC_ERROR;
+}
+JxlDecoderStatus JxlToJpegDecoder::SetXmp(const uint8_t* data, size_t size,
+                                          jpeg::JPEGData* jpeg_data) {
+  for (size_t i = 0; i < jpeg_data->app_data.size(); ++i) {
+    if (jpeg_data->app_marker_type[i] == jxl::jpeg::AppMarkerType::kXMP) {
+      if (jpeg_data->app_data[i].size() != size + 9) return JXL_DEC_ERROR;
+      // The first 9 bytes are used for JPEG marker header.
+      jpeg_data->app_data[i][0] = 0xE1;
+      // The second and third byte are already filled in correctly
+      memcpy(jpeg_data->app_data[i].data() + 3, jpeg::kXMPTag,
+             sizeof(jpeg::kXMPTag));
+      memcpy(jpeg_data->app_data[i].data() + 5, data, size);
+      return JXL_DEC_SUCCESS;
+    }
+  }
+  return JXL_DEC_ERROR;
+}
+
 #endif  // JPEGXL_ENABLE_TRANSCODE_JPEG
 
 }  // namespace jxl

--- a/lib/jxl/decode_to_jpeg.h
+++ b/lib/jxl/decode_to_jpeg.h
@@ -37,12 +37,6 @@ class JxlToJpegDecoder {
   // Returns whether the decoder is parsing a boxa JPEG box was parsed.
   bool IsParsingBox() const { return inside_box_; }
 
-  const jpeg::JPEGData* JpegData() const { return jpeg_data_.get(); }
-
-  // Return the parsed jpeg::JPEGData object and removes it from the
-  // JxlToJpegDecoder.
-  jpeg::JPEGData* ReleaseJpegData() { return jpeg_data_.release(); }
-
   // Sets the output buffer used when producing JPEG output.
   JxlDecoderStatus SetOutputBuffer(uint8_t* data, size_t size) {
     if (next_out_) return JXL_DEC_ERROR;
@@ -74,7 +68,26 @@ class JxlToJpegDecoder {
   // Uses box_size_, inside_box_ and box_until_eof_ to calculate how much to
   // consume. Potentially stores unparsed data in buffer_.
   // Potentially populates jpeg_data_. Potentially updates inside_box_.
+  // Returns JXL_DEC_JPEG_RECONSTRUCTION when finished, JXL_DEC_NEED_MORE_INPUT
+  // if more input is needed, JXL_DEC_ERROR on parsing error.
   JxlDecoderStatus Process(const uint8_t** next_in, size_t* avail_in);
+
+  // Returns how many exif or xmp app markers are present in the JPEG data. A
+  // return value higher than 1 would require multiple exif boxes or multiple
+  // xmp boxes in the container format, and this is not supported by the API and
+  // considered an error. May only be called after Process returned success.
+  static size_t NumExifMarkers(const jpeg::JPEGData& jpeg_data);
+  static size_t NumXmpMarkers(const jpeg::JPEGData& jpeg_data);
+
+  // Returns JXL_DEC_ERROR if there is no exif/XMP marker or the data size
+  // does not match, or this function is called before Process returned
+  // success, JXL_DEC_SUCCESS otherwise. As input, provide the full box contents
+  // but not the box header. In case of exif, this includes the 4-byte TIFF
+  // header, even though it won't be copied into the JPEG.
+  static JxlDecoderStatus SetExif(const uint8_t* data, size_t size,
+                                  jpeg::JPEGData* jpeg_data);
+  static JxlDecoderStatus SetXmp(const uint8_t* data, size_t size,
+                                 jpeg::JPEGData* jpeg_data);
 
   // Sets the JpegData of the ImageBundle passed if there is anything to set.
   // Releases the JpegData from this decoder if set.
@@ -145,9 +158,6 @@ class JxlToJpegDecoder {
   bool IsOutputSet() const { return false; }
   bool IsParsingBox() const { return false; }
 
-  const jpeg::JPEGData* JpegData() const { return nullptr; }
-  jpeg::JPEGData* ReleaseJpegData() { return nullptr; }
-
   JxlDecoderStatus SetOutputBuffer(uint8_t* /* data */, size_t /* size */) {
     return JXL_DEC_ERROR;
   }
@@ -160,6 +170,19 @@ class JxlToJpegDecoder {
   }
 
   Status SetImageBundleJpegData(ImageBundle* /* ib */) { return true; }
+
+  static size_t NumExifMarkers(const jpeg::JPEGData& /*jpeg_data*/) {
+    return 0;
+  }
+  static size_t NumXmpMarkers(const jpeg::JPEGData& /*jpeg_data*/) { return 0; }
+  static JxlDecoderStatus SetExif(const uint8_t* /*data*/, size_t /*size*/,
+                                  jpeg::JPEGData* /*jpeg_data*/) {
+    return JXL_DEC_ERROR;
+  }
+  static JxlDecoderStatus SetXmp(const uint8_t* /*data*/, size_t /*size*/,
+                                 jpeg::JPEGData* /*jpeg_data*/) {
+    return JXL_DEC_ERROR;
+  }
 
   JxlDecoderStatus WriteOutput(const jpeg::JPEGData& /* jpeg_data */) {
     return JXL_DEC_SUCCESS;


### PR DESCRIPTION
Previously, the API implementation didn't set the exif and xmp box data
into the jpeg reconstruction data.

This supports it, but only for the case where the exif and/or xmp boxes
appear before the codestream for now.