### PR TITLE
add EPF and Gaborish options to jxl_from_tree

### DIFF
--- a/tools/jxl_from_tree.cc
+++ b/tools/jxl_from_tree.cc
@@ -345,6 +345,16 @@ bool ParseNode(F& tok, Tree& tree, SplineData& spline_data,
     }
 
     spline_data.splines.push_back(std::move(spline));
+  } else if (t == "Gaborish") {
+    cparams.gaborish = jxl::Override::kOn;
+  } else if (t == "EPF") {
+    t = tok();
+    size_t num = 0;
+    cparams.epf = std::stoul(t, &num);
+    if (num != t.size() || cparams.epf > 3) {
+      fprintf(stderr, "Invalid EPF: %s\n", t.c_str());
+      return false;
+    }
   } else {
     fprintf(stderr, "Unexpected node type: %s\n", t.c_str());
     return false;


### PR DESCRIPTION
Adds options `EPF` and `Gaborish` to jxl_from_tree.

Slightly smaller files can be produced with `EPF 2` and `Gaborish` on, since that results in a default RestorationFilter bundle.