### PR TITLE
take signaling cost of hybriduintconfig into account

### DIFF
--- a/lib/jxl/enc_ans.cc
+++ b/lib/jxl/enc_ans.cc
@@ -541,6 +541,7 @@ void ChooseUintConfigs(const HistogramParams& params,
                        std::vector<Histogram>* clustered_histograms,
                        EntropyEncodingData* codes, size_t* log_alpha_size) {
   codes->uint_config.resize(clustered_histograms->size());
+
   if (params.uint_method == HistogramParams::HybridUintMethod::kNone) return;
   if (params.uint_method == HistogramParams::HybridUintMethod::kContextMap) {
     codes->uint_config.clear();
@@ -622,6 +623,9 @@ void ChooseUintConfigs(const HistogramParams& params,
     for (size_t i = 0; i < clustered_histograms->size(); i++) {
       if (!is_valid[i]) continue;
       float cost = (*clustered_histograms)[i].PopulationCost() + extra_bits[i];
+      // add signaling cost of the hybriduintconfig itself
+      cost += CeilLog2Nonzero(cfg.split_exponent + 1);
+      cost += CeilLog2Nonzero(cfg.split_exponent - cfg.msb_in_token + 1);
       if (cost < costs[i]) {
         codes->uint_config[i] = cfg;
         costs[i] = cost;


### PR DESCRIPTION
Take the signaling cost of the hybriduintconfig encoding itself into account. This results in config 0-0-0 being chosen instead of 4-2-0 in case of jxl art where everything is zero anyway.

Impact is at most one byte of size reduction per group, so pretty small :)

Before:
```
Encoding      kPixels    Bytes          BPP  E MP/s  D MP/s     Max norm        pnorm       BPP*pnorm   Bugs
------------------------------------------------------------------------------------------------------------
jxl:m           13270 16720514   10.0798482   0.384   3.846   0.00000000   0.00000000  0.000000000000      0
Aggregate:      13270 16720514   10.0798482   0.384   3.846   0.00000000   0.00000000  0.000000000000      0
```

After:
```
Encoding      kPixels    Bytes          BPP  E MP/s  D MP/s     Max norm        pnorm       BPP*pnorm   Bugs
------------------------------------------------------------------------------------------------------------
jxl:m           13270 16720512   10.0798470   0.323   3.141   0.00000000   0.00000000  0.000000000000      0
Aggregate:      13270 16720512   10.0798470   0.323   3.141   0.00000000   0.00000000  0.000000000000      0
```
