### PR TITLE
Temporarily limit docutils to 0.17 to avoid incompatibility with sphinx.

### DIFF
--- a/doc/sphinx/requirements.txt
+++ b/doc/sphinx/requirements.txt
@@ -1,3 +1,7 @@
 breathe
 sphinx
 sphinx-rtd-theme
+
+# sphinx 4.2 doesn't work with docutils 0.18. Remove this line once sphinx is
+# updated to 4.3. See https://github.com/sphinx-doc/sphinx/pull/9701
+docutils<0.18


### PR DESCRIPTION
sphinx 4.2 doesn't work with docutils 0.18 (it produces a warning which
we treat as error, at least). Prevent the builders from installing
version 0.18 of docutils to fix the workflow.

This should be removed once sphinx 4.3 is released.