### PR TITLE
Use enum for encoder distance and effort options

### DIFF
--- a/lib/include/jxl/encode.h
+++ b/lib/include/jxl/encode.h
@@ -73,42 +73,58 @@ typedef enum {
 } JxlEncoderStatus;
 
 /**
- * Id of options to set to JxlEncoderOptions.
+ * Id of options to set to JxlEncoderOptions with JxlEncoderOptionsSetInteger.
+ * NOTE: this enum includes most but not all encoder options. The image quality
+ * can be set with JxlEncoderOptionsSetDistance instead.
  */
 typedef enum {
+  /** Sets encoder effort/speed level without affecting decoding speed. Valid
+   * values are, from faster to slower speed: 1:lightning 2:thunder 3:falcon
+   * 4:cheetah 5:hare 6:wombat 7:squirrel 8:kitten 9:tortoise.
+   * Default: squirrel (7).
+   */
+  JXL_ENC_OPTION_EFFORT = 0,
+
+  /** Sets the decoding speed tier for the provided options. Minimum is 0
+   * (slowest to decode, best quality/density), and maximum is 4 (fastest to
+   * decode, at the cost of some quality/density). Default is 0.
+   */
+  JXL_ENC_OPTION_DECODING_SPEED = 1,
+
   /** Sets resampling option. If enabled, the image is downsampled before
    * compression, and upsampled to original size in the decoder. Integer option,
-   * use 0 for the default behavior (resampling only applied for low quality),
+   * use -1 for the default behavior (resampling only applied for low quality),
    * 1 for no downsampling (1x1), 2 for 2x2 downsampling, 4 for 4x4
-   * downsampling, 8 for 8x8 downsampling. The default value is 0.
+   * downsampling, 8 for 8x8 downsampling.
    */
-  JXL_ENC_OPTION_RESAMPLING = 0,
+  JXL_ENC_OPTION_RESAMPLING = 2,
 
   /** Similar to JXL_ENC_OPTION_RESAMPLING, but for extra channels. Integer
-   * option, use 1 for no downsampling (1x1), 2 for 2x2 downsampling, 4 for 4x4
-   * downsampling, 8 for 8x8 downsampling. The default value is 1.
+   * option, use -1 for the default behavior (depends on encoder
+   * implementation), 1 for no downsampling (1x1), 2 for 2x2 downsampling, 4 for
+   * 4x4 downsampling, 8 for 8x8 downsampling.
    */
-  JXL_ENC_OPTION_EXTRA_CHANNEL_RESAMPLING = 1,
+  JXL_ENC_OPTION_EXTRA_CHANNEL_RESAMPLING = 3,
 
   /** Enables or disables noise generation. Integer option, use -1 for the
-   * encoder default, 0 to disable, 1 to enable. The
+   * encoder default, 0 to disable, 1 to enable.
    */
-  JXL_ENC_OPTION_NOISE = 2,
+  JXL_ENC_OPTION_NOISE = 4,
 
   /** Enables or disables dots generation. Integer option, use -1 for the
    * encoder default, 0 to disable, 1 to enable.
    */
-  JXL_ENC_OPTION_DOTS = 3,
+  JXL_ENC_OPTION_DOTS = 5,
 
   /** Enables or disables patches generation. Integer option, use -1 for the
    * encoder default, 0 to disable, 1 to enable.
    */
-  JXL_ENC_OPTION_PATCHES = 4,
+  JXL_ENC_OPTION_PATCHES = 6,
 
   /** Enables or disables the gaborish filter. Integer option, use -1 for the
    * encoder default, 0 to disable, 1 to enable.
    */
-  JXL_ENC_OPTION_GABORISH = 5,
+  JXL_ENC_OPTION_GABORISH = 7,
 
   /** Enum value not to be used as an option. This value is added to force the
    * C compiler to have the enum to take a known size.
@@ -351,31 +367,45 @@ JXL_EXPORT JxlEncoderStatus
 JxlEncoderOptionsSetLossless(JxlEncoderOptions* options, JXL_BOOL lossless);
 
 /**
- * Set the decoding speed tier for the provided options. Minimum is 0 (highest
- * quality), and maximum is 4 (lowest quality). Default is 0.
+ * @param options set of encoder options to update with the new mode.
+ * @param effort the effort value to set.
+ * @return JXL_ENC_SUCCESS if the operation was successful, JXL_ENC_ERROR
+ * otherwise.
  *
+ * DEPRECATED: use JxlEncoderOptionsSetInteger(options, JXL_ENC_OPTION_EFFORT,
+ * effort)) instead.
+ */
+JXL_EXPORT JXL_DEPRECATED JxlEncoderStatus
+JxlEncoderOptionsSetEffort(JxlEncoderOptions* options, int effort);
+
+/**
  * @param options set of encoder options to update with the new decoding speed
  * tier.
  * @param tier the decoding speed tier to set.
  * @return JXL_ENC_SUCCESS if the operation was successful, JXL_ENC_ERROR
  * otherwise.
+ *
+ * DEPRECATED: use JxlEncoderOptionsSetInteger(options,
+ * JXL_ENC_OPTION_DECODING_SPEED, tier)) instead.
  */
-JXL_EXPORT JxlEncoderStatus
+JXL_EXPORT JXL_DEPRECATED JxlEncoderStatus
 JxlEncoderOptionsSetDecodingSpeed(JxlEncoderOptions* options, int tier);
 
 /**
- * Sets encoder effort/speed level without affecting decoding speed. Valid
- * values are, from faster to slower speed: 1:lightning 2:thunder 3:falcon
- * 4:cheetah 5:hare 6:wombat 7:squirrel 8:kitten 9:tortoise.
- * Default: squirrel (7).
+ * Sets an option of integer type to the encoder option. The JxlEncoderOptionId
+ * argument determines which option is set.
  *
  * @param options set of encoder options to update with the new mode.
- * @param effort the effort value to set.
- * @return JXL_ENC_SUCCESS if the operation was successful, JXL_ENC_ERROR
- * otherwise.
+ * @param option ID of the option to set.
+ * @param value Integer value to set for this option.
+ * @return JXL_ENC_SUCCESS if the operation was successful, JXL_ENC_ERROR in
+ * case of an error, such as invalid or unknown option id, or invalid integer
+ * value for the given option. If an error is returned, the state of the
+ * JxlEncoderOptions object is still valid and is the same as before this
+ * function was called.
  */
-JXL_EXPORT JxlEncoderStatus
-JxlEncoderOptionsSetEffort(JxlEncoderOptions* options, int effort);
+JXL_EXPORT JxlEncoderStatus JxlEncoderOptionsSetInteger(
+    JxlEncoderOptions* options, JxlEncoderOptionId option, int32_t value);
 
 /**
  * Sets the distance level for lossy compression: target max butteraugli
@@ -395,25 +425,6 @@ JxlEncoderOptionsSetEffort(JxlEncoderOptions* options, int effort);
  */
 JXL_EXPORT JxlEncoderStatus
 JxlEncoderOptionsSetDistance(JxlEncoderOptions* options, float distance);
-
-/**
- * Sets an option of integer type to the encoder option. The JxlEncoderOptionId
- * argument determines which option is set.
- *
- * TODO(lode): also use the option enum for the container, lossless, speed,
- * effort and distance options.
- *
- * @param options set of encoder options to update with the new mode.
- * @param option ID of the option to set.
- * @param value Integer value to set for this option.
- * @return JXL_ENC_SUCCESS if the operation was successful, JXL_ENC_ERROR in
- * case of an error, such as invalid or unknown option id, or invalid integer
- * value for the given option. If an error is returned, the state of the
- * JxlEncoderOptions object is still valid and is the same as before this
- * function was called.
- */
-JXL_EXPORT JxlEncoderStatus JxlEncoderOptionsSetAsInteger(
-    JxlEncoderOptions* options, JxlEncoderOptionId option, int32_t value);
 
 /**
  * Create a new set of encoder options, with all values initially copied from

--- a/lib/jxl/encode.cc
+++ b/lib/jxl/encode.cc
@@ -251,11 +251,7 @@ JxlEncoderStatus JxlEncoderOptionsSetLossless(JxlEncoderOptions* options,
 
 JxlEncoderStatus JxlEncoderOptionsSetEffort(JxlEncoderOptions* options,
                                             const int effort) {
-  if (effort < 1 || effort > 9) {
-    return JXL_ENC_ERROR;
-  }
-  options->values.cparams.speed_tier = static_cast<jxl::SpeedTier>(10 - effort);
-  return JXL_ENC_SUCCESS;
+  return JxlEncoderOptionsSetInteger(options, JXL_ENC_OPTION_EFFORT, effort);
 }
 
 JxlEncoderStatus JxlEncoderOptionsSetDistance(JxlEncoderOptions* options,
@@ -267,23 +263,42 @@ JxlEncoderStatus JxlEncoderOptionsSetDistance(JxlEncoderOptions* options,
   return JXL_ENC_SUCCESS;
 }
 
-JxlEncoderStatus JxlEncoderOptionsSetAsInteger(JxlEncoderOptions* options,
-                                               JxlEncoderOptionId option,
-                                               int32_t value) {
+JxlEncoderStatus JxlEncoderOptionsSetDecodingSpeed(JxlEncoderOptions* options,
+                                                   int tier) {
+  return JxlEncoderOptionsSetInteger(options, JXL_ENC_OPTION_DECODING_SPEED,
+                                     tier);
+}
+
+JxlEncoderStatus JxlEncoderOptionsSetInteger(JxlEncoderOptions* options,
+                                             JxlEncoderOptionId option,
+                                             int32_t value) {
   switch (option) {
+    case JXL_ENC_OPTION_EFFORT:
+      if (value < 1 || value > 9) {
+        return JXL_ENC_ERROR;
+      }
+      options->values.cparams.speed_tier =
+          static_cast<jxl::SpeedTier>(10 - value);
+      return JXL_ENC_SUCCESS;
+    case JXL_ENC_OPTION_DECODING_SPEED:
+      if (value < 0 || value > 4) {
+        return JXL_ENC_ERROR;
+      }
+      options->values.cparams.decoding_speed_tier = value;
+      return JXL_ENC_SUCCESS;
     case JXL_ENC_OPTION_RESAMPLING:
-      if (value != 0 && value != 1 && value != 2 && value != 4 && value != 8) {
+      if (value != -1 && value != 1 && value != 2 && value != 4 && value != 8) {
         return JXL_ENC_ERROR;
       }
       options->values.cparams.resampling = value;
       return JXL_ENC_SUCCESS;
     case JXL_ENC_OPTION_EXTRA_CHANNEL_RESAMPLING:
-      if (value != 0 && value != 1 && value != 2 && value != 4 && value != 8) {
+      if (value != -1 && value != 1 && value != 2 && value != 4 && value != 8) {
         return JXL_ENC_ERROR;
       }
       // The implementation doesn't support the default choice between 1x1 and
       // 2x2 for extra channels, so 1x1 is set as the default.
-      if (value == 0) value = 1;
+      if (value == -1) value = 1;
       options->values.cparams.ec_resampling = value;
       return JXL_ENC_SUCCESS;
     case JXL_ENC_OPTION_NOISE:
@@ -504,15 +519,6 @@ JxlEncoderStatus JxlEncoderProcessOutput(JxlEncoder* enc, uint8_t** next_out,
   if (!enc->output_byte_queue.empty() || !enc->input_frame_queue.empty()) {
     return JXL_ENC_NEED_MORE_OUTPUT;
   }
-  return JXL_ENC_SUCCESS;
-}
-
-JxlEncoderStatus JxlEncoderOptionsSetDecodingSpeed(JxlEncoderOptions* options,
-                                                   int tier) {
-  if (tier < 0 || tier > 4) {
-    return JXL_ENC_ERROR;
-  }
-  options->values.cparams.decoding_speed_tier = tier;
   return JXL_ENC_SUCCESS;
 }
 

--- a/lib/jxl/encode_test.cc
+++ b/lib/jxl/encode_test.cc
@@ -234,7 +234,8 @@ TEST(EncodeTest, OptionsTest) {
     JxlEncoderPtr enc = JxlEncoderMake(nullptr);
     EXPECT_NE(nullptr, enc.get());
     JxlEncoderOptions* options = JxlEncoderOptionsCreate(enc.get(), NULL);
-    EXPECT_EQ(JXL_ENC_SUCCESS, JxlEncoderOptionsSetEffort(options, 5));
+    EXPECT_EQ(JXL_ENC_SUCCESS,
+              JxlEncoderOptionsSetInteger(options, JXL_ENC_OPTION_EFFORT, 5));
     VerifyFrameEncoding(enc.get(), options);
     EXPECT_EQ(jxl::SpeedTier::kHare, enc->last_used_cparams.speed_tier);
   }
@@ -244,9 +245,11 @@ TEST(EncodeTest, OptionsTest) {
     EXPECT_NE(nullptr, enc.get());
     JxlEncoderOptions* options = JxlEncoderOptionsCreate(enc.get(), NULL);
     // Lower than currently supported values
-    EXPECT_EQ(JXL_ENC_ERROR, JxlEncoderOptionsSetEffort(options, 0));
+    EXPECT_EQ(JXL_ENC_ERROR,
+              JxlEncoderOptionsSetInteger(options, JXL_ENC_OPTION_EFFORT, 0));
     // Higher than currently supported values
-    EXPECT_EQ(JXL_ENC_ERROR, JxlEncoderOptionsSetEffort(options, 10));
+    EXPECT_EQ(JXL_ENC_ERROR,
+              JxlEncoderOptionsSetInteger(options, JXL_ENC_OPTION_EFFORT, 10));
   }
 
   {
@@ -278,7 +281,8 @@ TEST(EncodeTest, OptionsTest) {
     JxlEncoderPtr enc = JxlEncoderMake(nullptr);
     EXPECT_NE(nullptr, enc.get());
     JxlEncoderOptions* options = JxlEncoderOptionsCreate(enc.get(), NULL);
-    EXPECT_EQ(JXL_ENC_SUCCESS, JxlEncoderOptionsSetDecodingSpeed(options, 2));
+    EXPECT_EQ(JXL_ENC_SUCCESS, JxlEncoderOptionsSetInteger(
+                                   options, JXL_ENC_OPTION_DECODING_SPEED, 2));
     VerifyFrameEncoding(enc.get(), options);
     EXPECT_EQ(2u, enc->last_used_cparams.decoding_speed_tier);
   }

--- a/plugins/gimp/file-jxl-save.cc
+++ b/plugins/gimp/file-jxl-save.cc
@@ -761,8 +761,10 @@ bool SaveJpegXlImage(const gint32 image_id, const gint32 drawable_id,
   JxlEncoderOptions* enc_opts;
   enc_opts = JxlEncoderOptionsCreate(enc.get(), nullptr);
 
-  JxlEncoderOptionsSetEffort(enc_opts, jxl_save_opts.encoding_effort);
-  JxlEncoderOptionsSetDecodingSpeed(enc_opts, jxl_save_opts.faster_decoding);
+  JxlEncoderOptionsSetInteger(enc_opts, JXL_ENC_OPTION_EFFORT,
+                              jxl_save_opts.encoding_effort);
+  JxlEncoderOptionsSetInteger(enc_opts, JXL_ENC_OPTION_DECODING_SPEED,
+                              jxl_save_opts.faster_decoding);
 
   // lossless mode
   if (jxl_save_opts.lossless || jxl_save_opts.distance < 0.01) {


### PR DESCRIPTION
All options use the enum now.

The JxlEncoderOptionsSetLossless will be handled in a different MR,
since it's actually a combination of a modular, quality_pair and
color_transform option that still need to be added. The
JxlEncoderUseContainer option may also need some rework when
API to add boxes is added.

EDIT: also did this for the forgotten JxlEncoderOptionsSetDecodingSpeed option