### PR TITLE
Choose mirroring strategy after actual paddings are calculated

### DIFF
--- a/lib/jxl/dec_reconstruct.cc
+++ b/lib/jxl/dec_reconstruct.cc
@@ -445,15 +445,6 @@ class EnsurePaddingInPlaceRowByRow {
     *y0 = -std::min(image_rect.y0(), ypadding);
     *y1 = rect.ysize() + std::min(ypadding, image_ysize - image_rect.ysize() -
                                                 image_rect.y0());
-    if (image_rect.x0() >= xpadding &&
-        image_rect.x0() + image_rect.xsize() + xpadding <= image_xsize) {
-      // Nothing to do.
-      strategy_ = kSkip;
-    } else if (image_xsize >= 2 * xpadding) {
-      strategy_ = kFast;
-    } else {
-      strategy_ = kSlow;
-    }
     y0_ = rect.y0();
     JXL_DASSERT(rect.x0() >= xpadding);
     x0_ = x1_ = rect.x0() - xpadding;
@@ -464,6 +455,16 @@ class EnsurePaddingInPlaceRowByRow {
     if (image_rect.x0() + image_rect.xsize() + xpadding > image_xsize) {
       x2_ = rect.x0() + image_xsize - image_rect.x0();
     }
+
+    if ((x1_ == x0_) && (x3_ == x2_)) {
+      // Nothing to do.
+      strategy_ = kSkip;
+    } else if ((x1_ - x0_) <= xpadding && (x3_ - x2_) <= xpadding) {
+      strategy_ = kFast;
+    } else {
+      strategy_ = kSlow;
+    }
+
     JXL_DASSERT(image_xsize == (x2_ - x1_) ||
                 (x1_ - x0_ <= x2_ - x1_ && x3_ - x2_ <= x2_ - x1_));
   }


### PR DESCRIPTION
The example that is fixed:
  image_rect.x0 == 0
  image_rect.xsize == 16
  xpadding == 2
  image_xsize == 4
  rect.x0=8
  rect.xsize=16

Previously it was checked that 'image_xsize <= 2 * xpadding' to activate "fast" strategy.
Calculated right border is 14px wide that is much more than 2px padding -> requires
fully-fledged mirroring calculations ("slow" strategy).