### PR TITLE
Use the original image to compute masking in Butteraugli.

### DIFF
--- a/lib/jxl/butteraugli/butteraugli.cc
+++ b/lib/jxl/butteraugli/butteraugli.cc
@@ -1136,7 +1136,7 @@ void Mask(const ImageF& mask0, const ImageF& mask1,
   FuzzyErosion(blurred1, &diff1);
   for (size_t y = 0; y < ysize; ++y) {
     for (size_t x = 0; x < xsize; ++x) {
-      mask->Row(y)[x] = diff1.Row(y)[x];
+      mask->Row(y)[x] = diff0.Row(y)[x];
       if (diff_ac != nullptr) {
         static const float kMaskToErrorMul = 10.0;
         float diff = blurred0.Row(y)[x] - blurred1.Row(y)[x];

--- a/lib/jxl/jxl_test.cc
+++ b/lib/jxl/jxl_test.cc
@@ -197,7 +197,7 @@ TEST(JxlTest, RoundtripOtherTransforms) {
   EXPECT_LE(compressed_size, 23000u);
   EXPECT_THAT(ButteraugliDistance(*io, *io2, cparams.ba_params,
                                   /*distmap=*/nullptr, pool),
-              IsSlightlyBelow(4.0));
+              IsSlightlyBelow(3.0));
 
   // Check the consistency when performing another roundtrip.
   std::unique_ptr<CodecInOut> io3 = jxl::make_unique<CodecInOut>();
@@ -206,7 +206,7 @@ TEST(JxlTest, RoundtripOtherTransforms) {
   EXPECT_LE(compressed_size2, 23000u);
   EXPECT_THAT(ButteraugliDistance(*io, *io3, cparams.ba_params,
                                   /*distmap=*/nullptr, pool),
-              IsSlightlyBelow(4.0));
+              IsSlightlyBelow(3.0));
 }
 
 TEST(JxlTest, RoundtripResample2) {
@@ -223,7 +223,7 @@ TEST(JxlTest, RoundtripResample2) {
   EXPECT_LE(Roundtrip(&io, cparams, dparams, pool, &io2), 17000u);
   EXPECT_THAT(ButteraugliDistance(io, io2, cparams.ba_params,
                                   /*distmap=*/nullptr, pool),
-              IsSlightlyBelow(10));
+              IsSlightlyBelow(8));
 }
 
 TEST(JxlTest, RoundtripResample2MT) {
@@ -288,7 +288,7 @@ TEST(JxlTest, RoundtripResample4) {
   EXPECT_LE(Roundtrip(&io, cparams, dparams, pool, &io2), 6000u);
   EXPECT_THAT(ButteraugliDistance(io, io2, cparams.ba_params,
                                   /*distmap=*/nullptr, pool),
-              IsSlightlyBelow(28));
+              IsSlightlyBelow(22));
 }
 
 TEST(JxlTest, RoundtripResample8) {
@@ -305,7 +305,7 @@ TEST(JxlTest, RoundtripResample8) {
   EXPECT_LE(Roundtrip(&io, cparams, dparams, pool, &io2), 2100u);
   EXPECT_THAT(ButteraugliDistance(io, io2, cparams.ba_params,
                                   /*distmap=*/nullptr, pool),
-              IsSlightlyBelow(80));
+              IsSlightlyBelow(50));
 }
 
 TEST(JxlTest, RoundtripUnalignedD2) {
@@ -732,7 +732,7 @@ TEST(JxlTest, RoundtripGrayscale) {
     EXPECT_LE(compressed.size(), 1300u);
     EXPECT_THAT(ButteraugliDistance(io, io2, cparams.ba_params,
                                     /*distmap=*/nullptr, pool),
-                IsSlightlyBelow(7.0));
+                IsSlightlyBelow(6.0));
   }
 }
 
@@ -1228,7 +1228,7 @@ TEST(JxlTest, RoundtripYCbCr420) {
   // we're comparing an original PNG with a YCbCr 4:2:0 version
   EXPECT_THAT(ButteraugliDistance(io, io3, cparams.ba_params,
                                   /*distmap=*/nullptr, pool),
-              IsSlightlyBelow(2.8));
+              IsSlightlyBelow(3.0));
 }
 
 TEST(JxlTest, RoundtripDots) {


### PR DESCRIPTION
Before:
```
Encoding                kPixels    Bytes          BPP  E MP/s  D MP/s     Max norm        pnorm       BPP*pnorm   Bugs
----------------------------------------------------------------------------------------------------------------------
jxl:d1                    13270  2678634    1.6147963   4.325  30.178   1.70188427   0.61515643  0.993352329364      0
jxl:d1:tortoise           13270  2625565    1.5828040   0.198  30.289   1.34335029   0.61182869  0.968404909146      0
jxl:d1:epf0               13270  2663496    1.6056705   4.525  32.322   1.70183861   0.61701721  0.990726314686      0
jxl:d1:epf0:tortoise      13270  2612041    1.5746512   0.200  30.556   1.34055078   0.61332655  0.965775372929      0
jxl:d1:epf2               13270  2678603    1.6147776   4.493  28.471   1.70166183   0.61519468  0.993402597893      0
jxl:d1:epf2:tortoise      13270  2625195    1.5825810   0.199  27.172   1.34585810   0.61180372  0.968228918652      0
jxl:d2                    13270  1683712    1.0150143   4.797  30.441   3.10947037   0.98210674  0.996852423533      0
jxl:d2:tortoise           13270  1573531    0.9485925   0.320  32.720   2.46310854   1.03158689  0.978555560811      0
jxl:d2:epf0               13270  1667388    1.0051735   4.595  33.520   3.10947418   0.98832064  0.993433737530      0
jxl:d2:epf0:tortoise      13270  1559196    0.9399507   0.320  37.862   2.46315694   1.03815067  0.975810465201      0
jxl:d2:epf2               13270  1683712    1.0150143   4.868  30.112   3.10947037   0.98210674  0.996852423533      0
jxl:d2:epf2:tortoise      13270  1573531    0.9485925   0.325  33.598   2.46310854   1.03158689  0.978555560811      0
jxl:d3                    13270  1243679    0.7497434   4.280  30.961   3.78434587   1.30507065  0.978468148888      0
jxl:d3:tortoise           13270  1141750    0.6882962   0.357  32.325   3.62965083   1.39145244  0.957731468225      0
jxl:d3:epf0               13270  1226972    0.7396717   4.427  35.932   3.83104753   1.31665631  0.973893451658      0
jxl:d3:epf0:tortoise      13270  1126756    0.6792572   0.356  38.224   3.62963104   1.40301584  0.953008606382      0
jxl:d3:epf2               13270  1243780    0.7498043   4.159  30.367   3.78434587   1.30504908  0.978531441734      0
jxl:d3:epf2:tortoise      13270  1141782    0.6883155   0.358  33.149   3.62965083   1.39150323  0.957793265750      0
jxl:d4                    13270  1004814    0.6057453   4.403  23.039   5.53548670   1.59591498  0.966717984962      0
jxl:d4:tortoise           13270   910484    0.5488791   0.370  24.639   4.82455301   1.72064451  0.944425794645      0
jxl:d4:epf0               13270   989916    0.5967641   4.385  35.905   5.40953732   1.59797925  0.953616701130      0
jxl:d4:epf0:tortoise      13270   896631    0.5405279   0.384  39.288   4.65310192   1.72721399  0.933607359749      0
jxl:d4:epf2               13270  1004961    0.6058339   4.473  30.973   5.44652557   1.58231070  0.958617474630      0
jxl:d4:epf2:tortoise      13270   909674    0.5483908   0.381  30.919   4.65799379   1.71015844  0.937835138470      0
jxl:d6                    13270   718752    0.4332948   4.225  22.564   7.17935848   2.13714220  0.926012513752      0
jxl:d6:tortoise           13270   641698    0.3868433   0.328  24.082   6.92472696   2.32555537  0.899625463356      0
jxl:d6:epf0               13270   706347    0.4258165   4.363  38.962   7.10552168   2.11943320  0.902489601948      0
jxl:d6:epf0:tortoise      13270   630194    0.3799082   0.337  43.640   6.83466053   2.31353717  0.878931674430      0
jxl:d6:epf2               13270   718678    0.4332501   4.162  33.466   6.80208492   2.10031446  0.909961550060      0
jxl:d6:epf2:tortoise      13270   640141    0.3859047   0.337  34.369   6.76663256   2.29665034  0.886288049725      0
jxl:d8                    13270   576742    0.3476850   4.334  22.803   9.43436241   2.61434568  0.908968766493      0
jxl:d8:tortoise           13270   515577    0.3108121   0.333  23.038   8.32634068   2.86924110  0.891794826559      0
jxl:d8:epf0               13270   565542    0.3409332   4.359  39.957   7.98679543   2.56039342  0.872922998168      0
jxl:d8:epf0:tortoise      13270   503434    0.3034918   0.345  42.978   8.83266258   2.82980155  0.858821467876      0
jxl:d8:epf2               13270   576823    0.3477338   4.400  32.555   8.48999977   2.54703248  0.885689349853      0
jxl:d8:epf2:tortoise      13270   512496    0.3089547   0.341  33.241   8.62333107   2.81468579  0.869610489801      0
Aggregate:                13270  1099805    0.6630100   1.180  31.608   4.09325252   1.42244740  0.943096827206      0
```

After:
```
Encoding                kPixels    Bytes          BPP  E MP/s  D MP/s     Max norm        pnorm       BPP*pnorm   Bugs
----------------------------------------------------------------------------------------------------------------------
jxl:d1                    13270  2678634    1.6147963   4.328  31.125   1.68153656   0.60257544  0.973036598212      0
jxl:d1:tortoise           13270  2613251    1.5753806   0.200  29.754   1.33397424   0.60370355  0.951062864300      0
jxl:d1:epf0               13270  2663496    1.6056705   4.582  33.600   1.68149400   0.60495563  0.971359388069      0
jxl:d1:epf0:tortoise      13270  2600547    1.5677221   0.200  29.300   1.33369124   0.60554492  0.949326138226      0
jxl:d1:epf2               13270  2678603    1.6147776   4.564  29.018   1.68132198   0.60257560  0.973025584433      0
jxl:d1:epf2:tortoise      13270  2613612    1.5755982   0.201  27.294   1.33662891   0.60372253  0.951224154655      0
jxl:d2                    13270  1683712    1.0150143   4.835  30.222   3.00312042   0.95243347  0.966733631920      0
jxl:d2:tortoise           13270  1568509    0.9455650   0.316  34.682   2.47716522   1.00518743  0.950470041136      0
jxl:d2:epf0               13270  1667388    1.0051735   4.569  35.007   3.00312471   0.96212573  0.967103309027      0
jxl:d2:epf0:tortoise      13270  1555163    0.9375194   0.312  38.100   2.47721243   1.01503465  0.951614725095      0
jxl:d2:epf2               13270  1683712    1.0150143   4.881  29.099   3.00312042   0.95243347  0.966733631920      0
jxl:d2:epf2:tortoise      13270  1568509    0.9455650   0.318  32.464   2.47716522   1.00518743  0.950470041136      0
jxl:d3                    13270  1243679    0.7497434   4.241  30.153   3.66980815   1.25484599  0.940812542946      0
jxl:d3:tortoise           13270  1137242    0.6855786   0.351  32.610   3.63637161   1.34565021  0.922548999861      0
jxl:d3:epf0               13270  1226972    0.7396717   4.269  36.737   3.89280939   1.27539657  0.943374791244      0
jxl:d3:epf0:tortoise      13270  1123187    0.6771057   0.364  41.634   3.64454556   1.36610971  0.925000603559      0
jxl:d3:epf2               13270  1243780    0.7498043   4.296  29.833   3.66980815   1.25479097  0.940847689018      0
jxl:d3:epf2:tortoise      13270  1137164    0.6855316   0.359  30.839   3.63637161   1.34569101  0.922513700190      0
jxl:d4                    13270  1004814    0.6057453   4.437  23.757   4.85261440   1.50557311  0.911993821522      0
jxl:d4:tortoise           13270   904863    0.5454905   0.369  23.784   4.74218035   1.63598942  0.892416701909      0
jxl:d4:epf0               13270   989916    0.5967641   4.542  36.683   4.85253572   1.54257989  0.920556350660      0
jxl:d4:epf0:tortoise      13270   892251    0.5378875   0.377  37.913   4.78133154   1.67488591  0.900900117214      0
jxl:d4:epf2               13270  1004961    0.6058339   4.405  32.457   4.85257292   1.50989994  0.914748582254      0
jxl:d4:epf2:tortoise      13270   905912    0.5461229   0.380  33.899   4.74489403   1.64137110  0.896390332081      0
jxl:d6                    13270   718752    0.4332948   4.277  23.440   6.68833828   1.97617688  0.856267082888      0
jxl:d6:tortoise           13270   635236    0.3829477   0.326  25.012   6.73313189   2.16693052  0.829821072231      0
jxl:d6:epf0               13270   706347    0.4258165   4.337  39.195   6.91070318   2.03981730  0.868587839796      0
jxl:d6:epf0:tortoise      13270   625229    0.3769151   0.335  42.578   6.90295219   2.23033733  0.840647713886      0
jxl:d6:epf2               13270   718678    0.4332501   4.204  32.396   6.76956367   1.98289621  0.859090079501      0
jxl:d6:epf2:tortoise      13270   634080    0.3822508   0.337  33.245   6.75473166   2.17497633  0.831386485168      0
jxl:d8                    13270   576742    0.3476850   4.382  23.666   8.16276550   2.36454708  0.822117539824      0
jxl:d8:tortoise           13270   508511    0.3065524   0.335  23.064   8.24867535   2.63046063  0.806374022646      0
jxl:d8:epf0               13270   565542    0.3409332   4.319  39.576   7.78608036   2.44494236  0.833561904843      0
jxl:d8:epf0:tortoise      13270   499918    0.3013722   0.345  43.057   8.45994949   2.71273423  0.817542599868      0
jxl:d8:epf2               13270   576823    0.3477338   4.394  31.571   7.57549858   2.36666305  0.822968797015      0
jxl:d8:epf2:tortoise      13270   505274    0.3046010   0.340  33.649   8.52418518   2.63902027  0.803848205042      0
Aggregate:                13270  1096405    0.6609601   1.180  31.774   3.98343832   1.36518483  0.902332707979      0
```

Images for visual comparison:
https://old.lucaversari.it/jpeg_xl_data/bt_after/
https://old.lucaversari.it/jpeg_xl_data/bt_before/

Summary of results: at slower speeds, bitrates go down a bit. I cannot
tell the difference at low distances; at high (>4) distance, it looks
like some artefacts go away, but so do some details.