### PR TITLE
Add exif/xmp marker size check

### DIFF
--- a/lib/jxl/decode.cc
+++ b/lib/jxl/decode.cc
@@ -1900,16 +1900,20 @@ JxlDecoderStatus JxlDecoderProcessInput(JxlDecoder* dec) {
             return JXL_API_ERROR(
                 "multiple exif markers for JPEG reconstruction not supported");
           }
-          dec->recon_exif_size =
-              jxl::JxlToJpegDecoder::ExifBoxContentSize(*jpeg_data);
+          if (JXL_DEC_SUCCESS != jxl::JxlToJpegDecoder::ExifBoxContentSize(
+                                     *jpeg_data, &dec->recon_exif_size)) {
+            return JXL_API_ERROR("invalid jbrd exif size");
+          }
         }
         if (num_xmp) {
           if (num_xmp > 1) {
             return JXL_API_ERROR(
                 "multiple XMP markers for JPEG reconstruction not supported");
           }
-          dec->recon_xmp_size =
-              jxl::JxlToJpegDecoder::XmlBoxContentSize(*jpeg_data);
+          if (JXL_DEC_SUCCESS != jxl::JxlToJpegDecoder::XmlBoxContentSize(
+                                     *jpeg_data, &dec->recon_xmp_size)) {
+            return JXL_API_ERROR("invalid jbrd XMP size");
+          }
         }
 
         dec->box_stage = BoxStage::kHeader;

--- a/lib/jxl/decode_to_jpeg.h
+++ b/lib/jxl/decode_to_jpeg.h
@@ -86,8 +86,10 @@ class JxlToJpegDecoder {
 
   // Returns box content size for metadata, using the known data from the app
   // markers.
-  static size_t ExifBoxContentSize(const jpeg::JPEGData& jpeg_data);
-  static size_t XmlBoxContentSize(const jpeg::JPEGData& jpeg_data);
+  static JxlDecoderStatus ExifBoxContentSize(const jpeg::JPEGData& jpeg_data,
+                                             size_t* size);
+  static JxlDecoderStatus XmlBoxContentSize(const jpeg::JPEGData& jpeg_data,
+                                            size_t* size);
 
   // Returns JXL_DEC_ERROR if there is no exif/XMP marker or the data size
   // does not match, or this function is called before Process returned
@@ -186,11 +188,13 @@ class JxlToJpegDecoder {
     return 0;
   }
   static size_t NumXmpMarkers(const jpeg::JPEGData& /*jpeg_data*/) { return 0; }
-  static size_t ExifBoxContentSize(const jpeg::JPEGData& /*jpeg_data*/) {
-    return 0;
+  static size_t ExifBoxContentSize(const jpeg::JPEGData& /*jpeg_data*/,
+                                   size_t* /*size*/) {
+    return JXL_DEC_ERROR;
   }
-  static size_t XmlBoxContentSize(const jpeg::JPEGData& /*jpeg_data*/) {
-    return 0;
+  static size_t XmlBoxContentSize(const jpeg::JPEGData& /*jpeg_data*/,
+                                  size_t* /*size*/) {
+    return JXL_DEC_ERROR;
   }
   static JxlDecoderStatus SetExif(const uint8_t* /*data*/, size_t /*size*/,
                                   jpeg::JPEGData* /*jpeg_data*/) {


### PR DESCRIPTION
To avoid integer overflow by subtracting the header size