### PR TITLE
Fix some confusion about image_xsize for extra channels.

### DIFF
--- a/lib/jxl/dec_reconstruct.cc
+++ b/lib/jxl/dec_reconstruct.cc
@@ -441,7 +441,9 @@ class EnsurePaddingInPlaceRowByRow {
             size_t image_ysize, size_t xpadding, size_t ypadding, ssize_t* y0,
             ssize_t* y1) {
     // coordinates relative to rect.
-    JXL_DASSERT(SameSize(rect, image_rect));
+    JXL_ASSERT(SameSize(rect, image_rect));
+    JXL_ASSERT(image_rect.x0() + image_rect.xsize() <= image_xsize);
+    JXL_ASSERT(image_rect.y0() + image_rect.ysize() <= image_ysize);
     *y0 = -std::min(image_rect.y0(), ypadding);
     *y1 = rect.ysize() + std::min(ypadding, image_ysize - image_rect.ysize() -
                                                 image_rect.y0());
@@ -455,7 +457,7 @@ class EnsurePaddingInPlaceRowByRow {
       strategy_ = kSlow;
     }
     y0_ = rect.y0();
-    JXL_DASSERT(rect.x0() >= xpadding);
+    JXL_ASSERT(rect.x0() >= xpadding);
     x0_ = x1_ = rect.x0() - xpadding;
     // If close to the left border - do mirroring.
     if (image_rect.x0() < xpadding) x1_ = rect.x0() - image_rect.x0();
@@ -464,8 +466,11 @@ class EnsurePaddingInPlaceRowByRow {
     if (image_rect.x0() + image_rect.xsize() + xpadding > image_xsize) {
       x2_ = rect.x0() + image_xsize - image_rect.x0();
     }
-    JXL_DASSERT(image_xsize == (x2_ - x1_) ||
-                (x1_ - x0_ <= x2_ - x1_ && x3_ - x2_ <= x2_ - x1_));
+    JXL_ASSERT(x0_ <= x1_);
+    JXL_ASSERT(x1_ <= x2_);
+    JXL_ASSERT(x2_ <= x3_);
+    JXL_ASSERT(image_xsize == (x2_ - x1_) ||
+               (x1_ - x0_ <= x2_ - x1_ && x3_ - x2_ <= x2_ - x1_));
   }
 
  public:
@@ -793,7 +798,9 @@ Status FinalizeImageRect(
       }
       ssize_t ensure_padding_y0, ensure_padding_y1;
       EnsurePaddingInPlaceRowByRow ensure_padding;
-      Rect ec_image_rect = ScaleRectForEC(frame_rect, frame_header, ec);
+      // frame_rect can go up to frame_dim.xsize_padded, in VarDCT mode.
+      Rect ec_image_rect = ScaleRectForEC(
+          frame_rect.Crop(frame_dim.xsize, frame_dim.ysize), frame_header, ec);
       size_t ecxs = DivCeil(frame_dim.xsize_upsampled,
                             frame_header.extra_channel_upsampling[ec]);
       size_t ecys = DivCeil(frame_dim.ysize_upsampled,
@@ -836,8 +843,10 @@ Status FinalizeImageRect(
              extra_channels[ec].second.ysize() + rect_for_if_storage.ysize() -
                  rect_for_upsampling.ysize());
       extra_channels_for_patches.emplace_back(extra_channels[ec].first, r);
+      // frame_rect can go up to frame_dim.xsize_padded, in VarDCT mode.
       ec_padding[ec].Init(extra_channels[ec].first, extra_channels[ec].second,
-                          frame_rect, frame_dim.xsize, frame_dim.ysize, 2, 2,
+                          frame_rect.Crop(frame_dim.xsize, frame_dim.ysize),
+                          frame_dim.xsize, frame_dim.ysize, 2, 2,
                           &ensure_padding_upsampling_ec_y0,
                           &ensure_padding_upsampling_ec_y1);
     }
@@ -1153,7 +1162,9 @@ Status FinalizeFrameDecoding(ImageBundle* decoded,
       std::vector<std::pair<ImageF*, Rect>> ec_rects;
       ec_rects.reserve(decoded->extra_channels().size());
       for (size_t i = 0; i < decoded->extra_channels().size(); i++) {
-        Rect r = ScaleRectForEC(rects_to_process[rect_id], frame_header, i);
+        Rect r = ScaleRectForEC(
+            rects_to_process[rect_id].Crop(frame_dim.xsize, frame_dim.ysize),
+            frame_header, i);
         if (frame_header.extra_channel_upsampling[i] != 1) {
           Rect ec_input_rect(kBlockDim, 2, r.xsize(), r.ysize());
           auto eti =

--- a/lib/jxl/image.h
+++ b/lib/jxl/image.h
@@ -222,6 +222,12 @@ class Rect {
     return Rect(x0_, y0_, xsize_, ysize_, image.xsize(), image.ysize());
   }
 
+  // Construct a subrect that resides in the [0, ysize) x [0, xsize) region of
+  // the current rect.
+  Rect Crop(size_t area_xsize, size_t area_ysize) const {
+    return Rect(x0_, y0_, xsize_, ysize_, area_xsize, area_ysize);
+  }
+
   // Returns a rect that only contains `num` lines with offset `y` from `y0()`.
   Rect Lines(size_t y, size_t num) const {
     JXL_DASSERT(y + num <= ysize_);


### PR DESCRIPTION
image_xsize before upsampling was used, where the xsize after upsampling
should have been.
(cherry picked from commit be8d1060c059921c3d57590b5eeb6e58e84235e5)
(cherry picked from PR #796)