### PR TITLE
Add codestream level setting to encoder

### DIFF
--- a/lib/include/jxl/encode.h
+++ b/lib/include/jxl/encode.h
@@ -73,9 +73,12 @@ typedef enum {
 } JxlEncoderStatus;
 
 /**
- * Id of options to set to JxlEncoderOptions with JxlEncoderOptionsSetInteger.
+ * Id of per-frame options to set to JxlEncoderOptions with
+ * JxlEncoderOptionsSetInteger.
  * NOTE: this enum includes most but not all encoder options. The image quality
- * can be set with JxlEncoderOptionsSetDistance instead.
+ * is a frame option that can be set with JxlEncoderOptionsSetDistance instead.
+ * Options that apply globally, rather than per-frame, are set with their own
+ * functions and do not use the per-frame JxlEncoderOptions.
  */
 typedef enum {
   /** Sets encoder effort/speed level without affecting decoding speed. Valid
@@ -321,14 +324,49 @@ JXL_EXPORT JxlEncoderStatus JxlEncoderSetBasicInfo(JxlEncoder* enc,
                                                    const JxlBasicInfo* info);
 
 /**
+ * Sets a frame-specific option of integer type to the encoder options.
+ * The JxlEncoderOptionId argument determines which option is set.
+ *
+ * @param options set of encoder options to update with the new mode.
+ * @param option ID of the option to set.
+ * @param value Integer value to set for this option.
+ * @return JXL_ENC_SUCCESS if the operation was successful, JXL_ENC_ERROR in
+ * case of an error, such as invalid or unknown option id, or invalid integer
+ * value for the given option. If an error is returned, the state of the
+ * JxlEncoderOptions object is still valid and is the same as before this
+ * function was called.
+ */
+JXL_EXPORT JxlEncoderStatus JxlEncoderOptionsSetInteger(
+    JxlEncoderOptions* options, JxlEncoderOptionId option, int32_t value);
+
+/** Forces the encoder to use the box-based JPEG XL container format (BMFF).
+ *
+ * If enabled, the encoder always uses the container format, even if not
+ * necessary. If disabled, the encoder only uses the container format if
+ * required (such as for JPEG metadata @ref JxlEncoderStoreJPEGMetadata), and
+ * otherwise writes a direct codestream.
+ *
+ * By default this setting is disabled.
+ *
+ * This setting can only be set at the beginning, before encoding starts.
+ *
+ * @param enc encoder object.
+ * @param use_container true if the encoder should always output the JPEG XL
+ * container format.
+ * @return JXL_ENC_SUCCESS if the operation was successful, JXL_ENC_ERROR
+ * otherwise.
+ */
+JXL_EXPORT JxlEncoderStatus JxlEncoderUseContainer(JxlEncoder* enc,
+                                                   JXL_BOOL use_container);
+
+/**
  * Configure the encoder to store JPEG reconstruction metadata in the JPEG XL
  * container.
  *
- * The encoder must be configured to use the JPEG XL container format using @ref
- * JxlEncoderUseContainer for this to have any effect.
- *
  * If this is set to true and a single JPEG frame is added, it will be
  * possible to losslessly reconstruct the JPEG codestream.
+ *
+ * This setting can only be set at the beginning, before encoding starts.
  *
  * @param enc encoder object.
  * @param store_jpeg_metadata true if the encoder should store JPEG metadata.
@@ -338,22 +376,33 @@ JXL_EXPORT JxlEncoderStatus JxlEncoderSetBasicInfo(JxlEncoder* enc,
 JXL_EXPORT JxlEncoderStatus
 JxlEncoderStoreJPEGMetadata(JxlEncoder* enc, JXL_BOOL store_jpeg_metadata);
 
-/**
- * Configure the encoder to use the JPEG XL container format.
+/** Sets the feature level of the JPEG XL codestream. Valid values are 5 and
+ * 10.
  *
- * Using the JPEG XL container format allows to store metadata such as JPEG
- * reconstruction (@ref JxlEncoderStoreJPEGMetadata) or other metadata like
- * EXIF; but it adds a few bytes to the encoded file for container headers even
- * if there is no extra metadata.
+ * Level 5: for end-user image delivery, this level is the most widely
+ * supported level by image decoders and the recommended level to use unless a
+ * level 10 feature is absolutely necessary. Supports a maximum resolution
+ * 268435456 pixels total with a maximum width or height of 262144 pixels,
+ * maximum 16-bit color channel depth, maximum 120 frames per second for
+ * animation, maximum ICC color profile size of 4 MiB, it allows all color
+ * models and extra channel types except CMYK and the JXL_CHANNEL_BLACK extra
+ * channel, and a maximum of 4 extra channels in addition to the 3 color
+ * channels. It also sets boundaries to certain internally used coding tools.
  *
- * @param enc encoder object.
- * @param use_container true if the encoder should output the JPEG XL container
- * format.
- * @return JXL_ENC_SUCCESS if the operation was successful, JXL_ENC_ERROR
- * otherwise.
+ * Level 10: this level removes or increases the bounds of most of the level
+ * 5 limitations, allows CMYK color and up to 32 bits per color channel, but
+ * may be less widely supported.
+ *
+ * The default value is 5. To use level 10 features, the setting must be
+ * explicitely set to 10, the encoder will not automatically enable it. If
+ * incompatible parameters such as too high image resolution for the current
+ * level are set, the encoder will return an error. For internal coding tools,
+ * the encoder will only use those compatible with the level setting.
+ *
+ * This setting can only be set at the beginning, before encoding starts.
  */
-JXL_EXPORT JxlEncoderStatus JxlEncoderUseContainer(JxlEncoder* enc,
-                                                   JXL_BOOL use_container);
+JXL_EXPORT JxlEncoderStatus JxlEncoderSetCodestreamLevel(JxlEncoder* enc,
+                                                         int level);
 
 /**
  * Sets lossless/lossy mode for the provided options. Default is lossy.
@@ -390,22 +439,6 @@ JxlEncoderOptionsSetEffort(JxlEncoderOptions* options, int effort);
  */
 JXL_EXPORT JXL_DEPRECATED JxlEncoderStatus
 JxlEncoderOptionsSetDecodingSpeed(JxlEncoderOptions* options, int tier);
-
-/**
- * Sets an option of integer type to the encoder option. The JxlEncoderOptionId
- * argument determines which option is set.
- *
- * @param options set of encoder options to update with the new mode.
- * @param option ID of the option to set.
- * @param value Integer value to set for this option.
- * @return JXL_ENC_SUCCESS if the operation was successful, JXL_ENC_ERROR in
- * case of an error, such as invalid or unknown option id, or invalid integer
- * value for the given option. If an error is returned, the state of the
- * JxlEncoderOptions object is still valid and is the same as before this
- * function was called.
- */
-JXL_EXPORT JxlEncoderStatus JxlEncoderOptionsSetInteger(
-    JxlEncoderOptions* options, JxlEncoderOptionId option, int32_t value);
 
 /**
  * Sets the distance level for lossy compression: target max butteraugli

--- a/lib/jxl/encode_internal.h
+++ b/lib/jxl/encode_internal.h
@@ -19,6 +19,8 @@
 
 namespace jxl {
 
+// Options per-frame, this is not used for codestream-wide settings or global
+// encoder settings.
 typedef struct JxlEncoderOptionsValuesStruct {
   // lossless is a separate setting from cparams because it is a combination
   // setting that overrides multiple settings inside of cparams.
@@ -44,6 +46,8 @@ constexpr unsigned char kContainerHeader[] = {
     0,   0,   0, 0xc, 'J',  'X', 'L', ' ', 0xd, 0xa, 0x87,
     0xa, 0,   0, 0,   0x14, 'f', 't', 'y', 'p', 'j', 'x',
     'l', ' ', 0, 0,   0,    0,   'j', 'x', 'l', ' '};
+
+constexpr unsigned char kLevelBoxHeader[] = {0, 0, 0, 0x9, 'j', 'x', 'l', 'l'};
 
 namespace {
 template <typename T>
@@ -90,7 +94,12 @@ struct JxlEncoderStruct {
       input_frame_queue;
   std::vector<uint8_t> output_byte_queue;
 
-  bool use_container = false;
+  bool force_container = false;
+
+  // TODO(lode): move level into jxl::CompressParams since some C++
+  // implementation decisions should be based on it: level 10 allows more
+  // features to be used.
+  uint32_t codestream_level = 5;
   bool store_jpeg_metadata = false;
   jxl::CodecMetadata metadata;
   std::vector<uint8_t> jpeg_metadata;
@@ -105,6 +114,10 @@ struct JxlEncoderStruct {
   // Takes the first frame in the input_frame_queue, encodes it, and appends the
   // bytes to the output_byte_queue.
   JxlEncoderStatus RefillOutputByteQueue();
+
+  bool MustUseContainer() const {
+    return force_container || codestream_level != 5 || store_jpeg_metadata;
+  }
 
   // Appends the bytes of a JXL box header with the provided type and size to
   // the end of the output_byte_queue. If unbounded is true, the size won't be


### PR DESCRIPTION
Since this is a global codestream setting, this can't use the option
enum.

Also tuned related encoder settings:

-add comments to JxlEncoderOptionsSetInteger and related structs that
these settings apply only to frames, since this now confused myself,
trying to add the level and force_container settings to the enum while
those are global codestream settings

-added JxlEncoderSetCodestreamLevel to choose level 5 or level 10
compatibility

-changed JxlEncoderUseContainer to no longer be required, it only
forces the container when it is not needed. Using
JxlEncoderStoreJPEGMetadata or JxlEncoderSetCodestreamLevel will
automatically let the encoder emit the container format, it doesn't
require setting JxlEncoderUseContainer.

-added requirement for all of JxlEncoderUseContainer,
JxlEncoderStoreJPEGMetadata, JxlEncoderSetCodestreamLevel to be called
only at the beginning, since they cannot be used once the encoder
already output bytes with possibly the other signature type.