### PR TITLE
Remove ComputeTransposedScaled(I)DCT.

### DIFF
--- a/lib/jxl/dct-inl.h
+++ b/lib/jxl/dct-inl.h
@@ -273,42 +273,8 @@ struct IDCT1D<N, M, typename std::enable_if<(M > MaxLanes(FV<0>()))>::type> {
   }
 };
 
-// Computes the in-place NxN transposed-scaled-DCT (tsDCT) of block.
-// Requires that block is HWY_ALIGN'ed.
-//
-// See also DCTSlow, ComputeDCT
-template <size_t N>
-struct ComputeTransposedScaledDCT {
-  // scratch_space must be aligned, and should have space for N*N floats.
-  template <class From>
-  HWY_MAYBE_UNUSED void operator()(const From& from, float* JXL_RESTRICT to,
-                                   float* JXL_RESTRICT scratch_space) {
-    float* JXL_RESTRICT block = scratch_space;
-    DCT1D<N, N>()(from, DCTTo(to, N));
-    Transpose<N, N>::Run(DCTFrom(to, N), DCTTo(block, N));
-    DCT1D<N, N>()(DCTFrom(block, N), DCTTo(to, N));
-  }
-};
-
-// Computes the in-place NxN transposed-scaled-iDCT (tsIDCT)of block.
-// Requires that block is HWY_ALIGN'ed.
-//
-// See also IDCTSlow, ComputeIDCT.
-
-template <size_t N>
-struct ComputeTransposedScaledIDCT {
-  // scratch_space must be aligned, and should have space for N*N floats.
-  template <class To>
-  HWY_MAYBE_UNUSED void operator()(float* JXL_RESTRICT from, const To& to,
-                                   float* JXL_RESTRICT scratch_space) {
-    float* JXL_RESTRICT block = scratch_space;
-    IDCT1D<N, N>()(DCTFrom(from, N), DCTTo(block, N));
-    Transpose<N, N>::Run(DCTFrom(block, N), DCTTo(from, N));
-    IDCT1D<N, N>()(DCTFrom(from, N), to);
-  }
-};
-// Computes the non-transposed, scaled DCT of a block, that needs to be
-// HWY_ALIGN'ed. Used for rectangular blocks.
+// Computes the maybe-transposed, scaled DCT of a block, that needs to be
+// HWY_ALIGN'ed.
 template <size_t ROWS, size_t COLS>
 struct ComputeScaledDCT {
   // scratch_space must be aligned, and should have space for ROWS*COLS
@@ -329,8 +295,8 @@ struct ComputeScaledDCT {
     }
   }
 };
-// Computes the non-transposed, scaled DCT of a block, that needs to be
-// HWY_ALIGN'ed. Used for rectangular blocks.
+// Computes the maybe-transposed, scaled IDCT of a block, that needs to be
+// HWY_ALIGN'ed.
 template <size_t ROWS, size_t COLS>
 struct ComputeScaledIDCT {
   // scratch_space must be aligned, and should have space for ROWS*COLS

--- a/lib/jxl/dct_test.cc
+++ b/lib/jxl/dct_test.cc
@@ -35,7 +35,7 @@ template <size_t N>
 void ComputeDCT(float block[N * N]) {
   HWY_ALIGN float tmp_block[N * N];
   HWY_ALIGN float scratch_space[N * N];
-  ComputeTransposedScaledDCT<N>()(DCTFrom(block, N), tmp_block, scratch_space);
+  ComputeScaledDCT<N, N>()(DCTFrom(block, N), tmp_block, scratch_space);
 
   // Untranspose.
   Transpose<N, N>::Run(DCTFrom(tmp_block, N), DCTTo(block, N));
@@ -50,7 +50,7 @@ void ComputeIDCT(float block[N * N]) {
   // Untranspose.
   Transpose<N, N>::Run(DCTFrom(block, N), DCTTo(tmp_block, N));
 
-  ComputeTransposedScaledIDCT<N>()(tmp_block, DCTTo(block, N), scratch_space);
+  ComputeScaledIDCT<N, N>()(tmp_block, DCTTo(block, N), scratch_space);
 }
 
 template <size_t N>


### PR DESCRIPTION
ComputeScaled(I)DCT with ROWS == COLUMNS is identical.