### PR TITLE
Partially revert "Remove (almost) all uses of C++ distributions/RNGs."

### DIFF
--- a/tools/djxl_fuzzer.cc
+++ b/tools/djxl_fuzzer.cc
@@ -12,6 +12,7 @@
 #include <algorithm>
 #include <map>
 #include <mutex>
+#include <random>
 #include <vector>
 
 #include "hwy/targets.h"
@@ -19,7 +20,6 @@
 #include "jxl/decode_cxx.h"
 #include "jxl/thread_parallel_runner.h"
 #include "jxl/thread_parallel_runner_cxx.h"
-#include "lib/jxl/base/random.h"
 
 // Unpublised API.
 void SetDecoderMemoryLimitBase_(size_t memory_limit_base);
@@ -78,8 +78,8 @@ bool DecodeJpegXl(const uint8_t* jxl, size_t size, size_t max_pixels,
       std::min<size_t>(2, JxlThreadParallelRunnerDefaultNumWorkerThreads());
   auto runner = JxlThreadParallelRunnerMake(nullptr, num_threads);
 
-  jxl::Rng rng(spec.random_seed);
-  jxl::Rng::GeometricDistribution dist(1.0f / kStreamingTargetNumberOfChunks);
+  std::mt19937 mt(spec.random_seed);
+  std::exponential_distribution<> dis_streaming(kStreamingTargetNumberOfChunks);
 
   auto dec = JxlDecoderMake(nullptr);
   if (JXL_DEC_SUCCESS !=
@@ -185,7 +185,7 @@ bool DecodeJpegXl(const uint8_t* jxl, size_t size, size_t max_pixels,
         leftover -= used;
         streaming_size -= used;
         size_t chunk_size = std::max<size_t>(
-            1, size * std::min<double>(1.0, rng.Geometric(dist)));
+            1, size * std::min<double>(1.0, dis_streaming(mt)));
         size_t add_size =
             std::min<size_t>(chunk_size, leftover - streaming_size);
         if (add_size == 0) {
@@ -347,7 +347,8 @@ bool DecodeJpegXl(const uint8_t* jxl, size_t size, size_t max_pixels,
       }
 
       if (info.num_extra_channels > 0) {
-        size_t ec_index = rng.UniformU(0, info.num_extra_channels);
+        std::uniform_int_distribution<> dis(0, info.num_extra_channels);
+        size_t ec_index = dis(mt);
         // There is also a probability no extra channel is chosen
         if (ec_index < info.num_extra_channels) {
           size_t ec_index = info.num_extra_channels - 1;

--- a/tools/flicker_test/split_view.cc
+++ b/tools/flicker_test/split_view.cc
@@ -7,7 +7,6 @@
 
 #include <QMouseEvent>
 #include <QPainter>
-#include <random>
 
 namespace jxl {
 
@@ -59,7 +58,8 @@ void SplitView::startTest(QString imageName, const int blankingTimeMSecs,
                           const bool gray, const int grayFadingTimeMSecs,
                           const int grayTimeMSecs) {
   imageName_ = std::move(imageName);
-  originalSide_ = g_.Bernoulli(0.5f) ? Side::kLeft : Side::kRight;
+  std::bernoulli_distribution bernoulli;
+  originalSide_ = bernoulli(g_) ? Side::kLeft : Side::kRight;
   viewingTimer_.setInterval(1000 * viewingTimeSecs);
 
   flicker_.setDuration(advanceTimeMSecs);

--- a/tools/flicker_test/split_view.h
+++ b/tools/flicker_test/split_view.h
@@ -12,8 +12,7 @@
 #include <QTimer>
 #include <QVariantAnimation>
 #include <QWidget>
-
-#include "lib/jxl/base/random.h"
+#include <random>
 
 namespace jxl {
 
@@ -61,7 +60,7 @@ class SplitView : public QWidget {
 
   int spacing_ = 50;
 
-  Rng g_;
+  std::mt19937 g_;
 
   QString imageName_;
   QPixmap original_, altered_;


### PR DESCRIPTION
tools/ that use only the public API break if we try to also use internal
API (base/random.h) since those are not exposed. This particular header
happened to work in most cases because it was mostly header-only, except
when JXL_DEBUG_ON_ERROR is enabled.