### PR TITLE
Move printf macros PRIuS/PRIdS to printf_macros.h

### DIFF
--- a/lib/extras/codec_pgx.cc
+++ b/lib/extras/codec_pgx.cc
@@ -18,6 +18,7 @@
 #include "lib/jxl/base/byte_order.h"
 #include "lib/jxl/base/compiler_specific.h"
 #include "lib/jxl/base/file_io.h"
+#include "lib/jxl/base/printf_macros.h"
 #include "lib/jxl/color_management.h"
 #include "lib/jxl/dec_external_image.h"
 #include "lib/jxl/enc_external_image.h"

--- a/lib/extras/codec_png.cc
+++ b/lib/extras/codec_png.cc
@@ -22,6 +22,7 @@
 #include "lib/jxl/base/byte_order.h"
 #include "lib/jxl/base/compiler_specific.h"
 #include "lib/jxl/base/file_io.h"
+#include "lib/jxl/base/printf_macros.h"
 #include "lib/jxl/color_management.h"
 #include "lib/jxl/common.h"
 #include "lib/jxl/dec_external_image.h"

--- a/lib/extras/codec_pnm.cc
+++ b/lib/extras/codec_pnm.cc
@@ -18,6 +18,7 @@
 #include "lib/jxl/base/byte_order.h"
 #include "lib/jxl/base/compiler_specific.h"
 #include "lib/jxl/base/file_io.h"
+#include "lib/jxl/base/printf_macros.h"
 #include "lib/jxl/base/status.h"
 #include "lib/jxl/color_management.h"
 #include "lib/jxl/dec_external_image.h"

--- a/lib/extras/codec_psd.cc
+++ b/lib/extras/codec_psd.cc
@@ -19,6 +19,7 @@
 #include "lib/jxl/base/byte_order.h"
 #include "lib/jxl/base/compiler_specific.h"
 #include "lib/jxl/base/file_io.h"
+#include "lib/jxl/base/printf_macros.h"
 #include "lib/jxl/color_management.h"
 #include "lib/jxl/common.h"
 #include "lib/jxl/fields.h"  // AllDefault

--- a/lib/extras/codec_test.cc
+++ b/lib/extras/codec_test.cc
@@ -15,6 +15,7 @@
 #include "gtest/gtest.h"
 #include "lib/extras/codec_pgx.h"
 #include "lib/extras/codec_pnm.h"
+#include "lib/jxl/base/printf_macros.h"
 #include "lib/jxl/base/random.h"
 #include "lib/jxl/base/thread_pool_internal.h"
 #include "lib/jxl/color_management.h"

--- a/lib/jxl.cmake
+++ b/lib/jxl.cmake
@@ -35,6 +35,7 @@ set(JPEGXL_INTERNAL_SOURCES_DEC
   jxl/base/override.h
   jxl/base/padded_bytes.cc
   jxl/base/padded_bytes.h
+  jxl/base/printf_macros.h
   jxl/base/profiler.h
   jxl/base/random.cc
   jxl/base/random.h

--- a/lib/jxl/aux_out.cc
+++ b/lib/jxl/aux_out.cc
@@ -10,6 +10,7 @@
 #include <numeric>  // accumulate
 
 #include "lib/jxl/aux_out_fwd.h"
+#include "lib/jxl/base/printf_macros.h"
 #include "lib/jxl/enc_bit_writer.h"
 
 namespace jxl {

--- a/lib/jxl/aux_out.h
+++ b/lib/jxl/aux_out.h
@@ -8,6 +8,7 @@
 
 // Optional output information for debugging and analyzing size usage.
 
+#include <inttypes.h>
 #include <stddef.h>
 #include <stdint.h>
 #include <stdio.h>
@@ -103,7 +104,7 @@ static inline const char* LayerName(size_t layer) {
     case kLayerExtraChannels:
       return "extra channels";
     default:
-      JXL_ABORT("Invalid layer %" PRIuS "\n", layer);
+      JXL_ABORT("Invalid layer %d\n", static_cast<int>(layer));
   }
 }
 
@@ -119,12 +120,13 @@ struct AuxOut {
       clustered_entropy += victim.clustered_entropy;
     }
     void Print(size_t num_inputs) const {
-      printf("%10" PRIdS, total_bits);
+      printf("%10" PRId64, static_cast<int64_t>(total_bits));
       if (histogram_bits != 0) {
-        printf("   [c/i:%6.2f | hst:%8" PRIdS " | ex:%8" PRIdS
+        printf("   [c/i:%6.2f | hst:%8" PRId64 " | ex:%8" PRId64
                " | h+c+e:%12.3f",
-               num_clustered_histograms * 1.0 / num_inputs, histogram_bits >> 3,
-               extra_bits >> 3,
+               num_clustered_histograms * 1.0 / num_inputs,
+               static_cast<int64_t>(histogram_bits >> 3),
+               static_cast<int64_t>(extra_bits >> 3),
                (histogram_bits + clustered_entropy + extra_bits) / 8.0);
         printf("]");
       }

--- a/lib/jxl/base/cache_aligned.cc
+++ b/lib/jxl/base/cache_aligned.cc
@@ -20,8 +20,8 @@
 #include <hwy/base.h>  // kMaxVectorSize
 #include <limits>
 
+#include "lib/jxl/base/printf_macros.h"
 #include "lib/jxl/base/status.h"
-#include "lib/jxl/common.h"
 
 namespace jxl {
 namespace {

--- a/lib/jxl/base/printf_macros.h
+++ b/lib/jxl/base/printf_macros.h
@@ -1,0 +1,34 @@
+// Copyright (c) the JPEG XL Project Authors. All rights reserved.
+//
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+#ifndef LIB_JXL_BASE_PRINTF_MACROS_H_
+#define LIB_JXL_BASE_PRINTF_MACROS_H_
+
+// Format string macros. These should be included after any other system
+// library since those may unconditionally define these, depending on the
+// platform.
+
+// PRIuS and PRIdS macros to print size_t and ssize_t respectively.
+#if !defined(PRIdS)
+#if defined(_WIN64)
+#define PRIdS "lld"
+#elif defined(_WIN32)
+#define PRIdS "d"
+#else
+#define PRIdS "zd"
+#endif
+#endif  // PRIdS
+
+#if !defined(PRIuS)
+#if defined(_WIN64)
+#define PRIuS "llu"
+#elif defined(_WIN32)
+#define PRIuS "u"
+#else
+#define PRIuS "zu"
+#endif
+#endif  // PRIuS
+
+#endif  // LIB_JXL_BASE_PRINTF_MACROS_H_

--- a/lib/jxl/blending.cc
+++ b/lib/jxl/blending.cc
@@ -6,6 +6,7 @@
 #include "lib/jxl/blending.h"
 
 #include "lib/jxl/alpha.h"
+#include "lib/jxl/base/printf_macros.h"
 #include "lib/jxl/image_ops.h"
 
 namespace jxl {

--- a/lib/jxl/butteraugli/butteraugli.cc
+++ b/lib/jxl/butteraugli/butteraugli.cc
@@ -41,6 +41,7 @@
 #define HWY_TARGET_INCLUDE "lib/jxl/butteraugli/butteraugli.cc"
 #include <hwy/foreach_target.h>
 
+#include "lib/jxl/base/printf_macros.h"
 #include "lib/jxl/base/profiler.h"
 #include "lib/jxl/base/status.h"
 #include "lib/jxl/convolve.h"

--- a/lib/jxl/coeff_order_test.cc
+++ b/lib/jxl/coeff_order_test.cc
@@ -13,6 +13,7 @@
 #include <vector>
 
 #include "gtest/gtest.h"
+#include "lib/jxl/base/printf_macros.h"
 #include "lib/jxl/base/random.h"
 #include "lib/jxl/base/span.h"
 #include "lib/jxl/coeff_order_fwd.h"

--- a/lib/jxl/common.h
+++ b/lib/jxl/common.h
@@ -27,27 +27,6 @@
 #define JPEGXL_ENABLE_TRANSCODE_JPEG 1
 #endif  // JPEGXL_ENABLE_TRANSCODE_JPEG
 
-// PRIuS and PRIdS macros to print size_t and ssize_t respectively.
-#if !defined(PRIdS)
-#if defined(_WIN64)
-#define PRIdS "lld"
-#elif defined(_WIN32)
-#define PRIdS "d"
-#else
-#define PRIdS "zd"
-#endif
-#endif  // PRIdS
-
-#if !defined(PRIuS)
-#if defined(_WIN64)
-#define PRIuS "llu"
-#elif defined(_WIN32)
-#define PRIuS "u"
-#else
-#define PRIuS "zu"
-#endif
-#endif  // PRIuS
-
 namespace jxl {
 // Some enums and typedefs used by more than one header file.
 

--- a/lib/jxl/convolve_test.cc
+++ b/lib/jxl/convolve_test.cc
@@ -17,6 +17,7 @@
 
 #include "lib/jxl/base/compiler_specific.h"
 #include "lib/jxl/base/data_parallel.h"
+#include "lib/jxl/base/printf_macros.h"
 #include "lib/jxl/base/thread_pool_internal.h"
 #include "lib/jxl/image_ops.h"
 #include "lib/jxl/image_test_utils.h"

--- a/lib/jxl/dec_ans.cc
+++ b/lib/jxl/dec_ans.cc
@@ -12,6 +12,7 @@
 #include "lib/jxl/ans_common.h"
 #include "lib/jxl/ans_params.h"
 #include "lib/jxl/base/bits.h"
+#include "lib/jxl/base/printf_macros.h"
 #include "lib/jxl/base/profiler.h"
 #include "lib/jxl/base/status.h"
 #include "lib/jxl/common.h"

--- a/lib/jxl/dec_external_image.cc
+++ b/lib/jxl/dec_external_image.cc
@@ -22,6 +22,7 @@
 #include "lib/jxl/base/byte_order.h"
 #include "lib/jxl/base/cache_aligned.h"
 #include "lib/jxl/base/compiler_specific.h"
+#include "lib/jxl/base/printf_macros.h"
 #include "lib/jxl/color_management.h"
 #include "lib/jxl/common.h"
 #include "lib/jxl/sanitizers.h"

--- a/lib/jxl/dec_frame.cc
+++ b/lib/jxl/dec_frame.cc
@@ -21,6 +21,7 @@
 #include "lib/jxl/base/bits.h"
 #include "lib/jxl/base/compiler_specific.h"
 #include "lib/jxl/base/data_parallel.h"
+#include "lib/jxl/base/printf_macros.h"
 #include "lib/jxl/base/profiler.h"
 #include "lib/jxl/base/status.h"
 #include "lib/jxl/chroma_from_luma.h"

--- a/lib/jxl/dec_group.cc
+++ b/lib/jxl/dec_group.cc
@@ -23,6 +23,7 @@
 #include "lib/jxl/ac_strategy.h"
 #include "lib/jxl/aux_out.h"
 #include "lib/jxl/base/bits.h"
+#include "lib/jxl/base/printf_macros.h"
 #include "lib/jxl/base/profiler.h"
 #include "lib/jxl/base/status.h"
 #include "lib/jxl/coeff_order.h"

--- a/lib/jxl/dec_modular.cc
+++ b/lib/jxl/dec_modular.cc
@@ -18,6 +18,7 @@
 
 #include "lib/jxl/alpha.h"
 #include "lib/jxl/base/compiler_specific.h"
+#include "lib/jxl/base/printf_macros.h"
 #include "lib/jxl/base/span.h"
 #include "lib/jxl/base/status.h"
 #include "lib/jxl/compressed_dc.h"

--- a/lib/jxl/dec_patch_dictionary.cc
+++ b/lib/jxl/dec_patch_dictionary.cc
@@ -18,6 +18,7 @@
 #include "lib/jxl/ans_params.h"
 #include "lib/jxl/base/compiler_specific.h"
 #include "lib/jxl/base/override.h"
+#include "lib/jxl/base/printf_macros.h"
 #include "lib/jxl/base/status.h"
 #include "lib/jxl/blending.h"
 #include "lib/jxl/chroma_from_luma.h"

--- a/lib/jxl/enc_color_management.cc
+++ b/lib/jxl/enc_color_management.cc
@@ -31,6 +31,7 @@
 
 #include "lib/jxl/base/compiler_specific.h"
 #include "lib/jxl/base/data_parallel.h"
+#include "lib/jxl/base/printf_macros.h"
 #include "lib/jxl/base/status.h"
 #include "lib/jxl/field_encodings.h"
 #include "lib/jxl/linalg.h"

--- a/lib/jxl/enc_detect_dots.cc
+++ b/lib/jxl/enc_detect_dots.cc
@@ -21,6 +21,7 @@
 
 #include "lib/jxl/base/compiler_specific.h"
 #include "lib/jxl/base/data_parallel.h"
+#include "lib/jxl/base/printf_macros.h"
 #include "lib/jxl/base/profiler.h"
 #include "lib/jxl/base/status.h"
 #include "lib/jxl/codec_in_out.h"

--- a/lib/jxl/enc_modular.cc
+++ b/lib/jxl/enc_modular.cc
@@ -17,6 +17,7 @@
 #include "lib/jxl/aux_out.h"
 #include "lib/jxl/base/compiler_specific.h"
 #include "lib/jxl/base/padded_bytes.h"
+#include "lib/jxl/base/printf_macros.h"
 #include "lib/jxl/base/status.h"
 #include "lib/jxl/compressed_dc.h"
 #include "lib/jxl/dec_ans.h"

--- a/lib/jxl/fake_parallel_runner_testonly.h
+++ b/lib/jxl/fake_parallel_runner_testonly.h
@@ -10,6 +10,7 @@
 
 #include <vector>
 
+#include "jxl/parallel_runner.h"
 #include "lib/jxl/base/random.h"
 
 namespace jxl {

--- a/lib/jxl/fields.cc
+++ b/lib/jxl/fields.cc
@@ -12,6 +12,7 @@
 
 #include "hwy/base.h"
 #include "lib/jxl/base/bits.h"
+#include "lib/jxl/base/printf_macros.h"
 
 namespace jxl {
 

--- a/lib/jxl/fields.h
+++ b/lib/jxl/fields.h
@@ -8,6 +8,7 @@
 
 // Forward/backward-compatible 'bundles' with auto-serialized 'fields'.
 
+#include <inttypes.h>
 #include <stddef.h>
 #include <stdint.h>
 #include <stdio.h>
@@ -40,7 +41,8 @@ class BitsCoder {
                           size_t* JXL_RESTRICT encoded_bits) {
     *encoded_bits = bits;
     if (value >= (1ULL << bits)) {
-      return JXL_FAILURE("Value %u too large for %" PRIuS " bits", value, bits);
+      return JXL_FAILURE("Value %u too large for %" PRIu64 " bits", value,
+                         static_cast<uint64_t>(bits));
     }
     return true;
   }
@@ -53,8 +55,8 @@ class BitsCoder {
   static Status Write(const size_t bits, const uint32_t value,
                       BitWriter* JXL_RESTRICT writer) {
     if (value >= (1ULL << bits)) {
-      return JXL_FAILURE("Value %d too large to encode in %" PRIuS " bits",
-                         value, bits);
+      return JXL_FAILURE("Value %d too large to encode in %" PRIu64 " bits",
+                         value, static_cast<uint64_t>(bits));
     }
     writer->Write(bits, value);
     return true;

--- a/lib/jxl/frame_header.cc
+++ b/lib/jxl/frame_header.cc
@@ -6,6 +6,7 @@
 #include "lib/jxl/frame_header.h"
 
 #include "lib/jxl/aux_out.h"
+#include "lib/jxl/base/printf_macros.h"
 #include "lib/jxl/base/status.h"
 #include "lib/jxl/fields.h"
 

--- a/lib/jxl/gauss_blur_test.cc
+++ b/lib/jxl/gauss_blur_test.cc
@@ -11,6 +11,7 @@
 
 #include "gtest/gtest.h"
 #include "lib/extras/time.h"
+#include "lib/jxl/base/printf_macros.h"
 #include "lib/jxl/convolve.h"
 #include "lib/jxl/image_ops.h"
 #include "lib/jxl/image_test_utils.h"

--- a/lib/jxl/headers.cc
+++ b/lib/jxl/headers.cc
@@ -5,6 +5,7 @@
 
 #include "lib/jxl/headers.h"
 
+#include "lib/jxl/base/printf_macros.h"
 #include "lib/jxl/common.h"
 #include "lib/jxl/fields.h"
 

--- a/lib/jxl/image.h
+++ b/lib/jxl/image.h
@@ -8,6 +8,7 @@
 
 // SIMD/multicore-friendly planar image representation with row accessors.
 
+#include <inttypes.h>
 #include <stddef.h>
 #include <stdint.h>
 #include <string.h>
@@ -84,7 +85,7 @@ struct PlaneBase {
 #if defined(ADDRESS_SANITIZER) || defined(MEMORY_SANITIZER) || \
     defined(THREAD_SANITIZER)
     if (y >= ysize_) {
-      JXL_ABORT("Row(%" PRIuS ") in (%u x %u) image\n", y, xsize_, ysize_);
+      JXL_ABORT("Row(%" PRIu64 ") in (%u x %u) image\n", y, xsize_, ysize_);
     }
 #endif
 
@@ -422,9 +423,10 @@ class Image3 {
 #if defined(ADDRESS_SANITIZER) || defined(MEMORY_SANITIZER) || \
     defined(THREAD_SANITIZER)
     if (c >= kNumPlanes || y >= ysize()) {
-      JXL_ABORT("PlaneRow(%" PRIuS ", %" PRIuS ") in (%" PRIuS " x %" PRIuS
+      JXL_ABORT("PlaneRow(%" PRIu64 ", %" PRIu64 ") in (%" PRIu64 " x %" PRIu64
                 ") image\n",
-                c, y, xsize(), ysize());
+                static_cast<uint64_t>(c), static_cast<uint64_t>(y),
+                static_cast<uint64_t>(xsize()), static_cast<uint64_t>(ysize()));
     }
 #endif
   }

--- a/lib/jxl/image_bundle.cc
+++ b/lib/jxl/image_bundle.cc
@@ -11,6 +11,7 @@
 #include "lib/jxl/alpha.h"
 #include "lib/jxl/base/byte_order.h"
 #include "lib/jxl/base/padded_bytes.h"
+#include "lib/jxl/base/printf_macros.h"
 #include "lib/jxl/base/profiler.h"
 #include "lib/jxl/codec_in_out.h"
 #include "lib/jxl/color_management.h"

--- a/lib/jxl/image_ops_test.cc
+++ b/lib/jxl/image_ops_test.cc
@@ -12,6 +12,7 @@
 #include <utility>
 
 #include "gtest/gtest.h"
+#include "lib/jxl/base/printf_macros.h"
 #include "lib/jxl/image.h"
 #include "lib/jxl/image_test_utils.h"
 

--- a/lib/jxl/image_test_utils.h
+++ b/lib/jxl/image_test_utils.h
@@ -121,12 +121,13 @@ void VerifyRelativeError(const Plane<T>& expected, const Plane<T>& actual,
   if (any_bad) {
     // Never had a valid relative value, don't print it.
     if (max_relative < 0) {
-      fprintf(stderr, "c=%" PRIuS ": max +/- %E exceeds +/- %.2E\n", c, max_l1,
-              threshold_l1);
+      fprintf(stderr, "c=%" PRIu64 ": max +/- %E exceeds +/- %.2E\n",
+              static_cast<uint64_t>(c), max_l1, threshold_l1);
     } else {
       fprintf(stderr,
-              "c=%" PRIuS ": max +/- %E, x %E exceeds +/- %.2E, x %.2E\n", c,
-              max_l1, max_relative, threshold_l1, threshold_relative);
+              "c=%" PRIu64 ": max +/- %E, x %E exceeds +/- %.2E, x %.2E\n",
+              static_cast<uint64_t>(c), max_l1, max_relative, threshold_l1,
+              threshold_relative);
     }
     // Dump the expected image and actual image if the region is small enough.
     const intptr_t kMaxTestDumpSize = 16;

--- a/lib/jxl/jpeg/enc_jpeg_data_reader.cc
+++ b/lib/jxl/jpeg/enc_jpeg_data_reader.cc
@@ -12,6 +12,7 @@
 #include <string>
 #include <vector>
 
+#include "lib/jxl/base/printf_macros.h"
 #include "lib/jxl/base/status.h"
 #include "lib/jxl/common.h"
 #include "lib/jxl/jpeg/enc_jpeg_huffman_decode.h"

--- a/lib/jxl/jpeg/jpeg_data.cc
+++ b/lib/jxl/jpeg/jpeg_data.cc
@@ -5,6 +5,7 @@
 
 #include "lib/jxl/jpeg/jpeg_data.h"
 
+#include "lib/jxl/base/printf_macros.h"
 #include "lib/jxl/base/status.h"
 
 namespace jxl {

--- a/lib/jxl/jxl_test.cc
+++ b/lib/jxl/jxl_test.cc
@@ -19,6 +19,7 @@
 #include "lib/jxl/base/data_parallel.h"
 #include "lib/jxl/base/override.h"
 #include "lib/jxl/base/padded_bytes.h"
+#include "lib/jxl/base/printf_macros.h"
 #include "lib/jxl/base/thread_pool_internal.h"
 #include "lib/jxl/codec_in_out.h"
 #include "lib/jxl/codec_y4m_testonly.h"

--- a/lib/jxl/modular/encoding/enc_debug_tree.cc
+++ b/lib/jxl/modular/encoding/enc_debug_tree.cc
@@ -9,6 +9,7 @@
 #include <stdlib.h>
 
 #include "lib/jxl/base/os_macros.h"
+#include "lib/jxl/base/printf_macros.h"
 #include "lib/jxl/base/status.h"
 #include "lib/jxl/modular/encoding/context_predict.h"
 #include "lib/jxl/modular/encoding/dec_ma.h"

--- a/lib/jxl/modular/encoding/enc_encoding.cc
+++ b/lib/jxl/modular/encoding/enc_encoding.cc
@@ -14,6 +14,7 @@
 #include <unordered_map>
 #include <unordered_set>
 
+#include "lib/jxl/base/printf_macros.h"
 #include "lib/jxl/base/status.h"
 #include "lib/jxl/common.h"
 #include "lib/jxl/dec_ans.h"

--- a/lib/jxl/modular/encoding/encoding.cc
+++ b/lib/jxl/modular/encoding/encoding.cc
@@ -10,6 +10,7 @@
 
 #include <queue>
 
+#include "lib/jxl/base/printf_macros.h"
 #include "lib/jxl/modular/encoding/context_predict.h"
 #include "lib/jxl/modular/options.h"
 

--- a/lib/jxl/modular/transform/squeeze.cc
+++ b/lib/jxl/modular/transform/squeeze.cc
@@ -8,6 +8,7 @@
 #include <stdlib.h>
 
 #include "lib/jxl/base/data_parallel.h"
+#include "lib/jxl/base/printf_macros.h"
 #include "lib/jxl/common.h"
 #include "lib/jxl/modular/modular_image.h"
 #include "lib/jxl/modular/transform/transform.h"

--- a/lib/jxl/modular/transform/transform.cc
+++ b/lib/jxl/modular/transform/transform.cc
@@ -5,6 +5,7 @@
 
 #include "lib/jxl/modular/transform/transform.h"
 
+#include "lib/jxl/base/printf_macros.h"
 #include "lib/jxl/fields.h"
 #include "lib/jxl/modular/modular_image.h"
 #include "lib/jxl/modular/transform/palette.h"

--- a/lib/jxl/quant_weights.cc
+++ b/lib/jxl/quant_weights.cc
@@ -13,6 +13,7 @@
 #include <utility>
 
 #include "lib/jxl/base/bits.h"
+#include "lib/jxl/base/printf_macros.h"
 #include "lib/jxl/base/status.h"
 #include "lib/jxl/common.h"
 #include "lib/jxl/dct_scales.h"

--- a/lib/jxl/splines.cc
+++ b/lib/jxl/splines.cc
@@ -9,6 +9,7 @@
 #include <cmath>
 
 #include "lib/jxl/ans_params.h"
+#include "lib/jxl/base/printf_macros.h"
 #include "lib/jxl/base/status.h"
 #include "lib/jxl/chroma_from_luma.h"
 #include "lib/jxl/common.h"

--- a/lib/jxl/splines_test.cc
+++ b/lib/jxl/splines_test.cc
@@ -8,6 +8,7 @@
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
 #include "lib/extras/codec.h"
+#include "lib/jxl/base/printf_macros.h"
 #include "lib/jxl/dec_file.h"
 #include "lib/jxl/enc_butteraugli_comparator.h"
 #include "lib/jxl/enc_splines.h"

--- a/lib/lib.gni
+++ b/lib/lib.gni
@@ -52,6 +52,7 @@ libjxl_dec_sources = [
     "jxl/base/override.h",
     "jxl/base/padded_bytes.cc",
     "jxl/base/padded_bytes.h",
+    "jxl/base/printf_macros.h",
     "jxl/base/profiler.h",
     "jxl/base/random.cc",
     "jxl/base/random.h",

--- a/lib/profiler/profiler.cc
+++ b/lib/profiler/profiler.cc
@@ -432,7 +432,7 @@ void ThreadSpecific::ComputeOverhead() {
     std::sort(samples, samples + kNumSamples);
     self_overhead = samples[kNumSamples / 2];
 #if PROFILER_PRINT_OVERHEAD
-    printf("Overhead: %" PRIuS "\n", self_overhead);
+    printf("Overhead: %" PRIu64 "\n", static_cast<uint64_t>(self_overhead));
 #endif
     results_->SetSelfOverhead(self_overhead);
   }
@@ -468,7 +468,8 @@ void ThreadSpecific::ComputeOverhead() {
   std::sort(samples, samples + kNumSamples);
   const uint64_t child_overhead = samples[9 * kNumSamples / 10];
 #if PROFILER_PRINT_OVERHEAD
-  printf("Child overhead: %" PRIuS "\n", child_overhead);
+  printf("Child overhead: %" PRIu64 "\n",
+         static_cast<uint64_t>(child_overhead));
 #endif
   results_->SetChildOverhead(child_overhead);
 }

--- a/tools/args.h
+++ b/tools/args.h
@@ -8,6 +8,8 @@
 
 // Helpers for parsing command line arguments. No include guard needed.
 
+#include <inttypes.h>
+#include <stdint.h>
 #include <stdio.h>
 #include <string.h>
 
@@ -114,16 +116,16 @@ static inline bool ParseAndAppendKeyValue(const char* arg,
 
 static inline bool ParsePredictor(const char* arg, jxl::Predictor* out) {
   char* end;
-  size_t p = static_cast<size_t>(strtoull(arg, &end, 0));
+  uint64_t p = static_cast<uint64_t>(strtoull(arg, &end, 0));
   if (end[0] != '\0') {
     fprintf(stderr, "Invalid predictor: %s.\n", arg);
     return JXL_FAILURE("Args");
   }
   if (p >= jxl::kNumModularPredictors) {
     fprintf(stderr,
-            "Invalid predictor value %" PRIuS ", must be less than %" PRIuS
+            "Invalid predictor value %" PRIu64 ", must be less than %" PRIu64
             ".\n",
-            p, jxl::kNumModularPredictors);
+            p, static_cast<uint64_t>(jxl::kNumModularPredictors));
     return JXL_FAILURE("Args");
   }
   *out = static_cast<jxl::Predictor>(p);

--- a/tools/benchmark/benchmark_stats.cc
+++ b/tools/benchmark/benchmark_stats.cc
@@ -13,6 +13,7 @@
 #include <algorithm>
 #include <cmath>
 
+#include "lib/jxl/base/printf_macros.h"
 #include "lib/jxl/base/status.h"
 #include "tools/benchmark/benchmark_args.h"
 

--- a/tools/benchmark/benchmark_xl.cc
+++ b/tools/benchmark/benchmark_xl.cc
@@ -28,6 +28,7 @@
 #include "lib/jxl/base/data_parallel.h"
 #include "lib/jxl/base/file_io.h"
 #include "lib/jxl/base/padded_bytes.h"
+#include "lib/jxl/base/printf_macros.h"
 #include "lib/jxl/base/profiler.h"
 #include "lib/jxl/base/random.h"
 #include "lib/jxl/base/span.h"

--- a/tools/box/box_list_main.cc
+++ b/tools/box/box_list_main.cc
@@ -14,6 +14,7 @@
 #include "lib/jxl/base/file_io.h"
 #include "lib/jxl/base/override.h"
 #include "lib/jxl/base/padded_bytes.h"
+#include "lib/jxl/base/printf_macros.h"
 #include "lib/jxl/base/status.h"
 #include "tools/box/box.h"
 

--- a/tools/butteraugli_main.cc
+++ b/tools/butteraugli_main.cc
@@ -15,6 +15,7 @@
 #include "lib/jxl/base/data_parallel.h"
 #include "lib/jxl/base/file_io.h"
 #include "lib/jxl/base/padded_bytes.h"
+#include "lib/jxl/base/printf_macros.h"
 #include "lib/jxl/base/status.h"
 #include "lib/jxl/base/thread_pool_internal.h"
 #include "lib/jxl/butteraugli/butteraugli.h"

--- a/tools/cjxl.cc
+++ b/tools/cjxl.cc
@@ -25,6 +25,7 @@
 #include "lib/jxl/base/compiler_specific.h"
 #include "lib/jxl/base/data_parallel.h"
 #include "lib/jxl/base/padded_bytes.h"
+#include "lib/jxl/base/printf_macros.h"
 #include "lib/jxl/base/profiler.h"
 #include "lib/jxl/base/status.h"
 #include "lib/jxl/base/thread_pool_internal.h"

--- a/tools/djxl.cc
+++ b/tools/djxl.cc
@@ -16,6 +16,7 @@
 #include "lib/jxl/base/data_parallel.h"
 #include "lib/jxl/base/file_io.h"
 #include "lib/jxl/base/override.h"
+#include "lib/jxl/base/printf_macros.h"
 #include "lib/jxl/color_encoding_internal.h"
 #include "lib/jxl/color_management.h"
 #include "lib/jxl/dec_file.h"

--- a/tools/djxl_main.cc
+++ b/tools/djxl_main.cc
@@ -16,6 +16,7 @@
 #include "lib/jxl/base/file_io.h"
 #include "lib/jxl/base/override.h"
 #include "lib/jxl/base/padded_bytes.h"
+#include "lib/jxl/base/printf_macros.h"
 #include "lib/jxl/base/profiler.h"
 #include "lib/jxl/base/span.h"
 #include "lib/jxl/base/status.h"

--- a/tools/epf_main.cc
+++ b/tools/epf_main.cc
@@ -6,6 +6,7 @@
 #include <stdio.h>
 
 #include "lib/extras/codec.h"
+#include "lib/jxl/base/printf_macros.h"
 #include "lib/jxl/base/thread_pool_internal.h"
 #include "lib/jxl/enc_adaptive_quantization.h"
 #include "tools/args.h"

--- a/tools/speed_stats.cc
+++ b/tools/speed_stats.cc
@@ -5,14 +5,13 @@
 
 #include "tools/speed_stats.h"
 
+#include <inttypes.h>
 #include <math.h>
 #include <stddef.h>
 #include <stdio.h>
 
 #include <algorithm>
 #include <string>
-
-#include "lib/jxl/common.h"
 
 namespace jpegxl {
 namespace tools {
@@ -105,10 +104,12 @@ jxl::Status SpeedStats::Print(size_t worker_threads) {
   }
 
   fprintf(stderr,
-          "%" PRIuS " x %" PRIuS "%s%s%s, %" PRIuS " reps, %" PRIuS
+          "%" PRIu64 " x %" PRIu64 "%s%s%s, %" PRIu64 " reps, %" PRIu64
           " threads.\n",
-          xsize_, ysize_, mps_stats.c_str(), mbs_stats.c_str(), variability,
-          elapsed_.size(), worker_threads);
+          static_cast<uint64_t>(xsize_), static_cast<uint64_t>(ysize_),
+          mps_stats.c_str(), mbs_stats.c_str(), variability,
+          static_cast<uint64_t>(elapsed_.size()),
+          static_cast<uint64_t>(worker_threads));
   return true;
 }
 

--- a/tools/xyb_range.cc
+++ b/tools/xyb_range.cc
@@ -9,6 +9,7 @@
 
 #include "lib/jxl/base/compiler_specific.h"
 #include "lib/jxl/base/data_parallel.h"
+#include "lib/jxl/base/printf_macros.h"
 #include "lib/jxl/codec_in_out.h"
 #include "lib/jxl/color_encoding_internal.h"
 #include "lib/jxl/color_management.h"


### PR DESCRIPTION
PRIuS/PRIdS are the standard names for these macros that should be
defined by the system headers. We have an ifndef guard against double
definition, however it is possible for our header to be included before
a system header (in particular gtest) so this fails with a double
definition of the macro.

Move these definitions to a new header to avoid this issue.
This patch also adds a missing include header in
fake_parallel_runner_testonly.h.