### PR TITLE
Add JxlDecoderCloseInput to decoder API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,19 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+### Added
+ - decoder API: Ability to decode the content of metadata boxes:
+   `JXL_DEC_BOX`, `JXL_DEC_BOX_NEED_MORE_OUTPUT`,  `JxlDecoderSetBoxBuffer`,
+   `JxlDecoderGetBoxType`, `JxlDecoderGetBoxSizeRaw` and
+   `JxlDecoderSetDecompressBoxes`
+ - decoder API: ability to mark the input is finished: `JxlDecoderCloseInput`
+
+### Changed
+- decoder API: `JxlDecoderCloseInput` is required when using JXL_DEC_BOX, and
+  also encouraged, but not required for backwards compatiblity, for any other
+  usage of the decoder.
+
 ## [0.6.1] - 2021-10-29
 ### Changed
  - Security: Fix OOB read in splines rendering (#735 -

--- a/examples/decode_exif_metadata.cc
+++ b/examples/decode_exif_metadata.cc
@@ -36,6 +36,7 @@ bool DecodeJpegXlExif(const uint8_t* jxl, size_t size,
   }
 
   JxlDecoderSetInput(dec.get(), jxl, size);
+  JxlDecoderCloseInput(dec.get());
 
   const constexpr size_t kChunkSize = 65536;
   size_t output_pos = 0;

--- a/examples/decode_oneshot.cc
+++ b/examples/decode_oneshot.cc
@@ -52,6 +52,7 @@ bool DecodeJpegXlOneShot(const uint8_t* jxl, size_t size,
   JxlPixelFormat format = {4, JXL_TYPE_FLOAT, JXL_NATIVE_ENDIAN, 0};
 
   JxlDecoderSetInput(dec.get(), jxl, size);
+  JxlDecoderCloseInput(dec.get());
 
   for (;;) {
     JxlDecoderStatus status = JxlDecoderProcessInput(dec.get());

--- a/lib/include/jxl/decode.h
+++ b/lib/include/jxl/decode.h
@@ -467,11 +467,14 @@ JXL_EXPORT JxlDecoderStatus JxlDecoderProcessInput(JxlDecoder* dec);
  * Sets input data for JxlDecoderProcessInput. The data is owned by the caller
  * and may be used by the decoder until JxlDecoderReleaseInput is called or
  * the decoder is destroyed or reset so must be kept alive until then.
+ * Cannot be called if JxlDecoderSetInput was already called and
+ * JxlDecoderReleaseInput was not yet called, and cannot be called after
+ * JxlDecoderCloseInput indicating the end of input was called.
  * @param dec decoder object
  * @param data pointer to next bytes to read from
  * @param size amount of bytes available starting from data
- * @return JXL_DEC_ERROR if input was already set without releasing,
- * JXL_DEC_SUCCESS otherwise.
+ * @return JXL_DEC_ERROR if input was already set without releasing or
+ * JxlDecoderCloseInput was already called, JXL_DEC_SUCCESS otherwise.
  */
 JXL_EXPORT JxlDecoderStatus JxlDecoderSetInput(JxlDecoder* dec,
                                                const uint8_t* data,
@@ -495,6 +498,23 @@ JXL_EXPORT JxlDecoderStatus JxlDecoderSetInput(JxlDecoder* dec,
  * file are.
  */
 JXL_EXPORT size_t JxlDecoderReleaseInput(JxlDecoder* dec);
+
+/**
+ * Marks the input as finished, indicates that no more JxlDecoderSetInput will
+ * be called. This function allows the decoder to determine correctly if it
+ * should return success, need more input or error in certain cases. For
+ * backwards compatibility with a previous version of the API, using this
+ * function is optional when not using the JXL_DEC_BOX event (the decoder is
+ * able to determine the end of the image frames without marking the end), but
+ * using this function is required when using JXL_DEC_BOX for getting metadata
+ * box contents. This function does not replace JxlDecoderReleaseInput, that
+ * function should still be called if its return value is needed.
+ * JxlDecoderCloseInput should be called as soon as all known input bytes are
+ * set (e.g. at the beginning when not streaming but setting all input at once),
+ * before the final JxlDecoderProcessInput calls.
+ * @param dec decoder object
+ */
+JXL_EXPORT void JxlDecoderCloseInput(JxlDecoder* dec);
 
 /**
  * Outputs the basic image information, such as image dimensions, bit depth and

--- a/tools/djxl_fuzzer.cc
+++ b/tools/djxl_fuzzer.cc
@@ -107,6 +107,7 @@ bool DecodeJpegXl(const uint8_t* jxl, size_t size, size_t max_pixels,
   if (!spec.use_streaming) {
     // Set all input at once
     JxlDecoderSetInput(dec.get(), jxl, size);
+    JxlDecoderCloseInput(dec.get());
   }
 
   bool seen_basic_info = false;
@@ -193,7 +194,14 @@ bool DecodeJpegXl(const uint8_t* jxl, size_t size, size_t max_pixels,
           return false;
         }
         streaming_size += add_size;
-        JxlDecoderSetInput(dec.get(), jxl, streaming_size);
+        if (JXL_DEC_SUCCESS !=
+            JxlDecoderSetInput(dec.get(), jxl, streaming_size)) {
+          return false;
+        }
+        if (leftover == streaming_size) {
+          // All possible input bytes given
+          JxlDecoderCloseInput(dec.get());
+        }
 
         if (!tested_flush && seen_frame) {
           // Test flush max once to avoid too slow fuzzer run


### PR DESCRIPTION
This adds a function to mark input explicitely as closed.

This is required to be used for correctness when box metadata
is gotten, because from streaming input it is not possible to
determine whether the current box is the last box, or the
current bytes of an unbounded last box are the final bytes.
Before, the decoder could return success when the user still
had more input (when requesting box content only), which is
not entirely straightforward.

It should also be used in general from this point on for
consistency, though for backwards compatibility with the
previous released decoder API versions, is not required
to be used when JXL_DEC_BOX is not used.