### PR TITLE
release.md: reminder to mention API/ABI changes

### DIFF
--- a/doc/release.md
+++ b/doc/release.md
@@ -129,6 +129,10 @@ This will update the version in the following files:
  * `debian/changelog` to create the Debian package release with the new version.
    Debian changelog shouldn't repeat the library changelog, instead it should
    include changes to the packaging scripts.
+ 
+If there were incompatible API/ABI changes, make sure to also adapt the 
+corresponding section in 
+[CMakeLists.txt](https://github.com/libjxl/libjxl/blob/main/lib/CMakeLists.txt#L12).
 
 ## Cherry-pick fixes to a release
 


### PR DESCRIPTION
it is only relevant for < 1.0
after 1.0 the SOVERSION there is only the MAJOR number