### PR TITLE
Add API to encode boxes, header only (no implementation)

### DIFF
--- a/lib/jxl/encode.cc
+++ b/lib/jxl/encode.cc
@@ -464,7 +464,7 @@ void JxlEncoderReset(JxlEncoder* enc) {
   enc->input_closed = false;
   enc->basic_info_set = false;
   enc->color_encoding_set = false;
-  enc->force_container = false;
+  enc->use_container = false;
   enc->codestream_level = 5;
 }
 
@@ -477,11 +477,11 @@ void JxlEncoderDestroy(JxlEncoder* enc) {
 }
 
 JxlEncoderStatus JxlEncoderUseContainer(JxlEncoder* enc,
-                                        JXL_BOOL force_container) {
+                                        JXL_BOOL use_container) {
   if (enc->wrote_bytes) {
     return JXL_API_ERROR("this setting can only be set at the beginning");
   }
-  enc->force_container = static_cast<bool>(force_container);
+  enc->use_container = static_cast<bool>(use_container);
   return JXL_ENC_SUCCESS;
 }
 

--- a/lib/jxl/encode_internal.h
+++ b/lib/jxl/encode_internal.h
@@ -94,7 +94,7 @@ struct JxlEncoderStruct {
       input_frame_queue;
   std::vector<uint8_t> output_byte_queue;
 
-  bool force_container = false;
+  bool use_container = false;
 
   // TODO(lode): move level into jxl::CompressParams since some C++
   // implementation decisions should be based on it: level 10 allows more
@@ -116,7 +116,7 @@ struct JxlEncoderStruct {
   JxlEncoderStatus RefillOutputByteQueue();
 
   bool MustUseContainer() const {
-    return force_container || codestream_level != 5 || store_jpeg_metadata;
+    return use_container || codestream_level != 5 || store_jpeg_metadata;
   }
 
   // Appends the bytes of a JXL box header with the provided type and size to

--- a/lib/jxl/encode_test.cc
+++ b/lib/jxl/encode_test.cc
@@ -648,6 +648,41 @@ TEST(EncodeTest, JXL_TRANSCODE_JPEG_TEST(JPEGReconstructionTest)) {
   EXPECT_EQ(0, memcmp(decoded_jpeg_bytes.data(), orig.data(), orig.size()));
 }
 
+// This test is commented out until JxlEncoderAddBox is implemented, and is a
+// prototype of JxlEncoderAddBox usage, not a finished test implementation.
+#if 0
+TEST(EncodeTest, BoxTest) {
+  JxlEncoderPtr enc = JxlEncoderMake(nullptr);
+  EXPECT_NE(nullptr, enc.get());
+
+  // TODO(lode): create a test image, initialize encoder and options, prepare
+  // next_out and avail_out, and handle status and output buffer after the
+  // JxlEncoderProcessOutput calls below.
+
+  // Add an early metadata box
+  JxlEncoderAddBox("Exif", exif_data, exif_size);
+
+  // Write to output
+  status = JxlEncoderProcessOutput(enc.get(), &next_out, &avail_out);
+
+  // Add image frame
+  EXPECT_EQ(JXL_ENC_ERROR,
+            JxlEncoderAddImageFrame(options, &pixel_format, pixels.data(),
+                                    pixels.size()));
+  // Indicate this is the last frame
+  JxlEncoderCloseInput(enc.get());
+
+  // Write to output
+  status = JxlEncoderProcessOutput(enc.get(), &next_out, &avail_out);
+
+  // Add a late metadata box
+  JxlEncoderAddBox("XML ", xml_data, xml_size);
+
+  // Write to output
+  status = JxlEncoderProcessOutput(enc.get(), &next_out, &avail_out);
+}
+#endif
+
 #if JPEGXL_ENABLE_JPEG  // Loading .jpg files requires libjpeg support.
 TEST(EncodeTest, JXL_TRANSCODE_JPEG_TEST(JPEGFrameTest)) {
   for (int skip_basic_info = 0; skip_basic_info < 2; skip_basic_info++) {


### PR DESCRIPTION
Adds the function JxlEncoderAddBox, which can be used either before or
after encoding image frames.

Updates the JxlEncoderUseContainer documentation to noet say
"force" after all since for metadata boxes you need to call it
explicitely (the encoder cannot know on its own if boxes will be added
at the end only)

Adds documentation about the box format and individual box types so that
it is clear what types of metadata boxes this function can be used for
and which ones the encoder automatically adds.

Pair programmed with Jyrki, who also proposed to add good documentation
about the boxes and a prototype test.