### PR TITLE
encoder api: error codes

### DIFF
--- a/lib/jxl/enc_modular.cc
+++ b/lib/jxl/enc_modular.cc
@@ -742,18 +742,17 @@ Status ModularFrameEncoder::ComputeEncodingData(
   if (cparams.color_transform == ColorTransform::kNone && do_color && !fp &&
       gi.channel.size() - gi.nb_meta_channels >= 3 &&
       max_bitdepth + 1 < level_max_bitdepth) {
-    if (cparams.colorspace == 1 ||
-        (cparams.colorspace < 0 &&
-         (!cparams.IsLossless() || cparams.speed_tier > SpeedTier::kHare))) {
+    if (cparams.colorspace < 0 &&
+        (!cparams.IsLossless() || cparams.speed_tier > SpeedTier::kHare)) {
       Transform ycocg{TransformId::kRCT};
       ycocg.rct_type = 6;
       ycocg.begin_c = gi.nb_meta_channels;
       do_transform(gi, ycocg, weighted::Header(), pool);
       max_bitdepth++;
-    } else if (cparams.colorspace >= 2) {
+    } else if (cparams.colorspace > 0) {
       Transform sg(TransformId::kRCT);
       sg.begin_c = gi.nb_meta_channels;
-      sg.rct_type = cparams.colorspace - 2;
+      sg.rct_type = cparams.colorspace;
       do_transform(gi, sg, weighted::Header(), pool);
       max_bitdepth++;
     }

--- a/lib/jxl/encode_internal.h
+++ b/lib/jxl/encode_internal.h
@@ -106,6 +106,7 @@ void AppendBoxHeader(const jxl::BoxType& type, size_t size, bool unbounded,
 // Internal use only struct, can only be initialized correctly by
 // JxlEncoderCreate.
 struct JxlEncoderStruct {
+  JxlEncoderError error = JxlEncoderError::JXL_ENC_ERR_OK;
   JxlMemoryManager memory_manager;
   jxl::MemoryManagerUniquePtr<jxl::ThreadPool> thread_pool{
       nullptr, jxl::MemoryManagerDeleteHelper(&memory_manager)};
@@ -145,6 +146,7 @@ struct JxlEncoderStruct {
   // reconstruction box.
   bool wrote_bytes;
   jxl::CompressParams last_used_cparams;
+  JxlBasicInfo basic_info;
 
   // Encoder wrote a jxlp (partial codestream) box, so any next codestream
   // parts must also be written in jxlp boxes, a single jxlc box cannot be

--- a/lib/jxl/encode_test.cc
+++ b/lib/jxl/encode_test.cc
@@ -109,7 +109,7 @@ TEST(EncodeTest, AddFrameBeforeBasicInfoTest) {
   JxlColorEncoding color_encoding;
   JxlColorEncodingSetToSRGB(&color_encoding,
                             /*is_gray=*/pixel_format.num_channels < 3);
-  EXPECT_EQ(JXL_ENC_SUCCESS,
+  EXPECT_EQ(JXL_ENC_ERROR,
             JxlEncoderSetColorEncoding(enc.get(), &color_encoding));
   JxlEncoderFrameSettings* frame_settings =
       JxlEncoderFrameSettingsCreate(enc.get(), NULL);
@@ -178,9 +178,15 @@ void VerifyFrameEncoding(size_t xsize, size_t ysize, JxlEncoder* enc,
   EXPECT_EQ(JXL_ENC_SUCCESS, JxlEncoderSetCodestreamLevel(enc, 10));
   EXPECT_EQ(JXL_ENC_SUCCESS, JxlEncoderSetBasicInfo(enc, &basic_info));
   JxlColorEncoding color_encoding;
-  JxlColorEncodingSetToSRGB(&color_encoding,
-                            /*is_gray=*/pixel_format.num_channels < 3);
+  JxlColorEncodingSetToSRGB(&color_encoding, true);
+  EXPECT_EQ(JXL_ENC_ERROR, JxlEncoderSetColorEncoding(enc, &color_encoding));
+  JxlColorEncodingSetToSRGB(&color_encoding, false);
   EXPECT_EQ(JXL_ENC_SUCCESS, JxlEncoderSetColorEncoding(enc, &color_encoding));
+  pixel_format.num_channels = 1;
+  EXPECT_EQ(JXL_ENC_ERROR,
+            JxlEncoderAddImageFrame(frame_settings, &pixel_format,
+                                    pixels.data(), pixels.size()));
+  pixel_format.num_channels = 4;
   EXPECT_EQ(JXL_ENC_SUCCESS,
             JxlEncoderAddImageFrame(frame_settings, &pixel_format,
                                     pixels.data(), pixels.size()));
@@ -450,10 +456,7 @@ TEST(EncodeTest, frame_settingsTest) {
         JxlEncoderFrameSettingsSetOption(
             frame_settings, JXL_ENC_FRAME_SETTING_MODULAR_NB_PREV_CHANNELS, 7));
     VerifyFrameEncoding(enc.get(), frame_settings);
-    // It was set to 30, but becomes 32 because in the C++ implementation, the
-    // numerical RCT values are shifted 2 compared to the specification. The
-    // API uses the values seen in the JXL specification.
-    EXPECT_EQ(32, enc->last_used_cparams.colorspace);
+    EXPECT_EQ(30, enc->last_used_cparams.colorspace);
     EXPECT_EQ(2, enc->last_used_cparams.modular_group_size_shift);
     EXPECT_EQ(jxl::Predictor::Best, enc->last_used_cparams.options.predictor);
     EXPECT_EQ(0.77f, enc->last_used_cparams.options.nb_repeats);
@@ -1304,6 +1307,8 @@ TEST(EncodeTest, JXL_TRANSCODE_JPEG_TEST(JPEGFrameTest)) {
   for (int skip_basic_info = 0; skip_basic_info < 2; skip_basic_info++) {
     for (int skip_color_encoding = 0; skip_color_encoding < 2;
          skip_color_encoding++) {
+      // cannot set color encoding if basic info is not set
+      if (skip_basic_info && !skip_color_encoding) continue;
       const std::string jpeg_path = "jxl/flower/flower_cropped.jpg";
       const jxl::PaddedBytes orig = jxl::ReadTestData(jpeg_path);
       jxl::CodecInOut orig_io;

--- a/lib/jxl/jpeg/jpeg_data.cc
+++ b/lib/jxl/jpeg/jpeg_data.cc
@@ -365,6 +365,11 @@ Status JPEGData::VisitFields(Visitor* visitor) {
     if (visitor->IsReading()) inter_marker_data_sizes.emplace_back(len);
   }
   uint32_t tail_data_len = tail_data.size();
+  if (!visitor->IsReading() && tail_data_len > 4260096) {
+    error = JPEGReadError::TAIL_DATA_TOO_LARGE;
+    return JXL_FAILURE("Tail data too large (max size = 4260096, size = %u).",
+                       tail_data_len);
+  }
   JXL_RETURN_IF_ERROR(visitor->U32(Val(0), BitsOffset(8, 1),
                                    BitsOffset(16, 257), BitsOffset(22, 65793),
                                    0, &tail_data_len));

--- a/lib/jxl/jpeg/jpeg_data.h
+++ b/lib/jxl/jpeg/jpeg_data.h
@@ -105,6 +105,7 @@ enum struct JPEGReadError {
   EOB_RUN_TOO_LONG,
   IMAGE_TOO_LARGE,
   INVALID_QUANT_TBL_PRECISION,
+  TAIL_DATA_TOO_LARGE
 };
 
 // Quantization values for an 8x8 pixel block.

--- a/lib/jxl/test_utils.h
+++ b/lib/jxl/test_utils.h
@@ -81,6 +81,11 @@ void JxlBasicInfoSetFromPixelFormat(JxlBasicInfo* basic_info,
     default:
       JXL_ABORT("Unhandled JxlDataType");
   }
+  if (pixel_format->num_channels < 3) {
+    basic_info->num_color_channels = 1;
+  } else {
+    basic_info->num_color_channels = 3;
+  }
   if (pixel_format->num_channels == 2 || pixel_format->num_channels == 4) {
     basic_info->alpha_exponent_bits = basic_info->exponent_bits_per_sample;
     basic_info->alpha_bits = basic_info->bits_per_sample;

--- a/tools/cjxl.cc
+++ b/tools/cjxl.cc
@@ -417,8 +417,8 @@ void CompressArgs::AddCommandLineOptions(CommandLineParser* cmdline) {
 
   cmdline->AddOptionValue(
       'C', "colorspace", "K",
-      ("[modular encoding] color transform: 0=RGB, 1=YCoCg, "
-       "2-37=RCT (default: try several, depending on speed)"),
+      ("[modular encoding] color transform: -1=default, 0=RGB (none), "
+       "1-48=RCT (6=YCoCg, default: try several, depending on speed)"),
       &params.colorspace, &ParseSigned, 1);
 
   opt_m_group_size_id = cmdline->AddOptionValue(

--- a/tools/cjxl_ng_main.cc
+++ b/tools/cjxl_ng_main.cc
@@ -178,8 +178,8 @@ DEFINE_int32(modular_predictor, -1,
              "at slowest speed default 15.");
 
 DEFINE_int32(modular_colorspace, -1,
-             "[modular encoding] color transform: 0=RGB, 1=YCoCg, "
-             "2-37=RCT (default: try several, depending on speed)");
+             "[modular encoding] color transform: -1=default, 0=RGB (none), "
+             "1-48=RCT (6=YCoCg, default: try several, depending on speed)");
 
 DEFINE_int32(
     modular_channel_colors_global_percent, -1,
@@ -697,7 +697,7 @@ int main(int argc, char** argv) {
       process_flag("modular_predictor", FLAGS_modular_predictor,
                    JXL_ENC_FRAME_SETTING_MODULAR_PREDICTOR,
                    [](int32_t x) -> std::string {
-                     return (0 <= x && x <= 15)
+                     return (-1 <= x && x <= 15)
                                 ? ""
                                 : "Invalid --modular_predictor. Valid "
                                   "range is {-1, 0, 1, ..., 15}.\n";
@@ -706,10 +706,10 @@ int main(int argc, char** argv) {
           "modular_colorspace", FLAGS_modular_colorspace,
           JXL_ENC_FRAME_SETTING_MODULAR_COLOR_SPACE,
           [](int32_t x) -> std::string {
-            return (0 <= x && x <= 15)
+            return (-1 <= x && x <= 48)
                        ? ""
                        : "Invalid --modular_colorspace. Valid range is "
-                         "{-1, 0, 1, ..., 37}.\n";
+                         "{-1, 0, 1, ..., 48}.\n";
           });
       process_flag("modular_ma_tree_learning_percent",
                    FLAGS_modular_ma_tree_learning_percent,


### PR DESCRIPTION
~~Builds on top of https://github.com/libjxl/libjxl/pull/358 ~~

~~Adds an encoder api return code for the case where the `jbrd` cannot be stored (e.g. because there is too much tail data), but the jpeg image data itself can be recompressed. This is not a fatal error (can still produce a useful jxl that has all the image data and any exif/xmp if there was any), but it's also not just OK (the result is not bit-exact-reconstructible to the original jpeg file).~~

~~Applications that do not know this new return code will likely treat it as an (unknown) encoder error, which is fine (this is what would happen before, when failure to write the `jbrd` would be a fatal encode error).~~

Adds `JxlEncoderGetError` which can be used to check the reason why JXL_ENCODE_ERROR was returned: it could be either bad API usage, so an application bug, or an error condition that is not caused by an application bug and an application might want to react to it, e.g. by retrying JPEG recompression without storing the `jbrd` or by informing the user that the input is invalid.

Also check the tail data size and return an error slightly earlier if it is too large, and catch this error in cjxl, so instead of a somewhat mysterious error like this:

```
./lib/jxl/fields.cc:729: JXL_FAILURE: No feasible selector for 9936393
```

you now get a somewhat more useful error like this:

```
./lib/jxl/jpeg/jpeg_data.cc:367: JXL_FAILURE: Tail data too large (max size = 4260096, size = 9936393).
```