### PR TITLE
add test for upsampling and fix uint8 upsampling bug

### DIFF
--- a/lib/jxl/dec_reconstruct.cc
+++ b/lib/jxl/dec_reconstruct.cc
@@ -1057,7 +1057,8 @@ Status FinalizeImageRect(
          dec_state->rgb_output_is_rgba, alpha,
          alpha_rect.Lines(available_y, num_ys),
          upsampled_frame_rect.Lines(available_y, num_ys)
-             .Crop(Rect(0, 0, frame_dim.xsize, frame_dim.ysize)),
+             .Crop(Rect(0, 0, frame_dim.xsize_upsampled,
+                        frame_dim.ysize_upsampled)),
          dec_state->rgb_output, dec_state->rgb_stride);
       }
       if (dec_state->pixel_callback != nullptr) {


### PR DESCRIPTION
Adds upsampling to decode_test. ~~This test currently fails for uint8 output, due to an actual bug in that codepath. I haven't tried fixing the bug yet, but at least there's now an easy way to check if it is fixed :)~~

Fixes the upsampling bug in the uint8 codepath, thanks to @veluca93.  