### PR TITLE
Fix potential ODR violations

### DIFF
--- a/lib/jxl/fake_parallel_runner_testonly.h
+++ b/lib/jxl/fake_parallel_runner_testonly.h
@@ -11,6 +11,7 @@
 #include <vector>
 
 #include "jxl/parallel_runner.h"
+#include "lib/jxl/base/compiler_specific.h"
 #include "lib/jxl/base/random.h"
 
 namespace jxl {
@@ -67,7 +68,7 @@ class FakeParallelRunner {
 
 extern "C" {
 // Function to pass as the parallel runner.
-JxlParallelRetCode JxlFakeParallelRunner(
+JXL_INLINE JxlParallelRetCode JxlFakeParallelRunner(
     void* runner_opaque, void* jpegxl_opaque, JxlParallelRunInit init,
     JxlParallelRunFunction func, uint32_t start_range, uint32_t end_range) {
   return static_cast<jxl::FakeParallelRunner*>(runner_opaque)

--- a/lib/jxl/image_test_utils.h
+++ b/lib/jxl/image_test_utils.h
@@ -231,7 +231,7 @@ typename std::enable_if<std::is_integral<T>::value>::type RandomFillImage(
                 int64_t(std::numeric_limits<T>::max()) + 1);
 }
 
-void RandomFillImage(Plane<float>* image) {
+JXL_INLINE void RandomFillImage(Plane<float>* image) {
   Rng rng(129);
   GenerateImage(rng, image, 0.0f, std::numeric_limits<float>::max());
 }
@@ -251,7 +251,7 @@ typename std::enable_if<std::is_integral<T>::value>::type RandomFillImage(
                 int64_t(std::numeric_limits<T>::max()) + 1);
 }
 
-void RandomFillImage(Image3F* image) {
+JXL_INLINE void RandomFillImage(Image3F* image) {
   Rng rng(129);
   GenerateImage(rng, image, 0.0f, std::numeric_limits<float>::max());
 }


### PR DESCRIPTION
Make functions defined in the headers static inline to avoid potential
ODR violations.