### PR TITLE
Add gbench for UndoXYB and run it

### DIFF
--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -30,7 +30,7 @@ jobs:
             env_stack_size: 1
             max_stack: 3000
             # Conformance tooling test requires numpy.
-            apt_pkgs: python3-numpy
+            apt_pkgs: python3-numpy libbenchmark-dev libbenchmark-tools
           - name: debug
             # Runs on AVX3 CPUs require more stack than others. Make sure to
             # test on AVX3-enabled CPUs when changing this value.
@@ -197,6 +197,12 @@ jobs:
          contains(github.event.pull_request.labels.*.names, 'CI:full')))
       run: |
         STORE_IMAGES=0 ./ci.sh fast_benchmark
+    # Run gbench once, just to make sure it runs, not for actual benchmarking.
+    - name: gbench check
+      if: |
+        matrix.name == 'release' || github.event_name == 'push'
+      run: |
+        ./ci.sh gbench --benchmark_min_time=0
 
 
   cross_compile_ubuntu:

--- a/lib/gbench_main.cc
+++ b/lib/gbench_main.cc
@@ -1,0 +1,8 @@
+// Copyright (c) the JPEG XL Project Authors. All rights reserved.
+//
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+#include "benchmark/benchmark.h"
+
+BENCHMARK_MAIN();

--- a/lib/jxl/dec_reconstruct_gbench.cc
+++ b/lib/jxl/dec_reconstruct_gbench.cc
@@ -1,0 +1,46 @@
+// Copyright (c) the JPEG XL Project Authors. All rights reserved.
+//
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+#include "benchmark/benchmark.h"
+#include "lib/jxl/dec_reconstruct.h"
+#include "lib/jxl/image_ops.h"
+
+namespace jxl {
+
+static void BM_UndoXYB(benchmark::State& state, TransferFunction tf) {
+  const size_t xsize = state.range();
+  const size_t ysize = xsize;
+  Image3F src(xsize, ysize);
+  Image3F dst(xsize, ysize);
+  FillImage(1.f, &src);
+
+  OutputEncodingInfo output_info = {};
+  CodecMetadata metadata = {};
+  JXL_CHECK(output_info.Set(metadata, ColorEncoding::LinearSRGB(false)));
+  output_info.inverse_gamma = 1.;
+  // Set the TransferFunction since the code executed depends on this parameter.
+  output_info.color_encoding.tf.SetTransferFunction(tf);
+
+  ThreadPool* null_pool = nullptr;
+  for (auto _ : state) {
+    UndoXYB(src, &dst, output_info, null_pool);
+  }
+  state.SetItemsProcessed(xsize * ysize * state.iterations());
+}
+
+BENCHMARK_CAPTURE(BM_UndoXYB, Linear, TransferFunction::kLinear)
+    ->RangeMultiplier(4)
+    ->Range(512, 2048);
+BENCHMARK_CAPTURE(BM_UndoXYB, SRGB, TransferFunction::kSRGB)
+    ->RangeMultiplier(4)
+    ->Range(512, 2048);
+BENCHMARK_CAPTURE(BM_UndoXYB, PQ, TransferFunction::kPQ)
+    ->RangeMultiplier(4)
+    ->Range(512, 2048);
+BENCHMARK_CAPTURE(BM_UndoXYB, DCI, TransferFunction::kDCI)
+    ->RangeMultiplier(4)
+    ->Range(512, 2048);
+
+}  // namespace jxl

--- a/lib/jxl_benchmark.cmake
+++ b/lib/jxl_benchmark.cmake
@@ -8,6 +8,7 @@
 set(JPEGXL_INTERNAL_SOURCES_GBENCH
   extras/tone_mapping_gbench.cc
   jxl/dec_external_image_gbench.cc
+  jxl/dec_reconstruct_gbench.cc
   jxl/enc_external_image_gbench.cc
   jxl/gauss_blur_gbench.cc
   jxl/splines_gbench.cc
@@ -31,7 +32,7 @@ if(benchmark_FOUND)
 
   # Compiles all the benchmark files into a single binary. Individual benchmarks
   # can be run with --benchmark_filter.
-  add_executable(jxl_gbench "${JPEGXL_INTERNAL_SOURCES_GBENCH}")
+  add_executable(jxl_gbench "${JPEGXL_INTERNAL_SOURCES_GBENCH}" gbench_main.cc)
 
   target_compile_definitions(jxl_gbench PRIVATE
     -DTEST_DATA_PATH="${PROJECT_SOURCE_DIR}/third_party/testdata")
@@ -39,7 +40,6 @@ if(benchmark_FOUND)
     jxl_extras-static
     jxl-static
     benchmark::benchmark
-    benchmark::benchmark_main
   )
 endif() # benchmark_FOUND
 

--- a/lib/lib.gni
+++ b/lib/lib.gni
@@ -322,6 +322,7 @@ libjxl_enc_sources = [
 libjxl_gbench_sources = [
     "extras/tone_mapping_gbench.cc",
     "jxl/dec_external_image_gbench.cc",
+    "jxl/dec_reconstruct_gbench.cc",
     "jxl/enc_external_image_gbench.cc",
     "jxl/gauss_blur_gbench.cc",
     "jxl/splines_gbench.cc",


### PR DESCRIPTION
Run gbench in the PR release pipeline to make sure it runs and doesn't
crash. In some distributions benchmark_main doesn't actually export a
main() symbol. Workaround the problem by defining our own main()
function for gbench.

This patch adds a new gbench test for benchmarking UndoXYB.