### PR TITLE
API proposal: JxlDecoderSetCoalescing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
  - encoder API: ability to add metadata boxes, added new functions
    `JxlEncoderAddBox`, `JxlEncoderUseBoxes`, `JxlEncoderCloseBoxes` and
    `JxlEncoderCloseFrames`.
+ - decoder API: new function `JxlDecoderSetCoalesced` to allow decoding
+   non-coalesced (unblended) frames, e.g. layers of a composite still image
+   or the cropped frames of a recompressed GIF/APNG.
+ - decoder API: field added to `JxlFrameHeader`: a `JxlLayerInfo` struct
+   that contains crop dimensions and offsets and blending information for
+   the non-coalesced case.
+ - decoder API: new function `JxlDecoderGetExtraChannelBlendInfo` to get
+   the blending information for extra channels in the non-coalesced case.
 
 ### Changed
 - decoder API: using `JxlDecoderCloseInput` at the end of all input is required

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -15,7 +15,7 @@ set(JPEGXL_LIBRARY_VERSION
 # It is important to update this value when making incompatible API/ABI changes
 # so that programs that depend on libjxl can update their dependencies. Semantic
 # versioning allows 0.y.z to have incompatible changes in minor versions.
-set(JPEGXL_SO_MINOR_VERSION 6)
+set(JPEGXL_SO_MINOR_VERSION 7)
 if (JPEGXL_MAJOR_VERSION EQUAL 0)
 set(JPEGXL_LIBRARY_SOVERSION
     "${JPEGXL_MAJOR_VERSION}.${JPEGXL_SO_MINOR_VERSION}")

--- a/lib/jxl/dec_frame.h
+++ b/lib/jxl/dec_frame.h
@@ -63,6 +63,7 @@ class FrameDecoder {
     constraints_ = constraints;
   }
   void SetRenderSpotcolors(bool rsc) { render_spotcolors_ = rsc; }
+  void SetCoalescing(bool c) { coalescing_ = c; }
 
   // Read FrameHeader and table of contents from the given BitReader.
   // Also checks frame dimensions for their limits, and sets the output
@@ -254,6 +255,7 @@ class FrameDecoder {
   bool allow_partial_frames_;
   bool allow_partial_dc_global_;
   bool render_spotcolors_ = true;
+  bool coalescing_ = true;
 
   std::vector<uint8_t> processed_section_;
   std::vector<uint8_t> decoded_passes_per_ac_group_;

--- a/lib/jxl/dec_params.h
+++ b/lib/jxl/dec_params.h
@@ -26,6 +26,8 @@ struct DecompressParams {
   bool keep_dct = false;
   // If true, render spot colors (otherwise only returned as extra channels)
   bool render_spotcolors = true;
+  // If true, coalesce frames (otherwise return unblended frames)
+  bool coalescing = true;
 
   // These cannot be kOn because they need encoder support.
   Override preview = Override::kDefault;

--- a/lib/jxl/decode.cc
+++ b/lib/jxl/decode.cc
@@ -459,6 +459,7 @@ struct JxlDecoderStruct {
   // Settings
   bool keep_orientation;
   bool render_spotcolors;
+  bool coalescing;
 
   // Bitfield, for which informative events (JXL_DEC_BASIC_INFO, etc...) the
   // decoder returns a status. By default, do not return for any of the events,
@@ -704,6 +705,7 @@ void JxlDecoderReset(JxlDecoder* dec) {
   dec->thread_pool.reset();
   dec->keep_orientation = false;
   dec->render_spotcolors = true;
+  dec->coalescing = true;
   dec->orig_events_wanted = 0;
   dec->frame_references.clear();
   dec->frame_saved_as.clear();
@@ -811,6 +813,14 @@ JxlDecoderStatus JxlDecoderSetRenderSpotcolors(JxlDecoder* dec,
     return JXL_API_ERROR("Must set render_spotcolors option before starting");
   }
   dec->render_spotcolors = !!render_spotcolors;
+  return JXL_DEC_SUCCESS;
+}
+
+JxlDecoderStatus JxlDecoderSetCoalescing(JxlDecoder* dec, JXL_BOOL coalescing) {
+  if (dec->stage != DecoderStage::kInited) {
+    return JXL_API_ERROR("Must set coalescing option before starting");
+  }
+  dec->coalescing = !!coalescing;
   return JXL_DEC_SUCCESS;
 }
 
@@ -1188,6 +1198,7 @@ JxlDecoderStatus JxlDecoderProcessCodestream(JxlDecoder* dec, const uint8_t* in,
       jxl::DecompressParams dparams;
       dparams.preview = want_preview ? jxl::Override::kOn : jxl::Override::kOff;
       dparams.render_spotcolors = dec->render_spotcolors;
+      dparams.coalescing = true;
       jxl::ImageBundle ib(&dec->metadata.m);
       PassesDecoderState preview_dec_state;
       JXL_API_RETURN_IF_ERROR(preview_dec_state.output_encoding_info.Set(
@@ -1253,6 +1264,10 @@ JxlDecoderStatus JxlDecoderProcessCodestream(JxlDecoder* dec, const uint8_t* in,
       // is last of current still
       dec->is_last_of_still =
           dec->is_last_total || dec->frame_header->animation_frame.duration > 0;
+      // is kRegularFrame and coalescing is disabled
+      dec->is_last_of_still |=
+          (!dec->coalescing &&
+           dec->frame_header->frame_type == FrameType::kRegularFrame);
 
       const size_t internal_frame_index = dec->internal_frames;
       const size_t external_frame_index = dec->external_frames;
@@ -1336,6 +1351,7 @@ JxlDecoderStatus JxlDecoderProcessCodestream(JxlDecoder* dec, const uint8_t* in,
       dec->frame_dec.reset(new FrameDecoder(
           dec->passes_state.get(), dec->metadata, dec->thread_pool.get()));
       dec->frame_dec->SetRenderSpotcolors(dec->render_spotcolors);
+      dec->frame_dec->SetCoalescing(dec->coalescing);
 
       // If JPEG reconstruction is wanted and possible, set the jpeg_data of
       // the ImageBundle.
@@ -2310,6 +2326,10 @@ JxlDecoderStatus PrepareSizeCheck(const JxlDecoder* dec,
     // Don't know image dimensions yet, cannot check for valid size.
     return JXL_DEC_NEED_MORE_INPUT;
   }
+  if (!dec->coalescing &&
+      (!dec->frame_header || dec->frame_stage == FrameStage::kHeader)) {
+    return JXL_API_ERROR("Don't know frame dimensions yet");
+  }
   if (format->num_channels > 4) {
     return JXL_API_ERROR("More than 4 channels not supported");
   }
@@ -2328,6 +2348,22 @@ JxlDecoderStatus PrepareSizeCheck(const JxlDecoder* dec,
 
   return JXL_DEC_SUCCESS;
 }
+
+// helper function to get the dimensions of the current image buffer
+void GetCurrentDimensions(const JxlDecoder* dec, size_t& xsize, size_t& ysize,
+                          bool oriented) {
+  xsize = dec->metadata.oriented_xsize(dec->keep_orientation || !oriented);
+  ysize = dec->metadata.oriented_ysize(dec->keep_orientation || !oriented);
+  if (!dec->coalescing) {
+    xsize = dec->frame_header->ToFrameDimensions().xsize;
+    ysize = dec->frame_header->ToFrameDimensions().ysize;
+    if (!dec->keep_orientation && oriented &&
+        static_cast<int>(dec->metadata.m.GetOrientation()) > 4) {
+      std::swap(xsize, ysize);
+    }
+  }
+}
+
 }  // namespace
 
 JxlDecoderStatus JxlDecoderFlushImage(JxlDecoder* dec) {
@@ -2356,7 +2392,9 @@ JxlDecoderStatus JxlDecoderFlushImage(JxlDecoder* dec) {
   // ConvertImageInternal.
   size_t xsize = dec->ib->xsize();
   size_t ysize = dec->ib->ysize();
-  dec->ib->ShrinkTo(dec->metadata.size.xsize(), dec->metadata.size.ysize());
+  size_t xsize_nopadding, ysize_nopadding;
+  GetCurrentDimensions(dec, xsize_nopadding, ysize_nopadding, false);
+  dec->ib->ShrinkTo(xsize_nopadding, ysize_nopadding);
   JxlDecoderStatus status = jxl::ConvertImageInternal(
       dec, *dec->ib, dec->image_out_format,
       /*want_extra_channel=*/false,
@@ -2449,15 +2487,14 @@ JXL_EXPORT JxlDecoderStatus JxlDecoderImageOutBufferSize(
   if (format->num_channels < 3 && !dec->metadata.m.color_encoding.IsGray()) {
     return JXL_API_ERROR("Grayscale output not possible for color image");
   }
-
+  size_t xsize, ysize;
+  GetCurrentDimensions(dec, xsize, ysize, true);
   size_t row_size =
-      jxl::DivCeil(dec->metadata.oriented_xsize(dec->keep_orientation) *
-                       format->num_channels * bits,
-                   jxl::kBitsPerByte);
+      jxl::DivCeil(xsize * format->num_channels * bits, jxl::kBitsPerByte);
   if (format->align > 1) {
     row_size = jxl::DivCeil(row_size, format->align) * format->align;
   }
-  *size = row_size * dec->metadata.oriented_ysize(dec->keep_orientation);
+  *size = row_size * ysize;
 
   return JXL_DEC_SUCCESS;
 }
@@ -2510,13 +2547,14 @@ JxlDecoderStatus JxlDecoderExtraChannelBufferSize(const JxlDecoder* dec,
   JxlDecoderStatus status = PrepareSizeCheck(dec, format, &bits);
   if (status != JXL_DEC_SUCCESS) return status;
 
-  size_t row_size = jxl::DivCeil(
-      dec->metadata.oriented_xsize(dec->keep_orientation) * num_channels * bits,
-      jxl::kBitsPerByte);
+  size_t xsize, ysize;
+  GetCurrentDimensions(dec, xsize, ysize, true);
+  size_t row_size =
+      jxl::DivCeil(xsize * num_channels * bits, jxl::kBitsPerByte);
   if (format->align > 1) {
     row_size = jxl::DivCeil(row_size, format->align) * format->align;
   }
-  *size = row_size * dec->metadata.oriented_ysize(dec->keep_orientation);
+  *size = row_size * ysize;
 
   return JXL_DEC_SUCCESS;
 }
@@ -2585,7 +2623,70 @@ JxlDecoderStatus JxlDecoderGetFrameHeader(const JxlDecoder* dec,
   }
   header->name_length = dec->frame_header->name.size();
   header->is_last = dec->frame_header->is_last;
+  size_t xsize, ysize;
+  GetCurrentDimensions(dec, xsize, ysize, true);
+  header->layer_info.xsize = xsize;
+  header->layer_info.ysize = ysize;
+  if (!dec->coalescing && dec->frame_header->custom_size_or_origin) {
+    header->layer_info.crop_x0 = dec->frame_header->frame_origin.x0;
+    header->layer_info.crop_y0 = dec->frame_header->frame_origin.y0;
+  } else {
+    header->layer_info.crop_x0 = 0;
+    header->layer_info.crop_y0 = 0;
+  }
+  if (!dec->keep_orientation && !dec->coalescing) {
+    // orient the crop offset
+    size_t W = dec->metadata.oriented_xsize(false);
+    size_t H = dec->metadata.oriented_ysize(false);
+    if (metadata.orientation > 4) {
+      std::swap(header->layer_info.crop_x0, header->layer_info.crop_y0);
+    }
+    size_t o = (metadata.orientation - 1) & 3;
+    if (o > 0 && o < 3) {
+      header->layer_info.crop_x0 = W - xsize - header->layer_info.crop_x0;
+    }
+    if (o > 1) {
+      header->layer_info.crop_y0 = H - ysize - header->layer_info.crop_y0;
+    }
+  }
+  if (dec->coalescing) {
+    header->layer_info.blend_info.blendmode = JXL_BLEND_REPLACE;
+    header->layer_info.blend_info.source = 0;
+    header->layer_info.blend_info.alpha = 0;
+    header->layer_info.blend_info.clamp = JXL_FALSE;
+    header->layer_info.save_as_reference = 0;
+  } else {
+    header->layer_info.blend_info.blendmode =
+        static_cast<JxlBlendMode>(dec->frame_header->blending_info.mode);
+    header->layer_info.blend_info.source =
+        dec->frame_header->blending_info.source;
+    header->layer_info.blend_info.alpha =
+        dec->frame_header->blending_info.alpha_channel;
+    header->layer_info.blend_info.clamp =
+        dec->frame_header->blending_info.clamp;
+    header->layer_info.save_as_reference = dec->frame_header->save_as_reference;
+  }
+  return JXL_DEC_SUCCESS;
+}
 
+JxlDecoderStatus JxlDecoderGetExtraChannelBlendInfo(const JxlDecoder* dec,
+                                                    size_t index,
+                                                    JxlBlendInfo* blend_info) {
+  if (!dec->frame_header || dec->frame_stage == FrameStage::kHeader) {
+    return JXL_API_ERROR("no frame header available");
+  }
+  const auto& metadata = dec->metadata.m;
+  if (index >= metadata.num_extra_channels) {
+    return JXL_API_ERROR("Invalid extra channel index");
+  }
+  blend_info->blendmode = static_cast<JxlBlendMode>(
+      dec->frame_header->extra_channel_blending_info[index].mode);
+  blend_info->source =
+      dec->frame_header->extra_channel_blending_info[index].source;
+  blend_info->alpha =
+      dec->frame_header->extra_channel_blending_info[index].alpha_channel;
+  blend_info->clamp =
+      dec->frame_header->extra_channel_blending_info[index].clamp;
   return JXL_DEC_SUCCESS;
 }
 

--- a/lib/jxl/decode_test.cc
+++ b/lib/jxl/decode_test.cc
@@ -2970,6 +2970,431 @@ TEST(DecodeTest, SkipFrameWithBlendingTest) {
   JxlDecoderDestroy(dec);
 }
 
+TEST(DecodeTest, SkipFrameWithAlphaBlendingTest) {
+  size_t xsize = 90, ysize = 120;
+  constexpr size_t num_frames = 16;
+  std::vector<uint8_t> frames[num_frames + 5];
+  JxlPixelFormat format = {4, JXL_TYPE_UINT16, JXL_BIG_ENDIAN, 0};
+
+  jxl::CodecInOut io;
+  io.SetSize(xsize, ysize);
+  io.metadata.m.SetUintSamples(16);
+  io.metadata.m.color_encoding = jxl::ColorEncoding::SRGB(false);
+  io.metadata.m.have_animation = true;
+  io.frames.clear();
+  io.frames.reserve(num_frames + 5);
+  io.SetSize(xsize, ysize);
+
+  std::vector<uint32_t> frame_durations_c;
+  std::vector<uint32_t> frame_durations_nc;
+  std::vector<uint32_t> frame_xsize, frame_ysize, frame_x0, frame_y0;
+
+  for (size_t i = 0; i < num_frames; ++i) {
+    size_t cropxsize = 1 + xsize * 2 / (i + 1);
+    size_t cropysize = 1 + ysize * 3 / (i + 2);
+    int cropx0 = i * 3 - 8;
+    int cropy0 = i * 4 - 7;
+    if (i < 5) {
+      std::vector<uint8_t> frame_internal =
+          jxl::test::GetSomeTestImage(xsize / 2, ysize / 2, 4, i * 2 + 1);
+      // An internal frame with 0 duration, and use_for_next_frame, this is a
+      // frame that is not rendered and not output by default by the API, but on
+      // which the rendered frames depend
+      jxl::ImageBundle bundle_internal(&io.metadata.m);
+      EXPECT_TRUE(ConvertFromExternal(
+          jxl::Span<const uint8_t>(frame_internal.data(),
+                                   frame_internal.size()),
+          xsize / 2, ysize / 2, jxl::ColorEncoding::SRGB(/*is_gray=*/false),
+          /*has_alpha=*/true,
+          /*alpha_is_premultiplied=*/false, /*bits_per_sample=*/16,
+          JXL_BIG_ENDIAN, /*flipped_y=*/false, /*pool=*/nullptr,
+          &bundle_internal, /*float_in=*/false));
+      bundle_internal.duration = 0;
+      bundle_internal.use_for_next_frame = true;
+      bundle_internal.origin = {13, 17};
+      io.frames.push_back(std::move(bundle_internal));
+      frame_durations_nc.push_back(0);
+      frame_xsize.push_back(xsize / 2);
+      frame_ysize.push_back(ysize / 2);
+      frame_x0.push_back(13);
+      frame_y0.push_back(17);
+    }
+
+    std::vector<uint8_t> frame =
+        jxl::test::GetSomeTestImage(cropxsize, cropysize, 4, i * 2);
+    // Actual rendered frame
+    jxl::ImageBundle bundle(&io.metadata.m);
+    EXPECT_TRUE(ConvertFromExternal(
+        jxl::Span<const uint8_t>(frame.data(), frame.size()), cropxsize,
+        cropysize, jxl::ColorEncoding::SRGB(/*is_gray=*/false),
+        /*has_alpha=*/true,
+        /*alpha_is_premultiplied=*/false, /*bits_per_sample=*/16,
+        JXL_BIG_ENDIAN, /*flipped_y=*/false, /*pool=*/nullptr, &bundle,
+        /*float_in=*/false));
+    bundle.duration = 5 + i;
+    frame_durations_nc.push_back(5 + i);
+    frame_durations_c.push_back(5 + i);
+    frame_xsize.push_back(cropxsize);
+    frame_ysize.push_back(cropysize);
+    frame_x0.push_back(cropx0);
+    frame_y0.push_back(cropy0);
+    bundle.origin = {cropx0, cropy0};
+    // Create some variation in which frames depend on which.
+    if (i != 3 && i != 9 && i != 10) {
+      bundle.use_for_next_frame = true;
+    }
+    if (i != 12) {
+      bundle.blend = true;
+      bundle.blendmode = jxl::BlendMode::kBlend;
+    }
+    io.frames.push_back(std::move(bundle));
+  }
+
+  jxl::CompressParams cparams;
+  cparams.SetLossless();  // Lossless to verify pixels exactly after roundtrip.
+  cparams.speed_tier = jxl::SpeedTier::kThunder;
+  jxl::AuxOut aux_out;
+  jxl::PaddedBytes compressed;
+  jxl::PassesEncoderState enc_state;
+  EXPECT_TRUE(jxl::EncodeFile(cparams, &io, &enc_state, &compressed, &aux_out,
+                              nullptr));
+  // try both with and without coalescing
+  for (auto coalescing : {JXL_TRUE, JXL_FALSE}) {
+    // Independently decode all frames without any skipping, to create the
+    // expected blended frames, for the actual tests below to compare with.
+    {
+      JxlDecoder* dec = JxlDecoderCreate(NULL);
+      const uint8_t* next_in = compressed.data();
+      size_t avail_in = compressed.size();
+      EXPECT_EQ(JXL_DEC_SUCCESS, JxlDecoderSetCoalescing(dec, coalescing));
+      void* runner = JxlThreadParallelRunnerCreate(
+          NULL, JxlThreadParallelRunnerDefaultNumWorkerThreads());
+      EXPECT_EQ(JXL_DEC_SUCCESS, JxlDecoderSetParallelRunner(
+                                     dec, JxlThreadParallelRunner, runner));
+      EXPECT_EQ(JXL_DEC_SUCCESS,
+                JxlDecoderSubscribeEvents(dec, JXL_DEC_FULL_IMAGE));
+      EXPECT_EQ(JXL_DEC_SUCCESS, JxlDecoderSetInput(dec, next_in, avail_in));
+      for (size_t i = 0; i < num_frames + (coalescing ? 0 : 5); ++i) {
+        EXPECT_EQ(JXL_DEC_NEED_IMAGE_OUT_BUFFER, JxlDecoderProcessInput(dec));
+        size_t buffer_size;
+        EXPECT_EQ(JXL_DEC_SUCCESS,
+                  JxlDecoderImageOutBufferSize(dec, &format, &buffer_size));
+        if (coalescing)
+          EXPECT_EQ(xsize * ysize * 8, buffer_size);
+        else
+          EXPECT_EQ(frame_xsize[i] * frame_ysize[i] * 8, buffer_size);
+        frames[i].resize(buffer_size);
+        EXPECT_EQ(JXL_DEC_SUCCESS,
+                  JxlDecoderSetImageOutBuffer(dec, &format, frames[i].data(),
+                                              frames[i].size()));
+        EXPECT_EQ(JXL_DEC_FULL_IMAGE, JxlDecoderProcessInput(dec));
+      }
+
+      // After all frames were decoded, JxlDecoderProcessInput should return
+      // success to indicate all is done.
+      EXPECT_EQ(JXL_DEC_SUCCESS, JxlDecoderProcessInput(dec));
+      JxlThreadParallelRunnerDestroy(runner);
+      JxlDecoderDestroy(dec);
+    }
+
+    JxlDecoder* dec = JxlDecoderCreate(NULL);
+    const uint8_t* next_in = compressed.data();
+    size_t avail_in = compressed.size();
+
+    EXPECT_EQ(JXL_DEC_SUCCESS, JxlDecoderSetCoalescing(dec, coalescing));
+    void* runner = JxlThreadParallelRunnerCreate(
+        NULL, JxlThreadParallelRunnerDefaultNumWorkerThreads());
+    EXPECT_EQ(JXL_DEC_SUCCESS, JxlDecoderSetParallelRunner(
+                                   dec, JxlThreadParallelRunner, runner));
+
+    EXPECT_EQ(JXL_DEC_SUCCESS, JxlDecoderSubscribeEvents(
+                                   dec, JXL_DEC_BASIC_INFO | JXL_DEC_FRAME |
+                                            JXL_DEC_FULL_IMAGE));
+    EXPECT_EQ(JXL_DEC_SUCCESS, JxlDecoderSetInput(dec, next_in, avail_in));
+    EXPECT_EQ(JXL_DEC_BASIC_INFO, JxlDecoderProcessInput(dec));
+    JxlBasicInfo info;
+    EXPECT_EQ(JXL_DEC_SUCCESS, JxlDecoderGetBasicInfo(dec, &info));
+
+    for (size_t i = 0; i < num_frames; ++i) {
+      EXPECT_EQ(JXL_DEC_FRAME, JxlDecoderProcessInput(dec));
+
+      size_t buffer_size;
+      EXPECT_EQ(JXL_DEC_SUCCESS,
+                JxlDecoderImageOutBufferSize(dec, &format, &buffer_size));
+      std::vector<uint8_t> pixels(buffer_size);
+
+      JxlFrameHeader frame_header;
+      EXPECT_EQ(JXL_DEC_SUCCESS, JxlDecoderGetFrameHeader(dec, &frame_header));
+      EXPECT_EQ((coalescing ? frame_durations_c[i] : frame_durations_nc[i]),
+                frame_header.duration);
+
+      EXPECT_EQ(i + 1 == num_frames, frame_header.is_last);
+
+      EXPECT_EQ(JXL_DEC_NEED_IMAGE_OUT_BUFFER, JxlDecoderProcessInput(dec));
+
+      EXPECT_EQ(JXL_DEC_SUCCESS,
+                JxlDecoderSetImageOutBuffer(dec, &format, pixels.data(),
+                                            pixels.size()));
+
+      EXPECT_EQ(JXL_DEC_FULL_IMAGE, JxlDecoderProcessInput(dec));
+      if (coalescing)
+        EXPECT_EQ(frame_header.layer_info.xsize, xsize);
+      else
+        EXPECT_EQ(frame_header.layer_info.xsize, frame_xsize[i]);
+      if (coalescing)
+        EXPECT_EQ(frame_header.layer_info.ysize, ysize);
+      else
+        EXPECT_EQ(frame_header.layer_info.ysize, frame_ysize[i]);
+      EXPECT_EQ(0u,
+                ComparePixels(frames[i].data(), pixels.data(),
+                              frame_header.layer_info.xsize,
+                              frame_header.layer_info.ysize, format, format));
+
+      // Test rewinding mid-way, not decoding all frames.
+      if (i == 8) {
+        break;
+      }
+    }
+
+    JxlDecoderRewind(dec);
+    EXPECT_EQ(JXL_DEC_SUCCESS, JxlDecoderSubscribeEvents(
+                                   dec, JXL_DEC_FRAME | JXL_DEC_FULL_IMAGE));
+    EXPECT_EQ(JXL_DEC_SUCCESS, JxlDecoderSetInput(dec, next_in, avail_in));
+
+    for (size_t i = 0; i < num_frames + (coalescing ? 0 : 5); ++i) {
+      if (i == 3) {
+        JxlDecoderSkipFrames(dec, 5);
+        i += 5;
+      }
+
+      EXPECT_EQ(JXL_DEC_FRAME, JxlDecoderProcessInput(dec));
+      size_t buffer_size;
+      EXPECT_EQ(JXL_DEC_SUCCESS,
+                JxlDecoderImageOutBufferSize(dec, &format, &buffer_size));
+      std::vector<uint8_t> pixels(buffer_size);
+
+      JxlFrameHeader frame_header;
+      EXPECT_EQ(JXL_DEC_SUCCESS, JxlDecoderGetFrameHeader(dec, &frame_header));
+      EXPECT_EQ((coalescing ? frame_durations_c[i] : frame_durations_nc[i]),
+                frame_header.duration);
+
+      EXPECT_EQ(i + 1 == num_frames + (coalescing ? 0 : 5),
+                frame_header.is_last);
+
+      EXPECT_EQ(JXL_DEC_NEED_IMAGE_OUT_BUFFER, JxlDecoderProcessInput(dec));
+
+      EXPECT_EQ(JXL_DEC_SUCCESS,
+                JxlDecoderSetImageOutBuffer(dec, &format, pixels.data(),
+                                            pixels.size()));
+
+      EXPECT_EQ(JXL_DEC_FULL_IMAGE, JxlDecoderProcessInput(dec));
+      if (coalescing) {
+        EXPECT_EQ(frame_header.layer_info.xsize, xsize);
+        EXPECT_EQ(frame_header.layer_info.ysize, ysize);
+        EXPECT_EQ(frame_header.layer_info.crop_x0, 0);
+        EXPECT_EQ(frame_header.layer_info.crop_y0, 0);
+      } else {
+        EXPECT_EQ(frame_header.layer_info.xsize, frame_xsize[i]);
+        EXPECT_EQ(frame_header.layer_info.ysize, frame_ysize[i]);
+        EXPECT_EQ(frame_header.layer_info.crop_x0, frame_x0[i]);
+        EXPECT_EQ(frame_header.layer_info.crop_y0, frame_y0[i]);
+        EXPECT_EQ(frame_header.layer_info.blend_info.blendmode,
+                  i != 12 + 5 && frame_header.duration != 0
+                      ? 2
+                      : 0);  // kBlend or the default kReplace
+      }
+      EXPECT_EQ(0u,
+                ComparePixels(frames[i].data(), pixels.data(),
+                              frame_header.layer_info.xsize,
+                              frame_header.layer_info.ysize, format, format));
+    }
+
+    // After all frames were decoded, JxlDecoderProcessInput should return
+    // success to indicate all is done.
+    EXPECT_EQ(JXL_DEC_SUCCESS, JxlDecoderProcessInput(dec));
+
+    // Test rewinding the decoder and skipping different frames
+
+    JxlDecoderRewind(dec);
+    EXPECT_EQ(JXL_DEC_SUCCESS, JxlDecoderSubscribeEvents(
+                                   dec, JXL_DEC_FRAME | JXL_DEC_FULL_IMAGE));
+    EXPECT_EQ(JXL_DEC_SUCCESS, JxlDecoderSetInput(dec, next_in, avail_in));
+
+    for (size_t i = 0; i < num_frames + (coalescing ? 0 : 5); ++i) {
+      int test_skipping = (i == 9) ? 3 : 0;
+
+      EXPECT_EQ(JXL_DEC_FRAME, JxlDecoderProcessInput(dec));
+      size_t buffer_size;
+      EXPECT_EQ(JXL_DEC_SUCCESS,
+                JxlDecoderImageOutBufferSize(dec, &format, &buffer_size));
+      std::vector<uint8_t> pixels(buffer_size);
+
+      // Since this is after JXL_DEC_FRAME but before JXL_DEC_FULL_IMAGE, this
+      // should only skip the next frame, not the currently processed one.
+      if (test_skipping) JxlDecoderSkipFrames(dec, test_skipping);
+
+      JxlFrameHeader frame_header;
+      EXPECT_EQ(JXL_DEC_SUCCESS, JxlDecoderGetFrameHeader(dec, &frame_header));
+      EXPECT_EQ((coalescing ? frame_durations_c[i] : frame_durations_nc[i]),
+                frame_header.duration);
+
+      EXPECT_EQ(i + 1 == num_frames + (coalescing ? 0 : 5),
+                frame_header.is_last);
+
+      EXPECT_EQ(JXL_DEC_NEED_IMAGE_OUT_BUFFER, JxlDecoderProcessInput(dec));
+
+      EXPECT_EQ(JXL_DEC_SUCCESS,
+                JxlDecoderSetImageOutBuffer(dec, &format, pixels.data(),
+                                            pixels.size()));
+
+      EXPECT_EQ(JXL_DEC_FULL_IMAGE, JxlDecoderProcessInput(dec));
+      EXPECT_EQ(0u,
+                ComparePixels(frames[i].data(), pixels.data(),
+                              frame_header.layer_info.xsize,
+                              frame_header.layer_info.ysize, format, format));
+
+      if (test_skipping) i += test_skipping;
+    }
+
+    JxlThreadParallelRunnerDestroy(runner);
+    JxlDecoderDestroy(dec);
+  }
+}
+
+TEST(DecodeTest, OrientedCroppedFrameTest) {
+  size_t xsize = 90, ysize = 120;
+  JxlPixelFormat format = {4, JXL_TYPE_UINT16, JXL_BIG_ENDIAN, 0};
+
+  for (bool keep_orientation : {true, false}) {
+    for (uint32_t orientation = 1; orientation <= 8; orientation++) {
+      size_t oxsize = (!keep_orientation && orientation > 4 ? ysize : xsize);
+      size_t oysize = (!keep_orientation && orientation > 4 ? xsize : ysize);
+      jxl::CodecInOut io;
+      io.SetSize(xsize, ysize);
+      io.metadata.m.SetUintSamples(16);
+      io.metadata.m.color_encoding = jxl::ColorEncoding::SRGB(false);
+      io.metadata.m.orientation = orientation;
+      io.frames.clear();
+      io.SetSize(xsize, ysize);
+
+      for (size_t i = 0; i < 3; ++i) {
+        size_t cropxsize = 1 + xsize * 2 / (i + 1);
+        size_t cropysize = 1 + ysize * 3 / (i + 2);
+        int cropx0 = i * 3 - 8;
+        int cropy0 = i * 4 - 7;
+
+        std::vector<uint8_t> frame =
+            jxl::test::GetSomeTestImage(cropxsize, cropysize, 4, i * 2);
+        jxl::ImageBundle bundle(&io.metadata.m);
+        EXPECT_TRUE(ConvertFromExternal(
+            jxl::Span<const uint8_t>(frame.data(), frame.size()), cropxsize,
+            cropysize, jxl::ColorEncoding::SRGB(/*is_gray=*/false),
+            /*has_alpha=*/true,
+            /*alpha_is_premultiplied=*/false, /*bits_per_sample=*/16,
+            JXL_BIG_ENDIAN, /*flipped_y=*/false, /*pool=*/nullptr, &bundle,
+            /*float_in=*/false));
+        bundle.origin = {cropx0, cropy0};
+        bundle.use_for_next_frame = true;
+        io.frames.push_back(std::move(bundle));
+      }
+
+      jxl::CompressParams cparams;
+      cparams
+          .SetLossless();  // Lossless to verify pixels exactly after roundtrip.
+      cparams.speed_tier = jxl::SpeedTier::kThunder;
+      jxl::AuxOut aux_out;
+      jxl::PaddedBytes compressed;
+      jxl::PassesEncoderState enc_state;
+      EXPECT_TRUE(jxl::EncodeFile(cparams, &io, &enc_state, &compressed,
+                                  &aux_out, nullptr));
+
+      // 0 is merged frame as decoded with coalescing enabled (default)
+      // 1-3 are non-coalesced frames as decoded with coalescing disabled
+      // 4 is the manually merged frame
+      std::vector<uint8_t> frames[5];
+      frames[4].resize(xsize * ysize * 8, 0);
+
+      // try both with and without coalescing
+      for (auto coalescing : {JXL_TRUE, JXL_FALSE}) {
+        // Independently decode all frames without any skipping, to create the
+        // expected blended frames, for the actual tests below to compare with.
+        {
+          JxlDecoder* dec = JxlDecoderCreate(NULL);
+          const uint8_t* next_in = compressed.data();
+          size_t avail_in = compressed.size();
+          EXPECT_EQ(JXL_DEC_SUCCESS, JxlDecoderSetCoalescing(dec, coalescing));
+          EXPECT_EQ(JXL_DEC_SUCCESS,
+                    JxlDecoderSetKeepOrientation(dec, keep_orientation));
+          void* runner = JxlThreadParallelRunnerCreate(
+              NULL, JxlThreadParallelRunnerDefaultNumWorkerThreads());
+          EXPECT_EQ(JXL_DEC_SUCCESS, JxlDecoderSetParallelRunner(
+                                         dec, JxlThreadParallelRunner, runner));
+          EXPECT_EQ(JXL_DEC_SUCCESS,
+                    JxlDecoderSubscribeEvents(dec, JXL_DEC_FULL_IMAGE));
+          EXPECT_EQ(JXL_DEC_SUCCESS,
+                    JxlDecoderSetInput(dec, next_in, avail_in));
+          for (size_t i = (coalescing ? 0 : 1); i < (coalescing ? 1 : 4); ++i) {
+            EXPECT_EQ(JXL_DEC_NEED_IMAGE_OUT_BUFFER,
+                      JxlDecoderProcessInput(dec));
+            JxlFrameHeader frame_header;
+            EXPECT_EQ(JXL_DEC_SUCCESS,
+                      JxlDecoderGetFrameHeader(dec, &frame_header));
+            size_t buffer_size;
+            EXPECT_EQ(JXL_DEC_SUCCESS,
+                      JxlDecoderImageOutBufferSize(dec, &format, &buffer_size));
+            if (coalescing)
+              EXPECT_EQ(xsize * ysize * 8, buffer_size);
+            else
+              EXPECT_EQ(frame_header.layer_info.xsize *
+                            frame_header.layer_info.ysize * 8,
+                        buffer_size);
+            frames[i].resize(buffer_size);
+            EXPECT_EQ(JXL_DEC_SUCCESS,
+                      JxlDecoderSetImageOutBuffer(
+                          dec, &format, frames[i].data(), frames[i].size()));
+            EXPECT_EQ(JXL_DEC_FULL_IMAGE, JxlDecoderProcessInput(dec));
+            EXPECT_EQ(frame_header.layer_info.blend_info.blendmode,
+                      JXL_BLEND_REPLACE);
+            if (coalescing) {
+              EXPECT_EQ(frame_header.layer_info.xsize, oxsize);
+              EXPECT_EQ(frame_header.layer_info.ysize, oysize);
+              EXPECT_EQ(frame_header.layer_info.crop_x0, 0);
+              EXPECT_EQ(frame_header.layer_info.crop_y0, 0);
+            } else {
+              // manually merge this layer
+              int x0 = frame_header.layer_info.crop_x0;
+              int y0 = frame_header.layer_info.crop_y0;
+              int w = frame_header.layer_info.xsize;
+              int h = frame_header.layer_info.ysize;
+              for (int y = 0; y < static_cast<int>(oysize); y++) {
+                if (y < y0 || y >= y0 + h) continue;
+                // pointers do whole 16-bit RGBA pixels at a time
+                uint64_t* row_merged = static_cast<uint64_t*>(
+                    (void*)(frames[4].data() + y * oxsize * 8));
+                uint64_t* row_layer = static_cast<uint64_t*>(
+                    (void*)(frames[i].data() + (y - y0) * w * 8));
+                for (int x = 0; x < static_cast<int>(oxsize); x++) {
+                  if (x < x0 || x >= x0 + w) continue;
+                  row_merged[x] = row_layer[x - x0];
+                }
+              }
+            }
+          }
+
+          // After all frames were decoded, JxlDecoderProcessInput should return
+          // success to indicate all is done.
+          EXPECT_EQ(JXL_DEC_SUCCESS, JxlDecoderProcessInput(dec));
+          JxlThreadParallelRunnerDestroy(runner);
+          JxlDecoderDestroy(dec);
+        }
+      }
+
+      EXPECT_EQ(0u, ComparePixels(frames[0].data(), frames[4].data(), oxsize,
+                                  oysize, format, format));
+    }
+  }
+}
+
 TEST(DecodeTest, FlushTest) {
   // Size large enough for multiple groups, required to have progressive
   // stages


### PR DESCRIPTION
Proposed new decode option to disable frame coalescing.

This allows extracting layers from a multi-layer image (in case of Gimp/Photoshop-like use cases), and also possibly to save memory when decoding animations with lots of small cropped frames — at the cost of having to do the blending in the application instead of having the decoder handle it.
Obviously, default behavior doesn't change and still returns coalesced frames as before.

It is partially implemented, but more checks need to be added, and tests and an example application should still be added. Also documentation needs to be improved. This option does significantly change the behavior, e.g. you can no longer set the output buffer immediately after decoding the image header, but you have to do it after decoding the frame header (since without coalescing, frame dimensions are not related to image dimensions). There are probably some places left in the decoder implementation that have an implicit assumption that all frames are canvas-sized.

Only the most basic blend info is currently returned; this is not enough information to do the blending yourself. If and how exactly to expose the more exotic blend info is something that requires some more thought: likely in an application you only want to deal with the common case of normal blending of a simple stack of layers, not weird cases of blending using the non-first alpha channel using a nontrivial source frame etc.

In general, this approach also in principle just doesn't work, since a frame could require patches that are taken from a coalesced frame, which would be a problem because with coalescing disabled, we wouldn't have that source frame. That is currently not a problem in practice because the encoder never does that, but it is in principle a problem (could be solved, but it would be hard to do without just always _also_ doing the coalescing in case there's a patch reference in the future — and that would of course kill any memory benefits).

This feature (if it also gets added to the encode api) would make it possible to effectively use JPEG XL for layered images, e.g. as an option in the Gimp plugin. As far as I know, currently the only image formats that can be used in practice for layered images are TIFF, PSD, XCF and MIFF (ImageMagick's uncompressed internal format). The compression options in any of these formats are quite weak (essentially only uncompressed, RLE, and simple general-purpose compression). JPEG XL would be the first one to have good compression, which could be a killer feature for some use cases, since often near-lossless compression would be good enough but merging the layers is not OK. Compared to e.g. PSD, probably file size savings in the order of 90-95% could be achieved.