### PR TITLE
Skip gbench on msan since it is not instrumented.

### DIFF
--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -200,9 +200,12 @@ jobs:
       run: |
         STORE_IMAGES=0 ./ci.sh fast_benchmark
     # Run gbench once, just to make sure it runs, not for actual benchmarking.
+    # This doesn't work on msan because we use gbench library from the system
+    # which is not instrumented by msan.
     - name: gbench check
       if: |
-        matrix.name == 'release' || github.event_name == 'push'
+        matrix.name == 'release' || (
+          github.event_name == 'push' && matrix.name != 'msan')
       run: |
         ./ci.sh gbench --benchmark_min_time=0
 


### PR DESCRIPTION
benchmark library (gbench) is not instrumented with msan so running the
binary in msan mode fails. This patch skips it in the main pipeline.