### PR TITLE
Add color transform and already_downsampled enc options

### DIFF
--- a/lib/include/jxl/encode.h
+++ b/lib/include/jxl/encode.h
@@ -110,127 +110,146 @@ typedef enum {
    */
   JXL_ENC_OPTION_EXTRA_CHANNEL_RESAMPLING = 3,
 
+  /** Indicates the frame added with @ref JxlEncoderAddImageFrame is already
+   * downsampled by the downsampling factor set with @ref
+   * JXL_ENC_OPTION_RESAMPLING. The input frame must then be given in the
+   * downsampled resolution, not the full image resolution. The downsampled
+   * resolution is given by ceil(xsize / resampling), ceil(ysize / resampling)
+   * with xsize and ysize the dimensions given in the basic info, and resampling
+   * the factor set with @ref JXL_ENC_OPTION_RESAMPLING.
+   * Use 0 to disable, 1 to enable. Default value is 0.
+   */
+  JXL_ENC_OPTION_ALREADY_DOWNSAMPLED = 4,
+
   /** Adds noise to the image emulating photographic film noise, the higher the
    * given number, the grainier the image will be. As an example, a value of 100
    * gives low noise whereas a value of 3200 gives a lot of noise. The default
    * value is 0.
    */
-  JXL_ENC_OPTION_PHOTON_NOISE = 4,
+  JXL_ENC_OPTION_PHOTON_NOISE = 5,
 
   /** Enables adaptive noise generation. This setting is not recommended for
    * use, please use JXL_ENC_OPTION_PHOTON_NOISE instead. Use -1 for the default
    * (encoder chooses), 0 to disable, 1 to enable.
    */
-  JXL_ENC_OPTION_NOISE = 5,
+  JXL_ENC_OPTION_NOISE = 6,
 
   /** Enables or disables dots generation. Use -1 for the default (encoder
    * chooses), 0 to disable, 1 to enable.
    */
-  JXL_ENC_OPTION_DOTS = 6,
+  JXL_ENC_OPTION_DOTS = 7,
 
   /** Enables or disables patches generation. Use -1 for the default (encoder
    * chooses), 0 to disable, 1 to enable.
    */
-  JXL_ENC_OPTION_PATCHES = 7,
+  JXL_ENC_OPTION_PATCHES = 8,
 
   /** Edge preserving filter level, -1 to 3. Use -1 for the default (encoder
    * chooses), 0 to 3 to set a strength.
    */
-  JXL_ENC_OPTION_EPF = 8,
+  JXL_ENC_OPTION_EPF = 9,
 
   /** Enables or disables the gaborish filter. Use -1 for the default (encoder
    * chooses), 0 to disable, 1 to enable.
    */
-  JXL_ENC_OPTION_GABORISH = 9,
+  JXL_ENC_OPTION_GABORISH = 10,
 
   /** Enables modular encoding. Use -1 for default (encoder
    * chooses), 0 to enforce VarDCT mode (e.g. for photographic images), 1 to
    * enforce modular mode (e.g. for lossless images).
    */
-  JXL_ENC_OPTION_MODULAR = 10,
+  JXL_ENC_OPTION_MODULAR = 11,
 
   /** Enables or disables preserving color of invisible pixels. Use -1 for the
    * default (1 if lossless, 0 if lossy), 0 to disable, 1 to enable.
    */
-  JXL_ENC_OPTION_KEEP_INVISIBLE = 11,
+  JXL_ENC_OPTION_KEEP_INVISIBLE = 12,
 
   /** Determines the order in which 256x256 regions are stored in the codestream
    * for progressive rendering. Use -1 for the encoder
    * default, 0 for scanline order, 1 for center-first order.
    */
-  JXL_ENC_OPTION_GROUP_ORDER = 12,
+  JXL_ENC_OPTION_GROUP_ORDER = 13,
 
   /** Determines the horizontal position of center for the center-first group
    * order. Use -1 to automatically use the middle of the image, 0..xsize to
    * specifically set it.
    */
-  JXL_ENC_OPTION_GROUP_ORDER_CENTER_X = 13,
+  JXL_ENC_OPTION_GROUP_ORDER_CENTER_X = 14,
 
   /** Determines the center for the center-first group order. Use -1 to
    * automatically use the middle of the image, 0..ysize to specifically set it.
    */
-  JXL_ENC_OPTION_GROUP_ORDER_CENTER_Y = 14,
+  JXL_ENC_OPTION_GROUP_ORDER_CENTER_Y = 15,
 
   /** Enables or disables progressive encoding for modular mode. Use -1 for the
    * encoder default, 0 to disable, 1 to enable.
    */
-  JXL_ENC_OPTION_RESPONSIVE = 15,
+  JXL_ENC_OPTION_RESPONSIVE = 16,
 
   /** Set the progressive mode for the AC coefficients of VarDCT, using spectral
    * progression from the DCT coefficients. Use -1 for the encoder default, 0 to
    * disable, 1 to enable.
    */
-  JXL_ENC_OPTION_PROGRESSIVE_AC = 16,
+  JXL_ENC_OPTION_PROGRESSIVE_AC = 17,
 
   /** Set the progressive mode for the AC coefficients of VarDCT, using
    * quantization of the least significant bits. Use -1 for the encoder default,
    * 0 to disable, 1 to enable.
    */
-  JXL_ENC_OPTION_QPROGRESSIVE_AC = 17,
+  JXL_ENC_OPTION_QPROGRESSIVE_AC = 18,
 
   /** Set the progressive mode using lower-resolution DC images for VarDCT. Use
    * -1 for the encoder default, 0 to disable, 1 to have an extra 64x64 lower
    * resolution pass, 2 to have a 512x512 and 64x64 lower resolution pass.
    */
-  JXL_ENC_OPTION_PROGRESSIVE_DC = 18,
+  JXL_ENC_OPTION_PROGRESSIVE_DC = 19,
 
   /** Use Global channel palette if the amount of colors is smaller than this
    * percentage of range. Use 0-100 to set an explicit percentage, -1 to use the
    * encoder default. Used for modular encoding.
    */
-  JXL_ENC_OPTION_CHANNEL_COLORS_PRE_TRANSFORM_PERCENT = 19,
+  JXL_ENC_OPTION_CHANNEL_COLORS_PRE_TRANSFORM_PERCENT = 20,
 
   /** Use Local channel palette if the amount of colors is smaller than this
    * percentage of range. Use 0-100 to set an explicit percentage, -1 to use the
    * encoder default. Used for modular encoding.
    */
-  JXL_ENC_OPTION_CHANNEL_COLORS_PERCENT = 20,
+  JXL_ENC_OPTION_CHANNEL_COLORS_PERCENT = 21,
 
   /** Use color palette if amount of colors is smaller than or equal to this
    * amount, or -1 to use the encoder default. Used for modular encoding.
    */
-  JXL_ENC_OPTION_PALETTE_COLORS = 21,
+  JXL_ENC_OPTION_PALETTE_COLORS = 22,
 
   /** Enables or disables delta palette. Use -1 for the default (encoder
    * chooses), 0 to disable, 1 to enable. Used in modular mode.
    */
-  JXL_ENC_OPTION_LOSSY_PALETTE = 22,
+  JXL_ENC_OPTION_LOSSY_PALETTE = 23,
 
-  /** Color space for modular encoding: 0=RGB, 1=YCoCg, 2-37=RCT, -1=default:
-   * try several, depending on speed.
+  /** Color transform for internal encoding: -1 = default, 0=XYB, 1=none (RGB),
+   * 2=YCbCr. The XYB setting performs the forward XYB transform. None and
+   * YCbCr both perform no transform, but YCbCr is used to indicate that the
+   * encoded data losslessly represents YCbCr values.
    */
-  JXL_ENC_OPTION_MODULAR_COLOR_SPACE = 23,
+  JXL_ENC_OPTION_COLOR_TRANSFORM = 24,
+
+  /** Color space for modular encoding: -1=default, 0-35=reverse color transform
+   * index, e.g. index 0 = none, index 6 = YCoCg.
+   * The default behavior is to try several, depending on the speed setting.
+   */
+  JXL_ENC_OPTION_MODULAR_COLOR_SPACE = 25,
 
   /** Group size for modular encoding: -1=default, 0=128, 1=256, 2=512, 3=1024.
    */
-  JXL_ENC_OPTION_MODULAR_GROUP_SIZE = 24,
+  JXL_ENC_OPTION_MODULAR_GROUP_SIZE = 26,
 
   /** Predictor for modular encoding. -1 = default, 0=zero, 1=left, 2=top,
    * 3=avg0, 4=select, 5=gradient, 6=weighted, 7=topright, 8=topleft,
    * 9=leftleft, 10=avg1, 11=avg2, 12=avg3, 13=toptop predictive average 14=mix
    * 5 and 6, 15=mix everything.
    */
-  JXL_ENC_OPTION_MODULAR_PREDICTOR = 25,
+  JXL_ENC_OPTION_MODULAR_PREDICTOR = 27,
 
   /** Enum value not to be used as an option. This value is added to force the
    * C compiler to have the enum to take a known size.
@@ -751,8 +770,8 @@ JXL_EXPORT JxlEncoderStatus JxlEncoderSetCodestreamLevel(JxlEncoder* enc,
  * Enables lossless encoding.
  *
  * This is not an option like the others on itself, but rather while enabled it
- * overrides a set of existing options (such as distance and modular mode) that
- * enables bit-for-bit lossless encoding.
+ * overrides a set of existing options (such as distance, modular mode and
+ * color transform) that enables bit-for-bit lossless encoding.
  *
  * When disabled, those options are not overridden, but since those options
  * could still have been manually set to a combination that operates losslessly,

--- a/lib/jxl/enc_frame.cc
+++ b/lib/jxl/enc_frame.cc
@@ -334,6 +334,15 @@ Status MakeFrameHeader(const CompressParams& cparams,
     frame_header->frame_origin = ib.origin;
     size_t ups = 1;
     if (cparams.already_downsampled) ups = cparams.resampling;
+
+    // TODO(lode): this is not correct in case of odd original image sizes in
+    // combination with cparams.already_downsampled. Likely these values should
+    // be set to respectively frame_header->default_xsize() and
+    // frame_header->default_ysize() instead, the original (non downsampled)
+    // intended decoded image dimensions. But it may be more subtle than that
+    // if combined with crop. This issue causes custom_size_or_origin to be
+    // incorrectly set to true in case of already_downsampled with odd output
+    // image size when no cropping is used.
     frame_header->frame_size.xsize = ib.xsize() * ups;
     frame_header->frame_size.ysize = ib.ysize() * ups;
     if (ib.origin.x0 != 0 || ib.origin.y0 != 0 ||

--- a/lib/jxl/encode_test.cc
+++ b/lib/jxl/encode_test.cc
@@ -366,7 +366,10 @@ TEST(EncodeTest, OptionsTest) {
               JxlEncoderOptionsSetInteger(
                   options, JXL_ENC_OPTION_MODULAR_PREDICTOR, 14));
     VerifyFrameEncoding(enc.get(), options);
-    EXPECT_EQ(30, enc->last_used_cparams.colorspace);
+    // It was set to 30, but becomes 32 because in the C++ implementation, the
+    // numerical RCT values are shifted 2 compared to the specification. The
+    // API uses the values seen in the JXL specification.
+    EXPECT_EQ(32, enc->last_used_cparams.colorspace);
     EXPECT_EQ(2, enc->last_used_cparams.modular_group_size_shift);
     EXPECT_EQ(jxl::Predictor::Best, enc->last_used_cparams.options.predictor);
   }

--- a/lib/jxl/roundtrip_test.cc
+++ b/lib/jxl/roundtrip_test.cc
@@ -173,11 +173,20 @@ template <typename T>
 void VerifyRoundtripCompression(const size_t xsize, const size_t ysize,
                                 const JxlPixelFormat& input_pixel_format,
                                 const JxlPixelFormat& output_pixel_format,
-                                const bool lossless, const bool use_container) {
+                                const bool lossless, const bool use_container,
+                                const uint32_t resampling = 1,
+                                const bool already_downsampled = false) {
+  size_t orig_xsize = xsize;
+  size_t orig_ysize = ysize;
+  if (already_downsampled) {
+    orig_xsize = jxl::DivCeil(xsize, resampling);
+    orig_ysize = jxl::DivCeil(ysize, resampling);
+  }
+
   const std::vector<uint8_t> original_bytes =
-      GetTestImage<T>(xsize, ysize, input_pixel_format);
-  jxl::CodecInOut original_io =
-      ConvertTestImage(original_bytes, xsize, ysize, input_pixel_format, {});
+      GetTestImage<T>(orig_xsize, orig_ysize, input_pixel_format);
+  jxl::CodecInOut original_io = ConvertTestImage(
+      original_bytes, orig_xsize, orig_ysize, input_pixel_format, {});
 
   JxlEncoder* enc = JxlEncoderCreate(nullptr);
   EXPECT_NE(nullptr, enc);
@@ -201,6 +210,14 @@ void VerifyRoundtripCompression(const size_t xsize, const size_t ysize,
   EXPECT_EQ(JXL_ENC_SUCCESS, JxlEncoderSetColorEncoding(enc, &color_encoding));
   JxlEncoderOptions* opts = JxlEncoderOptionsCreate(enc, nullptr);
   JxlEncoderOptionsSetLossless(opts, lossless);
+  if (resampling > 1) {
+    EXPECT_EQ(JXL_ENC_SUCCESS,
+              JxlEncoderOptionsSetInteger(opts, JXL_ENC_OPTION_RESAMPLING,
+                                          resampling));
+    EXPECT_EQ(JXL_ENC_SUCCESS, JxlEncoderOptionsSetInteger(
+                                   opts, JXL_ENC_OPTION_ALREADY_DOWNSAMPLED,
+                                   already_downsampled));
+  }
   EXPECT_EQ(JXL_ENC_SUCCESS,
             JxlEncoderAddImageFrame(opts, &input_pixel_format,
                                     (void*)original_bytes.data(),
@@ -227,7 +244,7 @@ void VerifyRoundtripCompression(const size_t xsize, const size_t ysize,
   size_t buffer_size;
   EXPECT_EQ(JXL_DEC_SUCCESS, JxlDecoderImageOutBufferSize(
                                  dec, &output_pixel_format, &buffer_size));
-  if (&input_pixel_format == &output_pixel_format) {
+  if (&input_pixel_format == &output_pixel_format && !already_downsampled) {
     EXPECT_EQ(buffer_size, original_bytes.size());
   }
 
@@ -267,10 +284,20 @@ void VerifyRoundtripCompression(const size_t xsize, const size_t ysize,
   jxl::CodecInOut decoded_io = ConvertTestImage(
       decoded_bytes, xsize, ysize, output_pixel_format, icc_profile);
 
+  if (already_downsampled) {
+    jxl::Image3F* color = decoded_io.Main().color();
+    jxl::DownsampleImage(color, resampling);
+    if (decoded_io.Main().HasAlpha()) {
+      jxl::ImageF* alpha = decoded_io.Main().alpha();
+      jxl::DownsampleImage(alpha, resampling);
+    }
+    decoded_io.SetSize(color->xsize(), color->ysize());
+  }
+
   jxl::ButteraugliParams ba;
   float butteraugli_score = ButteraugliDistance(original_io, decoded_io, ba,
                                                 /*distmap=*/nullptr, nullptr);
-  if (lossless) {
+  if (lossless && !already_downsampled) {
     EXPECT_LE(butteraugli_score, 0.0f);
   } else {
     EXPECT_LE(butteraugli_score, 2.0f);
@@ -337,6 +364,23 @@ TEST(RoundtripTest, TestNonlinearSrgbAsXybEncoded) {
           /*lossless=*/false, (bool)use_container);
     }
   }
+}
+
+TEST(RoundtripTest, Resampling) {
+  JxlPixelFormat pixel_format =
+      JxlPixelFormat{3, JXL_TYPE_UINT8, JXL_NATIVE_ENDIAN, 0};
+  VerifyRoundtripCompression<uint8_t>(63, 129, pixel_format, pixel_format,
+                                      /*lossless=*/false,
+                                      /*use_container=*/false, 2,
+                                      /*already_downsampled=*/false);
+
+  // TODO(lode): also make this work for odd sizes. This requires a fix in
+  // enc_frame.cc to not set custom_size_or_origin to true due to even/odd
+  // mismatch.
+  VerifyRoundtripCompression<uint8_t>(64, 128, pixel_format, pixel_format,
+                                      /*lossless=*/true,
+                                      /*use_container=*/false, 2,
+                                      /*already_downsampled=*/true);
 }
 
 TEST(RoundtripTest, ExtraBoxesTest) {


### PR DESCRIPTION
Also added test for already_downsampled. Also added TODO for issue found
with already_downsampled on odd output sizes (something that you can do
through the API and should be possible, but cjxl can't do)