### PR TITLE
lib/jxl/encode.cc: add XYB fallback check to AddImageFrame

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -32,3 +32,4 @@ Samuel Leong <wvvwvvvvwvvw@gmail.com>
 Alex Xu (Hello71) <alex_y_xu@yahoo.ca>
 Vincent Torri <vincent.torri@gmail.com>
 Artem Selishchev
+Leo Izen <leo.izen@gmail.com>

--- a/lib/jxl/encode.cc
+++ b/lib/jxl/encode.cc
@@ -632,7 +632,7 @@ JxlEncoderStatus JxlEncoderAddImageFrame(const JxlEncoderOptions* options,
   }
 
   jxl::ColorEncoding c_current;
-  if (options->enc->metadata.m.xyb_encoded) {
+  if (!options->enc->color_encoding_set) {
     if ((pixel_format->data_type == JXL_TYPE_FLOAT) ||
         (pixel_format->data_type == JXL_TYPE_FLOAT16)) {
       c_current =

--- a/lib/jxl/encode.cc
+++ b/lib/jxl/encode.cc
@@ -607,7 +607,12 @@ JxlEncoderStatus JxlEncoderAddJPEGFrame(const JxlEncoderOptions* options,
 JxlEncoderStatus JxlEncoderAddImageFrame(const JxlEncoderOptions* options,
                                          const JxlPixelFormat* pixel_format,
                                          const void* buffer, size_t size) {
-  if (!options->enc->basic_info_set || !options->enc->color_encoding_set) {
+  if (!options->enc->basic_info_set ||
+      (!options->enc->color_encoding_set &&
+       !options->enc->metadata.m.xyb_encoded)) {
+    // Basic Info must be set, and color encoding must be set directly,
+    // or set to XYB via JxlBasicInfo.uses_original_profile = JXL_FALSE
+    // Otherwise, this is an API misuse.
     return JXL_ENC_ERROR;
   }
 

--- a/lib/jxl/encode_test.cc
+++ b/lib/jxl/encode_test.cc
@@ -79,7 +79,7 @@ TEST(EncodeTest, AddFrameBeforeColorEncodingTest) {
   jxl::test::JxlBasicInfoSetFromPixelFormat(&basic_info, &pixel_format);
   basic_info.xsize = xsize;
   basic_info.ysize = ysize;
-  basic_info.uses_original_profile = false;
+  basic_info.uses_original_profile = true;
   EXPECT_EQ(JXL_ENC_SUCCESS, JxlEncoderSetBasicInfo(enc.get(), &basic_info));
   JxlEncoderOptions* options = JxlEncoderOptionsCreate(enc.get(), NULL);
   EXPECT_EQ(JXL_ENC_ERROR,


### PR DESCRIPTION
The encoder will no longer refuse AddImageFrame if the
color encoding is set to XYB via JxlBasicInfo, even if it
is not set directly.