### PR TITLE
encoder api: extra channels

### DIFF
--- a/lib/include/jxl/encode.h
+++ b/lib/include/jxl/encode.h
@@ -742,7 +742,9 @@ JXL_EXPORT void JxlEncoderInitBasicInfo(JxlBasicInfo* info);
  *
  * If the JxlBasicInfo contains information of extra channels beyond an alpha
  * channel, then @ref JxlEncoderSetExtraChannelInfo must be called between
- * JxlEncoderSetBasicInfo and @ref JxlEncoderAddImageFrame.
+ * JxlEncoderSetBasicInfo and @ref JxlEncoderAddImageFrame. In order to indicate
+ * extra channels, the value of `info.num_extra_channels` should be set to the
+ * number of extra channels, also counting the alpha channel if present.
  *
  * @param enc encoder object.
  * @param info global image metadata. Object owned by the caller and its

--- a/lib/jxl/enc_external_image.cc
+++ b/lib/jxl/enc_external_image.cc
@@ -13,6 +13,7 @@
 #include <utility>
 #include <vector>
 
+#include "jxl/types.h"
 #include "lib/jxl/alpha.h"
 #include "lib/jxl/base/byte_order.h"
 #include "lib/jxl/color_management.h"
@@ -82,8 +83,126 @@ void JXL_INLINE LoadFloatRow(float* JXL_RESTRICT row_out, const uint8_t* in,
 
 uint32_t JXL_INLINE Load8(const uint8_t* p) { return *p; }
 
+Status PixelFormatToExternal(const JxlPixelFormat& pixel_format,
+                             size_t* bitdepth, bool* float_in) {
+  // TODO(zond): Make this accept uint32.
+  if (pixel_format.data_type == JXL_TYPE_FLOAT) {
+    *bitdepth = 32;
+    *float_in = true;
+  } else if (pixel_format.data_type == JXL_TYPE_FLOAT16) {
+    *bitdepth = 16;
+    *float_in = true;
+  } else if (pixel_format.data_type == JXL_TYPE_UINT8) {
+    *bitdepth = 8;
+    *float_in = false;
+  } else if (pixel_format.data_type == JXL_TYPE_UINT16) {
+    *bitdepth = 16;
+    *float_in = false;
+  } else {
+    return JXL_FAILURE("unsupported bitdepth");
+  }
+  return true;
+}
 }  // namespace
 
+Status ConvertFromExternal(Span<const uint8_t> bytes, size_t xsize,
+                           size_t ysize, size_t bits_per_sample,
+                           JxlEndianness endianness, ThreadPool* pool,
+                           ImageF* channel, bool float_in) {
+  // TODO(firsching): Avoid code duplication with the function below.
+  if (bits_per_sample < 1 || bits_per_sample > 32) {
+    return JXL_FAILURE("Invalid bits_per_sample value.");
+  }
+  // TODO(deymo): Implement 1-bit per sample as 8 samples per byte. In
+  // any other case we use DivCeil(bits_per_sample, 8) bytes per pixel per
+  // channel.
+  if (bits_per_sample == 1) {
+    return JXL_FAILURE("packed 1-bit per sample is not yet supported");
+  }
+
+  // bytes_per_pixel are only valid for
+  // bits_per_sample > 1.
+  const size_t bytes_per_pixel = DivCeil(bits_per_sample, jxl::kBitsPerByte);
+
+  const size_t row_size = xsize * bytes_per_pixel;
+  if (ysize && bytes.size() / ysize < row_size) {
+    return JXL_FAILURE("Buffer size is too small");
+  }
+
+  const bool little_endian =
+      endianness == JXL_LITTLE_ENDIAN ||
+      (endianness == JXL_NATIVE_ENDIAN && IsLittleEndian());
+
+  const uint8_t* const in = bytes.data();
+  if (float_in) {
+    RunOnPool(
+        pool, 0, static_cast<uint32_t>(ysize), ThreadPool::SkipInit(),
+        [&](const int task, int /*thread*/) {
+          const size_t y = task;
+          size_t i = row_size * task;
+          float* JXL_RESTRICT row_out = channel->Row(y);
+          if (bits_per_sample <= 16) {
+            if (little_endian) {
+              for (size_t x = 0; x < xsize; ++x) {
+                row_out[x] = LoadLEFloat16(in + i);
+                i += bytes_per_pixel;
+              }
+            } else {
+              for (size_t x = 0; x < xsize; ++x) {
+                row_out[x] = LoadBEFloat16(in + i);
+                i += bytes_per_pixel;
+              }
+            }
+          } else {
+            if (little_endian) {
+              for (size_t x = 0; x < xsize; ++x) {
+                row_out[x] = LoadLEFloat(in + i);
+                i += bytes_per_pixel;
+              }
+            } else {
+              for (size_t x = 0; x < xsize; ++x) {
+                row_out[x] = LoadBEFloat(in + i);
+                i += bytes_per_pixel;
+              }
+            }
+          }
+        },
+        "ConvertExtraChannelFloat");
+  } else {
+    float mul = 1. / ((1ull << bits_per_sample) - 1);
+    RunOnPool(
+        pool, 0, static_cast<uint32_t>(ysize), ThreadPool::SkipInit(),
+        [&](const int task, int /*thread*/) {
+          const size_t y = task;
+          size_t i = row_size * task;
+          float* JXL_RESTRICT row_out = channel->Row(y);
+          // TODO(deymo): add bits_per_sample == 1 case here. Also maybe
+          // implement masking if bits_per_sample is not a multiple of 8.
+          if (bits_per_sample <= 8) {
+            LoadFloatRow<Load8>(row_out, in + i, mul, xsize, bytes_per_pixel);
+          } else if (bits_per_sample <= 16) {
+            if (little_endian) {
+              LoadFloatRow<LoadLE16>(row_out, in + i, mul, xsize,
+                                     bytes_per_pixel);
+            } else {
+              LoadFloatRow<LoadBE16>(row_out, in + i, mul, xsize,
+                                     bytes_per_pixel);
+            }
+          } else {
+            if (little_endian) {
+              LoadFloatRow<LoadLE32>(row_out, in + i, mul, xsize,
+                                     bytes_per_pixel);
+            } else {
+              LoadFloatRow<LoadBE32>(row_out, in + i, mul, xsize,
+                                     bytes_per_pixel);
+            }
+          }
+        },
+        "ConvertExtraChannelUint");
+  }
+
+  return true;
+}
 Status ConvertFromExternal(Span<const uint8_t> bytes, size_t xsize,
                            size_t ysize, const ColorEncoding& c_current,
                            bool has_alpha, bool alpha_is_premultiplied,
@@ -287,6 +406,23 @@ Status ConvertFromExternal(Span<const uint8_t> bytes, size_t xsize,
   return true;
 }
 
+Status BufferToImageF(const JxlPixelFormat& pixel_format, size_t xsize,
+                      size_t ysize, const void* buffer, size_t size,
+                      ThreadPool* pool, ImageF* channel) {
+  size_t bitdepth;
+  bool float_in;
+
+  JXL_RETURN_IF_ERROR(
+      PixelFormatToExternal(pixel_format, &bitdepth, &float_in));
+
+  JXL_RETURN_IF_ERROR(ConvertFromExternal(
+      jxl::Span<const uint8_t>(static_cast<const uint8_t*>(buffer), size),
+      xsize, ysize, bitdepth, pixel_format.endianness, pool, channel,
+      float_in));
+
+  return true;
+}
+
 Status BufferToImageBundle(const JxlPixelFormat& pixel_format, uint32_t xsize,
                            uint32_t ysize, const void* buffer, size_t size,
                            jxl::ThreadPool* pool,
@@ -294,23 +430,8 @@ Status BufferToImageBundle(const JxlPixelFormat& pixel_format, uint32_t xsize,
                            jxl::ImageBundle* ib) {
   size_t bitdepth;
   bool float_in;
-
-  // TODO(zond): Make this accept uint32.
-  if (pixel_format.data_type == JXL_TYPE_FLOAT) {
-    bitdepth = 32;
-    float_in = true;
-  } else if (pixel_format.data_type == JXL_TYPE_FLOAT16) {
-    bitdepth = 16;
-    float_in = true;
-  } else if (pixel_format.data_type == JXL_TYPE_UINT8) {
-    bitdepth = 8;
-    float_in = false;
-  } else if (pixel_format.data_type == JXL_TYPE_UINT16) {
-    bitdepth = 16;
-    float_in = false;
-  } else {
-    return JXL_FAILURE("unsupported bitdepth");
-  }
+  JXL_RETURN_IF_ERROR(
+      PixelFormatToExternal(pixel_format, &bitdepth, &float_in));
 
   JXL_RETURN_IF_ERROR(ConvertFromExternal(
       jxl::Span<const uint8_t>(static_cast<const uint8_t*>(buffer), size),

--- a/lib/jxl/enc_external_image.h
+++ b/lib/jxl/enc_external_image.h
@@ -31,6 +31,11 @@ constexpr size_t RowSize(size_t xsize, size_t channels,
              : xsize * channels * DivCeil(bits_per_sample, kBitsPerByte);
 }
 
+Status ConvertFromExternal(Span<const uint8_t> bytes, size_t xsize,
+                           size_t ysize, size_t bits_per_sample,
+                           JxlEndianness endianness, ThreadPool* pool,
+                           ImageF* channel, bool float_in);
+
 // Convert an interleaved pixel buffer to the internal ImageBundle
 // representation. This is the opposite of ConvertToExternal().
 Status ConvertFromExternal(Span<const uint8_t> bytes, size_t xsize,
@@ -39,7 +44,9 @@ Status ConvertFromExternal(Span<const uint8_t> bytes, size_t xsize,
                            size_t bits_per_sample, JxlEndianness endianness,
                            bool flipped_y, ThreadPool* pool, ImageBundle* ib,
                            bool float_in);
-
+Status BufferToImageF(const JxlPixelFormat& pixel_format, size_t xsize,
+                      size_t ysize, const void* buffer, size_t size,
+                      ThreadPool* pool, ImageF* channel);
 Status BufferToImageBundle(const JxlPixelFormat& pixel_format, uint32_t xsize,
                            uint32_t ysize, const void* buffer, size_t size,
                            jxl::ThreadPool* pool,

--- a/lib/jxl/test_utils.h
+++ b/lib/jxl/test_utils.h
@@ -91,8 +91,10 @@ void JxlBasicInfoSetFromPixelFormat(JxlBasicInfo* basic_info,
     basic_info->alpha_exponent_bits = 0;
     if (basic_info->bits_per_sample == 32) {
       basic_info->alpha_bits = 16;
+      basic_info->num_extra_channels = 1;
     } else {
       basic_info->alpha_bits = basic_info->bits_per_sample;
+      basic_info->num_extra_channels = 1;
     }
   } else {
     basic_info->alpha_exponent_bits = 0;


### PR DESCRIPTION
This adds `JxlEncoderSetExtraChannelBuffer` and
modifies the a roundtrip test to test it.

Pair with Lode