### PR TITLE
Avoid deprecated Highway functions

### DIFF
--- a/lib/jxl/dec_reconstruct.cc
+++ b/lib/jxl/dec_reconstruct.cc
@@ -357,8 +357,8 @@ void DoYCbCrUpsampling(size_t hs, size_t vs, ImageF* plane_in, const Rect& rect,
         Store(left, d, out + x);
         Store(right, d, out + x + 1);
 #else
-        Store(InterleaveLower(left, right), d, out + x);
-        Store(InterleaveUpper(left, right), d, out + x + Lanes(d));
+        Store(InterleaveLower(d, left, right), d, out + x);
+        Store(InterleaveUpper(d, left, right), d, out + x + Lanes(d));
 #endif
       }
     }

--- a/lib/jxl/dec_upsample.cc
+++ b/lib/jxl/dec_upsample.cc
@@ -176,8 +176,8 @@ void Upsample(const ImageF& src, const Rect& src_rect, ImageF* dst,
         min = Min(LoadU(df, raw_min_row + sx + fx), min);
         max = Max(LoadU(df, raw_max_row + sx + fx), max);
       }
-      min = MinOfLanes(min);
-      max = MaxOfLanes(max);
+      min = MinOfLanes(df, min);
+      max = MaxOfLanes(df, max);
       for (size_t lx = 0; lx < N; lx += V) {
         StoreU(min, df, min_row + N * sx + lx);
         StoreU(max, df, max_row + N * sx + lx);

--- a/lib/jxl/enc_ac_strategy.cc
+++ b/lib/jxl/enc_ac_strategy.cc
@@ -429,8 +429,8 @@ float EstimateEntropy(const AcStrategy& acs, size_t x, size_t y,
     }
     entropy_v += nzeros_v * cost1;
 
-    entropy += GetLane(SumOfLanes(entropy_v));
-    size_t num_nzeros = GetLane(SumOfLanes(nzeros_v));
+    entropy += GetLane(SumOfLanes(df, entropy_v));
+    size_t num_nzeros = GetLane(SumOfLanes(df, nzeros_v));
     // Add #bit of num_nonzeros, as an estimate of the cost for encoding the
     // number of non-zeros of the block.
     size_t nbits = CeilLog2Nonzero(num_nzeros + 1) + 1;
@@ -441,9 +441,9 @@ float EstimateEntropy(const AcStrategy& acs, size_t x, size_t y,
   float ret =
       entropy +
       masking *
-          ((config.info_loss_multiplier * GetLane(SumOfLanes(info_loss))) +
+          ((config.info_loss_multiplier * GetLane(SumOfLanes(df, info_loss))) +
            (config.info_loss_multiplier2 *
-            sqrt(num_blocks * GetLane(SumOfLanes(info_loss2)))));
+            sqrt(num_blocks * GetLane(SumOfLanes(df, info_loss2)))));
   return ret;
 }
 

--- a/lib/jxl/enc_adaptive_quantization.cc
+++ b/lib/jxl/enc_adaptive_quantization.cc
@@ -189,7 +189,7 @@ V GammaModulation(const D d, const size_t x, const size_t y,
       overall_ratio += avg_ratio;
     }
   }
-  overall_ratio = SumOfLanes(overall_ratio);
+  overall_ratio = SumOfLanes(d, overall_ratio);
   overall_ratio *= Set(d, 1.0f / 64);
   // ideally -1.0, but likely optimal correction adds some entropy, so slightly
   // less than that.
@@ -246,12 +246,12 @@ V ColorModulation(const D d, const size_t x, const size_t y,
   // blue we consider as if it was fully red or blue.
   static const float ratio = 30.610615782142737f;  // out of 64 pixels.
 
-  auto overall_red_coverage = SumOfLanes(red_coverage);
+  auto overall_red_coverage = SumOfLanes(d, red_coverage);
   overall_red_coverage =
       Min(overall_red_coverage, Set(d, ratio * kRedRampLength));
   overall_red_coverage *= Set(d, red_strength / ratio);
 
-  auto overall_blue_coverage = SumOfLanes(blue_coverage);
+  auto overall_blue_coverage = SumOfLanes(d, blue_coverage);
   overall_blue_coverage =
       Min(overall_blue_coverage, Set(d, ratio * kBlueRampLength));
   overall_blue_coverage *= Set(d, blue_strength / ratio);
@@ -295,7 +295,7 @@ V HfModulation(const D d, const size_t x, const size_t y, const ImageF& xyb,
     }
   }
 
-  sum = SumOfLanes(sum);
+  sum = SumOfLanes(d, sum);
   return MulAdd(sum, Set(d, -2.0052193233688884f / 112), out_val);
 }
 

--- a/lib/jxl/enc_ar_control_field.cc
+++ b/lib/jxl/enc_ar_control_field.cc
@@ -157,7 +157,7 @@ void ProcessTile(const Image3F& opsin, PassesEncoderState* enc_state,
           sum += LoadU(df4, rows_in[iy] + x * 4 + ix + 2);
         }
       }
-      row_out[x] = GetLane(Sqrt(SumOfLanes(sum))) * (1.0f / 4.0f);
+      row_out[x] = GetLane(Sqrt(SumOfLanes(df4, sum))) * (1.0f / 4.0f);
     }
   }
   // Indexing iy and ix is a bit tricky as we include a 2 pixel border
@@ -193,7 +193,7 @@ void ProcessTile(const Image3F& opsin, PassesEncoderState* enc_state,
             sum += Load(df4, rows_in[iy] + sx + ix);
           }
         }
-        row_out[x] = GetLane(Sqrt(SumOfLanes(sum))) * (1.0f / 4.0f);
+        row_out[x] = GetLane(Sqrt(SumOfLanes(df4, sum))) * (1.0f / 4.0f);
       } else {
         float sum = 0;
         for (size_t iy = sy; iy < ey; iy++) {

--- a/lib/jxl/enc_butteraugli_pnorm.cc
+++ b/lib/jxl/enc_butteraugli_pnorm.cc
@@ -87,13 +87,13 @@ double ComputeDistanceP(const ImageF& distmap, const ButteraugliParams& params,
     }
     double v = 0;
     v += pow(
-        onePerPixels * (sum1[0] + GetLane(SumOfLanes(Load(d, sum_totals0)))),
+        onePerPixels * (sum1[0] + GetLane(SumOfLanes(d, Load(d, sum_totals0)))),
         1.0 / (p * 1.0));
     v += pow(
-        onePerPixels * (sum1[1] + GetLane(SumOfLanes(Load(d, sum_totals1)))),
+        onePerPixels * (sum1[1] + GetLane(SumOfLanes(d, Load(d, sum_totals1)))),
         1.0 / (p * 2.0));
     v += pow(
-        onePerPixels * (sum1[2] + GetLane(SumOfLanes(Load(d, sum_totals2)))),
+        onePerPixels * (sum1[2] + GetLane(SumOfLanes(d, Load(d, sum_totals2)))),
         1.0 / (p * 4.0));
     v /= 3.0;
     return v;

--- a/lib/jxl/enc_chroma_from_luma.cc
+++ b/lib/jxl/enc_chroma_from_luma.cc
@@ -91,9 +91,9 @@ struct CFLFunction {
       fdme_v += IfThenElse(av >= thres, zero, dme);
     }
 
-    *fpeps = first_derivative_peps + GetLane(SumOfLanes(fdpe_v));
-    *fmeps = first_derivative_meps + GetLane(SumOfLanes(fdme_v));
-    return first_derivative + GetLane(SumOfLanes(fd_v));
+    *fpeps = first_derivative_peps + GetLane(SumOfLanes(df, fdpe_v));
+    *fmeps = first_derivative_meps + GetLane(SumOfLanes(df, fdme_v));
+    return first_derivative + GetLane(SumOfLanes(df, fd_v));
   }
 
   const float* JXL_RESTRICT values_m;
@@ -124,8 +124,8 @@ int32_t FindBestMultiplier(const float* values_m, const float* values_s,
       cb = MulAdd(a, b, cb);
     }
     // + distance_mul * x^2 * num
-    x = -GetLane(SumOfLanes(cb)) /
-        (GetLane(SumOfLanes(ca)) + num * distance_mul * 0.5f);
+    x = -GetLane(SumOfLanes(df, cb)) /
+        (GetLane(SumOfLanes(df, ca)) + num * distance_mul * 0.5f);
   } else {
     constexpr float eps = 1;
     constexpr float kClamp = 20.0f;

--- a/lib/jxl/enc_cluster.cc
+++ b/lib/jxl/enc_cluster.cc
@@ -49,7 +49,7 @@ void HistogramEntropy(const Histogram& a) {
     const auto counts = LoadU(di, &a.data_[i]);
     entropy_lanes += Entropy(ConvertTo(df, counts), inv_tot, total);
   }
-  a.entropy_ += GetLane(SumOfLanes(entropy_lanes));
+  a.entropy_ += GetLane(SumOfLanes(df, entropy_lanes));
 }
 
 float HistogramDistance(const Histogram& a, const Histogram& b) {
@@ -71,7 +71,7 @@ float HistogramDistance(const Histogram& a, const Histogram& b) {
     const auto counts = ConvertTo(df, a_counts + b_counts);
     distance_lanes += Entropy(counts, inv_tot, total);
   }
-  const float total_distance = GetLane(SumOfLanes(distance_lanes));
+  const float total_distance = GetLane(SumOfLanes(df, distance_lanes));
   return total_distance - a.entropy_ - b.entropy_;
 }
 

--- a/lib/jxl/enc_entropy_coder.cc
+++ b/lib/jxl/enc_entropy_coder.cc
@@ -86,7 +86,7 @@ int32_t NumNonZeroExceptLLF(const size_t cx, const size_t cy,
 
   // We want area - sum_zero, add because neg_sum_zero is already negated.
   const int32_t nzeros =
-      int32_t(cx * cy * kDCTBlockSize) + GetLane(SumOfLanes(neg_sum_zero));
+      int32_t(cx * cy * kDCTBlockSize) + GetLane(SumOfLanes(di, neg_sum_zero));
 
   const int32_t shifted_nzeros = static_cast<int32_t>(
       (nzeros + covered_blocks - 1) >> log2_covered_blocks);
@@ -135,7 +135,7 @@ int32_t NumNonZero8x8ExceptDC(const int32_t* JXL_RESTRICT block,
 
   // We want 64 - sum_zero, add because neg_sum_zero is already negated.
   const int32_t nzeros =
-      int32_t(kDCTBlockSize) + GetLane(SumOfLanes(neg_sum_zero));
+      int32_t(kDCTBlockSize) + GetLane(SumOfLanes(di, neg_sum_zero));
 
   *nzeros_pos = nzeros;
 

--- a/lib/jxl/enc_fast_heuristics.cc
+++ b/lib/jxl/enc_fast_heuristics.cc
@@ -94,8 +94,8 @@ Status Heuristics(PassesEncoderState* enc_state,
               cb = MulAdd(a, b, cb);
             }
           }
-          float best =
-              -GetLane(SumOfLanes(cb)) / (GetLane(SumOfLanes(ca)) + 1e-9f);
+          float best = -GetLane(SumOfLanes(df, cb)) /
+                       (GetLane(SumOfLanes(df, ca)) + 1e-9f);
           int8_t& res = (c == 0 ? shared.cmap.ytox_map : shared.cmap.ytob_map)
                             .Row(ty)[tx];
           res = std::max(-128.0f, std::min(127.0f, roundf(best)));
@@ -124,8 +124,8 @@ Status Heuristics(PassesEncoderState* enc_state,
                 max = IfThenElse(max > nn, max, nn);
               }
             }
-            row_out_avg[x] = GetLane(SumOfLanes(sum));
-            row_out[x] = GetLane(MaxOfLanes(max));
+            row_out_avg[x] = GetLane(SumOfLanes(df4, sum));
+            row_out[x] = GetLane(MaxOfLanes(df4, max));
           }
         }
       },

--- a/lib/jxl/gauss_blur.cc
+++ b/lib/jxl/gauss_blur.cc
@@ -421,7 +421,7 @@ ImageF ConvolveXSampleAndTranspose(const ImageF& in,
       for (int i = -r; i <= r; i += Lanes(df)) {
         sum = MulAdd(LoadU(df, rowp + x + i), LoadU(df, kernelp + i), sum);
       }
-      out.Row(ox)[y] = GetLane(SumOfLanes(sum));
+      out.Row(ox)[y] = GetLane(SumOfLanes(df, sum));
     }
     for (; x < in.xsize(); x += res, ++ox) {
       float sum = 0.0f;

--- a/lib/jxl/modular/encoding/enc_ma.cc
+++ b/lib/jxl/modular/encoding/enc_ma.cc
@@ -60,7 +60,7 @@ float EstimateBits(const int32_t *counts, int32_t *rounded_counts,
     bits_lanes -=
         IfThenElse(counts_v == zero, zero, counts_v * BitCast(df, nbps));
   }
-  return GetLane(SumOfLanes(bits_lanes));
+  return GetLane(SumOfLanes(df, bits_lanes));
 }
 
 void MakeSplitNode(size_t pos, int property, int splitval, Predictor lpred,

--- a/lib/jxl/rational_polynomial_test.cc
+++ b/lib/jxl/rational_polynomial_test.cc
@@ -50,7 +50,7 @@ struct EvalLog2 {
     const HWY_FULL(int32_t) di;
     const auto x_bits = BitCast(di, vx);
     // Cannot handle negative numbers / NaN.
-    JXL_DASSERT(AllTrue(Abs(x_bits) == x_bits));
+    JXL_DASSERT(AllTrue(di, Abs(x_bits) == x_bits));
 
     // Range reduction to [-1/3, 1/3] - 3 integer, 2 float ops
     const auto exp_bits = x_bits - Set(di, 0x3f2aaaab);  // = 2/3

--- a/lib/jxl/splines.cc
+++ b/lib/jxl/splines.cc
@@ -53,7 +53,7 @@ float ContinuousIDCT(const float dct[32], float t) {
     auto local_res = LoadU(df, dct + i) * cos;
     result = MulAdd(Set(df, square_root<2>::value), local_res, result);
   }
-  return GetLane(SumOfLanes(result));
+  return GetLane(SumOfLanes(df, result));
 }
 
 template <typename DF>

--- a/lib/jxl/transpose-inl.h
+++ b/lib/jxl/transpose-inl.h
@@ -137,25 +137,26 @@ JXL_INLINE_TRANSPOSE void GenericTransposeBlock(TransposeSimdTag<true>,
   static_assert(COLS_or_0 % 4 == 0, "Invalid number of columns");
   for (size_t n = 0; n < ROWS; n += 4) {
     for (size_t m = 0; m < COLS; m += 4) {
-      const auto p0 = from.LoadPart(BlockDesc<4>(), n + 0, m + 0);
-      const auto p1 = from.LoadPart(BlockDesc<4>(), n + 1, m + 0);
-      const auto p2 = from.LoadPart(BlockDesc<4>(), n + 2, m + 0);
-      const auto p3 = from.LoadPart(BlockDesc<4>(), n + 3, m + 0);
+      const BlockDesc<4> d;
+      const auto p0 = from.LoadPart(d, n + 0, m + 0);
+      const auto p1 = from.LoadPart(d, n + 1, m + 0);
+      const auto p2 = from.LoadPart(d, n + 2, m + 0);
+      const auto p3 = from.LoadPart(d, n + 3, m + 0);
 
-      const auto q0 = InterleaveLower(p0, p2);
-      const auto q1 = InterleaveLower(p1, p3);
-      const auto q2 = InterleaveUpper(p0, p2);
-      const auto q3 = InterleaveUpper(p1, p3);
+      const auto q0 = InterleaveLower(d, p0, p2);
+      const auto q1 = InterleaveLower(d, p1, p3);
+      const auto q2 = InterleaveUpper(d, p0, p2);
+      const auto q3 = InterleaveUpper(d, p1, p3);
 
-      const auto r0 = InterleaveLower(q0, q1);
-      const auto r1 = InterleaveUpper(q0, q1);
-      const auto r2 = InterleaveLower(q2, q3);
-      const auto r3 = InterleaveUpper(q2, q3);
+      const auto r0 = InterleaveLower(d, q0, q1);
+      const auto r1 = InterleaveUpper(d, q0, q1);
+      const auto r2 = InterleaveLower(d, q2, q3);
+      const auto r3 = InterleaveUpper(d, q2, q3);
 
-      to.StorePart(BlockDesc<4>(), r0, m + 0, n + 0);
-      to.StorePart(BlockDesc<4>(), r1, m + 1, n + 0);
-      to.StorePart(BlockDesc<4>(), r2, m + 2, n + 0);
-      to.StorePart(BlockDesc<4>(), r3, m + 3, n + 0);
+      to.StorePart(d, r0, m + 0, n + 0);
+      to.StorePart(d, r1, m + 1, n + 0);
+      to.StorePart(d, r2, m + 2, n + 0);
+      to.StorePart(d, r3, m + 3, n + 0);
     }
   }
 }


### PR DESCRIPTION
Instead use the newer overloads with the extra d arg required to
support SVE/RISC-V.