### PR TITLE
Copy pre_color_transform image instead of moving.

### DIFF
--- a/lib/jxl/dec_frame.cc
+++ b/lib/jxl/dec_frame.cc
@@ -949,7 +949,7 @@ Status FrameDecoder::FinalizeFrame() {
     } else {
       reference_frame.storage = ImageBundle(decoded_->metadata());
       reference_frame.storage.SetFromImage(
-          std::move(dec_state_->pre_color_transform_frame),
+          CopyImage(dec_state_->pre_color_transform_frame),
           decoded_->c_current());
       if (decoded_->HasExtraChannels()) {
         const std::vector<ImageF>* ecs = &dec_state_->pre_color_transform_ec;


### PR DESCRIPTION
It is created on ProcessAcGlobal and not expected to be removed.

NB: it might be possible to swap it with  fresh image instead of copying; but it might be dangerous, in case unshrink is required.

Fixes #842 