### PR TITLE
Add use-boxes and close-boxes functions to encoder API

### DIFF
--- a/lib/include/jxl/encode.h
+++ b/lib/include/jxl/encode.h
@@ -396,7 +396,7 @@ JXL_EXPORT JxlEncoderStatus JxlEncoderSetExtraChannelBuffer(
     const void* buffer, size_t size, uint32_t index);
 
 /** Adds a metadata box to the file format. JxlEncoderProcessOutput must be used
- * to effectively write the box to the output. @ref JxlEncoderUseContainer must
+ * to effectively write the box to the output. @ref JxlEncoderUseBoxes must
  * be enabled before using this function.
  *
  * Background information about the container format and boxes follows here:
@@ -513,6 +513,29 @@ JXL_EXPORT JxlEncoderStatus JxlEncoderAddBox(JxlEncoder* enc, JxlBoxType type,
                                              const uint8_t* contents,
                                              size_t size,
                                              JXL_BOOL compress_box);
+
+/**
+ * Indicates the intention to add metadata boxes. This allows @ref
+ * JxlEncoderAddBox to be used. When using this function, then it is required
+ * to use @ref JxlEncoderCloseBoxes at the end.
+ *
+ * By default the encoder assumes no metadata boxes will be added.
+ *
+ * This setting can only be set at the beginning, before encoding starts.
+ *
+ * @param enc encoder object.
+ */
+JXL_EXPORT JxlEncoderStatus JxlEncoderUseBoxes(JxlEncoder* enc);
+
+/**
+ * Declares that no further boxes will be added with @ref JxlEncoderAddBox.
+ * This function must be called after the last box is added so the encoder knows
+ * the stream will be finished. It is not necessary to use this function if
+ * @ref JxlEncoderUseBoxes is not used.
+ *
+ * @param enc encoder object.
+ */
+JXL_EXPORT JxlEncoderStatus JxlEncoderCloseBoxes(JxlEncoder* enc);
 
 /**
  * Declares that this encoder will not encode any further frames. Further
@@ -643,16 +666,13 @@ JXL_EXPORT JxlEncoderStatus JxlEncoderSetExtraChannelName(JxlEncoder* enc,
 JXL_EXPORT JxlEncoderStatus JxlEncoderOptionsSetInteger(
     JxlEncoderOptions* options, JxlEncoderOptionId option, int32_t value);
 
-/** Indicates the encoder should use the box-based JPEG XL container format
- * (BMFF) instead of outputting the codestream bytes directly. Both with and
- * without container are valid JPEG XL files, but the container is necessary
- * when metadata, level 10 features or JPEG reconstruction is used.
+/** Forces the encoder to use the box-based container format (BMFF) even
+ * when not necessary.
  *
- * If enabled, the encoder always uses the container format, even if not
- * necessary. If disabled, the encoder will still use the container format if
- * required (such as for JPEG metadata @ref JxlEncoderStoreJPEGMetadata).
- *
- * This setting must be explicitely enabled before using @ref JxlEncoderAddBox.
+ * When using @ref JxlEncoderUseBoxes, @ref JxlEncoderStoreJPEGMetadata or @ref
+ * JxlEncoderSetCodestreamLevel with level 10, the encoder will automatically
+ * also use the container format, it is not necessary to use
+ * JxlEncoderUseContainer for those use cases.
  *
  * By default this setting is disabled.
  *
@@ -660,7 +680,7 @@ JXL_EXPORT JxlEncoderStatus JxlEncoderOptionsSetInteger(
  *
  * @param enc encoder object.
  * @param use_container true if the encoder should always output the JPEG XL
- * container format.
+ * container format, false to only output it when necessary.
  * @return JXL_ENC_SUCCESS if the operation was successful, JXL_ENC_ERROR
  * otherwise.
  */


### PR DESCRIPTION
Add two new functions for boxes to the encoder API, to require user to
indicate they plan to add metadata boxes, and close boxes.

The reason is: it is more efficient for the encoder, if it knows no more
boxes will follow, to output a final codestream box of unbounded size.
On the other hand, if the possibility exists that the user wants to add
a box after the final codestream box, the encoder will have to output a
box with size indicated in the header, so it must hold on to the entire
output before passing it to the user to be able to write the size in the
box header.

Without the use-boxes and close-boxes functions, the encoder would
always have to operate under the assumption a box after the codestream
could follow.

In theory it's possible to have only JxlEncoderCloseBoxes, but then the
user would always have to call it, even when not intending to use any
boxes at all, so instead only assuming there can be boxes after calling
JxlEncoderUseBoxes has less such traps.