### PR TITLE
Add JxlEncoderCloseFrames

### DIFF
--- a/lib/include/jxl/encode.h
+++ b/lib/include/jxl/encode.h
@@ -491,7 +491,7 @@ JXL_EXPORT JxlEncoderStatus JxlEncoderSetExtraChannelBuffer(
  * For now metadata boxes can only be added before or after the codestream with
  * all frames, so using JxlEncoderAddBox is only possible before the first
  * JxlEncoderAddImageFrame call, and/or after the last JxlEncoderAddImageFrame
- * call and JxlEncoderCloseInput. Support for adding boxes in-between the
+ * call and JxlEncoderCloseFrames. Support for adding boxes in-between the
  * codestream, and/or in-between image frames may be added later, and would
  * cause the encoder to use jxlp boxes for the codestream.
  *
@@ -533,6 +533,9 @@ JXL_EXPORT JxlEncoderStatus JxlEncoderUseBoxes(JxlEncoder* enc);
  * the stream will be finished. It is not necessary to use this function if
  * @ref JxlEncoderUseBoxes is not used.
  *
+ * NOTE: if you don't need to close frames and boxes at separate times, you can
+ * use @ref JxlEncoderCloseInput instead to close both at once.
+ *
  * @param enc encoder object.
  */
 JXL_EXPORT JxlEncoderStatus JxlEncoderCloseBoxes(JxlEncoder* enc);
@@ -541,9 +544,21 @@ JXL_EXPORT JxlEncoderStatus JxlEncoderCloseBoxes(JxlEncoder* enc);
  * Declares that this encoder will not encode any further frames. Further
  * metadata boxes may still be added.
  *
- * Must be called between JxlEncoderAddImageFrame/JPEGFrame of the last frame
- * and the next call to JxlEncoderProcessOutput, or JxlEncoderProcessOutput
- * won't output the last frame correctly.
+ * NOTE: if you don't need to close frames and boxes at separate times, you can
+ * use @ref JxlEncoderCloseInput instead to close both at once.
+ *
+ * @param enc encoder object.
+ */
+JXL_EXPORT void JxlEncoderCloseFrames(JxlEncoder* enc);
+
+/**
+ * Closes any input to the encoder, equivalent to calling JxlEncoderCloseFrames
+ * as well as calling JxlEncoderCloseBoxes if needed. No further input of any
+ * kind may be given to the encoder, but further @ref JxlEncoderProcessOutput
+ * calls should be done to create the final output.
+ *
+ * The requirements of both @ref JxlEncoderCloseFrames and @ref
+ * JxlEncoderCloseBoxes apply to this function.
  *
  * @param enc encoder object.
  */

--- a/lib/jxl/encode.cc
+++ b/lib/jxl/encode.cc
@@ -86,7 +86,7 @@ JxlEncoderStatus JxlEncoderStruct::RefillOutputByteQueue() {
 
   // TODO(zond): Handle progressive mode like EncodeFile does it.
   // TODO(zond): Handle animation like EncodeFile does it, by checking if
-  //             JxlEncoderCloseInput has been called and if the frame queue is
+  //             JxlEncoderCloseFrames has been called and if the frame queue is
   //             empty (to see if it's the last animation frame).
 
   if (metadata.m.xyb_encoded) {
@@ -707,7 +707,12 @@ JxlEncoderStatus JxlEncoderAddImageFrame(const JxlEncoderOptions* options,
   return JXL_ENC_SUCCESS;
 }
 
-void JxlEncoderCloseInput(JxlEncoder* enc) { enc->input_closed = true; }
+void JxlEncoderCloseFrames(JxlEncoder* enc) { enc->input_closed = true; }
+
+void JxlEncoderCloseInput(JxlEncoder* enc) {
+  JxlEncoderCloseFrames(enc);
+  // TODO(lode): also call JxlEncoderCloseBoxes once implemented
+}
 
 JxlEncoderStatus JxlEncoderProcessOutput(JxlEncoder* enc, uint8_t** next_out,
                                          size_t* avail_out) {


### PR DESCRIPTION
Edited MR description after Jon's idea to keep JxlEncoderCloseInput:

Adds the separate JxlEncoderCloseFrames to close only frames.
JxlEncoderCloseInput now closes both frames and boxes.

The individual closing can also be necessary as it helps user declare
encoder can be more efficient e.g. if more frames will be added but no
more metadata boxes.

The combined JxlEncoderCloseInput is both backwards compatible and
convenient.

(Old description below:

Rename JxlEncoderCloseInput to JxlEncoderCloseFrames

This to distinguish it from CloseBoxes. The encoder needs to know
separately when each type of input ends, to allow to correctly generate
the correct box header for the final box. The CloseInput name is quite
confusing when it only closes frames and other input like boxes can
still be added.

See https://github.com/libjxl/libjxl/pull/852 for the addition of the
close boxes function.

Given that this is a rename of an always needed function, this is a
backwards incompatible change.

I believe it's still possible to do this without affecting a large
amount of usages (unlike decoder API which would require updating several
usages). The encoder API has also not been marked as frozen.

It's also OK to not submit this MR. There'll then be a function with a
bad and possibly confusing name in the encoder API in that case, but
it remains backwards compatible.)
