### PR TITLE
make tests a bit faster

### DIFF
--- a/lib/jxl/decode_test.cc
+++ b/lib/jxl/decode_test.cc
@@ -1496,6 +1496,7 @@ TEST_P(DecodeTestParam, PixelTest) {
                                 0};
   jxl::CompressParams cparams;
   cparams.SetLossless();  // Lossless to verify pixels exactly after roundtrip.
+  cparams.speed_tier = jxl::SpeedTier::kThunder;
   cparams.resampling = config.upsampling;
   cparams.ec_resampling = config.upsampling;
   jxl::PaddedBytes compressed = jxl::CreateTestJXLCodestream(
@@ -1747,6 +1748,7 @@ TEST(DecodeTest, PixelTestWithICCProfileLossless) {
   JxlPixelFormat format_orig = {4, JXL_TYPE_UINT16, JXL_BIG_ENDIAN, 0};
   jxl::CompressParams cparams;
   cparams.SetLossless();  // Lossless to verify pixels exactly after roundtrip.
+  cparams.speed_tier = jxl::SpeedTier::kThunder;
   // For variation: some have container and no preview, others have preview
   // and no container.
   jxl::PaddedBytes compressed = jxl::CreateTestJXLCodestream(
@@ -2264,6 +2266,7 @@ TEST(DecodeTest, AlignTest) {
 
   jxl::CompressParams cparams;
   cparams.SetLossless();  // Lossless to verify pixels exactly after roundtrip.
+  cparams.speed_tier = jxl::SpeedTier::kThunder;
   jxl::PaddedBytes compressed = jxl::CreateTestJXLCodestream(
       jxl::Span<const uint8_t>(pixels.data(), pixels.size()), xsize, ysize, 4,
       cparams, kCSBF_None, JXL_ORIENT_IDENTITY, false);
@@ -2321,6 +2324,7 @@ TEST(DecodeTest, AnimationTest) {
 
   jxl::CompressParams cparams;
   cparams.SetLossless();  // Lossless to verify pixels exactly after roundtrip.
+  cparams.speed_tier = jxl::SpeedTier::kThunder;
   jxl::AuxOut aux_out;
   jxl::PaddedBytes compressed;
   jxl::PassesEncoderState enc_state;
@@ -2424,6 +2428,7 @@ TEST(DecodeTest, AnimationTestStreaming) {
 
   jxl::CompressParams cparams;
   cparams.SetLossless();  // Lossless to verify pixels exactly after roundtrip.
+  cparams.speed_tier = jxl::SpeedTier::kThunder;
   jxl::AuxOut aux_out;
   jxl::PaddedBytes compressed;
   jxl::PassesEncoderState enc_state;
@@ -2529,6 +2534,7 @@ TEST(DecodeTest, ExtraChannelTest) {
 
   jxl::CompressParams cparams;
   cparams.SetLossless();  // Lossless to verify pixels exactly after roundtrip.
+  cparams.speed_tier = jxl::SpeedTier::kThunder;
   jxl::PaddedBytes compressed = jxl::CreateTestJXLCodestream(
       jxl::Span<const uint8_t>(pixels.data(), pixels.size()), xsize, ysize, 4,
       cparams, kCSBF_None, JXL_ORIENT_IDENTITY, false);
@@ -2645,6 +2651,7 @@ TEST(DecodeTest, SkipFrameTest) {
 
   jxl::CompressParams cparams;
   cparams.SetLossless();  // Lossless to verify pixels exactly after roundtrip.
+  cparams.speed_tier = jxl::SpeedTier::kThunder;
   jxl::AuxOut aux_out;
   jxl::PaddedBytes compressed;
   jxl::PassesEncoderState enc_state;
@@ -2807,6 +2814,7 @@ TEST(DecodeTest, SkipFrameWithBlendingTest) {
 
   jxl::CompressParams cparams;
   cparams.SetLossless();  // Lossless to verify pixels exactly after roundtrip.
+  cparams.speed_tier = jxl::SpeedTier::kThunder;
   jxl::AuxOut aux_out;
   jxl::PaddedBytes compressed;
   jxl::PassesEncoderState enc_state;
@@ -3187,6 +3195,7 @@ TEST(DecodeTest, FlushTestLosslessProgressiveAlpha) {
       jxl::test::GetSomeTestImage(xsize, ysize, num_channels, 0);
   jxl::CompressParams cparams;
   cparams.SetLossless();
+  cparams.speed_tier = jxl::SpeedTier::kThunder;
   cparams.responsive = 1;
   jxl::PaddedBytes data = jxl::CreateTestJXLCodestream(
       jxl::Span<const uint8_t>(pixels.data(), pixels.size()), xsize, ysize,
@@ -3235,7 +3244,7 @@ TEST(DecodeTest, FlushTestLosslessProgressiveAlpha) {
 
   EXPECT_LE(ComparePixels(pixels2.data(), pixels.data(), xsize, ysize, format,
                           format, 2560.0),
-            1700u);
+            2700u);
 
   EXPECT_EQ(JXL_DEC_NEED_MORE_INPUT, JxlDecoderProcessInput(dec));
 
@@ -3648,6 +3657,7 @@ TEST(DecodeTest, PartialCodestreamBoxTest) {
   JxlPixelFormat format_orig = {4, JXL_TYPE_UINT16, JXL_BIG_ENDIAN, 0};
   jxl::CompressParams cparams;
   cparams.SetLossless();  // Lossless to verify pixels exactly after roundtrip.
+  cparams.speed_tier = jxl::SpeedTier::kThunder;
   jxl::PaddedBytes compressed = jxl::CreateTestJXLCodestream(
       jxl::Span<const uint8_t>(pixels.data(), pixels.size()), xsize, ysize, 4,
       cparams, kCSBF_Multi, JXL_ORIENT_IDENTITY, false, true);

--- a/lib/jxl/encode_test.cc
+++ b/lib/jxl/encode_test.cc
@@ -9,7 +9,7 @@
 #include "jxl/encode_cxx.h"
 #include "lib/extras/codec.h"
 #include "lib/jxl/dec_file.h"
-#include "lib/jxl/enc_butteraugli_comparator.h"
+#include "lib/jxl/enc_butteraugli_pnorm.h"
 #include "lib/jxl/encode_internal.h"
 #include "lib/jxl/jpeg/dec_jpeg_data.h"
 #include "lib/jxl/jpeg/dec_jpeg_data_writer.h"
@@ -198,10 +198,7 @@ void VerifyFrameEncoding(size_t xsize, size_t ysize, JxlEncoder* enc,
       dparams, jxl::Span<const uint8_t>(compressed.data(), compressed.size()),
       &decoded_io, /*pool=*/nullptr));
 
-  jxl::ButteraugliParams ba;
-  EXPECT_LE(ButteraugliDistance(input_io, decoded_io, ba,
-                                /*distmap=*/nullptr, nullptr),
-            3.0f);
+  EXPECT_LE(ComputeDistance2(input_io.Main(), decoded_io.Main()), 1.8);
 }
 
 void VerifyFrameEncoding(JxlEncoder* enc, const JxlEncoderOptions* options) {
@@ -506,8 +503,7 @@ struct Container {
 TEST(EncodeTest, SingleFrameBoundedJXLCTest) {
   JxlEncoderPtr enc = JxlEncoderMake(nullptr);
   EXPECT_NE(nullptr, enc.get());
-  EXPECT_EQ(JXL_ENC_SUCCESS, JxlEncoderUseContainer(enc.get(),
-			  true));
+  EXPECT_EQ(JXL_ENC_SUCCESS, JxlEncoderUseContainer(enc.get(), true));
   JxlEncoderOptions* options = JxlEncoderOptionsCreate(enc.get(), NULL);
 
   size_t xsize = 71;
@@ -524,7 +520,8 @@ TEST(EncodeTest, SingleFrameBoundedJXLCTest) {
   JxlColorEncoding color_encoding;
   JxlColorEncodingSetToSRGB(&color_encoding,
                             /*is_gray=*/false);
-  EXPECT_EQ(JXL_ENC_SUCCESS, JxlEncoderSetColorEncoding(enc.get(), &color_encoding));
+  EXPECT_EQ(JXL_ENC_SUCCESS,
+            JxlEncoderSetColorEncoding(enc.get(), &color_encoding));
   EXPECT_EQ(JXL_ENC_SUCCESS,
             JxlEncoderAddImageFrame(options, &pixel_format, pixels.data(),
                                     pixels.size()));
@@ -716,7 +713,7 @@ TEST(EncodeTest, JXL_TRANSCODE_JPEG_TEST(JPEGFrameTest)) {
 
       JxlEncoderPtr enc = JxlEncoderMake(nullptr);
       JxlEncoderOptions* options = JxlEncoderOptionsCreate(enc.get(), NULL);
-
+      JxlEncoderOptionsSetInteger(options, JXL_ENC_OPTION_EFFORT, 1);
       if (!skip_basic_info) {
         JxlBasicInfo basic_info;
         JxlEncoderInitBasicInfo(&basic_info);
@@ -760,10 +757,7 @@ TEST(EncodeTest, JXL_TRANSCODE_JPEG_TEST(JPEGFrameTest)) {
           jxl::Span<const uint8_t>(compressed.data(), compressed.size()),
           &decoded_io, /*pool=*/nullptr));
 
-      jxl::ButteraugliParams ba;
-      EXPECT_LE(ButteraugliDistance(orig_io, decoded_io, ba,
-                                    /*distmap=*/nullptr, nullptr),
-                2.5f);
+      EXPECT_LE(ComputeDistance2(orig_io.Main(), decoded_io.Main()), 3.5);
     }
   }
 }


### PR DESCRIPTION
As encode_test and decode_test are testing more stuff, CI is becoming quite slow. Some tests are unnecessarily slow, e.g. because default lossless encode speed is used (while the compression density / coding tools don't really matter for that test), or because Butteraugli is used when a cheaper metric is sufficient.

This makes encode_test and decode_test about twice as fast, without really changing anything.