### PR TITLE
fix MA tree size check

### DIFF
--- a/lib/jxl/dec_modular.cc
+++ b/lib/jxl/dec_modular.cc
@@ -160,7 +160,6 @@ Status ModularFrameDecoder::DecodeGlobalInfo(BitReader* reader,
     nb_chans = 1;
   }
   do_color = decode_color;
-  if (!do_color) nb_chans = 0;
   size_t nb_extra = metadata.extra_channel_info.size();
   bool has_tree = reader->ReadBits(1);
   if (has_tree) {
@@ -171,6 +170,7 @@ Status ModularFrameDecoder::DecodeGlobalInfo(BitReader* reader,
     JXL_RETURN_IF_ERROR(
         DecodeHistograms(reader, (tree.size() + 1) / 2, &code, &context_map));
   }
+  if (!do_color) nb_chans = 0;
 
   bool fp = metadata.bit_depth.floating_point_sample;
 

--- a/lib/jxl/modular/encoding/dec_ma.cc
+++ b/lib/jxl/modular/encoding/dec_ma.cc
@@ -5,6 +5,7 @@
 
 #include "lib/jxl/modular/encoding/dec_ma.h"
 
+#include "lib/jxl/base/printf_macros.h"
 #include "lib/jxl/dec_ans.h"
 #include "lib/jxl/modular/encoding/ma_common.h"
 #include "lib/jxl/modular/modular_image.h"
@@ -41,7 +42,9 @@ Status DecodeTree(BitReader *br, ANSSymbolReader *reader,
   while (to_decode > 0) {
     JXL_RETURN_IF_ERROR(br->AllReadsWithinBounds());
     if (tree->size() > tree_size_limit) {
-      return JXL_FAILURE("Tree is too large");
+      return JXL_FAILURE("Tree is too large: %" PRIuS " nodes vs %" PRIuS
+                         " max nodes",
+                         tree->size(), tree_size_limit);
     }
     to_decode--;
     uint32_t prop1 = reader->ReadHybridUint(kPropertyContext, br, context_map);


### PR DESCRIPTION
Fixes https://github.com/libjxl/libjxl/issues/848

The MA tree size check was not counting the color channels in the VarDCT case, while it should (the DC is still using modular and might benefit from a tree larger than 1024 nodes).

This now conforms to the profile spec again.

(one could argue that the dimensions should be divided by 64 for the color channels in the VarDCT case, but that's not what we specced and probably it doesn't matter that much)

The encoder still doesn't verify that it isn't generating a tree that is too large; however it seems extremely unlikely that this would happen accidentally given that the (corrected) bounds are quite generous.