### PR TITLE
call JxlDecoderCloseInput and fclose in jxlinfo

### DIFF
--- a/examples/jxlinfo.c
+++ b/examples/jxlinfo.c
@@ -67,6 +67,7 @@ int PrintBasicInfo(FILE* file) {
       }
       data_size = remaining + read_size;
       JxlDecoderSetInput(dec, data, data_size);
+      if (feof(file)) JxlDecoderCloseInput(dec);
     } else if (status == JXL_DEC_SUCCESS) {
       // Finished all processing.
       break;
@@ -319,9 +320,11 @@ int main(int argc, char* argv[]) {
   }
 
   if (!PrintBasicInfo(file)) {
+    fclose(file);
     fprintf(stderr, "Couldn't print basic info\n");
     return 1;
   }
 
+  fclose(file);
   return 0;
 }


### PR DESCRIPTION
Fixes https://github.com/libjxl/libjxl/issues/859

In principle, jxlinfo could return an error when the file ends with a not-until-eof box, since then the decoder would keep asking for more input (since there might be more boxes after that one).

@lvandeve could you check that it's calling JxlDecoderCloseInput at the correct time?