### PR TITLE
Refector encoder for box output, and support jxlp

### DIFF
--- a/lib/jxl/decode_test.cc
+++ b/lib/jxl/decode_test.cc
@@ -3371,6 +3371,10 @@ TEST(DecodeTest, ContinueFinalNonEssentialBoxTest) {
 
   EXPECT_EQ(JXL_DEC_BASIC_INFO, JxlDecoderProcessInput(dec));
   EXPECT_EQ(JXL_DEC_FRAME, JxlDecoderProcessInput(dec));
+  // The decoder returns success despite not having seen the final unknown box
+  // yet. This is because calling JxlDecoderCloseInput is not mandatory for
+  // backwards compatibility, so it doesn't know more bytes follow, the current
+  // bytes ended at a perfectly valid place.
   EXPECT_EQ(JXL_DEC_SUCCESS, JxlDecoderProcessInput(dec));
 
   size_t remaining = JxlDecoderReleaseInput(dec);

--- a/lib/jxl/encode_internal.h
+++ b/lib/jxl/encode_internal.h
@@ -25,18 +25,14 @@ typedef struct JxlEncoderOptionsValuesStruct {
   // lossless is a separate setting from cparams because it is a combination
   // setting that overrides multiple settings inside of cparams.
   bool lossless;
-  jxl::CompressParams cparams;
+  CompressParams cparams;
 } JxlEncoderOptionsValues;
-
-typedef struct JxlEncoderQueuedFrame {
-  JxlEncoderOptionsValues option_values;
-  jxl::ImageBundle frame;
-} JxlEncoderQueuedFrame;
 
 typedef std::array<uint8_t, 4> BoxType;
 
-// Utility function that makes a BoxType from a null terminated string literal.
-constexpr BoxType MakeBoxType(const char (&type)[5]) {
+// Utility function that makes a BoxType from a string literal. The string must
+// have 4 characters, a 5th null termination character is optional.
+constexpr BoxType MakeBoxType(const char* type) {
   return BoxType(
       {{static_cast<uint8_t>(type[0]), static_cast<uint8_t>(type[1]),
         static_cast<uint8_t>(type[2]), static_cast<uint8_t>(type[3])}});
@@ -48,6 +44,26 @@ constexpr unsigned char kContainerHeader[] = {
     'l', ' ', 0, 0,   0,    0,   'j', 'x', 'l', ' '};
 
 constexpr unsigned char kLevelBoxHeader[] = {0, 0, 0, 0x9, 'j', 'x', 'l', 'l'};
+
+struct JxlEncoderQueuedFrame {
+  JxlEncoderOptionsValues option_values;
+  ImageBundle frame;
+};
+
+struct JxlEncoderQueuedBox {
+  BoxType type;
+  std::vector<uint8_t> contents;
+  bool compress_box;
+};
+
+// Either a frame, or a box, not both.
+struct JxlEncoderQueuedInput {
+  JxlEncoderQueuedInput(const JxlMemoryManager& memory_manager)
+      : frame(nullptr, jxl::MemoryManagerDeleteHelper(&memory_manager)),
+        box(nullptr, jxl::MemoryManagerDeleteHelper(&memory_manager)) {}
+  MemoryManagerUniquePtr<JxlEncoderQueuedFrame> frame;
+  MemoryManagerUniquePtr<JxlEncoderQueuedBox> box;
+};
 
 namespace {
 template <typename T>
@@ -84,35 +100,50 @@ void AppendBoxHeader(const jxl::BoxType& type, size_t size, bool unbounded,
 
 }  // namespace jxl
 
+// Internal use only struct, can only be initialized correctly by
+// JxlEncoderCreate.
 struct JxlEncoderStruct {
   JxlMemoryManager memory_manager;
   jxl::MemoryManagerUniquePtr<jxl::ThreadPool> thread_pool{
       nullptr, jxl::MemoryManagerDeleteHelper(&memory_manager)};
   std::vector<jxl::MemoryManagerUniquePtr<JxlEncoderOptions>> encoder_options;
 
-  std::vector<jxl::MemoryManagerUniquePtr<jxl::JxlEncoderQueuedFrame>>
-      input_frame_queue;
+  std::vector<jxl::JxlEncoderQueuedInput> input_queue;
   std::vector<uint8_t> output_byte_queue;
 
-  bool use_container = false;
+  // Force using the container even if not needed
+  bool use_container;
+  // User declared they will add metadata boxes
+  bool use_boxes;
 
   // TODO(lode): move level into jxl::CompressParams since some C++
   // implementation decisions should be based on it: level 10 allows more
   // features to be used.
-  uint32_t codestream_level = 5;
-  bool store_jpeg_metadata = false;
+  uint32_t codestream_level;
+  bool store_jpeg_metadata;
   jxl::CodecMetadata metadata;
   std::vector<uint8_t> jpeg_metadata;
 
-  bool wrote_bytes = false;
+  // Wrote any output at all, so wrote the data before the first user added
+  // frame or box, such as signature, basic info, ICC profile or jpeg
+  // reconstruction box.
+  bool wrote_bytes;
   jxl::CompressParams last_used_cparams;
 
-  bool input_closed = false;
-  bool basic_info_set = false;
-  bool color_encoding_set = false;
+  // Encoder wrote a jxlp (partial codestream) box, so any next codestream
+  // parts must also be written in jxlp boxes, a single jxlc box cannot be
+  // used. The counter is used for the 4-byte jxlp box index header.
+  size_t jxlp_counter;
 
-  // Takes the first frame in the input_frame_queue, encodes it, and appends the
-  // bytes to the output_byte_queue.
+  bool frames_closed;
+  bool boxes_closed;
+  bool basic_info_set;
+  bool color_encoding_set;
+
+  std::vector<jxl::JxlEncoderQueuedBox> boxes;
+
+  // Takes the first frame in the input_queue, encodes it, and appends
+  // the bytes to the output_byte_queue.
   JxlEncoderStatus RefillOutputByteQueue();
 
   bool MustUseContainer() const {

--- a/lib/jxl/roundtrip_test.cc
+++ b/lib/jxl/roundtrip_test.cc
@@ -258,6 +258,9 @@ void VerifyRoundtripCompression(const size_t xsize, const size_t ysize,
                                  decoded_bytes.data(), decoded_bytes.size()));
 
   EXPECT_EQ(JXL_DEC_FULL_IMAGE, JxlDecoderProcessInput(dec));
+  // Check if there are no further errors after getting the full image, e.g.
+  // check that the final codestream box is actually marked as last.
+  EXPECT_EQ(JXL_DEC_SUCCESS, JxlDecoderProcessInput(dec));
 
   JxlDecoderDestroy(dec);
 


### PR DESCRIPTION
Various refactorings in the encoder to prepare for adding the
implementation of the add-boxes functions.

This also makes the encoder support jxlp boxes (partial codestream
boxes): it'll now add each frame in its own jxlp box, and possibly
an as early as possible jxlp box with the basic info, because it's
much simpler in the encoder to insert other boxes between frames when
using jxlp rather than a single jxlc. This is more efficient for the
decoder too since no more boxes with unbounded size are used.

Also made the decoder more strict about final jxlp being indicated:
experimenting with this new encoder feature showed that the decoder
ignored the error of not having a jxlp box marked as last.