### PR TITLE
Implement JxlEncoderAddBox in the encoder API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,11 +12,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
    `JxlDecoderGetBoxType`, `JxlDecoderGetBoxSizeRaw` and
    `JxlDecoderSetDecompressBoxes`
  - decoder API: ability to mark the input is finished: `JxlDecoderCloseInput`
+ - encoder API: ability to add metadata boxes, added new functions
+   `JxlEncoderAddBox`, `JxlEncoderUseBoxes`, `JxlEncoderCloseBoxes` and
+   `JxlEncoderCloseFrames`.
 
 ### Changed
-- decoder API: `JxlDecoderCloseInput` is required when using JXL_DEC_BOX, and
-  also encouraged, but not required for backwards compatiblity, for any other
-  usage of the decoder.
+- decoder API: using `JxlDecoderCloseInput` at the end of all input is required
+  when using JXL_DEC_BOX, and is now also encouraged in other cases, but not
+  required in those other cases for backwards compatiblity.
+- encoder API: `JxlEncoderCloseInput` now closes both frames and boxes input.
 
 ## [0.6.1] - 2021-10-29
 ### Changed

--- a/lib/include/jxl/encode.h
+++ b/lib/include/jxl/encode.h
@@ -537,7 +537,7 @@ JXL_EXPORT JxlEncoderStatus JxlEncoderUseBoxes(JxlEncoder* enc);
  *
  * @param enc encoder object.
  */
-JXL_EXPORT JxlEncoderStatus JxlEncoderCloseBoxes(JxlEncoder* enc);
+JXL_EXPORT void JxlEncoderCloseBoxes(JxlEncoder* enc);
 
 /**
  * Declares that no frames will be added and @ref JxlEncoderAddImageFrame and

--- a/lib/jxl/encode_internal.h
+++ b/lib/jxl/encode_internal.h
@@ -108,6 +108,8 @@ struct JxlEncoderStruct {
       nullptr, jxl::MemoryManagerDeleteHelper(&memory_manager)};
   std::vector<jxl::MemoryManagerUniquePtr<JxlEncoderOptions>> encoder_options;
 
+  size_t num_queued_frames;
+  size_t num_queued_boxes;
   std::vector<jxl::JxlEncoderQueuedInput> input_queue;
   std::vector<uint8_t> output_byte_queue;
 
@@ -140,14 +142,13 @@ struct JxlEncoderStruct {
   bool basic_info_set;
   bool color_encoding_set;
 
-  std::vector<jxl::JxlEncoderQueuedBox> boxes;
-
   // Takes the first frame in the input_queue, encodes it, and appends
   // the bytes to the output_byte_queue.
   JxlEncoderStatus RefillOutputByteQueue();
 
   bool MustUseContainer() const {
-    return use_container || codestream_level != 5 || store_jpeg_metadata;
+    return use_container || codestream_level != 5 || store_jpeg_metadata ||
+           use_boxes;
   }
 
   // Appends the bytes of a JXL box header with the provided type and size to


### PR DESCRIPTION
This implemented the JxlEncoderAddBox function to add boxes and enables
the test for it.

Brotli compressed boxes are not yet supported in this MR