### PR TITLE
clarify pixel_format vs JxlBasicInfo in the encode API

### DIFF
--- a/lib/include/jxl/encode.h
+++ b/lib/include/jxl/encode.h
@@ -337,10 +337,21 @@ JXL_EXPORT JxlEncoderStatus JxlEncoderAddJPEGFrame(
  * JxlEncoderSetBasicInfo before JxlEncoderAddImageFrame.
  *
  * Currently only some data types for pixel formats are supported:
- * - JXL_TYPE_UINT8
- * - JXL_TYPE_UINT16
+ * - JXL_TYPE_UINT8, with range 0..255
+ * - JXL_TYPE_UINT16, with range 0..65535
  * - JXL_TYPE_FLOAT16, with nominal range 0..1
  * - JXL_TYPE_FLOAT, with nominal range 0..1
+ *
+ * Note: the sample data type in pixel_format is allowed to be different from
+ * what is described in the JxlBasicInfo. The type in pixel_format describes the
+ * format of the uncompressed pixel buffer. The bits_per_sample and
+ * exponent_bits_per_sample in the JxlBasicInfo describes what will actually be
+ * encoded in the JPEG XL codestream. For example, to encode a 12-bit image, you
+ * would set bits_per_sample to 12, and you could use e.g. JXL_TYPE_UINT16
+ * (where the values are rescaled to 16-bit, i.e. multiplied by 65535/4095) or
+ * JXL_TYPE_FLOAT (where the values are rescaled to 0..1, i.e. multiplied
+ * by 1.f/4095.f). While it is allowed, it is obviously not recommended to use a
+ * pixel_format with lower precision than what is specified in the JxlBasicInfo.
  *
  * We support interleaved channels as described by the JxlPixelFormat:
  * - single-channel data, e.g. grayscale
@@ -357,6 +368,10 @@ JXL_EXPORT JxlEncoderStatus JxlEncoderAddJPEGFrame(
  * JxlEncoderSetICCProfile. If false, the pixels are assumed to be nonlinear
  * sRGB for integer data types (JXL_TYPE_UINT8, JXL_TYPE_UINT16), and linear
  * sRGB for floating point data types (JXL_TYPE_FLOAT16, JXL_TYPE_FLOAT).
+ * Sample values in floating-point pixel formats are allowed to be outside the
+ * nominal range, e.g. to represent out-of-sRGB-gamut colors in the
+ * uses_original_profile=false case. They are however not allowed to be NaN or
+ * +-infinity.
  *
  * @param options set of encoder options to use when encoding the frame.
  * @param pixel_format format for pixels. Object owned by the caller and its


### PR DESCRIPTION
Adds a few sentence to the encode API documentation to clarify that pixel_format and basic info can be different.