### PR TITLE
build gdk-pixbuf plugin when building for MSYS

### DIFF
--- a/plugins/CMakeLists.txt
+++ b/plugins/CMakeLists.txt
@@ -3,7 +3,7 @@
 # Use of this source code is governed by a BSD-style
 # license that can be found in the LICENSE file.
 
-if(NOT WIN32)
+if(NOT MSVC)
   add_subdirectory(gdk-pixbuf)
 endif()
 


### PR DESCRIPTION
fixes https://github.com/libjxl/libjxl/issues/647

(at least I hope it does)