### PR TITLE
fix no-coalescing fuzzerbugs

### DIFF
--- a/lib/jxl/dec_external_image.cc
+++ b/lib/jxl/dec_external_image.cc
@@ -315,11 +315,14 @@ Status ConvertChannelsToExternal(const ImageF* channels[], size_t num_channels,
   // First channel may not be nullptr.
   size_t xsize = channels[0]->xsize();
   size_t ysize = channels[0]->ysize();
-
   if (stride < bytes_per_pixel * xsize) {
     return JXL_FAILURE("stride is smaller than scanline width in bytes: %" PRIuS
                        " vs %" PRIuS,
                        stride, bytes_per_pixel * xsize);
+  }
+  if (!out_callback &&
+      out_size < (ysize - 1) * stride + bytes_per_pixel * xsize) {
+    return JXL_FAILURE("out_size is too small to store image");
   }
 
   const bool little_endian =

--- a/lib/jxl/decode.cc
+++ b/lib/jxl/decode.cc
@@ -824,6 +824,28 @@ JxlDecoderStatus JxlDecoderSetCoalescing(JxlDecoder* dec, JXL_BOOL coalescing) {
   return JXL_DEC_SUCCESS;
 }
 
+namespace {
+// helper function to get the dimensions of the current image buffer
+void GetCurrentDimensions(const JxlDecoder* dec, size_t& xsize, size_t& ysize,
+                          bool oriented) {
+  if (dec->frame_header->nonserialized_is_preview) {
+    xsize = dec->metadata.oriented_preview_xsize(dec->keep_orientation);
+    ysize = dec->metadata.oriented_preview_ysize(dec->keep_orientation);
+    return;
+  }
+  xsize = dec->metadata.oriented_xsize(dec->keep_orientation || !oriented);
+  ysize = dec->metadata.oriented_ysize(dec->keep_orientation || !oriented);
+  if (!dec->coalescing) {
+    xsize = dec->frame_header->ToFrameDimensions().xsize;
+    ysize = dec->frame_header->ToFrameDimensions().ysize;
+    if (!dec->keep_orientation && oriented &&
+        static_cast<int>(dec->metadata.m.GetOrientation()) > 4) {
+      std::swap(xsize, ysize);
+    }
+  }
+}
+}  // namespace
+
 namespace jxl {
 namespace {
 
@@ -992,15 +1014,9 @@ JxlDecoderStatus JxlDecoderReadAllHeaders(JxlDecoder* dec, const uint8_t* in,
   return JXL_DEC_SUCCESS;
 }
 
-static size_t GetStride(const JxlDecoder* dec, const JxlPixelFormat& format,
-                        const jxl::ImageBundle* frame = nullptr) {
-  size_t xsize = dec->metadata.xsize();
-  if (!dec->keep_orientation && dec->metadata.m.orientation > 4) {
-    xsize = dec->metadata.ysize();
-  }
-  if (frame) {
-    xsize = dec->keep_orientation ? frame->xsize() : frame->oriented_xsize();
-  }
+static size_t GetStride(const JxlDecoder* dec, const JxlPixelFormat& format) {
+  size_t xsize, ysize;
+  GetCurrentDimensions(dec, xsize, ysize, true);
   size_t stride = xsize * (BitsPerChannel(format.data_type) *
                            format.num_channels / jxl::kBitsPerByte);
   if (format.align > 1) {
@@ -1022,7 +1038,7 @@ static JxlDecoderStatus ConvertImageInternal(
     JxlImageOutCallback out_callback, void* out_opaque) {
   // TODO(lode): handle mismatch of RGB/grayscale color profiles and pixel data
   // color/grayscale format
-  const size_t stride = GetStride(dec, format, &frame);
+  const size_t stride = GetStride(dec, format);
 
   bool float_format = format.data_type == JXL_TYPE_FLOAT ||
                       format.data_type == JXL_TYPE_FLOAT16;
@@ -2347,21 +2363,6 @@ JxlDecoderStatus PrepareSizeCheck(const JxlDecoder* dec,
   }
 
   return JXL_DEC_SUCCESS;
-}
-
-// helper function to get the dimensions of the current image buffer
-void GetCurrentDimensions(const JxlDecoder* dec, size_t& xsize, size_t& ysize,
-                          bool oriented) {
-  xsize = dec->metadata.oriented_xsize(dec->keep_orientation || !oriented);
-  ysize = dec->metadata.oriented_ysize(dec->keep_orientation || !oriented);
-  if (!dec->coalescing) {
-    xsize = dec->frame_header->ToFrameDimensions().xsize;
-    ysize = dec->frame_header->ToFrameDimensions().ysize;
-    if (!dec->keep_orientation && oriented &&
-        static_cast<int>(dec->metadata.m.GetOrientation()) > 4) {
-      std::swap(xsize, ysize);
-    }
-  }
 }
 
 }  // namespace


### PR DESCRIPTION
~~Couldn't find any fuzzerbugs running it locally for a short while, but still good to test both coalesced and non-coalesced decoding to find potential bugs.~~

Fixes a fuzzer-found bug in the uint8 buffer case (where stride was not computed correctly in the no-coalescing case).
Also adds an ASSERT in dec_external_image to hopefully find more such bugs and to turn buffer overruns into an abort.