### PR TITLE
Test fix: In conformance tests, use liblcms2.so.2 rather than liblcms…

### DIFF
--- a/tools/conformance/lcms2.py
+++ b/tools/conformance/lcms2.py
@@ -9,7 +9,7 @@ from numpy.ctypeslib import ndpointer
 import numpy
 import os
 
-lcms2_lib_path = os.getenv("LCMS2_LIB_PATH", "liblcms2.so")
+lcms2_lib_path = os.getenv("LCMS2_LIB_PATH", "liblcms2.so.2")
 lcms2_lib = ctypes.cdll.LoadLibrary(lcms2_lib_path)
 
 native_open_profile = lcms2_lib.cmsOpenProfileFromMem


### PR DESCRIPTION
…2.so

The latter only exists on some Linux distributions.