### PR TITLE
header only: proposed encoder animation API

### DIFF
--- a/lib/include/jxl/codestream_header.h
+++ b/lib/include/jxl/codestream_header.h
@@ -369,11 +369,16 @@ typedef struct {
   uint32_t timecode;
 
   /** Length of the frame name in bytes, or 0 if no name.
-   * Excludes null termination character.
+   * Excludes null termination character. This value is set by the decoder.
+   * For the encoder, this value is ignored and @ref JxlEncoderSetFrameName is
+   * used instead to set the name and the length.
    */
   uint32_t name_length;
 
-  /** Indicates this is the last animation frame.
+  /** Indicates this is the last animation frame. This value is set by the
+   * decoder to indicate no further frames follow. For the encoder, it is not
+   * required to set this value and it is ignored, @ref JxlEncoderCloseFrames is
+   * used to indicate the last frame to the encoder instead.
    */
   JXL_BOOL is_last;
 


### PR DESCRIPTION
Adds function for setting the frame header containing animation
duration. Header-only, no implementation yet.

This change is open for discussion: let's find the best way to add this
to the encoder.

In this proposal, this setting is set to the JxlEncoderOptions, because
JxlEncoderOptions ara in reality frame options. The frame header
belongs to a frame, so setting its information to JxlEncoderOptions looks more
logical than setting it to JxlEncoder directly. Other opinions are
welcome.

JxlEncoderOptions is a confusing, JxlFrameOptions or similar could have
been a better name, you cannot use it to set boxes-related options to
the encoder for example. To clear this up, I also renamed it "frame_options"
wherever it was called "options" before and improved its documentation where used.
