### PR TITLE
Write animation in basic info in encoder

### DIFF
--- a/lib/jxl/encode.cc
+++ b/lib/jxl/encode.cc
@@ -369,6 +369,22 @@ JxlEncoderStatus JxlEncoderSetBasicInfo(JxlEncoder* enc,
       info->relative_to_max_display;
   enc->metadata.m.tone_mapping.linear_below = info->linear_below;
   enc->basic_info_set = true;
+
+  enc->metadata.m.have_animation = info->have_animation;
+  if (info->have_animation) {
+    if (info->animation.tps_denominator < 1) {
+      return JXL_API_ERROR(
+          "If animation is used, tps_denominator must be >= 1");
+    }
+    if (info->animation.tps_numerator < 1) {
+      return JXL_API_ERROR("If animation is used, tps_numerator must be >= 1");
+    }
+    enc->metadata.m.animation.tps_numerator = info->animation.tps_numerator;
+    enc->metadata.m.animation.tps_denominator = info->animation.tps_denominator;
+    enc->metadata.m.animation.num_loops = info->animation.num_loops;
+    enc->metadata.m.animation.have_timecodes = info->animation.have_timecodes;
+  }
+
   return JXL_ENC_SUCCESS;
 }
 


### PR DESCRIPTION
This writes the animation settings to the main image header. This is
part of what is needed to fully support animation, but does not yet
allow setting the time of each individual frame.

This change inadvertedly ended up in the header-only pull request https://github.com/libjxl/libjxl/pull/909

Implemented in a separate pull request now, and added test for this (and
most other basic info as well)