### PR TITLE
Don’t use designated initializers

### DIFF
--- a/lib/jxl/enc_color_management.cc
+++ b/lib/jxl/enc_color_management.cc
@@ -935,12 +935,12 @@ float* JxlCmsGetDstBuf(void* cms_data, size_t thread) {
 
 const JxlCmsInterface& GetJxlCms() {
   static constexpr JxlCmsInterface kInterface = {
-      .init_data = nullptr,
-      .init = &JxlCmsInit,
-      .get_src_buf = &JxlCmsGetSrcBuf,
-      .get_dst_buf = &JxlCmsGetDstBuf,
-      .run = &DoColorSpaceTransform,
-      .destroy = &JxlCmsDestroy};
+      /*init_data=*/nullptr,
+      /*init=*/&JxlCmsInit,
+      /*get_src_buf=*/&JxlCmsGetSrcBuf,
+      /*get_dst_buf=*/&JxlCmsGetDstBuf,
+      /*run=*/&DoColorSpaceTransform,
+      /*destroy=*/&JxlCmsDestroy};
   return kInterface;
 }
 


### PR DESCRIPTION
They are technically a C++20 feature and MSVC complains.