### PR TITLE
Implement the simple render pipeline.

### DIFF
--- a/lib/jxl.cmake
+++ b/lib/jxl.cmake
@@ -196,6 +196,7 @@ set(JPEGXL_INTERNAL_SOURCES_DEC
   jxl/render_pipeline/render_pipeline_stage.h
   jxl/render_pipeline/simple_render_pipeline.cc
   jxl/render_pipeline/simple_render_pipeline.h
+  jxl/render_pipeline/test_render_pipeline_stages.h
   jxl/sanitizers.h
   jxl/splines.cc
   jxl/splines.h

--- a/lib/jxl/render_pipeline/low_memory_render_pipeline.cc
+++ b/lib/jxl/render_pipeline/low_memory_render_pipeline.cc
@@ -6,7 +6,7 @@
 #include "lib/jxl/render_pipeline/low_memory_render_pipeline.h"
 
 namespace jxl {
-void LowMemoryRenderPipeline::PrepareForThreads(size_t num) {
+void LowMemoryRenderPipeline::PrepareForThreadsInternal(size_t num) {
   JXL_ABORT("Not implemented");
 }
 

--- a/lib/jxl/render_pipeline/low_memory_render_pipeline.h
+++ b/lib/jxl/render_pipeline/low_memory_render_pipeline.h
@@ -16,12 +16,10 @@ namespace jxl {
 // A multithreaded, low-memory rendering pipeline that only allocates a minimal
 // amount of buffers.
 class LowMemoryRenderPipeline : public RenderPipeline {
- public:
-  void PrepareForThreads(size_t num) override;
-
- private:
   std::vector<std::pair<ImageF*, Rect>> PrepareBuffers(
       size_t group_id, size_t thread_id) override;
+
+  void PrepareForThreadsInternal(size_t num) override;
 
   void ProcessBuffers(size_t group_id, size_t thread_id) override;
 };

--- a/lib/jxl/render_pipeline/render_pipeline.cc
+++ b/lib/jxl/render_pipeline/render_pipeline.cc
@@ -117,6 +117,18 @@ void RenderPipeline::InputReady(
   ProcessBuffers(group_id, thread_id);
 }
 
+void RenderPipeline::PrepareForThreads(size_t num) {
+  temp_buffers_.resize(num);
+  for (auto& thread_buffers : temp_buffers_) {
+    thread_buffers.reserve(stages_.size());
+    for (const auto& stage : stages_) {
+      thread_buffers.push_back(
+          AllocateArray(sizeof(float) * stage->settings_.temp_buffer_size));
+    }
+  }
+  PrepareForThreadsInternal(num);
+}
+
 RenderPipelineInput::~RenderPipelineInput() {
   if (pipeline_) {
     pipeline_->InputReady(group_id_, thread_id_, buffers_);

--- a/lib/jxl/render_pipeline/render_pipeline_test.cc
+++ b/lib/jxl/render_pipeline/render_pipeline_test.cc
@@ -13,42 +13,16 @@
 #include <vector>
 
 #include "gtest/gtest.h"
+#include "lib/jxl/render_pipeline/test_render_pipeline_stages.h"
 
 namespace jxl {
 namespace {
 
-class TrivialStage : public RenderPipelineStage {
- public:
-  TrivialStage(size_t shift, size_t border)
-      : RenderPipelineStage(
-            RenderPipelineStage::Settings::Symmetric(shift, border)) {}
-
-  void ProcessRow(RowInfo input_rows, RowInfo output_rows, size_t xextra,
-                  size_t xsize, size_t xpos, size_t ypos,
-                  float* JXL_RESTRICT temp) const final {}
-
-  RenderPipelineChannelMode GetChannelMode(size_t c) const final {
-    return RenderPipelineChannelMode::kInOut;
-  }
-};
-class FinalTrivialStage : public RenderPipelineStage {
- public:
-  FinalTrivialStage() : RenderPipelineStage(RenderPipelineStage::Settings()) {}
-
-  void ProcessRow(RowInfo input_rows, RowInfo output_rows, size_t xextra,
-                  size_t xsize, size_t xpos, size_t ypos,
-                  float* JXL_RESTRICT temp) const final {}
-
-  RenderPipelineChannelMode GetChannelMode(size_t c) const final {
-    return RenderPipelineChannelMode::kInput;
-  }
-};
-
 TEST(RenderPipelineTest, Build) {
   RenderPipeline::Builder builder(/*channel_shifts=*/{{1, 1}});
-  builder.AddStage(jxl::make_unique<TrivialStage>(1, 1));  // shift, border
-  builder.AddStage(jxl::make_unique<TrivialStage>(0, 2));  // no shift, border
-  builder.AddStage(jxl::make_unique<FinalTrivialStage>());
+  builder.AddStage(jxl::make_unique<UpsampleXSlowStage>());
+  builder.AddStage(jxl::make_unique<UpsampleYSlowStage>());
+  builder.AddStage(jxl::make_unique<Check0FinalStage>());
   builder.UseSimpleImplementation();
   FrameDimensions frame_dimensions;
   frame_dimensions.Set(/*xsize=*/1024, /*ysize=*/1024, /*group_size_shift=*/0,
@@ -59,9 +33,9 @@ TEST(RenderPipelineTest, Build) {
 
 TEST(RenderPipelineTest, CallAllGroups) {
   RenderPipeline::Builder builder({{1, 1}});
-  builder.AddStage(jxl::make_unique<TrivialStage>(1, 1));  // shift, border
-  builder.AddStage(jxl::make_unique<TrivialStage>(0, 2));  // no shift, border
-  builder.AddStage(jxl::make_unique<FinalTrivialStage>());
+  builder.AddStage(jxl::make_unique<UpsampleXSlowStage>());
+  builder.AddStage(jxl::make_unique<UpsampleYSlowStage>());
+  builder.AddStage(jxl::make_unique<Check0FinalStage>());
   builder.UseSimpleImplementation();
   FrameDimensions frame_dimensions;
   frame_dimensions.Set(/*xsize=*/1024, /*ysize=*/1024, /*group_size_shift=*/0,
@@ -72,17 +46,11 @@ TEST(RenderPipelineTest, CallAllGroups) {
 
   for (size_t i = 0; i < frame_dimensions.num_groups; i++) {
     const auto& input_buffers = pipeline->GetInputBuffers(i, 0);
-    (void)input_buffers;
-    /*
-    TODO(veluca): call this function once the render pipeline actually prepares
-    buffers.
-
     FillPlane(0.0f, input_buffers.GetBuffer(0).first,
               input_buffers.GetBuffer(0).second);
-    */
   }
 
-  EXPECT_TRUE(pipeline->IsDone());
+  EXPECT_TRUE(pipeline->ReceivedAllInput());
 }
 
 }  // namespace

--- a/lib/jxl/render_pipeline/simple_render_pipeline.cc
+++ b/lib/jxl/render_pipeline/simple_render_pipeline.cc
@@ -6,16 +6,169 @@
 #include "lib/jxl/render_pipeline/simple_render_pipeline.h"
 
 namespace jxl {
-void SimpleRenderPipeline::PrepareForThreads(size_t num) {
-  // TODO(veluca): actually allocate input buffers.
+void SimpleRenderPipeline::PrepareForThreadsInternal(size_t num) {
+  auto ch_size = [](size_t frame_size, size_t shift) {
+    return DivCeil(frame_size, 1 << shift) + kRenderPipelineXOffset * 2;
+  };
+  for (auto ch_shifts : channel_shifts_[0]) {
+    channel_data_.push_back(
+        ImageF(ch_size(frame_dimensions_.xsize_padded, ch_shifts.first),
+               ch_size(frame_dimensions_.ysize_padded, ch_shifts.second)));
+  }
 }
 
 std::vector<std::pair<ImageF*, Rect>> SimpleRenderPipeline::PrepareBuffers(
     size_t group_id, size_t thread_id) {
-  return {};
+  std::vector<std::pair<ImageF*, Rect>> ret;
+  std::pair<size_t, size_t> min_color_shifts{64, 64};
+  for (size_t c = 0; c < channel_data_.size() && c < 3; c++) {
+    min_color_shifts.first =
+        std::min(min_color_shifts.first, channel_shifts_[0][c].first);
+    min_color_shifts.second =
+        std::min(min_color_shifts.first, channel_shifts_[0][c].second);
+  }
+  for (size_t c = 0; c < channel_data_.size(); c++) {
+    const size_t gx = group_id % frame_dimensions_.xsize_groups;
+    const size_t gy = group_id / frame_dimensions_.xsize_groups;
+    size_t xgroupdim =
+        (frame_dimensions_.group_dim << min_color_shifts.first) >>
+        channel_shifts_[0][c].first;
+    size_t ygroupdim =
+        (frame_dimensions_.group_dim << min_color_shifts.second) >>
+        channel_shifts_[0][c].second;
+    const Rect rect(kRenderPipelineXOffset + gx * xgroupdim,
+                    kRenderPipelineXOffset + gy * ygroupdim, xgroupdim,
+                    ygroupdim,
+                    kRenderPipelineXOffset + frame_dimensions_.xsize_padded,
+                    kRenderPipelineXOffset + frame_dimensions_.ysize_padded);
+    ret.emplace_back(&channel_data_[c], rect);
+  }
+  return ret;
 }
 
 void SimpleRenderPipeline::ProcessBuffers(size_t group_id, size_t thread_id) {
-  // TODO(veluca): actually run the pipeline.
+  if (!ReceivedAllInput()) return;
+  for (size_t stage_id = 0; stage_id < stages_.size(); stage_id++) {
+    const auto& stage = stages_[stage_id];
+    // Prepare buffers for kInOut channels.
+    std::vector<ImageF> new_channels(channel_data_.size());
+    std::vector<ImageF*> output_channels(channel_data_.size());
+
+    std::vector<std::pair<size_t, size_t>> input_sizes(channel_data_.size());
+    for (size_t c = 0; c < channel_data_.size(); c++) {
+      input_sizes[c] =
+          std::make_pair(channel_data_[c].xsize() - kRenderPipelineXOffset * 2,
+                         channel_data_[c].ysize() - kRenderPipelineXOffset * 2);
+    }
+
+    for (size_t c = 0; c < channel_data_.size(); c++) {
+      if (stage->GetChannelMode(c) != RenderPipelineChannelMode::kInOut) {
+        continue;
+      }
+      new_channels[c] =
+          ImageF((input_sizes[c].first << stage->settings_.shift_x) +
+                     kRenderPipelineXOffset * 2,
+                 (input_sizes[c].second << stage->settings_.shift_y) +
+                     kRenderPipelineXOffset * 2);
+      output_channels[c] = &new_channels[c];
+    }
+
+    auto get_row = [&](size_t c, int64_t y) {
+      return channel_data_[c].Row(kRenderPipelineXOffset + y) +
+             kRenderPipelineXOffset;
+    };
+
+    // Add mirrored pixes to all kInOut channels.
+    for (size_t c = 0; c < channel_data_.size(); c++) {
+      if (stage->GetChannelMode(c) != RenderPipelineChannelMode::kInOut) {
+        continue;
+      }
+      // Horizontal mirroring.
+      for (size_t y = 0; y < input_sizes[c].second; y++) {
+        float* row = get_row(c, y);
+        for (size_t ix = 0; ix < stage->settings_.border_x; ix++) {
+          *(row - ix - 1) = *(row + ix);
+          *(row + ix + input_sizes[c].first) =
+              *(row + input_sizes[c].first - ix - 1);
+        }
+      }
+      // Vertical mirroring.
+      for (int iy = 0; iy < static_cast<int>(stage->settings_.border_y); iy++) {
+        memcpy(get_row(c, -iy - 1) - stage->settings_.border_x,
+               get_row(c, iy) - stage->settings_.border_x,
+               sizeof(float) *
+                   (input_sizes[c].first + 2 * stage->settings_.border_x));
+        memcpy(
+            get_row(c, input_sizes[c].second + iy) - stage->settings_.border_x,
+            get_row(c, input_sizes[c].second - iy - 1) -
+                stage->settings_.border_x,
+            sizeof(float) *
+                (input_sizes[c].first + 2 * stage->settings_.border_x));
+      }
+    }
+
+    // All non-ignored channels should have the same size.
+    constexpr size_t kInf = size_t(-1);
+    size_t ysize = kInf;
+    size_t xsize = kInf;
+    for (size_t c = 0; c < channel_data_.size(); c++) {
+      if (stage->GetChannelMode(c) == RenderPipelineChannelMode::kIgnored) {
+        continue;
+      }
+      JXL_ASSERT(ysize == input_sizes[c].second || ysize == kInf);
+      ysize = input_sizes[c].second;
+      JXL_ASSERT(xsize == input_sizes[c].first || xsize == kInf);
+      xsize = input_sizes[c].first;
+    }
+
+    JXL_ASSERT(ysize != kInf);
+    JXL_ASSERT(xsize != kInf);
+
+    RenderPipelineStage::RowInfo input_rows(channel_data_.size());
+    RenderPipelineStage::RowInfo output_rows(channel_data_.size());
+
+    // Run the pipeline.
+    {
+      int border_y = stage->settings_.border_y;
+      for (size_t y = 0; y < ysize; y++) {
+        // Prepare input rows.
+        for (size_t c = 0; c < channel_data_.size(); c++) {
+          input_rows[c].resize(2 * border_y + 1);
+          for (int iy = -border_y; iy <= border_y; iy++) {
+            input_rows[c][iy + border_y] =
+                channel_data_[c].Row(y + kRenderPipelineXOffset + iy);
+          }
+        }
+        // Prepare output rows.
+        for (size_t c = 0; c < channel_data_.size(); c++) {
+          if (!output_channels[c]) continue;
+          output_rows[c].resize(1 << stage->settings_.shift_y);
+          for (size_t iy = 0; iy < output_rows[c].size(); iy++) {
+            output_rows[c][iy] = output_channels[c]->Row(
+                (y << stage->settings_.shift_y) + iy + kRenderPipelineXOffset);
+          }
+        }
+        stage->ProcessRow(
+            input_rows, output_rows, /*xextra=*/0, xsize,
+            /*xpos=*/0, /*ypos=*/0,
+            reinterpret_cast<float*>(temp_buffers_[thread_id][stage_id].get()));
+      }
+    }
+
+    // Move new channels to current channels.
+    for (size_t c = 0; c < channel_data_.size(); c++) {
+      if (stage->GetChannelMode(c) != RenderPipelineChannelMode::kInOut) {
+        continue;
+      }
+      channel_data_[c] = std::move(new_channels[c]);
+    }
+    for (const auto& ch : channel_data_) {
+      (void)ch;
+      JXL_CHECK_IMAGE_INITIALIZED(
+          ch, Rect(kRenderPipelineXOffset, kRenderPipelineXOffset,
+                   ch.xsize() - 2 * kRenderPipelineXOffset,
+                   ch.ysize() - 2 * kRenderPipelineXOffset));
+    }
+  }
 }
 }  // namespace jxl

--- a/lib/jxl/render_pipeline/simple_render_pipeline.h
+++ b/lib/jxl/render_pipeline/simple_render_pipeline.h
@@ -17,14 +17,18 @@ namespace jxl {
 // amounts of memory and be slow. It is intended to be used mostly for testing
 // purposes.
 class SimpleRenderPipeline : public RenderPipeline {
- public:
-  void PrepareForThreads(size_t num) override;
-
- private:
   std::vector<std::pair<ImageF*, Rect>> PrepareBuffers(
       size_t group_id, size_t thread_id) override;
 
   void ProcessBuffers(size_t group_id, size_t thread_id) override;
+
+  void RunPipeline();
+
+  void PrepareForThreadsInternal(size_t num) override;
+
+  // Full frame buffers. Both X and Y dimensions are padded by
+  // kRenderPipelineXOffset.
+  std::vector<ImageF> channel_data_;
 };
 
 }  // namespace jxl

--- a/lib/jxl/render_pipeline/test_render_pipeline_stages.h
+++ b/lib/jxl/render_pipeline/test_render_pipeline_stages.h
@@ -1,0 +1,98 @@
+// Copyright (c) the JPEG XL Project Authors. All rights reserved.
+//
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+#include <math.h>
+#include <stdint.h>
+#include <stdio.h>
+
+#include <algorithm>
+#include <utility>
+#include <vector>
+
+#include "gtest/gtest.h"
+#include "lib/jxl/render_pipeline/render_pipeline_stage.h"
+
+namespace jxl {
+
+class UpsampleXSlowStage : public RenderPipelineStage {
+ public:
+  UpsampleXSlowStage()
+      : RenderPipelineStage(RenderPipelineStage::Settings::ShiftX(1, 1)) {}
+
+  void ProcessRow(const RowInfo& input_rows, const RowInfo& output_rows,
+                  size_t xextra, size_t xsize, size_t xpos, size_t ypos,
+                  float* JXL_RESTRICT temp) const final {
+    for (size_t c = 0; c < input_rows.size(); c++) {
+      const float* row = GetInputRow(input_rows, c, 0);
+      float* row_out = GetOutputRow(output_rows, c, 0);
+      for (int64_t x = -xextra; x < (int64_t)(xsize + xextra); x++) {
+        float xp = row[x + kRenderPipelineXOffset - 1];
+        float xc = row[x + kRenderPipelineXOffset];
+        float xn = row[x + kRenderPipelineXOffset + 1];
+        float xout0 = xp * 0.25f + xc * 0.75f;
+        float xout1 = xc * 0.75f + xn * 0.25f;
+        row_out[kRenderPipelineXOffset + 2 * x + 0] = xout0;
+        row_out[kRenderPipelineXOffset + 2 * x + 1] = xout1;
+      }
+    }
+  }
+
+  RenderPipelineChannelMode GetChannelMode(size_t c) const final {
+    return RenderPipelineChannelMode::kInOut;
+  }
+};
+
+class UpsampleYSlowStage : public RenderPipelineStage {
+ public:
+  UpsampleYSlowStage()
+      : RenderPipelineStage(RenderPipelineStage::Settings::ShiftY(1, 1)) {}
+
+  void ProcessRow(const RowInfo& input_rows, const RowInfo& output_rows,
+                  size_t xextra, size_t xsize, size_t xpos, size_t ypos,
+                  float* JXL_RESTRICT temp) const final {
+    for (size_t c = 0; c < input_rows.size(); c++) {
+      const float* rowp = GetInputRow(input_rows, c, -1);
+      const float* rowc = GetInputRow(input_rows, c, 0);
+      const float* rown = GetInputRow(input_rows, c, 1);
+      float* row_out0 = GetOutputRow(output_rows, c, 0);
+      float* row_out1 = GetOutputRow(output_rows, c, 1);
+      for (int64_t x = -xextra; x < (int64_t)(xsize + xextra); x++) {
+        float xp = rowp[x + kRenderPipelineXOffset];
+        float xc = rowc[x + kRenderPipelineXOffset];
+        float xn = rown[x + kRenderPipelineXOffset];
+        float yout0 = xp * 0.25f + xc * 0.75f;
+        float yout1 = xc * 0.75f + xn * 0.25f;
+        row_out0[kRenderPipelineXOffset + x] = yout0;
+        row_out1[kRenderPipelineXOffset + x] = yout1;
+      }
+    }
+  }
+
+  RenderPipelineChannelMode GetChannelMode(size_t c) const final {
+    return RenderPipelineChannelMode::kInOut;
+  }
+};
+
+class Check0FinalStage : public RenderPipelineStage {
+ public:
+  Check0FinalStage() : RenderPipelineStage(RenderPipelineStage::Settings()) {}
+
+  void ProcessRow(const RowInfo& input_rows, const RowInfo& output_rows,
+                  size_t xextra, size_t xsize, size_t xpos, size_t ypos,
+                  float* JXL_RESTRICT temp) const final {
+    for (size_t c = 0; c < input_rows.size(); c++) {
+      for (size_t x = 0; x < xsize; x++) {
+        JXL_CHECK(fabsf(GetInputRow(input_rows, c,
+                                    0)[x + kRenderPipelineXOffset]) < 1e-8);
+      }
+    }
+  }
+
+  RenderPipelineChannelMode GetChannelMode(size_t c) const final {
+    return RenderPipelineChannelMode::kInput;
+  }
+};
+
+}  // namespace jxl

--- a/lib/lib.gni
+++ b/lib/lib.gni
@@ -214,6 +214,7 @@ libjxl_dec_sources = [
     "jxl/render_pipeline/render_pipeline_stage.h",
     "jxl/render_pipeline/simple_render_pipeline.cc",
     "jxl/render_pipeline/simple_render_pipeline.h",
+    "jxl/render_pipeline/test_render_pipeline_stages.h",
     "jxl/sanitizers.h",
     "jxl/splines.cc",
     "jxl/splines.h",


### PR DESCRIPTION
The pipeline is single-threaded and uses a large amount of memory.
Also modify trivial stages to test the behaviour of the pipeline, by
checking that downsampled all-0 input is upsampled to all-0.