### PR TITLE
Rename JxlEncoderOptions to JxlEncoderFrameSettings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,12 +23,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
    the non-coalesced case.
  - decoder API: new function `JxlDecoderGetExtraChannelBlendInfo` to get
    the blending information for extra channels in the non-coalesced case.
+ - encoder API: added ability to set several encoder options to frames using
+   `JxlEncoderFrameSettingsSetOption`
 
 ### Changed
 - decoder API: using `JxlDecoderCloseInput` at the end of all input is required
   when using JXL_DEC_BOX, and is now also encouraged in other cases, but not
   required in those other cases for backwards compatiblity.
 - encoder API: `JxlEncoderCloseInput` now closes both frames and boxes input.
+
+### Deprecated
+- encoder API: `JxlEncoderOptions`: use `JxlEncoderFrameSettings` instead
+- encoder API: `JxlEncoderOptionsCreate`: use `JxlEncoderFrameSettingsCreate`
+  instead
+- encoder API: `JxlEncoderOptionsSetDistance`: use `JxlEncoderSetFrameDistance`
+  instead
+- encoder API: `JxlEncoderOptionsSetLossless`: use `JxlEncoderSetFrameLossless`
+  instead
+- encoder API: `JxlEncoderOptionsSetEffort`: use `JxlEncoderFrameSettingsSetOption(
+  frame_settings, JXL_ENC_FRAME_SETTING_EFFORT, effort)` instead.
+- encoder API: `JxlEncoderOptionsSetDecodingSpeed`: use
+  `JxlEncoderFrameSettingsSetOption(frame_settings,
+  JXL_ENC_FRAME_SETTING_DECODING_SPEED, tier)` instead.
 
 ## [0.6.1] - 2021-10-29
 ### Changed

--- a/examples/encode_oneshot.cc
+++ b/examples/encode_oneshot.cc
@@ -184,7 +184,7 @@ bool EncodeJxlOneshot(const std::vector<float>& pixels, const uint32_t xsize,
   }
 
   if (JXL_ENC_SUCCESS !=
-      JxlEncoderAddImageFrame(JxlEncoderOptionsCreate(enc.get(), nullptr),
+      JxlEncoderAddImageFrame(JxlEncoderFrameSettingsCreate(enc.get(), nullptr),
                               &pixel_format, (void*)pixels.data(),
                               sizeof(float) * pixels.size())) {
     fprintf(stderr, "JxlEncoderAddImageFrame failed\n");

--- a/lib/include/jxl/codestream_header.h
+++ b/lib/include/jxl/codestream_header.h
@@ -370,8 +370,9 @@ typedef struct {
 
   /** Length of the frame name in bytes, or 0 if no name.
    * Excludes null termination character. This value is set by the decoder.
-   * For the encoder, this value is ignored and @ref JxlEncoderSetFrameName is
-   * used instead to set the name and the length.
+   * For the encoder, this value is ignored and @ref
+   * JxlEncoderFrameSettingsSetName is used instead to set the name and the
+   * length.
    */
   uint32_t name_length;
 

--- a/lib/include/jxl/encode.h
+++ b/lib/include/jxl/encode.h
@@ -41,18 +41,18 @@ JXL_EXPORT uint32_t JxlEncoderVersion(void);
 typedef struct JxlEncoderStruct JxlEncoder;
 
 /**
- * The settings for a single image frame to be encoded with the JXL encoder.
- * This includes options such as compression speed, as well as frame metadata.
+ * Settings and metadata for a single image frame. This includes encoder options
+ * for a frame such as compression quality and speed.
  *
- * Despite the name JxlEncoderOptions, it represents settings of a frame, not
- * the entire encoder. Most settings, such as image quality and speed settings,
- * are frame settings though.
- *
- * Allocated and initialized with JxlEncoderOptionsCreate().
+ * Allocated and initialized with JxlEncoderFrameSettingsCreate().
  * Cleaned up and deallocated when the encoder is destroyed with
  * JxlEncoderDestroy().
  */
-typedef struct JxlEncoderOptionsStruct JxlEncoderOptions;
+typedef struct JxlEncoderFrameSettingsStruct JxlEncoderFrameSettings;
+
+/** DEPRECATED: Use JxlEncoderFrameSettings instead.
+ */
+typedef JxlEncoderFrameSettings JxlEncoderOptions;
 
 /**
  * Return value for multiple encoder functions.
@@ -78,12 +78,9 @@ typedef enum {
 } JxlEncoderStatus;
 
 /**
- * Id of per-frame options to set to JxlEncoderOptions with
- * JxlEncoderOptionsSetInteger.
- * NOTE: this enum includes most but not all encoder options. The image quality
- * is a frame option that can be set with JxlEncoderOptionsSetDistance instead.
- * Options that apply globally, rather than per-frame, are set with their own
- * functions and do not use the per-frame JxlEncoderOptions.
+ * Id of encoder options for a frame. This includes options such as the
+ * image quality and compression speed for this frame. This does not include
+ * non-frame related encoder options such as for boxes.
  */
 typedef enum {
   /** Sets encoder effort/speed level without affecting decoding speed. Valid
@@ -91,13 +88,13 @@ typedef enum {
    * 4:cheetah 5:hare 6:wombat 7:squirrel 8:kitten 9:tortoise.
    * Default: squirrel (7).
    */
-  JXL_ENC_OPTION_EFFORT = 0,
+  JXL_ENC_FRAME_SETTING_EFFORT = 0,
 
   /** Sets the decoding speed tier for the provided options. Minimum is 0
    * (slowest to decode, best quality/density), and maximum is 4 (fastest to
    * decode, at the cost of some quality/density). Default is 0.
    */
-  JXL_ENC_OPTION_DECODING_SPEED = 1,
+  JXL_ENC_FRAME_SETTING_DECODING_SPEED = 1,
 
   /** Sets resampling option. If enabled, the image is downsampled before
    * compression, and upsampled to original size in the decoder. Integer option,
@@ -105,161 +102,161 @@ typedef enum {
    * 1 for no downsampling (1x1), 2 for 2x2 downsampling, 4 for 4x4
    * downsampling, 8 for 8x8 downsampling.
    */
-  JXL_ENC_OPTION_RESAMPLING = 2,
+  JXL_ENC_FRAME_SETTING_RESAMPLING = 2,
 
-  /** Similar to JXL_ENC_OPTION_RESAMPLING, but for extra channels. Integer
-   * option, use -1 for the default behavior (depends on encoder
+  /** Similar to JXL_ENC_FRAME_SETTING_RESAMPLING, but for extra channels.
+   * Integer option, use -1 for the default behavior (depends on encoder
    * implementation), 1 for no downsampling (1x1), 2 for 2x2 downsampling, 4 for
    * 4x4 downsampling, 8 for 8x8 downsampling.
    */
-  JXL_ENC_OPTION_EXTRA_CHANNEL_RESAMPLING = 3,
+  JXL_ENC_FRAME_SETTING_EXTRA_CHANNEL_RESAMPLING = 3,
 
   /** Indicates the frame added with @ref JxlEncoderAddImageFrame is already
    * downsampled by the downsampling factor set with @ref
-   * JXL_ENC_OPTION_RESAMPLING. The input frame must then be given in the
+   * JXL_ENC_FRAME_SETTING_RESAMPLING. The input frame must then be given in the
    * downsampled resolution, not the full image resolution. The downsampled
    * resolution is given by ceil(xsize / resampling), ceil(ysize / resampling)
    * with xsize and ysize the dimensions given in the basic info, and resampling
-   * the factor set with @ref JXL_ENC_OPTION_RESAMPLING.
+   * the factor set with @ref JXL_ENC_FRAME_SETTING_RESAMPLING.
    * Use 0 to disable, 1 to enable. Default value is 0.
    */
-  JXL_ENC_OPTION_ALREADY_DOWNSAMPLED = 4,
+  JXL_ENC_FRAME_SETTING_ALREADY_DOWNSAMPLED = 4,
 
   /** Adds noise to the image emulating photographic film noise, the higher the
    * given number, the grainier the image will be. As an example, a value of 100
    * gives low noise whereas a value of 3200 gives a lot of noise. The default
    * value is 0.
    */
-  JXL_ENC_OPTION_PHOTON_NOISE = 5,
+  JXL_ENC_FRAME_SETTING_PHOTON_NOISE = 5,
 
   /** Enables adaptive noise generation. This setting is not recommended for
-   * use, please use JXL_ENC_OPTION_PHOTON_NOISE instead. Use -1 for the default
-   * (encoder chooses), 0 to disable, 1 to enable.
+   * use, please use JXL_ENC_FRAME_SETTING_PHOTON_NOISE instead. Use -1 for the
+   * default (encoder chooses), 0 to disable, 1 to enable.
    */
-  JXL_ENC_OPTION_NOISE = 6,
+  JXL_ENC_FRAME_SETTING_NOISE = 6,
 
   /** Enables or disables dots generation. Use -1 for the default (encoder
    * chooses), 0 to disable, 1 to enable.
    */
-  JXL_ENC_OPTION_DOTS = 7,
+  JXL_ENC_FRAME_SETTING_DOTS = 7,
 
   /** Enables or disables patches generation. Use -1 for the default (encoder
    * chooses), 0 to disable, 1 to enable.
    */
-  JXL_ENC_OPTION_PATCHES = 8,
+  JXL_ENC_FRAME_SETTING_PATCHES = 8,
 
   /** Edge preserving filter level, -1 to 3. Use -1 for the default (encoder
    * chooses), 0 to 3 to set a strength.
    */
-  JXL_ENC_OPTION_EPF = 9,
+  JXL_ENC_FRAME_SETTING_EPF = 9,
 
   /** Enables or disables the gaborish filter. Use -1 for the default (encoder
    * chooses), 0 to disable, 1 to enable.
    */
-  JXL_ENC_OPTION_GABORISH = 10,
+  JXL_ENC_FRAME_SETTING_GABORISH = 10,
 
   /** Enables modular encoding. Use -1 for default (encoder
    * chooses), 0 to enforce VarDCT mode (e.g. for photographic images), 1 to
    * enforce modular mode (e.g. for lossless images).
    */
-  JXL_ENC_OPTION_MODULAR = 11,
+  JXL_ENC_FRAME_SETTING_MODULAR = 11,
 
   /** Enables or disables preserving color of invisible pixels. Use -1 for the
    * default (1 if lossless, 0 if lossy), 0 to disable, 1 to enable.
    */
-  JXL_ENC_OPTION_KEEP_INVISIBLE = 12,
+  JXL_ENC_FRAME_SETTING_KEEP_INVISIBLE = 12,
 
   /** Determines the order in which 256x256 regions are stored in the codestream
    * for progressive rendering. Use -1 for the encoder
    * default, 0 for scanline order, 1 for center-first order.
    */
-  JXL_ENC_OPTION_GROUP_ORDER = 13,
+  JXL_ENC_FRAME_SETTING_GROUP_ORDER = 13,
 
   /** Determines the horizontal position of center for the center-first group
    * order. Use -1 to automatically use the middle of the image, 0..xsize to
    * specifically set it.
    */
-  JXL_ENC_OPTION_GROUP_ORDER_CENTER_X = 14,
+  JXL_ENC_FRAME_SETTING_GROUP_ORDER_CENTER_X = 14,
 
   /** Determines the center for the center-first group order. Use -1 to
    * automatically use the middle of the image, 0..ysize to specifically set it.
    */
-  JXL_ENC_OPTION_GROUP_ORDER_CENTER_Y = 15,
+  JXL_ENC_FRAME_SETTING_GROUP_ORDER_CENTER_Y = 15,
 
   /** Enables or disables progressive encoding for modular mode. Use -1 for the
    * encoder default, 0 to disable, 1 to enable.
    */
-  JXL_ENC_OPTION_RESPONSIVE = 16,
+  JXL_ENC_FRAME_SETTING_RESPONSIVE = 16,
 
   /** Set the progressive mode for the AC coefficients of VarDCT, using spectral
    * progression from the DCT coefficients. Use -1 for the encoder default, 0 to
    * disable, 1 to enable.
    */
-  JXL_ENC_OPTION_PROGRESSIVE_AC = 17,
+  JXL_ENC_FRAME_SETTING_PROGRESSIVE_AC = 17,
 
   /** Set the progressive mode for the AC coefficients of VarDCT, using
    * quantization of the least significant bits. Use -1 for the encoder default,
    * 0 to disable, 1 to enable.
    */
-  JXL_ENC_OPTION_QPROGRESSIVE_AC = 18,
+  JXL_ENC_FRAME_SETTING_QPROGRESSIVE_AC = 18,
 
   /** Set the progressive mode using lower-resolution DC images for VarDCT. Use
    * -1 for the encoder default, 0 to disable, 1 to have an extra 64x64 lower
    * resolution pass, 2 to have a 512x512 and 64x64 lower resolution pass.
    */
-  JXL_ENC_OPTION_PROGRESSIVE_DC = 19,
+  JXL_ENC_FRAME_SETTING_PROGRESSIVE_DC = 19,
 
   /** Use Global channel palette if the amount of colors is smaller than this
    * percentage of range. Use 0-100 to set an explicit percentage, -1 to use the
    * encoder default. Used for modular encoding.
    */
-  JXL_ENC_OPTION_CHANNEL_COLORS_GLOBAL_PERCENT = 20,
+  JXL_ENC_FRAME_SETTING_CHANNEL_COLORS_GLOBAL_PERCENT = 20,
 
   /** Use Local (per-group) channel palette if the amount of colors is smaller
    * than this percentage of range. Use 0-100 to set an explicit percentage, -1
    * to use the encoder default. Used for modular encoding.
    */
-  JXL_ENC_OPTION_CHANNEL_COLORS_GROUP_PERCENT = 21,
+  JXL_ENC_FRAME_SETTING_CHANNEL_COLORS_GROUP_PERCENT = 21,
 
   /** Use color palette if amount of colors is smaller than or equal to this
    * amount, or -1 to use the encoder default. Used for modular encoding.
    */
-  JXL_ENC_OPTION_PALETTE_COLORS = 22,
+  JXL_ENC_FRAME_SETTING_PALETTE_COLORS = 22,
 
   /** Enables or disables delta palette. Use -1 for the default (encoder
    * chooses), 0 to disable, 1 to enable. Used in modular mode.
    */
-  JXL_ENC_OPTION_LOSSY_PALETTE = 23,
+  JXL_ENC_FRAME_SETTING_LOSSY_PALETTE = 23,
 
   /** Color transform for internal encoding: -1 = default, 0=XYB, 1=none (RGB),
    * 2=YCbCr. The XYB setting performs the forward XYB transform. None and
    * YCbCr both perform no transform, but YCbCr is used to indicate that the
    * encoded data losslessly represents YCbCr values.
    */
-  JXL_ENC_OPTION_COLOR_TRANSFORM = 24,
+  JXL_ENC_FRAME_SETTING_COLOR_TRANSFORM = 24,
 
   /** Color space for modular encoding: -1=default, 0-35=reverse color transform
    * index, e.g. index 0 = none, index 6 = YCoCg.
    * The default behavior is to try several, depending on the speed setting.
    */
-  JXL_ENC_OPTION_MODULAR_COLOR_SPACE = 25,
+  JXL_ENC_FRAME_SETTING_MODULAR_COLOR_SPACE = 25,
 
   /** Group size for modular encoding: -1=default, 0=128, 1=256, 2=512, 3=1024.
    */
-  JXL_ENC_OPTION_MODULAR_GROUP_SIZE = 26,
+  JXL_ENC_FRAME_SETTING_MODULAR_GROUP_SIZE = 26,
 
   /** Predictor for modular encoding. -1 = default, 0=zero, 1=left, 2=top,
    * 3=avg0, 4=select, 5=gradient, 6=weighted, 7=topright, 8=topleft,
    * 9=leftleft, 10=avg1, 11=avg2, 12=avg3, 13=toptop predictive average 14=mix
    * 5 and 6, 15=mix everything.
    */
-  JXL_ENC_OPTION_MODULAR_PREDICTOR = 27,
+  JXL_ENC_FRAME_SETTING_MODULAR_PREDICTOR = 27,
 
   /** Fraction of pixels used to learn MA trees as a percentage. -1 = default,
    * 0 = no MA and fast decode, 50 = default value, 100 = all, values above
    * 100 are also permitted. Higher values use more encoder memory.
    */
-  JXL_ENC_OPTION_MODULAR_MA_TREE_LEARNING_PERCENT = 28,
+  JXL_ENC_FRAME_SETTING_MODULAR_MA_TREE_LEARNING_PERCENT = 28,
 
   /** Number of extra (previous-channel) MA tree properties to use. -1 =
    * default, 0-11 = valid values. Recommended values are in the range 0 to 3,
@@ -267,19 +264,19 @@ typedef enum {
    * excluding color channels when using VarDCT mode). Higher value gives slower
    * encoding and slower decoding.
    */
-  JXL_ENC_OPTION_MODULAR_NB_PREV_CHANNELS = 29,
+  JXL_ENC_FRAME_SETTING_MODULAR_NB_PREV_CHANNELS = 29,
 
   /** Enable or disable CFL (chroma-from-luma) for lossless JPEG recompression.
    * -1 = default, 0 = disable CFL, 1 = enable CFL.
    */
-  JXL_ENC_OPTION_JPEG_RECON_CFL = 30,
+  JXL_ENC_FRAME_SETTING_JPEG_RECON_CFL = 30,
 
   /** Enum value not to be used as an option. This value is added to force the
    * C compiler to have the enum to take a known size.
    */
-  JXL_ENC_OPTION_FILL_ENUM = 65535,
+  JXL_ENC_FRAME_SETTING_FILL_ENUM = 65535,
 
-} JxlEncoderOptionId;
+} JxlEncoderFrameSettingId;
 
 /**
  * Creates an instance of JxlEncoder and initializes it.
@@ -379,37 +376,39 @@ JXL_EXPORT JxlEncoderStatus JxlEncoderProcessOutput(JxlEncoder* enc,
  * time duration of 0, making them form a composite still. See @ref
  * JxlFrameHeader for more information.
  *
- * This information is stored in the JxlEncoderOptions and so is used for any
- * frame encoded with these JxlEncoderOptions. It is ok to change between @ref
- * JxlEncoderAddImageFrame calls, each added image frame will have the frame
- * header that was set in the options at the time of calling
+ * This information is stored in the JxlEncoderFrameSettings and so is used for
+ * any frame encoded with these JxlEncoderFrameSettings. It is ok to change
+ * between @ref JxlEncoderAddImageFrame calls, each added image frame will have
+ * the frame header that was set in the options at the time of calling
  * JxlEncoderAddImageFrame.
  *
  * The is_last and name_length fields of the JxlFrameHeader are ignored, use
  * @ref JxlEncoderCloseFrames to indicate last frame, and @ref
- * JxlEncoderSetFrameName to indicate the name and its length instead. Calling
- * this function will clear any name that was previously set with @ref
- * JxlEncoderSetFrameName.
+ * JxlEncoderFrameSettingsSetName to indicate the name and its length instead.
+ * Calling this function will clear any name that was previously set with @ref
+ * JxlEncoderFrameSettingsSetName.
  *
  * @param frame_settings set of options and metadata for this frame. Also
  * includes reference to the encoder object.
  * @param frame_header frame header data to set.
  * @return JXL_ENC_SUCCESS on success, JXL_ENC_ERROR on error
  */
-JXL_EXPORT JxlEncoderStatus JxlEncoderSetFrameInfo(
-    JxlEncoderOptions* frame_settings, const JxlFrameHeader* frame_header);
+JXL_EXPORT JxlEncoderStatus
+JxlEncoderFrameSettingsSetInfo(JxlEncoderFrameSettings* frame_settings,
+                               const JxlFrameHeader* frame_header);
 
 /**
  * Sets the name of the animation frame. This function is optional, frames are
  * not required to have a name. This setting is a part of the frame header, and
- * the same principles as for @ref JxlEncoderSetFrameInfo apply. The
+ * the same principles as for @ref JxlEncoderFrameSettingsSetInfo apply. The
  * name_length field of JxlFrameHeader is ignored by the encoder, this function
  * determines the name length instead as the length in bytes of the C string.
  *
  * The maximum possible name length is 1071 bytes (excluding terminating null
  * character).
  *
- * Calling @ref JxlEncoderSetFrameInfo clears any name that was previously set.
+ * Calling @ref JxlEncoderFrameSettingsSetInfo clears any name that was
+ * previously set.
  *
  * @param frame_options set of options and metadata for this frame. Also
  * includes reference to the encoder object.
@@ -417,8 +416,8 @@ JXL_EXPORT JxlEncoderStatus JxlEncoderSetFrameInfo(
  * string (zero terminated).
  * @return JXL_ENC_SUCCESS on success, JXL_ENC_ERROR on error
  */
-JXL_EXPORT JxlEncoderStatus JxlEncoderSetFrameName(
-    JxlEncoderOptions* frame_options, const char* frame_name);
+JXL_EXPORT JxlEncoderStatus JxlEncoderFrameSettingsSetName(
+    JxlEncoderFrameSettings* frame_options, const char* frame_name);
 
 /**
  * Sets the buffer to read JPEG encoded bytes from for the next frame to encode.
@@ -443,7 +442,7 @@ JXL_EXPORT JxlEncoderStatus JxlEncoderSetFrameName(
  * @return JXL_ENC_SUCCESS on success, JXL_ENC_ERROR on error
  */
 JXL_EXPORT JxlEncoderStatus
-JxlEncoderAddJPEGFrame(const JxlEncoderOptions* frame_settings,
+JxlEncoderAddJPEGFrame(const JxlEncoderFrameSettings* frame_settings,
                        const uint8_t* buffer, size_t size);
 
 /**
@@ -497,8 +496,8 @@ JxlEncoderAddJPEGFrame(const JxlEncoderOptions* frame_settings,
  * @return JXL_ENC_SUCCESS on success, JXL_ENC_ERROR on error
  */
 JXL_EXPORT JxlEncoderStatus JxlEncoderAddImageFrame(
-    const JxlEncoderOptions* frame_settings, const JxlPixelFormat* pixel_format,
-    const void* buffer, size_t size);
+    const JxlEncoderFrameSettings* frame_settings,
+    const JxlPixelFormat* pixel_format, const void* buffer, size_t size);
 
 /**
  * Sets the buffer to read pixels from for an extra channel at a given index.
@@ -523,8 +522,9 @@ JXL_EXPORT JxlEncoderStatus JxlEncoderAddImageFrame(
  * @return JXL_ENC_SUCCESS on success, JXL_ENC_ERROR on error
  */
 JXL_EXPORT JxlEncoderStatus JxlEncoderSetExtraChannelBuffer(
-    const JxlEncoderOptions* frame_settings, const JxlPixelFormat* pixel_format,
-    const void* buffer, size_t size, uint32_t index);
+    const JxlEncoderFrameSettings* frame_settings,
+    const JxlPixelFormat* pixel_format, const void* buffer, size_t size,
+    uint32_t index);
 
 /** Adds a metadata box to the file format. JxlEncoderProcessOutput must be used
  * to effectively write the box to the output. @ref JxlEncoderUseBoxes must
@@ -784,7 +784,8 @@ JXL_EXPORT JxlEncoderStatus JxlEncoderSetExtraChannelInfo(
  * Sets the name for the extra channel at the given index in UTF-8. The index
  * must be smaller than the num_extra_channels in the associated JxlBasicInfo.
  *
- * TODO(lode): remove size parameter for consistency with JxlEncoderSetFrameName
+ * TODO(lode): remove size parameter for consistency with
+ * JxlEncoderFrameSettingsSetName
  *
  * @param enc encoder object
  * @param index index of the extra channel to set.
@@ -800,7 +801,7 @@ JXL_EXPORT JxlEncoderStatus JxlEncoderSetExtraChannelName(JxlEncoder* enc,
 
 /**
  * Sets a frame-specific option of integer type to the encoder options.
- * The JxlEncoderOptionId argument determines which option is set.
+ * The JxlEncoderFrameSettingId argument determines which option is set.
  *
  * @param frame_settings set of options and metadata for this frame. Also
  * includes reference to the encoder object.
@@ -809,12 +810,12 @@ JXL_EXPORT JxlEncoderStatus JxlEncoderSetExtraChannelName(JxlEncoder* enc,
  * @return JXL_ENC_SUCCESS if the operation was successful, JXL_ENC_ERROR in
  * case of an error, such as invalid or unknown option id, or invalid integer
  * value for the given option. If an error is returned, the state of the
- * JxlEncoderOptions object is still valid and is the same as before this
+ * JxlEncoderFrameSettings object is still valid and is the same as before this
  * function was called.
  */
-JXL_EXPORT JxlEncoderStatus
-JxlEncoderOptionsSetInteger(JxlEncoderOptions* frame_settings,
-                            JxlEncoderOptionId option, int32_t value);
+JXL_EXPORT JxlEncoderStatus JxlEncoderFrameSettingsSetOption(
+    JxlEncoderFrameSettings* frame_settings, JxlEncoderFrameSettingId option,
+    int32_t value);
 
 /** Forces the encoder to use the box-based container format (BMFF) even
  * when not necessary.
@@ -927,8 +928,13 @@ JXL_EXPORT int JxlEncoderGetRequiredCodestreamLevel(const JxlEncoder* enc);
  * @return JXL_ENC_SUCCESS if the operation was successful, JXL_ENC_ERROR
  * otherwise.
  */
-JXL_EXPORT JxlEncoderStatus JxlEncoderOptionsSetLossless(
-    JxlEncoderOptions* frame_settings, JXL_BOOL lossless);
+JXL_EXPORT JxlEncoderStatus JxlEncoderSetFrameLossless(
+    JxlEncoderFrameSettings* frame_settings, JXL_BOOL lossless);
+
+/** DEPRECATED: use JxlEncoderSetFrameLossless instead.
+ */
+JXL_EXPORT JxlEncoderStatus
+JxlEncoderOptionsSetLossless(JxlEncoderFrameSettings*, JXL_BOOL);
 
 /**
  * @param frame_settings set of options and metadata for this frame. Also
@@ -937,11 +943,11 @@ JXL_EXPORT JxlEncoderStatus JxlEncoderOptionsSetLossless(
  * @return JXL_ENC_SUCCESS if the operation was successful, JXL_ENC_ERROR
  * otherwise.
  *
- * DEPRECATED: use JxlEncoderOptionsSetInteger(options, JXL_ENC_OPTION_EFFORT,
- * effort)) instead.
+ * DEPRECATED: use JxlEncoderFrameSettingsSetOption(frame_settings,
+ * JXL_ENC_FRAME_SETTING_EFFORT, effort) instead.
  */
 JXL_EXPORT JXL_DEPRECATED JxlEncoderStatus
-JxlEncoderOptionsSetEffort(JxlEncoderOptions* frame_settings, int effort);
+JxlEncoderOptionsSetEffort(JxlEncoderFrameSettings* frame_settings, int effort);
 
 /**
  * @param frame_settings set of options and metadata for this frame. Also
@@ -950,16 +956,16 @@ JxlEncoderOptionsSetEffort(JxlEncoderOptions* frame_settings, int effort);
  * @return JXL_ENC_SUCCESS if the operation was successful, JXL_ENC_ERROR
  * otherwise.
  *
- * DEPRECATED: use JxlEncoderOptionsSetInteger(options,
- * JXL_ENC_OPTION_DECODING_SPEED, tier)) instead.
+ * DEPRECATED: use JxlEncoderFrameSettingsSetOption(frame_settings,
+ * JXL_ENC_FRAME_SETTING_DECODING_SPEED, tier) instead.
  */
-JXL_EXPORT JXL_DEPRECATED JxlEncoderStatus
-JxlEncoderOptionsSetDecodingSpeed(JxlEncoderOptions* frame_settings, int tier);
+JXL_EXPORT JXL_DEPRECATED JxlEncoderStatus JxlEncoderOptionsSetDecodingSpeed(
+    JxlEncoderFrameSettings* frame_settings, int tier);
 
 /**
  * Sets the distance level for lossy compression: target max butteraugli
  * distance, lower = higher quality. Range: 0 .. 15.
- * 0.0 = mathematically lossless (however, use JxlEncoderOptionsSetLossless
+ * 0.0 = mathematically lossless (however, use JxlEncoderSetFrameLossless
  * instead to use true lossless, as setting distance to 0 alone is not the only
  * requirement). 1.0 = visually lossless. Recommended range: 0.5 .. 3.0. Default
  * value: 1.0.
@@ -970,8 +976,13 @@ JxlEncoderOptionsSetDecodingSpeed(JxlEncoderOptions* frame_settings, int tier);
  * @return JXL_ENC_SUCCESS if the operation was successful, JXL_ENC_ERROR
  * otherwise.
  */
+JXL_EXPORT JxlEncoderStatus JxlEncoderSetFrameDistance(
+    JxlEncoderFrameSettings* frame_settings, float distance);
+
+/** DEPRECATED: use JxlEncoderSetFrameDistance instead.
+ */
 JXL_EXPORT JxlEncoderStatus
-JxlEncoderOptionsSetDistance(JxlEncoderOptions* frame_settings, float distance);
+JxlEncoderOptionsSetDistance(JxlEncoderFrameSettings*, float);
 
 /**
  * Create a new set of encoder options, with all values initially copied from
@@ -979,17 +990,22 @@ JxlEncoderOptionsSetDistance(JxlEncoderOptions* frame_settings, float distance);
  *
  * The returned pointer is an opaque struct tied to the encoder and it will be
  * deallocated by the encoder when JxlEncoderDestroy() is called. For functions
- * taking both a @ref JxlEncoder and a @ref JxlEncoderOptions, only
- * JxlEncoderOptions created with this function for the same encoder instance
- * can be used.
+ * taking both a @ref JxlEncoder and a @ref JxlEncoderFrameSettings, only
+ * JxlEncoderFrameSettings created with this function for the same encoder
+ * instance can be used.
  *
  * @param enc encoder object.
  * @param source source options to copy initial values from, or NULL to get
  * defaults initialized to defaults.
  * @return the opaque struct pointer identifying a new set of encoder options.
  */
-JXL_EXPORT JxlEncoderOptions* JxlEncoderOptionsCreate(
-    JxlEncoder* enc, const JxlEncoderOptions* source);
+JXL_EXPORT JxlEncoderFrameSettings* JxlEncoderFrameSettingsCreate(
+    JxlEncoder* enc, const JxlEncoderFrameSettings* source);
+
+/** DEPRECATED: use JxlEncoderFrameSettingsCreate instead.
+ */
+JXL_EXPORT JxlEncoderFrameSettings* JxlEncoderOptionsCreate(
+    JxlEncoder*, const JxlEncoderFrameSettings*);
 
 /**
  * Sets a color encoding to be sRGB.

--- a/lib/jxl/encode_internal.h
+++ b/lib/jxl/encode_internal.h
@@ -19,14 +19,14 @@
 
 namespace jxl {
 
-// Options per-frame, this is not used for codestream-wide settings or global
-// encoder settings.
-typedef struct JxlEncoderOptionsValuesStruct {
+// The encoder options (such as quality, compression speed, ...) for a single
+// frame, but not encoder-wide options such as box-related options.
+typedef struct JxlEncoderFrameSettingsValuesStruct {
   // lossless is a separate setting from cparams because it is a combination
   // setting that overrides multiple settings inside of cparams.
   bool lossless;
   CompressParams cparams;
-} JxlEncoderOptionsValues;
+} JxlEncoderFrameSettingsValues;
 
 typedef std::array<uint8_t, 4> BoxType;
 
@@ -46,7 +46,7 @@ constexpr unsigned char kContainerHeader[] = {
 constexpr unsigned char kLevelBoxHeader[] = {0, 0, 0, 0x9, 'j', 'x', 'l', 'l'};
 
 struct JxlEncoderQueuedFrame {
-  JxlEncoderOptionsValues option_values;
+  JxlEncoderFrameSettingsValues option_values;
   ImageBundle frame;
 };
 
@@ -107,7 +107,8 @@ struct JxlEncoderStruct {
   jxl::MemoryManagerUniquePtr<jxl::ThreadPool> thread_pool{
       nullptr, jxl::MemoryManagerDeleteHelper(&memory_manager)};
   JxlCmsInterface cms;
-  std::vector<jxl::MemoryManagerUniquePtr<JxlEncoderOptions>> encoder_options;
+  std::vector<jxl::MemoryManagerUniquePtr<JxlEncoderFrameSettings>>
+      encoder_options;
 
   size_t num_queued_frames;
   size_t num_queued_boxes;
@@ -158,9 +159,9 @@ struct JxlEncoderStruct {
   void AppendBoxHeader(const jxl::BoxType& type, size_t size, bool unbounded);
 };
 
-struct JxlEncoderOptionsStruct {
+struct JxlEncoderFrameSettingsStruct {
   JxlEncoder* enc;
-  jxl::JxlEncoderOptionsValues values;
+  jxl::JxlEncoderFrameSettingsValues values;
 };
 
 #endif  // LIB_JXL_ENCODE_INTERNAL_H_

--- a/plugins/gimp/file-jxl-save.cc
+++ b/plugins/gimp/file-jxl-save.cc
@@ -758,13 +758,14 @@ bool SaveJpegXlImage(const gint32 image_id, const gint32 drawable_id,
   }
 
   // set encoder options
-  JxlEncoderOptions* enc_opts;
-  enc_opts = JxlEncoderOptionsCreate(enc.get(), nullptr);
+  JxlEncoderFrameSettings* frame_settings;
+  frame_settings = JxlEncoderFrameSettingsCreate(enc.get(), nullptr);
 
-  JxlEncoderOptionsSetInteger(enc_opts, JXL_ENC_OPTION_EFFORT,
-                              jxl_save_opts.encoding_effort);
-  JxlEncoderOptionsSetInteger(enc_opts, JXL_ENC_OPTION_DECODING_SPEED,
-                              jxl_save_opts.faster_decoding);
+  JxlEncoderFrameSettingsSetOption(frame_settings, JXL_ENC_FRAME_SETTING_EFFORT,
+                                   jxl_save_opts.encoding_effort);
+  JxlEncoderFrameSettingsSetOption(frame_settings,
+                                   JXL_ENC_FRAME_SETTING_DECODING_SPEED,
+                                   jxl_save_opts.faster_decoding);
 
   // lossless mode
   if (jxl_save_opts.lossless || jxl_save_opts.distance < 0.01) {
@@ -772,16 +773,16 @@ bool SaveJpegXlImage(const gint32 image_id, const gint32 drawable_id,
       // lossless mode doesn't work well with floating point
       jxl_save_opts.distance = 0.01;
       jxl_save_opts.lossless = false;
-      JxlEncoderOptionsSetLossless(enc_opts, false);
-      JxlEncoderOptionsSetDistance(enc_opts, 0.01);
+      JxlEncoderSetFrameLossless(frame_settings, false);
+      JxlEncoderSetFrameDistance(frame_settings, 0.01);
     } else {
-      JxlEncoderOptionsSetDistance(enc_opts, 0);
-      JxlEncoderOptionsSetLossless(enc_opts, true);
+      JxlEncoderSetFrameDistance(frame_settings, 0);
+      JxlEncoderSetFrameLossless(frame_settings, true);
     }
   } else {
     jxl_save_opts.lossless = false;
-    JxlEncoderOptionsSetLossless(enc_opts, false);
-    JxlEncoderOptionsSetDistance(enc_opts, jxl_save_opts.distance);
+    JxlEncoderSetFrameLossless(frame_settings, false);
+    JxlEncoderSetFrameDistance(frame_settings, jxl_save_opts.distance);
   }
 
   // this sets some basic_info properties
@@ -850,7 +851,7 @@ bool SaveJpegXlImage(const gint32 image_id, const gint32 drawable_id,
 
     // send layer to encoder
     if (JXL_ENC_SUCCESS !=
-        JxlEncoderAddImageFrame(enc_opts, &jxl_save_opts.pixel_format,
+        JxlEncoderAddImageFrame(frame_settings, &jxl_save_opts.pixel_format,
                                 pixels_buffer_2, buffer_size)) {
       g_printerr(SAVE_PROC " Error: JxlEncoderAddImageFrame failed\n");
       return false;


### PR DESCRIPTION
As discussed in https://github.com/libjxl/libjxl/pull/909

The reason for this is that these settings only apply to a frame, they
include frame metadata, and the name encoder options could be taken to
mean global options of the encoder.

Identifiers that already existed in the 0.6 release have the old name
marked as deprecated: JxlEncoderOptions, JxlEncoderOptionsCreate,
JxlEncoderOptionsSetDistance, JxlEncoderOptionsSetLossless

Other functions that are already marked deprecated are kept as-is, e.g.
JxlEncoderOptionsSetDecodingSpeed

Other identifiers that changed name have not been part of a release yet
so can be renamed without keeping the old name as deprecated:
JxlEncoderSetIntegerOption, JxlEncoderFrameSettingId and the enum values