### PR TITLE
Apply the HLG OOTF when encoding to VarDCT and unapply it when decoding to HLG

### DIFF
--- a/lib/include/jxl/cms_interface.h
+++ b/lib/include/jxl/cms_interface.h
@@ -4,7 +4,9 @@
  * license that can be found in the LICENSE file.
  */
 
-/** @file cms_interface.h
+/** @addtogroup libjxl_common
+ * @{
+ * @file cms_interface.h
  * @brief Interface to allow the injection of different color management systems
  * (CMSes, also called color management modules, or CMMs) in JPEG XL.
  *
@@ -64,11 +66,19 @@ typedef struct {
  * @param output_profile the colorspace to which JxlCmsInterface::run should
  *        convert the input data.
  * @param intensity_target for colorspaces where luminance is relative
- *        (essentially: not PQ), indicates the luminance of (1, 1, 1). This is
- *        only useful for conversions between a relative luminance colorspace
- *        and an absolute luminance one, in either direction.
- *        @p intensity_target cd/m² in the absolute colorspace should map to and
- *        from (1, 1, 1) in the relative one.
+ *        (essentially: not PQ), indicates the luminance at which (1, 1, 1) will
+ *        be displayed. This is useful for conversions between PQ and a relative
+ *        luminance colorspace, in either direction: @p intensity_target cd/m²
+ *        in PQ should map to and from (1, 1, 1) in the relative one.\n
+ *        It is also used for conversions to and from HLG, as it is
+ *        scene-referred while other colorspaces are assumed to be
+ *        display-referred. That is, conversions from HLG should apply the OOTF
+ *        for a peak display luminance of @p intensity_target, and conversions
+ *        to HLG should undo it. The OOTF is a gamma function applied to the
+ *        luminance channel (https://www.itu.int/rec/R-REC-BT.2100-2-201807-I
+ *        page 7), with the gamma value computed as
+ *        <tt>1.2 * 1.111^log2(intensity_target / 1000)</tt> (footnote 2 page 8
+ *        of the same document).
  * @return The data needed for the transform, or @c NULL in case of failure.
  *         This will be passed to the other functions as @c user_data.
  */
@@ -218,3 +228,5 @@ typedef struct {
 #endif
 
 #endif /* JXL_CMS_INTERFACE_H_ */
+
+/** @} */

--- a/lib/jxl/color_encoding_internal.cc
+++ b/lib/jxl/color_encoding_internal.cc
@@ -703,8 +703,8 @@ Status AdaptToXYZD50(float wx, float wy, float matrix[9]) {
   return true;
 }
 
-Status PrimariesToXYZD50(float rx, float ry, float gx, float gy, float bx,
-                         float by, float wx, float wy, float matrix[9]) {
+Status PrimariesToXYZ(float rx, float ry, float gx, float gy, float bx,
+                      float by, float wx, float wy, float matrix[9]) {
   if (wx < 0 || wx > 1 || wy <= 0 || wy > 1) {
     return JXL_FAILURE("Invalid white point");
   }
@@ -727,9 +727,14 @@ Status PrimariesToXYZD50(float rx, float ry, float gx, float gy, float bx,
       xyz[0], 0, 0, 0, xyz[1], 0, 0, 0, xyz[2],
   };
 
-  float toXYZ[9];
-  MatMul(primaries, a, 3, 3, 3, toXYZ);
+  MatMul(primaries, a, 3, 3, 3, matrix);
+  return true;
+}
 
+Status PrimariesToXYZD50(float rx, float ry, float gx, float gy, float bx,
+                         float by, float wx, float wy, float matrix[9]) {
+  float toXYZ[9];
+  JXL_RETURN_IF_ERROR(PrimariesToXYZ(rx, ry, gx, gy, bx, by, wx, wy, toXYZ));
   float d50[9];
   JXL_RETURN_IF_ERROR(AdaptToXYZD50(wx, wy, d50));
 

--- a/lib/jxl/color_encoding_internal.h
+++ b/lib/jxl/color_encoding_internal.h
@@ -450,6 +450,8 @@ void ConvertInternalToExternalColorEncoding(const jxl::ColorEncoding& internal,
 Status ConvertExternalToInternalColorEncoding(const JxlColorEncoding& external,
                                               jxl::ColorEncoding* internal);
 
+Status PrimariesToXYZ(float rx, float ry, float gx, float gy, float bx,
+                      float by, float wx, float wy, float matrix[9]);
 Status PrimariesToXYZD50(float rx, float ry, float gx, float gy, float bx,
                          float by, float wx, float wy, float matrix[9]);
 Status AdaptToXYZD50(float wx, float wy, float matrix[9]);

--- a/lib/jxl/dec_xyb.h
+++ b/lib/jxl/dec_xyb.h
@@ -41,6 +41,11 @@ struct OutputEncodingInfo {
   Status Set(const CodecMetadata& metadata, const ColorEncoding& default_enc);
   bool all_default_opsin = true;
   bool color_encoding_is_original = false;
+  // Luminances of color_encoding's primaries, used for the HLG inverse OOTF.
+  // Default to sRGB's.
+  float luminances[3] = {0.2126, 0.7152, 0.0722};
+  // Also used for the HLG inverse OOTF.
+  float intensity_target;
 };
 
 // Converts `inout` (not padded) from opsin to linear sRGB in-place. Called from


### PR DESCRIPTION
This effectively makes VarDCT always display-referred, instead of being
display-referred if and only if the original colorspace did not happen
to be HLG. It means that the linear output of the decoder is now always
suitable for display at a peak luminance of `intensity_target`.

JxlCmsInterface now has the responsibility of converting between scene
and display light if HLG is involved on one side and not the other. The
default implementation, JxlCms, does it and can be used for inspiration.

Images previously encoded from HLG to VarDCT with the default HLG
`intensity_target` of 1000, having not had the OOTF applied, will now be
decoded to a HLG signal brighter than the original since the OOTF will
nevertheless still be unapplied. But arguably, it was a bug of previous
encoders, since the linear signal was also too bright for display at a
peak luminance of 1000 cd/m².