### PR TITLE
make modular encoding faster (mostly lightning)

### DIFF
--- a/lib/jxl/enc_ans.h
+++ b/lib/jxl/enc_ans.h
@@ -93,6 +93,7 @@ struct EntropyEncodingData {
 
 // Integer to be encoded by an entropy coder, either ANS or Huffman.
 struct Token {
+  Token() {}
   Token(uint32_t c, uint32_t value)
       : is_lz77_length(false), context(c), value(value) {}
   uint32_t is_lz77_length : 1;

--- a/lib/jxl/modular/transform/enc_rct.cc
+++ b/lib/jxl/modular/transform/enc_rct.cc
@@ -12,7 +12,7 @@
 
 namespace jxl {
 
-Status FwdRCT(Image& input, size_t begin_c, size_t rct_type) {
+Status FwdRCT(Image& input, size_t begin_c, size_t rct_type, ThreadPool* pool) {
   JXL_RETURN_IF_ERROR(CheckEqualChannels(input, begin_c, begin_c + 2));
   if (rct_type == 0) {  // noop
     return false;
@@ -31,7 +31,7 @@ Status FwdRCT(Image& input, size_t begin_c, size_t rct_type) {
   size_t h = input.channel[m + 0].h;
   int second = (custom % 7) >> 1;
   int third = (custom % 7) & 1;
-  for (size_t y = 0; y < h; y++) {
+  const auto do_rct = [&](const int y, const int thread) {
     const pixel_type* in0 = input.channel[m + (permutation % 3)].Row(y);
     const pixel_type* in1 =
         input.channel[m + ((permutation + 1 + permutation / 3) % 3)].Row(y);
@@ -40,8 +40,8 @@ Status FwdRCT(Image& input, size_t begin_c, size_t rct_type) {
     pixel_type* out0 = input.channel[m].Row(y);
     pixel_type* out1 = input.channel[m + 1].Row(y);
     pixel_type* out2 = input.channel[m + 2].Row(y);
-    for (size_t x = 0; x < w; x++) {
-      if (custom == 6) {
+    if (custom == 6) {
+      for (size_t x = 0; x < w; x++) {
         pixel_type R = in0[x];
         pixel_type G = in1[x];
         pixel_type B = in2[x];
@@ -49,7 +49,9 @@ Status FwdRCT(Image& input, size_t begin_c, size_t rct_type) {
         pixel_type tmp = B + (out1[x] >> 1);
         out2[x] = G - tmp;
         out0[x] = tmp + (out2[x] >> 1);
-      } else {
+      }
+    } else {
+      for (size_t x = 0; x < w; x++) {
         pixel_type First = in0[x];
         pixel_type Second = in1[x];
         pixel_type Third = in2[x];
@@ -64,8 +66,8 @@ Status FwdRCT(Image& input, size_t begin_c, size_t rct_type) {
         out2[x] = Third;
       }
     }
-  }
-  return true;
+  };
+  return RunOnPool(pool, 0, h, ThreadPool::NoInit, do_rct, "FwdRCT");
 }
 
 }  // namespace jxl

--- a/lib/jxl/modular/transform/enc_rct.h
+++ b/lib/jxl/modular/transform/enc_rct.h
@@ -10,7 +10,7 @@
 
 namespace jxl {
 
-Status FwdRCT(Image &input, size_t begin_c, size_t rct_type);
+Status FwdRCT(Image &input, size_t begin_c, size_t rct_type, ThreadPool *pool);
 
 }  // namespace jxl
 

--- a/lib/jxl/modular/transform/enc_transform.cc
+++ b/lib/jxl/modular/transform/enc_transform.cc
@@ -15,7 +15,7 @@ Status TransformForward(Transform &t, Image &input,
                         const weighted::Header &wp_header, ThreadPool *pool) {
   switch (t.id) {
     case TransformId::kRCT:
-      return FwdRCT(input, t.begin_c, t.rct_type);
+      return FwdRCT(input, t.begin_c, t.rct_type, pool);
     case TransformId::kSqueeze:
       return FwdSqueeze(input, t.squeezes, pool);
     case TransformId::kPalette:


### PR DESCRIPTION
Some speed tweaks, mostly for lossless -e 1.

No change in density nor in quality.

Before:
```
Encoding [Modular, lossless, lightning], 4 threads.
Compressed to 16788658 bytes (12.222 bpp).
4064 x 2704, geomean: 25.72 MP/s [20.88, 26.89], 30 reps, 4 threads.

real	0m13.375s
user	0m28.461s
sys	0m1.183s
```

After:
```
Encoding [Modular, lossless, lightning], 4 threads.
Compressed to 16788658 bytes (12.222 bpp).
4064 x 2704, geomean: 35.07 MP/s [26.63, 40.60], 30 reps, 4 threads.

real	0m9.960s
user	0m23.619s
sys	0m1.411s
```

So with 4 threads in real time it's about 35% faster, in terms of cpu time it's about 20% faster.

For comparison: when I use ImageMagick's `convert` to encode the same image 30 times, it takes 137 seconds with default settings, and still 39 seconds with `-quality 10` (which in case of png encoding means faster encoding).

The -e 1 jxl is 16788658 bytes (and was encoded in 1/3 of a second), the default ImageMagick png is 17774160 bytes (and took about 4 seconds to encode), the fast png is 19030828 bytes (and took a bit over 1 second).

So for local use cases where you just want to quickly save an image losslessly, this might be an attractive option.
