### PR TITLE
Properly unpoison memory in codec_apng.

### DIFF
--- a/lib/extras/codec_apng.cc
+++ b/lib/extras/codec_apng.cc
@@ -54,6 +54,7 @@
 #include "lib/jxl/image.h"
 #include "lib/jxl/image_bundle.h"
 #include "lib/jxl/luminance.h"
+#include "lib/jxl/sanitizers.h"
 #include "png.h" /* original (unpatched) libpng is ok */
 
 namespace jxl {
@@ -370,7 +371,11 @@ int processing_finish(png_structp png_ptr, png_infop info_ptr,
   png_textp text_ptr;
   int num_text;
   png_get_text(png_ptr, info_ptr, &text_ptr, &num_text);
+  msan::UnpoisonMemory(&num_text, sizeof(num_text));
+  msan::UnpoisonMemory(&text_ptr, sizeof(text_ptr));
   for (int i = 0; i < num_text; i++) {
+    msan::UnpoisonMemory(text_ptr[i].text, text_ptr[i].text_length + 1);
+    msan::UnpoisonCStr(text_ptr[i].key);
     (void)BlobsReaderPNG::Decode(text_ptr[i], metadata);
   }
 
@@ -487,6 +492,7 @@ Status DecodeImageAPNG(const Span<const uint8_t> bytes,
               frame->blend = bop != 0;
 
               for (size_t y = 0; y < h0; ++y) {
+                msan::UnpoisonMemory(frameRaw.rows[y], bytes_per_pixel * w0);
                 memcpy(static_cast<uint8_t*>(frame->color.pixels()) +
                            frame->color.stride * y,
                        frameRaw.rows[y], bytes_per_pixel * w0);
@@ -609,6 +615,7 @@ Status DecodeImageAPNG(const Span<const uint8_t> bytes,
           png_uint_32 proflen;
           png_get_iCCP(png_ptr, info_ptr, &name, &compression_type, &profile,
                        &proflen);
+          msan::UnpoisonMemory(&proflen, sizeof(proflen));
           ppf->icc.resize(proflen);
           memcpy(ppf->icc.data(), profile, proflen);
           have_color = true;

--- a/lib/jxl/sanitizers.h
+++ b/lib/jxl/sanitizers.h
@@ -78,6 +78,12 @@ static JXL_INLINE JXL_MAYBE_UNUSED void UnpoisonMemory(const volatile void* m,
   __msan_unpoison(m, size);
 }
 
+static JXL_INLINE JXL_MAYBE_UNUSED void UnpoisonCStr(const char* c) {
+  do {
+    UnpoisonMemory(c, 1);
+  } while (*c++);
+}
+
 static JXL_INLINE JXL_MAYBE_UNUSED void MemoryIsInitialized(
     const volatile void* m, size_t size) {
   __msan_check_mem_is_initialized(m, size);
@@ -248,6 +254,7 @@ static JXL_INLINE JXL_MAYBE_UNUSED void CheckImageInitialized(
 
 static JXL_INLINE JXL_MAYBE_UNUSED void PoisonMemory(const void*, size_t) {}
 static JXL_INLINE JXL_MAYBE_UNUSED void UnpoisonMemory(const void*, size_t) {}
+static JXL_INLINE JXL_MAYBE_UNUSED void UnpoisonCStr(const char*) {}
 static JXL_INLINE JXL_MAYBE_UNUSED void MemoryIsInitialized(const void*,
                                                             size_t) {}
 


### PR DESCRIPTION
As libpng is not compiled with msan, msan believes memory coming from it
is uninitialized. This patch fixes that.