### PR TITLE
Add a testing infrastructure for the rendering pipeline.

### DIFF
--- a/lib/jxl/dec_cache.h
+++ b/lib/jxl/dec_cache.h
@@ -22,6 +22,7 @@
 #include "lib/jxl/image.h"
 #include "lib/jxl/passes_state.h"
 #include "lib/jxl/quant_weights.h"
+#include "lib/jxl/render_pipeline/render_pipeline.h"
 #include "lib/jxl/sanitizers.h"
 
 namespace jxl {
@@ -105,6 +106,10 @@ struct PassesDecoderState {
 
   // Manages the status of borders.
   GroupBorderAssigner group_border_assigner;
+
+  // Rendering pipeline. TODO(veluca): eventually, this pipeline will replace
+  // most of the state in this struct.
+  std::unique_ptr<RenderPipeline> render_pipeline;
 
   // TODO(veluca): this should eventually become "iff no global modular
   // transform was applied".
@@ -294,6 +299,8 @@ struct PassesDecoderState {
       shared_storage.coeff_orders.resize(sz);
     }
     if (shared->frame_header.flags & FrameHeader::kNoise) {
+      // TODO(veluca): adapt this code to output to the rendering pipeline.
+      JXL_CHECK(!render_pipeline);
       noise = Image3F(shared->frame_dim.xsize_upsampled_padded,
                       shared->frame_dim.ysize_upsampled_padded);
       size_t num_x_groups = DivCeil(noise.xsize(), kGroupDim);

--- a/lib/jxl/dec_modular.cc
+++ b/lib/jxl/dec_modular.cc
@@ -472,6 +472,8 @@ Status ModularFrameDecoder::ModularImageToDecodedRect(
 
   size_t c = 0;
   if (do_color) {
+    // TODO(veluca): adapt this code to output to the rendering pipeline.
+    JXL_CHECK(!dec_state->render_pipeline);
     const bool rgb_from_gray =
         metadata->m.color_encoding.IsGray() &&
         frame_header.color_transform == ColorTransform::kNone;
@@ -560,6 +562,8 @@ Status ModularFrameDecoder::ModularImageToDecodedRect(
     }
   }
   for (size_t ec = 0; ec < dec_state->extra_channels.size(); ec++, c++) {
+    // TODO(veluca): adapt this code to output to the rendering pipeline.
+    JXL_CHECK(!dec_state->render_pipeline);
     const ExtraChannelInfo& eci = output->metadata()->extra_channel_info[ec];
     int bits = eci.bit_depth.bits_per_sample;
     int exp_bits = eci.bit_depth.exponent_bits_per_sample;

--- a/lib/jxl/dec_params.h
+++ b/lib/jxl/dec_params.h
@@ -44,6 +44,10 @@ struct DecompressParams {
   bool allow_partial_files = false;
   // Allow even more progression.
   bool allow_more_progressive_steps = false;
+
+  // Internal test-only setting: whether or not to use the slow rendering
+  // pipeline.
+  bool use_slow_render_pipeline = false;
 };
 
 }  // namespace jxl

--- a/lib/jxl/dec_reconstruct.cc
+++ b/lib/jxl/dec_reconstruct.cc
@@ -582,6 +582,10 @@ Status FinalizeImageRect(
     const std::vector<std::pair<ImageF*, Rect>>& extra_channels,
     PassesDecoderState* dec_state, size_t thread,
     ImageBundle* JXL_RESTRICT output_image, const Rect& frame_rect) {
+  // Do nothing if using the rendering pipeline.
+  if (dec_state->render_pipeline) {
+    return true;
+  }
   const ImageFeatures& image_features = dec_state->shared->image_features;
   const FrameHeader& frame_header = dec_state->shared->frame_header;
   const ImageMetadata& metadata = frame_header.nonserialized_metadata->m;

--- a/lib/jxl/decode.cc
+++ b/lib/jxl/decode.cc
@@ -1366,7 +1366,8 @@ JxlDecoderStatus JxlDecoderProcessCodestream(JxlDecoder* dec, const uint8_t* in,
       }
 
       dec->frame_dec.reset(new FrameDecoder(
-          dec->passes_state.get(), dec->metadata, dec->thread_pool.get()));
+          dec->passes_state.get(), dec->metadata, dec->thread_pool.get(),
+          /*use_slow_rendering_pipeline=*/false));
       dec->frame_dec->SetRenderSpotcolors(dec->render_spotcolors);
       dec->frame_dec->SetCoalescing(dec->coalescing);
 

--- a/lib/jxl/image_test_utils.h
+++ b/lib/jxl/image_test_utils.h
@@ -80,7 +80,7 @@ bool SamePixels(const Image3<T>& image1, const Image3<T>& image2) {
 }
 
 // Use for floating-point images with fairly large numbers; tolerates small
-// absolute errors and/or small relative errors. Returns max_relative.
+// absolute errors and/or small relative errors.
 template <typename T>
 void VerifyRelativeError(const Plane<T>& expected, const Plane<T>& actual,
                          const double threshold_l1,

--- a/lib/jxl/render_pipeline/render_pipeline.h
+++ b/lib/jxl/render_pipeline/render_pipeline.h
@@ -20,23 +20,27 @@ class RenderPipelineInput {
  public:
   RenderPipelineInput(const RenderPipelineInput&) = delete;
   RenderPipelineInput(RenderPipelineInput&& other) noexcept {
+    *this = std::move(other);
+  }
+  RenderPipelineInput& operator=(RenderPipelineInput&& other) noexcept {
     pipeline_ = other.pipeline_;
     group_id_ = other.group_id_;
     thread_id_ = other.thread_id_;
     buffers_ = std::move(other.buffers_);
     other.pipeline_ = nullptr;
+    return *this;
   }
 
   RenderPipelineInput() = default;
   ~RenderPipelineInput();
 
   const std::pair<ImageF*, Rect>& GetBuffer(size_t c) const {
-    JXL_DASSERT(c < buffers_.size());
+    JXL_ASSERT(c < buffers_.size());
     return buffers_[c];
   }
 
  private:
-  RenderPipeline* pipeline_;
+  RenderPipeline* pipeline_ = nullptr;
   size_t group_id_;
   size_t thread_id_;
   std::vector<std::pair<ImageF*, Rect>> buffers_;
@@ -115,6 +119,8 @@ class RenderPipeline {
 
   virtual void ProcessBuffers(size_t group_id, size_t thread_id) = 0;
 
+  // Note that this method may be called multiple times with different (or
+  // equal) `num`.
   virtual void PrepareForThreadsInternal(size_t num) = 0;
 };
 

--- a/lib/jxl/render_pipeline/render_pipeline_test.cc
+++ b/lib/jxl/render_pipeline/render_pipeline_test.cc
@@ -13,7 +13,13 @@
 #include <vector>
 
 #include "gtest/gtest.h"
+#include "lib/extras/codec.h"
+#include "lib/jxl/enc_params.h"
+#include "lib/jxl/fake_parallel_runner_testonly.h"
+#include "lib/jxl/image_test_utils.h"
 #include "lib/jxl/render_pipeline/test_render_pipeline_stages.h"
+#include "lib/jxl/test_utils.h"
+#include "lib/jxl/testdata.h"
 
 namespace jxl {
 namespace {
@@ -52,6 +58,115 @@ TEST(RenderPipelineTest, CallAllGroups) {
 
   EXPECT_TRUE(pipeline->ReceivedAllInput());
 }
+
+struct RenderPipelineTestInputSettings {
+  // Input image.
+  std::string input_path;
+  size_t xsize, ysize;
+  // Encoding settings.
+  CompressParams cparams;
+  // Short name for the encoder settings.
+  std::string cparams_descr;
+};
+
+class RenderPipelineTestParam
+    : public ::testing::TestWithParam<RenderPipelineTestInputSettings> {};
+
+TEST_P(RenderPipelineTestParam, PipelineTest) {
+  RenderPipelineTestInputSettings config = GetParam();
+
+  // Use a parallel runner that randomly shuffles tasks to detect possible
+  // border handling bugs.
+  FakeParallelRunner fake_pool(/*order_seed=*/123, /*num_threads=*/8);
+  ThreadPool pool(&JxlFakeParallelRunner, &fake_pool);
+  const PaddedBytes orig = ReadTestData(config.input_path);
+
+  CodecInOut io;
+  ASSERT_TRUE(SetFromBytes(Span<const uint8_t>(orig), &io, &pool));
+  io.ShrinkTo(config.xsize, config.ysize);
+
+  PaddedBytes compressed;
+
+  PassesEncoderState enc_state;
+  ASSERT_TRUE(EncodeFile(config.cparams, &io, &enc_state, &compressed,
+                         GetJxlCms(), /*aux_out=*/nullptr, &pool));
+
+  DecompressParams dparams;
+
+  CodecInOut io_default;
+  ASSERT_TRUE(DecodeFile(dparams, compressed, &io_default, &pool));
+  CodecInOut io_slow_pipeline;
+  dparams.use_slow_render_pipeline = true;
+  ASSERT_TRUE(DecodeFile(dparams, compressed, &io_slow_pipeline, &pool));
+
+  JXL_CHECK(EncodeToFile(io_default, "/tmp/default.png"));
+  JXL_CHECK(EncodeToFile(io_slow_pipeline, "/tmp/pipeline.png"));
+
+  ASSERT_EQ(io_default.frames.size(), io_slow_pipeline.frames.size());
+  for (size_t i = 0; i < io_default.frames.size(); i++) {
+    VerifyRelativeError(*io_default.frames[i].color(),
+                        *io_slow_pipeline.frames[i].color(), 1e-5, 1e-5);
+    for (size_t ec = 0; ec < io_default.frames[i].extra_channels().size();
+         ec++) {
+      VerifyRelativeError(io_default.frames[i].extra_channels()[ec],
+                          io_slow_pipeline.frames[i].extra_channels()[ec], 1e-5,
+                          1e-5);
+    }
+  }
+}
+
+std::vector<RenderPipelineTestInputSettings> GeneratePipelineTests() {
+  std::vector<RenderPipelineTestInputSettings> all_tests;
+
+  for (size_t size : {128, 256, 258, 777}) {
+    RenderPipelineTestInputSettings settings;
+    settings.input_path = "imagecompression.info/flower_foveon.png";
+    settings.xsize = size;
+    settings.ysize = size;
+
+    settings.cparams.butteraugli_distance = 1.0;
+    settings.cparams.patches = Override::kOff;
+    settings.cparams.dots = Override::kOff;
+    settings.cparams.gaborish = Override::kOff;
+    settings.cparams.epf = 0;
+    settings.cparams.color_transform = ColorTransform::kXYB;
+    settings.cparams_descr = "NoGabNoEpfNoPatches";
+    all_tests.push_back(settings);
+
+    settings.cparams.color_transform = ColorTransform::kNone;
+    settings.cparams_descr = "NoGabNoEpfNoPatchesNoXYB";
+    all_tests.push_back(settings);
+  }
+
+  return all_tests;
+}
+
+std::ostream& operator<<(std::ostream& os,
+                         const RenderPipelineTestInputSettings& c) {
+  std::string filename;
+  size_t pos = c.input_path.find_last_of('/');
+  if (pos == std::string::npos) {
+    filename = c.input_path;
+  } else {
+    filename = c.input_path.substr(pos + 1);
+  }
+  std::replace_if(
+      filename.begin(), filename.end(), [](char c) { return !isalnum(c); },
+      '_');
+  os << filename << "_" << c.xsize << "x" << c.ysize << "_" << c.cparams_descr;
+  return os;
+}
+
+std::string PipelineTestDescription(
+    const testing::TestParamInfo<RenderPipelineTestParam::ParamType>& info) {
+  std::stringstream name;
+  name << info.param;
+  return name.str();
+}
+
+JXL_GTEST_INSTANTIATE_TEST_SUITE_P(RenderPipelineTest, RenderPipelineTestParam,
+                                   testing::ValuesIn(GeneratePipelineTests()),
+                                   PipelineTestDescription);
 
 }  // namespace
 }  // namespace jxl

--- a/lib/jxl/render_pipeline/stage_write_to_ib.cc
+++ b/lib/jxl/render_pipeline/stage_write_to_ib.cc
@@ -21,7 +21,6 @@ class WriteToImageBundleStage : public RenderPipelineStage {
                   size_t xextra, size_t xsize, size_t xpos, size_t ypos,
                   float* JXL_RESTRICT temp) const final {
     for (size_t c = 0; c < 3; c++) {
-      JXL_ASSERT(image_bundle_->color()->xsize() <= xpos + xsize + xextra);
       memcpy(image_bundle_->color()->PlaneRow(c, ypos) + xpos - xextra,
              GetInputRow(input_rows, c, 0) + kRenderPipelineXOffset - xextra,
              sizeof(float) * (xsize + 2 * xextra));


### PR DESCRIPTION
This patch adds a (not exposed) option that uses the rendering pipeline,
giving an error for all stages that are not implemented, and uses this
flag to verify the same behaviour between the slow pipeline and the
current behaviour in new tests.