### PR TITLE
expose intrinsic size in the API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,9 +27,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
    `JxlEncoderFrameSettingsSetOption`
  - encoder API: new function `JxlEncoderFrameSettingsSetInfo` to set animation
    and blending parameters of the frame.
- - decoder/encoder API: add fields to `JXLBasicInfo`: a boolean
-   `have_intrinsic_size` and a new `JXLIntrinsicSizeHeader` struct that contains
-   the dimensions of the intrinsic size.
+ - decoder/encoder API: add two fields to `JXLBasicInfo`: `intrinsic_xsize`
+   and `intrinsic_ysize` to signal the intrinsic size.
 
 ### Changed
 - decoder API: using `JxlDecoderCloseInput` at the end of all input is required

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
    `JxlEncoderFrameSettingsSetOption`
  - encoder API: new function `JxlEncoderFrameSettingsSetInfo` to set animation
    and blending parameters of the frame.
+ - decoder/encoder API: add fields to `JXLBasicInfo`: a boolean
+   `have_intrinsic_size` and a new `JXLIntrinsicSizeHeader` struct that contains
+   the dimensions of the intrinsic size.
 
 ### Changed
 - decoder API: using `JxlDecoderCloseInput` at the end of all input is required

--- a/examples/jxlinfo.c
+++ b/examples/jxlinfo.c
@@ -106,6 +106,11 @@ int PrintBasicInfo(FILE* file) {
         printf("num_loops: %u\n", info.animation.num_loops);
         printf("have_timecodes: %d\n", info.animation.have_timecodes);
       }
+      printf("have_intrinsic_size: %d\n", info.have_intrinsic_size);
+      if (info.have_intrinsic_size) {
+        printf("intrinsic xsize: %u\n", info.intrinsic_size.xsize);
+        printf("intrinsic ysize: %u\n", info.intrinsic_size.ysize);
+      }
       const char* const orientation_string[8] = {
           "Normal",          "Flipped horizontally",
           "Upside down",     "Flipped vertically",

--- a/examples/jxlinfo.c
+++ b/examples/jxlinfo.c
@@ -106,11 +106,8 @@ int PrintBasicInfo(FILE* file) {
         printf("num_loops: %u\n", info.animation.num_loops);
         printf("have_timecodes: %d\n", info.animation.have_timecodes);
       }
-      printf("have_intrinsic_size: %d\n", info.have_intrinsic_size);
-      if (info.have_intrinsic_size) {
-        printf("intrinsic xsize: %u\n", info.intrinsic_size.xsize);
-        printf("intrinsic ysize: %u\n", info.intrinsic_size.ysize);
-      }
+      printf("intrinsic xsize: %u\n", info.intrinsic_xsize);
+      printf("intrinsic ysize: %u\n", info.intrinsic_ysize);
       const char* const orientation_string[8] = {
           "Normal",          "Flipped horizontally",
           "Upside down",     "Flipped vertically",

--- a/lib/include/jxl/codestream_header.h
+++ b/lib/include/jxl/codestream_header.h
@@ -241,24 +241,26 @@ typedef struct {
    */
   JxlAnimationHeader animation;
 
-  /** Indicates if an intrinsic size is present in the codestream.
-   * If JXL_TRUE, the intrinsic image size is given by intrinsic_size.
+  /** Intrinsic width of the image.
    * The intrinsic size can be different from the actual size in pixels
    * (as given by xsize and ysize) and it denotes the recommended dimensions
    * for displaying the image, i.e. applications are advised to resample the
    * decoded image to the intrinsic dimensions.
    */
-  JXL_BOOL have_intrinsic_size;
+  uint32_t intrinsic_xsize;
 
-  /** Dimensions of the intrinsic size, only used if have_intrinsic_size is
-   * JXL_TRUE.
+  /** Intrinsic heigth of the image.
+   * The intrinsic size can be different from the actual size in pixels
+   * (as given by xsize and ysize) and it denotes the recommended dimensions
+   * for displaying the image, i.e. applications are advised to resample the
+   * decoded image to the intrinsic dimensions.
    */
-  JxlIntrinsicSizeHeader intrinsic_size;
+  uint32_t intrinsic_ysize;
 
   /** Padding for forwards-compatibility, in case more fields are exposed
    * in a future version of the library.
    */
-  uint8_t padding[96];
+  uint8_t padding[100];
 } JxlBasicInfo;
 
 /** Information for a single extra channel.

--- a/lib/include/jxl/codestream_header.h
+++ b/lib/include/jxl/codestream_header.h
@@ -190,14 +190,6 @@ typedef struct {
    */
   JXL_BOOL have_animation;
 
-  /** Indicates if an intrinsic size is present in the codestream.
-   * If JXL_TRUE, the intrinsic image size is given by intrinsic_size.
-   * The intrinsic size can be different from the actual size in pixels (as given by xsize and ysize)
-   * and it denotes the recommended dimensions for displaying the image,
-   * i.e. applications are advised to resample the decoded image to the intrinsic dimensions.
-   */
-  JXL_BOOL have_intrinsic_size;
-
   /** Image orientation, value 1-8 matching the values used by JEITA CP-3451C
    * (Exif version 2.3).
    */
@@ -249,6 +241,14 @@ typedef struct {
    */
   JxlAnimationHeader animation;
 
+  /** Indicates if an intrinsic size is present in the codestream.
+   * If JXL_TRUE, the intrinsic image size is given by intrinsic_size.
+   * The intrinsic size can be different from the actual size in pixels (as given by xsize and ysize)
+   * and it denotes the recommended dimensions for displaying the image,
+   * i.e. applications are advised to resample the decoded image to the intrinsic dimensions.
+   */
+  JXL_BOOL have_intrinsic_size;
+
   /** Dimensions of the intrinsic size, only used if have_intrinsic_size is
    * JXL_TRUE.
    */
@@ -257,7 +257,7 @@ typedef struct {
   /** Padding for forwards-compatibility, in case more fields are exposed
    * in a future version of the library.
    */
-  uint8_t padding[108];
+  uint8_t padding[96];
 } JxlBasicInfo;
 
 /** Information for a single extra channel.

--- a/lib/include/jxl/codestream_header.h
+++ b/lib/include/jxl/codestream_header.h
@@ -72,6 +72,15 @@ typedef struct {
   uint32_t ysize;
 } JxlPreviewHeader;
 
+/** The intrinsic size header */
+typedef struct {
+  /** Preview width in pixels */
+  uint32_t xsize;
+
+  /** Preview height in pixels */
+  uint32_t ysize;
+} JxlIntrinsicSizeHeader;
+
 /** The codestream animation header, optionally present in the beginning of
  * the codestream, and if it is it applies to all animation frames, unlike
  * JxlFrameHeader which applies to an individual frame.
@@ -181,6 +190,11 @@ typedef struct {
    */
   JXL_BOOL have_animation;
 
+  /** Indicates if an intrinsic size is present in the codestream.
+   * Its dimensions are not included in the basic info.
+   */
+  JXL_BOOL have_intrinsic_size;
+
   /** Image orientation, value 1-8 matching the values used by JEITA CP-3451C
    * (Exif version 2.3).
    */
@@ -231,6 +245,11 @@ typedef struct {
    * used if have_animation is JXL_TRUE.
    */
   JxlAnimationHeader animation;
+
+  /** Dimensions of the intrinsic size, only used if have_intrinsic_size is
+   * JXL_TRUE.
+   */
+  JxlIntrinsicSizeHeader intrinsic_size;
 
   /** Padding for forwards-compatibility, in case more fields are exposed
    * in a future version of the library.

--- a/lib/include/jxl/codestream_header.h
+++ b/lib/include/jxl/codestream_header.h
@@ -74,10 +74,10 @@ typedef struct {
 
 /** The intrinsic size header */
 typedef struct {
-  /** Preview width in pixels */
+  /** Intrinsic width in pixels */
   uint32_t xsize;
 
-  /** Preview height in pixels */
+  /** Intrinsic height in pixels */
   uint32_t ysize;
 } JxlIntrinsicSizeHeader;
 
@@ -191,7 +191,10 @@ typedef struct {
   JXL_BOOL have_animation;
 
   /** Indicates if an intrinsic size is present in the codestream.
-   * Its dimensions are not included in the basic info.
+   * If JXL_TRUE, the intrinsic image size is given by intrinsic_size.
+   * The intrinsic size can be different from the actual size in pixels (as given by xsize and ysize)
+   * and it denotes the recommended dimensions for displaying the image,
+   * i.e. applications are advised to resample the decoded image to the intrinsic dimensions.
    */
   JXL_BOOL have_intrinsic_size;
 

--- a/lib/include/jxl/codestream_header.h
+++ b/lib/include/jxl/codestream_header.h
@@ -243,9 +243,10 @@ typedef struct {
 
   /** Indicates if an intrinsic size is present in the codestream.
    * If JXL_TRUE, the intrinsic image size is given by intrinsic_size.
-   * The intrinsic size can be different from the actual size in pixels (as given by xsize and ysize)
-   * and it denotes the recommended dimensions for displaying the image,
-   * i.e. applications are advised to resample the decoded image to the intrinsic dimensions.
+   * The intrinsic size can be different from the actual size in pixels
+   * (as given by xsize and ysize) and it denotes the recommended dimensions
+   * for displaying the image, i.e. applications are advised to resample the
+   * decoded image to the intrinsic dimensions.
    */
   JXL_BOOL have_intrinsic_size;
 

--- a/lib/jxl/decode.cc
+++ b/lib/jxl/decode.cc
@@ -2128,7 +2128,7 @@ JxlDecoderStatus JxlDecoderProcessInput(JxlDecoder* dec) {
 }
 
 // To ensure ABI forward-compatibility, this struct has a constant size.
-static_assert(sizeof(JxlBasicInfo) == 216,
+static_assert(sizeof(JxlBasicInfo) == 204,
               "JxlBasicInfo struct size should remain constant");
 
 JxlDecoderStatus JxlDecoderGetBasicInfo(const JxlDecoder* dec,

--- a/lib/jxl/decode.cc
+++ b/lib/jxl/decode.cc
@@ -2128,7 +2128,7 @@ JxlDecoderStatus JxlDecoderProcessInput(JxlDecoder* dec) {
 }
 
 // To ensure ABI forward-compatibility, this struct has a constant size.
-static_assert(sizeof(JxlBasicInfo) == 204,
+static_assert(sizeof(JxlBasicInfo) == 216,
               "JxlBasicInfo struct size should remain constant");
 
 JxlDecoderStatus JxlDecoderGetBasicInfo(const JxlDecoder* dec,
@@ -2148,7 +2148,7 @@ JxlDecoderStatus JxlDecoderGetBasicInfo(const JxlDecoder* dec,
 
     info->have_preview = meta.have_preview;
     info->have_animation = meta.have_animation;
-    // TODO(janwas): intrinsic_size
+    info->have_intrinsic_size = meta.have_intrinsic_size;
     info->orientation = static_cast<JxlOrientation>(meta.orientation);
 
     if (!dec->keep_orientation) {
@@ -2190,6 +2190,11 @@ JxlDecoderStatus JxlDecoderGetBasicInfo(const JxlDecoder* dec,
           dec->metadata.m.animation.tps_denominator;
       info->animation.num_loops = dec->metadata.m.animation.num_loops;
       info->animation.have_timecodes = dec->metadata.m.animation.have_timecodes;
+    }
+
+    if (info->have_intrinsic_size) {
+      info->intrinsic_size.xsize = dec->metadata.m.intrinsic_size.xsize();
+      info->intrinsic_size.ysize = dec->metadata.m.intrinsic_size.ysize();
     }
   }
 

--- a/lib/jxl/decode.cc
+++ b/lib/jxl/decode.cc
@@ -2148,7 +2148,6 @@ JxlDecoderStatus JxlDecoderGetBasicInfo(const JxlDecoder* dec,
 
     info->have_preview = meta.have_preview;
     info->have_animation = meta.have_animation;
-    info->have_intrinsic_size = meta.have_intrinsic_size;
     info->orientation = static_cast<JxlOrientation>(meta.orientation);
 
     if (!dec->keep_orientation) {
@@ -2192,9 +2191,12 @@ JxlDecoderStatus JxlDecoderGetBasicInfo(const JxlDecoder* dec,
       info->animation.have_timecodes = dec->metadata.m.animation.have_timecodes;
     }
 
-    if (info->have_intrinsic_size) {
-      info->intrinsic_size.xsize = dec->metadata.m.intrinsic_size.xsize();
-      info->intrinsic_size.ysize = dec->metadata.m.intrinsic_size.ysize();
+    if (meta.have_intrinsic_size) {
+      info->intrinsic_xsize = dec->metadata.m.intrinsic_size.xsize();
+      info->intrinsic_ysize = dec->metadata.m.intrinsic_size.ysize();
+    } else {
+      info->intrinsic_xsize = info->xsize;
+      info->intrinsic_ysize = info->ysize;
     }
   }
 

--- a/lib/jxl/decode_test.cc
+++ b/lib/jxl/decode_test.cc
@@ -178,8 +178,8 @@ void AppendTestBox(const char* type, const char* contents, size_t contents_size,
 PaddedBytes CreateTestJXLCodestream(
     Span<const uint8_t> pixels, size_t xsize, size_t ysize, size_t num_channels,
     const CompressParams& cparams, CodeStreamBoxFormat add_container,
-    JxlOrientation orientation, bool add_preview, bool add_icc_profile = false,
-    PaddedBytes* jpeg_codestream = nullptr) {
+    JxlOrientation orientation, bool add_preview, bool add_intrinsic_size,
+    bool add_icc_profile = false, PaddedBytes* jpeg_codestream = nullptr) {
   // Compress the pixels with JPEG XL.
   bool grayscale = (num_channels <= 2);
   bool include_alpha = !(num_channels & 1) && jpeg_codestream == nullptr;
@@ -229,6 +229,10 @@ PaddedBytes CreateTestJXLCodestream(
     io.metadata.m.have_preview = true;
     EXPECT_TRUE(io.metadata.m.preview_size.Set(io.preview_frame.xsize(),
                                                io.preview_frame.ysize()));
+  }
+  if (add_intrinsic_size) {
+    io.metadata.m.have_intrinsic_size = true;
+    EXPECT_TRUE(io.metadata.m.intrinsic_size.Set(xsize / 3, ysize / 3));
   }
   io.metadata.m.orientation = orientation;
   AuxOut aux_out;
@@ -1151,6 +1155,7 @@ struct PixelTestConfig {
   size_t xsize;
   size_t ysize;
   bool add_preview;
+  bool add_intrinsic_size;
   // Output format.
   JxlEndianness endianness;
   JxlDataType data_type;
@@ -1192,7 +1197,7 @@ TEST_P(DecodeTestParam, PixelTest) {
   jxl::PaddedBytes compressed = jxl::CreateTestJXLCodestream(
       jxl::Span<const uint8_t>(pixels.data(), pixels.size()), config.xsize,
       config.ysize, orig_channels, cparams, config.add_container,
-      config.orientation, config.add_preview);
+      config.orientation, config.add_preview, config.add_intrinsic_size);
 
   JxlPixelFormat format = {config.output_channels, config.data_type,
                            config.endianness, 0};
@@ -1282,14 +1287,16 @@ std::vector<PixelTestConfig> GeneratePixelTests() {
   };
 
   auto make_test = [&](ChannelInfo ch, size_t xsize, size_t ysize, bool preview,
-                       CodeStreamBoxFormat box, JxlOrientation orientation,
-                       bool keep_orientation, OutputFormat format,
-                       bool use_callback, bool set_buffer_early,
-                       bool resizable_runner, size_t upsampling) {
+                       bool intrinsic_size, CodeStreamBoxFormat box,
+                       JxlOrientation orientation, bool keep_orientation,
+                       OutputFormat format, bool use_callback,
+                       bool set_buffer_early, bool resizable_runner,
+                       size_t upsampling) {
     PixelTestConfig c;
     c.grayscale = ch.grayscale;
     c.include_alpha = ch.include_alpha;
     c.add_preview = preview;
+    c.add_intrinsic_size = intrinsic_size;
     c.xsize = xsize;
     c.ysize = ysize;
     c.add_container = (CodeStreamBoxFormat)box;
@@ -1311,6 +1318,7 @@ std::vector<PixelTestConfig> GeneratePixelTests() {
       for (size_t upsampling : {1, 2, 4, 8}) {
         for (OutputFormat fmt : out_formats) {
           make_test(ch, 301, 33, /*add_preview=*/false,
+                    /*add_intrinsic_size=*/false,
                     CodeStreamBoxFormat::kCSBF_None, JXL_ORIENT_IDENTITY,
                     /*keep_orientation=*/false, fmt, use_callback,
                     /*set_buffer_early=*/false, /*resizable_runner=*/false,
@@ -1322,21 +1330,33 @@ std::vector<PixelTestConfig> GeneratePixelTests() {
   // Test codestream formats.
   for (size_t box = 1; box < kCSBF_NUM_ENTRIES; ++box) {
     make_test(ch_info[0], 77, 33, /*add_preview=*/false,
-              (CodeStreamBoxFormat)box, JXL_ORIENT_IDENTITY,
+              /*add_intrinsic_size=*/false, (CodeStreamBoxFormat)box,
+              JXL_ORIENT_IDENTITY,
               /*keep_orientation=*/false, out_formats[0],
               /*use_callback=*/false,
               /*set_buffer_early=*/false, /*resizable_runner=*/false, 1);
   }
   // Test previews.
   for (int add_preview = 0; add_preview <= 1; add_preview++) {
-    make_test(ch_info[0], 77, 33, add_preview, CodeStreamBoxFormat::kCSBF_None,
-              JXL_ORIENT_IDENTITY, /*keep_orientation=*/false, out_formats[0],
+    make_test(ch_info[0], 77, 33, add_preview, /*add_intrinsic_size=*/false,
+              CodeStreamBoxFormat::kCSBF_None, JXL_ORIENT_IDENTITY,
+              /*keep_orientation=*/false, out_formats[0],
+              /*use_callback=*/false, /*set_buffer_early=*/false,
+              /*resizable_runner=*/false, 1);
+  }
+  // Test intrinsic sizes.
+  for (int add_intrinsic_size = 0; add_intrinsic_size <= 1;
+       add_intrinsic_size++) {
+    make_test(ch_info[0], 55, 34, /*add_preview=*/false, add_intrinsic_size,
+              CodeStreamBoxFormat::kCSBF_None, JXL_ORIENT_IDENTITY,
+              /*keep_orientation=*/false, out_formats[0],
               /*use_callback=*/false, /*set_buffer_early=*/false,
               /*resizable_runner=*/false, 1);
   }
   // Test setting buffers early.
   make_test(ch_info[0], 300, 33, /*add_preview=*/false,
-            CodeStreamBoxFormat::kCSBF_None, JXL_ORIENT_IDENTITY,
+            /*add_intrinsic_size=*/false, CodeStreamBoxFormat::kCSBF_None,
+            JXL_ORIENT_IDENTITY,
             /*keep_orientation=*/false, out_formats[0],
             /*use_callback=*/false, /*set_buffer_early=*/true,
             /*resizable_runner=*/false, 1);
@@ -1344,7 +1364,8 @@ std::vector<PixelTestConfig> GeneratePixelTests() {
   // Test using the resizable runner
   for (size_t i = 0; i < 4; i++) {
     make_test(ch_info[0], 300 << i, 33 << i, /*add_preview=*/false,
-              CodeStreamBoxFormat::kCSBF_None, JXL_ORIENT_IDENTITY,
+              /*add_intrinsic_size=*/false, CodeStreamBoxFormat::kCSBF_None,
+              JXL_ORIENT_IDENTITY,
               /*keep_orientation=*/false, out_formats[0],
               /*use_callback=*/false, /*set_buffer_early=*/false,
               /*resizable_runner=*/true, 1);
@@ -1353,13 +1374,13 @@ std::vector<PixelTestConfig> GeneratePixelTests() {
   // Test orientations.
   for (int orientation = 1; orientation <= 8; ++orientation) {
     make_test(ch_info[0], 280, 12, /*add_preview=*/false,
-              CodeStreamBoxFormat::kCSBF_None,
+              /*add_intrinsic_size=*/false, CodeStreamBoxFormat::kCSBF_None,
               static_cast<JxlOrientation>(orientation),
               /*keep_orientation=*/false, out_formats[0],
               /*use_callback=*/false, /*set_buffer_early=*/true,
               /*resizable_runner=*/false, 1);
     make_test(ch_info[0], 280, 12, /*add_preview=*/false,
-              CodeStreamBoxFormat::kCSBF_None,
+              /*add_intrinsic_size=*/false, CodeStreamBoxFormat::kCSBF_None,
               static_cast<JxlOrientation>(orientation),
               /*keep_orientation=*/true, out_formats[0],
               /*use_callback=*/false, /*set_buffer_early=*/true,
@@ -1409,6 +1430,7 @@ std::ostream& operator<<(std::ostream& os, const PixelTestConfig& c) {
     os << (size_t)c.add_container;
   }
   if (c.add_preview) os << "Preview";
+  if (c.add_intrinsic_size) os << "IntrinicSize";
   if (c.use_callback) os << "Callback";
   if (c.set_buffer_early) os << "EarlyBuffer";
   if (c.use_resizable_runner) os << "ResizableRunner";
@@ -1443,7 +1465,7 @@ TEST(DecodeTest, PixelTestWithICCProfileLossless) {
   // and no container.
   jxl::PaddedBytes compressed = jxl::CreateTestJXLCodestream(
       jxl::Span<const uint8_t>(pixels.data(), pixels.size()), xsize, ysize, 4,
-      cparams, kCSBF_None, JXL_ORIENT_IDENTITY, false, true);
+      cparams, kCSBF_None, JXL_ORIENT_IDENTITY, false, false, true);
 
   for (uint32_t channels = 3; channels <= 4; ++channels) {
     {
@@ -1503,6 +1525,7 @@ TEST(DecodeTest, PixelTestWithICCProfileLossy) {
   jxl::PaddedBytes compressed = jxl::CreateTestJXLCodestream(
       jxl::Span<const uint8_t>(pixels.data(), pixels.size()), xsize, ysize, 3,
       cparams, kCSBF_None, JXL_ORIENT_IDENTITY, /*add_preview=*/false,
+      /*add_intrinsic_size=*/false,
       /*add_icc_profile=*/true);
   uint32_t channels = 3;
 
@@ -1561,6 +1584,7 @@ TEST(DecodeTest, PixelTestOpaqueSrgbLossy) {
     jxl::PaddedBytes compressed = jxl::CreateTestJXLCodestream(
         jxl::Span<const uint8_t>(pixels.data(), pixels.size()), xsize, ysize, 3,
         cparams, kCSBF_None, JXL_ORIENT_IDENTITY, /*add_preview=*/false,
+        /*add_intrinsic_size=*/false,
         /*add_icc_profile=*/false);
 
     JxlPixelFormat format = {channels, JXL_TYPE_UINT8, JXL_LITTLE_ENDIAN, 0};
@@ -1629,6 +1653,7 @@ TEST(DecodeTest, PixelTestOpaqueSrgbLossyNoise) {
     jxl::PaddedBytes compressed = jxl::CreateTestJXLCodestream(
         jxl::Span<const uint8_t>(pixels.data(), pixels.size()), xsize, ysize, 3,
         cparams, kCSBF_None, JXL_ORIENT_IDENTITY, /*add_preview=*/false,
+        /*add_intrinsic_size=*/false,
         /*add_icc_profile=*/false);
 
     JxlPixelFormat format = {channels, JXL_TYPE_UINT8, JXL_LITTLE_ENDIAN, 0};
@@ -1714,6 +1739,7 @@ void TestPartialStream(bool reconstructible_jpeg) {
         jxl::Span<const uint8_t>(pixels.data(), pixels.size()), xsize, ysize,
         channels, cparams, add_container, JXL_ORIENT_IDENTITY,
         /*add_preview=*/true,
+        /*add_intrinsic_size=*/false,
         /*add_icc_profile=*/false,
         reconstructible_jpeg ? &jpeg_codestreams[i] : nullptr);
   }
@@ -1878,7 +1904,8 @@ TEST(DecodeTest, PreviewTest) {
   jxl::CompressParams cparams;
   jxl::PaddedBytes compressed = jxl::CreateTestJXLCodestream(
       jxl::Span<const uint8_t>(pixels.data(), pixels.size()), xsize, ysize, 3,
-      cparams, kCSBF_Multi, JXL_ORIENT_IDENTITY, /*add_preview=*/true);
+      cparams, kCSBF_Multi, JXL_ORIENT_IDENTITY, /*add_preview=*/true,
+      /*add_intrinsic_size=*/false);
 
   JxlPixelFormat format = {3, JXL_TYPE_UINT8, JXL_LITTLE_ENDIAN, 0};
 
@@ -1965,7 +1992,7 @@ TEST(DecodeTest, AlignTest) {
   cparams.speed_tier = jxl::SpeedTier::kThunder;
   jxl::PaddedBytes compressed = jxl::CreateTestJXLCodestream(
       jxl::Span<const uint8_t>(pixels.data(), pixels.size()), xsize, ysize, 4,
-      cparams, kCSBF_None, JXL_ORIENT_IDENTITY, false);
+      cparams, kCSBF_None, JXL_ORIENT_IDENTITY, false, false);
 
   size_t align = 17;
   JxlPixelFormat format = {3, JXL_TYPE_UINT8, JXL_LITTLE_ENDIAN, align};
@@ -2233,7 +2260,7 @@ TEST(DecodeTest, ExtraChannelTest) {
   cparams.speed_tier = jxl::SpeedTier::kThunder;
   jxl::PaddedBytes compressed = jxl::CreateTestJXLCodestream(
       jxl::Span<const uint8_t>(pixels.data(), pixels.size()), xsize, ysize, 4,
-      cparams, kCSBF_None, JXL_ORIENT_IDENTITY, false);
+      cparams, kCSBF_None, JXL_ORIENT_IDENTITY, false, false);
 
   size_t align = 17;
   JxlPixelFormat format = {3, JXL_TYPE_UINT8, JXL_LITTLE_ENDIAN, align};
@@ -3103,7 +3130,7 @@ TEST(DecodeTest, FlushTest) {
   jxl::CompressParams cparams;
   jxl::PaddedBytes data = jxl::CreateTestJXLCodestream(
       jxl::Span<const uint8_t>(pixels.data(), pixels.size()), xsize, ysize,
-      num_channels, cparams, kCSBF_None, JXL_ORIENT_IDENTITY, true);
+      num_channels, cparams, kCSBF_None, JXL_ORIENT_IDENTITY, true, false);
   JxlPixelFormat format = {num_channels, JXL_TYPE_UINT16, JXL_BIG_ENDIAN, 0};
 
   std::vector<uint8_t> pixels2;
@@ -3177,7 +3204,7 @@ TEST(DecodeTest, FlushTestLossyProgressiveAlpha) {
   jxl::CompressParams cparams;
   jxl::PaddedBytes data = jxl::CreateTestJXLCodestream(
       jxl::Span<const uint8_t>(pixels.data(), pixels.size()), xsize, ysize,
-      num_channels, cparams, kCSBF_None, JXL_ORIENT_IDENTITY, true);
+      num_channels, cparams, kCSBF_None, JXL_ORIENT_IDENTITY, true, false);
   JxlPixelFormat format = {num_channels, JXL_TYPE_UINT16, JXL_BIG_ENDIAN, 0};
 
   std::vector<uint8_t> pixels2;
@@ -3248,7 +3275,7 @@ TEST(DecodeTest, FlushTestLossyProgressiveAlphaUpsampling) {
   cparams.ec_resampling = 4;
   jxl::PaddedBytes data = jxl::CreateTestJXLCodestream(
       jxl::Span<const uint8_t>(pixels.data(), pixels.size()), xsize, ysize,
-      num_channels, cparams, kCSBF_None, JXL_ORIENT_IDENTITY, true);
+      num_channels, cparams, kCSBF_None, JXL_ORIENT_IDENTITY, true, false);
   JxlPixelFormat format = {num_channels, JXL_TYPE_UINT16, JXL_BIG_ENDIAN, 0};
 
   std::vector<uint8_t> pixels2;
@@ -3322,7 +3349,7 @@ TEST(DecodeTest, FlushTestLosslessProgressiveAlpha) {
   cparams.responsive = 1;
   jxl::PaddedBytes data = jxl::CreateTestJXLCodestream(
       jxl::Span<const uint8_t>(pixels.data(), pixels.size()), xsize, ysize,
-      num_channels, cparams, kCSBF_None, JXL_ORIENT_IDENTITY, true);
+      num_channels, cparams, kCSBF_None, JXL_ORIENT_IDENTITY, true, false);
   JxlPixelFormat format = {num_channels, JXL_TYPE_UINT16, JXL_BIG_ENDIAN, 0};
 
   std::vector<uint8_t> pixels2;
@@ -3427,6 +3454,7 @@ TEST(DecodeTest, JXL_TRANSCODE_JPEG_TEST(JPEGReconstructTestCodestream)) {
       jxl::Span<const uint8_t>(pixels.data(), pixels.size()), xsize, ysize,
       channels, cparams, kCSBF_Single, JXL_ORIENT_IDENTITY,
       /*add_preview=*/true,
+      /*add_intrinsic_size=*/false,
       /*add_icc_profile=*/false, &jpeg_codestream);
   VerifyJPEGReconstruction(compressed, jpeg_codestream);
 }
@@ -3480,7 +3508,8 @@ TEST(DecodeTest, ContinueFinalNonEssentialBoxTest) {
   // Lossless to verify pixels exactly after roundtrip.
   jxl::PaddedBytes compressed = jxl::CreateTestJXLCodestream(
       jxl::Span<const uint8_t>(pixels.data(), pixels.size()), xsize, ysize, 4,
-      cparams, kCSBF_Multi_Other_Terminated, JXL_ORIENT_IDENTITY, false, true);
+      cparams, kCSBF_Multi_Other_Terminated, JXL_ORIENT_IDENTITY, false, false,
+      true);
 
   // The non-essential final box size including 8-byte header
   size_t final_box_size = unk3_box_size + 8;
@@ -3541,7 +3570,8 @@ TEST(DecodeTest, BoxTest) {
   jxl::CompressParams cparams;
   jxl::PaddedBytes compressed = jxl::CreateTestJXLCodestream(
       jxl::Span<const uint8_t>(pixels.data(), pixels.size()), xsize, ysize, 4,
-      cparams, kCSBF_Multi_Other_Terminated, JXL_ORIENT_IDENTITY, false, true);
+      cparams, kCSBF_Multi_Other_Terminated, JXL_ORIENT_IDENTITY, false, false,
+      true);
 
   JxlDecoder* dec = JxlDecoderCreate(nullptr);
 
@@ -3604,7 +3634,7 @@ TEST(DecodeTest, ExifBrobBoxTest) {
   cparams.SetLossless();  // Lossless to verify pixels exactly after roundtrip.
   jxl::PaddedBytes compressed = jxl::CreateTestJXLCodestream(
       jxl::Span<const uint8_t>(pixels.data(), pixels.size()), xsize, ysize, 4,
-      cparams, kCSBF_Brob_Exif, JXL_ORIENT_IDENTITY, false, true);
+      cparams, kCSBF_Brob_Exif, JXL_ORIENT_IDENTITY, false, false, true);
 
   // Test raw brob box, not brotli-decompressing
   for (int streaming = 0; streaming < 2; ++streaming) {
@@ -3787,7 +3817,7 @@ TEST(DecodeTest, PartialCodestreamBoxTest) {
   cparams.speed_tier = jxl::SpeedTier::kThunder;
   jxl::PaddedBytes compressed = jxl::CreateTestJXLCodestream(
       jxl::Span<const uint8_t>(pixels.data(), pixels.size()), xsize, ysize, 4,
-      cparams, kCSBF_Multi, JXL_ORIENT_IDENTITY, false, true);
+      cparams, kCSBF_Multi, JXL_ORIENT_IDENTITY, false, false, true);
 
   std::vector<uint8_t> extracted_codestream;
 

--- a/lib/jxl/decode_test.cc
+++ b/lib/jxl/decode_test.cc
@@ -231,7 +231,6 @@ PaddedBytes CreateTestJXLCodestream(
                                                io.preview_frame.ysize()));
   }
   if (add_intrinsic_size) {
-    io.metadata.m.have_intrinsic_size = true;
     EXPECT_TRUE(io.metadata.m.intrinsic_size.Set(xsize / 3, ysize / 3));
   }
   io.metadata.m.orientation = orientation;

--- a/lib/jxl/encode.cc
+++ b/lib/jxl/encode.cc
@@ -12,6 +12,7 @@
 #include <cstring>
 
 #include "jxl/codestream_header.h"
+#include "jxl/types.h"
 #include "lib/jxl/aux_out.h"
 #include "lib/jxl/base/span.h"
 #include "lib/jxl/codec_in_out.h"
@@ -415,6 +416,7 @@ void JxlEncoderInitBasicInfo(JxlBasicInfo* info) {
   info->uses_original_profile = JXL_FALSE;
   info->have_preview = JXL_FALSE;
   info->have_animation = JXL_FALSE;
+  info->have_intrinsic_size = JXL_FALSE;
   info->orientation = JXL_ORIENT_IDENTITY;
   info->num_color_channels = 3;
   info->num_extra_channels = 0;
@@ -423,6 +425,8 @@ void JxlEncoderInitBasicInfo(JxlBasicInfo* info) {
   info->alpha_premultiplied = JXL_FALSE;
   info->preview.xsize = 0;
   info->preview.ysize = 0;
+  info->intrinsic_size.xsize = 0;
+  info->intrinsic_size.ysize = 0;
   info->animation.tps_numerator = 10;
   info->animation.tps_denominator = 1;
   info->animation.num_loops = 0;

--- a/lib/jxl/encode.cc
+++ b/lib/jxl/encode.cc
@@ -416,7 +416,6 @@ void JxlEncoderInitBasicInfo(JxlBasicInfo* info) {
   info->uses_original_profile = JXL_FALSE;
   info->have_preview = JXL_FALSE;
   info->have_animation = JXL_FALSE;
-  info->have_intrinsic_size = JXL_FALSE;
   info->orientation = JXL_ORIENT_IDENTITY;
   info->num_color_channels = 3;
   info->num_extra_channels = 0;
@@ -425,8 +424,8 @@ void JxlEncoderInitBasicInfo(JxlBasicInfo* info) {
   info->alpha_premultiplied = JXL_FALSE;
   info->preview.xsize = 0;
   info->preview.ysize = 0;
-  info->intrinsic_size.xsize = 0;
-  info->intrinsic_size.ysize = 0;
+  info->intrinsic_xsize = 0;
+  info->intrinsic_ysize = 0;
   info->animation.tps_numerator = 10;
   info->animation.tps_denominator = 1;
   info->animation.num_loops = 0;


### PR DESCRIPTION
We add fields in the `JXLBasicInfo`: a boolean `have_intrinsic_size` and
a new `JXLIntrinsicSizeHeader` struct that contains the dimensions of
the intrinsic size.
We add a parameter in the parameterized decode tests, in order to test
the intrinsic size.