### PR TITLE
Simplify RenderingPipeline's handling of shifts.

### DIFF
--- a/lib/jxl/dec_frame.cc
+++ b/lib/jxl/dec_frame.cc
@@ -665,8 +665,7 @@ void FrameDecoder::PreparePipeline() {
     JXL_ABORT("Not implemented: chroma subsampling");
   }
 
-  RenderPipeline::Builder builder(
-      std::vector<std::pair<size_t, size_t>>{{0, 0}, {0, 0}, {0, 0}});
+  RenderPipeline::Builder builder(/*num_c=*/3);
 
   if (use_slow_rendering_pipeline_) {
     builder.UseSimpleImplementation();

--- a/lib/jxl/render_pipeline/render_pipeline.h
+++ b/lib/jxl/render_pipeline/render_pipeline.h
@@ -51,10 +51,7 @@ class RenderPipeline {
  public:
   class Builder {
    public:
-    // Initial shifts for the channels (following the same convention as
-    // RenderPipelineStage for naming the channels).
-    explicit Builder(std::vector<std::pair<size_t, size_t>> channel_shifts)
-        : channel_shifts_(std::move(channel_shifts)) {}
+    explicit Builder(size_t num_c) : num_c_(num_c) { JXL_ASSERT(num_c > 0); }
 
     // Adds a stage to the pipeline. Must be called at least once; the last
     // added stage cannot have kInOut channels.
@@ -71,7 +68,7 @@ class RenderPipeline {
 
    private:
     std::vector<std::unique_ptr<RenderPipelineStage>> stages_;
-    std::vector<std::pair<size_t, size_t>> channel_shifts_;
+    size_t num_c_;
     bool use_simple_implementation_ = false;
   };
 

--- a/lib/jxl/render_pipeline/render_pipeline_test.cc
+++ b/lib/jxl/render_pipeline/render_pipeline_test.cc
@@ -25,7 +25,7 @@ namespace jxl {
 namespace {
 
 TEST(RenderPipelineTest, Build) {
-  RenderPipeline::Builder builder(/*channel_shifts=*/{{1, 1}});
+  RenderPipeline::Builder builder(/*num_c=*/1);
   builder.AddStage(jxl::make_unique<UpsampleXSlowStage>());
   builder.AddStage(jxl::make_unique<UpsampleYSlowStage>());
   builder.AddStage(jxl::make_unique<Check0FinalStage>());
@@ -33,12 +33,12 @@ TEST(RenderPipelineTest, Build) {
   FrameDimensions frame_dimensions;
   frame_dimensions.Set(/*xsize=*/1024, /*ysize=*/1024, /*group_size_shift=*/0,
                        /*max_hshift=*/0, /*max_vshift=*/0,
-                       /*modular_mode=*/false, /*upsampling=*/2);
+                       /*modular_mode=*/false, /*upsampling=*/1);
   std::move(builder).Finalize(frame_dimensions);
 }
 
 TEST(RenderPipelineTest, CallAllGroups) {
-  RenderPipeline::Builder builder({{1, 1}});
+  RenderPipeline::Builder builder(/*num_c=*/1);
   builder.AddStage(jxl::make_unique<UpsampleXSlowStage>());
   builder.AddStage(jxl::make_unique<UpsampleYSlowStage>());
   builder.AddStage(jxl::make_unique<Check0FinalStage>());
@@ -46,7 +46,7 @@ TEST(RenderPipelineTest, CallAllGroups) {
   FrameDimensions frame_dimensions;
   frame_dimensions.Set(/*xsize=*/1024, /*ysize=*/1024, /*group_size_shift=*/0,
                        /*max_hshift=*/0, /*max_vshift=*/0,
-                       /*modular_mode=*/false, /*upsampling=*/2);
+                       /*modular_mode=*/false, /*upsampling=*/1);
   auto pipeline = std::move(builder).Finalize(frame_dimensions);
   pipeline->PrepareForThreads(1);
 
@@ -98,9 +98,6 @@ TEST_P(RenderPipelineTestParam, PipelineTest) {
   CodecInOut io_slow_pipeline;
   dparams.use_slow_render_pipeline = true;
   ASSERT_TRUE(DecodeFile(dparams, compressed, &io_slow_pipeline, &pool));
-
-  JXL_CHECK(EncodeToFile(io_default, "/tmp/default.png"));
-  JXL_CHECK(EncodeToFile(io_slow_pipeline, "/tmp/pipeline.png"));
 
   ASSERT_EQ(io_default.frames.size(), io_slow_pipeline.frames.size());
   for (size_t i = 0; i < io_default.frames.size(); i++) {


### PR DESCRIPTION
As a side effect, this fixes test failures in coverage builds.