### PR TITLE
allow thermal channels

### DIFF
--- a/lib/jxl/image_metadata.h
+++ b/lib/jxl/image_metadata.h
@@ -65,7 +65,7 @@ static inline constexpr uint64_t EnumBits(ExtraChannel /*unused*/) {
   using EC = ExtraChannel;
   return MakeBit(EC::kAlpha) | MakeBit(EC::kDepth) | MakeBit(EC::kSpotColor) |
          MakeBit(EC::kSelectionMask) | MakeBit(EC::kBlack) | MakeBit(EC::kCFA) |
-         MakeBit(EC::kUnknown) | MakeBit(EC::kOptional);
+         MakeBit(EC::kThermal) | MakeBit(EC::kUnknown) | MakeBit(EC::kOptional);
 }
 
 // Used in ImageMetadata and ExtraChannelInfo.

--- a/lib/jxl/roundtrip_test.cc
+++ b/lib/jxl/roundtrip_test.cc
@@ -515,6 +515,7 @@ TEST(RoundtripTest, Uint16FrameRoundtripTest) {
 TEST(RoundtripTest, Uint8FrameRoundtripTest) {
   std::vector<std::vector<std::pair<JxlExtraChannelType, std::string>>>
       extra_channels_cases = {{},
+                              {{JXL_CHANNEL_THERMAL, "temperature"}},
                               {{JXL_CHANNEL_ALPHA, "my extra alpha channel"}},
                               {{JXL_CHANNEL_CFA, "my cfa channel"}},
                               {{JXL_CHANNEL_CFA, "my cfa channel"},


### PR DESCRIPTION
Currently it is impossible to encode a `JXL_CHANNEL_THERMAL`, we fix
this by adding the corresponding `MakeBit`.