### PR TITLE
Make the skcms version of JxlCms handle grayscale the way it should

### DIFF
--- a/lib/jxl/color_management.cc
+++ b/lib/jxl/color_management.cc
@@ -3,12 +3,6 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-// Defined by build system; this avoids IDE warnings. Must come before
-// color_management.h (affects header definitions).
-#ifndef JPEGXL_ENABLE_SKCMS
-#define JPEGXL_ENABLE_SKCMS 0
-#endif
-
 #include "lib/jxl/color_management.h"
 
 #include <math.h>

--- a/lib/jxl/enc_image_bundle.cc
+++ b/lib/jxl/enc_image_bundle.cc
@@ -30,11 +30,7 @@ Status CopyToT(const ImageMetadata* metadata, const ImageBundle* ib,
   ColorSpaceTransform c_transform(cms);
   // Changing IsGray is probably a bug.
   JXL_CHECK(ib->IsGray() == c_desired.IsGray());
-#if JPEGXL_ENABLE_SKCMS
-  bool is_gray = false;
-#else
   bool is_gray = ib->IsGray();
-#endif
   if (out->xsize() < rect.xsize() || out->ysize() < rect.ysize()) {
     *out = Image3F(rect.xsize(), rect.ysize());
   } else {


### PR DESCRIPTION
Code outside of the CMS should not depend on whether JxlCms is built
with skcms or lcms2 as it could dynamically be set to an entirely
different CMS.