### PR TITLE
Support progressive event for DC

### DIFF
--- a/lib/include/jxl/decode.h
+++ b/lib/include/jxl/decode.h
@@ -289,8 +289,11 @@ typedef enum {
    * this point, the flushed image will correspond exactly to this point in
    * decoding, and not yet contain partial results (such as partially more fine
    * detail) of a next step. By default, this event will trigger maximum once
-   * per frame, when a 8x8th resolution (DC) image is ready. Use @ref
-   * JxlDecoderSetProgressiveDetail to configure more fine-grainedness.
+   * per frame, when a 8x8th resolution (DC) image is ready (the image data is
+   * still returned at full resolution, giving upscaled DC). Use @ref
+   * JxlDecoderSetProgressiveDetail to configure more fine-grainedness. The
+   * event is not guaranteed to trigger, not all images have progressive steps
+   * or DC encoded.
    */
   JXL_DEC_FRAME_PROGRESSION = 0x8000,
 } JxlDecoderStatus;

--- a/lib/jxl/dec_frame.cc
+++ b/lib/jxl/dec_frame.cc
@@ -361,6 +361,7 @@ Status FrameDecoder::InitFrame(BitReader* JXL_RESTRICT br, ImageBundle* decoded,
   decoded_ac_global_ = false;
   is_finalized_ = false;
   finalized_dc_ = false;
+  num_sections_done_ = 0;
   decoded_dc_groups_.clear();
   decoded_dc_groups_.resize(frame_dim_.num_dc_groups);
   decoded_passes_per_ac_group_.clear();
@@ -719,6 +720,18 @@ void FrameDecoder::PreparePipeline() {
   dec_state_->render_pipeline = std::move(builder).Finalize(frame_dim_);
 }
 
+void FrameDecoder::MarkSections(const SectionInfo* sections, size_t num,
+                                SectionStatus* section_status) {
+  num_sections_done_ = num;
+  for (size_t i = 0; i < num; i++) {
+    if (section_status[i] == SectionStatus::kSkipped ||
+        section_status[i] == SectionStatus::kPartial) {
+      processed_section_[sections[i].id] = false;
+      num_sections_done_--;
+    }
+  }
+}
+
 Status FrameDecoder::ProcessSections(const SectionInfo* sections, size_t num,
                                      SectionStatus* section_status) {
   if (num == 0) return true;  // Nothing to process
@@ -730,7 +743,9 @@ Status FrameDecoder::ProcessSections(const SectionInfo* sections, size_t num,
       frame_dim_.num_groups,
       std::vector<size_t>(frame_header_.passes.num_passes, num));
   std::vector<size_t> num_ac_passes(frame_dim_.num_groups);
-  if (frame_dim_.num_groups == 1 && frame_header_.passes.num_passes == 1) {
+  bool single_section =
+      frame_dim_.num_groups == 1 && frame_header_.passes.num_passes == 1;
+  if (single_section) {
     JXL_ASSERT(num == 1);
     JXL_ASSERT(sections[0].id == 0);
     if (processed_section_[0] == false) {
@@ -816,6 +831,34 @@ Status FrameDecoder::ProcessSections(const SectionInfo* sections, size_t num,
     }
     FinalizeDC();
     AllocateOutput();
+    if (pause_at_progressive_ && !single_section) {
+      bool can_return_dc = true;
+      if (single_section) {
+        // If there's only one group and one pass, there is no separate section
+        // for DC and the entire full resolution image is available at once.
+        can_return_dc = false;
+      }
+      if (!decoded_->metadata()->extra_channel_info.empty()) {
+        // If extra channels are encoded with modular without squeeze, they
+        // don't support DC. If the are encoded with squeeze, DC works in theory
+        // but the implementation may not yet correctly support this for Flush.
+        // Therefore, can't correctly pause for a progressive step if there is
+        // an extra channel (including alpha channel)
+        can_return_dc = false;
+      }
+      if (frame_header_.encoding != FrameEncoding::kVarDCT) {
+        // DC is not guaranteed to be available in modular mode and may be a
+        // black image. If squeeze is used, it may be available depending on the
+        // current implementation.
+        // TODO(lode): do return DC if it's known that flushing at this point
+        // will produce a valid 1/8th downscaled image with modular encoding.
+        can_return_dc = false;
+      }
+      if (can_return_dc) {
+        MarkSections(sections, num, section_status);
+        return true;
+      }
+    }
   }
 
   if (finalized_dc_) dec_state_->EnsureBordersStorage();
@@ -874,12 +917,7 @@ Status FrameDecoder::ProcessSections(const SectionInfo* sections, size_t num,
   }
   if (has_error) return JXL_FAILURE("Error in AC group");
 
-  for (size_t i = 0; i < num; i++) {
-    if (section_status[i] == SectionStatus::kSkipped ||
-        section_status[i] == SectionStatus::kPartial) {
-      processed_section_[sections[i].id] = false;
-    }
-  }
+  MarkSections(sections, num, section_status);
   return true;
 }
 

--- a/lib/jxl/dec_frame.h
+++ b/lib/jxl/dec_frame.h
@@ -137,6 +137,15 @@ class FrameDecoder {
   // Returns whether a DC image has been decoded, accessible at low resolution
   // at passes.shared_storage.dc_storage
   bool HasDecodedDC() const { return finalized_dc_; }
+  bool HasDecodedAll() const { return NumSections() == num_sections_done_; }
+
+  // If enabled, ProcessSections will stop and return true when the DC
+  // sections have been processed, instead of starting the AC sections. This
+  // will only occur if supported (that is, flushing will produce a valid
+  // 1/8th*1/8th resolution image). The return value of true then does not mean
+  // all sections have been processed, use HasDecodedDC and HasDecodedAll
+  // to check the true finished state.
+  void SetPauseAtProgressive() { pause_at_progressive_ = true; }
 
   // Sets the buffer to which uint8 sRGB pixels will be decoded. This is not
   // supported for all images. If it succeeds, HasRGBBuffer() will return true.
@@ -205,6 +214,8 @@ class FrameDecoder {
   Status ProcessACGroup(size_t ac_group_id, BitReader* JXL_RESTRICT* br,
                         size_t num_passes, size_t thread, bool force_draw,
                         bool dc_only);
+  void MarkSections(const SectionInfo* sections, size_t num,
+                    SectionStatus* section_status);
 
   // Allocates storage for parallel decoding using up to `num_threads` threads
   // of up to `num_tasks` tasks. The value of `thread` passed to
@@ -270,6 +281,7 @@ class FrameDecoder {
   bool decoded_dc_global_;
   bool decoded_ac_global_;
   bool finalized_dc_ = true;
+  size_t num_sections_done_ = 0;
   bool is_finalized_ = true;
   size_t num_renders_ = 0;
   bool allocated_ = false;
@@ -285,6 +297,8 @@ class FrameDecoder {
 
   // Testing setting: whether or not to use the slow rendering pipeline.
   bool use_slow_rendering_pipeline_;
+
+  bool pause_at_progressive_ = false;
 };
 
 }  // namespace jxl


### PR DESCRIPTION
This implements the progressive API event fo rthe DC image.

This is currently only supported for vardct without extra channels: for
modular and extra channels it's only supported if squeeze is used, and
it may not correctly work with Flush yet in that case.