### PR TITLE
Remove JXL_ENC_NOT_SUPPORTED

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - encoder API: `JxlEncoderOptionsSetDecodingSpeed`: use
   `JxlEncoderFrameSettingsSetOption(frame_settings,
   JXL_ENC_FRAME_SETTING_DECODING_SPEED, tier)` instead.
+- encoder API: deprecated `JXL_ENC_NOT_SUPPORTED`, the encoder returns
+  `JXL_ENC_ERROR` instead and there is no need to handle
+  `JXL_ENC_NOT_SUPPORTED`.
 
 ## [0.6.1] - 2021-10-29
 ### Changed

--- a/lib/include/jxl/encode.h
+++ b/lib/include/jxl/encode.h
@@ -71,7 +71,8 @@ typedef enum {
    */
   JXL_ENC_NEED_MORE_OUTPUT = 2,
 
-  /** The encoder doesn't (yet) support this.
+  /** DEPRECATED: the encoder does not return this status and there is no need
+   * to handle or expect it.
    */
   JXL_ENC_NOT_SUPPORTED = 3,
 

--- a/lib/jxl/encode.cc
+++ b/lib/jxl/encode.cc
@@ -483,10 +483,12 @@ JxlEncoderStatus JxlEncoderSetBasicInfo(JxlEncoder* enc,
              info->exponent_bits_per_sample == 5) {
     enc->metadata.m.SetFloat16Samples();
   } else {
-    return JXL_ENC_NOT_SUPPORTED;
+    return JXL_API_ERROR(
+        "other exponent bits per sample combinations than IEEE binary32 and "
+        "binary16 not (yet) supported");
   }
   if (info->alpha_bits > 0 && info->alpha_exponent_bits > 0) {
-    return JXL_ENC_NOT_SUPPORTED;
+    return JXL_API_ERROR("floating point alpha not (yet) supported");
   }
 
   switch (info->alpha_bits) {


### PR DESCRIPTION
Only use JXL_ENC_ERROR for errors. This prevents the user having to
distinguish between different error cases, and is similar to how the
decoder works. Also, JXL_ENC_NOT_SUPPORTED was not used for sufficiently
many cases to be worth its additional handling.