### PR TITLE
Save blending options in encoder

### DIFF
--- a/lib/include/jxl/codestream_header.h
+++ b/lib/include/jxl/codestream_header.h
@@ -315,7 +315,7 @@ typedef struct {
 } JxlHeaderExtensions;
 
 /** Frame blend modes.
- * If coalescing is enabled (default), this can be ignored.
+ * When decoding, if coalescing is enabled (default), this can be ignored.
  */
 typedef enum {
   JXL_BLEND_REPLACE = 0,
@@ -326,11 +326,12 @@ typedef enum {
 } JxlBlendMode;
 
 /** The information about blending the color channels or a single extra channel.
- * If coalescing is enabled (default), this can be ignored.
+ * When decoding, if coalescing is enabled (default), this can be ignored and
+ * the blend mode is considered to be JXL_BLEND_REPLACE.
+ * When encoding, these settings apply to the pixel data given to the encoder.
  */
 typedef struct {
   /** Blend mode.
-   * Always equal to JXL_BLEND_REPLACE if coalescing is enabled.
    */
   JxlBlendMode blendmode;
   /** Reference frame ID to use as the 'bottom' layer (0-3).
@@ -346,32 +347,43 @@ typedef struct {
 } JxlBlendInfo;
 
 /** The information about layers.
- * If coalescing is enabled (default), this can be ignored.
+ * When decoding, if coalescing is enabled (default), this can be ignored.
+ * When encoding, these settings apply to the pixel data given to the encoder,
+ * the encoder could choose an internal representation that differs.
  */
 typedef struct {
-  /** Horizontal offset of the frame (can be negative, always zero if coalescing
-   * is enabled)
+  /** Whether cropping is applied for this frame. When decoding, if false,
+   * crop_x0 and crop_y0 are set to zero, and xsize and ysize to the main
+   * image dimensions. When encoding and this is false, those fields are
+   * ignored. When decoding, if coalescing is enabled (default), this is always
+   * false, regardless of the internal encoding in the JPEG XL codestream.
+   */
+  JXL_BOOL have_crop;
+
+  /** Horizontal offset of the frame (can be negative).
    */
   int32_t crop_x0;
-  /** Vertical offset of the frame (can be negative, always zero if coalescing
-   * is enabled)
+
+  /** Vertical offset of the frame (can be negative).
    */
   int32_t crop_y0;
-  /** Width of the frame (number of columns, always equal to image width if
-   * coalescing is enabled)
+
+  /** Width of the frame (number of columns).
    */
   uint32_t xsize;
-  /** Height of the frame (number of rows, always equal to image height if
-   * coalescing is enabled)
+
+  /** Height of the frame (number of rows).
    */
   uint32_t ysize;
+
   /** The blending info for the color channels. Blending info for extra channels
    * has to be retrieved separately using JxlDecoderGetExtraChannelBlendInfo.
    */
   JxlBlendInfo blend_info;
+
   /** After blending, save the frame as reference frame with this ID (0-3).
    * Special case: if the frame duration is nonzero, ID 0 means "will not be
-   * referenced in the future".
+   * referenced in the future". This value is not used for the last frame.
    */
   uint32_t save_as_reference;
 } JxlLayerInfo;

--- a/lib/jxl/encode.cc
+++ b/lib/jxl/encode.cc
@@ -309,10 +309,29 @@ JxlEncoderStatus JxlEncoderStruct::RefillOutputByteQueue() {
     ib.name = input_frame->option_values.frame_name;
     ib.duration = input_frame->option_values.header.duration;
     ib.timecode = input_frame->option_values.header.timecode;
+    ib.blendmode = static_cast<jxl::BlendMode>(
+        input_frame->option_values.header.layer_info.blend_info.blendmode);
+    ib.blend =
+        input_frame->option_values.header.layer_info.blend_info.blendmode !=
+        JXL_BLEND_REPLACE;
+
+    size_t save_as_reference =
+        input_frame->option_values.header.layer_info.save_as_reference;
+    if (save_as_reference > 1 || (ib.duration == 0 && save_as_reference != 0)) {
+      // The encoder implementation does not yet support custom
+      // save_as_reference, only 0 or 1 to indicate saving or no saving in case
+      // of animation duration.
+      return JXL_API_ERROR("unsupported save_as_reference value");
+    }
+    ib.use_for_next_frame = !!save_as_reference;
 
     jxl::FrameInfo frame_info;
     bool last_frame = frames_closed && !num_queued_frames;
     frame_info.is_last = last_frame;
+    frame_info.save_as_reference = save_as_reference;
+
+    // TODO(lode): also handle have_crop and the cropping dimensions, this
+    // requires getting the pixel data from the user as a smaller image.
 
     if (!jxl::EncodeFrame(input_frame->option_values.cparams, frame_info,
                           &metadata, input_frame->frame, &enc_state, cms,
@@ -449,6 +468,7 @@ void JxlEncoderInitFrameHeader(JxlFrameHeader* frame_header) {
   // for the decoder to set) since last frame is determined by usage of
   // JxlEncoderCloseFrames instead.
   frame_header->is_last = JXL_TRUE;
+  frame_header->layer_info.have_crop = JXL_FALSE;
   frame_header->layer_info.crop_x0 = 0;
   frame_header->layer_info.crop_y0 = 0;
   // These must be set if have_crop is enabled, but the default value has
@@ -1242,8 +1262,6 @@ JxlEncoderStatus JxlEncoderFrameSettingsSetInfo(
   // Setting the frame header resets the frame name, it must be set again with
   // JxlEncoderFrameSettingsSetName if desired.
   frame_settings->values.frame_name = "";
-
-  // TODO(lode): also set and handle blending fields
 
   return JXL_ENC_SUCCESS;
 }

--- a/lib/jxl/encode_test.cc
+++ b/lib/jxl/encode_test.cc
@@ -1007,6 +1007,7 @@ TEST(EncodeTest, AnimationHeaderTest) {
   JxlEncoderInitFrameHeader(&header);
   header.duration = 50;
   header.timecode = 800;
+  header.layer_info.blend_info.blendmode = JXL_BLEND_BLEND;
   JxlEncoderFrameSettingsSetInfo(frame_settings, &header);
   JxlEncoderFrameSettingsSetName(frame_settings, frame_name.c_str());
 
@@ -1022,6 +1023,10 @@ TEST(EncodeTest, AnimationHeaderTest) {
   // Decode to verify the boxes, we don't decode to pixels, only the boxes.
   JxlDecoderPtr dec = JxlDecoderMake(nullptr);
   EXPECT_NE(nullptr, dec.get());
+
+  // To test the blend_info fields, coalescing must be set to false in the
+  // decoder.
+  EXPECT_EQ(JXL_DEC_SUCCESS, JxlDecoderSetCoalescing(dec.get(), JXL_FALSE));
   EXPECT_EQ(JXL_DEC_SUCCESS,
             JxlDecoderSubscribeEvents(dec.get(), JXL_DEC_FRAME));
   JxlDecoderSetInput(dec.get(), compressed.data(), compressed.size());
@@ -1041,6 +1046,8 @@ TEST(EncodeTest, AnimationHeaderTest) {
       EXPECT_EQ(JXL_DEC_SUCCESS, JxlDecoderGetFrameHeader(dec.get(), &header2));
       EXPECT_EQ(header.duration, header2.duration);
       EXPECT_EQ(header.timecode, header2.timecode);
+      EXPECT_EQ(header.layer_info.blend_info.blendmode,
+                header2.layer_info.blend_info.blendmode);
       EXPECT_EQ(frame_name.size(), header2.name_length);
       if (header2.name_length > 0) {
         std::string frame_name2(header2.name_length + 1, '\0');

--- a/lib/jxl/image_bundle.h
+++ b/lib/jxl/image_bundle.h
@@ -222,9 +222,13 @@ class ImageBundle {
   uint32_t duration = 0;
   uint32_t timecode = 0;
 
+  // TODO(lode): these fields do not match the JXL frame header, it should be
+  // possible to specify up to 4 (3 if nonzero duration) slots to save this
+  // frame as reference (see save_as_reference).
   bool use_for_next_frame = false;
   bool blend = false;
   BlendMode blendmode = BlendMode::kBlend;
+
   std::string name;
 
  private:


### PR DESCRIPTION
Implement several of the frame blending options in the encoder (that
is, pass them on to the C++ encoder)

This also adds the have_crop field to JxlLayerInfo: for initialization
purposes, as well as for the documentation, it's easier to have a flag
to disable it, than to indicate no crop by setting the the layer info
sizes to the full image dimensions (making the way to indicate the
default depenent on other circumstances)

Does not yet support cropping, or multi values for save as reference.