### PR TITLE
Remove CodecInOut::target_nits

### DIFF
--- a/lib/extras/codec.cc
+++ b/lib/extras/codec.cc
@@ -130,8 +130,8 @@ Status SetFromBytes(const Span<const uint8_t> bytes,
     skip_ppf_conversion = true;
   }
 #if JPEGXL_ENABLE_EXR
-  else if (extras::DecodeImageEXR(bytes, color_hints, io->constraints,
-                                  io->target_nits, pool, &ppf)) {
+  else if (extras::DecodeImageEXR(bytes, color_hints, io->constraints, pool,
+                                  &ppf)) {
     codec = Codec::kEXR;
   }
 #endif

--- a/lib/extras/codec_exr.cc
+++ b/lib/extras/codec_exr.cc
@@ -35,28 +35,6 @@ using ExrInt64 = decltype(std::declval<OpenEXR::IStream>().tellg());
 constexpr int kExrBitsPerSample = 16;
 constexpr int kExrAlphaBits = 16;
 
-float GetIntensityTarget(float target_nits, const OpenEXR::Header& exr_header) {
-  if (OpenEXR::hasWhiteLuminance(exr_header)) {
-    const float exr_luminance = OpenEXR::whiteLuminance(exr_header);
-    if (target_nits != 0) {
-      JXL_WARNING(
-          "overriding OpenEXR whiteLuminance of %g with user-specified value "
-          "of %g",
-          exr_luminance, target_nits);
-      return target_nits;
-    }
-    return exr_luminance;
-  }
-  if (target_nits != 0) {
-    return target_nits;
-  }
-  JXL_WARNING(
-      "no OpenEXR whiteLuminance tag found and no intensity_target specified, "
-      "defaulting to %g",
-      kDefaultIntensityTarget);
-  return kDefaultIntensityTarget;
-}
-
 size_t GetNumThreads(ThreadPool* pool) {
   size_t exr_num_threads = 1;
   RunOnPool(
@@ -130,8 +108,8 @@ class InMemoryOStream : public OpenEXR::OStream {
 }  // namespace
 
 Status DecodeImageEXR(Span<const uint8_t> bytes, const ColorHints& color_hints,
-                      const SizeConstraints& constraints, float target_nits,
-                      ThreadPool* pool, PackedPixelFile* ppf) {
+                      const SizeConstraints& constraints, ThreadPool* pool,
+                      PackedPixelFile* ppf) {
   // Get the number of threads we should be using for OpenEXR.
   // OpenEXR creates its own set of threads, independent from ours. `pool` is
   // only used for converting from a buffer of OpenEXR::Rgba to Image3F.
@@ -160,8 +138,9 @@ Status DecodeImageEXR(Span<const uint8_t> bytes, const ColorHints& color_hints,
   const bool has_alpha = (input.channels() & OpenEXR::RgbaChannels::WRITE_A) ==
                          OpenEXR::RgbaChannels::WRITE_A;
 
-  const float intensity_target =
-      GetIntensityTarget(target_nits, input.header());
+  const float intensity_target = OpenEXR::hasWhiteLuminance(input.header())
+                                     ? OpenEXR::whiteLuminance(input.header())
+                                     : kDefaultIntensityTarget;
 
   auto image_size = input.displayWindow().size();
   // Size is computed as max - min, but both bounds are inclusive.

--- a/lib/extras/codec_exr.h
+++ b/lib/extras/codec_exr.h
@@ -22,8 +22,8 @@ namespace extras {
 
 // Decodes `bytes` into `io`. color_hints are ignored.
 Status DecodeImageEXR(Span<const uint8_t> bytes, const ColorHints& color_hints,
-                      const SizeConstraints& constraints, float target_nits,
-                      ThreadPool* pool, PackedPixelFile* ppf);
+                      const SizeConstraints& constraints, ThreadPool* pool,
+                      PackedPixelFile* ppf);
 
 // Transforms from io->c_current to `c_desired` (with the transfer function set
 // to linear as that is the OpenEXR convention) and encodes into `bytes`.

--- a/lib/extras/codec_test.cc
+++ b/lib/extras/codec_test.cc
@@ -107,7 +107,6 @@ void TestRoundTrip(Codec codec, const size_t xsize, const size_t ysize,
 
   CodecInOut io2;
   ColorHints color_hints;
-  io2.target_nits = io.metadata.m.IntensityTarget();
   // Only for PNM because PNG will warn about ignoring them.
   if (codec == Codec::kPNM) {
     color_hints.Add("color_space", Description(c_external));

--- a/lib/jxl/codec_in_out.h
+++ b/lib/jxl/codec_in_out.h
@@ -165,25 +165,6 @@ class CodecInOut {
   // Decode to pixels or keep JPEG as quantized DCT coefficients
   DecodeTarget dec_target = DecodeTarget::kPixels;
 
-  // Intended white luminance, in nits (cd/m^2).
-  // It is used by codecs that do not know the absolute luminance of their
-  // images. For those codecs, decoders map from white to this luminance. There
-  // is no other way of knowing the target brightness for those codecs - depends
-  // on source material. 709 typically targets 100 nits, BT.2100 PQ up to 10K,
-  // but HDR content is more typically mastered to 4K nits. Codecs that do know
-  // the absolute luminance of their images will typically ignore it as a
-  // decoder input. The corresponding decoder output and encoder input is the
-  // intensity target in the metadata. ALL decoders MUST set that metadata
-  // appropriately, but it does not have to be identical to this hint. Encoders
-  // for codecs that do not encode absolute luminance levels should use that
-  // metadata to decide on what to map to white. Encoders for codecs that *do*
-  // encode absolute luminance levels may use it to decide on encoding values,
-  // but not in a way that would affect the range of interpreted luminance.
-  //
-  // 0 means that it is up to the codec to decide on a reasonable value to use.
-
-  float target_nits = 0;
-
   // -- DECODER OUTPUT:
 
   // Total number of pixels decoded (may differ from #frames * xsize * ysize

--- a/lib/jxl/jpeg/enc_jpeg_data.cc
+++ b/lib/jxl/jpeg/enc_jpeg_data.cc
@@ -361,8 +361,7 @@ Status DecodeImageJPG(const Span<const uint8_t> bytes, CodecInOut* io) {
   io->Main().color_transform =
       (!is_rgb || nbcomp == 1) ? ColorTransform::kYCbCr : ColorTransform::kNone;
 
-  io->metadata.m.SetIntensityTarget(
-      io->target_nits != 0 ? io->target_nits : kDefaultIntensityTarget);
+  io->metadata.m.SetIntensityTarget(kDefaultIntensityTarget);
   io->metadata.m.SetUintSamples(BITS_IN_JSAMPLE);
   io->SetFromImage(Image3F(jpeg_data->width, jpeg_data->height),
                    io->metadata.m.color_encoding);

--- a/lib/jxl/jxl_test.cc
+++ b/lib/jxl/jxl_test.cc
@@ -165,8 +165,8 @@ TEST(JxlTest, RoundtripSmallD1) {
     // And then, with a lower intensity target than the default, the bitrate
     // should be smaller.
     CodecInOut io_dim;
-    io_dim.target_nits = 100;
     ASSERT_TRUE(SetFromBytes(Span<const uint8_t>(orig), &io_dim, pool));
+    io_dim.metadata.m.SetIntensityTarget(100);
     io_dim.ShrinkTo(io_dim.xsize() / 8, io_dim.ysize() / 8);
     EXPECT_LT(Roundtrip(&io_dim, cparams, dparams, pool, &io_out),
               compressed_size);

--- a/lib/jxl/luminance.cc
+++ b/lib/jxl/luminance.cc
@@ -11,10 +11,6 @@
 namespace jxl {
 
 void SetIntensityTarget(CodecInOut* io) {
-  if (io->target_nits != 0) {
-    io->metadata.m.SetIntensityTarget(io->target_nits);
-    return;
-  }
   if (io->metadata.m.color_encoding.tf.IsPQ()) {
     // Peak luminance of PQ as defined by SMPTE ST 2084:2014.
     io->metadata.m.SetIntensityTarget(10000);

--- a/tools/benchmark/benchmark_codec_custom.cc
+++ b/tools/benchmark/benchmark_codec_custom.cc
@@ -129,8 +129,9 @@ class CustomCodec : public ImageCodec {
               std::vector<std::string>{encoded_filename, png_filename});
         },
         png_filename, speed_stats));
-    io->target_nits = saved_intensity_target_;
-    return SetFromFile(png_filename, ColorHints(), io, pool);
+    JXL_RETURN_IF_ERROR(SetFromFile(png_filename, ColorHints(), io, pool));
+    io->metadata.m.SetIntensityTarget(saved_intensity_target_);
+    return true;
   }
 
  private:

--- a/tools/benchmark/benchmark_xl.cc
+++ b/tools/benchmark/benchmark_xl.cc
@@ -945,12 +945,15 @@ class Benchmark {
           const size_t i = static_cast<size_t>(task);
           Status ok = true;
 
-          loaded_images[i].target_nits = Args()->intensity_target;
           loaded_images[i].dec_target = jpeg_transcoding_requested
                                             ? DecodeTarget::kQuantizedCoeffs
                                             : DecodeTarget::kPixels;
           if (!Args()->decode_only) {
             ok = SetFromFile(fnames[i], Args()->color_hints, &loaded_images[i]);
+            if (ok && Args()->intensity_target != 0) {
+              loaded_images[i].metadata.m.SetIntensityTarget(
+                  Args()->intensity_target);
+            }
           }
           if (!ok) {
             if (!Args()->silent_errors) {

--- a/tools/cjxl.cc
+++ b/tools/cjxl.cc
@@ -733,7 +733,6 @@ jxl::Status LoadAll(CompressArgs& args, jxl::ThreadPoolInternal* pool,
                     jxl::CodecInOut* io, double* decode_mps) {
   const double t0 = jxl::Now();
 
-  io->target_nits = args.intensity_target;
   io->dec_target = (args.jpeg_transcode ? jxl::DecodeTarget::kQuantizedCoeffs
                                         : jxl::DecodeTarget::kPixels);
   jxl::Codec input_codec;
@@ -741,6 +740,9 @@ jxl::Status LoadAll(CompressArgs& args, jxl::ThreadPoolInternal* pool,
                    &input_codec)) {
     fprintf(stderr, "Failed to read image %s.\n", args.params.file_in);
     return false;
+  }
+  if (args.intensity_target != 0) {
+    io->metadata.m.SetIntensityTarget(args.intensity_target);
   }
   if (input_codec != jxl::Codec::kJPG) args.jpeg_transcode = false;
   if (args.jpeg_transcode) args.params.butteraugli_distance = 0;


### PR DESCRIPTION
Previously, target_nits served as a hint to set intensity_target in the
various codecs. It was set prior to decoding an image, and if non-zero,
codecs were to give it precedence over what they would have otherwise
set from the image itself (e.g. EXR would set it from the whiteLuminance
header, PQ images would get 10000 given that we have no other source of
mastering metadata than the user).

The reason for doing it this way was historical (it used to affect the
numerical pixel values that the codecs would return) and does not apply
anymore, so now we can simply let the codecs set it however they like it
and then override it if requested.