### PR TITLE
Split linear profile creation for source and destination

### DIFF
--- a/tools/comparison_viewer/image_loading.cc
+++ b/tools/comparison_viewer/image_loading.cc
@@ -55,6 +55,8 @@ QImage loadImage(const QString& filename, const QByteArray& targetIccProfile,
   if (!loadFromFile(filename, color_hints, &decoded, &pool)) {
     return QImage();
   }
+  // TODO(sboukortt): make this configurable.
+  decoded.metadata.m.SetIntensityTarget(kDefaultIntensityTarget);
   const ImageBundle& ib = decoded.Main();
 
   ColorEncoding targetColorSpace;


### PR DESCRIPTION
This fixes conversions between HLG/PQ and a non-sRGB/PQ/HLG transfer
function (e.g. gamma or a LUT profile), which would not occur during
typical use of cjxl/djxl but may occur e.g. when viewing HLG images
using the comparison tool. This now works properly although it is not
yet possible to set the peak luminance to use for the OOTF in this use
case.