### PR TITLE
Improve encoder API blending support

### DIFF
--- a/lib/jxl/enc_frame.cc
+++ b/lib/jxl/enc_frame.cc
@@ -366,19 +366,24 @@ Status MakeFrameHeader(const CompressParams& cparams,
     // encoded in case a blend mode involving alpha is used and there are more
     // than one extra channels.
     size_t index = 0;
-    if (extra_channels.size() > 1) {
-      for (size_t i = 0; i < extra_channels.size(); i++) {
-        if (extra_channels[i].type == ExtraChannel::kAlpha) {
-          index = i;
-          break;
+    if (frame_info.alpha_channel == -1) {
+      if (extra_channels.size() > 1) {
+        for (size_t i = 0; i < extra_channels.size(); i++) {
+          if (extra_channels[i].type == ExtraChannel::kAlpha) {
+            index = i;
+            break;
+          }
         }
       }
+    } else {
+      index = static_cast<size_t>(frame_info.alpha_channel);
+      JXL_ASSERT(index == 0 || index < extra_channels.size());
     }
     frame_header->blending_info.alpha_channel = index;
     frame_header->blending_info.mode =
         ib.blend ? ib.blendmode : BlendMode::kReplace;
-    // previous frames are saved with ID 1.
-    frame_header->blending_info.source = 1;
+    frame_header->blending_info.source = frame_info.source;
+    frame_header->blending_info.clamp = frame_info.clamp;
     for (size_t i = 0; i < extra_channels.size(); i++) {
       frame_header->extra_channel_blending_info[i].alpha_channel = index;
       BlendMode default_blend = ib.blendmode;

--- a/lib/jxl/enc_frame.h
+++ b/lib/jxl/enc_frame.h
@@ -20,6 +20,9 @@ namespace jxl {
 
 // Information needed for encoding a frame that is not contained elsewhere and
 // does not belong to `cparams`.
+// TODO(lode): if possible, it might be better to replace FrameInfo and several
+// fields from ImageBundle (such as frame name and duration) by direct usage of
+// jxl::FrameHeader itself.
 struct FrameInfo {
   // TODO(veluca): consider adding more parameters, such as custom patches.
   bool save_before_color_transform = false;
@@ -35,6 +38,20 @@ struct FrameInfo {
   bool is_preview = false;
   // Information for storing this frame for future use (only for non-DC frames).
   size_t save_as_reference = 0;
+  // The source frame for blending of a next frame, matching the
+  // save_as_reference value of a previous frame. Animated frames can use
+  // save_as_reference values 1, 2 and 3, while composite still frames can use
+  // save_as_reference values 0, 1, 2 and 3. The current C++ encoder
+  // implementation is assuming and using 1 for all frames of animations, so
+  // using that as the default value here.
+  // Corresponds to BlendingInfo::source from the FrameHeader.
+  size_t source = 1;
+  // Corresponds to BlendingInfo::clamp from the FrameHeader.
+  size_t clamp = 1;
+  // Corresponds to BlendingInfo::alpha_channel from the FrameHeader, or set to
+  // -1 to automatically choose it as the index of the first extra channel of
+  // type alpha.
+  int alpha_channel = -1;
 };
 
 // Encodes a single frame (including its header) into a byte stream.  Groups may

--- a/lib/jxl/encode.cc
+++ b/lib/jxl/encode.cc
@@ -307,8 +307,17 @@ JxlEncoderStatus JxlEncoderStruct::RefillOutputByteQueue() {
     // these.
     jxl::ImageBundle& ib = input_frame->frame;
     ib.name = input_frame->option_values.frame_name;
-    ib.duration = input_frame->option_values.header.duration;
-    ib.timecode = input_frame->option_values.header.timecode;
+    if (metadata.m.have_animation) {
+      ib.duration = input_frame->option_values.header.duration;
+      ib.timecode = input_frame->option_values.header.timecode;
+    } else {
+      // If have_animation is false, the encoder should ignore the duration and
+      // timecode values. However, assigning them to ib will cause the encoder
+      // to write an invalid frame header that can't be decoded so ensure
+      // they're the default value of 0 here.
+      ib.duration = 0;
+      ib.timecode = 0;
+    }
     ib.blendmode = static_cast<jxl::BlendMode>(
         input_frame->option_values.header.layer_info.blend_info.blendmode);
     ib.blend =
@@ -317,18 +326,18 @@ JxlEncoderStatus JxlEncoderStruct::RefillOutputByteQueue() {
 
     size_t save_as_reference =
         input_frame->option_values.header.layer_info.save_as_reference;
-    if (save_as_reference > 1 || (ib.duration == 0 && save_as_reference != 0)) {
-      // The encoder implementation does not yet support custom
-      // save_as_reference, only 0 or 1 to indicate saving or no saving in case
-      // of animation duration.
-      return JXL_API_ERROR("unsupported save_as_reference value");
-    }
     ib.use_for_next_frame = !!save_as_reference;
 
     jxl::FrameInfo frame_info;
     bool last_frame = frames_closed && !num_queued_frames;
     frame_info.is_last = last_frame;
     frame_info.save_as_reference = save_as_reference;
+    frame_info.source =
+        input_frame->option_values.header.layer_info.blend_info.source;
+    frame_info.clamp =
+        input_frame->option_values.header.layer_info.blend_info.clamp;
+    frame_info.alpha_channel =
+        input_frame->option_values.header.layer_info.blend_info.alpha;
 
     // TODO(lode): also handle have_crop and the cropping dimensions, this
     // requires getting the pixel data from the user as a smaller image.
@@ -1267,6 +1276,16 @@ JxlEncoderStatus JxlEncoderProcessOutput(JxlEncoder* enc, uint8_t** next_out,
 
 JxlEncoderStatus JxlEncoderFrameSettingsSetInfo(
     JxlEncoderOptions* frame_settings, const JxlFrameHeader* frame_header) {
+  if (frame_header->layer_info.blend_info.source > 3) {
+    return JXL_API_ERROR("invalid blending source index");
+  }
+  // If there are no extra channels, it's ok for the value to be 0.
+  if (frame_header->layer_info.blend_info.alpha != 0 &&
+      frame_header->layer_info.blend_info.alpha >=
+          frame_settings->enc->metadata.m.extra_channel_info.size()) {
+    return JXL_API_ERROR("alpha blend channel index out of bounds");
+  }
+
   frame_settings->values.header = *frame_header;
   // Setting the frame header resets the frame name, it must be set again with
   // JxlEncoderFrameSettingsSetName if desired.

--- a/lib/jxl/encode_test.cc
+++ b/lib/jxl/encode_test.cc
@@ -1008,6 +1008,8 @@ TEST(EncodeTest, AnimationHeaderTest) {
   header.duration = 50;
   header.timecode = 800;
   header.layer_info.blend_info.blendmode = JXL_BLEND_BLEND;
+  header.layer_info.blend_info.source = 2;
+  header.layer_info.blend_info.clamp = 1;
   JxlEncoderFrameSettingsSetInfo(frame_settings, &header);
   JxlEncoderFrameSettingsSetName(frame_settings, frame_name.c_str());
 
@@ -1048,6 +1050,10 @@ TEST(EncodeTest, AnimationHeaderTest) {
       EXPECT_EQ(header.timecode, header2.timecode);
       EXPECT_EQ(header.layer_info.blend_info.blendmode,
                 header2.layer_info.blend_info.blendmode);
+      EXPECT_EQ(header.layer_info.blend_info.clamp,
+                header2.layer_info.blend_info.clamp);
+      EXPECT_EQ(header.layer_info.blend_info.source,
+                header2.layer_info.blend_info.source);
       EXPECT_EQ(frame_name.size(), header2.name_length);
       if (header2.name_length > 0) {
         std::string frame_name2(header2.name_length + 1, '\0');


### PR DESCRIPTION
Make it work correctly: support the correct source frame. Also remove
the check for source, as experimenting reveals all from 0 to 3 work for
composite stills. Also support passing on the clamp and alpha index
settings.