### PR TITLE
make djxl handle jxlp

### DIFF
--- a/lib/jxl/jxl_test.cc
+++ b/lib/jxl/jxl_test.cc
@@ -1408,8 +1408,7 @@ jxl::Status DecompressJxlToJPEGForTest(
     const jpegxl::tools::JpegXlContainer& container, jxl::ThreadPool* pool,
     jxl::PaddedBytes* output) {
   output->clear();
-  jxl::Span<const uint8_t> compressed(container.codestream,
-                                      container.codestream_size);
+  jxl::Span<const uint8_t> compressed(container.codestream);
 
   JXL_RETURN_IF_ERROR(compressed.size() >= 2);
 
@@ -1444,8 +1443,7 @@ size_t RoundtripJpeg(const PaddedBytes& jpeg_in, ThreadPool* pool) {
                          GetJxlCms(),
                          /*aux_out=*/nullptr, pool));
   jpegxl::tools::JpegXlContainer enc_container;
-  enc_container.codestream = codestream.data();
-  enc_container.codestream_size = codestream.size();
+  enc_container.codestream = std::move(codestream);
   jpeg::JPEGData data_in = *io.Main().jpeg_data;
   jxl::PaddedBytes jpeg_data;
   EXPECT_TRUE(EncodeJPEGData(data_in, &jpeg_data));

--- a/tools/box/box.h
+++ b/tools/box/box.h
@@ -92,9 +92,7 @@ struct JpegXlContainer {
   size_t jpeg_reconstruction_size = 0;
 
   // The main JPEG XL codestream, of which there must be 1 in the container.
-  // TODO(lode): support split codestream: there may be multiple jxlp boxes.
-  const uint8_t* codestream = nullptr;  // Not owned
-  size_t codestream_size = 0;
+  jxl::PaddedBytes codestream;
 };
 
 // Returns whether `data` starts with a container header; definitely returns

--- a/tools/box/box_test.cc
+++ b/tools/box/box_test.cc
@@ -41,8 +41,7 @@ TEST(BoxTest, BoxTest) {
   container.xmlc.emplace_back(xml1.data(), xml1.size());
   container.jumb = jumb.data();
   container.jumb_size = jumb.size();
-  container.codestream = codestream.data();
-  container.codestream_size = codestream.size();
+  container.codestream = std::move(codestream);
 
   jxl::PaddedBytes file;
   EXPECT_EQ(true,
@@ -71,7 +70,7 @@ TEST(BoxTest, BoxTest) {
   }
   EXPECT_EQ(jumb.size(), container2.jumb_size);
   EXPECT_EQ(0, memcmp(jumb.data(), container2.jumb, container2.jumb_size));
-  EXPECT_EQ(codestream.size(), container2.codestream_size);
-  EXPECT_EQ(0, memcmp(codestream.data(), container2.codestream,
-                      container2.codestream_size));
+  EXPECT_EQ(container.codestream.size(), container2.codestream.size());
+  EXPECT_EQ(0, memcmp(container.codestream.data(), container2.codestream.data(),
+                      container2.codestream.size()));
 }

--- a/tools/cjxl_main.cc
+++ b/tools/cjxl_main.cc
@@ -88,8 +88,7 @@ int CompressJpegXlMain(int argc, const char* argv[]) {
   int ret = CjxlRetCode::OK;
   if (args.use_container) {
     JpegXlContainer container;
-    container.codestream = compressed.data();
-    container.codestream_size = compressed.size();
+    container.codestream = std::move(compressed);
     if (!io.blobs.exif.empty()) {
       container.exif = io.blobs.exif.data();
       container.exif_size = io.blobs.exif.size();
@@ -114,12 +113,11 @@ int CompressJpegXlMain(int argc, const char* argv[]) {
         ret = CjxlRetCode::DROPPED_JBRD;
       }
     }
-    jxl::PaddedBytes container_file;
-    if (!EncodeJpegXlContainerOneShot(container, &container_file)) {
+    compressed.clear();
+    if (!EncodeJpegXlContainerOneShot(container, &compressed)) {
       fprintf(stderr, "Failed to encode container format\n");
       return CjxlRetCode::ERR_CONTAINER;
     }
-    compressed.swap(container_file);
     if (!args.quiet) {
       const size_t pixels = io.xsize() * io.ysize();
       const double bpp =

--- a/tools/djxl.cc
+++ b/tools/djxl.cc
@@ -192,8 +192,7 @@ jxl::Status DecompressJxlToJPEG(const JpegXlContainer& container,
   output->clear();
   const double t0 = jxl::Now();
 
-  jxl::Span<const uint8_t> compressed(container.codestream,
-                                      container.codestream_size);
+  jxl::Span<const uint8_t> compressed(container.codestream);
 
   JXL_RETURN_IF_ERROR(compressed.size() >= 2);
 


### PR DESCRIPTION

djxl could not handle partial jxl codestream boxes, which made it fail to decode files produced by the current api encoder.

This fixes that.