### PR TITLE
Allow setting extra channel blend info in enc API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,8 +25,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
    the blending information for extra channels in the non-coalesced case.
  - encoder API: added ability to set several encoder options to frames using
    `JxlEncoderFrameSettingsSetOption`
- - encoder API: new function `JxlEncoderFrameSettingsSetInfo` to set animation
-   and blending parameters of the frame.
+ - encoder API: new functions `JxlEncoderFrameSettingsSetInfo` and
+   `JxlEncoderFrameSettingsSetExtraChannelBlendInfo` to set animation
+   and blending parameters of the frame, and `JxlEncoderInitFrameHeader` and
+   `JxlEncoderInitBlendInfo` to initialize the structs to set.
  - decoder/encoder API: add two fields to `JXLBasicInfo`: `intrinsic_xsize`
    and `intrinsic_ysize` to signal the intrinsic size.
  - encoder API: ability to encode arbitrary extra channels:

--- a/lib/include/jxl/encode.h
+++ b/lib/include/jxl/encode.h
@@ -403,6 +403,21 @@ JxlEncoderFrameSettingsSetInfo(JxlEncoderFrameSettings* frame_settings,
                                const JxlFrameHeader* frame_header);
 
 /**
+ * Sets blend info of an extra channel. The blend info of extra channels is set
+ * separately from that of the color channels, the color channels are set with
+ * @ref JxlEncoderFrameSettingsSetInfo.
+ *
+ * @param frame_settings set of options and metadata for this frame. Also
+ * includes reference to the encoder object.
+ * @param index index of the extra channel to use.
+ * @param blend_info blend info to set for the extra channel
+ * @return JXL_ENC_SUCCESS on success, JXL_ENC_ERROR on error
+ */
+JXL_EXPORT JxlEncoderStatus JxlEncoderFrameSettingsSetExtraChannelBlendInfo(
+    JxlEncoderFrameSettings* frame_settings, size_t index,
+    const JxlBlendInfo* blend_info);
+
+/**
  * Sets the name of the animation frame. This function is optional, frames are
  * not required to have a name. This setting is a part of the frame header, and
  * the same principles as for @ref JxlEncoderFrameSettingsSetInfo apply. The
@@ -754,6 +769,7 @@ JXL_EXPORT JxlEncoderStatus JxlEncoderSetICCProfile(JxlEncoder* enc,
  * @param info global image metadata. Object owned by the caller.
  */
 JXL_EXPORT void JxlEncoderInitBasicInfo(JxlBasicInfo* info);
+
 /**
  * Initializes a JxlFrameHeader struct to default values.
  * For forwards-compatibility, this function has to be called before values
@@ -765,6 +781,15 @@ JXL_EXPORT void JxlEncoderInitBasicInfo(JxlBasicInfo* info);
  * @param frame_header frame metadata. Object owned by the caller.
  */
 JXL_EXPORT void JxlEncoderInitFrameHeader(JxlFrameHeader* frame_header);
+
+/**
+ * Initializes a JxlBlendInfo struct to default values.
+ * For forwards-compatibility, this function has to be called before values
+ * are assigned to the struct fields.
+ *
+ * @param blend_info blending info. Object owned by the caller.
+ */
+JXL_EXPORT void JxlEncoderInitBlendInfo(JxlBlendInfo* blend_info);
 
 /**
  * Sets the global metadata of the image encoded by this encoder.

--- a/lib/jxl/enc_frame.cc
+++ b/lib/jxl/enc_frame.cc
@@ -384,16 +384,21 @@ Status MakeFrameHeader(const CompressParams& cparams,
         ib.blend ? ib.blendmode : BlendMode::kReplace;
     frame_header->blending_info.source = frame_info.source;
     frame_header->blending_info.clamp = frame_info.clamp;
+    const auto& extra_channel_info = frame_info.extra_channel_blending_info;
     for (size_t i = 0; i < extra_channels.size(); i++) {
-      frame_header->extra_channel_blending_info[i].alpha_channel = index;
-      BlendMode default_blend = ib.blendmode;
-      if (extra_channels[i].type != ExtraChannel::kBlack && i != index) {
-        // K needs to be blended, spot colors and other stuff gets added
-        default_blend = BlendMode::kAdd;
+      if (i < extra_channel_info.size()) {
+        frame_header->extra_channel_blending_info[i] = extra_channel_info[i];
+      } else {
+        frame_header->extra_channel_blending_info[i].alpha_channel = index;
+        BlendMode default_blend = ib.blendmode;
+        if (extra_channels[i].type != ExtraChannel::kBlack && i != index) {
+          // K needs to be blended, spot colors and other stuff gets added
+          default_blend = BlendMode::kAdd;
+        }
+        frame_header->extra_channel_blending_info[i].mode =
+            ib.blend ? default_blend : BlendMode::kReplace;
+        frame_header->extra_channel_blending_info[i].source = 1;
       }
-      frame_header->extra_channel_blending_info[i].mode =
-          ib.blend ? default_blend : BlendMode::kReplace;
-      frame_header->extra_channel_blending_info[i].source = 1;
     }
   }
 

--- a/lib/jxl/enc_frame.h
+++ b/lib/jxl/enc_frame.h
@@ -52,6 +52,12 @@ struct FrameInfo {
   // -1 to automatically choose it as the index of the first extra channel of
   // type alpha.
   int alpha_channel = -1;
+
+  // If non-empty, uses this blending info for the extra channels, otherwise
+  // automatically chooses it. The encoder API will fill this vector with the
+  // extra channel info and allows more options. The non-API cjxl leaves it
+  // empty and relies on the default behavior.
+  std::vector<BlendingInfo> extra_channel_blending_info;
 };
 
 // Encodes a single frame (including its header) into a byte stream.  Groups may

--- a/lib/jxl/encode_internal.h
+++ b/lib/jxl/encode_internal.h
@@ -27,6 +27,7 @@ typedef struct JxlEncoderFrameSettingsValuesStruct {
   bool lossless;
   CompressParams cparams;
   JxlFrameHeader header;
+  std::vector<JxlBlendInfo> extra_channel_blend_info;
   std::string frame_name;
 } JxlEncoderFrameSettingsValues;
 

--- a/lib/jxl/encode_test.cc
+++ b/lib/jxl/encode_test.cc
@@ -1010,7 +1010,12 @@ TEST(EncodeTest, AnimationHeaderTest) {
   header.layer_info.blend_info.blendmode = JXL_BLEND_BLEND;
   header.layer_info.blend_info.source = 2;
   header.layer_info.blend_info.clamp = 1;
+  JxlBlendInfo extra_channel_blend_info;
+  JxlEncoderInitBlendInfo(&extra_channel_blend_info);
+  extra_channel_blend_info.blendmode = JXL_BLEND_MULADD;
   JxlEncoderFrameSettingsSetInfo(frame_settings, &header);
+  JxlEncoderFrameSettingsSetExtraChannelBlendInfo(frame_settings, 0,
+                                                  &extra_channel_blend_info);
   JxlEncoderFrameSettingsSetName(frame_settings, frame_name.c_str());
 
   std::vector<uint8_t> compressed = std::vector<uint8_t>(64);
@@ -1055,6 +1060,11 @@ TEST(EncodeTest, AnimationHeaderTest) {
       EXPECT_EQ(header.layer_info.blend_info.source,
                 header2.layer_info.blend_info.source);
       EXPECT_EQ(frame_name.size(), header2.name_length);
+      JxlBlendInfo extra_channel_blend_info2;
+      JxlDecoderGetExtraChannelBlendInfo(dec.get(), 0,
+                                         &extra_channel_blend_info2);
+      EXPECT_EQ(extra_channel_blend_info.blendmode,
+                extra_channel_blend_info2.blendmode);
       if (header2.name_length > 0) {
         std::string frame_name2(header2.name_length + 1, '\0');
         EXPECT_EQ(JXL_DEC_SUCCESS,


### PR DESCRIPTION
Note: the function name for setting extra channel info is very long and
I'm considering shortening this one and JxlEncoderFrameSettingsSetInfo
to match the decoder equivalents in an upcoming MR