### PR TITLE
Rename JxlEncoderFrameSettingsSetInfo and JxlEncoderFrameSettingsSetE…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,8 +25,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
    the blending information for extra channels in the non-coalesced case.
  - encoder API: added ability to set several encoder options to frames using
    `JxlEncoderFrameSettingsSetOption`
- - encoder API: new functions `JxlEncoderFrameSettingsSetInfo` and
-   `JxlEncoderFrameSettingsSetExtraChannelBlendInfo` to set animation
+ - encoder API: new functions `JxlEncoderSetFrameHeader` and
+   `JxlEncoderSetExtraChannelBlendInfo` to set animation
    and blending parameters of the frame, and `JxlEncoderInitFrameHeader` and
    `JxlEncoderInitBlendInfo` to initialize the structs to set.
  - decoder/encoder API: add two fields to `JXLBasicInfo`: `intrinsic_xsize`

--- a/lib/include/jxl/encode.h
+++ b/lib/include/jxl/encode.h
@@ -399,13 +399,13 @@ JXL_EXPORT JxlEncoderStatus JxlEncoderProcessOutput(JxlEncoder* enc,
  * @return JXL_ENC_SUCCESS on success, JXL_ENC_ERROR on error
  */
 JXL_EXPORT JxlEncoderStatus
-JxlEncoderFrameSettingsSetInfo(JxlEncoderFrameSettings* frame_settings,
-                               const JxlFrameHeader* frame_header);
+JxlEncoderSetFrameHeader(JxlEncoderFrameSettings* frame_settings,
+                         const JxlFrameHeader* frame_header);
 
 /**
  * Sets blend info of an extra channel. The blend info of extra channels is set
  * separately from that of the color channels, the color channels are set with
- * @ref JxlEncoderFrameSettingsSetInfo.
+ * @ref JxlEncoderSetFrameHeader.
  *
  * @param frame_settings set of options and metadata for this frame. Also
  * includes reference to the encoder object.
@@ -413,21 +413,21 @@ JxlEncoderFrameSettingsSetInfo(JxlEncoderFrameSettings* frame_settings,
  * @param blend_info blend info to set for the extra channel
  * @return JXL_ENC_SUCCESS on success, JXL_ENC_ERROR on error
  */
-JXL_EXPORT JxlEncoderStatus JxlEncoderFrameSettingsSetExtraChannelBlendInfo(
+JXL_EXPORT JxlEncoderStatus JxlEncoderSetExtraChannelBlendInfo(
     JxlEncoderFrameSettings* frame_settings, size_t index,
     const JxlBlendInfo* blend_info);
 
 /**
  * Sets the name of the animation frame. This function is optional, frames are
  * not required to have a name. This setting is a part of the frame header, and
- * the same principles as for @ref JxlEncoderFrameSettingsSetInfo apply. The
+ * the same principles as for @ref JxlEncoderSetFrameHeader apply. The
  * name_length field of JxlFrameHeader is ignored by the encoder, this function
  * determines the name length instead as the length in bytes of the C string.
  *
  * The maximum possible name length is 1071 bytes (excluding terminating null
  * character).
  *
- * Calling @ref JxlEncoderFrameSettingsSetInfo clears any name that was
+ * Calling @ref JxlEncoderSetFrameHeader clears any name that was
  * previously set.
  *
  * @param frame_settings set of options and metadata for this frame. Also

--- a/lib/jxl/encode.cc
+++ b/lib/jxl/encode.cc
@@ -1299,8 +1299,8 @@ JxlEncoderStatus JxlEncoderProcessOutput(JxlEncoder* enc, uint8_t** next_out,
   return JXL_ENC_SUCCESS;
 }
 
-JxlEncoderStatus JxlEncoderFrameSettingsSetInfo(
-    JxlEncoderOptions* frame_settings, const JxlFrameHeader* frame_header) {
+JxlEncoderStatus JxlEncoderSetFrameHeader(JxlEncoderOptions* frame_settings,
+                                          const JxlFrameHeader* frame_header) {
   if (frame_header->layer_info.blend_info.source > 3) {
     return JXL_API_ERROR("invalid blending source index");
   }
@@ -1319,7 +1319,7 @@ JxlEncoderStatus JxlEncoderFrameSettingsSetInfo(
   return JXL_ENC_SUCCESS;
 }
 
-JxlEncoderStatus JxlEncoderFrameSettingsSetExtraChannelBlendInfo(
+JxlEncoderStatus JxlEncoderSetExtraChannelBlendInfo(
     JxlEncoderOptions* frame_settings, size_t index,
     const JxlBlendInfo* blend_info) {
   if (index >= frame_settings->enc->metadata.m.num_extra_channels) {

--- a/lib/jxl/encode_test.cc
+++ b/lib/jxl/encode_test.cc
@@ -1013,9 +1013,9 @@ TEST(EncodeTest, AnimationHeaderTest) {
   JxlBlendInfo extra_channel_blend_info;
   JxlEncoderInitBlendInfo(&extra_channel_blend_info);
   extra_channel_blend_info.blendmode = JXL_BLEND_MULADD;
-  JxlEncoderFrameSettingsSetInfo(frame_settings, &header);
-  JxlEncoderFrameSettingsSetExtraChannelBlendInfo(frame_settings, 0,
-                                                  &extra_channel_blend_info);
+  JxlEncoderSetFrameHeader(frame_settings, &header);
+  JxlEncoderSetExtraChannelBlendInfo(frame_settings, 0,
+                                     &extra_channel_blend_info);
   JxlEncoderFrameSettingsSetName(frame_settings, frame_name.c_str());
 
   std::vector<uint8_t> compressed = std::vector<uint8_t>(64);


### PR DESCRIPTION
…xtraChannelBlendInfo

Renames JxlEncoderFrameSettingsSetInfo to JxlEncoderSetFrameHeader, and
JxlEncoderFrameSettingsSetExtraChannelBlendInfo to
JxlEncoderSetExtraChannelBlendInfo.

This matches the decoder counterparts JxlDecoderGetFrameHeader and
JxlDecoderGetExtraChannelBlendInfo

It also makes the names, which are long and hard to remember, simpler.
THe fact that it uses the frame settings is already implied by taking a
FrameSettings argument. So overall this looks like the right thing to do
to keep the functions more memorable (shorter name and matching decoder)