### PR TITLE
Also rename JxlEncoderFrameSettingsSetName

### DIFF
--- a/lib/include/jxl/codestream_header.h
+++ b/lib/include/jxl/codestream_header.h
@@ -407,9 +407,8 @@ typedef struct {
 
   /** Length of the frame name in bytes, or 0 if no name.
    * Excludes null termination character. This value is set by the decoder.
-   * For the encoder, this value is ignored and @ref
-   * JxlEncoderFrameSettingsSetName is used instead to set the name and the
-   * length.
+   * For the encoder, this value is ignored and @ref JxlEncoderSetFrameName is
+   * used instead to set the name and the length.
    */
   uint32_t name_length;
 

--- a/lib/include/jxl/encode.h
+++ b/lib/include/jxl/encode.h
@@ -388,9 +388,9 @@ JXL_EXPORT JxlEncoderStatus JxlEncoderProcessOutput(JxlEncoder* enc,
  *
  * The is_last and name_length fields of the JxlFrameHeader are ignored, use
  * @ref JxlEncoderCloseFrames to indicate last frame, and @ref
- * JxlEncoderFrameSettingsSetName to indicate the name and its length instead.
+ * JxlEncoderSetFrameName to indicate the name and its length instead.
  * Calling this function will clear any name that was previously set with @ref
- * JxlEncoderFrameSettingsSetName.
+ * JxlEncoderSetFrameName.
  *
  * @param frame_settings set of options and metadata for this frame. Also
  * includes reference to the encoder object.
@@ -436,7 +436,7 @@ JXL_EXPORT JxlEncoderStatus JxlEncoderSetExtraChannelBlendInfo(
  * string (zero terminated). Owned by the caller, and copied internally.
  * @return JXL_ENC_SUCCESS on success, JXL_ENC_ERROR on error
  */
-JXL_EXPORT JxlEncoderStatus JxlEncoderFrameSettingsSetName(
+JXL_EXPORT JxlEncoderStatus JxlEncoderSetFrameName(
     JxlEncoderFrameSettings* frame_settings, const char* frame_name);
 
 /**
@@ -841,7 +841,7 @@ JXL_EXPORT JxlEncoderStatus JxlEncoderSetExtraChannelInfo(
  * must be smaller than the num_extra_channels in the associated JxlBasicInfo.
  *
  * TODO(lode): remove size parameter for consistency with
- * JxlEncoderFrameSettingsSetName
+ * JxlEncoderSetFrameName
  *
  * @param enc encoder object
  * @param index index of the extra channel to set.

--- a/lib/jxl/encode.cc
+++ b/lib/jxl/encode.cc
@@ -1313,7 +1313,7 @@ JxlEncoderStatus JxlEncoderSetFrameHeader(JxlEncoderOptions* frame_settings,
 
   frame_settings->values.header = *frame_header;
   // Setting the frame header resets the frame name, it must be set again with
-  // JxlEncoderFrameSettingsSetName if desired.
+  // JxlEncoderSetFrameName if desired.
   frame_settings->values.frame_name = "";
 
   return JXL_ENC_SUCCESS;
@@ -1337,8 +1337,8 @@ JxlEncoderStatus JxlEncoderSetExtraChannelBlendInfo(
   return JXL_ENC_SUCCESS;
 }
 
-JxlEncoderStatus JxlEncoderFrameSettingsSetName(
-    JxlEncoderFrameSettings* frame_settings, const char* frame_name) {
+JxlEncoderStatus JxlEncoderSetFrameName(JxlEncoderFrameSettings* frame_settings,
+                                        const char* frame_name) {
   std::string str = frame_name;
   if (str.size() > 1071) {
     return JXL_API_ERROR("frame name can be max 1071 bytes long");

--- a/lib/jxl/encode_test.cc
+++ b/lib/jxl/encode_test.cc
@@ -1016,7 +1016,7 @@ TEST(EncodeTest, AnimationHeaderTest) {
   JxlEncoderSetFrameHeader(frame_settings, &header);
   JxlEncoderSetExtraChannelBlendInfo(frame_settings, 0,
                                      &extra_channel_blend_info);
-  JxlEncoderFrameSettingsSetName(frame_settings, frame_name.c_str());
+  JxlEncoderSetFrameName(frame_settings, frame_name.c_str());
 
   std::vector<uint8_t> compressed = std::vector<uint8_t>(64);
   uint8_t* next_out = compressed.data();


### PR DESCRIPTION
After https://github.com/libjxl/libjxl/pull/990, this funtion was
forgotten, rename to JxlEncoderSetFrameName to match the decoder's
JxlDecoderGetFrameName