### PR TITLE
reduce MSVC warnings a bit

### DIFF
--- a/lib/jxl/bit_reader_test.cc
+++ b/lib/jxl/bit_reader_test.cc
@@ -54,7 +54,7 @@ struct Symbol {
 TEST(BitReaderTest, TestRoundTrip) {
   ThreadPoolInternal pool(8);
   pool.Run(0, 1000, ThreadPool::SkipInit(),
-           [](const int task, const int /* thread */) {
+           [](const uint32_t task, size_t /* thread */) {
              constexpr size_t kMaxBits = 8000;
              BitWriter writer;
              BitWriter::Allotment allotment(&writer, kMaxBits);
@@ -86,14 +86,14 @@ TEST(BitReaderTest, TestRoundTrip) {
 TEST(BitReaderTest, TestSkip) {
   ThreadPoolInternal pool(8);
   pool.Run(0, 96, ThreadPool::SkipInit(),
-           [](const int task, const int /* thread */) {
+           [](const uint32_t task, size_t /* thread */) {
              constexpr size_t kSize = 100;
 
              for (size_t skip = 0; skip < 128; ++skip) {
                BitWriter writer;
                BitWriter::Allotment allotment(&writer, kSize * kBitsPerByte);
                // Start with "task" 1-bits.
-               for (int i = 0; i < task; ++i) {
+               for (size_t i = 0; i < task; ++i) {
                  writer.Write(1, 1);
                }
 
@@ -113,7 +113,7 @@ TEST(BitReaderTest, TestSkip) {
                BitReader reader1(writer.GetSpan());
                BitReader reader2(writer.GetSpan());
                // Verify initial 1-bits
-               for (int i = 0; i < task; ++i) {
+               for (size_t i = 0; i < task; ++i) {
                  EXPECT_EQ(1u, reader1.ReadBits(1));
                  EXPECT_EQ(1u, reader2.ReadBits(1));
                }

--- a/lib/jxl/convolve.cc
+++ b/lib/jxl/convolve.cc
@@ -841,7 +841,7 @@ class ConvolveT {
     const int64_t stride = in.PixelsPerRow();
     RunOnPool(
         pool, ybegin, yend, ThreadPool::SkipInit(),
-        [&](const int y, int /*thread*/) HWY_ATTR {
+        [&](const uint32_t y, size_t /*thread*/) HWY_ATTR {
           RunRow<kSizeModN>(rect.ConstRow(in, y), rect.xsize(), stride,
                             WrapRowUnchanged(), weights, out->Row(y));
         },
@@ -858,7 +858,7 @@ class ConvolveT {
     const int64_t stride = in.PixelsPerRow();
     RunOnPool(
         pool, ybegin, yend, ThreadPool::SkipInit(),
-        [&](const int y, int /*thread*/) HWY_ATTR {
+        [&](const uint32_t y, size_t /*thread*/) HWY_ATTR {
           for (size_t c = 0; c < 3; ++c) {
             RunRow<kSizeModN>(rect.ConstPlaneRow(in, c, y), rect.xsize(),
                               stride, WrapRowUnchanged(), weights,
@@ -951,7 +951,7 @@ void Symmetric5(const ImageF& in, const Rect& rect,
   const size_t ysize = rect.ysize();
   RunOnPool(
       pool, 0, static_cast<uint32_t>(ysize), ThreadPool::SkipInit(),
-      [&](const int task, int /*thread*/) {
+      [&](const uint32_t task, size_t /*thread*/) {
         const int64_t iy = task;
 
         if (iy < 2 || iy >= static_cast<ssize_t>(ysize) - 2) {
@@ -971,7 +971,7 @@ void Symmetric5_3(const Image3F& in, const Rect& rect,
   const size_t ysize = rect.ysize();
   RunOnPool(
       pool, 0, static_cast<uint32_t>(ysize), ThreadPool::SkipInit(),
-      [&](const int task, int /*thread*/) {
+      [&](const uint32_t task, size_t /*thread*/) {
         const size_t iy = task;
 
         if (iy < 2 || iy >= ysize - 2) {
@@ -1154,7 +1154,7 @@ void SlowSymmetric3(const ImageF& in, const Rect& rect,
 
   RunOnPool(
       pool, 0, static_cast<uint32_t>(ysize), ThreadPool::SkipInit(),
-      [&](const int task, int /*thread*/) {
+      [&](const uint32_t task, size_t /*thread*/) {
         const int64_t iy = task;
         float* JXL_RESTRICT out_row = out->Row(static_cast<size_t>(iy));
 
@@ -1179,7 +1179,7 @@ void SlowSymmetric3(const Image3F& in, const Rect& rect,
 
   RunOnPool(
       pool, 0, static_cast<uint32_t>(ysize), ThreadPool::SkipInit(),
-      [&](const int task, int /*thread*/) {
+      [&](const uint32_t task, size_t /*thread*/) {
         const int64_t iy = task;
         const size_t oy = static_cast<size_t>(iy);
 
@@ -1237,7 +1237,7 @@ void SlowSeparable5(const ImageF& in, const Rect& rect,
   const size_t ysize = rect.ysize();
   RunOnPool(
       pool, 0, static_cast<uint32_t>(ysize), ThreadPool::SkipInit(),
-      [&](const int task, int /*thread*/) {
+      [&](const uint32_t task, size_t /*thread*/) {
         const int64_t y = task;
 
         float* const JXL_RESTRICT row_out = out->Row(y);
@@ -1267,7 +1267,7 @@ void SlowSeparable7(const ImageF& in, const Rect& rect,
   const size_t ysize = rect.ysize();
   RunOnPool(
       pool, 0, static_cast<uint32_t>(ysize), ThreadPool::SkipInit(),
-      [&](const int task, int /*thread*/) {
+      [&](const uint32_t task, size_t /*thread*/) {
         const int64_t y = task;
 
         float* const JXL_RESTRICT row_out = out->Row(y);
@@ -1298,7 +1298,7 @@ void SlowLaplacian5(const ImageF& in, const Rect& rect, ThreadPool* pool,
 
   RunOnPool(
       pool, 0, static_cast<uint32_t>(ysize), ThreadPool::SkipInit(),
-      [&](const int task, int /*thread*/) {
+      [&](const uint32_t task, size_t /*thread*/) {
         const int64_t y = task;
 
         const float* const JXL_RESTRICT row_t =

--- a/lib/jxl/convolve_test.cc
+++ b/lib/jxl/convolve_test.cc
@@ -138,7 +138,7 @@ void TestConvolve() {
 
   ThreadPoolInternal pool(4);
   pool.Run(kConvolveMaxRadius, 40, ThreadPool::SkipInit(),
-           [](const int task, int /*thread*/) {
+           [](const uint32_t task, size_t /*thread*/) {
              const size_t xsize = task;
              Rng rng(129 + 13 * xsize);
 

--- a/lib/jxl/data_parallel_test.cc
+++ b/lib/jxl/data_parallel_test.cc
@@ -53,8 +53,8 @@ int TestInit(void* jpegxl_opaque, size_t num_threads) { return 0; }
 
 TEST_F(DataParallelTest, RunnerCalledParamenters) {
   EXPECT_TRUE(pool_.Run(
-      1234, 5678, [](const size_t num_threads) { return true; },
-      [](const int task, const int thread) { return; }));
+      1234, 5678, [](size_t /* num_threads */) { return true; },
+      [](uint32_t /* task */, size_t /* thread */) { return; }));
   EXPECT_EQ(1, runner_called_);
   EXPECT_NE(nullptr, init_);
   EXPECT_NE(nullptr, func_);
@@ -66,21 +66,21 @@ TEST_F(DataParallelTest, RunnerCalledParamenters) {
 TEST_F(DataParallelTest, RunnerFailurePropagates) {
   runner_return_ = -1;  // FakeRunner return value.
   EXPECT_FALSE(pool_.Run(
-      1234, 5678, [](const size_t num_threads) { return false; },
-      [](const int task, const int thread) { return; }));
+      1234, 5678, [](size_t /* num_threads */) { return false; },
+      [](uint32_t /* task */, size_t /* thread */) { return; }));
   EXPECT_FALSE(RunOnPool(
-      nullptr, 1234, 5678, [](const size_t num_threads) { return false; },
-      [](const int task, const int thread) { return; }, "Test"));
+      nullptr, 1234, 5678, [](size_t /* num_threads */) { return false; },
+      [](uint32_t /* task */, size_t /* thread */) { return; }, "Test"));
 }
 
 TEST_F(DataParallelTest, RunnerNotCalledOnEmptyRange) {
   runner_return_ = -1;  // FakeRunner return value.
   EXPECT_TRUE(pool_.Run(
-      123, 123, [](const size_t num_threads) { return false; },
-      [](const int task, const int thread) { return; }));
+      123, 123, [](size_t /* num_threads */) { return false; },
+      [](uint32_t /* task */, size_t /* thread */) { return; }));
   EXPECT_TRUE(RunOnPool(
-      nullptr, 123, 123, [](const size_t num_threads) { return false; },
-      [](const int task, const int thread) { return; }, "Test"));
+      nullptr, 123, 123, [](size_t /* num_threads */) { return false; },
+      [](uint32_t /* task */, size_t /* thread */) { return; }, "Test"));
   // We don't call the external runner when the range is empty. We don't even
   // need to call the init function.
   EXPECT_EQ(0, runner_called_);

--- a/lib/jxl/dec_cache.h
+++ b/lib/jxl/dec_cache.h
@@ -306,7 +306,8 @@ struct PassesDecoderState {
       size_t num_x_groups = DivCeil(noise.xsize(), kGroupDim);
       size_t num_y_groups = DivCeil(noise.ysize(), kGroupDim);
       PROFILER_ZONE("GenerateNoise");
-      auto generate_noise = [&](int group_index, int _) {
+      auto generate_noise = [&](const uint32_t group_index,
+                                size_t /* thread */) {
         size_t gx = group_index % num_x_groups;
         size_t gy = group_index / num_x_groups;
         Rect rect(gx * kGroupDim, gy * kGroupDim, kGroupDim, kGroupDim,

--- a/lib/jxl/dec_external_image.cc
+++ b/lib/jxl/dec_external_image.cc
@@ -132,7 +132,7 @@ void UndoOrientation(jxl::Orientation undo_orientation, const Plane<T>& image,
     out = Plane<T>(xsize, ysize);
     RunOnPool(
         pool, 0, static_cast<uint32_t>(ysize), ThreadPool::SkipInit(),
-        [&](const int task, int /*thread*/) {
+        [&](const uint32_t task, size_t /*thread*/) {
           const int64_t y = task;
           const T* JXL_RESTRICT row_in = image.Row(y);
           T* JXL_RESTRICT row_out = out.Row(y);
@@ -145,7 +145,7 @@ void UndoOrientation(jxl::Orientation undo_orientation, const Plane<T>& image,
     out = Plane<T>(xsize, ysize);
     RunOnPool(
         pool, 0, static_cast<uint32_t>(ysize), ThreadPool::SkipInit(),
-        [&](const int task, int /*thread*/) {
+        [&](const uint32_t task, size_t /*thread*/) {
           const int64_t y = task;
           const T* JXL_RESTRICT row_in = image.Row(y);
           T* JXL_RESTRICT row_out = out.Row(ysize - y - 1);
@@ -158,7 +158,7 @@ void UndoOrientation(jxl::Orientation undo_orientation, const Plane<T>& image,
     out = Plane<T>(xsize, ysize);
     RunOnPool(
         pool, 0, static_cast<uint32_t>(ysize), ThreadPool::SkipInit(),
-        [&](const int task, int /*thread*/) {
+        [&](const uint32_t task, size_t /*thread*/) {
           const int64_t y = task;
           const T* JXL_RESTRICT row_in = image.Row(y);
           T* JXL_RESTRICT row_out = out.Row(ysize - y - 1);
@@ -171,7 +171,7 @@ void UndoOrientation(jxl::Orientation undo_orientation, const Plane<T>& image,
     out = Plane<T>(ysize, xsize);
     RunOnPool(
         pool, 0, static_cast<uint32_t>(ysize), ThreadPool::SkipInit(),
-        [&](const int task, int /*thread*/) {
+        [&](const uint32_t task, size_t /*thread*/) {
           const int64_t y = task;
           const T* JXL_RESTRICT row_in = image.Row(y);
           for (size_t x = 0; x < xsize; ++x) {
@@ -183,7 +183,7 @@ void UndoOrientation(jxl::Orientation undo_orientation, const Plane<T>& image,
     out = Plane<T>(ysize, xsize);
     RunOnPool(
         pool, 0, static_cast<uint32_t>(ysize), ThreadPool::SkipInit(),
-        [&](const int task, int /*thread*/) {
+        [&](const uint32_t task, size_t /*thread*/) {
           const int64_t y = task;
           const T* JXL_RESTRICT row_in = image.Row(y);
           for (size_t x = 0; x < xsize; ++x) {
@@ -195,7 +195,7 @@ void UndoOrientation(jxl::Orientation undo_orientation, const Plane<T>& image,
     out = Plane<T>(ysize, xsize);
     RunOnPool(
         pool, 0, static_cast<uint32_t>(ysize), ThreadPool::SkipInit(),
-        [&](const int task, int /*thread*/) {
+        [&](const uint32_t task, size_t /*thread*/) {
           const int64_t y = task;
           const T* JXL_RESTRICT row_in = image.Row(y);
           for (size_t x = 0; x < xsize; ++x) {
@@ -207,7 +207,7 @@ void UndoOrientation(jxl::Orientation undo_orientation, const Plane<T>& image,
     out = Plane<T>(ysize, xsize);
     RunOnPool(
         pool, 0, static_cast<uint32_t>(ysize), ThreadPool::SkipInit(),
-        [&](const int task, int /*thread*/) {
+        [&](const uint32_t task, size_t /*thread*/) {
           const int64_t y = task;
           const T* JXL_RESTRICT row_in = image.Row(y);
           for (size_t x = 0; x < xsize; ++x) {
@@ -352,7 +352,7 @@ Status ConvertChannelsToExternal(const ImageF* channels[], size_t num_channels,
             InitOutCallback(num_threads);
             return true;
           },
-          [&](const int task, int thread) {
+          [&](const uint32_t task, const size_t thread) {
             const int64_t y = task;
             const float* JXL_RESTRICT row_in[kConvertMaxChannels];
             for (size_t c = 0; c < num_channels; c++) {
@@ -394,7 +394,7 @@ Status ConvertChannelsToExternal(const ImageF* channels[], size_t num_channels,
             InitOutCallback(num_threads);
             return true;
           },
-          [&](const int task, int thread) {
+          [&](const uint32_t task, const size_t thread) {
             const int64_t y = task;
             uint8_t* row_out =
                 out_callback
@@ -429,7 +429,7 @@ Status ConvertChannelsToExternal(const ImageF* channels[], size_t num_channels,
           InitOutCallback(num_threads);
           return true;
         },
-        [&](const int task, int thread) {
+        [&](const uint32_t task, const size_t thread) {
           const int64_t y = task;
           uint8_t* row_out =
               out_callback

--- a/lib/jxl/dec_frame.h
+++ b/lib/jxl/dec_frame.h
@@ -280,6 +280,7 @@ class FrameDecoder {
   std::vector<uint8_t> decoded_dc_groups_;
   bool decoded_dc_global_;
   bool decoded_ac_global_;
+  bool HasEverything() const;
   bool finalized_dc_ = true;
   size_t num_sections_done_ = 0;
   bool is_finalized_ = true;

--- a/lib/jxl/dec_modular.cc
+++ b/lib/jxl/dec_modular.cc
@@ -515,7 +515,7 @@ Status ModularFrameDecoder::ModularImageToDecodedRect(
         JXL_ASSERT(!fp);
         RunOnPool(
             pool, 0, ysize_shifted, jxl::ThreadPool::SkipInit(),
-            [&](const int task, const int thread) {
+            [&](const uint32_t task, size_t /* thread */) {
               const size_t y = task;
               const pixel_type* const JXL_RESTRICT row_in = ch_in.Row(y);
               const pixel_type* const JXL_RESTRICT row_in_Y =
@@ -530,7 +530,7 @@ Status ModularFrameDecoder::ModularImageToDecodedRect(
         int exp_bits = metadata->m.bit_depth.exponent_bits_per_sample;
         RunOnPool(
             pool, 0, ysize_shifted, jxl::ThreadPool::SkipInit(),
-            [&](const int task, const int thread) {
+            [&](const uint32_t task, size_t /* thread */) {
               const size_t y = task;
               const pixel_type* const JXL_RESTRICT row_in = ch_in.Row(y);
               float* const JXL_RESTRICT row_out = r.PlaneRow(&decoded, c, y);
@@ -540,7 +540,7 @@ Status ModularFrameDecoder::ModularImageToDecodedRect(
       } else {
         RunOnPool(
             pool, 0, ysize_shifted, jxl::ThreadPool::SkipInit(),
-            [&](const int task, const int thread) {
+            [&](const uint32_t task, size_t /* thread */) {
               const size_t y = task;
               const pixel_type* const JXL_RESTRICT row_in = ch_in.Row(y);
               if (rgb_from_gray) {

--- a/lib/jxl/dec_reconstruct.cc
+++ b/lib/jxl/dec_reconstruct.cc
@@ -464,7 +464,7 @@ void UndoXYB(const Image3F& src, Image3F* dst,
   CopyImageTo(src, dst);
   RunOnPool(
       pool, 0, src.ysize(), ThreadPool::SkipInit(),
-      [&](int y, int /*thread*/) {
+      [&](const uint32_t y, size_t /*thread*/) {
         JXL_CHECK(HWY_DYNAMIC_DISPATCH(UndoXYBInPlace)(dst, Rect(*dst).Line(y),
                                                        output_info));
       },
@@ -1169,7 +1169,7 @@ Status FinalizeFrameDecoding(ImageBundle* decoded,
         rects_to_process.push_back(rect);
       }
     }
-    const auto allocate_storage = [&](size_t num_threads) {
+    const auto allocate_storage = [&](const size_t num_threads) {
       dec_state->EnsureStorage(num_threads);
       return true;
     };
@@ -1193,7 +1193,7 @@ Status FinalizeFrameDecoding(ImageBundle* decoded,
     }
 
     std::atomic<bool> apply_features_ok{true};
-    auto run_apply_features = [&](size_t rect_id, size_t thread) {
+    auto run_apply_features = [&](const uint32_t rect_id, size_t thread) {
       size_t xstart = PassesDecoderState::kGroupDataXBorder;
       size_t ystart = PassesDecoderState::kGroupDataYBorder;
       for (size_t c = 0; c < 3; c++) {
@@ -1303,7 +1303,7 @@ Status FinalizeFrameDecoding(ImageBundle* decoded,
     std::atomic<bool> blending_ok{true};
     JXL_RETURN_IF_ERROR(RunOnPool(
         pool, 0, rects_to_process.size(), ThreadPool::SkipInit(),
-        [&](size_t i, size_t /*thread*/) {
+        [&](const uint32_t i, size_t /*thread*/) {
           const Rect& rect = rects_to_process[i];
           auto rect_blender = blender.PrepareRect(
               rect, *foreground.color(), foreground.extra_channels(), rect);

--- a/lib/jxl/dec_xyb.cc
+++ b/lib/jxl/dec_xyb.cc
@@ -37,7 +37,7 @@ void OpsinToLinearInplace(Image3F* JXL_RESTRICT inout, ThreadPool* pool,
   const size_t xsize = inout->xsize();  // not padded
   RunOnPool(
       pool, 0, inout->ysize(), ThreadPool::SkipInit(),
-      [&](const int task, const int thread) {
+      [&](const uint32_t task, size_t /* thread */) {
         const size_t y = task;
 
         // Faster than adding via ByteOffset at end of loop.
@@ -77,7 +77,7 @@ void OpsinToLinear(const Image3F& opsin, const Rect& rect, ThreadPool* pool,
 
   RunOnPool(
       pool, 0, static_cast<int>(rect.ysize()), ThreadPool::SkipInit(),
-      [&](const int task, int /*thread*/) {
+      [&](const uint32_t task, size_t /*thread*/) {
         const size_t y = static_cast<size_t>(task);
 
         // Faster than adding via ByteOffset at end of loop.

--- a/lib/jxl/enc_adaptive_quantization.cc
+++ b/lib/jxl/enc_adaptive_quantization.cc
@@ -591,11 +591,11 @@ ImageF AdaptiveQuantizationMap(const float butteraugli_target,
       pool, 0,
       DivCeil(frame_dim.xsize_blocks, kEncTileDimInBlocks) *
           DivCeil(frame_dim.ysize_blocks, kEncTileDimInBlocks),
-      [&](size_t num_threads) {
+      [&](const size_t num_threads) {
         impl.PrepareBuffers(num_threads);
         return true;
       },
-      [&](const int tid, int thread) {
+      [&](const uint32_t tid, const size_t thread) {
         size_t n_enc_tiles =
             DivCeil(frame_dim.xsize_blocks, kEncTileDimInBlocks);
         size_t tx = tid % n_enc_tiles;
@@ -1091,12 +1091,13 @@ ImageBundle RoundtripImage(const Image3F& opsin, PassesEncoderState* enc_state,
   }
 
   hwy::AlignedUniquePtr<GroupDecCache[]> group_dec_caches;
-  const auto allocate_storage = [&](size_t num_threads) {
+  const auto allocate_storage = [&](const size_t num_threads) {
     dec_state->EnsureStorage(num_threads);
     group_dec_caches = hwy::MakeUniqueAlignedArray<GroupDecCache>(num_threads);
     return true;
   };
-  const auto process_group = [&](const int group_index, const int thread) {
+  const auto process_group = [&](const uint32_t group_index,
+                                 const size_t thread) {
     if (dec_state->shared->frame_header.loop_filter.epf_iters > 0) {
       ComputeSigma(dec_state->shared->BlockGroupRect(group_index),
                    dec_state.get());

--- a/lib/jxl/enc_detect_dots.cc
+++ b/lib/jxl/enc_detect_dots.cc
@@ -55,7 +55,7 @@ ImageF SumOfSquareDifferences(const Image3F& forig, const Image3F& smooth,
   ImageF sum_of_squares(forig.xsize(), forig.ysize());
   RunOnPool(
       pool, 0, forig.ysize(), ThreadPool::SkipInit(),
-      [&](const int task, const int thread) {
+      [&](const uint32_t task, size_t thread) {
         const size_t y = static_cast<size_t>(task);
         const float* JXL_RESTRICT orig_row0 = forig.Plane(0).ConstRow(y);
         const float* JXL_RESTRICT orig_row1 = forig.Plane(1).ConstRow(y);

--- a/lib/jxl/enc_external_image.cc
+++ b/lib/jxl/enc_external_image.cc
@@ -137,7 +137,7 @@ Status ConvertFromExternal(Span<const uint8_t> bytes, size_t xsize,
   if (float_in) {
     RunOnPool(
         pool, 0, static_cast<uint32_t>(ysize), ThreadPool::SkipInit(),
-        [&](const int task, int /*thread*/) {
+        [&](const uint32_t task, size_t /*thread*/) {
           const size_t y = task;
           size_t i = row_size * task;
           float* JXL_RESTRICT row_out = channel->Row(y);
@@ -172,7 +172,7 @@ Status ConvertFromExternal(Span<const uint8_t> bytes, size_t xsize,
     float mul = 1. / ((1ull << bits_per_sample) - 1);
     RunOnPool(
         pool, 0, static_cast<uint32_t>(ysize), ThreadPool::SkipInit(),
-        [&](const int task, int /*thread*/) {
+        [&](const uint32_t task, size_t /*thread*/) {
           const size_t y = task;
           size_t i = row_size * task;
           float* JXL_RESTRICT row_out = channel->Row(y);
@@ -251,7 +251,7 @@ Status ConvertFromExternal(Span<const uint8_t> bytes, size_t xsize,
     for (size_t c = 0; c < color_channels; ++c) {
       RunOnPool(
           pool, 0, static_cast<uint32_t>(ysize), ThreadPool::SkipInit(),
-          [&](const int task, int /*thread*/) {
+          [&](const uint32_t task, size_t /*thread*/) {
             const size_t y = get_y(task);
             size_t i =
                 row_size * task + (c * bits_per_sample / jxl::kBitsPerByte);
@@ -290,7 +290,7 @@ Status ConvertFromExternal(Span<const uint8_t> bytes, size_t xsize,
     for (size_t c = 0; c < color_channels; ++c) {
       RunOnPool(
           pool, 0, static_cast<uint32_t>(ysize), ThreadPool::SkipInit(),
-          [&](const int task, int /*thread*/) {
+          [&](const uint32_t task, size_t /*thread*/) {
             const size_t y = get_y(task);
             size_t i = row_size * task + c * bytes_per_channel;
             float* JXL_RESTRICT row_out = color.PlaneRow(c, y);
@@ -335,7 +335,7 @@ Status ConvertFromExternal(Span<const uint8_t> bytes, size_t xsize,
     if (float_in) {
       RunOnPool(
           pool, 0, static_cast<uint32_t>(ysize), ThreadPool::SkipInit(),
-          [&](const int task, int /*thread*/) {
+          [&](const uint32_t task, size_t /*thread*/) {
             const size_t y = get_y(task);
             size_t i = row_size * task +
                        (color_channels * bits_per_sample / jxl::kBitsPerByte);
@@ -371,7 +371,7 @@ Status ConvertFromExternal(Span<const uint8_t> bytes, size_t xsize,
       float mul = 1. / ((1ull << bits_per_sample) - 1);
       RunOnPool(
           pool, 0, static_cast<uint32_t>(ysize), ThreadPool::SkipInit(),
-          [&](const int task, int /*thread*/) {
+          [&](const uint32_t task, size_t /*thread*/) {
             const size_t y = get_y(task);
             size_t i = row_size * task + color_channels * bytes_per_channel;
             float* JXL_RESTRICT row_out = alpha.Row(y);

--- a/lib/jxl/enc_frame.cc
+++ b/lib/jxl/enc_frame.cc
@@ -535,7 +535,8 @@ class LossyFrameEncoder {
       group_caches_.resize(num_threads);
       return true;
     };
-    const auto tokenize_group = [&](const int group_index, const int thread) {
+    const auto tokenize_group = [&](const uint32_t group_index,
+                                    const size_t thread) {
       // Tokenize coefficients.
       const Rect rect = shared.BlockGroupRect(group_index);
       for (size_t idx_pass = 0; idx_pass < enc_state_->passes.size();
@@ -659,7 +660,7 @@ class LossyFrameEncoder {
             kScale * kZeroBiasDefault[c] *
             0.9999f;  // just epsilon less for better rounding
 
-        auto process_row = [&](int task, int thread) {
+        auto process_row = [&](const uint32_t task, const size_t thread) {
           size_t ty = task;
           int8_t* JXL_RESTRICT row_out = map->Row(ty);
           for (size_t tx = 0; tx < map->xsize(); ++tx) {
@@ -856,7 +857,8 @@ class LossyFrameEncoder {
 
     // disable DC frame for now
     shared.frame_header.UpdateFlag(false, FrameHeader::kUseDcFrame);
-    auto compute_dc_coeffs = [&](int group_index, int /* thread */) {
+    auto compute_dc_coeffs = [&](const uint32_t group_index,
+                                 size_t /* thread */) {
       modular_frame_encoder->AddVarDCTDC(dc, group_index, /*nl_dc=*/false,
                                          enc_state_, /*jpeg_transcode=*/true);
       modular_frame_encoder->AddACMetadata(group_index, /*jpeg_transcode=*/true,
@@ -883,7 +885,8 @@ class LossyFrameEncoder {
       group_caches_.resize(num_threads);
       return true;
     };
-    const auto tokenize_group = [&](const int group_index, const int thread) {
+    const auto tokenize_group = [&](const uint32_t group_index,
+                                    const size_t thread) {
       // Tokenize coefficients.
       const Rect rect = shared.BlockGroupRect(group_index);
       for (size_t idx_pass = 0; idx_pass < enc_state_->passes.size();
@@ -1132,7 +1135,7 @@ Status EncodeFrame(const CompressParams& cparams_orig,
   // lambda type by making LossyFrameEncoder a template instead, but this is
   // simpler.
   const std::function<Status(size_t)> resize_aux_outs =
-      [&aux_outs, aux_out](size_t num_threads) -> Status {
+      [&aux_outs, aux_out](const size_t num_threads) -> Status {
     if (aux_out != nullptr) {
       size_t old_size = aux_outs.size();
       for (size_t i = num_threads; i < old_size; i++) {
@@ -1296,7 +1299,8 @@ Status EncodeFrame(const CompressParams& cparams_orig,
   JXL_RETURN_IF_ERROR(modular_frame_encoder->EncodeStream(
       get_output(0), aux_out, kLayerModularGlobal, ModularStreamId::Global()));
 
-  const auto process_dc_group = [&](const int group_index, const int thread) {
+  const auto process_dc_group = [&](const uint32_t group_index,
+                                    const size_t thread) {
     AuxOut* my_aux_out = aux_out ? &aux_outs[thread] : nullptr;
     BitWriter* output = get_output(group_index + 1);
     if (frame_header->encoding == FrameEncoding::kVarDCT &&
@@ -1335,7 +1339,8 @@ Status EncodeFrame(const CompressParams& cparams_orig,
   }
 
   std::atomic<int> num_errors{0};
-  const auto process_group = [&](const int group_index, const int thread) {
+  const auto process_group = [&](const uint32_t group_index,
+                                 const size_t thread) {
     AuxOut* my_aux_out = aux_out ? &aux_outs[thread] : nullptr;
 
     for (size_t i = 0; i < num_passes; i++) {

--- a/lib/jxl/enc_heuristics.cc
+++ b/lib/jxl/enc_heuristics.cc
@@ -869,7 +869,7 @@ Status DefaultEncoderHeuristics::LossyFrameHeuristics(
   cfl_heuristics.Init(*opsin);
   acs_heuristics.Init(*opsin, enc_state);
 
-  auto process_tile = [&](size_t tid, size_t thread) {
+  auto process_tile = [&](const uint32_t tid, const size_t thread) {
     size_t n_enc_tiles =
         DivCeil(enc_state->shared.frame_dim.xsize_blocks, kEncTileDimInBlocks);
     size_t tx = tid % n_enc_tiles;

--- a/lib/jxl/enc_image_bundle.cc
+++ b/lib/jxl/enc_image_bundle.cc
@@ -39,12 +39,12 @@ Status CopyToT(const ImageMetadata* metadata, const ImageBundle* ib,
   std::atomic<bool> ok{true};
   RunOnPool(
       pool, 0, rect.ysize(),
-      [&](size_t num_threads) {
+      [&](const size_t num_threads) {
         return c_transform.Init(ib->c_current(), c_desired,
                                 metadata->IntensityTarget(), rect.xsize(),
                                 num_threads);
       },
-      [&](const int y, const int thread) {
+      [&](const uint32_t y, const size_t thread) {
         float* mutable_src_buf = c_transform.BufSrc(thread);
         const float* src_buf = mutable_src_buf;
         // Interleave input.

--- a/lib/jxl/enc_modular.cc
+++ b/lib/jxl/enc_modular.cc
@@ -805,7 +805,7 @@ Status ModularFrameEncoder::ComputeEncodingData(
 
   RunOnPool(
       pool, 0, stream_params.size(), ThreadPool::SkipInit(),
-      [&](size_t i, size_t _) {
+      [&](const uint32_t i, size_t /* thread */) {
         stream_options[stream_params[i].id.ID(frame_dim)] = cparams.options;
         JXL_CHECK(PrepareStreamParams(
             stream_params[i].rect, cparams, stream_params[i].minShift,
@@ -928,7 +928,7 @@ Status ModularFrameEncoder::PrepareEncoding(ThreadPool* pool,
     std::vector<Tree> trees(useful_splits.size() - 1);
     RunOnPool(
         pool, 0, useful_splits.size() - 1, ThreadPool::SkipInit(),
-        [&](size_t chunk, size_t _) {
+        [&](const uint32_t chunk, size_t /* thread */) {
           // TODO(veluca): parallelize more.
           size_t total_pixels = 0;
           uint32_t start = useful_splits[chunk];
@@ -1024,7 +1024,7 @@ Status ModularFrameEncoder::PrepareEncoding(ThreadPool* pool,
   image_widths.resize(num_streams);
   RunOnPool(
       pool, 0, num_streams, ThreadPool::SkipInit(),
-      [&](size_t stream_id, size_t _) {
+      [&](const uint32_t stream_id, size_t /* thread */) {
         AuxOut my_aux_out;
         if (aux_out) {
           my_aux_out.dump_image = aux_out->dump_image;

--- a/lib/jxl/enc_patch_dictionary.cc
+++ b/lib/jxl/enc_patch_dictionary.cc
@@ -254,7 +254,7 @@ std::vector<PatchInfo> FindTextLikePatches(
   ZeroFillImage(&is_screenshot_like);
   uint8_t* JXL_RESTRICT screenshot_row = is_screenshot_like.Row(0);
   const size_t screenshot_stride = is_screenshot_like.PixelsPerRow();
-  const auto process_row = [&](uint64_t y, int _) {
+  const auto process_row = [&](const uint32_t y, size_t /* thread */) {
     for (uint64_t x = 0; x < opsin.xsize() / kPatchSide; x++) {
       bool all_same = true;
       for (size_t iy = 0; iy < static_cast<size_t>(kPatchSide); iy++) {

--- a/lib/jxl/enc_xyb.cc
+++ b/lib/jxl/enc_xyb.cc
@@ -167,7 +167,7 @@ void LinearSRGBToXYB(const Image3F& linear,
   const HWY_FULL(float) d;
   RunOnPool(
       pool, 0, static_cast<uint32_t>(linear.ysize()), ThreadPool::SkipInit(),
-      [&](const int task, const int /*thread*/) {
+      [&](const uint32_t task, size_t /*thread*/) {
         const size_t y = static_cast<size_t>(task);
         const float* JXL_RESTRICT row_in0 = linear.ConstPlaneRow(0, y);
         const float* JXL_RESTRICT row_in1 = linear.ConstPlaneRow(1, y);
@@ -194,7 +194,7 @@ void SRGBToXYB(const Image3F& srgb, const float* JXL_RESTRICT premul_absorb,
   const HWY_FULL(float) d;
   RunOnPool(
       pool, 0, static_cast<uint32_t>(srgb.ysize()), ThreadPool::SkipInit(),
-      [&](const int task, const int /*thread*/) {
+      [&](const uint32_t task, size_t /*thread*/) {
         const size_t y = static_cast<size_t>(task);
         const float* JXL_RESTRICT row_srgb0 = srgb.ConstPlaneRow(0, y);
         const float* JXL_RESTRICT row_srgb1 = srgb.ConstPlaneRow(1, y);
@@ -223,7 +223,7 @@ void SRGBToXYBAndLinear(const Image3F& srgb,
   const HWY_FULL(float) d;
   RunOnPool(
       pool, 0, static_cast<uint32_t>(srgb.ysize()), ThreadPool::SkipInit(),
-      [&](const int task, const int /*thread*/) {
+      [&](const uint32_t task, size_t /*thread*/) {
         const size_t y = static_cast<size_t>(task);
         const float* JXL_RESTRICT row_srgb0 = srgb.ConstPlaneRow(0, y);
         const float* JXL_RESTRICT row_srgb1 = srgb.ConstPlaneRow(1, y);

--- a/lib/jxl/gauss_blur.cc
+++ b/lib/jxl/gauss_blur.cc
@@ -594,7 +594,7 @@ void FastGaussianHorizontal(const hwy::AlignedUniquePtr<RecursiveGaussian>& rg,
   const intptr_t xsize = in.xsize();
   RunOnPool(
       pool, 0, in.ysize(), ThreadPool::SkipInit(),
-      [&](const int task, const int /*thread*/) {
+      [&](const uint32_t task, size_t /*thread*/) {
         const size_t y = task;
         const float* row_in = in.ConstRow(y);
         float* JXL_RESTRICT row_out = out->Row(y);

--- a/lib/jxl/lehmer_code_test.cc
+++ b/lib/jxl/lehmer_code_test.cc
@@ -73,13 +73,13 @@ void RoundtripSizeRange(ThreadPool* pool, uint32_t begin, uint32_t end) {
 
   RunOnPool(
       pool, begin, end,
-      [&working_sets, end](size_t num_threads) {
+      [&working_sets, end](const size_t num_threads) {
         for (size_t i = 0; i < num_threads; i++) {
           working_sets.emplace_back(end - 1);
         }
         return true;
       },
-      [&working_sets](int n, int thread) {
+      [&working_sets](const uint32_t n, const size_t thread) {
         Roundtrip(n, &working_sets[thread]);
       },
       "lehmer test");

--- a/lib/jxl/modular/encoding/context_predict.h
+++ b/lib/jxl/modular/encoding/context_predict.h
@@ -314,7 +314,8 @@ class MATreeLookup {
       }
       bool p0 = properties[node.property0] <= node.splitval0;
       uint32_t off0 = properties[node.properties[0]] <= node.splitvals[0];
-      uint32_t off1 = 2 | (properties[node.properties[1]] <= node.splitvals[1]);
+      uint32_t off1 =
+          2 | (properties[node.properties[1]] <= node.splitvals[1] ? 1 : 0);
       pos = node.childID + (p0 ? off1 : off0);
     }
   }

--- a/lib/jxl/modular/transform/palette.h
+++ b/lib/jxl/modular/transform/palette.h
@@ -148,7 +148,7 @@ static Status InvPalette(Image &input, uint32_t begin_c, uint32_t nb_colors,
     if (nb == 1) {
       RunOnPool(
           pool, 0, h, ThreadPool::SkipInit(),
-          [&](const int task, const int thread) {
+          [&](const uint32_t task, size_t /* thread */) {
             const size_t y = task;
             pixel_type *p = input.channel[c0].Row(y);
             for (size_t x = 0; x < w; x++) {
@@ -163,7 +163,7 @@ static Status InvPalette(Image &input, uint32_t begin_c, uint32_t nb_colors,
     } else {
       RunOnPool(
           pool, 0, h, ThreadPool::SkipInit(),
-          [&](const int task, const int thread) {
+          [&](const uint32_t task, size_t /* thread */) {
             const size_t y = task;
             std::vector<pixel_type *> p_out(nb);
             const pixel_type *p_index = input.channel[c0].Row(y);
@@ -187,7 +187,7 @@ static Status InvPalette(Image &input, uint32_t begin_c, uint32_t nb_colors,
     if (predictor == Predictor::Weighted) {
       RunOnPool(
           pool, 0, nb, ThreadPool::SkipInit(),
-          [&](size_t c, size_t _) {
+          [&](const uint32_t c, size_t /* thread */) {
             Channel &channel = input.channel[c0 + c];
             weighted::State wp_state(wp_header, channel.w, channel.h);
             for (size_t y = 0; y < channel.h; y++) {
@@ -218,7 +218,7 @@ static Status InvPalette(Image &input, uint32_t begin_c, uint32_t nb_colors,
     } else {
       RunOnPool(
           pool, 0, nb, ThreadPool::SkipInit(),
-          [&](size_t c, size_t _) {
+          [&](const uint32_t c, size_t /* thread */) {
             Channel &channel = input.channel[c0 + c];
             for (size_t y = 0; y < channel.h; y++) {
               pixel_type *JXL_RESTRICT p = channel.Row(y);

--- a/lib/jxl/modular/transform/rct.cc
+++ b/lib/jxl/modular/transform/rct.cc
@@ -80,7 +80,7 @@ Status InvRCT(Image& input, size_t begin_c, size_t rct_type, ThreadPool* pool) {
       InvRCTRow<4>, InvRCTRow<5>, InvRCTRow<6>};
   RunOnPool(
       pool, 0, h, ThreadPool::SkipInit(),
-      [&](const int task, const int thread) {
+      [&](const uint32_t task, size_t /* thread */) {
         const size_t y = task;
         const pixel_type* in0 = input.channel[m].Row(y);
         const pixel_type* in1 = input.channel[m + 1].Row(y);

--- a/lib/jxl/modular/transform/squeeze.cc
+++ b/lib/jxl/modular/transform/squeeze.cc
@@ -45,7 +45,7 @@ void InvHSqueeze(Image &input, uint32_t c, uint32_t rc, ThreadPool *pool) {
 
   RunOnPool(
       pool, 0, chin.h, ThreadPool::SkipInit(),
-      [&](const int task, const int thread) {
+      [&](const uint32_t task, size_t /* thread */) {
         const size_t y = task;
         const pixel_type *JXL_RESTRICT p_residual = chin_residual.Row(y);
         const pixel_type *JXL_RESTRICT p_avg = chin.Row(y);
@@ -115,7 +115,7 @@ void InvVSqueeze(Image &input, uint32_t c, uint32_t rc, ThreadPool *pool) {
   constexpr int kColsPerThread = 64;
   RunOnPool(
       pool, 0, DivCeil(chin.w, kColsPerThread), ThreadPool::SkipInit(),
-      [&](const int task, const int thread) {
+      [&](const uint32_t task, size_t /* thread */) {
         const size_t x0 = task * kColsPerThread;
         const size_t x1 = std::min((size_t)(task + 1) * kColsPerThread, chin.w);
         // We only iterate up to std::min(chin_residual.h, chin.h) which is

--- a/lib/jxl/noise.h
+++ b/lib/jxl/noise.h
@@ -26,7 +26,7 @@ struct NoiseParams {
   float lut[kNumNoisePoints];
 
   void Clear() {
-    for (float& i : lut) i = 0;
+    for (float& i : lut) i = 0.f;
   }
   bool HasAny() const {
     for (float i : lut) {
@@ -44,10 +44,10 @@ static inline std::pair<int, float> IndexAndFrac(float x) {
   float floor_x;
   float frac_x = std::modf(scaled_x, &floor_x);
   if (JXL_UNLIKELY(scaled_x >= kScaleNumerator)) {
-    floor_x = kScaleNumerator - 1;
-    frac_x = 1;
+    floor_x = kScaleNumerator - 1.f;
+    frac_x = 1.f;
   }
-  return std::make_pair(static_cast<size_t>(static_cast<int>(floor_x)), frac_x);
+  return std::make_pair(static_cast<int>(floor_x), frac_x);
 }
 
 struct NoiseLevel {

--- a/lib/jxl/passes_test.cc
+++ b/lib/jxl/passes_test.cc
@@ -187,7 +187,7 @@ TEST(PassesTest, AllDownsampleFeasible) {
   // TODO(veluca): re-enable downsampling 16.
   std::vector<size_t> downsamplings = {1, 2, 4, 8};  //, 16};
 
-  auto check = [&](uint32_t task, uint32_t /* thread */) -> void {
+  auto check = [&](const uint32_t task, size_t /* thread */) -> void {
     const size_t downsampling = downsamplings[task];
     DecompressParams dparams;
     dparams.max_downsampling = downsampling;
@@ -233,7 +233,7 @@ TEST(PassesTest, AllDownsampleFeasibleQProgressive) {
   // factors achievable.
   std::vector<size_t> downsamplings = {1, 2, 4, 8};
 
-  auto check = [&](uint32_t task, uint32_t /* thread */) -> void {
+  auto check = [&](const uint32_t task, size_t /* thread */) -> void {
     const size_t downsampling = downsamplings[task];
     DecompressParams dparams;
     dparams.max_downsampling = downsampling;

--- a/lib/jxl/quantizer.h
+++ b/lib/jxl/quantizer.h
@@ -139,8 +139,8 @@ class Quantizer {
   JXL_INLINE const float* InvMulDC() const { return inv_mul_dc_; }
 
   JXL_INLINE void ClearDCMul() {
-    std::fill(mul_dc_, mul_dc_ + 4, 1);
-    std::fill(inv_mul_dc_, inv_mul_dc_ + 4, 1);
+    std::fill(mul_dc_, mul_dc_ + 4, 1.f);
+    std::fill(inv_mul_dc_, inv_mul_dc_ + 4, 1.f);
   }
 
   void ComputeGlobalScaleAndQuant(float quant_dc, float quant_median,

--- a/lib/jxl/xorshift128plus_test.cc
+++ b/lib/jxl/xorshift128plus_test.cc
@@ -292,7 +292,7 @@ void TestFloat() {
   const uint32_t kMaxSeed = 16384;  // All 14-bit seeds
 #endif  // JXL_DISABLE_SLOW_TESTS
   pool.Run(0, kMaxSeed, ThreadPool::SkipInit(),
-           [](const int seed, const int /*thread*/) {
+           [](const uint32_t seed, size_t /*thread*/) {
              HWY_ALIGN Xorshift128Plus rng(seed);
 
              const HWY_FULL(uint32_t) du;
@@ -336,7 +336,7 @@ void TestNotZero() {
   const uint32_t kMaxSeed = 2000;
 #endif  // JXL_DISABLE_SLOW_TESTS
   pool.Run(0, kMaxSeed, ThreadPool::SkipInit(),
-           [](const int task, const int /*thread*/) {
+           [](const uint32_t task, size_t /*thread*/) {
              HWY_ALIGN uint64_t lanes[Xorshift128Plus::N];
 
              HWY_ALIGN Xorshift128Plus rng(task);


### PR DESCRIPTION
~~Remove meaningless `const`s,~~ add some `.f` to float assignments, avoid comparisons between uint8 and bool etc.

Also makes all RunOnPool  data functions have the signature `void datafunc(uint32, size_t)` instead of the mix of int, uint32, uint64, size_t that we had there. They all get their actual arguments as uint32 and size_t anyway (casted to whatever was in the lambda declaration because the templating makes that work), so there's no point using different types.