### PR TITLE
ensure at least 2 mantissa bits

### DIFF
--- a/lib/jxl/encode.cc
+++ b/lib/jxl/encode.cc
@@ -190,7 +190,8 @@ JxlEncoderStatus CheckValidBitdepth(uint32_t bits_per_sample,
       return JXL_API_ERROR("Invalid value for bits_per_sample");
     }
   } else if ((exponent_bits_per_sample > 8) ||
-             (bits_per_sample > 24 + exponent_bits_per_sample)) {
+             (bits_per_sample > 24 + exponent_bits_per_sample) ||
+             (bits_per_sample < 3 + exponent_bits_per_sample)) {
     return JXL_API_ERROR("Invalid float description");
   }
   return JXL_ENC_SUCCESS;


### PR DESCRIPTION
Spec says the number of mantissa bits has to be in the range [2, 23] — so including the sign bit, there have to be at least 3 bits besides the exponent bits.