### PR TITLE
don't ignore JxlPixelFormat.align when encoding

### DIFF
--- a/lib/extras/packed_image_convert.cc
+++ b/lib/extras/packed_image_convert.cc
@@ -114,7 +114,7 @@ Status ConvertPackedPixelFileToCodecInOut(const PackedPixelFile& ppf,
         /*alpha_is_premultiplied=*/ppf.info.alpha_premultiplied,
         frame_bits_per_sample, frame.color.format.endianness,
         /*flipped_y=*/frame.color.flipped_y, pool, &bundle,
-        /*float_in=*/float_in));
+        /*float_in=*/float_in, /*align=*/0));
 
     // TODO(deymo): Convert the extra channels. FIXME!
     JXL_CHECK(frame.extra_channels.empty());

--- a/lib/jxl/decode_test.cc
+++ b/lib/jxl/decode_test.cc
@@ -198,8 +198,8 @@ PaddedBytes CreateTestJXLCodestream(
   io.metadata.m.color_encoding = color_encoding;
   EXPECT_TRUE(ConvertFromExternal(
       pixels, xsize, ysize, color_encoding, /*has_alpha=*/include_alpha,
-      /*alpha_is_premultiplied=*/false, bitdepth, JXL_BIG_ENDIAN,
-      /*flipped_y=*/false, &pool, &io.Main(), /*float_in=*/false));
+      /*alpha_is_premultiplied=*/false, /*bits_per_sample=*/16, JXL_BIG_ENDIAN,
+      /*flipped_y=*/false, &pool, &io.Main(), /*float_in=*/false, /*align=*/0));
   jxl::PaddedBytes jpeg_data;
   if (jpeg_codestream != nullptr) {
 #if JPEGXL_ENABLE_JPEG
@@ -1224,7 +1224,8 @@ TEST_P(DecodeTestParam, PixelTest) {
     EXPECT_TRUE(ConvertFromExternal(
         bytes, config.xsize, config.ysize, color_encoding, config.include_alpha,
         /*alpha_is_premultiplied=*/false, 16, JXL_BIG_ENDIAN,
-        /*flipped_y=*/false, nullptr, &io.Main(), /*float_in=*/false));
+        /*flipped_y=*/false, nullptr, &io.Main(), /*float_in=*/false,
+        /*align=*/0));
 
     for (size_t i = 0; i < pixels.size(); i++) pixels[i] = 0;
     EXPECT_TRUE(ConvertToExternal(
@@ -1543,17 +1544,19 @@ TEST(DecodeTest, PixelTestWithICCProfileLossy) {
   EXPECT_TRUE(ConvertFromExternal(
       span0, xsize, ysize, color_encoding0,
       /*has_alpha=*/false, false, 16, format_orig.endianness,
-      /*flipped_y=*/false, /*pool=*/nullptr, &io0.Main(), /*float_in=*/false));
+      /*flipped_y=*/false, /*pool=*/nullptr, &io0.Main(), /*float_in=*/false,
+      /*align=*/0));
 
   jxl::ColorEncoding color_encoding1;
   EXPECT_TRUE(color_encoding1.SetICC(std::move(icc)));
   jxl::Span<const uint8_t> span1(pixels2.data(), pixels2.size());
   jxl::CodecInOut io1;
   io1.SetSize(xsize, ysize);
-  EXPECT_TRUE(ConvertFromExternal(
-      span1, xsize, ysize, color_encoding1,
-      /*has_alpha=*/false, false, 32, format.endianness,
-      /*flipped_y=*/false, /*pool=*/nullptr, &io1.Main(), /*float_in=*/true));
+  EXPECT_TRUE(ConvertFromExternal(span1, xsize, ysize, color_encoding1,
+                                  /*has_alpha=*/false, false, 32,
+                                  format.endianness,
+                                  /*flipped_y=*/false, /*pool=*/nullptr,
+                                  &io1.Main(), /*float_in=*/true, /*align=*/0));
 
   jxl::ButteraugliParams ba;
   EXPECT_THAT(ButteraugliDistance(io0, io1, ba, jxl::GetJxlCms(),
@@ -1596,11 +1599,11 @@ TEST(DecodeTest, PixelTestOpaqueSrgbLossy) {
     jxl::Span<const uint8_t> span0(pixels.data(), pixels.size());
     jxl::CodecInOut io0;
     io0.SetSize(xsize, ysize);
-    EXPECT_TRUE(ConvertFromExternal(span0, xsize, ysize, color_encoding0,
-                                    /*has_alpha=*/false, false, 16,
-                                    format_orig.endianness,
-                                    /*flipped_y=*/false, /*pool=*/nullptr,
-                                    &io0.Main(), /*float_in=*/false));
+    EXPECT_TRUE(ConvertFromExternal(
+        span0, xsize, ysize, color_encoding0,
+        /*has_alpha=*/false, false, 16, format_orig.endianness,
+        /*flipped_y=*/false, /*pool=*/nullptr, &io0.Main(), /*float_in=*/false,
+        /*align=*/0));
 
     jxl::ColorEncoding color_encoding1 = jxl::ColorEncoding::SRGB(false);
     jxl::Span<const uint8_t> span1(pixels2.data(), pixels2.size());
@@ -1608,19 +1611,19 @@ TEST(DecodeTest, PixelTestOpaqueSrgbLossy) {
     if (channels == 4) {
       io1.metadata.m.SetAlphaBits(8);
       io1.SetSize(xsize, ysize);
-      EXPECT_TRUE(ConvertFromExternal(span1, xsize, ysize, color_encoding1,
-                                      /*has_alpha=*/true, false, 8,
-                                      format.endianness,
-                                      /*flipped_y=*/false, /*pool=*/nullptr,
-                                      &io1.Main(), /*float_in=*/false));
+      EXPECT_TRUE(
+          ConvertFromExternal(span1, xsize, ysize, color_encoding1,
+                              /*has_alpha=*/true, false, 8, format.endianness,
+                              /*flipped_y=*/false, /*pool=*/nullptr,
+                              &io1.Main(), /*float_in=*/false, /*align=*/0));
       io1.metadata.m.SetAlphaBits(0);
       io1.Main().ClearExtraChannels();
     } else {
-      EXPECT_TRUE(ConvertFromExternal(span1, xsize, ysize, color_encoding1,
-                                      /*has_alpha=*/false, false, 8,
-                                      format.endianness,
-                                      /*flipped_y=*/false, /*pool=*/nullptr,
-                                      &io1.Main(), /*float_in=*/false));
+      EXPECT_TRUE(
+          ConvertFromExternal(span1, xsize, ysize, color_encoding1,
+                              /*has_alpha=*/false, false, 8, format.endianness,
+                              /*flipped_y=*/false, /*pool=*/nullptr,
+                              &io1.Main(), /*float_in=*/false, /*align=*/0));
     }
 
     jxl::ButteraugliParams ba;
@@ -1665,11 +1668,11 @@ TEST(DecodeTest, PixelTestOpaqueSrgbLossyNoise) {
     jxl::Span<const uint8_t> span0(pixels.data(), pixels.size());
     jxl::CodecInOut io0;
     io0.SetSize(xsize, ysize);
-    EXPECT_TRUE(ConvertFromExternal(span0, xsize, ysize, color_encoding0,
-                                    /*has_alpha=*/false, false, 16,
-                                    format_orig.endianness,
-                                    /*flipped_y=*/false, /*pool=*/nullptr,
-                                    &io0.Main(), /*float_in=*/false));
+    EXPECT_TRUE(ConvertFromExternal(
+        span0, xsize, ysize, color_encoding0,
+        /*has_alpha=*/false, false, 16, format_orig.endianness,
+        /*flipped_y=*/false, /*pool=*/nullptr, &io0.Main(), /*float_in=*/false,
+        /*align=*/0));
 
     jxl::ColorEncoding color_encoding1 = jxl::ColorEncoding::SRGB(false);
     jxl::Span<const uint8_t> span1(pixels2.data(), pixels2.size());
@@ -1677,19 +1680,19 @@ TEST(DecodeTest, PixelTestOpaqueSrgbLossyNoise) {
     if (channels == 4) {
       io1.metadata.m.SetAlphaBits(8);
       io1.SetSize(xsize, ysize);
-      EXPECT_TRUE(ConvertFromExternal(span1, xsize, ysize, color_encoding1,
-                                      /*has_alpha=*/true, false, 8,
-                                      format.endianness,
-                                      /*flipped_y=*/false, /*pool=*/nullptr,
-                                      &io1.Main(), /*float_in=*/false));
+      EXPECT_TRUE(
+          ConvertFromExternal(span1, xsize, ysize, color_encoding1,
+                              /*has_alpha=*/true, false, 8, format.endianness,
+                              /*flipped_y=*/false, /*pool=*/nullptr,
+                              &io1.Main(), /*float_in=*/false, /*align=*/0));
       io1.metadata.m.SetAlphaBits(0);
       io1.Main().ClearExtraChannels();
     } else {
-      EXPECT_TRUE(ConvertFromExternal(span1, xsize, ysize, color_encoding1,
-                                      /*has_alpha=*/false, false, 8,
-                                      format.endianness,
-                                      /*flipped_y=*/false, /*pool=*/nullptr,
-                                      &io1.Main(), /*float_in=*/false));
+      EXPECT_TRUE(
+          ConvertFromExternal(span1, xsize, ysize, color_encoding1,
+                              /*has_alpha=*/false, false, 8, format.endianness,
+                              /*flipped_y=*/false, /*pool=*/nullptr,
+                              &io1.Main(), /*float_in=*/false, /*align=*/0));
     }
 
     jxl::ButteraugliParams ba;
@@ -1728,7 +1731,6 @@ void TestPartialStream(bool reconstructible_jpeg) {
   std::vector<jxl::PaddedBytes> jpeg_codestreams(kCSBF_NUM_ENTRIES);
   for (size_t i = 0; i < kCSBF_NUM_ENTRIES; ++i) {
     CodeStreamBoxFormat add_container = (CodeStreamBoxFormat)i;
-
     codestreams[i] = jxl::CreateTestJXLCodestream(
         jxl::Span<const uint8_t>(pixels.data(), pixels.size()), xsize, ysize,
         channels, cparams, add_container, JXL_ORIENT_IDENTITY,
@@ -2034,7 +2036,7 @@ TEST(DecodeTest, AnimationTest) {
         ysize, jxl::ColorEncoding::SRGB(/*is_gray=*/false), /*has_alpha=*/false,
         /*alpha_is_premultiplied=*/false, /*bits_per_sample=*/16,
         JXL_BIG_ENDIAN, /*flipped_y=*/false, /*pool=*/nullptr, &bundle,
-        /*float_in=*/false));
+        /*float_in=*/false, /*align=*/0));
     bundle.duration = frame_durations[i];
     io.frames.push_back(std::move(bundle));
   }
@@ -2138,7 +2140,7 @@ TEST(DecodeTest, AnimationTestStreaming) {
         ysize, jxl::ColorEncoding::SRGB(/*is_gray=*/false), /*has_alpha=*/false,
         /*alpha_is_premultiplied=*/false, /*bits_per_sample=*/16,
         JXL_BIG_ENDIAN, /*flipped_y=*/false, /*pool=*/nullptr, &bundle,
-        /*float_in=*/false));
+        /*float_in=*/false, /*align=*/0));
     bundle.duration = frame_durations[i];
     io.frames.push_back(std::move(bundle));
   }
@@ -2363,7 +2365,7 @@ TEST(DecodeTest, SkipFrameTest) {
         ysize, jxl::ColorEncoding::SRGB(/*is_gray=*/false), /*has_alpha=*/false,
         /*alpha_is_premultiplied=*/false, /*bits_per_sample=*/16,
         JXL_BIG_ENDIAN, /*flipped_y=*/false, /*pool=*/nullptr, &bundle,
-        /*float_in=*/false));
+        /*float_in=*/false, /*align=*/0));
     bundle.duration = frame_durations[i];
     io.frames.push_back(std::move(bundle));
   }
@@ -2500,7 +2502,7 @@ TEST(DecodeTest, SkipFrameWithBlendingTest) {
           /*has_alpha=*/false,
           /*alpha_is_premultiplied=*/false, /*bits_per_sample=*/16,
           JXL_BIG_ENDIAN, /*flipped_y=*/false, /*pool=*/nullptr,
-          &bundle_internal, /*float_in=*/false));
+          &bundle_internal, /*float_in=*/false, /*align=*/0));
       bundle_internal.duration = 0;
       bundle_internal.use_for_next_frame = true;
       io.frames.push_back(std::move(bundle_internal));
@@ -2516,7 +2518,7 @@ TEST(DecodeTest, SkipFrameWithBlendingTest) {
         jxl::ColorEncoding::SRGB(/*is_gray=*/false), /*has_alpha=*/false,
         /*alpha_is_premultiplied=*/false, /*bits_per_sample=*/16,
         JXL_BIG_ENDIAN, /*flipped_y=*/false, /*pool=*/nullptr, &bundle,
-        /*float_in=*/false));
+        /*float_in=*/false, /*align=*/0));
     bundle.duration = frame_durations[i];
     // Create some variation in which frames depend on which.
     if (i != 3 && i != 9 && i != 10) {
@@ -2727,7 +2729,7 @@ TEST(DecodeTest, SkipFrameWithAlphaBlendingTest) {
           /*has_alpha=*/true,
           /*alpha_is_premultiplied=*/false, /*bits_per_sample=*/16,
           JXL_BIG_ENDIAN, /*flipped_y=*/false, /*pool=*/nullptr,
-          &bundle_internal, /*float_in=*/false));
+          &bundle_internal, /*float_in=*/false, /*align=*/0));
       bundle_internal.duration = 0;
       bundle_internal.use_for_next_frame = true;
       bundle_internal.origin = {13, 17};
@@ -2749,7 +2751,7 @@ TEST(DecodeTest, SkipFrameWithAlphaBlendingTest) {
         /*has_alpha=*/true,
         /*alpha_is_premultiplied=*/false, /*bits_per_sample=*/16,
         JXL_BIG_ENDIAN, /*flipped_y=*/false, /*pool=*/nullptr, &bundle,
-        /*float_in=*/false));
+        /*float_in=*/false, /*align=*/0));
     bundle.duration = 5 + i;
     frame_durations_nc.push_back(5 + i);
     frame_durations_c.push_back(5 + i);
@@ -3010,7 +3012,7 @@ TEST(DecodeTest, OrientedCroppedFrameTest) {
           /*has_alpha=*/true,
           /*alpha_is_premultiplied=*/false, /*bits_per_sample=*/16,
           JXL_BIG_ENDIAN, /*flipped_y=*/false, /*pool=*/nullptr, &bundle,
-          /*float_in=*/false));
+          /*float_in=*/false, /*align=*/0));
       bundle.origin = {cropx0, cropy0};
       bundle.use_for_next_frame = true;
       io.frames.push_back(std::move(bundle));

--- a/lib/jxl/enc_external_image.h
+++ b/lib/jxl/enc_external_image.h
@@ -21,20 +21,10 @@
 #include "lib/jxl/image_bundle.h"
 
 namespace jxl {
-
-// Return the size in bytes of a given xsize, channels and bits_per_sample
-// interleaved image.
-constexpr size_t RowSize(size_t xsize, size_t channels,
-                         size_t bits_per_sample) {
-  return bits_per_sample == 1
-             ? DivCeil(xsize, kBitsPerByte)
-             : xsize * channels * DivCeil(bits_per_sample, kBitsPerByte);
-}
-
 Status ConvertFromExternal(Span<const uint8_t> bytes, size_t xsize,
                            size_t ysize, size_t bits_per_sample,
                            JxlEndianness endianness, ThreadPool* pool,
-                           ImageF* channel, bool float_in);
+                           ImageF* channel, bool float_in, size_t align);
 
 // Convert an interleaved pixel buffer to the internal ImageBundle
 // representation. This is the opposite of ConvertToExternal().
@@ -43,7 +33,7 @@ Status ConvertFromExternal(Span<const uint8_t> bytes, size_t xsize,
                            bool has_alpha, bool alpha_is_premultiplied,
                            size_t bits_per_sample, JxlEndianness endianness,
                            bool flipped_y, ThreadPool* pool, ImageBundle* ib,
-                           bool float_in);
+                           bool float_in, size_t align);
 Status BufferToImageF(const JxlPixelFormat& pixel_format, size_t xsize,
                       size_t ysize, const void* buffer, size_t size,
                       ThreadPool* pool, ImageF* channel);

--- a/lib/jxl/enc_external_image_gbench.cc
+++ b/lib/jxl/enc_external_image_gbench.cc
@@ -32,7 +32,7 @@ void BM_EncExternalImage_ConvertImageRGBA(benchmark::State& state) {
           /*alpha_is_premultiplied=*/false,
           /*bits_per_sample=*/8, JXL_NATIVE_ENDIAN,
           /*flipped_y=*/false,
-          /*pool=*/nullptr, &ib, /*float_in=*/false));
+          /*pool=*/nullptr, &ib, /*float_in=*/false, /*align=*/0));
     }
   }
 

--- a/lib/jxl/enc_external_image_test.cc
+++ b/lib/jxl/enc_external_image_test.cc
@@ -30,18 +30,18 @@ TEST(ExternalImageTest, InvalidSize) {
       Span<const uint8_t>(buf, 10), /*xsize=*/10, /*ysize=*/100,
       /*c_current=*/ColorEncoding::SRGB(), /*has_alpha=*/true,
       /*alpha_is_premultiplied=*/false, /*bits_per_sample=*/16, JXL_BIG_ENDIAN,
-      /*flipped_y=*/false, nullptr, &ib, /*float_in=*/false));
+      /*flipped_y=*/false, nullptr, &ib, /*float_in=*/false, /*align=*/0));
   EXPECT_FALSE(ConvertFromExternal(
       Span<const uint8_t>(buf, sizeof(buf) - 1), /*xsize=*/10, /*ysize=*/100,
       /*c_current=*/ColorEncoding::SRGB(), /*has_alpha=*/true,
       /*alpha_is_premultiplied=*/false, /*bits_per_sample=*/16, JXL_BIG_ENDIAN,
-      /*flipped_y=*/false, nullptr, &ib, /*float_in=*/false));
+      /*flipped_y=*/false, nullptr, &ib, /*float_in=*/false, /*align=*/0));
   EXPECT_TRUE(ConvertFromExternal(
       Span<const uint8_t>(buf, sizeof(buf)), /*xsize=*/10,
       /*ysize=*/100, /*c_current=*/ColorEncoding::SRGB(),
       /*has_alpha=*/true, /*alpha_is_premultiplied=*/false,
       /*bits_per_sample=*/16, JXL_BIG_ENDIAN,
-      /*flipped_y=*/false, nullptr, &ib, /*float_in=*/false));
+      /*flipped_y=*/false, nullptr, &ib, /*float_in=*/false, /*align=*/0));
 }
 #endif
 
@@ -61,7 +61,7 @@ TEST(ExternalImageTest, AlphaMissing) {
       /*c_current=*/ColorEncoding::SRGB(),
       /*has_alpha=*/true, /*alpha_is_premultiplied=*/false,
       /*bits_per_sample=*/8, JXL_BIG_ENDIAN,
-      /*flipped_y=*/false, nullptr, &ib, /*float_in=*/false));
+      /*flipped_y=*/false, nullptr, &ib, /*float_in=*/false, /*align=*/0));
   EXPECT_FALSE(ib.HasAlpha());
 }
 

--- a/lib/jxl/roundtrip_test.cc
+++ b/lib/jxl/roundtrip_test.cc
@@ -98,12 +98,13 @@ jxl::CodecInOut ConvertTestImage(const std::vector<uint8_t>& buf,
   } else {
     color_encoding = jxl::ColorEncoding::SRGB(is_gray);
   }
-  EXPECT_TRUE(ConvertFromExternal(
-      jxl::Span<const uint8_t>(buf.data(), buf.size()), xsize, ysize,
-      color_encoding, has_alpha,
-      /*alpha_is_premultiplied=*/false,
-      /*bits_per_sample=*/bitdepth, pixel_format.endianness,
-      /*flipped_y=*/false, /*pool=*/nullptr, &io.Main(), float_in));
+  EXPECT_TRUE(
+      ConvertFromExternal(jxl::Span<const uint8_t>(buf.data(), buf.size()),
+                          xsize, ysize, color_encoding, has_alpha,
+                          /*alpha_is_premultiplied=*/false,
+                          /*bits_per_sample=*/bitdepth, pixel_format.endianness,
+                          /*flipped_y=*/false, /*pool=*/nullptr, &io.Main(),
+                          float_in, /*align=*/0));
   return io;
 }
 
@@ -239,7 +240,8 @@ void VerifyRoundtripCompression(
                                      extra_channel_bytes.size()),
             xsize, ysize, basic_info.bits_per_sample,
             input_pixel_format.endianness, /*pool=*/nullptr, &alpha_channel,
-            /*float_in=*/input_pixel_format.data_type == JXL_TYPE_FLOAT),
+            /*float_in=*/input_pixel_format.data_type == JXL_TYPE_FLOAT,
+            /*align=*/0),
         true);
 
     original_io.metadata.m.SetAlphaBits(basic_info.bits_per_sample);

--- a/lib/jxl/test_utils.h
+++ b/lib/jxl/test_utils.h
@@ -374,7 +374,7 @@ jxl::CodecInOut SomeTestImageToCodecInOut(const std::vector<uint8_t>& buf,
       /*has_alpha=*/num_channels == 2 || num_channels == 4,
       /*alpha_is_premultiplied=*/false, /*bits_per_sample=*/16, JXL_BIG_ENDIAN,
       /*flipped_y=*/false, /*pool=*/nullptr,
-      /*ib=*/&io.Main(), /*float_in=*/false));
+      /*ib=*/&io.Main(), /*float_in=*/false, 0));
   return io;
 }
 

--- a/tools/benchmark/benchmark_codec_avif.cc
+++ b/tools/benchmark/benchmark_codec_avif.cc
@@ -312,7 +312,7 @@ class AvifCodec : public ImageCodec {
               rgb_image.width, rgb_image.height, color, has_alpha,
               /*alpha_is_premultiplied=*/false, rgb_image.depth,
               JXL_NATIVE_ENDIAN, /*flipped_y=*/false, pool, &ib,
-              /*float_in=*/false));
+              /*float_in=*/false, /*align=*/0));
           io->frames.push_back(std::move(ib));
           io->dec_pixels += rgb_image.width * rgb_image.height;
         }

--- a/tools/benchmark/benchmark_codec_webp.cc
+++ b/tools/benchmark/benchmark_codec_webp.cc
@@ -40,9 +40,10 @@ Status FromSRGB(const size_t xsize, const size_t ysize, const bool is_gray,
   const ColorEncoding& c = ColorEncoding::SRGB(is_gray);
   const size_t bits_per_sample = (is_16bit ? 2 : 1) * kBitsPerByte;
   const Span<const uint8_t> span(pixels, end - pixels);
-  return ConvertFromExternal(
-      span, xsize, ysize, c, has_alpha, alpha_is_premultiplied, bits_per_sample,
-      endianness, /*flipped_y=*/false, pool, ib, /*float_in=*/false);
+  return ConvertFromExternal(span, xsize, ysize, c, has_alpha,
+                             alpha_is_premultiplied, bits_per_sample,
+                             endianness, /*flipped_y=*/false, pool, ib,
+                             /*float_in=*/false, /*align=*/0);
 }
 
 struct WebPArgs {

--- a/tools/fuzzer_corpus.cc
+++ b/tools/fuzzer_corpus.cc
@@ -199,10 +199,12 @@ bool GenerateFile(const char* output_dir, const ImageSpec& spec,
   for (uint32_t frame = 0; frame < spec.num_frames; frame++) {
     jxl::ImageBundle ib(&io.metadata.m);
     const bool has_alpha = spec.alpha_bit_depth != 0;
-    size_t row_size = jxl::RowSize(
-        spec.width, io.metadata.m.color_encoding.Channels() + has_alpha,
-        io.metadata.m.bit_depth.bits_per_sample);
-    size_t bytes_per_pixel = row_size / spec.width;
+    const size_t bytes_per_sample =
+        jxl::DivCeil(io.metadata.m.bit_depth.bits_per_sample, 8);
+    const size_t bytes_per_pixel =
+        bytes_per_sample *
+        (io.metadata.m.color_encoding.Channels() + has_alpha);
+    const size_t row_size = spec.width * bytes_per_pixel;
     std::vector<uint8_t> img_data(row_size * spec.height, 0);
     for (size_t y = 0; y < spec.height; y++) {
       size_t pos = row_size * y;
@@ -219,7 +221,7 @@ bool GenerateFile(const char* output_dir, const ImageSpec& spec,
         /*has_alpha=*/has_alpha,
         /*alpha_is_premultiplied=*/spec.alpha_is_premultiplied,
         io.metadata.m.bit_depth.bits_per_sample, JXL_LITTLE_ENDIAN,
-        false /* flipped_y */, nullptr, &ib, /*float_in=*/false));
+        false /* flipped_y */, nullptr, &ib, /*float_in=*/false, /*align=*/0));
     io.frames.push_back(std::move(ib));
   }
 


### PR DESCRIPTION
Row alignment (stride) was ignored when passing an image buffer in JxlEncoderAddImageFrame. This should fix that.

Also check if the buffer size has the right size: currently it was only checking if it is large enough, but if it's too large then it's better to return an error than to just silently ignore the additional bytes — most likely this is API usage error.

Fix one of the tests where we had such an API usage error (interpreting a 16-bit input buffer as 8-bit), which didn't really matter for that particular test but still...