### PR TITLE
enc buffer api: check if buffer size matches

### DIFF
--- a/lib/include/jxl/encode.h
+++ b/lib/include/jxl/encode.h
@@ -531,7 +531,8 @@ JxlEncoderAddJPEGFrame(const JxlEncoderFrameSettings* frame_settings,
  * contents are copied internally.
  * @param buffer buffer type to input the pixel data from. Owned by the caller
  * and its contents are copied internally.
- * @param size size of buffer in bytes.
+ * @param size size of buffer in bytes. This size should match what is implied
+ * by the frame dimensions and the pixel format.
  * @return JXL_ENC_SUCCESS on success, JXL_ENC_ERROR on error
  */
 JXL_EXPORT JxlEncoderStatus JxlEncoderAddImageFrame(
@@ -556,7 +557,8 @@ JXL_EXPORT JxlEncoderStatus JxlEncoderAddImageFrame(
  * number of channels for an extra channel is always assumed to be one.
  * @param buffer buffer type to input the pixel data from. Owned by the caller
  * and its contents are copied internally.
- * @param size size of buffer in bytes.
+ * @param size size of buffer in bytes. This size should match what is implied
+ * by the frame dimensions and the pixel format.
  * @param index index of the extra channel to use.
  * @return JXL_ENC_SUCCESS on success, JXL_ENC_ERROR on error
  */

--- a/lib/jxl/enc_external_image.cc
+++ b/lib/jxl/enc_external_image.cc
@@ -135,6 +135,11 @@ Status ConvertFromExternal(Span<const uint8_t> bytes, size_t xsize,
   }
   JXL_ASSERT(channel->xsize() == xsize);
   JXL_ASSERT(channel->ysize() == ysize);
+  // Too large buffer is likely an application bug, so also fail for that.
+  // Do allow padding to stride in last row though.
+  if (bytes.size() > row_size * ysize) {
+    return JXL_FAILURE("Buffer size is too large");
+  }
 
   const bool little_endian =
       endianness == JXL_LITTLE_ENDIAN ||
@@ -247,6 +252,14 @@ Status ConvertFromExternal(Span<const uint8_t> bytes, size_t xsize,
         "Buffer size is too small: expected at least %" PRIuS
         " bytes (= %" PRIuS " * %" PRIuS " * %" PRIuS "), got %" PRIuS " bytes",
         bytes_to_read, xsize, ysize, bytes_per_pixel, bytes.size());
+  }
+  // Too large buffer is likely an application bug, so also fail for that.
+  // Do allow padding to stride in last row though.
+  if (bytes.size() > row_size * ysize) {
+    return JXL_FAILURE(
+        "Buffer size is too large: expected at most %" PRIuS " bytes (= %" PRIuS
+        " * %" PRIuS " * %" PRIuS "), got %" PRIuS " bytes",
+        row_size * ysize, xsize, ysize, bytes_per_pixel, bytes.size());
   }
   const bool little_endian =
       endianness == JXL_LITTLE_ENDIAN ||


### PR DESCRIPTION
Follow-up on https://github.com/libjxl/libjxl/pull/1020: check that the buffer size matches what is expected, don't just check if it's large enough. If the size doesn't match, it's likely an API usage error (e.g. interpreting an RGBA buffer as RGB) so it's more useful to return a meaningful error in this case than to cause head scratching for the application developer.

Also updating documentation to clarify that the size has to match.

The only degree of freedom this check is leaving, is the padding at the end of the last row in case `align` is being used. You can choose whether to pass a buffer with or without that padding.