### PR TITLE
assume RGB pixels are all-opaque (if there's alpha)

### DIFF
--- a/lib/extras/packed_image_convert.cc
+++ b/lib/extras/packed_image_convert.cc
@@ -144,11 +144,13 @@ Status ConvertPackedPixelFileToCodecInOut(const PackedPixelFile& ppf,
         /*flipped_y=*/frame.color.flipped_y, pool, &bundle,
         /*float_in=*/float_in, /*align=*/0));
 
-    for (const auto& ppf_ec : frame.extra_channels) {
-      bundle.extra_channels().emplace_back(ppf_ec.xsize, ppf_ec.ysize);
+    bundle.extra_channels().resize(io->metadata.m.extra_channel_info.size());
+    for (size_t i = 0; i < frame.extra_channels.size(); i++) {
+      const auto& ppf_ec = frame.extra_channels[i];
+      bundle.extra_channels()[i] = ImageF(ppf_ec.xsize, ppf_ec.ysize);
       JXL_CHECK(BufferToImageF(ppf_ec.format, ppf_ec.xsize, ppf_ec.ysize,
                                ppf_ec.pixels(), ppf_ec.pixels_size, pool,
-                               &bundle.extra_channels().back()));
+                               &bundle.extra_channels()[i]));
     }
 
     io->frames.push_back(std::move(bundle));

--- a/lib/include/jxl/encode.h
+++ b/lib/include/jxl/encode.h
@@ -509,6 +509,8 @@ JxlEncoderAddJPEGFrame(const JxlEncoderFrameSettings* frame_settings,
  *
  * Extra channels not handled here need to be set by @ref
  * JxlEncoderSetExtraChannelBuffer.
+ * If the image has alpha, and alpha is not passed here, it will implicitly be
+ * set to all-opaque (an alpha value of 1.0 everywhere).
  *
  * The color profile of the pixels depends on the value of uses_original_profile
  * in the JxlBasicInfo. If true, the pixels are assumed to be encoded in the

--- a/lib/jxl/enc_external_image.cc
+++ b/lib/jxl/enc_external_image.cc
@@ -419,6 +419,12 @@ Status ConvertFromExternal(Span<const uint8_t> bytes, size_t xsize,
     }
 
     ib->SetAlpha(std::move(alpha), alpha_is_premultiplied);
+  } else if (!has_alpha && ib->HasAlpha()) {
+    // if alpha is not passed, but it is expected, then assume
+    // it is all-opaque
+    ImageF alpha(xsize, ysize);
+    FillImage(1.0f, &alpha);
+    ib->SetAlpha(std::move(alpha), alpha_is_premultiplied);
   }
 
   return true;


### PR DESCRIPTION
Fixes #1026.

I think it is reasonable to allow passing RGB data to the encoder if the image is actually RGBA, and make the assumption that the alpha channel is all-opaque. This is symmetric to what we do in the decoder when requesting RGBA data from an RGB image.

An alternative could be to make it an error to not explicitly pass alpha if the image has alpha.

Theoretically you could first set the RGB with AddImageFrame and then set the A with SetExtraChannelBuffer, which should still work but it will unnecessarily set the A to all-opaque first. If you do it the other way around, it's a bigger problem: then with this change you'll end up overwriting the A with all-opaque. In any case we should make a choice here and document the behavior.

More generally: it looks like we currently silently use uninitialized memory for any extra channels that aren't explicitly passed to the encoder, including alpha (at least I _think_ that's what's going on). It's probably not a good idea to keep it like that. I think we should either keep track of and check that the extra channels were all passed, or silently initialize them to all-zeroes (and all-ones for alpha) so that a buggy application that forgets to initialize them will at least not end up encoding some random memory dump (which is a big security bug).