### PR TITLE
Move {En,De}codeImageJPGCoefficients out of codec_jpg

### DIFF
--- a/lib/extras/codec.h
+++ b/lib/extras/codec.h
@@ -55,14 +55,14 @@ std::string ExtensionFromCodec(Codec codec, bool is_gray,
 
 // If and only if extension is ".pfm", *bits_per_sample is updated to 32 so
 // that Encode() would encode to PFM instead of PPM.
-Codec CodecFromExtension(const std::string& extension,
-                         size_t* JXL_RESTRICT bits_per_sample);
+Codec CodecFromExtension(std::string extension,
+                         size_t* JXL_RESTRICT bits_per_sample = nullptr);
 
 // Decodes "bytes" and sets io->metadata.m.
 // color_space_hint may specify the color space, otherwise, defaults to sRGB.
 Status SetFromBytes(const Span<const uint8_t> bytes,
                     const ColorHints& color_hints, CodecInOut* io,
-                    ThreadPool* pool, Codec* orig_codec);
+                    ThreadPool* pool = nullptr, Codec* orig_codec = nullptr);
 // Helper function to use no color_space_hint.
 JXL_INLINE Status SetFromBytes(const Span<const uint8_t> bytes, CodecInOut* io,
                                ThreadPool* pool = nullptr,

--- a/lib/extras/codec.h
+++ b/lib/extras/codec.h
@@ -39,7 +39,10 @@ enum class Codec : uint32_t {
 
 static inline constexpr uint64_t EnumBits(Codec /*unused*/) {
   // Return only fully-supported codecs (kGIF is decode-only).
-  return MakeBit(Codec::kPNM) | MakeBit(Codec::kPNG)
+  return MakeBit(Codec::kPNM)
+#if JPEGXL_ENABLE_APNG
+         | MakeBit(Codec::kPNG)
+#endif
 #if JPEGXL_ENABLE_JPEG
          | MakeBit(Codec::kJPG)
 #endif

--- a/lib/extras/codec_jpg.h
+++ b/lib/extras/codec_jpg.h
@@ -26,12 +26,6 @@ enum class JpegEncoder {
   kSJpeg,
 };
 
-static inline bool IsJPG(const Span<const uint8_t> bytes) {
-  if (bytes.size() < 2) return false;
-  if (bytes[0] != 0xFF || bytes[1] != 0xD8) return false;
-  return true;
-}
-
 // Decodes `bytes` into `io`. color_hints are ignored.
 // `elapsed_deinterleave`, if non-null, will be set to the time (in seconds)
 // that it took to deinterleave the raw JSAMPLEs to planar floats.
@@ -42,16 +36,6 @@ Status DecodeImageJPG(Span<const uint8_t> bytes, const ColorHints& color_hints,
 Status EncodeImageJPG(const CodecInOut* io, JpegEncoder encoder, size_t quality,
                       YCbCrChromaSubsampling chroma_subsampling,
                       ThreadPool* pool, PaddedBytes* bytes);
-
-// Temporary wrappers to load the JPEG coefficients to a CodecInOut. This should
-// be replaced by calling the corresponding JPEG input and output functions on
-// the API.
-
-// Decodes the JPEG image coefficients to a CodecIO for lossless recompression.
-Status DecodeImageJPGCoefficients(Span<const uint8_t> bytes, CodecInOut* io);
-
-// Reconstructs the JPEG from the coefficients and metadata in CodecInOut.
-Status EncodeImageJPGCoefficients(const CodecInOut* io, PaddedBytes* bytes);
 
 }  // namespace extras
 }  // namespace jxl

--- a/lib/extras/codec_test.cc
+++ b/lib/extras/codec_test.cc
@@ -184,8 +184,7 @@ TEST(CodecTest, TestRoundTrip) {
 }
 #endif
 
-CodecInOut DecodeRoundtrip(const std::string& pathname, Codec expected_codec,
-                           ThreadPool* pool,
+CodecInOut DecodeRoundtrip(const std::string& pathname, ThreadPool* pool,
                            const ColorHints& color_hints = ColorHints()) {
   CodecInOut io;
   const PaddedBytes orig = ReadTestData(pathname);
@@ -195,7 +194,7 @@ CodecInOut DecodeRoundtrip(const std::string& pathname, Codec expected_codec,
 
   // Encode/Decode again to make sure Encode carries through all metadata.
   PaddedBytes encoded;
-  JXL_CHECK(Encode(io, expected_codec, io.metadata.m.color_encoding,
+  JXL_CHECK(Encode(io, Codec::kPNG, io.metadata.m.color_encoding,
                    io.metadata.m.bit_depth.bits_per_sample, &encoded, pool));
 
   CodecInOut io2;
@@ -345,7 +344,7 @@ TEST(CodecTest, TestPNGSuite) {
 
 void VerifyWideGamutMetadata(const std::string& relative_pathname,
                              const Primaries primaries, ThreadPool* pool) {
-  const CodecInOut io = DecodeRoundtrip(relative_pathname, Codec::kPNG, pool);
+  const CodecInOut io = DecodeRoundtrip(relative_pathname, pool);
 
   EXPECT_EQ(8u, io.metadata.m.bit_depth.bits_per_sample);
   EXPECT_FALSE(io.metadata.m.bit_depth.floating_point_sample);

--- a/lib/jxl/codec_in_out.h
+++ b/lib/jxl/codec_in_out.h
@@ -69,11 +69,6 @@ struct Blobs {
   PaddedBytes xmp;
 };
 
-// For Codec::kJPG, convert between JPEG and pixels or between JPEG and
-// quantized DCT coefficients
-// For pixel data, the nominal range is 0..1.
-enum class DecodeTarget { kPixels, kQuantizedCoeffs };
-
 // Holds a preview, a main image or one or more frames, plus the inputs/outputs
 // to/from decoding/encoding.
 class CodecInOut {
@@ -162,8 +157,6 @@ class CodecInOut {
   // -- DECODER INPUT:
 
   SizeConstraints constraints;
-  // Decode to pixels or keep JPEG as quantized DCT coefficients
-  DecodeTarget dec_target = DecodeTarget::kPixels;
 
   // -- DECODER OUTPUT:
 

--- a/lib/jxl/encode.cc
+++ b/lib/jxl/encode.cc
@@ -1095,7 +1095,7 @@ JxlEncoderStatus JxlEncoderAddJPEGFrame(
   if (frame_settings->enc->store_jpeg_metadata) {
     jxl::jpeg::JPEGData data_in = *io.Main().jpeg_data;
     jxl::PaddedBytes jpeg_data;
-    if (!EncodeJPEGData(data_in, &jpeg_data)) {
+    if (!jxl::jpeg::EncodeJPEGData(data_in, &jpeg_data)) {
       return JXL_ENC_ERROR;
     }
     frame_settings->enc->jpeg_metadata = std::vector<uint8_t>(

--- a/lib/jxl/jpeg/dec_jpeg_data_writer.cc
+++ b/lib/jxl/jpeg/dec_jpeg_data_writer.cc
@@ -979,5 +979,13 @@ Status WriteJpeg(const JPEGData& jpg, const JPEGOutput& out) {
   }
 }
 
+Status EncodeImageJPGCoefficients(const CodecInOut* io, PaddedBytes* bytes) {
+  auto write = [&bytes](const uint8_t* buf, size_t len) {
+    bytes->append(buf, buf + len);
+    return len;
+  };
+  return WriteJpeg(*io->Main().jpeg_data, write);
+}
+
 }  // namespace jpeg
 }  // namespace jxl

--- a/lib/jxl/jpeg/dec_jpeg_data_writer.h
+++ b/lib/jxl/jpeg/dec_jpeg_data_writer.h
@@ -13,6 +13,7 @@
 
 #include <functional>
 
+#include "lib/jxl/codec_in_out.h"
 #include "lib/jxl/jpeg/jpeg_data.h"
 
 namespace jxl {
@@ -23,6 +24,9 @@ namespace jpeg {
 using JPEGOutput = std::function<size_t(const uint8_t* buf, size_t len)>;
 
 Status WriteJpeg(const JPEGData& jpg, const JPEGOutput& out);
+
+// Reconstructs the JPEG from the coefficients and metadata in CodecInOut.
+Status EncodeImageJPGCoefficients(const CodecInOut* io, PaddedBytes* bytes);
 
 }  // namespace jpeg
 }  // namespace jxl

--- a/lib/jxl/jpeg/enc_jpeg_data.cc
+++ b/lib/jxl/jpeg/enc_jpeg_data.cc
@@ -207,6 +207,10 @@ Status SetBlobsFromJpegData(const jpeg::JPEGData& jpeg_data, Blobs* blobs) {
   return true;
 }
 
+static inline bool IsJPG(const Span<const uint8_t> bytes) {
+  return bytes.size() >= 2 && bytes[0] == 0xFF && bytes[1] == 0xD8;
+}
+
 }  // namespace
 
 Status SetColorEncodingFromJpegData(const jpeg::JPEGData& jpg,
@@ -290,6 +294,7 @@ Status EncodeJPEGData(JPEGData& jpeg_data, PaddedBytes* bytes) {
 }
 
 Status DecodeImageJPG(const Span<const uint8_t> bytes, CodecInOut* io) {
+  if (!IsJPG(bytes)) return false;
   io->frames.clear();
   io->frames.reserve(1);
   io->frames.emplace_back(&io->metadata.m);

--- a/lib/jxl/jpeg/enc_jpeg_data.h
+++ b/lib/jxl/jpeg/enc_jpeg_data.h
@@ -21,7 +21,8 @@ Status SetColorEncodingFromJpegData(const jpeg::JPEGData& jpg,
  * Decodes bytes containing JPEG codestream into a CodecInOut as coefficients
  * only, for lossless JPEG transcoding.
  */
-Status DecodeImageJPG(const Span<const uint8_t> bytes, CodecInOut* io);
+Status DecodeImageJPG(Span<const uint8_t> bytes, CodecInOut* io);
+
 }  // namespace jpeg
 }  // namespace jxl
 

--- a/lib/jxl/render_pipeline/render_pipeline_test.cc
+++ b/lib/jxl/render_pipeline/render_pipeline_test.cc
@@ -17,6 +17,7 @@
 #include "lib/jxl/enc_params.h"
 #include "lib/jxl/fake_parallel_runner_testonly.h"
 #include "lib/jxl/image_test_utils.h"
+#include "lib/jxl/jpeg/enc_jpeg_data.h"
 #include "lib/jxl/render_pipeline/test_render_pipeline_stages.h"
 #include "lib/jxl/test_utils.h"
 #include "lib/jxl/testdata.h"
@@ -87,9 +88,10 @@ TEST_P(RenderPipelineTestParam, PipelineTest) {
 
   CodecInOut io;
   if (config.jpeg_transcode) {
-    io.dec_target = DecodeTarget::kQuantizedCoeffs;
+    ASSERT_TRUE(jpeg::DecodeImageJPG(Span<const uint8_t>(orig), &io));
+  } else {
+    ASSERT_TRUE(SetFromBytes(Span<const uint8_t>(orig), &io, &pool));
   }
-  ASSERT_TRUE(SetFromBytes(Span<const uint8_t>(orig), &io, &pool));
   io.ShrinkTo(config.xsize, config.ysize);
 
   PaddedBytes compressed;

--- a/lib/jxl_extras.cmake
+++ b/lib/jxl_extras.cmake
@@ -3,14 +3,9 @@
 # Use of this source code is governed by a BSD-style
 # license that can be found in the LICENSE file.
 
-# codec_jpg is included always for loading of lossless reconstruction but
-# decoding to pixels is only supported if libjpeg is found and
-# JPEGXL_ENABLE_JPEG=1.
 set(JPEGXL_EXTRAS_SOURCES
   extras/codec.cc
   extras/codec.h
-  extras/codec_jpg.cc
-  extras/codec_jpg.h
   extras/codec_pgx.cc
   extras/codec_pgx.h
   extras/codec_pnm.cc
@@ -61,6 +56,10 @@ endif()
 
 find_package(JPEG)
 if(JPEG_FOUND)
+  target_sources(jxl_extras-static PRIVATE
+    extras/codec_jpg.cc
+    extras/codec_jpg.h
+  )
   target_include_directories(jxl_extras-static PUBLIC "${JPEG_INCLUDE_DIRS}")
   target_link_libraries(jxl_extras-static PUBLIC ${JPEG_LIBRARIES})
   target_compile_definitions(jxl_extras-static PUBLIC -DJPEGXL_ENABLE_JPEG=1)

--- a/lib/lib.gni
+++ b/lib/lib.gni
@@ -437,8 +437,6 @@ libjxl_testlib_sources = [
 libjxl_extras_sources = [
     "extras/codec.cc",
     "extras/codec.h",
-    "extras/codec_jpg.cc",
-    "extras/codec_jpg.h",
     "extras/codec_pgx.cc",
     "extras/codec_pgx.h",
     "extras/codec_pnm.cc",

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -236,9 +236,6 @@ if(${JPEGXL_ENABLE_BENCHMARK})
       "${CMAKE_CURRENT_LIST_DIR}/benchmark/benchmark_codec_jpeg.cc"
       "${CMAKE_CURRENT_LIST_DIR}/benchmark/benchmark_codec_jpeg.h"
     )
-    target_compile_definitions(benchmark_xl PRIVATE -DBENCHMARK_JPEG)
-    target_include_directories(benchmark_xl PRIVATE ${JPEG_INCLUDE_DIR})
-    target_link_libraries(benchmark_xl ${JPEG_LIBRARIES})
   endif ()
 
   if(NOT JPEGXL_BUNDLE_LIBPNG)

--- a/tools/benchmark/benchmark_codec.cc
+++ b/tools/benchmark/benchmark_codec.cc
@@ -27,9 +27,9 @@
 #include "lib/jxl/image_ops.h"
 #include "tools/benchmark/benchmark_args.h"
 #include "tools/benchmark/benchmark_codec_custom.h"
-#ifdef BENCHMARK_JPEG
+#ifdef JPEGXL_ENABLE_JPEG
 #include "tools/benchmark/benchmark_codec_jpeg.h"
-#endif  // BENCHMARK_JPEG
+#endif  // JPEG_ENABLE_JPEG
 #include "tools/benchmark/benchmark_codec_jxl.h"
 #include "tools/benchmark/benchmark_codec_png.h"
 #include "tools/benchmark/benchmark_stats.h"
@@ -165,7 +165,7 @@ ImageCodecPtr CreateImageCodec(const std::string& description) {
   } else if (name == "custom") {
     result.reset(CreateNewCustomCodec(*Args()));
 #endif
-#ifdef BENCHMARK_JPEG
+#ifdef JPEGXL_ENABLE_JPEG
   } else if (name == "jpeg") {
     result.reset(CreateNewJPEGCodec(*Args()));
 #endif  // BENCHMARK_JPEG

--- a/tools/benchmark/benchmark_codec_jpeg.cc
+++ b/tools/benchmark/benchmark_codec_jpeg.cc
@@ -7,7 +7,6 @@
 #include <stddef.h>
 #include <stdio.h>
 // After stddef/stdio
-#include <jpeglib.h>
 #include <stdint.h>
 #include <string.h>
 

--- a/tools/build_cleaner.py
+++ b/tools/build_cleaner.py
@@ -70,7 +70,7 @@ def SplitLibFiles(repo_files):
                        if fn.endswith('_gbench.cc'))
   lib_srcs = [fn for fn in lib_srcs if fn not in gbench_srcs]
   # Exclude optional codecs from extras.
-  exclude_extras = ['/codec_gif', '/codec_apng', '/codec_exr']
+  exclude_extras = ['/codec_gif', '/codec_apng', '/codec_exr', '/codec_jpg']
   extras_srcs = [fn for fn in extras_srcs if fn not in gbench_srcs and
                  not any(patt in fn for patt in testonly) and
                  not any(patt in fn for patt in exclude_extras)]

--- a/tools/cjpeg_hdr.cc
+++ b/tools/cjpeg_hdr.cc
@@ -14,7 +14,6 @@
 #include <hwy/highway.h>
 
 #include "lib/extras/codec.h"
-#include "lib/extras/codec_jpg.h"
 #include "lib/jxl/base/file_io.h"
 #include "lib/jxl/base/padded_bytes.h"
 #include "lib/jxl/codec_in_out.h"
@@ -27,7 +26,7 @@
 #include "lib/jxl/image_bundle.h"
 #include "lib/jxl/image_metadata.h"
 #include "lib/jxl/image_ops.h"
-#include "lib/jxl/jpeg/jpeg_data.h"
+#include "lib/jxl/jpeg/dec_jpeg_data_writer.h"
 #include "lib/jxl/quant_weights.h"
 
 HWY_BEFORE_NAMESPACE();
@@ -288,7 +287,7 @@ int HBDJPEGMain(int argc, const char* argv[]) {
   (ycbcr, io.metadata.m.color_encoding.ICC(), qf, frame_dim,
    out.Main().jpeg_data.get());
   jxl::PaddedBytes output;
-  if (!jxl::extras::EncodeImageJPGCoefficients(&out, &output)) {
+  if (!jxl::jpeg::EncodeImageJPGCoefficients(&out, &output)) {
     return 1;
   }
   if (!jxl::WriteFile(output, argv[2])) {

--- a/tools/djxl.cc
+++ b/tools/djxl.cc
@@ -8,7 +8,6 @@
 #include <stdio.h>
 
 #include "lib/extras/codec.h"
-#include "lib/extras/codec_jpg.h"
 #include "lib/extras/color_description.h"
 #include "lib/extras/time.h"
 #include "lib/extras/tone_mapping.h"
@@ -24,6 +23,7 @@
 #include "lib/jxl/image.h"
 #include "lib/jxl/image_bundle.h"
 #include "lib/jxl/image_ops.h"
+#include "lib/jxl/jpeg/dec_jpeg_data_writer.h"
 #include "tools/args.h"
 #include "tools/box/box.h"
 
@@ -209,7 +209,7 @@ jxl::Status DecompressJxlToJPEG(const JpegXlContainer& container,
   if (!DecodeJpegXlToJpeg(args.params, container, &io, pool)) {
     return JXL_FAILURE("Failed to decode JXL to JPEG");
   }
-  if (!jxl::extras::EncodeImageJPGCoefficients(&io, output)) {
+  if (!jxl::jpeg::EncodeImageJPGCoefficients(&io, output)) {
     return JXL_FAILURE("Failed to generate JPEG");
   }
   stats->SetImageSize(io.xsize(), io.ysize());
@@ -276,8 +276,17 @@ jxl::Status WriteJxlOutput(const DecompressArgs& args, const char* file_out,
                          ? std::string(file_out)
                          : std::string(file_out, extension - file_out);
   if (extension == nullptr) extension = "";
-  if (!io.metadata.m.have_animation || !strcmp(extension, ".png")) {
-    if (!EncodeToFile(io, c_out, bits_per_sample, file_out, pool)) {
+  const jxl::Codec codec = jxl::CodecFromExtension(extension);
+  if (!io.metadata.m.have_animation || codec == jxl::Codec::kPNG) {
+    bool ok;
+    if (io.Main().IsJPEG() && codec == jxl::Codec::kJPG) {
+      jxl::PaddedBytes encoded;
+      ok = jxl::jpeg::EncodeImageJPGCoefficients(&io, &encoded) &&
+           jxl::WriteFile(encoded, file_out);
+    } else {
+      ok = jxl::EncodeToFile(io, c_out, bits_per_sample, file_out, pool);
+    }
+    if (!ok) {
       fprintf(stderr, "Failed to write decoded image.\n");
       return false;
     }

--- a/tools/fuzzer_corpus.cc
+++ b/tools/fuzzer_corpus.cc
@@ -22,7 +22,9 @@
 #include <random>
 #include <vector>
 
+#if JPEGXL_ENABLE_JPEG
 #include "lib/extras/codec_jpg.h"
+#endif
 #include "lib/jxl/aux_out.h"
 #include "lib/jxl/base/data_parallel.h"
 #include "lib/jxl/base/file_io.h"
@@ -221,6 +223,7 @@ bool GenerateFile(const char* output_dir, const ImageSpec& spec,
     io.frames.push_back(std::move(ib));
   }
 
+#if JPEGXL_ENABLE_JPEG
   if (spec.is_reconstructible_jpeg) {
     // If this image is supposed to be a reconstructible JPEG, collect the JPEG
     // metadata and encode it in the beginning of the compressed bytes.
@@ -242,6 +245,7 @@ bool GenerateFile(const char* output_dir, const ImageSpec& spec,
     jxl::AppendBoxHeader(jxl::MakeBoxType("jxlc"), 0, true, &header);
     compressed.append(header);
   }
+#endif
 
   jxl::CompressParams params;
   params.speed_tier = spec.params.speed_tier;


### PR DESCRIPTION
This is a step towards making codec_* not depend on CodecInOut /
ImageBundle.