### PR TITLE
Fix gdk-pixbuf installation path in cross-compilation

### DIFF
--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -314,8 +314,8 @@ jobs:
           libopenexr-dev:${{ matrix.arch }}
 
           # GTK plugins
-          libgdk-pixbuf2.0-dev
-          libgtk2.0-dev
+          libgdk-pixbuf2.0-dev:${{ matrix.arch }}
+          libgtk2.0-dev:${{ matrix.arch }}
 
           # QT
           libqt5x11extras5-dev:${{ matrix.arch }}

--- a/plugins/gdk-pixbuf/CMakeLists.txt
+++ b/plugins/gdk-pixbuf/CMakeLists.txt
@@ -25,7 +25,7 @@ set_target_properties(pixbufloader-jxl PROPERTIES
 # shared library.
 target_link_libraries(pixbufloader-jxl jxl jxl_threads skcms-interface PkgConfig::Gdk-Pixbuf)
 
-pkg_get_variable(GDK_PIXBUF_MODULEDIR gdk-pixbuf-2.0 gdk_pixbuf_moduledir)
+execute_process(COMMAND ${PKG_CONFIG_EXECUTABLE} gdk-pixbuf-2.0 --variable gdk_pixbuf_moduledir --define-variable=prefix=${CMAKE_INSTALL_PREFIX} OUTPUT_VARIABLE GDK_PIXBUF_MODULEDIR OUTPUT_STRIP_TRAILING_WHITESPACE)
 install(TARGETS pixbufloader-jxl LIBRARY DESTINATION "${GDK_PIXBUF_MODULEDIR}")
 
 # Instead of the following, we might instead add the

--- a/plugins/gdk-pixbuf/pixbufloader-jxl.c
+++ b/plugins/gdk-pixbuf/pixbufloader-jxl.c
@@ -86,7 +86,12 @@ G_DECLARE_FINAL_TYPE(GdkPixbufJxlAnimationIter, gdk_pixbuf_jxl_animation_iter,
 G_DEFINE_TYPE(GdkPixbufJxlAnimationIter, gdk_pixbuf_jxl_animation_iter,
               GDK_TYPE_PIXBUF_ANIMATION_ITER);
 
-static void gdk_pixbuf_jxl_animation_init(GdkPixbufJxlAnimation *obj) {}
+static void gdk_pixbuf_jxl_animation_init(GdkPixbufJxlAnimation *obj) {
+  // Suppress "unused function" warnings.
+  (void)glib_autoptr_cleanup_GdkPixbufJxlAnimation;
+  (void)GDK_JXL_ANIMATION;
+  (void)GDK_IS_JXL_ANIMATION;
+}
 
 static gboolean gdk_pixbuf_jxl_animation_is_static_image(
     GdkPixbufAnimation *anim) {
@@ -154,6 +159,9 @@ static void gdk_pixbuf_jxl_animation_class_init(
 }
 
 static void gdk_pixbuf_jxl_animation_iter_init(GdkPixbufJxlAnimationIter *obj) {
+  (void)glib_autoptr_cleanup_GdkPixbufJxlAnimationIter;
+  (void)GDK_JXL_ANIMATION_ITER;
+  (void)GDK_IS_JXL_ANIMATION_ITER;
 }
 
 static int gdk_pixbuf_jxl_animation_iter_get_delay_time(


### PR DESCRIPTION
Drive-by: install arch-dependent packaages for gdk-pixbuf for cross-compilation.