### PR TITLE
fix bugs in extra channel encoding

### DIFF
--- a/lib/jxl/enc_external_image.cc
+++ b/lib/jxl/enc_external_image.cc
@@ -128,6 +128,8 @@ Status ConvertFromExternal(Span<const uint8_t> bytes, size_t xsize,
   if (ysize && bytes.size() / ysize < row_size) {
     return JXL_FAILURE("Buffer size is too small");
   }
+  JXL_ASSERT(channel->xsize() == xsize);
+  JXL_ASSERT(channel->ysize() == ysize);
 
   const bool little_endian =
       endianness == JXL_LITTLE_ENDIAN ||

--- a/lib/jxl/image_bundle.cc
+++ b/lib/jxl/image_bundle.cc
@@ -99,9 +99,15 @@ void ImageBundle::SetAlpha(ImageF&& alpha, bool alpha_is_premultiplied) {
   JXL_CHECK(eci != nullptr);
   JXL_CHECK(alpha.xsize() != 0 && alpha.ysize() != 0);
   JXL_CHECK(eci->alpha_associated == alpha_is_premultiplied);
-  extra_channels_.insert(
-      extra_channels_.begin() + (eci - metadata_->extra_channel_info.data()),
-      std::move(alpha));
+  if (extra_channels_.size() < metadata_->extra_channel_info.size()) {
+    // TODO(jon): get rid of this case
+    extra_channels_.insert(
+        extra_channels_.begin() + (eci - metadata_->extra_channel_info.data()),
+        std::move(alpha));
+  } else {
+    extra_channels_[eci - metadata_->extra_channel_info.data()] =
+        std::move(alpha);
+  }
   // num_extra_channels is automatically set in visitor
   VerifySizes();
 }


### PR DESCRIPTION
Fixes two encoder bugs:

- Not enough extra channels were allocated when you have e.g. a kBlack channel while passing an RGBA buffer.
- JxlEncoderSetExtraChannelBuffer() was incorrectly using image dimensions instead of frame dimensions