### PR TITLE
In PackedPixelFile->CodecInOut conversions, respect intensity_target if present

### DIFF
--- a/lib/extras/packed_image_convert.cc
+++ b/lib/extras/packed_image_convert.cc
@@ -147,7 +147,11 @@ Status ConvertPackedPixelFileToCodecInOut(const PackedPixelFile& ppf,
     // uint case.
     io->metadata.m.bit_depth.bits_per_sample = io->Main().DetectRealBitdepth();
   }
-  SetIntensityTarget(io);
+  if (ppf.info.intensity_target != 0) {
+    io->metadata.m.SetIntensityTarget(ppf.info.intensity_target);
+  } else {
+    SetIntensityTarget(io);
+  }
   io->CheckMetadata();
   return true;
 }


### PR DESCRIPTION
This restores correct propagation of the whiteLuminance tag from EXR
input.