### PR TITLE
more targets in debug_ci

### DIFF
--- a/.github/workflows/debug_ci.yml
+++ b/.github/workflows/debug_ci.yml
@@ -48,7 +48,7 @@ jobs:
         fetch-depth: 2
     - name: Build
       run: |
-        ./ci.sh $(echo ${{ github.ref }} | sed 's_refs/heads/ci-\([a-z]*\)-debug_\1_') \
+        ./ci.sh $(echo ${{ github.ref }} | sed 's_refs/heads/ci-\([a-z_]*\)-debug_\1_') \
           -DJPEGXL_FORCE_SYSTEM_BROTLI=ON
       env:
         SKIP_TEST: 1


### PR DESCRIPTION
We allow underscores in the name of between `ci-` and `-debug`, so that
it is possible to also run `./ci.sh msan_install` and other targets that
include an underscore.