### PR TITLE
Try to make (A|M)San builds faster

### DIFF
--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -41,9 +41,12 @@ jobs:
             cxxflags: -DHWY_DISABLED_TARGETS=~HWY_SCALAR
           # Disabling optional features to speed up msan build a little bit.
           - name: msan
+            skip_install: true
             cmake_args: >-
               -DJPEGXL_ENABLE_DEVTOOLS=OFF -DJPEGXL_ENABLE_PLUGINS=OFF
               -DJPEGXL_ENABLE_VIEWERS=OFF
+          - name: asan
+            skip_install: true
           - name: coverage
             apt_pkgs: gcovr
             # Coverage builds require a bit more RAM.

--- a/third_party/CMakeLists.txt
+++ b/third_party/CMakeLists.txt
@@ -82,6 +82,9 @@ endif()  # BUILD_TESTING
 
 # Highway
 set(HWY_SYSTEM_GTEST ON CACHE INTERNAL "")
+if((SANITIZER STREQUAL "asan") OR (SANITIZER STREQUAL "msan"))
+  set(HWY_EXAMPLES_TESTS_INSTALL OFF CACHE INTERNAL "")
+endif()
 if (EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/highway/CMakeLists.txt" AND
     NOT JPEGXL_FORCE_SYSTEM_HWY)
   add_subdirectory(highway)


### PR DESCRIPTION
Disable HWY tests/examples/install.
Asan build: 25m -> 18m
Msan build:  31m -> 19m