### PR TITLE
Use upsampled dimensions in GetCurrentDimensions

### DIFF
--- a/lib/jxl/decode.cc
+++ b/lib/jxl/decode.cc
@@ -850,8 +850,9 @@ void GetCurrentDimensions(const JxlDecoder* dec, size_t& xsize, size_t& ysize,
   xsize = dec->metadata.oriented_xsize(dec->keep_orientation || !oriented);
   ysize = dec->metadata.oriented_ysize(dec->keep_orientation || !oriented);
   if (!dec->coalescing) {
-    xsize = dec->frame_header->ToFrameDimensions().xsize;
-    ysize = dec->frame_header->ToFrameDimensions().ysize;
+    const auto frame_dim = dec->frame_header->ToFrameDimensions();
+    xsize = frame_dim.xsize_upsampled;
+    ysize = frame_dim.ysize_upsampled;
     if (!dec->keep_orientation && oriented &&
         static_cast<int>(dec->metadata.m.GetOrientation()) > 4) {
       std::swap(xsize, ysize);


### PR DESCRIPTION
djxl_fuzzer expects that frame header layer_info contains dimensions
that correspond to what is passed to callback.