### PR TITLE
Use upsampled dimensions in GetCurrentDimensions

### DIFF
--- a/lib/jxl/decode.cc
+++ b/lib/jxl/decode.cc
@@ -850,8 +850,9 @@ void GetCurrentDimensions(const JxlDecoder* dec, size_t& xsize, size_t& ysize,
   xsize = dec->metadata.oriented_xsize(dec->keep_orientation || !oriented);
   ysize = dec->metadata.oriented_ysize(dec->keep_orientation || !oriented);
   if (!dec->coalescing) {
-    xsize = dec->frame_header->ToFrameDimensions().xsize;
-    ysize = dec->frame_header->ToFrameDimensions().ysize;
+    const auto frame_dim = dec->frame_header->ToFrameDimensions();
+    xsize = frame_dim.xsize_upsampled;
+    ysize = frame_dim.ysize_upsampled;
     if (!dec->keep_orientation && oriented &&
         static_cast<int>(dec->metadata.m.GetOrientation()) > 4) {
       std::swap(xsize, ysize);
@@ -2671,9 +2672,11 @@ JxlDecoderStatus JxlDecoderGetFrameHeader(const JxlDecoder* dec,
   if (!dec->coalescing && dec->frame_header->custom_size_or_origin) {
     header->layer_info.crop_x0 = dec->frame_header->frame_origin.x0;
     header->layer_info.crop_y0 = dec->frame_header->frame_origin.y0;
+    header->layer_info.have_crop = JXL_TRUE;
   } else {
     header->layer_info.crop_x0 = 0;
     header->layer_info.crop_y0 = 0;
+    header->layer_info.have_crop = JXL_FALSE;
   }
   if (!dec->keep_orientation && !dec->coalescing) {
     // orient the crop offset


### PR DESCRIPTION
djxl_fuzzer expects that frame header layer_info contains dimensions
that correspond to what is passed to callback.