### PR TITLE
Fix rendering pipeline with multiple passes.

### DIFF
--- a/lib/jxl/dec_frame.cc
+++ b/lib/jxl/dec_frame.cc
@@ -737,7 +737,7 @@ void FrameDecoder::PreparePipeline() {
     num_c += 3;
   }
 
-  RenderPipeline::Builder builder(num_c, frame_header_.passes.num_passes);
+  RenderPipeline::Builder builder(num_c);
 
   if (use_slow_rendering_pipeline_) {
     builder.UseSimpleImplementation();

--- a/lib/jxl/render_pipeline/render_pipeline.cc
+++ b/lib/jxl/render_pipeline/render_pipeline.cc
@@ -55,7 +55,6 @@ std::unique_ptr<RenderPipeline> RenderPipeline::Builder::Finalize(
   res->frame_dimensions_ = frame_dimensions;
   res->uses_noise_ = uses_noise_;
   res->group_completed_passes_.resize(frame_dimensions.num_groups);
-  res->num_passes_ = num_passes_;
   res->channel_shifts_.resize(stages_.size());
   res->channel_shifts_[0].resize(num_c_);
   for (size_t i = 1; i < stages_.size(); i++) {

--- a/lib/jxl/render_pipeline/render_pipeline.h
+++ b/lib/jxl/render_pipeline/render_pipeline.h
@@ -51,11 +51,7 @@ class RenderPipeline {
  public:
   class Builder {
    public:
-    explicit Builder(size_t num_c, size_t num_passes)
-        : num_c_(num_c), num_passes_(num_passes) {
-      JXL_ASSERT(num_c > 0);
-      JXL_ASSERT(num_passes > 0);
-    }
+    explicit Builder(size_t num_c) : num_c_(num_c) { JXL_ASSERT(num_c > 0); }
 
     // Adds a stage to the pipeline. Must be called at least once; the last
     // added stage cannot have kInOut channels.
@@ -77,7 +73,6 @@ class RenderPipeline {
    private:
     std::vector<std::unique_ptr<RenderPipelineStage>> stages_;
     size_t num_c_;
-    size_t num_passes_;
     bool use_simple_implementation_ = false;
     bool uses_noise_ = false;
   };
@@ -95,9 +90,9 @@ class RenderPipeline {
   // different threads, provided that a different `thread_id` is given.
   RenderPipelineInput GetInputBuffers(size_t group_id, size_t thread_id);
 
-  bool ReceivedAllInput() const {
+  size_t PassesWithAllInput() const {
     return *std::min_element(group_completed_passes_.begin(),
-                             group_completed_passes_.end()) == num_passes_;
+                             group_completed_passes_.end());
   }
 
  protected:
@@ -113,8 +108,6 @@ class RenderPipeline {
 
   // Indexed by thread_id
   std::vector<CacheAlignedUniquePtr> temp_buffers_;
-
-  size_t num_passes_;
 
   friend class RenderPipelineInput;
 

--- a/lib/jxl/render_pipeline/render_pipeline_test.cc
+++ b/lib/jxl/render_pipeline/render_pipeline_test.cc
@@ -26,7 +26,7 @@ namespace jxl {
 namespace {
 
 TEST(RenderPipelineTest, Build) {
-  RenderPipeline::Builder builder(/*num_c=*/1, /*num_passes=*/1);
+  RenderPipeline::Builder builder(/*num_c=*/1);
   builder.AddStage(jxl::make_unique<UpsampleXSlowStage>());
   builder.AddStage(jxl::make_unique<UpsampleYSlowStage>());
   builder.AddStage(jxl::make_unique<Check0FinalStage>());
@@ -39,7 +39,7 @@ TEST(RenderPipelineTest, Build) {
 }
 
 TEST(RenderPipelineTest, CallAllGroups) {
-  RenderPipeline::Builder builder(/*num_c=*/1, /*num_passes=*/1);
+  RenderPipeline::Builder builder(/*num_c=*/1);
   builder.AddStage(jxl::make_unique<UpsampleXSlowStage>());
   builder.AddStage(jxl::make_unique<UpsampleYSlowStage>());
   builder.AddStage(jxl::make_unique<Check0FinalStage>());
@@ -58,7 +58,7 @@ TEST(RenderPipelineTest, CallAllGroups) {
     input_buffers.Done();
   }
 
-  EXPECT_TRUE(pipeline->ReceivedAllInput());
+  EXPECT_TRUE(pipeline->PassesWithAllInput() == 1);
 }
 
 struct RenderPipelineTestInputSettings {

--- a/lib/jxl/render_pipeline/simple_render_pipeline.cc
+++ b/lib/jxl/render_pipeline/simple_render_pipeline.cc
@@ -55,7 +55,8 @@ std::vector<std::pair<ImageF*, Rect>> SimpleRenderPipeline::PrepareBuffers(
 }
 
 void SimpleRenderPipeline::ProcessBuffers(size_t group_id, size_t thread_id) {
-  if (!ReceivedAllInput()) return;
+  if (PassesWithAllInput() <= processed_passes_) return;
+  processed_passes_++;
 
   for (const auto& ch : channel_data_) {
     (void)ch;

--- a/lib/jxl/render_pipeline/simple_render_pipeline.h
+++ b/lib/jxl/render_pipeline/simple_render_pipeline.h
@@ -29,6 +29,7 @@ class SimpleRenderPipeline : public RenderPipeline {
   // Full frame buffers. Both X and Y dimensions are padded by
   // kRenderPipelineXOffset.
   std::vector<ImageF> channel_data_;
+  size_t processed_passes_ = 0;
 };
 
 }  // namespace jxl


### PR DESCRIPTION
This allows more tests to pass. Remaining failing tests under ASAN:

    377 - BlendingTest.Crops (ILLEGAL)
    1196 - DecodeTest.SkipFrameWithBlendingTest (ILLEGAL)
    1197 - DecodeTest.SkipFrameWithAlphaBlendingTest (ILLEGAL)
    1198 - DecodeTest.OrientedCroppedFrameTest (ILLEGAL)
    1200 - DecodeTest.FlushTestLossyProgressiveAlpha (Failed)
    1201 - DecodeTest.FlushTestLossyProgressiveAlphaUpsampling (ILLEGAL)
    1596 - EncodeTest.frame_settingsTest (ILLEGAL)
    1603 - EncodeTest.CroppedFrameTest (ILLEGAL)
    1955 - JxlTest.RoundtripAlphaResamplingOnlyAlpha (ILLEGAL)
    1970 - JxlTest.RoundtripAnimation (ILLEGAL)
    1971 - JxlTest.RoundtripLosslessAnimation (ILLEGAL)
    2200 - RoundtripTest.TestICCProfile (Failed)
    2235 - SplinesTest.ClearedEveryFrame (ILLEGAL)
    2257 - pixbufloader_test_jxl (ILLEGAL)
    2259 - conformance_tooling_test (Failed)

Some of those tests are failing because of blending not being
implemented. The others will be fixed in follow up PRs.