### PR TITLE
Do not fill input rows for ignored channels.

### DIFF
--- a/lib/jxl/render_pipeline/render_pipeline_test.cc
+++ b/lib/jxl/render_pipeline/render_pipeline_test.cc
@@ -175,11 +175,15 @@ Splines CreateTestSplines() {
 std::vector<RenderPipelineTestInputSettings> GeneratePipelineTests() {
   std::vector<RenderPipelineTestInputSettings> all_tests;
 
-  for (size_t size : {128, 256, 258, 777}) {
+  std::pair<size_t, size_t> sizes[] = {
+      {128, 128}, {256, 256}, {258, 258}, {533, 401}, {777, 777},
+  };
+
+  for (auto size : sizes) {
     RenderPipelineTestInputSettings settings;
     settings.input_path = "imagecompression.info/flower_foveon.png";
-    settings.xsize = size;
-    settings.ysize = size;
+    settings.xsize = size.first;
+    settings.ysize = size.second;
 
     // Base settings.
     settings.cparams.butteraugli_distance = 1.0;
@@ -311,6 +315,15 @@ std::vector<RenderPipelineTestInputSettings> GeneratePipelineTests() {
       auto s = settings;
       s.input_path = "wide-gamut-tests/R2020-sRGB-blue.png";
       s.cparams_descr = "AlphaVarDCT";
+      all_tests.push_back(s);
+    }
+
+    {
+      auto s = settings;
+      s.input_path = "wide-gamut-tests/R2020-sRGB-blue.png";
+      s.cparams_descr = "AlphaVarDCTUpsamplingEPF";
+      s.cparams.epf = 1;
+      s.cparams.ec_resampling = 2;
       all_tests.push_back(s);
     }
 

--- a/lib/jxl/render_pipeline/simple_render_pipeline.cc
+++ b/lib/jxl/render_pipeline/simple_render_pipeline.cc
@@ -109,14 +109,14 @@ void SimpleRenderPipeline::ProcessBuffers(size_t group_id, size_t thread_id) {
         }
       }
       // Vertical mirroring.
-      for (int iy = 0; iy < static_cast<int>(stage->settings_.border_y); iy++) {
-        memcpy(get_row(c, -iy - 1) - stage->settings_.border_x,
-               get_row(c, iy) - stage->settings_.border_x,
+      for (int y = 0; y < static_cast<int>(stage->settings_.border_y); y++) {
+        memcpy(get_row(c, -y - 1) - stage->settings_.border_x,
+               get_row(c, y) - stage->settings_.border_x,
                sizeof(float) *
                    (input_sizes[c].first + 2 * stage->settings_.border_x));
         memcpy(
-            get_row(c, input_sizes[c].second + iy) - stage->settings_.border_x,
-            get_row(c, input_sizes[c].second - iy - 1) -
+            get_row(c, input_sizes[c].second + y) - stage->settings_.border_x,
+            get_row(c, input_sizes[c].second - y - 1) -
                 stage->settings_.border_x,
             sizeof(float) *
                 (input_sizes[c].first + 2 * stage->settings_.border_x));
@@ -145,6 +145,9 @@ void SimpleRenderPipeline::ProcessBuffers(size_t group_id, size_t thread_id) {
       for (size_t y = 0; y < ysize; y++) {
         // Prepare input rows.
         for (size_t c = 0; c < channel_data_.size(); c++) {
+          if (stage->GetChannelMode(c) == RenderPipelineChannelMode::kIgnored) {
+            continue;
+          }
           input_rows[c].resize(2 * border_y + 1);
           for (int iy = -border_y; iy <= border_y; iy++) {
             input_rows[c][iy + border_y] =


### PR DESCRIPTION
This causes calling Row() with invalid values, which causes debug mode
failures in some conditions.