### PR TITLE
Queue PR workflows...

### DIFF
--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -14,6 +14,10 @@ on:
   pull_request:
     types: [opened, reopened, labeled, synchronize]
 
+concurrency: 
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event_name }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   ubuntu_build:
     name: Ubuntu Build ${{ matrix.name }}

--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -14,6 +14,10 @@ on:
   pull_request:
     types: [opened, reopened, labeled, synchronize]
 
+concurrency: 
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event_name }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -19,6 +19,10 @@ on:
       - '**CMakeLists.txt'
       - .github/workflows/fuzz.yml
 
+concurrency: 
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event_name }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   fuzzing:
     runs-on: ubuntu-latest


### PR DESCRIPTION
And (hopefully) cancel the older ones.

This should help when PR gets updated while previous runs are not finished.