### PR TITLE
fast_lossless: clean up Bash buildscripts

### DIFF
--- a/experimental/fast_lossless/build-android.sh
+++ b/experimental/fast_lossless/build-android.sh
@@ -1,22 +1,26 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 # Copyright (c) the JPEG XL Project Authors. All rights reserved.
 #
 # Use of this source code is governed by a BSD-style
 # license that can be found in the LICENSE file.
+set -e
 
-
-DIR=$(realpath $(dirname $0))
+DIR=$(realpath "$(dirname "$0")")
 
 mkdir -p /tmp/build-android
 cd /tmp/build-android
 
-CXX=$ANDROID_NDK/toolchains/llvm/prebuilt/linux-x86_64/bin/aarch64-linux-android30-clang++
+CXX="$ANDROID_NDK"/toolchains/llvm/prebuilt/linux-x86_64/bin/aarch64-linux-android30-clang++
+if ! command -v "$CXX" >/dev/null ; then
+  printf >&2 '%s: Android C++ compiler not found, is ANDROID_NDK set properly?\n' "${0##*/}"
+  exit 1
+fi
 
-[ -f lodepng.cpp ] || wget https://raw.githubusercontent.com/lvandeve/lodepng/8c6a9e30576f07bf470ad6f09458a2dcd7a6a84a/lodepng.cpp
-[ -f lodepng.h ] || wget https://raw.githubusercontent.com/lvandeve/lodepng/8c6a9e30576f07bf470ad6f09458a2dcd7a6a84a/lodepng.h
-[ -f lodepng.o ] || $CXX lodepng.cpp -O3 -o lodepng.o -c
+[ -f lodepng.cpp ] || curl -o lodepng.cpp --url 'https://raw.githubusercontent.com/lvandeve/lodepng/8c6a9e30576f07bf470ad6f09458a2dcd7a6a84a/lodepng.cpp'
+[ -f lodepng.h ] || curl -o lodepng.h --url 'https://raw.githubusercontent.com/lvandeve/lodepng/8c6a9e30576f07bf470ad6f09458a2dcd7a6a84a/lodepng.h'
+[ -f lodepng.o ] || "$CXX" lodepng.cpp -O3 -o lodepng.o -c
 
-$CXX -O3 -g -DFASTLL_ENABLE_NEON_INTRINSICS -fopenmp \
+"$CXX" -O3 -DFASTLL_ENABLE_NEON_INTRINSICS -fopenmp \
   -I. lodepng.o \
-  ${DIR}/fast_lossless.cc ${DIR}/fast_lossless_main.cc \
+  "${DIR}"/fast_lossless.cc "${DIR}"/fast_lossless_main.cc \
   -o fast_lossless

--- a/experimental/fast_lossless/build.sh
+++ b/experimental/fast_lossless/build.sh
@@ -1,19 +1,26 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 # Copyright (c) the JPEG XL Project Authors. All rights reserved.
 #
 # Use of this source code is governed by a BSD-style
 # license that can be found in the LICENSE file.
+set -e
 
-mkdir -p build
-cd build
+DIR=$(realpath "$(dirname "$0")")
+mkdir -p "$DIR"/build
+cd "$DIR"/build
 
-CXX=clang++
+# set CXX to clang++ if not set in the environment
+CXX="${CXX-clang++}"
+if ! command -v "$CXX" >/dev/null ; then
+  printf >&2 '%s: C++ compiler not found\n' "${0##*/}"
+  exit 1
+fi
 
-[ -f lodepng.cpp ] || wget https://raw.githubusercontent.com/lvandeve/lodepng/8c6a9e30576f07bf470ad6f09458a2dcd7a6a84a/lodepng.cpp
-[ -f lodepng.h ] || wget https://raw.githubusercontent.com/lvandeve/lodepng/8c6a9e30576f07bf470ad6f09458a2dcd7a6a84a/lodepng.h
-[ -f lodepng.o ] || $CXX lodepng.cpp -O3 -mavx2 -o lodepng.o -c
+[ -f lodepng.cpp ] || curl -o lodepng.cpp --url 'https://raw.githubusercontent.com/lvandeve/lodepng/8c6a9e30576f07bf470ad6f09458a2dcd7a6a84a/lodepng.cpp'
+[ -f lodepng.h ] || curl -o lodepng.h --url 'https://raw.githubusercontent.com/lvandeve/lodepng/8c6a9e30576f07bf470ad6f09458a2dcd7a6a84a/lodepng.h'
+[ -f lodepng.o ] || "$CXX" lodepng.cpp -O3 -mavx2 -o lodepng.o -c
 
-$CXX -O3 -mavx2 -g -DFASTLL_ENABLE_AVX2_INTRINSICS -fopenmp \
+"$CXX" -O3 -mavx2 -DFASTLL_ENABLE_AVX2_INTRINSICS -fopenmp \
   -I. lodepng.o \
-  ../fast_lossless.cc ../fast_lossless_main.cc \
+  "$DIR"/fast_lossless.cc "$DIR"/fast_lossless_main.cc \
   -o fast_lossless


### PR DESCRIPTION
This cleans up the bash buildscripts so they should be more robust and work better cross-platform. 