### PR TITLE
bundle gflags for windows build

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -319,6 +319,7 @@ jobs:
           -DJPEGXL_ENABLE_TCMALLOC=OFF \
           -DJPEGXL_ENABLE_VIEWERS=OFF \
           -DVCPKG_TARGET_TRIPLET=${{ matrix.triplet }} \
+          -DJPEGXL_BUNDLE_GFLAGS=ON \
         #
     - name: Build
       shell: 'bash'


### PR DESCRIPTION
In the `windows_build` of "Release build/deploy" there is we get a

`LINK : fatal error LNK1181: cannot open input file 'gflags.lib'`

As a workaround we build our own gflags instead.