### PR TITLE
GFLAGS is supposed to be used by tools only

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -20,6 +20,7 @@ Alex Xu (Hello71) <alex_y_xu@yahoo.ca>
 Alexander Sago <cagelight@gmail.com>
 Andrius Lukas Narbutas <andrius4669@gmail.com>
 Artem Selishchev
+David Burnett <vargolsoft@gmail.com>
 Dirk Lemstra <dirk@lemstra.org>
 Don Olmstead <don.j.olmstead@gmail.com>
 Jon Sneyers <jon@cloudinary.com>

--- a/third_party/CMakeLists.txt
+++ b/third_party/CMakeLists.txt
@@ -157,25 +157,27 @@ if (JPEGXL_ENABLE_VIEWERS OR NOT JPEGXL_ENABLE_SKCMS)
 endif()
 
 # gflags
-if (JPEGXL_BUNDLE_GFLAGS)
-  # Compile gflags from sources.
-  set(GFLAGS_BUILD_TESTING OFF)
-  add_subdirectory(gflags)
-  configure_file("${CMAKE_CURRENT_SOURCE_DIR}/gflags/COPYING.txt"
-                 ${PROJECT_BINARY_DIR}/LICENSE.gflags COPYONLY)
-else()
-  # Use sytem libgflags-dev
-  find_package(gflags REQUIRED)
-  if (NOT gflags_FOUND)
-    message(FATAL_ERROR
-      "Gflags not found, install libgflags-dev or download gflags source to"
-      "third_party/gflags from https://github.com/gflags/gflags. You can use"
-      " ${PROJECT_SOURCE_DIR}/deps.sh to download the dependency.")
-  endif()
-  if(JPEGXL_DEP_LICENSE_DIR)
-    configure_file("${JPEGXL_DEP_LICENSE_DIR}/libgflags-dev/copyright"
+if(JPEGXL_ENABLE_TOOLS)
+  if (JPEGXL_BUNDLE_GFLAGS)
+    # Compile gflags from sources.
+    set(GFLAGS_BUILD_TESTING OFF)
+    add_subdirectory(gflags)
+    configure_file("${CMAKE_CURRENT_SOURCE_DIR}/gflags/COPYING.txt"
                    ${PROJECT_BINARY_DIR}/LICENSE.gflags COPYONLY)
-  endif()  # JPEGXL_DEP_LICENSE_DIR
+  else()
+    # Use sytem libgflags-dev
+    find_package(gflags REQUIRED)
+    if (NOT gflags_FOUND)
+      message(FATAL_ERROR
+        "Gflags not found, install libgflags-dev or download gflags source to"
+        "third_party/gflags from https://github.com/gflags/gflags. You can use"
+        " ${PROJECT_SOURCE_DIR}/deps.sh to download the dependency.")
+    endif()
+    if(JPEGXL_DEP_LICENSE_DIR)
+      configure_file("${JPEGXL_DEP_LICENSE_DIR}/libgflags-dev/copyright"
+                     ${PROJECT_BINARY_DIR}/LICENSE.gflags COPYONLY)
+    endif()  # JPEGXL_DEP_LICENSE_DIR
+  endif()
 endif()
 
 # libpng


### PR DESCRIPTION
Current CMakeFiles.txt looks for gflags unless it is bundled, as gflags is only required by the tools this breaks builds where the tools are disabled.

This change only does a search for gflags if tools is set to enabled 