### PR TITLE
Add info for compiling with docker container

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -20,6 +20,7 @@ Alex Xu (Hello71) <alex_y_xu@yahoo.ca>
 Alexander Sago <cagelight@gmail.com>
 Andrius Lukas Narbutas <andrius4669@gmail.com>
 Artem Selishchev
+CanadianBaconBoi <beamconnor@gmail.com>
 David Burnett <vargolsoft@gmail.com>
 Dirk Lemstra <dirk@lemstra.org>
 Don Olmstead <don.j.olmstead@gmail.com>

--- a/doc/building_wasm.md
+++ b/doc/building_wasm.md
@@ -72,6 +72,10 @@ source $OPT/emsdk/emsdk_env.sh
 # Specify JS engine binary
 export V8=$OPT/.jsvu/v8
 
+# If building using the jpegxl-builder docker container prefix the following commands with:
+# CMAKE_FLAGS=-I/usr/wasm32/include
+# ex. CMAKE_FLAGS=-I/usr/wasm32/include BUILD_TARGET=wasm32 emconfigure ./ci.sh release
+
 # Either build with regular WASM:
 BUILD_TARGET=wasm32 emconfigure ./ci.sh release
 # or with SIMD WASM:


### PR DESCRIPTION
The docker container does not build the wasm artifact normally using the provided commands.
The build commands need `CMAKE_FLAGS=-I/usr/wasm32/include` prefixed to them in order to actually build.