### PR TITLE
Fix a simple warning reported by gcc

### DIFF
--- a/lib/jxl/render_pipeline/render_pipeline_stage.h
+++ b/lib/jxl/render_pipeline/render_pipeline_stage.h
@@ -121,7 +121,7 @@ class RenderPipelineStage {
   float* GetOutputRow(const RowInfo& output_rows, size_t c,
                       size_t offset) const {
     JXL_DASSERT(GetChannelMode(c) == RenderPipelineChannelMode::kInOut);
-    JXL_DASSERT(offset <= 1 << settings_.shift_y);
+    JXL_DASSERT(offset <= 1ul << settings_.shift_y);
     return output_rows[c][offset] + kRenderPipelineXOffset;
   }
 


### PR DESCRIPTION
Warning is:

jxl/render_pipeline/render_pipeline_stage.h:124:24: warning: comparison of integer expressions of different signedness: ‘size_t’ {aka ‘long unsigned int’} and ‘int’ [-Wsign-compare]
  124 |     JXL_DASSERT(offset <= 1 << settings_.shift_y);
      |                 ~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~