### PR TITLE
Make sure to initialize `br_pos` to zero

### DIFF
--- a/lib/jxl/ans_test.cc
+++ b/lib/jxl/ans_test.cc
@@ -229,7 +229,7 @@ void TestCheckpointing(bool ans, bool lz77) {
     ANSSymbolReader reader(&decoded_codes, &br);
 
     ANSSymbolReader::Checkpoint checkpoint;
-    size_t br_pos;
+    size_t br_pos = 0;
     constexpr size_t kInterval = ANSSymbolReader::kMaxCheckpointInterval - 2;
     for (size_t i = 0; i < input_values[0].size(); i++) {
       if (i % kInterval == 0 && i > 0) {


### PR DESCRIPTION
This will solve the following warning reported by gcc:

libjxl/lib/jxl/dec_bit_reader.h: In function ‘void jxl::{anonymous}::TestCheckpointing(bool, bool)’:
libjxl/lib/jxl/dec_bit_reader.h:176:10: warning: ‘br_pos’ may be used uninitialized in this function [-Wmaybe-uninitialized]
  176 |     skip -= bits_in_buf_;
      |     ~~~~~^~~~~~~~~~~~~~~
libjxl/lib/jxl/ans_test.cc:232:12: note: ‘br_pos’ was declared here
  232 |     size_t br_pos;
      |            ^~~~~~