### PR TITLE
convert CodecInOut to PackedPixelFile

### DIFF
--- a/lib/extras/packed_image_convert.cc
+++ b/lib/extras/packed_image_convert.cc
@@ -160,8 +160,7 @@ Status ConvertCodecInOutToPackedPixelFile(const CodecInOut& io,
                io.metadata.m.bit_depth.exponent_bits_per_sample);
     alpha_premultiplied = alpha_channel->alpha_associated;
   }
-  const bool is_gray = io.metadata.m.color_encoding.IsGray();
-  (void)is_gray;
+
   // Convert the image metadata
   ppf->info.xsize = io.metadata.size.xsize();
   ppf->info.ysize = io.metadata.size.ysize();
@@ -185,10 +184,12 @@ Status ConvertCodecInOutToPackedPixelFile(const CodecInOut& io,
   ppf->info.animation.num_loops = io.metadata.m.animation.num_loops;
 
   // Convert the color encoding
-  // TODO(firsching): do specific ICC profiles need special treatment here?
-  ConvertInternalToExternalColorEncoding(io.metadata.m.color_encoding,
-                                         &ppf->color_encoding);
-  io.metadata.m.color_encoding.IsSRGB();
+  ppf->icc.assign(io.metadata.m.color_encoding.ICC().begin(),
+                  io.metadata.m.color_encoding.ICC().end());
+  if (ppf->icc.empty()) {
+    ConvertInternalToExternalColorEncoding(io.metadata.m.color_encoding,
+                                           &ppf->color_encoding);
+  }
 
   // Convert the extra blobs
   ppf->metadata.exif.assign(io.blobs.exif.begin(), io.blobs.exif.end());

--- a/lib/extras/packed_image_convert.cc
+++ b/lib/extras/packed_image_convert.cc
@@ -206,7 +206,7 @@ Status ConvertCodecInOutToPackedPixelFile(const CodecInOut& io,
     // It is ok for the frame.color().kNumPlanes to not match the
     // number of channels on the image.
     const bool float_out = frame.metadata()->bit_depth.floating_point_sample;
-    const uint32_t num_channels = frame.color().kNumPlanes;
+    const uint32_t num_channels = frame.color().kNumPlanes + has_alpha;
     JxlPixelFormat format{/*num_channels=*/num_channels,
                           /*data_type=*/pixel_format.data_type,
                           /*endianness=*/pixel_format.endianness,
@@ -223,8 +223,9 @@ Status ConvertCodecInOutToPackedPixelFile(const CodecInOut& io,
         /*out_callback=*/nullptr, /*out_opaque=*/nullptr,
         frame.metadata()->GetOrientation()));
 
-    // TODO(firsching): Convert the extra channels. FIXME!
-    JXL_CHECK(frame.extra_channels().empty());
+    // TODO(firsching): Convert the extra channels, beside one potential alpha
+    // channel. FIXME!
+    JXL_CHECK(frame.extra_channels().size() <= has_alpha);
     ppf->frames.push_back(std::move(packed_frame));
   }
 

--- a/lib/extras/packed_image_convert.cc
+++ b/lib/extras/packed_image_convert.cc
@@ -190,11 +190,9 @@ Status ConvertCodecInOutToPackedPixelFile(const CodecInOut& io,
   ppf->info.animation.num_loops = io.metadata.m.animation.num_loops;
 
   // Convert the color encoding
-  ppf->icc.assign(io.metadata.m.color_encoding.ICC().begin(),
-                  io.metadata.m.color_encoding.ICC().end());
+  ppf->icc.assign(c_desired.ICC().begin(), c_desired.ICC().end());
   if (ppf->icc.empty()) {
-    ConvertInternalToExternalColorEncoding(io.metadata.m.color_encoding,
-                                           &ppf->color_encoding);
+    ConvertInternalToExternalColorEncoding(c_desired, &ppf->color_encoding);
   }
 
   // Convert the extra blobs

--- a/lib/extras/packed_image_convert.cc
+++ b/lib/extras/packed_image_convert.cc
@@ -164,6 +164,7 @@ Status ConvertCodecInOutToPackedPixelFile(const CodecInOut& io,
   // Convert the image metadata
   ppf->info.xsize = io.metadata.size.xsize();
   ppf->info.ysize = io.metadata.size.ysize();
+  ppf->info.num_color_channels = io.metadata.m.color_encoding.Channels();
   ppf->info.bits_per_sample = io.metadata.m.bit_depth.bits_per_sample;
   ppf->info.exponent_bits_per_sample =
       io.metadata.m.bit_depth.exponent_bits_per_sample;

--- a/lib/extras/packed_image_convert.h
+++ b/lib/extras/packed_image_convert.h
@@ -21,7 +21,7 @@ namespace extras {
 Status ConvertPackedPixelFileToCodecInOut(const PackedPixelFile& ppf,
                                           ThreadPool* pool, CodecInOut* io);
 
-// Converts an internal CodecInOut for use with internal function to an axternal
+// Converts an internal CodecInOut for use with internal function to an external
 // PackedPixelFile.
 Status ConvertCodecInOutToPackedPixelFile(const CodecInOut& io,
                                           ThreadPool* pool,

--- a/lib/extras/packed_image_convert.h
+++ b/lib/extras/packed_image_convert.h
@@ -21,6 +21,11 @@ namespace extras {
 Status ConvertPackedPixelFileToCodecInOut(const PackedPixelFile& ppf,
                                           ThreadPool* pool, CodecInOut* io);
 
+// Converts an internal CodecInOut for use with internal function to an axternal
+// PackedPixelFile.
+Status ConvertCodecInOutToPackedPixelFile(const CodecInOut& io,
+                                          ThreadPool* pool,
+                                          PackedPixelFile* ppf);
 }  // namespace extras
 }  // namespace jxl
 

--- a/lib/extras/packed_image_convert.h
+++ b/lib/extras/packed_image_convert.h
@@ -9,6 +9,7 @@
 // Helper functions to convert from the external image types to the internal
 // CodecInOut to help transitioning to the external types.
 
+#include "jxl/types.h"
 #include "lib/extras/packed_image.h"
 #include "lib/jxl/base/status.h"
 #include "lib/jxl/codec_in_out.h"
@@ -24,6 +25,8 @@ Status ConvertPackedPixelFileToCodecInOut(const PackedPixelFile& ppf,
 // Converts an internal CodecInOut for use with internal function to an external
 // PackedPixelFile.
 Status ConvertCodecInOutToPackedPixelFile(const CodecInOut& io,
+                                          const JxlPixelFormat& pixel_format,
+                                          const ColorEncoding& c_desired,
                                           ThreadPool* pool,
                                           PackedPixelFile* ppf);
 }  // namespace extras


### PR DESCRIPTION
Adding a new function fo convert a CodecInOut to a PackedPixelFile. The
idea is to use this for djxl when changing the encoder in `extras/enc/`
to use PackedPixelFile instead of CodecInOut.