### PR TITLE
up to 12-bit Grayscale, Gray+Alpha, RGB and RGBA input via pgm/ppm/pam

### DIFF
--- a/experimental/fast_lossless/fast_lossless.h
+++ b/experimental/fast_lossless/fast_lossless.h
@@ -8,7 +8,7 @@
 #include <stdlib.h>
 
 size_t FastLosslessEncode(const unsigned char* rgba, size_t width,
-                          size_t row_stride, size_t height, int effort,
-                          unsigned char** output);
+                          size_t row_stride, size_t height, size_t nb_chans,
+                          size_t bitdepth, int effort, unsigned char** output);
 
 #endif

--- a/experimental/fast_lossless/fast_lossless_main.cc
+++ b/experimental/fast_lossless/fast_lossless_main.cc
@@ -12,6 +12,7 @@
 
 #include "fast_lossless.h"
 #include "lodepng.h"
+#include "pam-input.h"
 
 int main(int argc, char** argv) {
   if (argc < 3) {
@@ -22,7 +23,7 @@ int main(int argc, char** argv) {
   const char* in = argv[1];
   const char* out = argv[2];
   int effort = argc >= 4 ? atoi(argv[3]) : 2;
-  size_t num_reps = argc >= 5 ? atoi(argv[4]) : 0;
+  size_t num_reps = argc >= 5 ? atoi(argv[4]) : 1;
 
   if (effort < 0 || effort > 127) {
     fprintf(
@@ -32,26 +33,29 @@ int main(int argc, char** argv) {
   }
 
   unsigned char* png;
-  unsigned width, height;
+  unsigned w, h;
+  size_t nb_chans = 4, bitdepth = 8;
 
-  unsigned error = lodepng_decode32_file(&png, &width, &height, in);
+  unsigned error = lodepng_decode32_file(&png, &w, &h, in);
 
-  if (error) {
+  size_t width = w, height = h;
+  if (error && !DecodePAM(in, &png, &width, &height, &nb_chans, &bitdepth)) {
     fprintf(stderr, "lodepng error %u: %s\n", error, lodepng_error_text(error));
     return 1;
   }
 
   size_t encoded_size = 0;
   unsigned char* encoded = nullptr;
+  size_t stride = width * nb_chans * (bitdepth > 8 ? 2 : 1);
 
-  if (num_reps > 0) {
-    auto start = std::chrono::high_resolution_clock::now();
-    for (size_t _ = 0; _ < num_reps; _++) {
-      free(encoded);
-      encoded_size =
-          FastLosslessEncode(png, width, width * 4, height, effort, &encoded);
-    }
-    auto stop = std::chrono::high_resolution_clock::now();
+  auto start = std::chrono::high_resolution_clock::now();
+  for (size_t _ = 0; _ < num_reps; _++) {
+    free(encoded);
+    encoded_size = FastLosslessEncode(png, width, stride, height, nb_chans,
+                                      bitdepth, effort, &encoded);
+  }
+  auto stop = std::chrono::high_resolution_clock::now();
+  if (num_reps > 1) {
     float us =
         std::chrono::duration_cast<std::chrono::microseconds>(stop - start)
             .count();
@@ -60,9 +64,6 @@ int main(int argc, char** argv) {
     fprintf(stderr, "%10.3f MP/s\n", mps);
     fprintf(stderr, "%10.3f bits/pixel\n",
             encoded_size * 8.0 / float(width) / float(height));
-  } else {
-    encoded_size =
-        FastLosslessEncode(png, width, width * 4, height, effort, &encoded);
   }
 
   FILE* o = fopen(out, "wb");

--- a/experimental/fast_lossless/pam-input.h
+++ b/experimental/fast_lossless/pam-input.h
@@ -1,0 +1,289 @@
+// Copyright (c) the JPEG XL Project Authors. All rights reserved.
+//
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+#include <limits.h>
+#include <stdlib.h>
+#include <string.h>
+
+bool error_msg(const char* message) {
+  fprintf(stderr, "%s\n", message);
+  return false;
+}
+#define return_on_error(X) \
+  if (!X) return false;
+
+size_t Log2(uint32_t value) { return 31 - __builtin_clz(value); }
+
+struct HeaderPNM {
+  size_t xsize;
+  size_t ysize;
+  bool is_gray;    // PGM
+  bool has_alpha;  // PAM
+  size_t bits_per_sample;
+};
+
+class Parser {
+ public:
+  explicit Parser(uint8_t* data, size_t length)
+      : pos_(data), end_(data + length) {}
+
+  // Sets "pos" to the first non-header byte/pixel on success.
+  bool ParseHeader(HeaderPNM* header, const uint8_t** pos) {
+    // codec.cc ensures we have at least two bytes => no range check here.
+    if (pos_[0] != 'P') return false;
+    const uint8_t type = pos_[1];
+    pos_ += 2;
+
+    switch (type) {
+      case '5':
+        header->is_gray = true;
+        return ParseHeaderPNM(header, pos);
+
+      case '6':
+        header->is_gray = false;
+        return ParseHeaderPNM(header, pos);
+
+      case '7':
+        return ParseHeaderPAM(header, pos);
+    }
+    return false;
+  }
+
+  // Exposed for testing
+  bool ParseUnsigned(size_t* number) {
+    if (pos_ == end_) return error_msg("PNM: reached end before number");
+    if (!IsDigit(*pos_)) return error_msg("PNM: expected unsigned number");
+
+    *number = 0;
+    while (pos_ < end_ && *pos_ >= '0' && *pos_ <= '9') {
+      *number *= 10;
+      *number += *pos_ - '0';
+      ++pos_;
+    }
+
+    return true;
+  }
+
+  bool ParseSigned(double* number) {
+    if (pos_ == end_) return error_msg("PNM: reached end before signed");
+
+    if (*pos_ != '-' && *pos_ != '+' && !IsDigit(*pos_)) {
+      return error_msg("PNM: expected signed number");
+    }
+
+    // Skip sign
+    const bool is_neg = *pos_ == '-';
+    if (is_neg || *pos_ == '+') {
+      ++pos_;
+      if (pos_ == end_) return error_msg("PNM: reached end before digits");
+    }
+
+    // Leading digits
+    *number = 0.0;
+    while (pos_ < end_ && *pos_ >= '0' && *pos_ <= '9') {
+      *number *= 10;
+      *number += *pos_ - '0';
+      ++pos_;
+    }
+
+    // Decimal places?
+    if (pos_ < end_ && *pos_ == '.') {
+      ++pos_;
+      double place = 0.1;
+      while (pos_ < end_ && *pos_ >= '0' && *pos_ <= '9') {
+        *number += (*pos_ - '0') * place;
+        place *= 0.1;
+        ++pos_;
+      }
+    }
+
+    if (is_neg) *number = -*number;
+    return true;
+  }
+
+ private:
+  static bool IsDigit(const uint8_t c) { return '0' <= c && c <= '9'; }
+  static bool IsLineBreak(const uint8_t c) { return c == '\r' || c == '\n'; }
+  static bool IsWhitespace(const uint8_t c) {
+    return IsLineBreak(c) || c == '\t' || c == ' ';
+  }
+
+  bool SkipBlank() {
+    if (pos_ == end_) return error_msg("PNM: reached end before blank");
+    const uint8_t c = *pos_;
+    if (c != ' ' && c != '\n') return error_msg("PNM: expected blank");
+    ++pos_;
+    return true;
+  }
+
+  bool SkipSingleWhitespace() {
+    if (pos_ == end_) return error_msg("PNM: reached end before whitespace");
+    if (!IsWhitespace(*pos_)) return error_msg("PNM: expected whitespace");
+    ++pos_;
+    return true;
+  }
+
+  bool SkipWhitespace() {
+    if (pos_ == end_) return error_msg("PNM: reached end before whitespace");
+    if (!IsWhitespace(*pos_) && *pos_ != '#') {
+      return error_msg("PNM: expected whitespace/comment");
+    }
+
+    while (pos_ < end_ && IsWhitespace(*pos_)) {
+      ++pos_;
+    }
+
+    // Comment(s)
+    while (pos_ != end_ && *pos_ == '#') {
+      while (pos_ != end_ && !IsLineBreak(*pos_)) {
+        ++pos_;
+      }
+      // Newline(s)
+      while (pos_ != end_ && IsLineBreak(*pos_)) pos_++;
+    }
+
+    while (pos_ < end_ && IsWhitespace(*pos_)) {
+      ++pos_;
+    }
+    return true;
+  }
+
+  bool MatchString(const char* keyword) {
+    const uint8_t* ppos = pos_;
+    while (*keyword) {
+      if (ppos >= end_) return error_msg("PAM: unexpected end of input");
+      if (*keyword != *ppos) return false;
+      ppos++;
+      keyword++;
+    }
+    pos_ = ppos;
+    return_on_error(SkipWhitespace());
+    return true;
+  }
+
+  bool ParseHeaderPAM(HeaderPNM* header, const uint8_t** pos) {
+    size_t num_channels = 3;
+    size_t max_val = 255;
+    while (!MatchString("ENDHDR")) {
+      return_on_error(SkipWhitespace());
+      if (MatchString("WIDTH")) {
+        return_on_error(ParseUnsigned(&header->xsize));
+      } else if (MatchString("HEIGHT")) {
+        return_on_error(ParseUnsigned(&header->ysize));
+      } else if (MatchString("DEPTH")) {
+        return_on_error(ParseUnsigned(&num_channels));
+      } else if (MatchString("MAXVAL")) {
+        return_on_error(ParseUnsigned(&max_val));
+      } else if (MatchString("TUPLTYPE")) {
+        if (MatchString("RGB_ALPHA")) {
+          header->has_alpha = true;
+        } else if (MatchString("RGB")) {
+        } else if (MatchString("GRAYSCALE_ALPHA")) {
+          header->has_alpha = true;
+          header->is_gray = true;
+        } else if (MatchString("GRAYSCALE")) {
+          header->is_gray = true;
+        } else if (MatchString("BLACKANDWHITE_ALPHA")) {
+          header->has_alpha = true;
+          header->is_gray = true;
+          max_val = 1;
+        } else if (MatchString("BLACKANDWHITE")) {
+          header->is_gray = true;
+          max_val = 1;
+        } else {
+          return error_msg("PAM: unknown TUPLTYPE");
+        }
+      } else {
+        return error_msg("PAM: unknown header keyword");
+      }
+    }
+    if (num_channels !=
+        (header->has_alpha ? 1 : 0) + (header->is_gray ? 1 : 3)) {
+      return error_msg("PAM: bad DEPTH");
+    }
+    if (max_val == 0 || max_val >= 65536) {
+      return error_msg("PAM: bad MAXVAL");
+    }
+    header->bits_per_sample = Log2(max_val + 1);
+
+    *pos = pos_;
+    return true;
+  }
+
+  bool ParseHeaderPNM(HeaderPNM* header, const uint8_t** pos) {
+    return_on_error(SkipWhitespace());
+    return_on_error(ParseUnsigned(&header->xsize));
+
+    return_on_error(SkipWhitespace());
+    return_on_error(ParseUnsigned(&header->ysize));
+
+    return_on_error(SkipWhitespace());
+    size_t max_val;
+    return_on_error(ParseUnsigned(&max_val));
+    if (max_val == 0 || max_val >= 65536) {
+      return error_msg("PNM: bad MaxVal");
+    }
+    header->bits_per_sample = Log2(max_val + 1);
+
+    return_on_error(SkipSingleWhitespace());
+
+    *pos = pos_;
+    return true;
+  }
+
+  const uint8_t* pos_;
+  const uint8_t* const end_;
+};
+
+bool load_file(unsigned char** out, size_t* outsize, const char* filename) {
+  FILE* file;
+  file = fopen(filename, "rb");
+  if (!file) return false;
+  if (fseek(file, 0, SEEK_END) != 0) {
+    fclose(file);
+    return false;
+  }
+  *outsize = ftell(file);
+  if (*outsize == LONG_MAX || *outsize < 9 || fseek(file, 0, SEEK_SET)) {
+    fclose(file);
+    return false;
+  }
+  *out = (unsigned char*)malloc(*outsize);
+  if (!(*out)) return false;
+  size_t readsize;
+  readsize = fread(*out, 1, *outsize, file);
+  fclose(file);
+  if (readsize != *outsize) return false;
+  return true;
+}
+
+bool DecodePAM(const char* filename, uint8_t** buffer, size_t* w, size_t* h,
+               size_t* nb_chans, size_t* bitdepth) {
+  unsigned char* in_file;
+  size_t in_size;
+  if (!load_file(&in_file, &in_size, filename))
+    return error_msg("Could not read input file");
+  Parser parser(in_file, in_size);
+  HeaderPNM header = {};
+  const uint8_t* pos = nullptr;
+  if (!parser.ParseHeader(&header, &pos)) return false;
+
+  if (header.bits_per_sample == 0 || header.bits_per_sample > 12) {
+    return error_msg("PNM: bits_per_sample invalid (can do at most 12-bit)");
+  }
+  *w = header.xsize;
+  *h = header.ysize;
+  *bitdepth = header.bits_per_sample;
+  *nb_chans = (header.is_gray ? 1 : 3) + (header.has_alpha ? 1 : 0);
+
+  size_t pnm_remaining_size = in_file + in_size - pos;
+  size_t buffer_size = *w * *h * *nb_chans * (*bitdepth > 8 ? 2 : 1);
+  if (pnm_remaining_size < buffer_size) {
+    return error_msg("PNM file too small");
+  }
+  *buffer = (uint8_t*)malloc(buffer_size);
+  memcpy(*buffer, pos, buffer_size);
+  return true;
+}


### PR DESCRIPTION
fjxl:

Generalizes 8-bit RGBA input to any bitdepth <= 12 and any number of channels <= 4.
Adds pgm/ppm/pam input support to the main file.

For now, SIMD is only used in the 8-bit codepath, since there are some assumptions/constraints in the SIMD code that are broken by having a larger range for the symbols than what is needed for 11-bit.

Compression of 8-bit images is not affected much, the only differences are:
- slightly less compact encoding of the huffman code itself because kNumRaw was bumped up (typically +2 or +3 bytes per file) — can be fixed later
- slightly better and faster compression when giving input as Grayscale, Gray+Alpha or RGB instead of as RGBA
- slightly denser when palette can be used (~0.2% smaller on my test set of palette images)
- significantly denser if input is < 8-bit (e.g. RGB555 images) and given as a pgm/ppm/pam with the right bitdepth

Compression of 10-bit and 12-bit images seems to be competitive with HTJ2K (faster and similar density) and it is significantly better than what PNG can do (since PNG has to encode it as 16-bit).

For example: starting from 10-bit versions of the images at https://imagecompression.info/test_images/

```
$ time for i in *.ppm; do ./fast_lossless $i $i.jxl; done

real	0m3.929s
user	0m3.038s
sys	0m0.877s

$ time for i in *.ppm; do convert $i $i.png; done

real	3m46.036s
user	3m44.866s
sys	0m0.827s

$ stat -c "%s %n" *
37748754 artificial.ppm
3276884 artificial.ppm.jxl
4205436 artificial.ppm.png
234317970 big_building.ppm
86764214 big_building.ppm.jxl
149990883 big_building.ppm.png
166202418 big_tree.ppm
70156489 big_tree.ppm.jxl
114775030 big_tree.ppm.png
66784224 bridge.ppm
28188323 bridge.ppm.jxl
48568111 bridge.ppm.png
36096018 cathedral.ppm
13492838 cathedral.ppm.jxl
22221471 cathedral.ppm.png
64065396 deer.ppm
31340869 deer.ppm.jxl
51272316 deer.ppm.png
883080 fast_lossless
44255250 fireworks.ppm
10245917 fireworks.ppm.jxl
13344987 fireworks.ppm.png
20575314 flower_foveon.ppm
5173085 flower_foveon.ppm.jxl
8947005 flower_foveon.ppm.png
37748754 hdr.ppm
11293198 hdr.ppm.jxl
18428265 hdr.ppm.png
36096018 leaves_iso_1600.ppm
15289280 leaves_iso_1600.ppm.jxl
26390011 leaves_iso_1600.ppm.png
36096018 leaves_iso_200.ppm
13514509 leaves_iso_200.ppm.jxl
24043586 leaves_iso_200.ppm.png
44255250 nightshot_iso_100.ppm
12829317 nightshot_iso_100.ppm.jxl
19704805 nightshot_iso_100.ppm.png
44255250 nightshot_iso_1600.ppm
18550928 nightshot_iso_1600.ppm.jxl
28748839 nightshot_iso_1600.ppm.png
72726546 spider_web.ppm
16635304 spider_web.ppm.jxl
29510200 spider_web.ppm.png
```

Total png size: 560 MB (in almost 4 minutes)
Total jxl size: 337 MB (in about 4 seconds)
(ojph_compress took a bit over 10 seconds for a total size of 334 MB)

12-bit versions of the same images:
Total png size: 615 MB (in over 4 minutes)
Total jxl size: 449 MB (in about 4 seconds)
Total htj2k size: 452 MB (in about 10 seconds)

This is with non-SIMD huffman coding, possibly a further speedup could be possible if huffman coding can be generalized to deal with >11-bit symbols.