### PR TITLE
Prevent a potential out of bounds write access

### DIFF
--- a/lib/jxl/color_management.cc
+++ b/lib/jxl/color_management.cc
@@ -499,8 +499,10 @@ Status MaybeCreateProfile(const ColorEncoding& c,
   // TODO(lode): manually verify with a reliable tool that this creates correct
   // signature (profile id) for ICC profiles.
   PaddedBytes icc_sum = *icc;
-  memset(icc_sum.data() + 44, 0, 4);
-  memset(icc_sum.data() + 64, 0, 4);
+  if (icc_sum.size() >= 64 + 4) {
+    memset(icc_sum.data() + 44, 0, 4);
+    memset(icc_sum.data() + 64, 0, 4);
+  }
   uint8_t checksum[16];
   ICCComputeMD5(icc_sum, checksum);
 


### PR DESCRIPTION
This commit will fix the following warning reported by gcc-10:

lib/jxl/color_management.cc:502:9: error: 'void* memset(void*, int, size_t)' offset [0, 3] is out of the bounds [0, 0] [-Werror=array-bounds]
  502 |   memset(icc_sum.data() + 44, 0, 4);
      |   ~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~
libjxl/lib/jxl/color_management.cc:503:9: error: 'void* memset(void*, int, size_t)' offset [0, 3] is out of the bounds [0, 0] [-Werror=array-bounds]
  503 |   memset(icc_sum.data() + 64, 0, 4);
      |   ~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~