### PR TITLE
Add unified safeguard for truncated group decoding.

### DIFF
--- a/lib/jxl/base/scope_guard.h
+++ b/lib/jxl/base/scope_guard.h
@@ -18,7 +18,7 @@ class ScopeGuard {
   ScopeGuard &operator=(const ScopeGuard &) = delete;
   ScopeGuard &operator=(ScopeGuard &&) = delete;
 
-  // Some compilers have different RVO rules -> require move constructor.
+  // Pre-C++17 does not guarantee RVO -> require move constructor.
   ScopeGuard(ScopeGuard &&other) : callback_(std::move(other.callback_)) {
     other.armed_ = false;
   }
@@ -30,6 +30,8 @@ class ScopeGuard {
   ~ScopeGuard() {
     if (armed_) callback_();
   }
+
+  void Disarm() { armed_ = false; }
 
  private:
   Callback callback_;


### PR DESCRIPTION
Before planes were zeroified only if the very late stage failed.
Now the scope guard is placed after meta-apply, so that there is no
escape path to leave planes uninitialized (if truncated groups are allowed).