### PR TITLE
Add corner-case check in APNG decoding (no frames decoded)

### DIFF
--- a/lib/extras/dec/apng.cc
+++ b/lib/extras/dec/apng.cc
@@ -731,6 +731,7 @@ Status DecodeImageAPNG(const Span<const uint8_t> bytes,
       previous_frame_should_be_cleared = false;
     }
   }
+  if (ppf->frames.empty()) return JXL_FAILURE("No frames decoded");
   ppf->frames.back().frame_info.is_last = true;
 
   return true;


### PR DESCRIPTION
It is assumed, that ppf.frames should not be empty.