### PR TITLE
Do not keep around copies of the natural coefficient order.

### DIFF
--- a/lib/jxl/ac_strategy.cc
+++ b/lib/jxl/ac_strategy.cc
@@ -23,72 +23,70 @@ namespace jxl {
 // square block frequency along the (i + j == const) diagonals is roughly the
 // same. For historical reasons, consecutive diagonals are traversed
 // in alternating directions - so called "zig-zag" (or "snake") order.
-AcStrategy::CoeffOrderAndLut::CoeffOrderAndLut() {
-  for (size_t s = 0; s < AcStrategy::kNumValidStrategies; s++) {
-    const AcStrategy acs = AcStrategy::FromRawStrategy(s);
-    size_t cx = acs.covered_blocks_x();
-    size_t cy = acs.covered_blocks_y();
-    CoefficientLayout(&cy, &cx);
-    JXL_ASSERT((AcStrategy::CoeffOrderAndLut::kOffset[s + 1] -
-                AcStrategy::CoeffOrderAndLut::kOffset[s]) == cx * cy);
-    coeff_order_t* JXL_RESTRICT order_start =
-        order + AcStrategy::CoeffOrderAndLut::kOffset[s] * kDCTBlockSize;
-    coeff_order_t* JXL_RESTRICT lut_start =
-        lut + AcStrategy::CoeffOrderAndLut::kOffset[s] * kDCTBlockSize;
+template <bool is_lut>
+static void CoeffOrderAndLut(AcStrategy acs, coeff_order_t* out) {
+  size_t cx = acs.covered_blocks_x();
+  size_t cy = acs.covered_blocks_y();
+  CoefficientLayout(&cy, &cx);
 
-    // CoefficientLayout ensures cx >= cy.
-    // We compute the zigzag order for a cx x cx block, then discard all the
-    // lines that are not multiple of the ratio between cx and cy.
-    size_t xs = cx / cy;
-    size_t xsm = xs - 1;
-    size_t xss = CeilLog2Nonzero(xs);
-    // First half of the block
-    size_t cur = cx * cy;
-    for (size_t i = 0; i < cx * kBlockDim; i++) {
-      for (size_t j = 0; j <= i; j++) {
-        size_t x = j;
-        size_t y = i - j;
-        if (i % 2) std::swap(x, y);
-        if ((y & xsm) != 0) continue;
-        y >>= xss;
-        size_t val = 0;
-        if (x < cx && y < cy) {
-          val = y * cx + x;
-        } else {
-          val = cur++;
-        }
-        lut_start[y * cx * kBlockDim + x] = val;
-        order_start[val] = y * cx * kBlockDim + x;
+  // CoefficientLayout ensures cx >= cy.
+  // We compute the zigzag order for a cx x cx block, then discard all the
+  // lines that are not multiple of the ratio between cx and cy.
+  size_t xs = cx / cy;
+  size_t xsm = xs - 1;
+  size_t xss = CeilLog2Nonzero(xs);
+  // First half of the block
+  size_t cur = cx * cy;
+  for (size_t i = 0; i < cx * kBlockDim; i++) {
+    for (size_t j = 0; j <= i; j++) {
+      size_t x = j;
+      size_t y = i - j;
+      if (i % 2) std::swap(x, y);
+      if ((y & xsm) != 0) continue;
+      y >>= xss;
+      size_t val = 0;
+      if (x < cx && y < cy) {
+        val = y * cx + x;
+      } else {
+        val = cur++;
+      }
+      if (is_lut) {
+        out[y * cx * kBlockDim + x] = val;
+      } else {
+        out[val] = y * cx * kBlockDim + x;
       }
     }
-    // Second half
-    for (size_t ip = cx * kBlockDim - 1; ip > 0; ip--) {
-      size_t i = ip - 1;
-      for (size_t j = 0; j <= i; j++) {
-        size_t x = cx * kBlockDim - 1 - (i - j);
-        size_t y = cx * kBlockDim - 1 - j;
-        if (i % 2) std::swap(x, y);
-        if ((y & xsm) != 0) continue;
-        y >>= xss;
-        size_t val = cur++;
-        lut_start[y * cx * kBlockDim + x] = val;
-        order_start[val] = y * cx * kBlockDim + x;
+  }
+  // Second half
+  for (size_t ip = cx * kBlockDim - 1; ip > 0; ip--) {
+    size_t i = ip - 1;
+    for (size_t j = 0; j <= i; j++) {
+      size_t x = cx * kBlockDim - 1 - (i - j);
+      size_t y = cx * kBlockDim - 1 - j;
+      if (i % 2) std::swap(x, y);
+      if ((y & xsm) != 0) continue;
+      y >>= xss;
+      size_t val = cur++;
+      if (is_lut) {
+        out[y * cx * kBlockDim + x] = val;
+      } else {
+        out[val] = y * cx * kBlockDim + x;
       }
     }
   }
 }
 
-const AcStrategy::CoeffOrderAndLut* AcStrategy::CoeffOrder() {
-  static AcStrategy::CoeffOrderAndLut* order =
-      new AcStrategy::CoeffOrderAndLut();
-  return order;
+void AcStrategy::ComputeNaturalCoeffOrder(coeff_order_t* order) const {
+  CoeffOrderAndLut</*is_lut=*/false>(*this, order);
+}
+void AcStrategy::ComputeNaturalCoeffOrderLut(coeff_order_t* lut) const {
+  CoeffOrderAndLut</*is_lut=*/true>(*this, lut);
 }
 
 // These definitions are needed before C++17.
 constexpr size_t AcStrategy::kMaxCoeffBlocks;
 constexpr size_t AcStrategy::kMaxBlockDim;
 constexpr size_t AcStrategy::kMaxCoeffArea;
-constexpr size_t AcStrategy::CoeffOrderAndLut::kOffset[];
 
 AcStrategyImage::AcStrategyImage(size_t xsize, size_t ysize)
     : layers_(xsize, ysize) {

--- a/lib/jxl/ac_strategy.h
+++ b/lib/jxl/ac_strategy.h
@@ -133,15 +133,8 @@ class AcStrategy {
   // Round-trip, for any given strategy s:
   //  X = NaturalCoeffOrder(s)[NaturalCoeffOrderLutN(s)[X]]
   //  X = NaturalCoeffOrderLut(s)[NaturalCoeffOrderN(s)[X]]
-  JXL_INLINE const coeff_order_t* NaturalCoeffOrder() const {
-    return CoeffOrder()->order +
-           CoeffOrderAndLut::kOffset[RawStrategy()] * kDCTBlockSize;
-  }
-
-  JXL_INLINE const coeff_order_t* NaturalCoeffOrderLut() const {
-    return CoeffOrder()->lut +
-           CoeffOrderAndLut::kOffset[RawStrategy()] * kDCTBlockSize;
-  }
+  void ComputeNaturalCoeffOrder(coeff_order_t* order) const;
+  void ComputeNaturalCoeffOrderLut(coeff_order_t* lut) const;
 
   // Number of 8x8 blocks that this strategy will cover. 0 for non-top-left
   // blocks inside a multi-block transform.
@@ -172,23 +165,6 @@ class AcStrategy {
     return kLut[size_t(strategy_)];
   }
 
-  struct CoeffOrderAndLut {
-    // Those offsets get multiplied by kDCTBlockSize.
-    // TODO(veluca): reduce this array by merging together the same order type.
-    static constexpr size_t kOffset[kNumValidStrategies + 1] = {
-        0,  1,  2,  3,  4,  8,   24,  26,  28,  32,  36,  44,   52,   53,
-        54, 55, 56, 57, 58, 122, 154, 186, 442, 570, 698, 1722, 2234, 2746,
-    };
-    static constexpr size_t kTotalTableSize =
-        kOffset[kNumValidStrategies] * kDCTBlockSize;
-    coeff_order_t order[kTotalTableSize];
-    coeff_order_t lut[kTotalTableSize];
-
-   private:
-    CoeffOrderAndLut();
-    friend class AcStrategy;
-  };
-
  private:
   friend class AcStrategyRow;
   JXL_INLINE AcStrategy(Type strategy, bool is_first)
@@ -198,8 +174,6 @@ class AcStrategy {
 
   Type strategy_;
   bool is_first_;
-
-  static const CoeffOrderAndLut* CoeffOrder();
 };
 
 // Class to use a certain row of the AC strategy.

--- a/lib/jxl/coeff_order.cc
+++ b/lib/jxl/coeff_order.cc
@@ -26,16 +26,6 @@
 
 namespace jxl {
 
-void SetDefaultOrder(AcStrategy acs, coeff_order_t* JXL_RESTRICT order) {
-  PROFILER_FUNC;
-  const size_t size =
-      kDCTBlockSize * acs.covered_blocks_x() * acs.covered_blocks_y();
-  const coeff_order_t* natural_coeff_order = acs.NaturalCoeffOrder();
-  for (size_t k = 0; k < size; ++k) {
-    order[k] = natural_coeff_order[k];
-  }
-}
-
 uint32_t CoeffOrderContext(uint32_t val) {
   uint32_t token, nbits, bits;
   HybridUintConfig(0, 0, 0).Encode(val, &token, &nbits, &bits);
@@ -90,6 +80,7 @@ namespace {
 
 Status DecodeCoeffOrder(AcStrategy acs, coeff_order_t* order, BitReader* br,
                         ANSSymbolReader* reader,
+                        std::vector<coeff_order_t>& natural_order,
                         const std::vector<uint8_t>& context_map) {
   PROFILER_FUNC;
   const size_t llf = acs.covered_blocks_x() * acs.covered_blocks_y();
@@ -98,9 +89,8 @@ Status DecodeCoeffOrder(AcStrategy acs, coeff_order_t* order, BitReader* br,
   JXL_RETURN_IF_ERROR(
       ReadPermutation(llf, size, order, br, reader, context_map));
   if (order == nullptr) return true;
-  const coeff_order_t* natural_coeff_order = acs.NaturalCoeffOrder();
   for (size_t k = 0; k < size; ++k) {
-    order[k] = natural_coeff_order[order[k]];
+    order[k] = natural_order[order[k]];
   }
   return true;
 }
@@ -113,6 +103,7 @@ Status DecodeCoeffOrders(uint16_t used_orders, uint32_t used_acs,
   std::vector<uint8_t> context_map;
   ANSCode code;
   std::unique_ptr<ANSSymbolReader> reader;
+  std::vector<coeff_order_t> natural_order;
   // Bitstream does not have histograms if no coefficient order is used.
   if (used_orders != 0) {
     JXL_RETURN_IF_ERROR(
@@ -130,18 +121,28 @@ Status DecodeCoeffOrders(uint16_t used_orders, uint32_t used_acs,
     computed |= 1 << ord;
     AcStrategy acs = AcStrategy::FromRawStrategy(o);
     bool used = (acs_mask & (1 << ord)) != 0;
+
+    const size_t llf = acs.covered_blocks_x() * acs.covered_blocks_y();
+    const size_t size = kDCTBlockSize * llf;
+
+    if (used || (used_orders & (1 << ord))) {
+      if (natural_order.size() < size) natural_order.resize(size);
+      acs.ComputeNaturalCoeffOrder(natural_order.data());
+    }
+
     if ((used_orders & (1 << ord)) == 0) {
       // No need to set the default order if no ACS uses this order.
       if (used) {
         for (size_t c = 0; c < 3; c++) {
-          SetDefaultOrder(acs, &order[CoeffOrderOffset(ord, c)]);
+          memcpy(&order[CoeffOrderOffset(ord, c)], natural_order.data(),
+                 size * sizeof(*order));
         }
       }
     } else {
       for (size_t c = 0; c < 3; c++) {
         coeff_order_t* dest = used ? &order[CoeffOrderOffset(ord, c)] : nullptr;
-        JXL_RETURN_IF_ERROR(
-            DecodeCoeffOrder(acs, dest, br, reader.get(), context_map));
+        JXL_RETURN_IF_ERROR(DecodeCoeffOrder(acs, dest, br, reader.get(),
+                                             natural_order, context_map));
       }
     }
   }

--- a/lib/jxl/coeff_order.h
+++ b/lib/jxl/coeff_order.h
@@ -53,8 +53,6 @@ constexpr uint32_t kPermutationContexts = 8;
 
 uint32_t CoeffOrderContext(uint32_t val);
 
-void SetDefaultOrder(AcStrategy acs, coeff_order_t* JXL_RESTRICT order);
-
 Status DecodeCoeffOrders(uint16_t used_orders, uint32_t used_acs,
                          coeff_order_t* order, BitReader* br);
 

--- a/lib/jxl/enc_coeff_order.h
+++ b/lib/jxl/enc_coeff_order.h
@@ -24,8 +24,9 @@
 namespace jxl {
 
 // Orders that are actually used in part of image. `rect` is in block units.
-uint32_t ComputeUsedOrders(SpeedTier speed, const AcStrategyImage& ac_strategy,
-                           const Rect& rect);
+// Returns {orders that are used, orders that might be made non-default}.
+std::pair<uint32_t, uint32_t> ComputeUsedOrders(
+    SpeedTier speed, const AcStrategyImage& ac_strategy, const Rect& rect);
 
 // Modify zig-zag order, so that DCT bands with more zeros go later.
 // Order of DCT bands with same number of zeros is untouched, so
@@ -33,7 +34,7 @@ uint32_t ComputeUsedOrders(SpeedTier speed, const AcStrategyImage& ac_strategy,
 void ComputeCoeffOrder(SpeedTier speed, const ACImage& acs,
                        const AcStrategyImage& ac_strategy,
                        const FrameDimensions& frame_dim, uint32_t& used_orders,
-                       coeff_order_t* JXL_RESTRICT order);
+                       uint16_t used_acs, coeff_order_t* JXL_RESTRICT order);
 
 void EncodeCoeffOrders(uint16_t used_orders,
                        const coeff_order_t* JXL_RESTRICT order,

--- a/lib/jxl/enc_frame.cc
+++ b/lib/jxl/enc_frame.cc
@@ -994,19 +994,20 @@ class LossyFrameEncoder {
  private:
   void ComputeAllCoeffOrders(const FrameDimensions& frame_dim) {
     PROFILER_FUNC;
+    // No coefficient reordering in Falcon or faster.
+    auto used_orders_info = ComputeUsedOrders(
+        enc_state_->cparams.speed_tier, enc_state_->shared.ac_strategy,
+        Rect(enc_state_->shared.raw_quant_field));
+    enc_state_->used_orders.clear();
     enc_state_->used_orders.resize(
-        enc_state_->progressive_splitter.GetNumPasses());
+        enc_state_->progressive_splitter.GetNumPasses(),
+        used_orders_info.second);
     for (size_t i = 0; i < enc_state_->progressive_splitter.GetNumPasses();
          i++) {
-      // No coefficient reordering in Falcon or faster.
-      if (enc_state_->cparams.speed_tier < SpeedTier::kFalcon) {
-        enc_state_->used_orders[i] = ComputeUsedOrders(
-            enc_state_->cparams.speed_tier, enc_state_->shared.ac_strategy,
-            Rect(enc_state_->shared.raw_quant_field));
-      }
       ComputeCoeffOrder(
           enc_state_->cparams.speed_tier, *enc_state_->coeffs[i],
           enc_state_->shared.ac_strategy, frame_dim, enc_state_->used_orders[i],
+          used_orders_info.first,
           &enc_state_->shared
                .coeff_orders[i * enc_state_->shared.coeff_order_size]);
     }


### PR DESCRIPTION
This cuts static memory usage by 1.5mb, with minor impact on speed:

```
Before:
Encoding      kPixels    Bytes          BPP  E MP/s  D MP/s     Max norm        pnorm       BPP*pnorm   Bugs
------------------------------------------------------------------------------------------------------------
jxl:d0.7        13270  3400483    2.0499581   5.592  48.001   1.50473666   0.47348297  0.970620226409      0
jxl:d1          13270  2678725    1.6148512   5.885  51.535   1.68153656   0.60257544  0.973069654737      0
jxl:d2          13270  1683788    1.0150602   6.256  54.283   3.00312042   0.95243347  0.966777268691      0
jxl:d4          13270  1004956    0.6058309   6.122  38.064   4.85261440   1.50554379  0.912104941537      0
jxl:d6          13270   718865    0.4333629   5.912  37.250   7.34840679   1.97809701  0.857233817426      0
jxl:d8          13270   576902    0.3477815   5.992  36.630   8.16245556   2.36179685  0.821389132427      0
Aggregate:      13270  1362308    0.8212584   5.956  43.710   3.60956523   1.11400975  0.914889813753      0

2268 x 1512, geomean: 90.43 MP/s [54.13, 91.49], 100 reps, 0 threads.

After:
Encoding      kPixels    Bytes          BPP  E MP/s  D MP/s     Max norm        pnorm       BPP*pnorm   Bugs
------------------------------------------------------------------------------------------------------------
jxl:d0.7        13270  3400483    2.0499581   5.466  47.067   1.50473666   0.47348297  0.970620226409      0
jxl:d1          13270  2678725    1.6148512   5.750  50.382   1.68153656   0.60257544  0.973069654737      0
jxl:d2          13270  1683788    1.0150602   6.102  53.015   3.00312042   0.95243347  0.966777268691      0
jxl:d4          13270  1004956    0.6058309   5.979  37.066   4.85261440   1.50554379  0.912104941537      0
jxl:d6          13270   718865    0.4333629   5.772  36.305   7.34840679   1.97809701  0.857233817426      0
jxl:d8          13270   576902    0.3477815   5.852  35.697   8.16245556   2.36179685  0.821389132427      0
Aggregate:      13270  1362308    0.8212584   5.817  42.674   3.60956523   1.11400975  0.914889813753      0

2268 x 1512, geomean: 92.22 MP/s [56.89, 93.08], 100 reps, 0 threads.
```