### PR TITLE
Do not keep around default quantization matrices

### DIFF
--- a/lib/jxl/compressed_image_test.cc
+++ b/lib/jxl/compressed_image_test.cc
@@ -77,6 +77,8 @@ void RunRGBRoundTrip(float distance, bool fast) {
   PassesEncoderState enc_state;
   JXL_CHECK(InitializePassesSharedState(frame_header, &enc_state.shared));
 
+  JXL_CHECK(enc_state.shared.matrices.EnsureComputed(~0u));
+
   enc_state.shared.quantizer.SetQuant(4.0f, 4.0f,
                                       &enc_state.shared.raw_quant_field);
   enc_state.shared.ac_strategy.FillDCT8();

--- a/lib/jxl/dec_frame.cc
+++ b/lib/jxl/dec_frame.cc
@@ -545,6 +545,8 @@ Status FrameDecoder::ProcessACGlobal(BitReader* br) {
   if (frame_header_.encoding == FrameEncoding::kVarDCT) {
     JXL_RETURN_IF_ERROR(dec_state_->shared_storage.matrices.Decode(
         br, &modular_frame_decoder_));
+    JXL_RETURN_IF_ERROR(dec_state_->shared_storage.matrices.EnsureComputed(
+        dec_state_->used_acs));
 
     size_t num_histo_bits =
         CeilLog2Nonzero(dec_state_->shared->frame_dim.num_groups);

--- a/lib/jxl/dec_group.cc
+++ b/lib/jxl/dec_group.cc
@@ -97,15 +97,14 @@ void Transpose8x8InPlace(int32_t* JXL_RESTRICT block) {
 template <ACType ac_type>
 void DequantLane(Vec<D> scaled_dequant_x, Vec<D> scaled_dequant_y,
                  Vec<D> scaled_dequant_b,
-                 const float* JXL_RESTRICT dequant_matrices, size_t dq_ofs,
-                 size_t size, size_t k, Vec<D> x_cc_mul, Vec<D> b_cc_mul,
+                 const float* JXL_RESTRICT dequant_matrices, size_t size,
+                 size_t k, Vec<D> x_cc_mul, Vec<D> b_cc_mul,
                  const float* JXL_RESTRICT biases, ACPtr qblock[3],
                  float* JXL_RESTRICT block) {
-  const auto x_mul = Load(d, dequant_matrices + dq_ofs + k) * scaled_dequant_x;
-  const auto y_mul =
-      Load(d, dequant_matrices + dq_ofs + size + k) * scaled_dequant_y;
+  const auto x_mul = Load(d, dequant_matrices + k) * scaled_dequant_x;
+  const auto y_mul = Load(d, dequant_matrices + size + k) * scaled_dequant_y;
   const auto b_mul =
-      Load(d, dequant_matrices + dq_ofs + 2 * size + k) * scaled_dequant_b;
+      Load(d, dequant_matrices + 2 * size + k) * scaled_dequant_b;
 
   Vec<DI> quantized_x_int;
   Vec<DI> quantized_y_int;
@@ -139,9 +138,8 @@ template <ACType ac_type>
 void DequantBlock(const AcStrategy& acs, float inv_global_scale, int quant,
                   float x_dm_multiplier, float b_dm_multiplier, Vec<D> x_cc_mul,
                   Vec<D> b_cc_mul, size_t kind, size_t size,
-                  const Quantizer& quantizer,
-                  const float* JXL_RESTRICT dequant_matrices,
-                  size_t covered_blocks, const size_t* sbx,
+                  const Quantizer& quantizer, size_t covered_blocks,
+                  const size_t* sbx,
                   const float* JXL_RESTRICT* JXL_RESTRICT dc_row,
                   size_t dc_stride, const float* JXL_RESTRICT biases,
                   ACPtr qblock[3], float* JXL_RESTRICT block) {
@@ -153,12 +151,12 @@ void DequantBlock(const AcStrategy& acs, float inv_global_scale, int quant,
   const auto scaled_dequant_y = Set(d, scaled_dequant_s);
   const auto scaled_dequant_b = Set(d, scaled_dequant_s * b_dm_multiplier);
 
-  const size_t dq_ofs = quantizer.DequantMatrixOffset(kind, 0);
+  const float* dequant_matrices = quantizer.DequantMatrix(kind, 0);
 
   for (size_t k = 0; k < covered_blocks * kDCTBlockSize; k += Lanes(d)) {
     DequantLane<ac_type>(scaled_dequant_x, scaled_dequant_y, scaled_dequant_b,
-                         dequant_matrices, dq_ofs, size, k, x_cc_mul, b_cc_mul,
-                         biases, qblock, block);
+                         dequant_matrices, size, k, x_cc_mul, b_cc_mul, biases,
+                         qblock, block);
   }
   for (size_t c = 0; c < 3; c++) {
     LowestFrequenciesFromDC(acs.Strategy(), dc_row[c] + sbx[c], dc_stride,
@@ -186,8 +184,6 @@ Status DecodeGroupImpl(GetBlock* JXL_RESTRICT get_block,
   const size_t dc_stride = dec_state->shared->dc->PixelsPerRow();
 
   const float inv_global_scale = dec_state->shared->quantizer.InvGlobalScale();
-  const float* JXL_RESTRICT dequant_matrices =
-      dec_state->shared->quantizer.DequantMatrix(0, 0);
 
   const YCbCrChromaSubsampling& cs =
       dec_state->shared->frame_header.chroma_subsampling;
@@ -428,7 +424,7 @@ Status DecodeGroupImpl(GetBlock* JXL_RESTRICT get_block,
           dequant_block(
               acs, inv_global_scale, row_quant[bx], dec_state->x_dm_multiplier,
               dec_state->b_dm_multiplier, x_cc_mul, b_cc_mul, acs.RawStrategy(),
-              size, dec_state->shared->quantizer, dequant_matrices,
+              size, dec_state->shared->quantizer,
               acs.covered_blocks_y() * acs.covered_blocks_x(), sbx, dc_rows,
               dc_stride,
               dec_state->output_encoding_info.opsin_params.quant_biases, qblock,

--- a/lib/jxl/enc_ac_strategy.cc
+++ b/lib/jxl/enc_ac_strategy.cc
@@ -1008,6 +1008,17 @@ void AcStrategyHeuristics::Init(const Image3F& src,
   const CompressParams& cparams = enc_state->cparams;
   const float butteraugli_target = cparams.butteraugli_distance;
 
+  if (cparams.speed_tier >= SpeedTier::kCheetah) {
+    JXL_CHECK(enc_state->shared.matrices.EnsureComputed(1));  // DCT8 only
+  } else {
+    uint32_t acs_mask = 0;
+    // All transforms up to 64x64.
+    for (size_t i = 0; i < AcStrategy::DCT128X128; i++) {
+      acs_mask |= (1 << i);
+    }
+    JXL_CHECK(enc_state->shared.matrices.EnsureComputed(acs_mask));
+  }
+
   // Image row pointers and strides.
   config.quant_field_row = enc_state->initial_quant_field.Row(0);
   config.quant_field_stride = enc_state->initial_quant_field.PixelsPerRow();

--- a/lib/jxl/enc_heuristics.cc
+++ b/lib/jxl/enc_heuristics.cc
@@ -866,6 +866,9 @@ Status DefaultEncoderHeuristics::LossyFrameHeuristics(
     GaborishInverse(opsin, 0.9908511000000001f, pool);
   }
 
+  FindBestDequantMatrices(cparams, *opsin, modular_frame_encoder,
+                          &enc_state->shared.matrices);
+
   cfl_heuristics.Init(*opsin);
   acs_heuristics.Init(*opsin, enc_state);
 
@@ -933,9 +936,6 @@ Status DefaultEncoderHeuristics::LossyFrameHeuristics(
     cfl_heuristics.ComputeDC(/*fast=*/cparams.speed_tier >= SpeedTier::kWombat,
                              &enc_state->shared.cmap);
   }
-
-  FindBestDequantMatrices(cparams, *opsin, modular_frame_encoder,
-                          &enc_state->shared.matrices);
 
   // Refine quantization levels.
   FindBestQuantizer(original_pixels, *opsin, enc_state, cms, pool, aux_out);

--- a/lib/jxl/quant_weights.cc
+++ b/lib/jxl/quant_weights.cc
@@ -21,13 +21,20 @@
 #include "lib/jxl/fields.h"
 #include "lib/jxl/image.h"
 
+#undef HWY_TARGET_INCLUDE
+#define HWY_TARGET_INCLUDE "lib/jxl/quant_weights.cc"
+#include <hwy/foreach_target.h>
+#include <hwy/highway.h>
+
+#include "lib/jxl/fast_math-inl.h"
+
+HWY_BEFORE_NAMESPACE();
 namespace jxl {
+namespace HWY_NAMESPACE {
 
 // kQuantWeights[N * N * c + N * y + x] is the relative weight of the (x, y)
 // coefficient in component c. Higher weights correspond to finer quantization
 // intervals and more bits spent in encoding.
-
-namespace {
 
 static constexpr const float kAlmostZero = 1e-8f;
 
@@ -75,33 +82,47 @@ void GetQuantWeightsIdentity(const QuantEncoding::IdWeights& idweights,
   }
 }
 
-float Mult(float v) {
-  if (v > 0) return 1 + v;
-  return 1 / (1 - v);
-}
-
 float Interpolate(float pos, float max, const float* array, size_t len) {
   float scaled_pos = pos * (len - 1) / max;
   size_t idx = scaled_pos;
-  JXL_ASSERT(idx + 1 < len);
+  JXL_DASSERT(idx + 1 < len);
   float a = array[idx];
   float b = array[idx + 1];
-  return a * pow(b / a, scaled_pos - idx);
+  return a * FastPowf(b / a, scaled_pos - idx);
+}
+
+float Mult(float v) {
+  if (v > 0.0f) return 1.0f + v;
+  return 1.0f / (1.0f - v);
+}
+
+using DF4 = HWY_CAPPED(float, 4);
+
+hwy::HWY_NAMESPACE::Vec<DF4> InterpolateVec(
+    hwy::HWY_NAMESPACE::Vec<DF4> scaled_pos, const float* array) {
+  HWY_CAPPED(int32_t, 4) di;
+
+  auto idx = ConvertTo(di, scaled_pos);
+
+  auto frac = scaled_pos - ConvertTo(DF4(), idx);
+
+  // TODO(veluca): in theory, this could be done with 8 TableLookupBytes, but
+  // it's probably slower.
+  auto a = GatherIndex(DF4(), array, idx);
+  auto b = GatherIndex(DF4(), array + 1, idx);
+
+  return a * FastPowf(DF4(), b / a, frac);
 }
 
 // Computes quant weights for a COLS*ROWS-sized transform, using num_bands
 // eccentricity bands and num_ebands eccentricity bands. If print_mode is 1,
 // prints the resulting matrix; if print_mode is 2, prints the matrix in a
 // format suitable for a 3d plot with gnuplot.
-template <size_t print_mode = 0>
 Status GetQuantWeights(
     size_t ROWS, size_t COLS,
     const DctQuantWeightParams::DistanceBandsArray& distance_bands,
     size_t num_bands, float* out) {
   for (size_t c = 0; c < 3; c++) {
-    if (print_mode) {
-      fprintf(stderr, "Channel %" PRIuS "\n", c);
-    }
     float bands[DctQuantWeightParams::kMaxDistanceBands] = {
         distance_bands[c][0]};
     if (bands[0] < kAlmostZero) return JXL_FAILURE("Invalid distance bands");
@@ -109,31 +130,234 @@ Status GetQuantWeights(
       bands[i] = bands[i - 1] * Mult(distance_bands[c][i]);
       if (bands[i] < kAlmostZero) return JXL_FAILURE("Invalid distance bands");
     }
-    for (size_t y = 0; y < ROWS; y++) {
-      for (size_t x = 0; x < COLS; x++) {
-        float dx = 1.0f * x / (COLS - 1);
-        float dy = 1.0f * y / (ROWS - 1);
-        float distance = std::sqrt(dx * dx + dy * dy);
-        float weight =
-            num_bands == 1
-                ? bands[0]
-                : Interpolate(distance, std::sqrt(2) + 1e-6f, bands, num_bands);
-
-        if (print_mode == 1) {
-          fprintf(stderr, "%15.12f, ", weight);
-        }
-        if (print_mode == 2) {
-          fprintf(stderr, "%" PRIuS " %" PRIuS " %15.12f\n", x, y, weight);
-        }
-        out[c * COLS * ROWS + y * COLS + x] = weight;
+    float scale = (num_bands - 1) / (kSqrt2 + 1e-6f);
+    float rcpcol = scale / (COLS - 1);
+    float rcprow = scale / (ROWS - 1);
+    JXL_ASSERT(COLS >= Lanes(DF4()));
+    HWY_ALIGN float l0123[4] = {0, 1, 2, 3};
+    for (uint32_t y = 0; y < ROWS; y++) {
+      float dy = y * rcprow;
+      float dy2 = dy * dy;
+      for (uint32_t x = 0; x < COLS; x += Lanes(DF4())) {
+        auto dx = (Set(DF4(), x) + Load(DF4(), l0123)) * Set(DF4(), rcpcol);
+        auto scaled_distance = Sqrt(MulAdd(dx, dx, Set(DF4(), dy2)));
+        auto weight = num_bands == 1 ? Set(DF4(), bands[0])
+                                     : InterpolateVec(scaled_distance, bands);
+        StoreU(weight, DF4(), out + c * COLS * ROWS + y * COLS + x);
       }
-      if (print_mode) fprintf(stderr, "\n");
-      if (print_mode == 1) fprintf(stderr, "\n");
     }
-    if (print_mode) fprintf(stderr, "\n");
   }
   return true;
 }
+
+// TODO(veluca): SIMD-fy. With 256x256, this is actually slow.
+Status ComputeQuantTable(const QuantEncoding& encoding,
+                         float* JXL_RESTRICT table,
+                         float* JXL_RESTRICT inv_table, size_t table_num,
+                         DequantMatrices::QuantTable kind, size_t* pos) {
+  constexpr size_t N = kBlockDim;
+  size_t wrows = 8 * DequantMatrices::required_size_x[kind],
+         wcols = 8 * DequantMatrices::required_size_y[kind];
+  size_t num = wrows * wcols;
+
+  std::vector<float> weights(3 * num);
+
+  switch (encoding.mode) {
+    case QuantEncoding::kQuantModeLibrary: {
+      // Library and copy quant encoding should get replaced by the actual
+      // parameters by the caller.
+      JXL_ASSERT(false);
+      break;
+    }
+    case QuantEncoding::kQuantModeID: {
+      JXL_ASSERT(num == kDCTBlockSize);
+      GetQuantWeightsIdentity(encoding.idweights, weights.data());
+      break;
+    }
+    case QuantEncoding::kQuantModeDCT2: {
+      JXL_ASSERT(num == kDCTBlockSize);
+      GetQuantWeightsDCT2(encoding.dct2weights, weights.data());
+      break;
+    }
+    case QuantEncoding::kQuantModeDCT4: {
+      JXL_ASSERT(num == kDCTBlockSize);
+      float weights4x4[3 * 4 * 4];
+      // Always use 4x4 GetQuantWeights for DCT4 quantization tables.
+      JXL_RETURN_IF_ERROR(
+          GetQuantWeights(4, 4, encoding.dct_params.distance_bands,
+                          encoding.dct_params.num_distance_bands, weights4x4));
+      for (size_t c = 0; c < 3; c++) {
+        for (size_t y = 0; y < kBlockDim; y++) {
+          for (size_t x = 0; x < kBlockDim; x++) {
+            weights[c * num + y * kBlockDim + x] =
+                weights4x4[c * 16 + (y / 2) * 4 + (x / 2)];
+          }
+        }
+        weights[c * num + 1] /= encoding.dct4multipliers[c][0];
+        weights[c * num + N] /= encoding.dct4multipliers[c][0];
+        weights[c * num + N + 1] /= encoding.dct4multipliers[c][1];
+      }
+      break;
+    }
+    case QuantEncoding::kQuantModeDCT4X8: {
+      JXL_ASSERT(num == kDCTBlockSize);
+      float weights4x8[3 * 4 * 8];
+      // Always use 4x8 GetQuantWeights for DCT4X8 quantization tables.
+      JXL_RETURN_IF_ERROR(
+          GetQuantWeights(4, 8, encoding.dct_params.distance_bands,
+                          encoding.dct_params.num_distance_bands, weights4x8));
+      for (size_t c = 0; c < 3; c++) {
+        for (size_t y = 0; y < kBlockDim; y++) {
+          for (size_t x = 0; x < kBlockDim; x++) {
+            weights[c * num + y * kBlockDim + x] =
+                weights4x8[c * 32 + (y / 2) * 8 + x];
+          }
+        }
+        weights[c * num + N] /= encoding.dct4x8multipliers[c];
+      }
+      break;
+    }
+    case QuantEncoding::kQuantModeDCT: {
+      JXL_RETURN_IF_ERROR(GetQuantWeights(
+          wrows, wcols, encoding.dct_params.distance_bands,
+          encoding.dct_params.num_distance_bands, weights.data()));
+      break;
+    }
+    case QuantEncoding::kQuantModeRAW: {
+      if (!encoding.qraw.qtable || encoding.qraw.qtable->size() != 3 * num) {
+        return JXL_FAILURE("Invalid table encoding");
+      }
+      for (size_t i = 0; i < 3 * num; i++) {
+        weights[i] =
+            1.f / (encoding.qraw.qtable_den * (*encoding.qraw.qtable)[i]);
+      }
+      break;
+    }
+    case QuantEncoding::kQuantModeAFV: {
+      constexpr float kFreqs[] = {
+          0xBAD,
+          0xBAD,
+          0.8517778890324296,
+          5.37778436506804,
+          0xBAD,
+          0xBAD,
+          4.734747904497923,
+          5.449245381693219,
+          1.6598270267479331,
+          4,
+          7.275749096817861,
+          10.423227632456525,
+          2.662932286148962,
+          7.630657783650829,
+          8.962388608184032,
+          12.97166202570235,
+      };
+
+      float weights4x8[3 * 4 * 8];
+      JXL_RETURN_IF_ERROR((
+          GetQuantWeights(4, 8, encoding.dct_params.distance_bands,
+                          encoding.dct_params.num_distance_bands, weights4x8)));
+      float weights4x4[3 * 4 * 4];
+      JXL_RETURN_IF_ERROR((GetQuantWeights(
+          4, 4, encoding.dct_params_afv_4x4.distance_bands,
+          encoding.dct_params_afv_4x4.num_distance_bands, weights4x4)));
+
+      constexpr float lo = 0.8517778890324296;
+      constexpr float hi = 12.97166202570235f - lo + 1e-6f;
+      for (size_t c = 0; c < 3; c++) {
+        float bands[4];
+        bands[0] = encoding.afv_weights[c][5];
+        if (bands[0] < kAlmostZero) return JXL_FAILURE("Invalid AFV bands");
+        for (size_t i = 1; i < 4; i++) {
+          bands[i] = bands[i - 1] * Mult(encoding.afv_weights[c][i + 5]);
+          if (bands[i] < kAlmostZero) return JXL_FAILURE("Invalid AFV bands");
+        }
+        size_t start = c * 64;
+        auto set_weight = [&start, &weights](size_t x, size_t y, float val) {
+          weights[start + y * 8 + x] = val;
+        };
+        weights[start] = 1;  // Not used, but causes MSAN error otherwise.
+        // Weights for (0, 1) and (1, 0).
+        set_weight(0, 1, encoding.afv_weights[c][0]);
+        set_weight(1, 0, encoding.afv_weights[c][1]);
+        // AFV special weights for 3-pixel corner.
+        set_weight(0, 2, encoding.afv_weights[c][2]);
+        set_weight(2, 0, encoding.afv_weights[c][3]);
+        set_weight(2, 2, encoding.afv_weights[c][4]);
+
+        // All other AFV weights.
+        for (size_t y = 0; y < 4; y++) {
+          for (size_t x = 0; x < 4; x++) {
+            if (x < 2 && y < 2) continue;
+            float val = Interpolate(kFreqs[y * 4 + x] - lo, hi, bands, 4);
+            set_weight(2 * x, 2 * y, val);
+          }
+        }
+
+        // Put 4x8 weights in odd rows, except (1, 0).
+        for (size_t y = 0; y < kBlockDim / 2; y++) {
+          for (size_t x = 0; x < kBlockDim; x++) {
+            if (x == 0 && y == 0) continue;
+            weights[c * num + (2 * y + 1) * kBlockDim + x] =
+                weights4x8[c * 32 + y * 8 + x];
+          }
+        }
+        // Put 4x4 weights in even rows / odd columns, except (0, 1).
+        for (size_t y = 0; y < kBlockDim / 2; y++) {
+          for (size_t x = 0; x < kBlockDim / 2; x++) {
+            if (x == 0 && y == 0) continue;
+            weights[c * num + (2 * y) * kBlockDim + 2 * x + 1] =
+                weights4x4[c * 16 + y * 4 + x];
+          }
+        }
+      }
+      break;
+    }
+  }
+  size_t prev_pos = *pos;
+  HWY_CAPPED(float, 64) d;
+  for (size_t i = 0; i < num * 3; i += Lanes(d)) {
+    auto inv_val = LoadU(d, weights.data() + i);
+    if (JXL_UNLIKELY(!AllFalse(inv_val >= Set(d, 1.0f / kAlmostZero)) |
+                     !AllFalse(inv_val < Set(d, kAlmostZero)))) {
+      return JXL_FAILURE("Invalid quantization table");
+    }
+    auto val = Set(d, 1.0f) / inv_val;
+    StoreU(val, d, table + *pos + i);
+    StoreU(inv_val, d, inv_table + *pos + i);
+  }
+  (*pos) += 3 * num;
+
+  // Ensure that the lowest frequencies have a 0 inverse table.
+  // This does not affect en/decoding, but allows AC strategy selection to be
+  // slightly simpler.
+  size_t xs = DequantMatrices::required_size_x[kind];
+  size_t ys = DequantMatrices::required_size_y[kind];
+  CoefficientLayout(&ys, &xs);
+  for (size_t c = 0; c < 3; c++) {
+    for (size_t y = 0; y < ys; y++) {
+      for (size_t x = 0; x < xs; x++) {
+        inv_table[prev_pos + c * ys * xs * kDCTBlockSize + y * kBlockDim * xs +
+                  x] = 0;
+      }
+    }
+  }
+  return true;
+}
+
+// NOLINTNEXTLINE(google-readability-namespace-comments)
+}  // namespace HWY_NAMESPACE
+}  // namespace jxl
+HWY_AFTER_NAMESPACE();
+
+#if HWY_ONCE
+
+namespace jxl {
+namespace {
+
+HWY_EXPORT(ComputeQuantTable);
+
+static constexpr const float kAlmostZero = 1e-8f;
 
 Status DecodeDctParams(BitReader* br, DctQuantWeightParams* params) {
   params->num_distance_bands =
@@ -250,200 +474,6 @@ Status Decode(BitReader* br, QuantEncoding* encoding, size_t required_size_x,
   return true;
 }
 
-// TODO(veluca): SIMD-fy. With 256x256, this is actually slow.
-Status ComputeQuantTable(const QuantEncoding& encoding,
-                         float* JXL_RESTRICT table,
-                         float* JXL_RESTRICT inv_table, size_t table_num,
-                         DequantMatrices::QuantTable kind, size_t* pos) {
-  std::vector<float> weights(3 * kMaxQuantTableSize);
-
-  constexpr size_t N = kBlockDim;
-  size_t wrows = 8 * DequantMatrices::required_size_x[kind],
-         wcols = 8 * DequantMatrices::required_size_y[kind];
-  size_t num = wrows * wcols;
-
-  switch (encoding.mode) {
-    case QuantEncoding::kQuantModeLibrary: {
-      // Library and copy quant encoding should get replaced by the actual
-      // parameters by the caller.
-      JXL_ASSERT(false);
-      break;
-    }
-    case QuantEncoding::kQuantModeID: {
-      JXL_ASSERT(num == kDCTBlockSize);
-      GetQuantWeightsIdentity(encoding.idweights, weights.data());
-      break;
-    }
-    case QuantEncoding::kQuantModeDCT2: {
-      JXL_ASSERT(num == kDCTBlockSize);
-      GetQuantWeightsDCT2(encoding.dct2weights, weights.data());
-      break;
-    }
-    case QuantEncoding::kQuantModeDCT4: {
-      JXL_ASSERT(num == kDCTBlockSize);
-      float weights4x4[3 * 4 * 4];
-      // Always use 4x4 GetQuantWeights for DCT4 quantization tables.
-      JXL_RETURN_IF_ERROR(
-          GetQuantWeights(4, 4, encoding.dct_params.distance_bands,
-                          encoding.dct_params.num_distance_bands, weights4x4));
-      for (size_t c = 0; c < 3; c++) {
-        for (size_t y = 0; y < kBlockDim; y++) {
-          for (size_t x = 0; x < kBlockDim; x++) {
-            weights[c * num + y * kBlockDim + x] =
-                weights4x4[c * 16 + (y / 2) * 4 + (x / 2)];
-          }
-        }
-        weights[c * num + 1] /= encoding.dct4multipliers[c][0];
-        weights[c * num + N] /= encoding.dct4multipliers[c][0];
-        weights[c * num + N + 1] /= encoding.dct4multipliers[c][1];
-      }
-      break;
-    }
-    case QuantEncoding::kQuantModeDCT4X8: {
-      JXL_ASSERT(num == kDCTBlockSize);
-      float weights4x8[3 * 4 * 8];
-      // Always use 4x8 GetQuantWeights for DCT4X8 quantization tables.
-      JXL_RETURN_IF_ERROR(
-          GetQuantWeights(4, 8, encoding.dct_params.distance_bands,
-                          encoding.dct_params.num_distance_bands, weights4x8));
-      for (size_t c = 0; c < 3; c++) {
-        for (size_t y = 0; y < kBlockDim; y++) {
-          for (size_t x = 0; x < kBlockDim; x++) {
-            weights[c * num + y * kBlockDim + x] =
-                weights4x8[c * 32 + (y / 2) * 8 + x];
-          }
-        }
-        weights[c * num + N] /= encoding.dct4x8multipliers[c];
-      }
-      break;
-    }
-    case QuantEncoding::kQuantModeDCT: {
-      JXL_RETURN_IF_ERROR(GetQuantWeights(
-          wrows, wcols, encoding.dct_params.distance_bands,
-          encoding.dct_params.num_distance_bands, weights.data()));
-      break;
-    }
-    case QuantEncoding::kQuantModeRAW: {
-      if (!encoding.qraw.qtable || encoding.qraw.qtable->size() != 3 * num) {
-        return JXL_FAILURE("Invalid table encoding");
-      }
-      for (size_t i = 0; i < 3 * num; i++) {
-        weights[i] =
-            1.f / (encoding.qraw.qtable_den * (*encoding.qraw.qtable)[i]);
-      }
-      break;
-    }
-    case QuantEncoding::kQuantModeAFV: {
-      constexpr float kFreqs[] = {
-          0xBAD,
-          0xBAD,
-          0.8517778890324296,
-          5.37778436506804,
-          0xBAD,
-          0xBAD,
-          4.734747904497923,
-          5.449245381693219,
-          1.6598270267479331,
-          4,
-          7.275749096817861,
-          10.423227632456525,
-          2.662932286148962,
-          7.630657783650829,
-          8.962388608184032,
-          12.97166202570235,
-      };
-
-      float weights4x8[3 * 4 * 8];
-      JXL_RETURN_IF_ERROR((
-          GetQuantWeights(4, 8, encoding.dct_params.distance_bands,
-                          encoding.dct_params.num_distance_bands, weights4x8)));
-      float weights4x4[3 * 4 * 4];
-      JXL_RETURN_IF_ERROR((GetQuantWeights(
-          4, 4, encoding.dct_params_afv_4x4.distance_bands,
-          encoding.dct_params_afv_4x4.num_distance_bands, weights4x4)));
-
-      constexpr float lo = 0.8517778890324296;
-      constexpr float hi = 12.97166202570235 - lo + 1e-6;
-      for (size_t c = 0; c < 3; c++) {
-        float bands[4];
-        bands[0] = encoding.afv_weights[c][5];
-        if (bands[0] < kAlmostZero) return JXL_FAILURE("Invalid AFV bands");
-        for (size_t i = 1; i < 4; i++) {
-          bands[i] = bands[i - 1] * Mult(encoding.afv_weights[c][i + 5]);
-          if (bands[i] < kAlmostZero) return JXL_FAILURE("Invalid AFV bands");
-        }
-        size_t start = c * 64;
-        auto set_weight = [&start, &weights](size_t x, size_t y, float val) {
-          weights[start + y * 8 + x] = val;
-        };
-        weights[start] = 1;  // Not used, but causes MSAN error otherwise.
-        // Weights for (0, 1) and (1, 0).
-        set_weight(0, 1, encoding.afv_weights[c][0]);
-        set_weight(1, 0, encoding.afv_weights[c][1]);
-        // AFV special weights for 3-pixel corner.
-        set_weight(0, 2, encoding.afv_weights[c][2]);
-        set_weight(2, 0, encoding.afv_weights[c][3]);
-        set_weight(2, 2, encoding.afv_weights[c][4]);
-
-        // All other AFV weights.
-        for (size_t y = 0; y < 4; y++) {
-          for (size_t x = 0; x < 4; x++) {
-            if (x < 2 && y < 2) continue;
-            float val = Interpolate(kFreqs[y * 4 + x] - lo, hi, bands, 4);
-            set_weight(2 * x, 2 * y, val);
-          }
-        }
-
-        // Put 4x8 weights in odd rows, except (1, 0).
-        for (size_t y = 0; y < kBlockDim / 2; y++) {
-          for (size_t x = 0; x < kBlockDim; x++) {
-            if (x == 0 && y == 0) continue;
-            weights[c * num + (2 * y + 1) * kBlockDim + x] =
-                weights4x8[c * 32 + y * 8 + x];
-          }
-        }
-        // Put 4x4 weights in even rows / odd columns, except (0, 1).
-        for (size_t y = 0; y < kBlockDim / 2; y++) {
-          for (size_t x = 0; x < kBlockDim / 2; x++) {
-            if (x == 0 && y == 0) continue;
-            weights[c * num + (2 * y) * kBlockDim + 2 * x + 1] =
-                weights4x4[c * 16 + y * 4 + x];
-          }
-        }
-      }
-      break;
-    }
-  }
-  size_t prev_pos = *pos;
-  for (size_t c = 0; c < 3; c++) {
-    for (size_t i = 0; i < num; i++) {
-      float inv_val = weights[c * num + i];
-      if (inv_val > 1.0f / kAlmostZero || inv_val < kAlmostZero) {
-        return JXL_FAILURE("Invalid quantization table");
-      }
-      float val = 1.0f / inv_val;
-      table[*pos] = val;
-      inv_table[*pos] = inv_val;
-      (*pos)++;
-    }
-  }
-  // Ensure that the lowest frequencies have a 0 inverse table.
-  // This does not affect en/decoding, but allows AC strategy selection to be
-  // slightly simpler.
-  size_t xs = DequantMatrices::required_size_x[kind];
-  size_t ys = DequantMatrices::required_size_y[kind];
-  CoefficientLayout(&ys, &xs);
-  for (size_t c = 0; c < 3; c++) {
-    for (size_t y = 0; y < ys; y++) {
-      for (size_t x = 0; x < xs; x++) {
-        inv_table[prev_pos + c * ys * xs * kDCTBlockSize + y * kBlockDim * xs +
-                  x] = 0;
-      }
-    }
-  }
-  return true;
-}
-
 }  // namespace
 
 // These definitions are needed before C++17.
@@ -463,7 +493,8 @@ Status DequantMatrices::Decode(BitReader* br,
         jxl::Decode(br, &encodings_[i], required_size_x[i % kNum],
                     required_size_y[i % kNum], i, modular_frame_decoder));
   }
-  return DequantMatrices::Compute();
+  computed_mask_ = 0;
+  return true;
 }
 
 Status DequantMatrices::DecodeDC(BitReader* br) {
@@ -1126,61 +1157,78 @@ const QuantEncoding* DequantMatrices::Library() {
   return reinterpret_cast<const QuantEncoding*>(kDequantLibrary.data());
 }
 
-Status DequantMatrices::Compute() {
+DequantMatrices::DequantMatrices() {
+  encodings_.resize(size_t(QuantTable::kNum), QuantEncoding::Library(0));
   size_t pos = 0;
-
-  struct DefaultMatrices {
-    DefaultMatrices() {
-      const QuantEncoding* library = Library();
-      size_t pos = 0;
-      for (size_t i = 0; i < kNum; i++) {
-        JXL_CHECK(ComputeQuantTable(library[i], table, inv_table, i,
-                                    QuantTable(i), &pos));
-      }
-      JXL_CHECK(pos == kTotalTableSize);
+  size_t offsets[kNum * 3];
+  for (size_t i = 0; i < size_t(QuantTable::kNum); i++) {
+    size_t num = required_size_[i] * kDCTBlockSize;
+    for (size_t c = 0; c < 3; c++) {
+      offsets[3 * i + c] = pos + c * num;
     }
-    HWY_ALIGN_MAX float table[kTotalTableSize];
-    HWY_ALIGN_MAX float inv_table[kTotalTableSize];
-  };
-
-  static const DefaultMatrices& default_matrices =
-      *hwy::MakeUniqueAligned<DefaultMatrices>().release();
-
-  JXL_ASSERT(encodings_.size() == kNum);
-
-  bool has_nondefault_matrix = false;
-  for (const auto& enc : encodings_) {
-    if (enc.mode != QuantEncoding::kQuantModeLibrary) {
-      has_nondefault_matrix = true;
+    pos += 3 * num;
+  }
+  for (size_t i = 0; i < AcStrategy::kNumValidStrategies; i++) {
+    for (size_t c = 0; c < 3; c++) {
+      table_offsets_[i * 3 + c] = offsets[kQuantTable[i] * 3 + c];
     }
   }
-  if (has_nondefault_matrix) {
+}
+
+Status DequantMatrices::EnsureComputed(uint32_t acs_mask) {
+  const QuantEncoding* library = Library();
+
+  if (!table_storage_) {
     table_storage_ = hwy::AllocateAligned<float>(2 * kTotalTableSize);
     table_ = table_storage_.get();
     inv_table_ = table_storage_.get() + kTotalTableSize;
-    for (size_t table = 0; table < kNum; table++) {
-      size_t prev_pos = pos;
-      if (encodings_[table].mode == QuantEncoding::kQuantModeLibrary) {
-        size_t num = required_size_[table] * kDCTBlockSize;
-        memcpy(table_storage_.get() + prev_pos,
-               default_matrices.table + prev_pos, num * sizeof(float) * 3);
-        memcpy(table_storage_.get() + kTotalTableSize + prev_pos,
-               default_matrices.inv_table + prev_pos, num * sizeof(float) * 3);
-        pos += num * 3;
-      } else {
-        JXL_RETURN_IF_ERROR(
-            ComputeQuantTable(encodings_[table], table_storage_.get(),
-                              table_storage_.get() + kTotalTableSize, table,
-                              QuantTable(table), &pos));
-      }
-    }
-    JXL_ASSERT(pos == kTotalTableSize);
-  } else {
-    table_ = default_matrices.table;
-    inv_table_ = default_matrices.inv_table;
   }
+
+  size_t offsets[kNum * 3 + 1];
+  size_t pos = 0;
+  for (size_t i = 0; i < kNum; i++) {
+    size_t num = required_size_[i] * kDCTBlockSize;
+    for (size_t c = 0; c < 3; c++) {
+      offsets[3 * i + c] = pos + c * num;
+    }
+    pos += 3 * num;
+  }
+  offsets[kNum * 3] = pos;
+  JXL_ASSERT(pos == kTotalTableSize);
+
+  uint32_t kind_mask = 0;
+  for (size_t i = 0; i < AcStrategy::kNumValidStrategies; i++) {
+    if (acs_mask & (1u << i)) {
+      kind_mask |= 1u << kQuantTable[i];
+    }
+  }
+  uint32_t computed_kind_mask = 0;
+  for (size_t i = 0; i < AcStrategy::kNumValidStrategies; i++) {
+    if (computed_mask_ & (1u << i)) {
+      computed_kind_mask |= 1u << kQuantTable[i];
+    }
+  }
+  for (size_t table = 0; table < kNum; table++) {
+    if ((1 << table) & computed_kind_mask) continue;
+    if ((1 << table) & ~kind_mask) continue;
+    size_t pos = offsets[table * 3];
+    if (encodings_[table].mode == QuantEncoding::kQuantModeLibrary) {
+      JXL_CHECK(HWY_DYNAMIC_DISPATCH(ComputeQuantTable)(
+          library[table], table_storage_.get(),
+          table_storage_.get() + kTotalTableSize, table, QuantTable(table),
+          &pos));
+    } else {
+      JXL_RETURN_IF_ERROR(HWY_DYNAMIC_DISPATCH(ComputeQuantTable)(
+          encodings_[table], table_storage_.get(),
+          table_storage_.get() + kTotalTableSize, table, QuantTable(table),
+          &pos));
+    }
+    JXL_ASSERT(pos == offsets[table * 3 + 3]);
+  }
+  computed_mask_ |= acs_mask;
 
   return true;
 }
 
 }  // namespace jxl
+#endif

--- a/lib/jxl/quant_weights_test.cc
+++ b/lib/jxl/quant_weights_test.cc
@@ -173,6 +173,7 @@ TEST_P(QuantWeightsTargetTest, DCTUniform) {
   FrameHeader frame_header(&metadata);
   ModularFrameEncoder encoder(frame_header, CompressParams{});
   DequantMatricesSetCustom(&dequant_matrices, encodings, &encoder);
+  JXL_CHECK(dequant_matrices.EnsureComputed(~0u));
 
   const float dc_quant[3] = {1.0f / kUniformQuant, 1.0f / kUniformQuant,
                              1.0f / kUniformQuant};

--- a/lib/jxl/quantizer.h
+++ b/lib/jxl/quantizer.h
@@ -123,10 +123,6 @@ class Quantizer {
     return dequant_->InvMatrix(quant_kind, c);
   }
 
-  JXL_INLINE size_t DequantMatrixOffset(size_t quant_kind, size_t c) const {
-    return dequant_->MatrixOffset(quant_kind, c);
-  }
-
   // Calculates DC quantization step.
   JXL_INLINE float GetDcStep(size_t c) const {
     return inv_quant_dc_ * dequant_->DCQuant(c);


### PR DESCRIPTION
This saves ~3Mb of static memory. Speed impact with multiple repetitions
is negligible, significant speed improvement for one-off decodes.

Slight variation in 6th digit of en/decoding results due to more
approximate quant matrix computation.

```
Before:
Encoding      kPixels    Bytes          BPP  E MP/s  D MP/s     Max norm        pnorm       BPP*pnorm   Bugs
------------------------------------------------------------------------------------------------------------
jxl:d0.7        13270  3400483    2.0499581   5.466  47.067   1.50473666   0.47348297  0.970620226409      0
jxl:d1          13270  2678725    1.6148512   5.750  50.382   1.68153656   0.60257544  0.973069654737      0
jxl:d2          13270  1683788    1.0150602   6.102  53.015   3.00312042   0.95243347  0.966777268691      0
jxl:d4          13270  1004956    0.6058309   5.979  37.066   4.85261440   1.50554379  0.912104941537      0
jxl:d6          13270   718865    0.4333629   5.772  36.305   7.34840679   1.97809701  0.857233817426      0
jxl:d8          13270   576902    0.3477815   5.852  35.697   8.16245556   2.36179685  0.821389132427      0
Aggregate:      13270  1362308    0.8212584   5.817  42.674   3.60956523   1.11400975  0.914889813753      0

2268 x 1512, geomean: 90.43 MP/s [54.13, 91.49], 100 reps, 0 threads.
2268 x 1512, 56.57 MP/s [56.57, 56.57], 1 reps, 0 threads.

444 x 258, geomean: 62.33 MP/s [6.49, 63.54], 100 reps, 0 threads.
444 x 258, 7.06 MP/s [7.06, 7.06], 1 reps, 0 threads.

After:
Encoding      kPixels    Bytes          BPP  E MP/s  D MP/s     Max norm        pnorm       BPP*pnorm   Bugs
------------------------------------------------------------------------------------------------------------
jxl:d0.7        13270  3400473    2.0499520   5.424  46.559   1.50473595   0.47348321  0.970617862124      0
jxl:d1          13270  2678723    1.6148500   5.710  49.788   1.68153679   0.60257545  0.973068940575      0
jxl:d2          13270  1683788    1.0150602   6.064  52.348   3.00312042   0.95243348  0.966777275451      0
jxl:d4          13270  1004957    0.6058315   5.942  36.558   4.85261631   1.50554828  0.912108572859      0
jxl:d6          13270   718865    0.4333629   5.736  35.850   7.34841013   1.97809768  0.857234107317      0
jxl:d8          13270   576891    0.3477748   5.811  35.189   8.16245461   2.36179583  0.821373116628      0
Aggregate:      13270  1362303    0.8212554   5.777  42.136   3.60956547   1.11401039  0.914887016940      0

2268 x 1512, geomean: 90.40 MP/s [71.12, 91.11], 100 reps, 0 threads.
2268 x 1512, 68.69 MP/s [68.69, 68.69], 1 reps, 0 threads.

444 x 258, geomean: 63.93 MP/s [37.00, 64.71], 100 reps, 0 threads.
444 x 258, 37.56 MP/s [37.56, 37.56], 1 reps, 0 threads.
```