### PR TITLE
Faster unsqueeze / lossy modular

### DIFF
--- a/lib/jxl/modular/transform/squeeze.cc
+++ b/lib/jxl/modular/transform/squeeze.cc
@@ -12,13 +12,79 @@
 #include "lib/jxl/common.h"
 #include "lib/jxl/modular/modular_image.h"
 #include "lib/jxl/modular/transform/transform.h"
+#undef HWY_TARGET_INCLUDE
+#define HWY_TARGET_INCLUDE "lib/jxl/modular/transform/squeeze.cc"
+#include <hwy/foreach_target.h>
+#include <hwy/highway.h>
 
+#include "lib/jxl/simd_util-inl.h"
+
+HWY_BEFORE_NAMESPACE();
 namespace jxl {
+namespace HWY_NAMESPACE {
+
+using hwy::HWY_NAMESPACE::ShiftLeft;
+using hwy::HWY_NAMESPACE::ShiftRight;
+
+#if HWY_TARGET != HWY_SCALAR
+
+JXL_INLINE void FastUnsqueeze(const pixel_type *JXL_RESTRICT p_residual,
+                              const pixel_type *JXL_RESTRICT p_avg,
+                              const pixel_type *JXL_RESTRICT p_navg,
+                              const pixel_type *p_pout,
+                              pixel_type *JXL_RESTRICT p_out,
+                              pixel_type *p_nout) {
+  const HWY_CAPPED(pixel_type, 8) d;
+  const size_t N = Lanes(d);
+  auto onethird = Set(d, 0x55555556);
+  for (size_t x = 0; x < 8; x += N) {
+    auto avg = Load(d, p_avg + x);
+    auto next_avg = Load(d, p_navg + x);
+    auto top = Load(d, p_pout + x);
+    // Equivalent to SmoothTendency(top,avg,next_avg), but without branches
+    auto Ba = top - avg;
+    auto an = avg - next_avg;
+    auto nonmono = Ba ^ an;
+    auto absBa = Abs(Ba);
+    auto absan = Abs(an);
+    auto absBn = Abs(top - next_avg);
+    // Compute a3 = absBa / 3
+    auto a3e = BitCast(d, ShiftRight<32>(MulEven(absBa, onethird)));
+    auto a3oi = MulEven(Reverse(d, absBa), onethird);
+    auto a3o = BitCast(
+        d, Reverse(hwy::HWY_NAMESPACE::Repartition<pixel_type_w, decltype(d)>(),
+                   a3oi));
+    auto a3 = OddEven(a3o, a3e);
+    a3 += absBn + Set(d, 2);
+    auto absdiff = ShiftRight<2>(a3);
+    auto skipdiff = Ba != Zero(d);
+    skipdiff = And(skipdiff, an != Zero(d));
+    skipdiff = And(skipdiff, nonmono < Zero(d));
+    auto absBa2 = ShiftLeft<1>(absBa) + (absdiff & Set(d, 1));
+    absdiff =
+        IfThenElse(absdiff > absBa2, ShiftLeft<1>(absBa) + Set(d, 1), absdiff);
+    auto absan2 = ShiftLeft<1>(absan);
+    absdiff =
+        IfThenElse(absdiff + (absdiff & Set(d, 1)) > absan2, absan2, absdiff);
+    auto diff1 = IfThenElse(top < next_avg, Neg(absdiff), absdiff);
+    auto tendency = IfThenZeroElse(skipdiff, diff1);
+
+    auto diff_minus_tendency = Load(d, p_residual + x);
+    auto diff = diff_minus_tendency + tendency;
+    auto out = ShiftRight<1>(
+        ShiftLeft<1>(avg) + diff +
+        IfThenElse(diff < Zero(d), (diff & Set(d, 1)), Neg(diff & Set(d, 1))));
+    Store(out, d, p_out + x);
+    Store(out - diff, d, p_nout + x);
+  }
+}
+
+#endif
 
 Status InvHSqueeze(Image &input, uint32_t c, uint32_t rc, ThreadPool *pool) {
   JXL_ASSERT(c < input.channel.size());
   JXL_ASSERT(rc < input.channel.size());
-  const Channel &chin = input.channel[c];
+  Channel &chin = input.channel[c];
   const Channel &chin_residual = input.channel[rc];
   // These must be valid since we ran MetaApply already.
   JXL_ASSERT(chin.w == DivCeil(chin.w + chin_residual.w, 2));
@@ -42,40 +108,84 @@ Status InvHSqueeze(Image &input, uint32_t c, uint32_t rc, ThreadPool *pool) {
     input.channel[c] = std::move(chout);
     return true;
   }
+  auto unsqueeze_row = [&](size_t y, size_t x0) {
+    const pixel_type *JXL_RESTRICT p_residual = chin_residual.Row(y);
+    const pixel_type *JXL_RESTRICT p_avg = chin.Row(y);
+    pixel_type *JXL_RESTRICT p_out = chout.Row(y);
+    for (size_t x = x0; x < chin_residual.w; x++) {
+      pixel_type diff_minus_tendency = p_residual[x];
+      pixel_type avg = p_avg[x];
+      pixel_type next_avg = (x + 1 < chin.w ? p_avg[x + 1] : avg);
+      pixel_type left = (x ? p_out[(x << 1) - 1] : avg);
+      pixel_type tendency = SmoothTendency(left, avg, next_avg);
+      pixel_type diff = diff_minus_tendency + tendency;
+      pixel_type A =
+          ((avg * 2) + diff + (diff > 0 ? -(diff & 1) : (diff & 1))) >> 1;
+      p_out[(x << 1)] = A;
+      pixel_type B = A - diff;
+      p_out[(x << 1) + 1] = B;
+    }
+    if (chout.w & 1) p_out[chout.w - 1] = p_avg[chin.w - 1];
+  };
 
+  // somewhat complicated trickery just to be able to SIMD this.
+  // Horizontal unsqueeze has horizontal data dependencies, so we do
+  // 8 rows at a time and treat it as a vertical unsqueeze of a
+  // transposed 8x8 block (or 9x8 for one input).
+  constexpr size_t kRowsPerThread = 8;
   JXL_RETURN_IF_ERROR(RunOnPool(
-      pool, 0, chin.h, ThreadPool::NoInit,
+      pool, 0, DivCeil(chin.h, kRowsPerThread), ThreadPool::NoInit,
       [&](const uint32_t task, size_t /* thread */) {
-        const size_t y = task;
-        const pixel_type *JXL_RESTRICT p_residual = chin_residual.Row(y);
-        const pixel_type *JXL_RESTRICT p_avg = chin.Row(y);
-        pixel_type *JXL_RESTRICT p_out = chout.Row(y);
+        const size_t y0 = task * kRowsPerThread;
+        const size_t rows = std::min(kRowsPerThread, chin.h - y0);
+        size_t x = 0;
 
-        // special case for x=0 so we don't have to check x>0
-        pixel_type_w avg = p_avg[0];
-        pixel_type_w next_avg = (1 < chin.w ? p_avg[1] : avg);
-        pixel_type_w tendency = SmoothTendency(avg, avg, next_avg);
-        pixel_type_w diff = p_residual[0] + tendency;
-        pixel_type_w A =
-            ((avg * 2) + diff + (diff > 0 ? -(diff & 1) : (diff & 1))) >> 1;
-        pixel_type_w B = A - diff;
-        p_out[0] = A;
-        p_out[1] = B;
+#if HWY_TARGET != HWY_SCALAR
+        intptr_t onerow_in = chin.plane.PixelsPerRow();
+        intptr_t onerow_inr = chin_residual.plane.PixelsPerRow();
+        intptr_t onerow_out = chout.plane.PixelsPerRow();
+        const pixel_type *JXL_RESTRICT p_residual = chin_residual.Row(y0);
+        const pixel_type *JXL_RESTRICT p_avg = chin.Row(y0);
+        pixel_type *JXL_RESTRICT p_out = chout.Row(y0);
+        HWY_ALIGN pixel_type b_p_avg[9 * kRowsPerThread];
+        HWY_ALIGN pixel_type b_p_residual[8 * kRowsPerThread];
+        HWY_ALIGN pixel_type b_p_out_even[8 * kRowsPerThread];
+        HWY_ALIGN pixel_type b_p_out_odd[8 * kRowsPerThread];
+        HWY_ALIGN pixel_type b_p_out_evenT[8 * kRowsPerThread];
+        HWY_ALIGN pixel_type b_p_out_oddT[8 * kRowsPerThread];
+        const HWY_CAPPED(pixel_type, 8) d;
+        const size_t N = Lanes(d);
+        if (chin_residual.w > 16 && rows == kRowsPerThread) {
+          for (; x < chin_residual.w - 9; x += 8) {
+            Transpose8x8Block(p_residual + x, b_p_residual, onerow_inr);
+            Transpose8x8Block(p_avg + x, b_p_avg, onerow_in);
+            for (size_t y = 0; y < kRowsPerThread; y++) {
+              b_p_avg[8 * 8 + y] = p_avg[x + 8 + onerow_in * y];
+            }
+            for (size_t i = 0; i < 8; i++) {
+              FastUnsqueeze(b_p_residual + 8 * i, b_p_avg + 8 * i,
+                            b_p_avg + 8 * (i + 1),
+                            (x + i ? b_p_out_odd + 8 * ((x + i - 1) & 7)
+                                   : b_p_avg + 8 * i),
+                            b_p_out_even + 8 * i, b_p_out_odd + 8 * i);
+            }
 
-        for (size_t x = 1; x < chin_residual.w; x++) {
-          pixel_type_w diff_minus_tendency = p_residual[x];
-          pixel_type_w avg = p_avg[x];
-          pixel_type_w next_avg = (x + 1 < chin.w ? p_avg[x + 1] : avg);
-          pixel_type_w left = p_out[(x << 1) - 1];
-          pixel_type_w tendency = SmoothTendency(left, avg, next_avg);
-          pixel_type_w diff = diff_minus_tendency + tendency;
-          pixel_type_w A =
-              ((avg * 2) + diff + (diff > 0 ? -(diff & 1) : (diff & 1))) >> 1;
-          p_out[x << 1] = A;
-          pixel_type_w B = A - diff;
-          p_out[(x << 1) + 1] = B;
+            Transpose8x8Block(b_p_out_even, b_p_out_evenT, 8);
+            Transpose8x8Block(b_p_out_odd, b_p_out_oddT, 8);
+            for (size_t y = 0; y < kRowsPerThread; y++) {
+              for (size_t i = 0; i < kRowsPerThread; i += N) {
+                auto even = Load(d, b_p_out_evenT + 8 * y + i);
+                auto odd = Load(d, b_p_out_oddT + 8 * y + i);
+                StoreInterleaved(d, even, odd,
+                                 p_out + ((x + i) << 1) + onerow_out * y);
+              }
+            }
+          }
         }
-        if (chout.w & 1) p_out[chout.w - 1] = p_avg[chin.w - 1];
+#endif
+        for (size_t y = 0; y < rows; y++) {
+          unsqueeze_row(y0 + y, x);
+        }
       },
       "InvHorizontalSqueeze"));
   input.channel[c] = std::move(chout);
@@ -111,38 +221,46 @@ Status InvVSqueeze(Image &input, uint32_t c, uint32_t rc, ThreadPool *pool) {
     return true;
   }
 
-  intptr_t onerow_in = chin.plane.PixelsPerRow();
-  intptr_t onerow_out = chout.plane.PixelsPerRow();
   constexpr int kColsPerThread = 64;
   JXL_RETURN_IF_ERROR(RunOnPool(
       pool, 0, DivCeil(chin.w, kColsPerThread), ThreadPool::NoInit,
       [&](const uint32_t task, size_t /* thread */) {
         const size_t x0 = task * kColsPerThread;
         const size_t x1 = std::min((size_t)(task + 1) * kColsPerThread, chin.w);
+        const size_t w = x1 - x0;
         // We only iterate up to std::min(chin_residual.h, chin.h) which is
         // always chin_residual.h.
         for (size_t y = 0; y < chin_residual.h; y++) {
-          const pixel_type *JXL_RESTRICT p_residual = chin_residual.Row(y);
-          const pixel_type *JXL_RESTRICT p_avg = chin.Row(y);
-          pixel_type *JXL_RESTRICT p_out = chout.Row(y << 1);
-          for (size_t x = x0; x < x1; x++) {
-            pixel_type_w diff_minus_tendency = p_residual[x];
-            pixel_type_w avg = p_avg[x];
-
-            pixel_type_w next_avg = avg;
-            if (y + 1 < chin.h) next_avg = p_avg[x + onerow_in];
-            pixel_type_w top =
-                (y > 0 ? p_out[static_cast<ssize_t>(x) - onerow_out] : avg);
-            pixel_type_w tendency = SmoothTendency(top, avg, next_avg);
-            pixel_type_w diff = diff_minus_tendency + tendency;
-            pixel_type_w out =
-                ((avg * 2) + diff + (diff > 0 ? -(diff & 1) : (diff & 1))) >> 1;
+          const pixel_type *JXL_RESTRICT p_residual = chin_residual.Row(y) + x0;
+          const pixel_type *JXL_RESTRICT p_avg = chin.Row(y) + x0;
+          const pixel_type *JXL_RESTRICT p_navg =
+              chin.Row(y + 1 < chin.h ? y + 1 : y) + x0;
+          pixel_type *JXL_RESTRICT p_out = chout.Row(y << 1) + x0;
+          pixel_type *JXL_RESTRICT p_nout = chout.Row((y << 1) + 1) + x0;
+          const pixel_type *p_pout =
+              y > 0 ? chout.Row((y << 1) - 1) + x0 : p_avg;
+          size_t x = 0;
+#if HWY_TARGET != HWY_SCALAR
+          for (; x + 7 < w; x += 8) {
+            FastUnsqueeze(p_residual + x, p_avg + x, p_navg + x, p_pout + x,
+                          p_out + x, p_nout + x);
+          }
+#endif
+          for (; x < w; x++) {
+            pixel_type avg = p_avg[x];
+            pixel_type next_avg = p_navg[x];
+            pixel_type top = p_pout[x];
+            pixel_type tendency = SmoothTendency(top, avg, next_avg);
+            pixel_type diff_minus_tendency = p_residual[x];
+            pixel_type diff = diff_minus_tendency + tendency;
+            pixel_type out =
+                ((avg * 2) + diff + (diff < 0 ? (diff & 1) : -(diff & 1))) >> 1;
 
             p_out[x] = out;
             // If the chin_residual.h == chin.h, the output has an even number
             // of rows so the next line is fine. Otherwise, this loop won't
             // write to the last output row which is handled separately.
-            p_out[x + onerow_out] = p_out[x] - diff;
+            p_nout[x] = out - diff;
           }
         }
       },
@@ -158,6 +276,62 @@ Status InvVSqueeze(Image &input, uint32_t c, uint32_t rc, ThreadPool *pool) {
   }
   input.channel[c] = std::move(chout);
   return true;
+}
+
+Status InvSqueeze(Image &input, std::vector<SqueezeParams> parameters,
+                  ThreadPool *pool) {
+  for (int i = parameters.size() - 1; i >= 0; i--) {
+    JXL_RETURN_IF_ERROR(
+        CheckMetaSqueezeParams(parameters[i], input.channel.size()));
+    bool horizontal = parameters[i].horizontal;
+    bool in_place = parameters[i].in_place;
+    uint32_t beginc = parameters[i].begin_c;
+    uint32_t endc = parameters[i].begin_c + parameters[i].num_c - 1;
+    uint32_t offset;
+    if (in_place) {
+      offset = endc + 1;
+    } else {
+      offset = input.channel.size() + beginc - endc - 1;
+    }
+    if (beginc < input.nb_meta_channels) {
+      // This is checked in MetaSqueeze.
+      JXL_ASSERT(input.nb_meta_channels > parameters[i].num_c);
+      input.nb_meta_channels -= parameters[i].num_c;
+    }
+
+    for (uint32_t c = beginc; c <= endc; c++) {
+      uint32_t rc = offset + c - beginc;
+      // MetaApply should imply that `rc` is within range, otherwise there's a
+      // programming bug.
+      JXL_ASSERT(rc < input.channel.size());
+      if ((input.channel[c].w < input.channel[rc].w) ||
+          (input.channel[c].h < input.channel[rc].h)) {
+        return JXL_FAILURE("Corrupted squeeze transform");
+      }
+      if (horizontal) {
+        JXL_RETURN_IF_ERROR(InvHSqueeze(input, c, rc, pool));
+      } else {
+        JXL_RETURN_IF_ERROR(InvVSqueeze(input, c, rc, pool));
+      }
+    }
+    input.channel.erase(input.channel.begin() + offset,
+                        input.channel.begin() + offset + (endc - beginc + 1));
+  }
+  return true;
+}
+
+}  // namespace HWY_NAMESPACE
+}  // namespace jxl
+HWY_AFTER_NAMESPACE();
+
+#if HWY_ONCE
+
+namespace jxl {
+
+HWY_EXPORT(InvSqueeze);
+Status InvSqueeze(Image &input, std::vector<SqueezeParams> parameters,
+                  ThreadPool *pool) {
+  return HWY_DYNAMIC_DISPATCH(InvSqueeze)(input, parameters, pool);
 }
 
 void DefaultSqueezeParameters(std::vector<SqueezeParams> *parameters,
@@ -285,46 +459,6 @@ Status MetaSqueeze(Image &image, std::vector<SqueezeParams> *parameters) {
   return true;
 }
 
-Status InvSqueeze(Image &input, std::vector<SqueezeParams> parameters,
-                  ThreadPool *pool) {
-  for (int i = parameters.size() - 1; i >= 0; i--) {
-    JXL_RETURN_IF_ERROR(
-        CheckMetaSqueezeParams(parameters[i], input.channel.size()));
-    bool horizontal = parameters[i].horizontal;
-    bool in_place = parameters[i].in_place;
-    uint32_t beginc = parameters[i].begin_c;
-    uint32_t endc = parameters[i].begin_c + parameters[i].num_c - 1;
-    uint32_t offset;
-    if (in_place) {
-      offset = endc + 1;
-    } else {
-      offset = input.channel.size() + beginc - endc - 1;
-    }
-    if (beginc < input.nb_meta_channels) {
-      // This is checked in MetaSqueeze.
-      JXL_ASSERT(input.nb_meta_channels > parameters[i].num_c);
-      input.nb_meta_channels -= parameters[i].num_c;
-    }
-
-    for (uint32_t c = beginc; c <= endc; c++) {
-      uint32_t rc = offset + c - beginc;
-      // MetaApply should imply that `rc` is within range, otherwise there's a
-      // programming bug.
-      JXL_ASSERT(rc < input.channel.size());
-      if ((input.channel[c].w < input.channel[rc].w) ||
-          (input.channel[c].h < input.channel[rc].h)) {
-        return JXL_FAILURE("Corrupted squeeze transform");
-      }
-      if (horizontal) {
-        JXL_RETURN_IF_ERROR(InvHSqueeze(input, c, rc, pool));
-      } else {
-        JXL_RETURN_IF_ERROR(InvVSqueeze(input, c, rc, pool));
-      }
-    }
-    input.channel.erase(input.channel.begin() + offset,
-                        input.channel.begin() + offset + (endc - beginc + 1));
-  }
-  return true;
-}
-
 }  // namespace jxl
+
+#endif

--- a/lib/jxl/modular/transform/squeeze.h
+++ b/lib/jxl/modular/transform/squeeze.h
@@ -75,10 +75,6 @@ inline pixel_type_w SmoothTendency(pixel_type_w B, pixel_type_w a,
   return diff;
 }
 
-void InvHSqueeze(Image &input, int c, int rc, ThreadPool *pool);
-
-void InvVSqueeze(Image &input, int c, int rc, ThreadPool *pool);
-
 void DefaultSqueezeParameters(std::vector<SqueezeParams> *parameters,
                               const Image &image);
 


### PR DESCRIPTION
Some more specialization for the slower modular decode paths.

~~Vectorizeable unsqueeze.
Alas, my clang (12.0.1) requires a `pragma` to be convinced to vectorize the inner loop. Not sure how to proceed with that...~~

SIMDified unsqueeze.

Good decode speedup for images where this applies (lossy modular, lossless progressive modular, also should help a little for DC frames and VarDCT mode alpha channels).

Decoding a lossy modular image (produced with cjxl -m -q 80 -e 2), with AVX2:

Before:
2749 x 4049, geomean: 9.90 MP/s [8.67, 10.66], 10 reps, 0 threads.
2749 x 4049, geomean: 18.35 MP/s [15.42, 18.81], 10 reps, 2 threads.
2749 x 4049, geomean: 29.92 MP/s [23.30, 31.61], 10 reps, 4 threads.

After:
~~2749 x 4049, geomean: 14.94 MP/s [12.36, 15.50], 10 reps, 0 threads.
2749 x 4049, geomean: 26.91 MP/s [20.13, 28.25], 10 reps, 2 threads.
2749 x 4049, geomean: 39.48 MP/s [28.23, 40.84], 10 reps, 4 threads.~~

2749 x 4049, geomean: 17.56 MP/s [14.44, 17.95], 10 reps, 0 threads.
2749 x 4049, geomean: 31.24 MP/s [26.89, 32.48], 10 reps, 2 threads.
2749 x 4049, geomean: 46.14 MP/s [38.19, 50.40], 10 reps, 4 threads.
