### PR TITLE
Replace usage of __MACH__ with __APPLE__

### DIFF
--- a/lib/jxl/base/os_macros.h
+++ b/lib/jxl/base/os_macros.h
@@ -20,7 +20,7 @@
 #define JXL_OS_LINUX 0
 #endif
 
-#ifdef __MACH__
+#ifdef __APPLE__
 #define JXL_OS_MAC 1
 #else
 #define JXL_OS_MAC 0

--- a/lib/profiler/tsc_timer.h
+++ b/lib/profiler/tsc_timer.h
@@ -24,7 +24,7 @@
 #undef LoadFence
 #endif
 
-#if defined(__MACH__)
+#if defined(__APPLE__)
 #include <mach/mach.h>
 #include <mach/mach_time.h>
 #endif
@@ -122,7 +122,7 @@ static HWY_INLINE HWY_MAYBE_UNUSED Ticks TicksBefore() {
   LARGE_INTEGER counter;
   (void)QueryPerformanceCounter(&counter);
   t = counter.QuadPart;
-#elif defined(__MACH__)
+#elif defined(__APPLE__)
   t = mach_absolute_time();
 #elif defined(__HAIKU__)
   t = system_time_nsecs();  // since boot


### PR DESCRIPTION
It turns out that __MACH__ macro refer to the Mach kernel, which is also
used for GNU/Hurd. Prefer usage of macro __APPLE__ in this case.

This should solve the following compilation error:

lib/extras/time.cc:25:10: fatal error: mach/mach_time.h: No such file or directory

For reference:

* https://developer.apple.com/library/archive/documentation/Porting/Conceptual/PortingUnix/compiling/compiling.html#//apple_ref/doc/uid/TP40002850-SW13