### PR TITLE
Rework append implementation to avoid passing in NULL pointers

### DIFF
--- a/lib/jxl/base/padded_bytes.h
+++ b/lib/jxl/base/padded_bytes.h
@@ -160,9 +160,11 @@ class PaddedBytes {
   }
 
   void append(const uint8_t* begin, const uint8_t* end) {
-    size_t old_size = size();
-    resize(size() + (end - begin));
-    memcpy(data() + old_size, begin, end - begin);
+    if (end - begin > 0) {
+      size_t old_size = size();
+      resize(size() + (end - begin));
+      memcpy(data() + old_size, begin, end - begin);
+    }
   }
 
  private:

--- a/lib/jxl/blending.cc
+++ b/lib/jxl/blending.cc
@@ -453,7 +453,7 @@ void PerformBlending(const float* const* bg, const float* const* fg,
     JXL_ABORT("Unreachable");
   }
   for (size_t i = 0; i < 3 + num_ec; i++) {
-    memcpy(out[i] + x0, tmp.Row(i), xsize * sizeof(**out));
+    if (xsize != 0) memcpy(out[i] + x0, tmp.Row(i), xsize * sizeof(**out));
   }
 }
 

--- a/lib/jxl/decode_to_jpeg.h
+++ b/lib/jxl/decode_to_jpeg.h
@@ -121,7 +121,7 @@ class JxlToJpegDecoder {
     auto write = [&tmp_next_out, &tmp_avail_size](const uint8_t* buf,
                                                   size_t len) {
       size_t to_write = std::min<size_t>(tmp_avail_size, len);
-      memcpy(tmp_next_out, buf, to_write);
+      if (to_write != 0) memcpy(tmp_next_out, buf, to_write);
       tmp_next_out += to_write;
       tmp_avail_size -= to_write;
       return to_write;

--- a/lib/jxl/enc_bit_writer.cc
+++ b/lib/jxl/enc_bit_writer.cc
@@ -104,7 +104,8 @@ void BitWriter::AppendByteAligned(const std::vector<BitWriter>& others) {
   size_t pos = BitsWritten() / kBitsPerByte;
   for (const BitWriter& writer : others) {
     const Span<const uint8_t> span = writer.GetSpan();
-    memcpy(storage_.data() + pos, span.data(), span.size());
+    if (span.size() != 0)
+      memcpy(storage_.data() + pos, span.data(), span.size());
     pos += span.size();
   }
   storage_[pos++] = 0;  // for next Write

--- a/lib/jxl/image_ops.h
+++ b/lib/jxl/image_ops.h
@@ -776,7 +776,7 @@ void ZeroFillImage(Image3<T>* image) {
   for (size_t c = 0; c < 3; ++c) {
     for (size_t y = 0; y < image->ysize(); ++y) {
       T* JXL_RESTRICT row = image->PlaneRow(c, y);
-      memset(row, 0, image->xsize() * sizeof(T));
+      if (image->xsize() != 0) memset(row, 0, image->xsize() * sizeof(T));
     }
   }
 }


### PR DESCRIPTION
Documentation for std::memcpy clearly states that:

> If either dest or src is an invalid or null pointer, the behavior is
> undefined, even if count is zero.

ref:
* https://en.cppreference.com/w/cpp/string/byte/memcpy