### PR TITLE
fix composite still png output

### DIFF
--- a/lib/extras/enc/apng.cc
+++ b/lib/extras/enc/apng.cc
@@ -132,7 +132,9 @@ Status EncodeImageAPNG(const CodecInOut* io, const ColorEncoding& c_desired,
   size_t anim_chunks = 0;
   int W = 0, H = 0;
 
-  for (auto& frame : io->frames) {
+  for (size_t i = 0; i < io->frames.size(); i++) {
+    auto& frame = io->frames[i];
+    if (!have_anim && i + 1 < io->frames.size()) continue;
     png_structp png_ptr;
     png_infop info_ptr;
 


### PR DESCRIPTION
In the case of no-animation multi-frame images, the (a)png output was writing something weird that is basically a non-animated PNG that contains a sequence of frames (i.e. the first frame followed by a bunch of tail data). This fixes that: in the case of no animation, what needs to be encoded is the final frame (the result of merging all layers), not the first frame (the bottom layer).