### PR TITLE
check that all extra channels are initialized before encode

### DIFF
--- a/lib/jxl/encode_internal.h
+++ b/lib/jxl/encode_internal.h
@@ -51,6 +51,7 @@ constexpr unsigned char kLevelBoxHeader[] = {0, 0, 0, 0x9, 'j', 'x', 'l', 'l'};
 struct JxlEncoderQueuedFrame {
   JxlEncoderFrameSettingsValues option_values;
   ImageBundle frame;
+  std::vector<uint8_t> ec_initialized;
 };
 
 struct JxlEncoderQueuedBox {


### PR DESCRIPTION
Current behavior: when encoding a frame without setting buffers for all extra channels, uninitialized memory is used as input pixels for the extra channels.

This PR makes it an API usage error instead when that is attempted.