### PR TITLE
Fix division by zero in spline caching

### DIFF
--- a/lib/jxl/splines.cc
+++ b/lib/jxl/splines.cc
@@ -418,7 +418,7 @@ Status QuantizedSpline::Dequantize(const Spline::Point& starting_point,
   int current_x = static_cast<int>(roundf(starting_point.x)),
       current_y = static_cast<int>(roundf(starting_point.y));
   // It is not in spec, but reasonable limit to avoid overflows.
-  constexpr int kPosLimit = 1u << 30;
+  constexpr int kPosLimit = 1u << 23;
   if ((current_x >= kPosLimit) || (current_x <= -kPosLimit) ||
       (current_y >= kPosLimit) || (current_y <= -kPosLimit)) {
     return JXL_FAILURE("Spline coordinates out of bounds");


### PR DESCRIPTION
Internally splines are processed in floats.
For the first segment of spline a virtual mirrored point is added.

Lets take a look at spline with control points: (16777216, 0), (16777215, 0)
Mirrored point would be (16777217, 0), but alas, it is (16777217, 0) due to floating point precision.
Next, distance between points is calculated and at some point used as a divisor...