### PR TITLE
add brotli_effort option

### DIFF
--- a/lib/include/jxl/encode.h
+++ b/lib/include/jxl/encode.h
@@ -283,6 +283,13 @@ typedef enum {
    */
   JXL_ENC_FRAME_INDEX_BOX = 31,
 
+  /** Sets brotli encode effort for use in JPEG recompression and compressed
+   * metadata boxes (brob). Can be -1 (default) or 0 (fastest) to 11 (slowest).
+   * Default is based on the general encode effort in case of JPEG
+   * recompression, and 4 for brob boxes.
+   */
+  JXL_ENC_FRAME_SETTING_BROTLI_EFFORT = 32,
+
   /** Enum value not to be used as an option. This value is added to force the
    * C compiler to have the enum to take a known size.
    */

--- a/lib/jxl/decode_test.cc
+++ b/lib/jxl/decode_test.cc
@@ -211,7 +211,7 @@ PaddedBytes CreateTestJXLCodestream(
                             jpeg_bytes.data() + jpeg_bytes.size());
     EXPECT_TRUE(jxl::jpeg::DecodeImageJPG(
         jxl::Span<const uint8_t>(jpeg_bytes.data(), jpeg_bytes.size()), &io));
-    EXPECT_TRUE(EncodeJPEGData(*io.Main().jpeg_data, &jpeg_data));
+    EXPECT_TRUE(EncodeJPEGData(*io.Main().jpeg_data, &jpeg_data, cparams));
     io.metadata.m.xyb_encoded = false;
 #else   // JPEGXL_ENABLE_JPEG
     JXL_ABORT(
@@ -3586,7 +3586,8 @@ TEST(DecodeTest, JXL_TRANSCODE_JPEG_TEST(JPEGReconstructionTest)) {
                                /*aux_out=*/nullptr));
 
   jxl::PaddedBytes jpeg_data;
-  ASSERT_TRUE(EncodeJPEGData(*orig_io.Main().jpeg_data.get(), &jpeg_data));
+  ASSERT_TRUE(
+      EncodeJPEGData(*orig_io.Main().jpeg_data.get(), &jpeg_data, cparams));
   jxl::PaddedBytes container;
   container.append(jxl::kContainerHeader,
                    jxl::kContainerHeader + sizeof(jxl::kContainerHeader));

--- a/lib/jxl/enc_params.h
+++ b/lib/jxl/enc_params.h
@@ -127,6 +127,7 @@ struct CompressParams {
   float max_error[3] = {0.0, 0.0, 0.0};
 
   SpeedTier speed_tier = SpeedTier::kSquirrel;
+  int brotli_effort = -1;
 
   // 0 = default.
   // 1 = slightly worse quality.

--- a/lib/jxl/encode.cc
+++ b/lib/jxl/encode.cc
@@ -423,9 +423,10 @@ JxlEncoderStatus JxlEncoderStruct::RefillOutputByteQueue() {
       for (size_t i = 0; i < 4; i++) {
         compressed[i] = static_cast<uint8_t>(box->type[i]);
       }
-      if (JXL_ENC_SUCCESS != BrotliCompress(9, box->contents.data(),
-                                            box->contents.size(),
-                                            &compressed)) {
+      if (JXL_ENC_SUCCESS !=
+          BrotliCompress((brotli_effort >= 0 ? brotli_effort : 4),
+                         box->contents.data(), box->contents.size(),
+                         &compressed)) {
         return JXL_API_ERROR("Brotli compression for brob box failed");
       }
       jxl::AppendBoxHeader(jxl::MakeBoxType("brob"), compressed.size(), false,
@@ -774,6 +775,15 @@ JxlEncoderStatus JxlEncoderFrameSettingsSetOption(
       }
       frame_settings->values.cparams.speed_tier =
           static_cast<jxl::SpeedTier>(10 - value);
+      return JXL_ENC_SUCCESS;
+    case JXL_ENC_FRAME_SETTING_BROTLI_EFFORT:
+      if (value < -1 || value > 11) {
+        return JXL_ENC_ERROR;
+      }
+      // set cparams for brotli use in JPEG frames
+      frame_settings->values.cparams.brotli_effort = value;
+      // set enc option for brotli use in brob boxes
+      frame_settings->enc->brotli_effort = value;
       return JXL_ENC_SUCCESS;
     case JXL_ENC_FRAME_SETTING_DECODING_SPEED:
       if (value < 0 || value > 4) {
@@ -1137,7 +1147,8 @@ JxlEncoderStatus JxlEncoderAddJPEGFrame(
   if (frame_settings->enc->store_jpeg_metadata) {
     jxl::jpeg::JPEGData data_in = *io.Main().jpeg_data;
     jxl::PaddedBytes jpeg_data;
-    if (!jxl::jpeg::EncodeJPEGData(data_in, &jpeg_data)) {
+    if (!jxl::jpeg::EncodeJPEGData(data_in, &jpeg_data,
+                                   frame_settings->values.cparams)) {
       return JXL_ENC_ERROR;
     }
     frame_settings->enc->jpeg_metadata = std::vector<uint8_t>(

--- a/lib/jxl/encode_internal.h
+++ b/lib/jxl/encode_internal.h
@@ -147,6 +147,7 @@ struct JxlEncoderStruct {
   bool basic_info_set;
   bool color_encoding_set;
   bool intensity_target_set;
+  int brotli_effort = -1;
 
   // Takes the first frame in the input_queue, encodes it, and appends
   // the bytes to the output_byte_queue.

--- a/lib/jxl/jpeg/enc_jpeg_data.cc
+++ b/lib/jxl/jpeg/enc_jpeg_data.cc
@@ -230,7 +230,8 @@ Status SetColorEncodingFromJpegData(const jpeg::JPEGData& jpg,
   return color_encoding->SetICC(std::move(icc_profile));
 }
 
-Status EncodeJPEGData(JPEGData& jpeg_data, PaddedBytes* bytes) {
+Status EncodeJPEGData(JPEGData& jpeg_data, PaddedBytes* bytes,
+                      const CompressParams& cparams) {
   jpeg_data.app_marker_type.resize(jpeg_data.app_data.size(),
                                    AppMarkerType::kUnknown);
   JXL_RETURN_IF_ERROR(DetectIccProfile(jpeg_data));
@@ -241,7 +242,9 @@ Status EncodeJPEGData(JPEGData& jpeg_data, PaddedBytes* bytes) {
   *bytes = std::move(writer).TakeBytes();
   BrotliEncoderState* brotli_enc =
       BrotliEncoderCreateInstance(nullptr, nullptr, nullptr);
-  BrotliEncoderSetParameter(brotli_enc, BROTLI_PARAM_QUALITY, 11);
+  int effort = cparams.brotli_effort;
+  if (effort < 0) effort = 11 - static_cast<int>(cparams.speed_tier);
+  BrotliEncoderSetParameter(brotli_enc, BROTLI_PARAM_QUALITY, effort);
   size_t total_data = 0;
   for (size_t i = 0; i < jpeg_data.app_data.size(); i++) {
     if (jpeg_data.app_marker_type[i] != AppMarkerType::kUnknown) {

--- a/lib/jxl/jpeg/enc_jpeg_data.h
+++ b/lib/jxl/jpeg/enc_jpeg_data.h
@@ -8,11 +8,13 @@
 
 #include "lib/jxl/base/padded_bytes.h"
 #include "lib/jxl/codec_in_out.h"
+#include "lib/jxl/enc_params.h"
 #include "lib/jxl/jpeg/jpeg_data.h"
 
 namespace jxl {
 namespace jpeg {
-Status EncodeJPEGData(JPEGData& jpeg_data, PaddedBytes* bytes);
+Status EncodeJPEGData(JPEGData& jpeg_data, PaddedBytes* bytes,
+                      const CompressParams& cparams);
 
 Status SetColorEncodingFromJpegData(const jpeg::JPEGData& jpg,
                                     ColorEncoding* color_encoding);

--- a/lib/jxl/jxl_test.cc
+++ b/lib/jxl/jxl_test.cc
@@ -1448,7 +1448,7 @@ size_t RoundtripJpeg(const PaddedBytes& jpeg_in, ThreadPool* pool) {
   enc_container.codestream = std::move(codestream);
   jpeg::JPEGData data_in = *io.Main().jpeg_data;
   jxl::PaddedBytes jpeg_data;
-  EXPECT_TRUE(EncodeJPEGData(data_in, &jpeg_data));
+  EXPECT_TRUE(EncodeJPEGData(data_in, &jpeg_data, cparams));
   enc_container.jpeg_reconstruction = jpeg_data.data();
   enc_container.jpeg_reconstruction_size = jpeg_data.size();
   EXPECT_TRUE(EncodeJpegXlContainerOneShot(enc_container, &compressed));

--- a/tools/cjxl.cc
+++ b/tools/cjxl.cc
@@ -347,6 +347,12 @@ void CompressArgs::AddCommandLineOptions(CommandLineParser* cmdline) {
       "    Default: 7. Higher number is more effort (slower).",
       &params.speed_tier, &ParseSpeedTier);
 
+  cmdline->AddOptionValue('\0', "brotli_effort", "B_EFFORT",
+                          "Brotli effort setting. Range: 0 .. 11.\n"
+                          "    Default: -1 (based on EFFORT). Higher number is "
+                          "more effort (slower).",
+                          &params.brotli_effort, &ParseSigned, -1);
+
   cmdline->AddOptionValue(
       's', "speed", "ANIMAL",
       "Deprecated synonym for --effort. Valid values are:\n"
@@ -651,7 +657,10 @@ jxl::Status CompressArgs::ValidateArgs(const CommandLineParser& cmdline) {
   if (got_target_bpp || got_target_size) {
     jpeg_transcode = false;
   }
-
+  if (params.brotli_effort > 11) {
+    fprintf(stderr, "Invalid --brotli_effort value\n");
+    return false;
+  }
   if (got_target_bpp + got_target_size + got_distance + got_quality > 1) {
     fprintf(stderr,
             "You can specify only one of '--distance', '-q', "

--- a/tools/cjxl_main.cc
+++ b/tools/cjxl_main.cc
@@ -105,7 +105,7 @@ int CompressJpegXlMain(int argc, const char* argv[]) {
     jxl::PaddedBytes jpeg_data;
     if (args.store_jpeg_metadata && io.Main().IsJPEG()) {
       jxl::jpeg::JPEGData data_in = *io.Main().jpeg_data;
-      if (EncodeJPEGData(data_in, &jpeg_data)) {
+      if (EncodeJPEGData(data_in, &jpeg_data, args.params)) {
         container.jpeg_reconstruction = jpeg_data.data();
         container.jpeg_reconstruction_size = jpeg_data.size();
       } else {

--- a/tools/cjxl_ng_main.cc
+++ b/tools/cjxl_ng_main.cc
@@ -265,6 +265,10 @@ DEFINE_int64(
     "Encoder effort setting. Range: 1 .. 9.\n"
     "    Default: 7. Higher number is more effort (slower).");
 
+DEFINE_int32(brotli_effort, 9,
+             "Brotli effort setting. Range: 0 .. 11.\n"
+             "    Default: 9. Higher number is more effort (slower).");
+
 DEFINE_string(frame_indexing, "",
               "If non-empty, a string matching '^[01]*$'. If this string has a "
               "'1' in i-th position, then the i-th frame will be indexed in "
@@ -500,6 +504,16 @@ int main(int argc, char** argv) {
     }
     JxlEncoderFrameSettingsSetOption(jxl_encoder_frame_settings,
                                      JXL_ENC_FRAME_SETTING_EFFORT, flag_effort);
+
+    const int32_t flag_brotli_effort = FLAGS_brotli_effort;
+    if (!(-1 <= flag_brotli_effort && flag_brotli_effort <= 11)) {
+      std::cerr
+          << "Invalid --brotli_effort. Valid range is {-1, 0, 1, ..., 11}.\n";
+      return EXIT_FAILURE;
+    }
+    JxlEncoderFrameSettingsSetOption(jxl_encoder_frame_settings,
+                                     JXL_ENC_FRAME_SETTING_BROTLI_EFFORT,
+                                     flag_brotli_effort);
 
     const int32_t flag_epf = FLAGS_epf;
     if (!(-1 <= flag_epf && flag_epf <= 3)) {

--- a/tools/fuzzer_corpus.cc
+++ b/tools/fuzzer_corpus.cc
@@ -225,6 +225,9 @@ bool GenerateFile(const char* output_dir, const ImageSpec& spec,
     io.frames.push_back(std::move(ib));
   }
 
+  jxl::CompressParams params;
+  params.speed_tier = spec.params.speed_tier;
+
 #if JPEGXL_ENABLE_JPEG
   if (spec.is_reconstructible_jpeg) {
     // If this image is supposed to be a reconstructible JPEG, collect the JPEG
@@ -236,7 +239,8 @@ bool GenerateFile(const char* output_dir, const ImageSpec& spec,
     JXL_RETURN_IF_ERROR(jxl::jpeg::DecodeImageJPG(
         jxl::Span<const uint8_t>(jpeg_bytes.data(), jpeg_bytes.size()), &io));
     jxl::PaddedBytes jpeg_data;
-    JXL_RETURN_IF_ERROR(EncodeJPEGData(*io.Main().jpeg_data, &jpeg_data));
+    JXL_RETURN_IF_ERROR(
+        EncodeJPEGData(*io.Main().jpeg_data, &jpeg_data, params));
     std::vector<uint8_t> header;
     header.insert(header.end(), jxl::kContainerHeader,
                   jxl::kContainerHeader + sizeof(jxl::kContainerHeader));
@@ -249,8 +253,6 @@ bool GenerateFile(const char* output_dir, const ImageSpec& spec,
   }
 #endif
 
-  jxl::CompressParams params;
-  params.speed_tier = spec.params.speed_tier;
   params.modular_mode = spec.params.modular_mode;
   params.color_transform = spec.params.color_transform;
   params.butteraugli_distance = spec.params.butteraugli_distance;


### PR DESCRIPTION
Currently, when doing JPEG recompression, the `jbrd` is brotli-compressed with effort 11 (hardcoded), and when `brob` boxes are created, they are brotli-compressed with effort 9 (also hardcoded). This adds an encoder option to set a custom brotli effort for the uses of brotli in the JPEG XL file format.