### PR TITLE
Improve --faster_decoding for progressive lossless.

### DIFF
--- a/lib/jxl/enc_ans.cc
+++ b/lib/jxl/enc_ans.cc
@@ -556,6 +556,12 @@ void ChooseUintConfigs(const HistogramParams& params,
   codes->uint_config.resize(clustered_histograms->size());
 
   if (params.uint_method == HistogramParams::HybridUintMethod::kNone) return;
+  if (params.uint_method == HistogramParams::HybridUintMethod::k000) {
+    codes->uint_config.clear();
+    codes->uint_config.resize(clustered_histograms->size(),
+                              HybridUintConfig(0, 0, 0));
+    return;
+  }
   if (params.uint_method == HistogramParams::HybridUintMethod::kContextMap) {
     codes->uint_config.clear();
     codes->uint_config.resize(clustered_histograms->size(),
@@ -1504,6 +1510,9 @@ size_t BuildAndEncodeHistograms(const HistogramParams& params,
   // Unless we are using the kContextMap histogram option.
   if (params.uint_method == HistogramParams::HybridUintMethod::kContextMap) {
     uint_config = HybridUintConfig(2, 0, 1);
+  }
+  if (params.uint_method == HistogramParams::HybridUintMethod::k000) {
+    uint_config = HybridUintConfig(0, 0, 0);
   }
   if (ans_fuzzer_friendly_) {
     uint_config = HybridUintConfig(10, 0, 0);

--- a/lib/jxl/enc_ans_params.h
+++ b/lib/jxl/enc_ans_params.h
@@ -24,6 +24,7 @@ struct HistogramParams {
 
   enum class HybridUintMethod {
     kNone,        // just use kHybridUint420Config.
+    k000,         // force the fastest option.
     kFast,        // just try a couple of options.
     kContextMap,  // fast choice for ctx map.
     kBest,

--- a/lib/jxl/modular/options.h
+++ b/lib/jxl/modular/options.h
@@ -98,6 +98,7 @@ struct ModularOptions {
   // TODO(veluca): add tree kinds for JPEG recompression with CfL enabled,
   // general AC metadata, different DC qualities, and others.
   enum class TreeKind {
+    kTrivialTreeNoPredictor,
     kLearn,
     kJpegTranscodeACMeta,
     kFalconACMeta,


### PR DESCRIPTION
```
Before:
jyrki31:
Encoding                              kPixels    Bytes          BPP  E MP/s  D MP/s     Max norm        pnorm       BPP*pnorm   Bugs
------------------------------------------------------------------------------------------------------------------------------------
jxl:m:squirrel:faster_decoding=1:R      13270 21392160   12.8961183   2.443   7.117  -1.00000000   0.00000000  0.000000000000      0
jxl:m:cheetah:faster_decoding=1:R       13270 19474130   11.7398469   3.239   7.292  -1.00000000   0.00000000  0.000000000000      0
jxl:m:squirrel:faster_decoding=2:R      13270 22843671   13.7711518   2.958  14.900  -1.00000000   0.00000000  0.000000000000      0
jxl:m:cheetah:faster_decoding=2:R       13270 19320457   11.6472062   4.039  15.534  -1.00000000   0.00000000  0.000000000000      0
Aggregate:                              13270 20707325   12.4832701   3.118  10.469   0.00000000   0.00000000  0.000000000000      0

dicom:
Encoding                              kPixels    Bytes          BPP  E MP/s  D MP/s     Max norm        pnorm       BPP*pnorm   Bugs
------------------------------------------------------------------------------------------------------------------------------------
jxl:m:squirrel:faster_decoding=1:R      49942 43791632    7.0146945   3.576  12.854  -1.00000000   0.00000000  0.000000000000      0
jxl:m:cheetah:faster_decoding=1:R       49942 45711803    7.3222741   5.736  13.145  -1.00000000   0.00000000  0.000000000000      0
jxl:m:squirrel:faster_decoding=2:R      49942 47936015    7.6785560   4.084  25.907  -1.00000000   0.00000000  0.000000000000      0
jxl:m:cheetah:faster_decoding=2:R       49942 46025119    7.3724621   7.367  26.594  -1.00000000   0.00000000  0.000000000000      0
Aggregate:                              49942 45842583    7.3432229   4.984  18.472   0.00000000   0.00000000  0.000000000000      0

After:
jyrki31:
Encoding                              kPixels    Bytes          BPP  E MP/s  D MP/s     Max norm        pnorm       BPP*pnorm   Bugs
------------------------------------------------------------------------------------------------------------------------------------
jxl:m:squirrel:faster_decoding=1:R      13270 21795270   13.1391304   0.712  17.364  -1.00000000   0.00000000  0.000000000000      0
jxl:m:cheetah:faster_decoding=1:R       13270 19666039   11.8555380  10.880  17.300  -1.00000000   0.00000000  0.000000000000      0
jxl:m:squirrel:faster_decoding=2:R      13270 22359508   13.4792775   0.758  16.769  -1.00000000   0.00000000  0.000000000000      0
jxl:m:cheetah:faster_decoding=2:R       13270 20279229   12.2251954   9.929  16.159  -1.00000000   0.00000000  0.000000000000      0
Aggregate:                              13270 20996563   12.6576353   2.764  16.891   0.00000000   0.00000000  0.000000000000      0

dicom:
Encoding                              kPixels    Bytes          BPP  E MP/s  D MP/s     Max norm        pnorm       BPP*pnorm   Bugs
------------------------------------------------------------------------------------------------------------------------------------
jxl:m:squirrel:faster_decoding=1:R      49942 44317422    7.0989173   2.092  30.540  -1.00000000   0.00000000  0.000000000000      0
jxl:m:cheetah:faster_decoding=1:R       49942 45784608    7.3339363  18.418  29.663  -1.00000000   0.00000000  0.000000000000      0
jxl:m:squirrel:faster_decoding=2:R      49942 45281524    7.2533505   2.673  30.650  -1.00000000   0.00000000  0.000000000000      0
jxl:m:cheetah:faster_decoding=2:R       49942 46774415    7.4924869  18.612  29.978  -1.00000000   0.00000000  0.000000000000      0
Aggregate:                              49942 45530859    7.2932899   6.617  30.205   0.00000000   0.00000000  0.000000000000      0
```