### PR TITLE
Remove DecodePreview and SkipFrame.

### DIFF
--- a/lib/jxl/dec_frame.h
+++ b/lib/jxl/dec_frame.h
@@ -44,11 +44,6 @@ Status DecodeFrame(const DecompressParams& dparams,
                    const CodecMetadata& metadata,
                    const SizeConstraints* constraints, bool is_preview = false);
 
-// Leaves reader in the same state as DecodeFrame would. Used to skip preview.
-// Also updates `dec_state` with the new frame header.
-Status SkipFrame(const CodecMetadata& metadata, BitReader* JXL_RESTRICT reader,
-                 bool is_preview = false);
-
 // TODO(veluca): implement "forced drawing".
 class FrameDecoder {
  public:

--- a/lib/jxl/dec_params.h
+++ b/lib/jxl/dec_params.h
@@ -29,9 +29,6 @@ struct DecompressParams {
   // If true, coalesce frames (otherwise return unblended frames)
   bool coalescing = true;
 
-  // These cannot be kOn because they need encoder support.
-  Override preview = Override::kDefault;
-
   // How many passes to decode at most. By default, decode everything.
   uint32_t max_passes = std::numeric_limits<uint32_t>::max();
   // Alternatively, one can specify the maximum tolerable downscaling factor

--- a/lib/jxl/decode.cc
+++ b/lib/jxl/decode.cc
@@ -1230,7 +1230,6 @@ JxlDecoderStatus JxlDecoderProcessCodestream(JxlDecoder* dec, const uint8_t* in,
                                           size - dec->frame_start);
       auto reader = GetBitReader(compressed);
       jxl::DecompressParams dparams;
-      dparams.preview = want_preview ? jxl::Override::kOn : jxl::Override::kOff;
       dparams.render_spotcolors = dec->render_spotcolors;
       dparams.coalescing = true;
       jxl::ImageBundle ib(&dec->metadata.m);

--- a/lib/jxl/preview_test.cc
+++ b/lib/jxl/preview_test.cc
@@ -52,30 +52,19 @@ TEST(PreviewTest, RoundtripGivenPreview) {
   cparams.speed_tier = SpeedTier::kSquirrel;
   DecompressParams dparams;
 
-  dparams.preview = Override::kOff;
-
   CodecInOut io2;
   Roundtrip(&io, cparams, dparams, pool, &io2);
-  EXPECT_LE(ButteraugliDistance(io, io2, cparams.ba_params, GetJxlCms(),
-                                /*distmap=*/nullptr, pool),
-            2.5);
-  EXPECT_EQ(0u, io2.preview_frame.xsize());
+  EXPECT_EQ(preview_xsize, io2.metadata.m.preview_size.xsize());
+  EXPECT_EQ(preview_ysize, io2.metadata.m.preview_size.ysize());
+  EXPECT_EQ(preview_xsize, io2.preview_frame.xsize());
+  EXPECT_EQ(preview_ysize, io2.preview_frame.ysize());
 
-  dparams.preview = Override::kOn;
-
-  CodecInOut io3;
-  Roundtrip(&io, cparams, dparams, pool, &io3);
-  EXPECT_EQ(preview_xsize, io3.metadata.m.preview_size.xsize());
-  EXPECT_EQ(preview_ysize, io3.metadata.m.preview_size.ysize());
-  EXPECT_EQ(preview_xsize, io3.preview_frame.xsize());
-  EXPECT_EQ(preview_ysize, io3.preview_frame.ysize());
-
-  EXPECT_LE(ButteraugliDistance(io.preview_frame, io3.preview_frame,
+  EXPECT_LE(ButteraugliDistance(io.preview_frame, io2.preview_frame,
                                 cparams.ba_params, GetJxlCms(),
                                 /*distmap=*/nullptr, pool),
             2.5);
   EXPECT_LE(
-      ButteraugliDistance(io.Main(), io3.Main(), cparams.ba_params, GetJxlCms(),
+      ButteraugliDistance(io.Main(), io2.Main(), cparams.ba_params, GetJxlCms(),
                           /*distmap=*/nullptr, pool),
       2.5);
 }


### PR DESCRIPTION
They were basically only used in tests - the C API implements this
differently.