### PR TITLE
Intensity target defaults in the C API

### DIFF
--- a/lib/include/jxl/codestream_header.h
+++ b/lib/include/jxl/codestream_header.h
@@ -143,6 +143,8 @@ typedef struct {
    * representable value. The image does not necessarily contain a pixel
    * actually this bright. An encoder is allowed to set 255 for SDR images
    * without computing a histogram.
+   * Leaving this set to its default of 0 lets libjxl choose a sensible default
+   * value based on the color encoding.
    */
   float intensity_target;
 

--- a/lib/jxl/encode_internal.h
+++ b/lib/jxl/encode_internal.h
@@ -147,6 +147,7 @@ struct JxlEncoderStruct {
   bool boxes_closed;
   bool basic_info_set;
   bool color_encoding_set;
+  bool intensity_target_set;
 
   // Takes the first frame in the input_queue, encodes it, and appends
   // the bytes to the output_byte_queue.

--- a/lib/jxl/luminance.cc
+++ b/lib/jxl/luminance.cc
@@ -6,21 +6,22 @@
 #include "lib/jxl/luminance.h"
 
 #include "lib/jxl/codec_in_out.h"
-#include "lib/jxl/color_encoding_internal.h"
 
 namespace jxl {
 
-void SetIntensityTarget(CodecInOut* io) {
-  if (io->metadata.m.color_encoding.tf.IsPQ()) {
+void SetIntensityTarget(CodecInOut* io) { SetIntensityTarget(&io->metadata.m); }
+
+void SetIntensityTarget(ImageMetadata* m) {
+  if (m->color_encoding.tf.IsPQ()) {
     // Peak luminance of PQ as defined by SMPTE ST 2084:2014.
-    io->metadata.m.SetIntensityTarget(10000);
-  } else if (io->metadata.m.color_encoding.tf.IsHLG()) {
+    m->SetIntensityTarget(10000);
+  } else if (m->color_encoding.tf.IsHLG()) {
     // Nominal display peak luminance used as a reference by
     // Rec. ITU-R BT.2100-2.
-    io->metadata.m.SetIntensityTarget(1000);
+    m->SetIntensityTarget(1000);
   } else {
     // SDR
-    io->metadata.m.SetIntensityTarget(kDefaultIntensityTarget);
+    m->SetIntensityTarget(kDefaultIntensityTarget);
   }
 }
 

--- a/lib/jxl/luminance.h
+++ b/lib/jxl/luminance.h
@@ -11,10 +11,12 @@ namespace jxl {
 // Chooses a default intensity target based on the transfer function of the
 // image, if known. For SDR images or images not known to be HDR, returns
 // kDefaultIntensityTarget, for images known to have PQ or HLG transfer function
-// returns a higher value. If the image metadata already has a non-zero
-// intensity target, does nothing.
+// returns a higher value.
 class CodecInOut;
 void SetIntensityTarget(CodecInOut* io);
+
+struct ImageMetadata;
+void SetIntensityTarget(ImageMetadata* m);
 
 }  // namespace jxl
 

--- a/tools/cjxl_ng_main.cc
+++ b/tools/cjxl_ng_main.cc
@@ -338,9 +338,6 @@ jxl::Status LoadInput(const char* filename_in,
   if (image_data.size() < kMinBytes) return JXL_FAILURE("Input too small.");
   jxl::Span<const uint8_t> encoded(image_data);
 
-  // Manually fix intensity target 0 problem, decoder should set a
-  // reasonable default, but at least apng doesn't:
-  ppf.info.intensity_target = 255.f;
   ppf.info.orientation = JXL_ORIENT_IDENTITY;
   jxl::extras::ColorHints color_hints;
   jxl::SizeConstraints size_constraints;


### PR DESCRIPTION
On the C side, leaving JxlBasicInfo::intensity_target to its initial value of 0 lets the implementation choose a reasonable value based on the color encoding (1000 for HLG, 10000 for PQ, kDefaultIntensityTarget otherwise).

This also restores that behavior in cjxl, since ConvertPackedPixelFileToCodecInOut only calls SetIntensityTarget if ppf.info.intensity_target is 0, but starting in #1129, it was initialized to 255.