### PR TITLE
Revert "more speedups for fjxl decoding (#1149)"

### DIFF
--- a/lib/jxl/dec_huffman.cc
+++ b/lib/jxl/dec_huffman.cc
@@ -236,4 +236,20 @@ bool HuffmanDecodingData::ReadFromBitStream(size_t alphabet_size,
   return (table_size > 0);
 }
 
+// Decodes the next Huffman coded symbol from the bit-stream.
+uint16_t HuffmanDecodingData::ReadSymbol(BitReader* br) const {
+  size_t n_bits;
+  const HuffmanCode* table = table_.data();
+  table += br->PeekBits(kHuffmanTableBits);
+  n_bits = table->bits;
+  if (n_bits > kHuffmanTableBits) {
+    br->Consume(kHuffmanTableBits);
+    n_bits -= kHuffmanTableBits;
+    table += table->value;
+    table += br->PeekBits(n_bits);
+  }
+  br->Consume(table->bits);
+  return table->value;
+}
+
 }  // namespace jxl

--- a/lib/jxl/dec_huffman.h
+++ b/lib/jxl/dec_huffman.h
@@ -22,21 +22,7 @@ struct HuffmanDecodingData {
   // Returns false if the Huffman code lengths can not de decoded.
   bool ReadFromBitStream(size_t alphabet_size, BitReader* br);
 
-  // Decodes the next Huffman coded symbol from the bit-stream.
-  uint16_t ReadSymbol(BitReader* br) const {
-    size_t n_bits;
-    const HuffmanCode* table = table_.data();
-    table += br->PeekBits(kHuffmanTableBits);
-    n_bits = table->bits;
-    if (JXL_UNLIKELY(n_bits > kHuffmanTableBits)) {
-      br->Consume(kHuffmanTableBits);
-      n_bits -= kHuffmanTableBits;
-      table += table->value;
-      table += br->PeekBits(n_bits);
-    }
-    br->Consume(table->bits);
-    return table->value;
-  }
+  uint16_t ReadSymbol(BitReader* br) const;
 
   std::vector<HuffmanCode> table_;
 };

--- a/lib/jxl/modular/encoding/encoding.cc
+++ b/lib/jxl/modular/encoding/encoding.cc
@@ -197,8 +197,8 @@ Status DecodeModularChannelMAANS(BitReader *br, ANSSymbolReader *reader,
           }
         }
       }
-    } else if (predictor == Predictor::Gradient && offset == 0 && ctx_id == 1 &&
-               multiplier == 1 && reader->FJXLFastPath()) {
+    } else if (predictor == Predictor::Gradient && offset == 0 &&
+               multiplier == 1 && reader->HuffRleOnly()) {
       JXL_DEBUG_V(8, "Gradient RLE (fjxl) very fast track.");
       uint32_t run = 0;
       uint32_t v = 0;
@@ -210,7 +210,7 @@ Status DecodeModularChannelMAANS(BitReader *br, ANSSymbolReader *reader,
             (y ? channel.Row(y - 1) - 1 : r - 1);
         pixel_type_w guess = (y ? rtop[0] : 0);
         if (run == 0) {
-          reader->ReadHybridUintFJXLFastPath(br, &v, &run);
+          reader->ReadHybridUintClusteredHuffRleOnly(ctx_id, br, &v, &run);
           sv = UnpackSigned(v);
         } else {
           run--;
@@ -220,9 +220,9 @@ Status DecodeModularChannelMAANS(BitReader *br, ANSSymbolReader *reader,
           pixel_type left = r[x - 1];
           pixel_type top = rtop[x];
           pixel_type topleft = rtopleft[x];
-          pixel_type guess = ClampedGradient(top, left, topleft);
+          pixel_type_w guess = ClampedGradient(top, left, topleft);
           if (!run) {
-            reader->ReadHybridUintFJXLFastPath(br, &v, &run);
+            reader->ReadHybridUintClusteredHuffRleOnly(ctx_id, br, &v, &run);
             sv = UnpackSigned(v);
           } else {
             run--;

--- a/lib/jxl/modular_test.cc
+++ b/lib/jxl/modular_test.cc
@@ -18,7 +18,6 @@
 #include "lib/jxl/base/data_parallel.h"
 #include "lib/jxl/base/override.h"
 #include "lib/jxl/base/padded_bytes.h"
-#include "lib/jxl/base/random.h"
 #include "lib/jxl/base/thread_pool_internal.h"
 #include "lib/jxl/codec_in_out.h"
 #include "lib/jxl/color_encoding_internal.h"
@@ -34,7 +33,6 @@
 #include "lib/jxl/image_bundle.h"
 #include "lib/jxl/image_ops.h"
 #include "lib/jxl/image_test_utils.h"
-#include "lib/jxl/modular/encoding/context_predict.h"
 #include "lib/jxl/modular/encoding/enc_encoding.h"
 #include "lib/jxl/modular/encoding/encoding.h"
 #include "lib/jxl/test_utils.h"
@@ -322,24 +320,6 @@ TEST(ModularTest, RoundtripLosslessCustomFloat) {
   EXPECT_LE(Roundtrip(&io, cparams, dparams, pool, &io2), 23000u);
   EXPECT_EQ(0.0, ButteraugliDistance(io, io2, cparams.ba_params, GetJxlCms(),
                                      /*distmap=*/nullptr, pool));
-}
-
-TEST(ModularTest, ClampedGradientTest) {
-  Rng rng(0);
-  constexpr int max_bits = 29;
-  for (size_t i = 0; i < 100000; i++) {
-    int32_t a = rng.UniformI(-(1 << max_bits), 1 << max_bits);
-    int32_t b = rng.UniformI(-(1 << max_bits), 1 << max_bits);
-    int32_t c = rng.UniformI(-(1 << max_bits), 1 << max_bits);
-    int32_t cg = ClampedGradient(a, b, c);
-    int64_t la = a, lb = b, lc = c;
-    int64_t g = la + lb - lc;
-    int32_t M = (a > b ? a : b);
-    int32_t m = (a > b ? b : a);
-    if (g > M) g = M;
-    if (g < m) g = m;
-    EXPECT_EQ(cg, g);
-  }
 }
 
 }  // namespace


### PR DESCRIPTION
This breaks conformance test “lossless_pfm”.