### PR TITLE
AFV transform -- no special quantization

### DIFF
--- a/lib/jxl/enc_adaptive_quantization.cc
+++ b/lib/jxl/enc_adaptive_quantization.cc
@@ -729,7 +729,7 @@ ImageF TileDistMap(const ImageF& distmap, int tile_size, int margin,
 
 constexpr float kDcQuantPow = 0.57f;
 static const float kDcQuant = 1.12f;
-static const float kAcQuant = 0.825f;
+static const float kAcQuant = 0.8294f;
 
 void FindBestQuantization(const ImageBundle& linear, const Image3F& opsin,
                           PassesEncoderState* enc_state,

--- a/lib/jxl/enc_group.cc
+++ b/lib/jxl/enc_group.cc
@@ -112,7 +112,7 @@ retry:
       const float val = block_in[pos] * (qm[pos] * qac * qm_multiplier);
       float v = (std::abs(val) < thres[hfix]) ? 0 : rintf(val);
       const float error = std::abs(val) - std::abs(v);
-      hfError[hfix] += error;
+      hfError[hfix] += error * error;
       if (hfMaxError[hfix] < error) {
         hfMaxError[hfix] = error;
         hfMaxErrorIx[hfix] = pos;
@@ -124,13 +124,14 @@ retry:
     }
   }
   if (c != 1) return;
-  // TODO(veluca): include AFV?
-  const size_t kPartialBlockKinds =
+  constexpr size_t kPartialBlockKinds =
       (1 << AcStrategy::Type::IDENTITY) | (1 << AcStrategy::Type::DCT2X2) |
       (1 << AcStrategy::Type::DCT4X4) | (1 << AcStrategy::Type::DCT4X8) |
-      (1 << AcStrategy::Type::DCT8X4);
+      (1 << AcStrategy::Type::DCT8X4) | (1 << AcStrategy::Type::AFV0) |
+      (1 << AcStrategy::Type::AFV1) | (1 << AcStrategy::Type::AFV2) |
+      (1 << AcStrategy::Type::AFV3);
   if ((1 << quant_kind) & kPartialBlockKinds) return;
-  float hfErrorLimit = 0.1f * (xsize * ysize) * kDCTBlockSize * 0.25f;
+  float hfErrorLimit = 0.029f * (xsize * ysize) * kDCTBlockSize * 0.25f;
   bool goretry = false;
   for (int i = 1; i < 4; ++i) {
     if (hfError[i] >= hfErrorLimit &&

--- a/lib/jxl/jxl_test.cc
+++ b/lib/jxl/jxl_test.cc
@@ -595,7 +595,7 @@ TEST(JxlTest, RoundtripSmallPatchesAlpha) {
   EXPECT_LE(Roundtrip(&io, cparams, dparams, pool, &io2), 2000u);
   EXPECT_THAT(ButteraugliDistance(io, io2, cparams.ba_params, GetJxlCms(),
                                   /*distmap=*/nullptr, pool),
-              IsSlightlyBelow(0.32f));
+              IsSlightlyBelow(0.2f));
 }
 
 TEST(JxlTest, RoundtripSmallPatches) {
@@ -623,7 +623,7 @@ TEST(JxlTest, RoundtripSmallPatches) {
   EXPECT_LE(Roundtrip(&io, cparams, dparams, pool, &io2), 2000u);
   EXPECT_THAT(ButteraugliDistance(io, io2, cparams.ba_params, GetJxlCms(),
                                   /*distmap=*/nullptr, pool),
-              IsSlightlyBelow(0.32f));
+              IsSlightlyBelow(0.2f));
 }
 
 // Test header encoding of original bits per sample


### PR DESCRIPTION
Don't attempt to do energy preserving corrections for AFV0,1,2,3 transforms.

This affects quantization decisions 2 % of the surface area.

Elsewhere, use 2nd norm of dct coefficients as a decision criteria for
energy preservation.

0.23 % improvement in BPP*pnorm, doesn't look worse

Before:

```
Encoding        kPixels    Bytes          BPP  E MP/s  D MP/s     Max norm        pnorm   PSNR   QABPP  SmallB  DCT4x8     AFV  DCT8x8    8x16    8x32      16   16x32      32   32x64      64       BPP*pnorm   Bugs
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
jxl:d1:epf3       18628  3526882    1.5146401   1.505   8.358   1.98383951   0.58962135  40.89   2.081  0.8514 21.0155  2.1143  5.6176 19.0493  0.0000 31.9914  7.6574 12.3079  0.0880  0.0880  0.893064125707      0
jxl:d3:epf3       18628  1692627    0.7269085   1.389   7.874   4.90852022   1.22922247  35.47   2.240  0.6222 12.2123  1.9673  3.8565 12.9943  0.0000 15.7710 29.8846 23.2635  0.1209  0.0880  0.893532324542      0
jxl:d5:epf3       18628  1150426    0.4940572   1.386   7.956   6.67660809   1.74320295  32.92   2.295  0.4222  8.5709  1.6172  2.8849 11.1226  0.0000 11.8750 35.4999 28.5571  0.1209  0.1099  0.861241902532      0
jxl:d7:epf3       18628   907285    0.3896388   1.405   7.793   8.05294514   2.15448460  31.58   2.280  0.3085  6.7394  1.3591  2.3033 10.1901  0.0000 10.2217 38.3693 31.0253  0.1539  0.1099  0.839470883374      0
jxl:d20:epf3      18628   396589    0.1703175   1.472   7.680  15.94752407   4.33921654  27.78   2.018  0.0412  1.6103  0.3745  0.4147  5.3947  0.0000  5.3143 40.2795 46.1971  0.5387  0.6157  0.739044347732      0
jxl:d50:epf3      18628   208732    0.0896412   1.490   7.249  29.89767075   7.21159467  25.32   1.877  0.0010  0.2673  0.0577  0.0752  2.4785  0.0000  2.1507 29.8626 50.3858  3.9359 11.5658  0.646455829069      0
Aggregate:        18628   895531    0.3845911   1.440   7.811   7.93505110   2.09760131  31.93   2.126  0.1196  4.3067  0.7632  1.2845  8.4923  0.0000  9.4228 26.8529 28.9646  0.2736  0.2955  0.806718796672      0
```

After:

```
Encoding        kPixels    Bytes          BPP  E MP/s  D MP/s     Max norm        pnorm   PSNR   QABPP  SmallB  DCT4x8     AFV  DCT8x8    8x16    8x32      16   16x32      32   32x64      64       BPP*pnorm   Bugs
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
jxl:d1:epf3       18628  3529470    1.5157515   1.499   7.998   1.98408747   0.58785036  40.91   2.075  0.8534 21.0440  2.1219  5.6290 19.0163  0.0000 32.0546  7.5887 12.2969  0.0880  0.0880  0.891035070294      0
jxl:d3:epf3       18628  1694409    0.7276738   1.345   7.894   4.90885830   1.22621804  35.49   2.238  0.6287 12.2598  1.9638  3.8493 12.9812  0.0000 15.7930 29.9423 23.1535  0.1209  0.0880  0.892286790823      0
jxl:d5:epf3       18628  1150227    0.4939717   1.387   7.239   6.67535210   1.73773053  32.93   2.276  0.4216  8.5812  1.6168  2.8969 11.1054  0.0000 11.9423 35.5383 28.4581  0.1319  0.0880  0.858389707049      0
jxl:d7:epf3       18628   906991    0.3895126   1.363   7.714   8.10105801   2.14940249  31.58   2.276  0.3099  6.7614  1.3698  2.3077 10.2025  0.0000 10.1956 38.3995 30.9703  0.1539  0.1099  0.837219313354      0
jxl:d20:epf3      18628   394584    0.1694564   1.441   7.324  15.94752979   4.33898654  27.77   2.000  0.0419  1.6185  0.3786  0.4216  5.3940  0.0000  5.3445 40.3180 46.1311  0.5387  0.5937  0.735269051447      0
jxl:d50:epf3      18628   208823    0.0896803   1.458   6.800  29.89767075   7.21361409  25.32   1.877  0.0010  0.2711  0.0570  0.0763  2.4867  0.0000  2.1438 30.0385 50.2594  3.9249 11.5218  0.646918763578      0
Aggregate:        18628   895032    0.3843768   1.414   7.483   7.94294096   2.09385200  31.94   2.118  0.1203  4.3275  0.7643  1.2923  8.4925  0.0000  9.4368 26.8602 28.8932  0.2775  0.2828  0.804828176918      0
```