### PR TITLE
cjxl: add --strip_jpeg_metadata option

### DIFF
--- a/tools/cjxl.cc
+++ b/tools/cjxl.cc
@@ -255,7 +255,8 @@ void PrintMode(jxl::ThreadPoolInternal* pool, const jxl::CodecInOut& io,
           (args.use_container ? "Container | " : ""), mode, quality.c_str(),
           speed);
   if (args.use_container) {
-    if (args.jpeg_transcode) fprintf(stderr, " | JPEG reconstruction data");
+    if (args.jpeg_transcode && args.store_jpeg_metadata)
+      fprintf(stderr, " | JPEG reconstruction data");
     if (!io.blobs.exif.empty())
       fprintf(stderr, " | %" PRIuS "-byte Exif", io.blobs.exif.size());
     if (!io.blobs.xmp.empty())
@@ -306,6 +307,10 @@ void CompressArgs::AddCommandLineOptions(CommandLineParser* cmdline) {
                          "Do not encode using container format (strips "
                          "Exif/XMP/JPEG bitstream reconstruction data)",
                          &no_container, &SetBooleanTrue, 2);
+
+  cmdline->AddOptionFlag('\0', "strip_jpeg_metadata",
+                         "Do not encode JPEG bitstream reconstruction data",
+                         &store_jpeg_metadata, &SetBooleanFalse, 2);
 
   // Target distance/size/bpp
   opt_distance_id = cmdline->AddOptionValue(
@@ -709,7 +714,8 @@ jxl::Status CompressArgs::ValidateArgsAfterLoad(
     }
   }
   if (!io.blobs.exif.empty() || !io.blobs.xmp.empty() ||
-      !io.blobs.jumbf.empty() || !io.blobs.iptc.empty() || jpeg_transcode) {
+      !io.blobs.jumbf.empty() || !io.blobs.iptc.empty() ||
+      (jpeg_transcode && store_jpeg_metadata)) {
     use_container = true;
   }
   if (no_container) use_container = false;

--- a/tools/cjxl.h
+++ b/tools/cjxl.h
@@ -73,6 +73,8 @@ struct CompressArgs {
   // Reset to false if input image is not a JPEG.
   bool jpeg_transcode = true;
 
+  bool store_jpeg_metadata = true;
+
   float quality = -1001.f;  // Default to lossless if input is already lossy,
                             // or to VarDCT otherwise.
   bool progressive = false;

--- a/tools/cjxl_main.cc
+++ b/tools/cjxl_main.cc
@@ -103,7 +103,7 @@ int CompressJpegXlMain(int argc, const char* argv[]) {
       container.jumb_size = io.blobs.jumbf.size();
     }
     jxl::PaddedBytes jpeg_data;
-    if (io.Main().IsJPEG()) {
+    if (args.store_jpeg_metadata && io.Main().IsJPEG()) {
       jxl::jpeg::JPEGData data_in = *io.Main().jpeg_data;
       if (EncodeJPEGData(data_in, &jpeg_data)) {
         container.jpeg_reconstruction = jpeg_data.data();


### PR DESCRIPTION
it suppresses generating "jbrd" chunk in output. it is no-op if not in
jpeg transcode mode.

dunno if this is really that useful. i tested it and it seems to work, and seems like minimal added maintenance burden. i don't mind if you don't merge it though because cjxl_ng.