### PR TITLE
use actual num_channels instead of guessing from color encoding

### DIFF
--- a/lib/extras/packed_image_convert.cc
+++ b/lib/extras/packed_image_convert.cc
@@ -138,9 +138,7 @@ Status ConvertPackedPixelFileToCodecInOut(const PackedPixelFile& ppf,
                           frame.color.format.data_type == JXL_TYPE_FLOAT;
     JXL_RETURN_IF_ERROR(ConvertFromExternal(
         span, frame.color.xsize, frame.color.ysize,
-        io->metadata.m.color_encoding,
-        /*has_alpha=*/frame.color.format.num_channels == 2 ||
-            frame.color.format.num_channels == 4,
+        io->metadata.m.color_encoding, frame.color.format.num_channels,
         /*alpha_is_premultiplied=*/ppf.info.alpha_premultiplied,
         frame_bits_per_sample, frame.color.format.endianness,
         /*flipped_y=*/frame.color.flipped_y, pool, &bundle,

--- a/lib/jxl/decode_test.cc
+++ b/lib/jxl/decode_test.cc
@@ -197,7 +197,7 @@ PaddedBytes CreateTestJXLCodestream(
   // image match.
   io.metadata.m.color_encoding = color_encoding;
   EXPECT_TRUE(ConvertFromExternal(
-      pixels, xsize, ysize, color_encoding, /*has_alpha=*/include_alpha,
+      pixels, xsize, ysize, color_encoding, num_channels,
       /*alpha_is_premultiplied=*/false, /*bits_per_sample=*/16, JXL_BIG_ENDIAN,
       /*flipped_y=*/false, &pool, &io.Main(), /*float_in=*/false, /*align=*/0));
   jxl::PaddedBytes jpeg_data;
@@ -1223,7 +1223,8 @@ TEST_P(DecodeTestParam, PixelTest) {
     io.SetSize(config.xsize, config.ysize);
 
     EXPECT_TRUE(ConvertFromExternal(
-        bytes, config.xsize, config.ysize, color_encoding, config.include_alpha,
+        bytes, config.xsize, config.ysize, color_encoding,
+        config.output_channels,
         /*alpha_is_premultiplied=*/false, 16, JXL_BIG_ENDIAN,
         /*flipped_y=*/false, nullptr, &io.Main(), /*float_in=*/false,
         /*align=*/0));
@@ -1543,8 +1544,9 @@ TEST(DecodeTest, PixelTestWithICCProfileLossy) {
   jxl::CodecInOut io0;
   io0.SetSize(xsize, ysize);
   EXPECT_TRUE(ConvertFromExternal(
-      span0, xsize, ysize, color_encoding0,
-      /*has_alpha=*/false, false, 16, format_orig.endianness,
+      span0, xsize, ysize, color_encoding0, /*channels=*/3,
+      /*alpha_is_premultiplied=*/false, /*bits_per_sample=*/16,
+      format_orig.endianness,
       /*flipped_y=*/false, /*pool=*/nullptr, &io0.Main(), /*float_in=*/false,
       /*align=*/0));
 
@@ -1554,8 +1556,8 @@ TEST(DecodeTest, PixelTestWithICCProfileLossy) {
   jxl::CodecInOut io1;
   io1.SetSize(xsize, ysize);
   EXPECT_TRUE(ConvertFromExternal(span1, xsize, ysize, color_encoding1,
-                                  /*has_alpha=*/false, false, 32,
-                                  format.endianness,
+                                  channels, /*alpha_is_premultiplied=*/false,
+                                  /*bits_per_sample=*/32, format.endianness,
                                   /*flipped_y=*/false, /*pool=*/nullptr,
                                   &io1.Main(), /*float_in=*/true, /*align=*/0));
 
@@ -1601,31 +1603,21 @@ TEST(DecodeTest, PixelTestOpaqueSrgbLossy) {
     jxl::CodecInOut io0;
     io0.SetSize(xsize, ysize);
     EXPECT_TRUE(ConvertFromExternal(
-        span0, xsize, ysize, color_encoding0,
-        /*has_alpha=*/false, false, 16, format_orig.endianness,
+        span0, xsize, ysize, color_encoding0, /*channels=*/3,
+        /*alpha_is_premultiplied=*/false, /*bits_per_sample=*/16,
+        format_orig.endianness,
         /*flipped_y=*/false, /*pool=*/nullptr, &io0.Main(), /*float_in=*/false,
         /*align=*/0));
 
     jxl::ColorEncoding color_encoding1 = jxl::ColorEncoding::SRGB(false);
     jxl::Span<const uint8_t> span1(pixels2.data(), pixels2.size());
     jxl::CodecInOut io1;
-    if (channels == 4) {
-      io1.metadata.m.SetAlphaBits(8);
-      io1.SetSize(xsize, ysize);
-      EXPECT_TRUE(
-          ConvertFromExternal(span1, xsize, ysize, color_encoding1,
-                              /*has_alpha=*/true, false, 8, format.endianness,
-                              /*flipped_y=*/false, /*pool=*/nullptr,
-                              &io1.Main(), /*float_in=*/false, /*align=*/0));
-      io1.metadata.m.SetAlphaBits(0);
-      io1.Main().ClearExtraChannels();
-    } else {
-      EXPECT_TRUE(
-          ConvertFromExternal(span1, xsize, ysize, color_encoding1,
-                              /*has_alpha=*/false, false, 8, format.endianness,
-                              /*flipped_y=*/false, /*pool=*/nullptr,
-                              &io1.Main(), /*float_in=*/false, /*align=*/0));
-    }
+    EXPECT_TRUE(ConvertFromExternal(span1, xsize, ysize, color_encoding1,
+                                    channels, /*alpha_is_premultiplied=*/false,
+                                    /*bits_per_sample=*/8, format.endianness,
+                                    /*flipped_y=*/false, /*pool=*/nullptr,
+                                    &io1.Main(), /*float_in=*/false,
+                                    /*align=*/0));
 
     jxl::ButteraugliParams ba;
     EXPECT_THAT(ButteraugliDistance(io0, io1, ba, jxl::GetJxlCms(),
@@ -1670,31 +1662,21 @@ TEST(DecodeTest, PixelTestOpaqueSrgbLossyNoise) {
     jxl::CodecInOut io0;
     io0.SetSize(xsize, ysize);
     EXPECT_TRUE(ConvertFromExternal(
-        span0, xsize, ysize, color_encoding0,
-        /*has_alpha=*/false, false, 16, format_orig.endianness,
+        span0, xsize, ysize, color_encoding0, /*channels=*/3,
+        /*alpha_is_premultiplied=*/false, /*bits_per_sample=*/16,
+        format_orig.endianness,
         /*flipped_y=*/false, /*pool=*/nullptr, &io0.Main(), /*float_in=*/false,
         /*align=*/0));
 
     jxl::ColorEncoding color_encoding1 = jxl::ColorEncoding::SRGB(false);
     jxl::Span<const uint8_t> span1(pixels2.data(), pixels2.size());
     jxl::CodecInOut io1;
-    if (channels == 4) {
-      io1.metadata.m.SetAlphaBits(8);
-      io1.SetSize(xsize, ysize);
-      EXPECT_TRUE(
-          ConvertFromExternal(span1, xsize, ysize, color_encoding1,
-                              /*has_alpha=*/true, false, 8, format.endianness,
-                              /*flipped_y=*/false, /*pool=*/nullptr,
-                              &io1.Main(), /*float_in=*/false, /*align=*/0));
-      io1.metadata.m.SetAlphaBits(0);
-      io1.Main().ClearExtraChannels();
-    } else {
-      EXPECT_TRUE(
-          ConvertFromExternal(span1, xsize, ysize, color_encoding1,
-                              /*has_alpha=*/false, false, 8, format.endianness,
-                              /*flipped_y=*/false, /*pool=*/nullptr,
-                              &io1.Main(), /*float_in=*/false, /*align=*/0));
-    }
+    EXPECT_TRUE(ConvertFromExternal(span1, xsize, ysize, color_encoding1,
+                                    channels, /*alpha_is_premultiplied=*/false,
+                                    /*bits_per_sample=*/8, format.endianness,
+                                    /*flipped_y=*/false, /*pool=*/nullptr,
+                                    &io1.Main(), /*float_in=*/false,
+                                    /*align=*/0));
 
     jxl::ButteraugliParams ba;
     EXPECT_THAT(ButteraugliDistance(io0, io1, ba, jxl::GetJxlCms(),
@@ -2034,7 +2016,7 @@ TEST(DecodeTest, AnimationTest) {
 
     EXPECT_TRUE(ConvertFromExternal(
         jxl::Span<const uint8_t>(frames[i].data(), frames[i].size()), xsize,
-        ysize, jxl::ColorEncoding::SRGB(/*is_gray=*/false), /*has_alpha=*/false,
+        ysize, jxl::ColorEncoding::SRGB(/*is_gray=*/false), /*channels=*/3,
         /*alpha_is_premultiplied=*/false, /*bits_per_sample=*/16,
         JXL_BIG_ENDIAN, /*flipped_y=*/false, /*pool=*/nullptr, &bundle,
         /*float_in=*/false, /*align=*/0));
@@ -2138,7 +2120,7 @@ TEST(DecodeTest, AnimationTestStreaming) {
 
     EXPECT_TRUE(ConvertFromExternal(
         jxl::Span<const uint8_t>(frames[i].data(), frames[i].size()), xsize,
-        ysize, jxl::ColorEncoding::SRGB(/*is_gray=*/false), /*has_alpha=*/false,
+        ysize, jxl::ColorEncoding::SRGB(/*is_gray=*/false), /*channels=*/3,
         /*alpha_is_premultiplied=*/false, /*bits_per_sample=*/16,
         JXL_BIG_ENDIAN, /*flipped_y=*/false, /*pool=*/nullptr, &bundle,
         /*float_in=*/false, /*align=*/0));
@@ -2363,7 +2345,7 @@ TEST(DecodeTest, SkipFrameTest) {
 
     EXPECT_TRUE(ConvertFromExternal(
         jxl::Span<const uint8_t>(frames[i].data(), frames[i].size()), xsize,
-        ysize, jxl::ColorEncoding::SRGB(/*is_gray=*/false), /*has_alpha=*/false,
+        ysize, jxl::ColorEncoding::SRGB(/*is_gray=*/false), /*channels=*/3,
         /*alpha_is_premultiplied=*/false, /*bits_per_sample=*/16,
         JXL_BIG_ENDIAN, /*flipped_y=*/false, /*pool=*/nullptr, &bundle,
         /*float_in=*/false, /*align=*/0));
@@ -2500,7 +2482,7 @@ TEST(DecodeTest, SkipFrameWithBlendingTest) {
           jxl::Span<const uint8_t>(frame_internal.data(),
                                    frame_internal.size()),
           xsize, ysize, jxl::ColorEncoding::SRGB(/*is_gray=*/false),
-          /*has_alpha=*/false,
+          /*channels=*/3,
           /*alpha_is_premultiplied=*/false, /*bits_per_sample=*/16,
           JXL_BIG_ENDIAN, /*flipped_y=*/false, /*pool=*/nullptr,
           &bundle_internal, /*float_in=*/false, /*align=*/0));
@@ -2516,7 +2498,7 @@ TEST(DecodeTest, SkipFrameWithBlendingTest) {
     jxl::ImageBundle bundle(&io.metadata.m);
     EXPECT_TRUE(ConvertFromExternal(
         jxl::Span<const uint8_t>(frame.data(), frame.size()), xsize, ysize,
-        jxl::ColorEncoding::SRGB(/*is_gray=*/false), /*has_alpha=*/false,
+        jxl::ColorEncoding::SRGB(/*is_gray=*/false), /*channels=*/3,
         /*alpha_is_premultiplied=*/false, /*bits_per_sample=*/16,
         JXL_BIG_ENDIAN, /*flipped_y=*/false, /*pool=*/nullptr, &bundle,
         /*float_in=*/false, /*align=*/0));
@@ -2727,7 +2709,7 @@ TEST(DecodeTest, SkipFrameWithAlphaBlendingTest) {
           jxl::Span<const uint8_t>(frame_internal.data(),
                                    frame_internal.size()),
           xsize / 2, ysize / 2, jxl::ColorEncoding::SRGB(/*is_gray=*/false),
-          /*has_alpha=*/true,
+          /*channels=*/4,
           /*alpha_is_premultiplied=*/false, /*bits_per_sample=*/16,
           JXL_BIG_ENDIAN, /*flipped_y=*/false, /*pool=*/nullptr,
           &bundle_internal, /*float_in=*/false, /*align=*/0));
@@ -2748,8 +2730,7 @@ TEST(DecodeTest, SkipFrameWithAlphaBlendingTest) {
     jxl::ImageBundle bundle(&io.metadata.m);
     EXPECT_TRUE(ConvertFromExternal(
         jxl::Span<const uint8_t>(frame.data(), frame.size()), cropxsize,
-        cropysize, jxl::ColorEncoding::SRGB(/*is_gray=*/false),
-        /*has_alpha=*/true,
+        cropysize, jxl::ColorEncoding::SRGB(/*is_gray=*/false), /*channels=*/4,
         /*alpha_is_premultiplied=*/false, /*bits_per_sample=*/16,
         JXL_BIG_ENDIAN, /*flipped_y=*/false, /*pool=*/nullptr, &bundle,
         /*float_in=*/false, /*align=*/0));
@@ -3010,7 +2991,7 @@ TEST(DecodeTest, OrientedCroppedFrameTest) {
       EXPECT_TRUE(ConvertFromExternal(
           jxl::Span<const uint8_t>(frame.data(), frame.size()), cropxsize,
           cropysize, jxl::ColorEncoding::SRGB(/*is_gray=*/false),
-          /*has_alpha=*/true,
+          /*channels=*/4,
           /*alpha_is_premultiplied=*/false, /*bits_per_sample=*/16,
           JXL_BIG_ENDIAN, /*flipped_y=*/false, /*pool=*/nullptr, &bundle,
           /*float_in=*/false, /*align=*/0));

--- a/lib/jxl/enc_external_image.cc
+++ b/lib/jxl/enc_external_image.cc
@@ -212,7 +212,7 @@ Status ConvertFromExternal(Span<const uint8_t> bytes, size_t xsize,
 }
 Status ConvertFromExternal(Span<const uint8_t> bytes, size_t xsize,
                            size_t ysize, const ColorEncoding& c_current,
-                           bool has_alpha, bool alpha_is_premultiplied,
+                           size_t channels, bool alpha_is_premultiplied,
                            size_t bits_per_sample, JxlEndianness endianness,
                            bool flipped_y, ThreadPool* pool, ImageBundle* ib,
                            bool float_in, size_t align) {
@@ -227,7 +227,12 @@ Status ConvertFromExternal(Span<const uint8_t> bytes, size_t xsize,
   }
 
   const size_t color_channels = c_current.Channels();
-  const size_t channels = color_channels + has_alpha;
+  bool has_alpha = channels == 2 || channels == 4;
+  if (channels < color_channels) {
+    return JXL_FAILURE("Expected %" PRIuS
+                       " color channels, received only %" PRIuS " channels",
+                       color_channels, channels);
+  }
 
   // bytes_per_channel and bytes_per_pixel are only valid for
   // bits_per_sample > 1.
@@ -351,7 +356,7 @@ Status ConvertFromExternal(Span<const uint8_t> bytes, size_t xsize,
           [&](const uint32_t task, size_t /*thread*/) {
             const size_t y = get_y(task);
             size_t i = row_size * task +
-                       (color_channels * bits_per_sample / jxl::kBitsPerByte);
+                       ((channels - 1) * bits_per_sample / jxl::kBitsPerByte);
             float* JXL_RESTRICT row_out = alpha.Row(y);
             if (bits_per_sample <= 16) {
               if (little_endian) {
@@ -386,7 +391,7 @@ Status ConvertFromExternal(Span<const uint8_t> bytes, size_t xsize,
           pool, 0, static_cast<uint32_t>(ysize), ThreadPool::NoInit,
           [&](const uint32_t task, size_t /*thread*/) {
             const size_t y = get_y(task);
-            size_t i = row_size * task + color_channels * bytes_per_channel;
+            size_t i = row_size * task + (channels - 1) * bytes_per_channel;
             float* JXL_RESTRICT row_out = alpha.Row(y);
             // TODO(deymo): add bits_per_sample == 1 case here. Also maybe
             // implement masking if bits_per_sample is not a multiple of 8.
@@ -448,9 +453,7 @@ Status BufferToImageBundle(const JxlPixelFormat& pixel_format, uint32_t xsize,
 
   JXL_RETURN_IF_ERROR(ConvertFromExternal(
       jxl::Span<const uint8_t>(static_cast<const uint8_t*>(buffer), size),
-      xsize, ysize, c_current,
-      /*has_alpha=*/pixel_format.num_channels == 2 ||
-          pixel_format.num_channels == 4,
+      xsize, ysize, c_current, pixel_format.num_channels,
       /*alpha_is_premultiplied=*/false, bitdepth, pixel_format.endianness,
       /*flipped_y=*/false, pool, ib, float_in, pixel_format.align));
   ib->VerifyMetadata();

--- a/lib/jxl/enc_external_image.h
+++ b/lib/jxl/enc_external_image.h
@@ -30,7 +30,7 @@ Status ConvertFromExternal(Span<const uint8_t> bytes, size_t xsize,
 // representation. This is the opposite of ConvertToExternal().
 Status ConvertFromExternal(Span<const uint8_t> bytes, size_t xsize,
                            size_t ysize, const ColorEncoding& c_current,
-                           bool has_alpha, bool alpha_is_premultiplied,
+                           size_t channels, bool alpha_is_premultiplied,
                            size_t bits_per_sample, JxlEndianness endianness,
                            bool flipped_y, ThreadPool* pool, ImageBundle* ib,
                            bool float_in, size_t align);

--- a/lib/jxl/enc_external_image_gbench.cc
+++ b/lib/jxl/enc_external_image_gbench.cc
@@ -28,7 +28,7 @@ void BM_EncExternalImage_ConvertImageRGBA(benchmark::State& state) {
           Span<const uint8_t>(interleaved.data(), interleaved.size()), xsize,
           ysize,
           /*c_current=*/ColorEncoding::SRGB(),
-          /*has_alpha=*/true,
+          /*channels=*/4,
           /*alpha_is_premultiplied=*/false,
           /*bits_per_sample=*/8, JXL_NATIVE_ENDIAN,
           /*flipped_y=*/false,

--- a/lib/jxl/enc_external_image_test.cc
+++ b/lib/jxl/enc_external_image_test.cc
@@ -28,18 +28,18 @@ TEST(ExternalImageTest, InvalidSize) {
   const uint8_t buf[10 * 100 * 8] = {};
   EXPECT_FALSE(ConvertFromExternal(
       Span<const uint8_t>(buf, 10), /*xsize=*/10, /*ysize=*/100,
-      /*c_current=*/ColorEncoding::SRGB(), /*has_alpha=*/true,
+      /*c_current=*/ColorEncoding::SRGB(), /*channels=*/4,
       /*alpha_is_premultiplied=*/false, /*bits_per_sample=*/16, JXL_BIG_ENDIAN,
       /*flipped_y=*/false, nullptr, &ib, /*float_in=*/false, /*align=*/0));
   EXPECT_FALSE(ConvertFromExternal(
       Span<const uint8_t>(buf, sizeof(buf) - 1), /*xsize=*/10, /*ysize=*/100,
-      /*c_current=*/ColorEncoding::SRGB(), /*has_alpha=*/true,
+      /*c_current=*/ColorEncoding::SRGB(), /*channels=*/4,
       /*alpha_is_premultiplied=*/false, /*bits_per_sample=*/16, JXL_BIG_ENDIAN,
       /*flipped_y=*/false, nullptr, &ib, /*float_in=*/false, /*align=*/0));
   EXPECT_TRUE(ConvertFromExternal(
       Span<const uint8_t>(buf, sizeof(buf)), /*xsize=*/10,
       /*ysize=*/100, /*c_current=*/ColorEncoding::SRGB(),
-      /*has_alpha=*/true, /*alpha_is_premultiplied=*/false,
+      /*channels=*/4, /*alpha_is_premultiplied=*/false,
       /*bits_per_sample=*/16, JXL_BIG_ENDIAN,
       /*flipped_y=*/false, nullptr, &ib, /*float_in=*/false, /*align=*/0));
 }
@@ -59,7 +59,7 @@ TEST(ExternalImageTest, AlphaMissing) {
   EXPECT_TRUE(ConvertFromExternal(
       Span<const uint8_t>(buf, sizeof(buf)), xsize, ysize,
       /*c_current=*/ColorEncoding::SRGB(),
-      /*has_alpha=*/true, /*alpha_is_premultiplied=*/false,
+      /*channels=*/4, /*alpha_is_premultiplied=*/false,
       /*bits_per_sample=*/8, JXL_BIG_ENDIAN,
       /*flipped_y=*/false, nullptr, &ib, /*float_in=*/false, /*align=*/0));
   EXPECT_FALSE(ib.HasAlpha());

--- a/lib/jxl/roundtrip_test.cc
+++ b/lib/jxl/roundtrip_test.cc
@@ -38,8 +38,7 @@ jxl::CodecInOut ConvertTestImage(const std::vector<uint8_t>& buf,
   jxl::CodecInOut io;
   io.SetSize(xsize, ysize);
 
-  bool is_gray =
-      pixel_format.num_channels == 1 || pixel_format.num_channels == 2;
+  bool is_gray = pixel_format.num_channels < 3;
   bool has_alpha =
       pixel_format.num_channels == 2 || pixel_format.num_channels == 4;
 
@@ -98,13 +97,13 @@ jxl::CodecInOut ConvertTestImage(const std::vector<uint8_t>& buf,
   } else {
     color_encoding = jxl::ColorEncoding::SRGB(is_gray);
   }
-  EXPECT_TRUE(
-      ConvertFromExternal(jxl::Span<const uint8_t>(buf.data(), buf.size()),
-                          xsize, ysize, color_encoding, has_alpha,
-                          /*alpha_is_premultiplied=*/false,
-                          /*bits_per_sample=*/bitdepth, pixel_format.endianness,
-                          /*flipped_y=*/false, /*pool=*/nullptr, &io.Main(),
-                          float_in, /*align=*/0));
+  EXPECT_TRUE(ConvertFromExternal(
+      jxl::Span<const uint8_t>(buf.data(), buf.size()), xsize, ysize,
+      color_encoding, pixel_format.num_channels,
+      /*alpha_is_premultiplied=*/false,
+      /*bits_per_sample=*/bitdepth, pixel_format.endianness,
+      /*flipped_y=*/false, /*pool=*/nullptr, &io.Main(), float_in,
+      /*align=*/0));
   return io;
 }
 

--- a/lib/jxl/test_utils.h
+++ b/lib/jxl/test_utils.h
@@ -369,9 +369,7 @@ jxl::CodecInOut SomeTestImageToCodecInOut(const std::vector<uint8_t>& buf,
       /*is_gray=*/num_channels == 1 || num_channels == 2);
   EXPECT_TRUE(ConvertFromExternal(
       jxl::Span<const uint8_t>(buf.data(), buf.size()), xsize, ysize,
-      jxl::ColorEncoding::SRGB(/*is_gray=*/num_channels == 1 ||
-                               num_channels == 2),
-      /*has_alpha=*/num_channels == 2 || num_channels == 4,
+      jxl::ColorEncoding::SRGB(/*is_gray=*/num_channels < 3), num_channels,
       /*alpha_is_premultiplied=*/false, /*bits_per_sample=*/16, JXL_BIG_ENDIAN,
       /*flipped_y=*/false, /*pool=*/nullptr,
       /*ib=*/&io.Main(), /*float_in=*/false, 0));

--- a/tools/benchmark/benchmark_codec_avif.cc
+++ b/tools/benchmark/benchmark_codec_avif.cc
@@ -309,7 +309,7 @@ class AvifCodec : public ImageCodec {
           JXL_RETURN_IF_ERROR(ConvertFromExternal(
               Span<const uint8_t>(rgb_image.pixels,
                                   rgb_image.height * rgb_image.rowBytes),
-              rgb_image.width, rgb_image.height, color, has_alpha,
+              rgb_image.width, rgb_image.height, color, (has_alpha ? 4 : 3),
               /*alpha_is_premultiplied=*/false, rgb_image.depth,
               JXL_NATIVE_ENDIAN, /*flipped_y=*/false, pool, &ib,
               /*float_in=*/false, /*align=*/0));

--- a/tools/benchmark/benchmark_codec_webp.cc
+++ b/tools/benchmark/benchmark_codec_webp.cc
@@ -40,7 +40,8 @@ Status FromSRGB(const size_t xsize, const size_t ysize, const bool is_gray,
   const ColorEncoding& c = ColorEncoding::SRGB(is_gray);
   const size_t bits_per_sample = (is_16bit ? 2 : 1) * kBitsPerByte;
   const Span<const uint8_t> span(pixels, end - pixels);
-  return ConvertFromExternal(span, xsize, ysize, c, has_alpha,
+  return ConvertFromExternal(span, xsize, ysize, c,
+                             (is_gray ? 1 : 3) + (has_alpha ? 1 : 0),
                              alpha_is_premultiplied, bits_per_sample,
                              endianness, /*flipped_y=*/false, pool, ib,
                              /*float_in=*/false, /*align=*/0);

--- a/tools/fuzzer_corpus.cc
+++ b/tools/fuzzer_corpus.cc
@@ -218,7 +218,7 @@ bool GenerateFile(const char* output_dir, const ImageSpec& spec,
     const jxl::Span<const uint8_t> span(img_data.data(), img_data.size());
     JXL_RETURN_IF_ERROR(ConvertFromExternal(
         span, spec.width, spec.height, io.metadata.m.color_encoding,
-        /*has_alpha=*/has_alpha,
+        bytes_per_pixel / bytes_per_sample,
         /*alpha_is_premultiplied=*/spec.alpha_is_premultiplied,
         io.metadata.m.bit_depth.bits_per_sample, JXL_LITTLE_ENDIAN,
         false /* flipped_y */, nullptr, &ib, /*float_in=*/false, /*align=*/0));


### PR DESCRIPTION
Fixes #1198 

When an RGB(A) buffer is passed while the image is grayscale, use R and A instead of misinterpreting the buffer as Y(A) and ignoring the bottom part. G and B just get ignored in this case and G and B get copied from R (we could instead check that R==G==B in the input, but that comes at a small overhead just to catch potential wrong API usage; I think it will be sufficiently easy to debug for application developers if they see their color image gets incorrectly grayscaled when they accidentally incorrectly set the color encoding to grayscale).

When a Y(A) buffer is passed while the image is color, return a relevant error instead of just saying that the buffer is too small.
