### PR TITLE
fix default resampling in encode api

### DIFF
--- a/lib/jxl/enc_file.cc
+++ b/lib/jxl/enc_file.cc
@@ -198,20 +198,7 @@ Status EncodeFile(const CompressParams& cparams_orig, const CodecInOut* io,
     cparams.color_transform = io->Main().color_transform;
   }
 
-  // TODO(lode): move this to a common CompressParam post-initializer that is
-  // mandatory to be called, so that the encode API can also use it, once the
-  // encode API has the settings for resampling in the first place.
-  if (cparams.resampling == 0) {
-    cparams.resampling = 1;
-    // For very low bit rates, using 2x2 resampling gives better results on
-    // most photographic images, with an adjusted butteraugli score chosen to
-    // give roughly the same amount of bits per pixel.
-    if (!cparams.already_downsampled && cparams.butteraugli_distance >= 20) {
-      cparams.resampling = 2;
-      cparams.butteraugli_distance =
-          6 + ((cparams.butteraugli_distance - 20) * 0.25);
-    }
-  }
+  cparams.PostInit();
 
   std::unique_ptr<CodecMetadata> metadata = jxl::make_unique<CodecMetadata>();
   JXL_RETURN_IF_ERROR(PrepareCodecMetadataFromIO(cparams, io, metadata.get()));

--- a/lib/jxl/enc_frame.cc
+++ b/lib/jxl/enc_frame.cc
@@ -1052,6 +1052,7 @@ Status EncodeFrame(const CompressParams& cparams_orig,
   passes_enc_state->special_frames.clear();
 
   CompressParams cparams = cparams_orig;
+  cparams.PostInit();
 
   if (cparams.progressive_dc < 0) {
     if (cparams.progressive_dc != -1) {

--- a/lib/jxl/encode.cc
+++ b/lib/jxl/encode.cc
@@ -795,9 +795,6 @@ JxlEncoderStatus JxlEncoderFrameSettingsSetOption(
       if (value != -1 && value != 1 && value != 2 && value != 4 && value != 8) {
         return JXL_ENC_ERROR;
       }
-      // The implementation doesn't support the default choice between 1x1 and
-      // 2x2 for extra channels, so 1x1 is set as the default.
-      if (value == -1) value = 1;
       frame_settings->values.cparams.ec_resampling = value;
       return JXL_ENC_SUCCESS;
     case JXL_ENC_FRAME_SETTING_ALREADY_DOWNSAMPLED:

--- a/tools/cjxl.cc
+++ b/tools/cjxl.cc
@@ -428,15 +428,15 @@ void CompressArgs::AddCommandLineOptions(CommandLineParser* cmdline) {
                           "force disable/enable patches generation.",
                           &params.patches, &ParseOverride, 1);
   cmdline->AddOptionValue(
-      '\0', "resampling", "0|1|2|4|8",
-      "Subsample all color channels by this factor, or use 0 to choose the "
+      '\0', "resampling", "-1|1|2|4|8",
+      "Subsample all color channels by this factor, or use -1 to choose the "
       "resampling factor based on distance.",
-      &params.resampling, &ParseUnsigned, 0);
+      &params.resampling, &ParseSigned, 0);
   cmdline->AddOptionValue(
       '\0', "ec_resampling", "1|2|4|8",
       "Subsample all extra channels by this factor. If this value is smaller "
       "than the resampling of color channels, it will be increased to match.",
-      &params.ec_resampling, &ParseUnsigned, 2);
+      &params.ec_resampling, &ParseSigned, 2);
   cmdline->AddOptionFlag('\0', "already_downsampled",
                          "Do not downsample the given input before encoding, "
                          "but still signal that the decoder should upsample.",


### PR DESCRIPTION
Fixes #1210 so it does the correct thing when setting resampling to -1 in the API.