### PR TITLE
add Noise and XYBFactors options to jxl_from_tree

### DIFF
--- a/lib/jxl/enc_file.cc
+++ b/lib/jxl/enc_file.cc
@@ -198,7 +198,7 @@ Status EncodeFile(const CompressParams& cparams_orig, const CodecInOut* io,
     cparams.color_transform = io->Main().color_transform;
   }
 
-  cparams.PostInit();
+  JXL_RETURN_IF_ERROR(ParamsPostInit(&cparams));
 
   std::unique_ptr<CodecMetadata> metadata = jxl::make_unique<CodecMetadata>();
   JXL_RETURN_IF_ERROR(PrepareCodecMetadataFromIO(cparams, io, metadata.get()));

--- a/lib/jxl/enc_frame.cc
+++ b/lib/jxl/enc_frame.cc
@@ -213,7 +213,8 @@ uint64_t FrameFlagsFromParams(const CompressParams& cparams) {
   // noise is stored within the compressed image and adding noise makes things
   // worse.
   if (ApplyOverride(cparams.noise, dist >= kMinButteraugliForNoise) ||
-      cparams.photon_noise_iso > 0) {
+      cparams.photon_noise_iso > 0 ||
+      cparams.manual_noise.size() == NoiseParams::kNumNoisePoints) {
     flags |= FrameHeader::kNoise;
   }
 
@@ -303,7 +304,7 @@ Status MakeFrameHeader(const CompressParams& cparams,
   frame_header->flags = FrameFlagsFromParams(cparams);
   // Non-photon noise is not supported in the Modular encoder for now.
   if (frame_header->encoding != FrameEncoding::kVarDCT &&
-      cparams.photon_noise_iso == 0) {
+      cparams.photon_noise_iso == 0 && cparams.manual_noise.size() == 0) {
     frame_header->UpdateFlag(false, FrameHeader::Flags::kNoise);
   }
 
@@ -1042,6 +1043,30 @@ class LossyFrameEncoder {
   bool doing_jpeg_recompression = false;
 };
 
+Status ParamsPostInit(CompressParams* p) {
+  if (p->manual_noise.size() != 0 &&
+      p->manual_noise.size() != NoiseParams::kNumNoisePoints) {
+    return JXL_FAILURE("Invalid number of noise lut entries");
+  }
+  if (p->manual_xyb_factors.size() != 0 && p->manual_xyb_factors.size() != 3) {
+    return JXL_FAILURE("Invalid number of XYB quantization factors");
+  }
+  if (p->resampling <= 0) {
+    p->resampling = 1;
+    // For very low bit rates, using 2x2 resampling gives better results on
+    // most photographic images, with an adjusted butteraugli score chosen to
+    // give roughly the same amount of bits per pixel.
+    if (!p->already_downsampled && p->butteraugli_distance >= 20) {
+      p->resampling = 2;
+      p->butteraugli_distance = 6 + ((p->butteraugli_distance - 20) * 0.25);
+    }
+  }
+  if (p->ec_resampling <= 0) {
+    p->ec_resampling = p->resampling;
+  }
+  return true;
+}
+
 Status EncodeFrame(const CompressParams& cparams_orig,
                    const FrameInfo& frame_info, const CodecMetadata* metadata,
                    const ImageBundle& ib, PassesEncoderState* passes_enc_state,
@@ -1052,7 +1077,7 @@ Status EncodeFrame(const CompressParams& cparams_orig,
   passes_enc_state->special_frames.clear();
 
   CompressParams cparams = cparams_orig;
-  cparams.PostInit();
+  JXL_RETURN_IF_ERROR(ParamsPostInit(&cparams));
 
   if (cparams.progressive_dc < 0) {
     if (cparams.progressive_dc != -1) {
@@ -1290,6 +1315,12 @@ Status EncodeFrame(const CompressParams& cparams_orig,
   if (cparams.photon_noise_iso > 0) {
     lossy_frame_encoder.State()->shared.image_features.noise_params =
         SimulatePhotonNoise(ib.xsize(), ib.ysize(), cparams.photon_noise_iso);
+  }
+  if (cparams.manual_noise.size() == NoiseParams::kNumNoisePoints) {
+    for (size_t i = 0; i < NoiseParams::kNumNoisePoints; i++) {
+      lossy_frame_encoder.State()->shared.image_features.noise_params.lut[i] =
+          cparams.manual_noise[i];
+    }
   }
   if (frame_header->flags & FrameHeader::kNoise) {
     EncodeNoise(lossy_frame_encoder.State()->shared.image_features.noise_params,

--- a/lib/jxl/enc_frame.h
+++ b/lib/jxl/enc_frame.h
@@ -60,6 +60,9 @@ struct FrameInfo {
   std::vector<BlendingInfo> extra_channel_blending_info;
 };
 
+// Checks and adjusts CompressParams when they are all initialized.
+Status ParamsPostInit(CompressParams* p);
+
 // Encodes a single frame (including its header) into a byte stream.  Groups may
 // be processed in parallel by `pool`. metadata is the ImageMetadata encoded in
 // the codestream, and must be used for the FrameHeaders, do not use

--- a/lib/jxl/enc_params.h
+++ b/lib/jxl/enc_params.h
@@ -270,6 +270,9 @@ struct CompressParams {
       ec_resampling = resampling;
     }
   }
+
+  std::vector<float> manual_noise;
+  std::vector<float> manual_xyb_factors;
 };
 
 static constexpr float kMinButteraugliForDynamicAR = 0.5f;

--- a/tools/jxl_from_tree.cc
+++ b/tools/jxl_from_tree.cc
@@ -348,6 +348,9 @@ bool ParseNode(F& tok, Tree& tree, SplineData& spline_data,
     spline_data.splines.push_back(std::move(spline));
   } else if (t == "Gaborish") {
     cparams.gaborish = jxl::Override::kOn;
+  } else if (t == "DeltaPalette") {
+    cparams.lossy_palette = true;
+    cparams.palette_colors = 0;
   } else if (t == "EPF") {
     t = tok();
     size_t num = 0;
@@ -355,6 +358,28 @@ bool ParseNode(F& tok, Tree& tree, SplineData& spline_data,
     if (num != t.size() || cparams.epf > 3) {
       fprintf(stderr, "Invalid EPF: %s\n", t.c_str());
       return false;
+    }
+  } else if (t == "Noise") {
+    cparams.manual_noise.resize(8);
+    for (size_t i = 0; i < 8; i++) {
+      t = tok();
+      size_t num = 0;
+      cparams.manual_noise[i] = std::stof(t, &num);
+      if (num != t.size()) {
+        fprintf(stderr, "Invalid noise entry: %s\n", t.c_str());
+        return false;
+      }
+    }
+  } else if (t == "XYBFactors") {
+    cparams.manual_xyb_factors.resize(3);
+    for (size_t i = 0; i < 3; i++) {
+      t = tok();
+      size_t num = 0;
+      cparams.manual_xyb_factors[i] = std::stof(t, &num);
+      if (num != t.size()) {
+        fprintf(stderr, "Invalid XYB factor: %s\n", t.c_str());
+        return false;
+      }
     }
   } else {
     fprintf(stderr, "Unexpected node type: %s\n", t.c_str());
@@ -387,6 +412,8 @@ int JxlFromTree(const char* in, const char* out, const char* tree_out) {
   size_t width = 1024, height = 1024;
   int x0 = 0, y0 = 0;
   cparams.color_transform = ColorTransform::kNone;
+  cparams.resampling = 1;
+  cparams.ec_resampling = 1;
   cparams.modular_group_size_shift = 3;
   CodecInOut io;
   int have_next = 0;


### PR DESCRIPTION
Adds three new options to `jxl_from_tree` to manually specify:

- Noise lookup table: `Noise [8 floats in [0.0,1.0) range]`
- custom XYB quantization factors: `XYBFactors [3 floats]`
- Delta Palette: `DeltaPalette` (signals a default zero-color delta palette transform)

This allows setting XYB factors to their defaults `4096 512 256`, which makes the LfChannelDequantization bundle 1 bit instead of 49 bits, and using different factors than the default ones for modular to get different 'bit depths' in XYB too. In particular, this enables producing the currently known smallest jxl file as follows:
```
XYB
XYBFactors 4096 512 256
Gaborish
EPF 2
Width 512
Height 256
- Set 0
```

For noise this helps to produce test bitstreams to debug noise seeding.

Delta Palette is just to explore jxl art :)