### PR TITLE
Make gflags an IMPORTED GLOBAL library

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -28,6 +28,7 @@ Don Olmstead <don.j.olmstead@gmail.com>
 Heiko Becker <heirecka@exherbo.org>
 Jon Sneyers <jon@cloudinary.com>
 Kleis Auke Wolthuizen <github@kleisauke.nl>
+L. E. Segovia
 Leo Izen <leo.izen@gmail.com>
 Lovell Fuller
 Marcin Konicki <ahwayakchih@gmail.com>

--- a/third_party/CMakeLists.txt
+++ b/third_party/CMakeLists.txt
@@ -178,6 +178,9 @@ if(JPEGXL_ENABLE_TOOLS)
       configure_file("${JPEGXL_DEP_LICENSE_DIR}/libgflags-dev/copyright"
                      ${PROJECT_BINARY_DIR}/LICENSE.gflags COPYONLY)
     endif()  # JPEGXL_DEP_LICENSE_DIR
+    # https://gitlab.kitware.com/cmake/cmake/-/issues/22919
+    message(STATUS "Found: ${gflags_FOUND}")
+    set_target_properties(gflags PROPERTIES IMPORTED_GLOBAL TRUE)
   endif()
 endif()
 


### PR DESCRIPTION
See:

- https://github.com/microsoft/vcpkg/pull/20011

- https://stackoverflow.com/questions/45401212/how-to-make-imported-target-global-afterwards/48390363#48390363

Fixes #1197