### PR TITLE
change vector to deque

### DIFF
--- a/lib/jxl/encode.cc
+++ b/lib/jxl/encode.cc
@@ -48,7 +48,9 @@ namespace {
 template <typename T>
 void AppendJxlpBoxCounter(uint32_t counter, bool last, T* output) {
   if (last) counter |= 0x80000000;
-  StoreBE32(counter, jxl::Extend(output, 4));
+  for (size_t i = 0; i < 4; i++) {
+    output->push_back(counter >> (8 * (3 - i)) & 0xff);
+  }
 }
 
 void QueueFrame(
@@ -1344,8 +1346,7 @@ JxlEncoderStatus JxlEncoderProcessOutput(JxlEncoder* enc, uint8_t** next_out,
          (!enc->output_byte_queue.empty() || !enc->input_queue.empty())) {
     if (!enc->output_byte_queue.empty()) {
       size_t to_copy = std::min(*avail_out, enc->output_byte_queue.size());
-      memcpy(static_cast<void*>(*next_out), enc->output_byte_queue.data(),
-             to_copy);
+      std::copy_n(enc->output_byte_queue.begin(), to_copy, *next_out);
       *next_out += to_copy;
       *avail_out -= to_copy;
       enc->output_byte_queue.erase(enc->output_byte_queue.begin(),


### PR DESCRIPTION
might help when a client has a small output buffer

looks like O(n**2) writing would happen with vector erasing a small number of bytes in the beginning 