### PR TITLE
fail earlier when level is too low

### DIFF
--- a/lib/jxl/encode.cc
+++ b/lib/jxl/encode.cc
@@ -620,7 +620,15 @@ JxlEncoderStatus JxlEncoderSetBasicInfo(JxlEncoder* enc,
     enc->metadata.m.animation.num_loops = info->animation.num_loops;
     enc->metadata.m.animation.have_timecodes = info->animation.have_timecodes;
   }
-
+  std::string level_message;
+  int required_level = VerifyLevelSettings(enc, &level_message);
+  if (required_level == -1 ||
+      static_cast<int>(enc->codestream_level) < required_level) {
+    return JXL_API_ERROR("%s", ("Codestream level verification for level " +
+                                std::to_string(enc->codestream_level) +
+                                " failed: " + level_message)
+                                   .c_str());
+  }
   return JXL_ENC_SUCCESS;
 }
 
@@ -662,6 +670,15 @@ JXL_EXPORT JxlEncoderStatus JxlEncoderSetExtraChannelInfo(
   channel.spot_color[1] = info->spot_color[1];
   channel.spot_color[2] = info->spot_color[2];
   channel.spot_color[3] = info->spot_color[3];
+  std::string level_message;
+  int required_level = VerifyLevelSettings(enc, &level_message);
+  if (required_level == -1 ||
+      static_cast<int>(enc->codestream_level) < required_level) {
+    return JXL_API_ERROR("%s", ("Codestream level verification for level " +
+                                std::to_string(enc->codestream_level) +
+                                " failed: " + level_message)
+                                   .c_str());
+  }
   return JXL_ENC_SUCCESS;
 }
 

--- a/lib/jxl/encode_test.cc
+++ b/lib/jxl/encode_test.cc
@@ -755,16 +755,15 @@ TEST(EncodeTest, CodestreamLevelVerificationTest) {
   // Set an image dimension that is too large for level 5, but fits in level 10
 
   basic_info.xsize = 1ull << 30ull;
+  EXPECT_EQ(JXL_ENC_ERROR, JxlEncoderSetBasicInfo(enc.get(), &basic_info));
+  EXPECT_EQ(JXL_ENC_SUCCESS, JxlEncoderSetCodestreamLevel(enc.get(), 10));
   EXPECT_EQ(JXL_ENC_SUCCESS, JxlEncoderSetBasicInfo(enc.get(), &basic_info));
-
   EXPECT_EQ(10, JxlEncoderGetRequiredCodestreamLevel(enc.get()));
 
   // Set an image dimension that is too large even for level 10
 
   basic_info.xsize = 1ull << 31ull;
-  EXPECT_EQ(JXL_ENC_SUCCESS, JxlEncoderSetBasicInfo(enc.get(), &basic_info));
-
-  EXPECT_EQ(-1, JxlEncoderGetRequiredCodestreamLevel(enc.get()));
+  EXPECT_EQ(JXL_ENC_ERROR, JxlEncoderSetBasicInfo(enc.get(), &basic_info));
 }
 
 TEST(EncodeTest, JXL_TRANSCODE_JPEG_TEST(JPEGReconstructionTest)) {


### PR DESCRIPTION
Fixes https://github.com/libjxl/libjxl/issues/1237.

Return error earlier when attempting to encode an image that does not meet the level requirements. In particular: if it has more extra channels than what level 5 allows, return error already at `JxlEncoderSetBasicInfo`, and when trying to add a CMYK channel, return error already at `JxlEncoderSetExtraChannelInfo`. Currently these cases will cause error only when the actual encode of the first frame is started, which is unnecessarily late.