### PR TITLE
Deviate from upstream ppm specification and assume color space is sRGB

### DIFF
--- a/lib/extras/dec/pnm.cc
+++ b/lib/extras/dec/pnm.cc
@@ -312,6 +312,9 @@ Status DecodeImagePNM(const Span<const uint8_t> bytes,
     return JXL_FAILURE("PNM: bits_per_sample invalid");
   }
 
+  // PPM specify that in the raster, the sample values are "nonlinear" (BP.709,
+  // with gamma number of 2.2). Deviate from the specification and assume
+  // `sRGB` in our implementation.
   JXL_RETURN_IF_ERROR(ApplyColorHints(color_hints, /*color_already_set=*/false,
                                       header.is_gray, ppf));
 


### PR DESCRIPTION
[...]
In the raster, the sample values are "nonlinear." They are proportional
to the intensity of the ITU-R Recommendation BT.709 red, green, and blue
in the pixel, adjusted by the BT.709 gamma transfer function. (That
transfer function specifies a gamma number of 2.2 and has a linear
section for small intensities). A value of Maxval for all three samples
represents CIE D65 white and the most intense color in the color
universe of which the image is part (the color universe is all the
colors in all images to which this image might be compared).
[...]

* http://netpbm.sourceforge.net/doc/ppm.html