### PR TITLE
modular_16 and a cparam to conform to level restrictions

### DIFF
--- a/lib/jxl/dec_file.cc
+++ b/lib/jxl/dec_file.cc
@@ -66,7 +66,23 @@ Status DecodeFile(const DecompressParams& dparams,
   {
     BitReader reader(file);
     BitReaderScopedCloser reader_closer(&reader, &ret);
-    (void)reader.ReadFixedBits<16>();  // skip marker
+    if (reader.ReadFixedBits<16>() != 0x0AFF) {
+      // We don't have a naked codestream. Make a quick & dirty attempt to find
+      // the codestream.
+      // TODO(jon): get rid of this whole function
+      const unsigned char* begin = file.data();
+      const unsigned char* end = file.data() + file.size() - 4;
+      while (begin < end) {
+        if (!memcmp(begin, "jxlc", 4)) break;
+        begin++;
+      }
+      if (begin >= end) return JXL_FAILURE("Couldn't find jxl codestream");
+      reader.SkipBits(8 * (begin - file.data() + 2));
+      unsigned int firstbytes = reader.ReadFixedBits<16>();
+      if (firstbytes != 0x0AFF)
+        return JXL_FAILURE("Codestream didn't start with FF0A but with %X",
+                           firstbytes);
+    }
 
     {
       JXL_RETURN_IF_ERROR(DecodeHeaders(&reader, io));

--- a/lib/jxl/enc_modular.cc
+++ b/lib/jxl/enc_modular.cc
@@ -506,6 +506,9 @@ Status ModularFrameEncoder::ComputeEncodingData(
     }
   }
 
+  // in the non-float case, there is an implicit 0 sign bit
+  int max_bitdepth =
+      do_color ? metadata.bit_depth.bits_per_sample + (fp ? 0 : 1) : 0;
   Image& gi = stream_images[0];
   gi = Image(xsize, ysize, metadata.bit_depth.bits_per_sample, nb_chans);
   int c = 0;
@@ -515,8 +518,10 @@ Status ModularFrameEncoder::ComputeEncodingData(
     if (cparams.manual_xyb_factors.size() == 3) {
       DequantMatricesSetCustomDC(&enc_state->shared.matrices,
                                  cparams.manual_xyb_factors.data());
+      // TODO(jon): update max_bitdepth in this case
     } else {
       DequantMatricesSetCustomDC(&enc_state->shared.matrices, enc_factors);
+      max_bitdepth = 12;
     }
   }
   pixel_type maxval = gi.bitdepth < 32 ? (1u << gi.bitdepth) - 1 : 0;
@@ -589,6 +594,7 @@ Status ModularFrameEncoder::ComputeEncodingData(
     int exp_bits = eci.bit_depth.exponent_bits_per_sample;
     bool fp = eci.bit_depth.floating_point_sample;
     double factor = (fp ? 1 : ((1u << eci.bit_depth.bits_per_sample) - 1));
+    if (bits + (fp ? 0 : 1) > max_bitdepth) max_bitdepth = bits + (fp ? 0 : 1);
     std::atomic<bool> has_error{false};
     JXL_RETURN_IF_ERROR(RunOnPool(
         pool, 0, gi.channel[c].plane.ysize(), ThreadPool::NoInit,
@@ -605,6 +611,13 @@ Status ModularFrameEncoder::ComputeEncodingData(
     if (has_error) return JXL_FAILURE("Error in float to integer conversion");
   }
   JXL_ASSERT(c == nb_chans);
+
+  int level_max_bitdepth = (cparams.level == 5 ? 16 : 32);
+  if (max_bitdepth > level_max_bitdepth)
+    return JXL_FAILURE(
+        "Bitdepth too high for level %i (need %i bits, have only %i in this "
+        "level)",
+        cparams.level, max_bitdepth, level_max_bitdepth);
 
   // Set options and apply transformations
 
@@ -711,8 +724,10 @@ Status ModularFrameEncoder::ComputeEncodingData(
     }
   }
 
+  // don't do an RCT if we're short on bits
   if (cparams.color_transform == ColorTransform::kNone && do_color && !fp &&
-      gi.channel.size() - gi.nb_meta_channels >= 3) {
+      gi.channel.size() - gi.nb_meta_channels >= 3 &&
+      max_bitdepth + 1 < level_max_bitdepth) {
     if (cparams.colorspace == 1 ||
         (cparams.colorspace < 0 &&
          (quality < 100 || cparams.speed_tier > SpeedTier::kHare))) {
@@ -720,19 +735,30 @@ Status ModularFrameEncoder::ComputeEncodingData(
       ycocg.rct_type = 6;
       ycocg.begin_c = gi.nb_meta_channels;
       do_transform(gi, ycocg, weighted::Header(), pool);
+      max_bitdepth++;
     } else if (cparams.colorspace >= 2) {
       Transform sg(TransformId::kRCT);
       sg.begin_c = gi.nb_meta_channels;
       sg.rct_type = cparams.colorspace - 2;
       do_transform(gi, sg, weighted::Header(), pool);
+      max_bitdepth++;
     }
   }
 
-  if (cparams.responsive && !gi.channel.empty()) {
+  // don't do squeeze if we don't have some spare bits
+  if (cparams.responsive && !gi.channel.empty() &&
+      max_bitdepth + 2 < level_max_bitdepth) {
     Transform t(TransformId::kSqueeze);
     t.squeezes = cparams.squeezes;
     do_transform(gi, t, weighted::Header(), pool);
+    max_bitdepth += 2;
   }
+
+  if (max_bitdepth + 1 > level_max_bitdepth) {
+    // force no group RCTs if we don't have a spare bit
+    cparams.colorspace = 0;
+  }
+  JXL_ASSERT(max_bitdepth <= level_max_bitdepth);
 
   std::vector<uint32_t> quants;
 

--- a/lib/jxl/enc_params.h
+++ b/lib/jxl/enc_params.h
@@ -255,6 +255,10 @@ struct CompressParams {
   // Skip the downsampling before encoding if this is true.
   bool already_downsampled = false;
 
+  // Codestream level to conform to.
+  // -1: don't care
+  int level = -1;
+
   std::vector<float> manual_noise;
   std::vector<float> manual_xyb_factors;
 };

--- a/lib/jxl/encode_test.cc
+++ b/lib/jxl/encode_test.cc
@@ -173,6 +173,8 @@ void VerifyFrameEncoding(size_t xsize, size_t ysize, JxlEncoder* enc,
   } else {
     basic_info.uses_original_profile = false;
   }
+  // 16-bit alpha means this requires level 10
+  EXPECT_EQ(JXL_ENC_SUCCESS, JxlEncoderSetCodestreamLevel(enc, 10));
   EXPECT_EQ(JXL_ENC_SUCCESS, JxlEncoderSetBasicInfo(enc, &basic_info));
   JxlColorEncoding color_encoding;
   JxlColorEncodingSetToSRGB(&color_encoding,
@@ -198,7 +200,6 @@ void VerifyFrameEncoding(size_t xsize, size_t ysize, JxlEncoder* enc,
   }
   compressed.resize(next_out - compressed.data());
   EXPECT_EQ(JXL_ENC_SUCCESS, process_result);
-
   jxl::DecompressParams dparams;
   jxl::CodecInOut decoded_io;
   EXPECT_TRUE(jxl::DecodeFile(
@@ -630,6 +631,7 @@ TEST(EncodeTest, SingleFrameBoundedJXLCTest) {
   basic_info.xsize = xsize;
   basic_info.ysize = ysize;
   basic_info.uses_original_profile = false;
+  EXPECT_EQ(JXL_ENC_SUCCESS, JxlEncoderSetCodestreamLevel(enc.get(), 10));
   EXPECT_EQ(JXL_ENC_SUCCESS, JxlEncoderSetBasicInfo(enc.get(), &basic_info));
   JxlColorEncoding color_encoding;
   JxlColorEncodingSetToSRGB(&color_encoding,
@@ -739,7 +741,7 @@ TEST(EncodeTest, CodestreamLevelTest) {
 }
 
 TEST(EncodeTest, CodestreamLevelVerificationTest) {
-  JxlPixelFormat pixel_format = {4, JXL_TYPE_UINT16, JXL_BIG_ENDIAN, 0};
+  JxlPixelFormat pixel_format = {4, JXL_TYPE_UINT8, JXL_BIG_ENDIAN, 0};
 
   JxlBasicInfo basic_info;
   jxl::test::JxlBasicInfoSetFromPixelFormat(&basic_info, &pixel_format);
@@ -900,6 +902,7 @@ TEST(EncodeTest, BasicInfoTest) {
   basic_info.animation.tps_denominator = 77;
   basic_info.animation.num_loops = 10;
   basic_info.animation.have_timecodes = JXL_TRUE;
+  EXPECT_EQ(JXL_ENC_SUCCESS, JxlEncoderSetCodestreamLevel(enc.get(), 10));
   EXPECT_EQ(JXL_ENC_SUCCESS, JxlEncoderSetBasicInfo(enc.get(), &basic_info));
   JxlColorEncoding color_encoding;
   JxlColorEncodingSetToSRGB(&color_encoding, /*is_gray=*/false);
@@ -1001,6 +1004,7 @@ TEST(EncodeTest, AnimationHeaderTest) {
   basic_info.animation.tps_numerator = 1000;
   basic_info.animation.tps_denominator = 1;
   basic_info.animation.have_timecodes = JXL_TRUE;
+  EXPECT_EQ(JXL_ENC_SUCCESS, JxlEncoderSetCodestreamLevel(enc.get(), 10));
   EXPECT_EQ(JXL_ENC_SUCCESS, JxlEncoderSetBasicInfo(enc.get(), &basic_info));
   JxlColorEncoding color_encoding;
   JxlColorEncodingSetToSRGB(&color_encoding, /*is_gray=*/false);
@@ -1102,6 +1106,7 @@ TEST(EncodeTest, CroppedFrameTest) {
   basic_info.xsize = 100;
   basic_info.ysize = 100;
   basic_info.uses_original_profile = JXL_TRUE;
+  EXPECT_EQ(JXL_ENC_SUCCESS, JxlEncoderSetCodestreamLevel(enc.get(), 10));
   EXPECT_EQ(JXL_ENC_SUCCESS, JxlEncoderSetBasicInfo(enc.get(), &basic_info));
   JxlColorEncoding color_encoding;
   JxlColorEncodingSetToSRGB(&color_encoding, /*is_gray=*/false);
@@ -1194,6 +1199,7 @@ TEST(EncodeTest, BoxTest) {
     basic_info.xsize = xsize;
     basic_info.ysize = ysize;
     basic_info.uses_original_profile = false;
+    EXPECT_EQ(JXL_ENC_SUCCESS, JxlEncoderSetCodestreamLevel(enc.get(), 10));
     EXPECT_EQ(JXL_ENC_SUCCESS, JxlEncoderSetBasicInfo(enc.get(), &basic_info));
     JxlColorEncoding color_encoding;
     JxlColorEncodingSetToSRGB(&color_encoding,

--- a/lib/jxl/roundtrip_test.cc
+++ b/lib/jxl/roundtrip_test.cc
@@ -588,6 +588,7 @@ TEST(RoundtripTest, ExtraBoxesTest) {
   basic_info.xsize = xsize;
   basic_info.ysize = ysize;
   basic_info.uses_original_profile = false;
+  EXPECT_EQ(JXL_ENC_SUCCESS, JxlEncoderSetCodestreamLevel(enc, 10));
   EXPECT_EQ(JXL_ENC_SUCCESS, JxlEncoderSetBasicInfo(enc, &basic_info));
   JxlColorEncoding color_encoding;
   if (pixel_format.data_type == JXL_TYPE_FLOAT) {


### PR DESCRIPTION
Fixes some stuff related to levels and the `modular_16bit_buffers` header field.

- Set the `modular_16bit_buffers` field correctly in the encode api, i.e. only make it false if there is a reason for it (there is a modular channel that will not fit in int16_t).
- Check that field in VerifyLevelSettings, i.e. don't allow e.g. lossless uint16 to be encoded as level 5.
- Add a cparam option to set the level to conform to. E.g. if the level is 5 and the data is lossless 14-bit, then that's fine, but there are not enough spare bits to do RCTs + Squeeze, so disable those if we have to conform to level 5. However if we only have to conform to level 10, we can still do those things.
- In particular, don't do modular transforms that will potentially cause trouble even in level 10: e.g. when the data is lossless 32-bit float, there are no spare bits at all to do RCTs or Squeeze, so make sure this isn't done.

Currently cjxl doesn't write `jxll` boxes, and probably we don't want to bother with fixing that given that cjxl will soon be replaced by cjxl_ng. So currently encoding via the api requires the level to be set correctly, but encoding directly via EncodeFrame/EncodeFile (as is done in cjxl and in many of the tests) doesn't write `jxll` but also doesn't try to conform to level 5. I didn't try to fix that because that requires updating lots of tests (many tests use uint16 alpha so they require level 10) and eventually all encoding will happen via the api anyway.