### PR TITLE
return api error when trying to do XYB + lossless

### DIFF
--- a/lib/jxl/encode.cc
+++ b/lib/jxl/encode.cc
@@ -712,6 +712,10 @@ JxlEncoderFrameSettings* JxlEncoderOptionsCreate(
 
 JxlEncoderStatus JxlEncoderSetFrameLossless(
     JxlEncoderFrameSettings* frame_settings, const JXL_BOOL lossless) {
+  if (lossless && frame_settings->enc->basic_info_set &&
+      frame_settings->enc->metadata.m.xyb_encoded) {
+    return JXL_API_ERROR("Set use_original_profile=true for lossless encoding");
+  }
   frame_settings->values.lossless = lossless;
   return JXL_ENC_SUCCESS;
 }
@@ -1287,8 +1291,9 @@ JxlEncoderStatus JxlEncoderAddImageFrame(
                                 c_current, &(queued_frame->frame))) {
     return JXL_ENC_ERROR;
   }
-  if (frame_settings->values.lossless) {
-    queued_frame->option_values.cparams.SetLossless();
+  if (frame_settings->values.lossless &&
+      frame_settings->enc->metadata.m.xyb_encoded) {
+    return JXL_API_ERROR("Set use_original_profile=true for lossless encoding");
   }
   queued_frame->option_values.cparams.level =
       frame_settings->enc->codestream_level;


### PR DESCRIPTION
See also https://github.com/libjxl/libjxl/pull/272

Currently the encode api will happily let you call SetFrameLossless() when the image will be XYB encoded. This is a recipe for confusion, since the result will be not be fully lossless and it will be poorly compressed.

So instead, return API error with an error message that will hopefully avoid that mistake.