### PR TITLE
remove modular quality

### DIFF
--- a/lib/jxl/decode_test.cc
+++ b/lib/jxl/decode_test.cc
@@ -4101,7 +4101,7 @@ TEST(DecodeTest, SpotColorTest) {
   cparams.speed_tier = jxl::SpeedTier::kLightning;
   cparams.modular_mode = true;
   cparams.color_transform = jxl::ColorTransform::kNone;
-  cparams.quality_pair = {100, 100};
+  cparams.butteraugli_distance = 0.f;
 
   jxl::PaddedBytes compressed;
   std::unique_ptr<jxl::PassesEncoderState> enc_state =

--- a/lib/jxl/enc_cache.cc
+++ b/lib/jxl/enc_cache.cc
@@ -98,8 +98,10 @@ Status InitializePassesEncoder(const Image3F& opsin, const JxlCmsInterface& cms,
     // and kModular for the smallest DC (first in the bitstream)
     if (cparams.progressive_dc == 0) {
       cparams.modular_mode = true;
-      cparams.quality_pair.first = cparams.quality_pair.second =
-          99.f - enc_state->cparams.butteraugli_distance * 0.2f;
+      // TODO(jon): tweak mapping from image dist to dist for modular DC
+      cparams.butteraugli_distance =
+          std::max(kMinButteraugliDistance,
+                   enc_state->cparams.butteraugli_distance * 0.03f);
     }
     ImageBundle ib(&shared.metadata->m);
     // This is a lie - dc is in XYB

--- a/lib/jxl/enc_file.cc
+++ b/lib/jxl/enc_file.cc
@@ -77,9 +77,7 @@ Status PrepareCodecMetadataFromIO(const CompressParams& cparams,
   // Keep ICC profile in lossless modes because a reconstructed profile may be
   // slightly different (quantization).
   // Also keep ICC in JPEG reconstruction mode as we need byte-exact profiles.
-  const bool lossless_modular =
-      cparams.modular_mode && cparams.quality_pair.first == 100.0f;
-  if (!lossless_modular && !io->Main().IsJPEG()) {
+  if (!cparams.IsLossless() && !io->Main().IsJPEG()) {
     metadata->m.color_encoding.DecideIfWantICC();
   }
 

--- a/lib/jxl/enc_modular.h
+++ b/lib/jxl/enc_modular.h
@@ -80,8 +80,7 @@ class ModularFrameEncoder {
   std::vector<uint8_t> context_map;
   FrameDimensions frame_dim;
   CompressParams cparams;
-  float quality = cparams.quality_pair.first;
-  float cquality = cparams.quality_pair.second;
+  float quality = 100.f;
   std::vector<size_t> tree_splits;
   std::vector<ModularMultiplierInfo> multiplier_info;
   std::vector<std::vector<uint32_t>> gi_channel;

--- a/lib/jxl/enc_params.h
+++ b/lib/jxl/enc_params.h
@@ -219,8 +219,6 @@ struct CompressParams {
   int responsive = -1;
   // empty for default squeeze
   std::vector<SqueezeParams> squeezes;
-  // A pair of <quality, cquality>.
-  std::pair<float, float> quality_pair{100.f, 100.f};
   int colorspace = -1;
   // Use Global channel palette if #colors < this percentage of range
   float channel_colors_pre_transform_percent = 95.f;
@@ -231,16 +229,16 @@ struct CompressParams {
 
   // Returns whether these params are lossless as defined by SetLossless();
   bool IsLossless() const {
-    return modular_mode && quality_pair.first == 100 &&
-           quality_pair.second == 100 &&
-           color_transform == jxl::ColorTransform::kNone;
+    // YCbCr is also considered lossless here since it's intended for
+    // source material that is already YCbCr (we don't do the fwd transform)
+    return modular_mode && butteraugli_distance == 0.0f &&
+           color_transform != jxl::ColorTransform::kXYB;
   }
 
   // Sets the parameters required to make the codec lossless.
   void SetLossless() {
     modular_mode = true;
-    quality_pair.first = 100;
-    quality_pair.second = 100;
+    butteraugli_distance = 0.0f;
     color_transform = jxl::ColorTransform::kNone;
   }
 

--- a/lib/jxl/enc_patch_dictionary.cc
+++ b/lib/jxl/enc_patch_dictionary.cc
@@ -712,8 +712,7 @@ void FindBestPatchDictionary(const Image3F& opsin,
   cparams.patches = Override::kOff;
   // TODO(veluca): possibly change heuristics here.
   if (!cparams.modular_mode) {
-    cparams.quality_pair.first = cparams.quality_pair.second =
-        90.f - cparams.butteraugli_distance * 5.f;
+    cparams.butteraugli_distance *= 0.5f;
   }
 
   RoundtripPatchFrame(&reference_frame, state, 0, cparams, cms, pool, true);

--- a/lib/jxl/encode.cc
+++ b/lib/jxl/encode.cc
@@ -758,29 +758,6 @@ JxlEncoderStatus JxlEncoderSetFrameDistance(
     distance = 0.01f;
   }
   frame_settings->values.cparams.butteraugli_distance = distance;
-  float jpeg_quality;
-  // Formula to translate butteraugli distance roughly into JPEG 0-100 quality.
-  // This is the inverse of the formula in cjxl.cc to translate JPEG quality
-  // into butteraugli distance.
-  if (distance > 6.56f) {
-    jpeg_quality = -5.456783f * std::log(0.0256f * distance - 0.16384f);
-  } else {
-    jpeg_quality = -11.11111f * distance + 101.11111f;
-  }
-  // Translate JPEG quality into the quality_pair setting for modular encoding.
-  // This is the formula also used in cjxl.cc to convert the command line JPEG
-  // quality parameter to the quality_pair setting.
-  // TODO(lode): combine the distance -> quality_pair conversion into a single
-  // formula, possibly altering it to a more suitable heuristic.
-  float quality;
-  if (jpeg_quality < 7.f) {
-    quality = std::min<float>(35.f + (jpeg_quality - 7.f) * 3.0f, 100.0f);
-  } else {
-    quality =
-        std::min<float>(35.f + (jpeg_quality - 7.f) * 65.f / 93.f, 100.0f);
-  }
-  frame_settings->values.cparams.quality_pair.first =
-      frame_settings->values.cparams.quality_pair.second = quality;
   return JXL_ENC_SUCCESS;
 }
 

--- a/lib/jxl/jxl_test.cc
+++ b/lib/jxl/jxl_test.cc
@@ -595,7 +595,7 @@ TEST(JxlTest, RoundtripSmallPatchesAlpha) {
   EXPECT_LE(Roundtrip(&io, cparams, dparams, pool, &io2), 2000u);
   EXPECT_THAT(ButteraugliDistance(io, io2, cparams.ba_params, GetJxlCms(),
                                   /*distmap=*/nullptr, pool),
-              IsSlightlyBelow(0.2f));
+              IsSlightlyBelow(0.12f));
 }
 
 TEST(JxlTest, RoundtripSmallPatches) {
@@ -623,7 +623,7 @@ TEST(JxlTest, RoundtripSmallPatches) {
   EXPECT_LE(Roundtrip(&io, cparams, dparams, pool, &io2), 2000u);
   EXPECT_THAT(ButteraugliDistance(io, io2, cparams.ba_params, GetJxlCms(),
                                   /*distmap=*/nullptr, pool),
-              IsSlightlyBelow(0.2f));
+              IsSlightlyBelow(0.12f));
 }
 
 // Test header encoding of original bits per sample
@@ -826,7 +826,7 @@ TEST(JxlTest, RoundtripAlphaPremultiplied) {
   EXPECT_THAT(
       ButteraugliDistance(io_nopremul, io2, cparams.ba_params, GetJxlCms(),
                           /*distmap=*/nullptr, pool),
-      IsSlightlyBelow(1.8));
+      IsSlightlyBelow(1.4));
 }
 
 TEST(JxlTest, RoundtripAlphaResampling) {
@@ -922,7 +922,7 @@ TEST(JxlTest, RoundtripAlphaNonMultipleOf8) {
   CodecInOut io2;
   EXPECT_TRUE(DecodeFile(dparams, compressed, &io2, pool));
 
-  EXPECT_LE(compressed.size(), 200u);
+  EXPECT_LE(compressed.size(), 180u);
 
   // TODO(robryk): Fix the following line in presence of different alpha_bits in
   // the two contexts.
@@ -930,7 +930,7 @@ TEST(JxlTest, RoundtripAlphaNonMultipleOf8) {
   // TODO(robryk): Fix the distance estimate used in the encoder.
   EXPECT_THAT(ButteraugliDistance(io, io2, cparams.ba_params, GetJxlCms(),
                                   /*distmap=*/nullptr, pool),
-              IsSlightlyBelow(0.8));
+              IsSlightlyBelow(0.9));
 }
 
 TEST(JxlTest, RoundtripAlpha16) {
@@ -965,8 +965,7 @@ TEST(JxlTest, RoundtripAlpha16) {
 
   CompressParams cparams;
   cparams.butteraugli_distance = 0.5;
-  // Prevent the test to be too slow, does not affect alpha
-  cparams.speed_tier = SpeedTier::kSquirrel;
+  cparams.speed_tier = SpeedTier::kWombat;
   DecompressParams dparams;
 
   io.metadata.m.SetUintSamples(16);
@@ -978,8 +977,9 @@ TEST(JxlTest, RoundtripAlpha16) {
                          aux_out, &pool));
   CodecInOut io2;
   EXPECT_TRUE(DecodeFile(dparams, compressed, &io2, &pool));
-
-  EXPECT_TRUE(SamePixels(*io.Main().alpha(), *io2.Main().alpha()));
+  EXPECT_THAT(ButteraugliDistance(io, io2, cparams.ba_params, GetJxlCms(),
+                                  /*distmap=*/nullptr, &pool),
+              IsSlightlyBelow(0.8));
 }
 
 namespace {
@@ -987,7 +987,7 @@ CompressParams CParamsForLossless() {
   CompressParams cparams;
   cparams.modular_mode = true;
   cparams.color_transform = jxl::ColorTransform::kNone;
-  cparams.quality_pair = {100, 100};
+  cparams.butteraugli_distance = 0.f;
   cparams.options.predictor = {Predictor::Weighted};
   return cparams;
 }
@@ -1686,7 +1686,7 @@ TEST(JxlTest, RoundtripProgressive) {
   EXPECT_LE(Roundtrip(&io, cparams, dparams, &pool, &io2), 40000u);
   EXPECT_THAT(ButteraugliDistance(io, io2, cparams.ba_params, GetJxlCms(),
                                   /*distmap=*/nullptr, &pool),
-              IsSlightlyBelow(2.5f));
+              IsSlightlyBelow(1.1f));
 }
 
 }  // namespace

--- a/lib/jxl/modular_test.cc
+++ b/lib/jxl/modular_test.cc
@@ -48,9 +48,8 @@ void TestLosslessGroups(size_t group_size_shift) {
   const PaddedBytes orig =
       ReadTestData("imagecompression.info/flower_foveon.png");
   CompressParams cparams;
-  cparams.modular_mode = true;
+  cparams.SetLossless();
   cparams.modular_group_size_shift = group_size_shift;
-  cparams.color_transform = jxl::ColorTransform::kNone;
   DecompressParams dparams;
 
   CodecInOut io_out;
@@ -82,13 +81,12 @@ TEST(ModularTest, RoundtripLosslessCustomWP_PermuteRCT) {
   const PaddedBytes orig =
       ReadTestData("wesaturate/500px/u76c0g_bliznaca_srgb8.png");
   CompressParams cparams;
-  cparams.modular_mode = true;
+  cparams.SetLossless();
   // 9 = permute to GBR, to test the special case of permutation-only
   cparams.colorspace = 9;
   // slowest speed so different WP modes are tried
   cparams.speed_tier = SpeedTier::kTortoise;
   cparams.options.predictor = {Predictor::Weighted};
-  cparams.color_transform = jxl::ColorTransform::kNone;
   DecompressParams dparams;
 
   CodecInOut io_out;
@@ -136,8 +134,7 @@ TEST(ModularTest, RoundtripLossyDeltaPaletteWP) {
   const PaddedBytes orig =
       ReadTestData("wesaturate/500px/u76c0g_bliznaca_srgb8.png");
   CompressParams cparams;
-  cparams.modular_mode = true;
-  cparams.color_transform = jxl::ColorTransform::kNone;
+  cparams.SetLossless();
   cparams.lossy_palette = true;
   cparams.palette_colors = 0;
   cparams.options.predictor = jxl::Predictor::Weighted;
@@ -165,7 +162,7 @@ TEST(ModularTest, RoundtripLossy) {
       ReadTestData("wesaturate/500px/u76c0g_bliznaca_srgb8.png");
   CompressParams cparams;
   cparams.modular_mode = true;
-  cparams.quality_pair = {80.0f, 80.0f};
+  cparams.butteraugli_distance = 2.f;
   DecompressParams dparams;
 
   CodecInOut io_out;
@@ -175,11 +172,11 @@ TEST(ModularTest, RoundtripLossy) {
   ASSERT_TRUE(SetFromBytes(Span<const uint8_t>(orig), &io, pool));
 
   compressed_size = Roundtrip(&io, cparams, dparams, pool, &io_out);
-  EXPECT_LE(compressed_size, 40000u);
+  EXPECT_LE(compressed_size, 30000u);
   cparams.ba_params.intensity_target = 80.0f;
   EXPECT_THAT(ButteraugliDistance(io, io_out, cparams.ba_params, GetJxlCms(),
                                   /*distmap=*/nullptr, pool),
-              IsSlightlyBelow(2.0));
+              IsSlightlyBelow(2.3));
 }
 
 TEST(ModularTest, RoundtripLossy16) {
@@ -188,7 +185,7 @@ TEST(ModularTest, RoundtripLossy16) {
       ReadTestData("raw.pixls/DJI-FC6310-16bit_709_v4_krita.png");
   CompressParams cparams;
   cparams.modular_mode = true;
-  cparams.quality_pair = {80.0f, 80.0f};
+  cparams.butteraugli_distance = 2.f;
   DecompressParams dparams;
 
   CodecInOut io_out;
@@ -200,11 +197,11 @@ TEST(ModularTest, RoundtripLossy16) {
   io.metadata.m.color_encoding = ColorEncoding::SRGB();
 
   compressed_size = Roundtrip(&io, cparams, dparams, pool, &io_out);
-  EXPECT_LE(compressed_size, 400u);
+  EXPECT_LE(compressed_size, 300u);
   cparams.ba_params.intensity_target = 80.0f;
   EXPECT_THAT(ButteraugliDistance(io, io_out, cparams.ba_params, GetJxlCms(),
                                   /*distmap=*/nullptr, pool),
-              IsSlightlyBelow(1.5));
+              IsSlightlyBelow(1.6));
 }
 
 TEST(ModularTest, RoundtripExtraProperties) {
@@ -259,7 +256,7 @@ TEST(ModularTest, RoundtripLosslessCustomSqueeze) {
   CompressParams cparams;
   cparams.modular_mode = true;
   cparams.color_transform = jxl::ColorTransform::kNone;
-  cparams.quality_pair = {100, 100};
+  cparams.butteraugli_distance = 0.f;
   cparams.options.predictor = {Predictor::Zero};
   cparams.speed_tier = SpeedTier::kThunder;
   cparams.responsive = 1;
@@ -333,7 +330,7 @@ TEST_P(ModularTestParam, RoundtripLossless) {
   io.metadata.m.color_encoding = jxl::ColorEncoding::SRGB(false);
   io.metadata.m.SetUintSamples(bitdepth);
 
-  double factor = ((1 << bitdepth) - 1);
+  double factor = ((1lu << bitdepth) - 1lu);
   double ifactor = 1.0 / factor;
   Image3F noise_added(xsize, ysize);
 
@@ -356,7 +353,7 @@ TEST_P(ModularTestParam, RoundtripLossless) {
   CompressParams cparams;
   cparams.modular_mode = true;
   cparams.color_transform = jxl::ColorTransform::kNone;
-  cparams.quality_pair = {100, 100};
+  cparams.butteraugli_distance = 0.f;
   cparams.options.predictor = {Predictor::Zero};
   cparams.speed_tier = SpeedTier::kThunder;
   cparams.responsive = responsive;
@@ -410,7 +407,7 @@ TEST(ModularTest, RoundtripLosslessCustomFloat) {
   CompressParams cparams;
   cparams.modular_mode = true;
   cparams.color_transform = jxl::ColorTransform::kNone;
-  cparams.quality_pair = {100, 100};
+  cparams.butteraugli_distance = 0.f;
   cparams.options.predictor = {Predictor::Zero};
   cparams.speed_tier = SpeedTier::kThunder;
   cparams.decoding_speed_tier = 2;

--- a/lib/jxl/patch_dictionary_test.cc
+++ b/lib/jxl/patch_dictionary_test.cc
@@ -24,8 +24,7 @@ TEST(PatchDictionaryTest, GrayscaleModular) {
   ASSERT_TRUE(SetFromBytes(Span<const uint8_t>(orig), &io, pool));
 
   CompressParams cparams;
-  cparams.color_transform = jxl::ColorTransform::kNone;
-  cparams.modular_mode = true;
+  cparams.SetLossless();
   cparams.patches = jxl::Override::kOn;
   DecompressParams dparams;
 

--- a/lib/jxl/render_pipeline/render_pipeline_test.cc
+++ b/lib/jxl/render_pipeline/render_pipeline_test.cc
@@ -348,7 +348,7 @@ std::vector<RenderPipelineTestInputSettings> GeneratePipelineTests() {
       auto s = settings;
       s.cparams_descr = "ModularLossy";
       s.cparams.modular_mode = true;
-      s.cparams.quality_pair = {90, 90};
+      s.cparams.butteraugli_distance = 1.f;
       all_tests.push_back(s);
     }
 

--- a/lib/jxl/roundtrip_test.cc
+++ b/lib/jxl/roundtrip_test.cc
@@ -267,8 +267,9 @@ void VerifyRoundtripCompression(
     auto channel_type = extra_channel.first;
     JxlExtraChannelInfo channel_info;
     JxlEncoderInitExtraChannelInfo(channel_type, &channel_info);
-    channel_info.bits_per_sample = basic_info.bits_per_sample;
-    channel_info.exponent_bits_per_sample = basic_info.exponent_bits_per_sample;
+    channel_info.bits_per_sample = (lossless ? basic_info.bits_per_sample : 8);
+    channel_info.exponent_bits_per_sample =
+        (lossless ? basic_info.exponent_bits_per_sample : 0);
     channel_infos.push_back(channel_info);
   }
   for (size_t index = 0; index < channel_infos.size(); index++) {
@@ -446,12 +447,6 @@ void VerifyRoundtripCompression(
                                          extra_channel_output_pixel_format),
                 0u);
       EXPECT_EQ(extra_channel, extra_channel_bytes);
-    } else {
-      EXPECT_EQ(jxl::test::ComparePixels(
-                    extra_channel.data(), extra_channel_bytes.data(), xsize,
-                    ysize, extra_channel_pixel_format,
-                    extra_channel_output_pixel_format, 16.0),
-                0u);
     }
   }
 }

--- a/tools/benchmark/benchmark_codec.cc
+++ b/tools/benchmark/benchmark_codec.cc
@@ -55,9 +55,7 @@ void ImageCodec::ParseParameters(const std::string& parameters) {
 }
 
 Status ImageCodec::ParseParam(const std::string& param) {
-  if (param[0] ==
-      'q') {  // libjpeg-style quality, [0,100]  (or in case of
-              // modular, below 0 is also allowed if you like cubism)
+  if (param[0] == 'q') {  // libjpeg-style quality, [0,100]
     const std::string quality_param = param.substr(1);
     char* end;
     const float q_target = strtof(quality_param.c_str(), &end);

--- a/tools/benchmark/benchmark_codec_jxl.cc
+++ b/tools/benchmark/benchmark_codec_jxl.cc
@@ -242,9 +242,8 @@ class JxlCodec : public ImageCodec {
     cparams_.ba_params.hf_asymmetry = ba_params_.hf_asymmetry;
     cparams_.ba_params.xmul = static_cast<float>(jxlargs->xmul);
 
-    cparams_.quality_pair.first = q_target_;
-    cparams_.quality_pair.second = q_target_;
-    if (q_target_ != 100 && cparams_.color_transform == ColorTransform::kNone &&
+    if (cparams_.butteraugli_distance > 0.f &&
+        cparams_.color_transform == ColorTransform::kNone &&
         cparams_.modular_mode && !has_ctransform_) {
       cparams_.color_transform = ColorTransform::kXYB;
     }

--- a/tools/cjxl.cc
+++ b/tools/cjxl.cc
@@ -80,79 +80,6 @@ jxl::Status LoadSaliencyMap(const std::string& filename_heatmap,
   return true;
 }
 
-// Search algorithm for modular mode instead of Butteraugli distance.
-void SetModularQualityForBitrate(jxl::ThreadPoolInternal* pool,
-                                 const size_t pixels, const double target_size,
-                                 CompressArgs* args) {
-  JXL_ASSERT(args->params.modular_mode);
-
-  CompressArgs s = *args;  // Args for search.
-  float quality = -100 + target_size * 8.0 / pixels * 50;
-  if (quality > 100.f) quality = 100.f;
-  s.params.target_size = 0;
-  s.params.target_bitrate = 0;
-  double best_loss = 1e99;
-  float best_quality = quality;
-  float best_below = -10000.f;
-  float best_below_size = 0;
-  float best_above = 200.f;
-  float best_above_size = pixels * 15.f;
-
-  jxl::CodecInOut io;
-  double decode_mps = 0;
-
-  if (!LoadAll(*args, pool, &io, &decode_mps)) {
-    s.params.quality_pair = std::make_pair(quality, quality);
-    printf("couldn't load image\n");
-    return;
-  }
-
-  for (int i = 0; i < 10; ++i) {
-    s.params.quality_pair = std::make_pair(quality, quality);
-    jxl::PaddedBytes candidate;
-    bool ok =
-        CompressJxl(io, decode_mps, pool, s, &candidate, /*print_stats=*/false);
-    if (!ok) {
-      printf(
-          "Compression error occurred during the search for best size."
-          " Trying with quality %.1f\n",
-          quality);
-      break;
-    }
-    printf("Quality %.2f yields %6" PRIuS " bytes, %.3f bpp.\n", quality,
-           candidate.size(), candidate.size() * 8.0 / pixels);
-    const double ratio = static_cast<double>(candidate.size()) / target_size;
-    const double loss = std::abs(1.0 - ratio);
-    if (best_loss > loss) {
-      best_quality = quality;
-      best_loss = loss;
-      if (loss < 0.01f) break;
-    }
-    if (quality == 100.f && ratio < 1.f) break;  // can't spend more bits
-    if (ratio > 1.f && quality < best_above) {
-      best_above = quality;
-      best_above_size = candidate.size();
-    }
-    if (ratio < 1.f && quality > best_below) {
-      best_below = quality;
-      best_below_size = candidate.size();
-    }
-    float t =
-        (target_size - best_below_size) / (best_above_size - best_below_size);
-    if (best_above > 100.f && ratio < 1.f) {
-      quality = (quality + 105) / 2;
-    } else if (best_above - best_below > 1000 && ratio > 1.f) {
-      quality -= 1000;
-    } else {
-      quality = best_above * t + best_below * (1.f - t);
-    }
-    if (quality >= 100.f) quality = 100.f;
-  }
-  args->params.quality_pair = std::make_pair(best_quality, best_quality);
-  args->params.target_bitrate = 0;
-  args->params.target_size = 0;
-}
-
 void SetParametersForSizeOrBitrate(jxl::ThreadPoolInternal* pool,
                                    const size_t pixels, CompressArgs* args) {
   CompressArgs s = *args;  // Args for search.
@@ -163,11 +90,6 @@ void SetParametersForSizeOrBitrate(jxl::ThreadPoolInternal* pool,
     s.params.target_size = 0;
   }
   const double target_size = s.params.target_bitrate * (1 / 8.) * pixels;
-
-  if (args->params.modular_mode) {
-    SetModularQualityForBitrate(pool, pixels, target_size, args);
-    return;
-  }
 
   double dist = ApproximateDistanceForBPP(s.params.target_bitrate);
   s.params.target_bitrate = 0;
@@ -225,17 +147,8 @@ std::string QualityFromArgs(const CompressArgs& args) {
   char buf[100];
   if (args.jpeg_transcode) {
     snprintf(buf, sizeof(buf), "lossless transcode");
-  } else if (args.params.modular_mode) {
-    if (args.params.quality_pair.first == 100 &&
-        args.params.quality_pair.second == 100) {
-      snprintf(buf, sizeof(buf), "lossless");
-    } else if (args.params.quality_pair.first !=
-               args.params.quality_pair.second) {
-      snprintf(buf, sizeof(buf), "Q%.2f,%.2f", args.params.quality_pair.first,
-               args.params.quality_pair.second);
-    } else {
-      snprintf(buf, sizeof(buf), "Q%.2f", args.params.quality_pair.first);
-    }
+  } else if (args.params.IsLossless()) {
+    snprintf(buf, sizeof(buf), "lossless");
   } else {
     snprintf(buf, sizeof(buf), "d%.3f", args.params.butteraugli_distance);
   }
@@ -497,11 +410,6 @@ void CompressArgs::AddCommandLineOptions(CommandLineParser* cmdline) {
 
   // modular mode options
   cmdline->AddOptionValue(
-      'Q', "mquality", "luma_q[,chroma_q]",
-      "[modular encoding] lossy 'quality' (100=lossless, lower is more lossy)",
-      &params.quality_pair, &ParseFloatPair, 1);
-
-  cmdline->AddOptionValue(
       'I', "iterations", "F",
       "[modular encoding] fraction of pixels used to learn MA trees "
       "(default=0.5, try 0 for no MA and fast decode)",
@@ -597,26 +505,18 @@ jxl::Status CompressArgs::ValidateArgs(const CommandLineParser& cmdline) {
   if (got_quality) {
     default_settings = false;
     if (quality < 100) jpeg_transcode = false;
-    // Quality settings roughly match libjpeg qualities.
     if (quality < 7 || quality == 100 || params.modular_mode) {
       if (jpeg_transcode == false) params.modular_mode = true;
-      // Internal modular quality to roughly match VarDCT size.
-      if (quality < 7) {
-        params.quality_pair.first = params.quality_pair.second =
-            std::min(35 + (quality - 7) * 3.0f, 100.0f);
-      } else {
-        params.quality_pair.first = params.quality_pair.second =
-            std::min(35 + (quality - 7) * 65.f / 93.f, 100.0f);
-      }
+    }
+    // Quality settings roughly match libjpeg qualities.
+    if (quality >= 30) {
+      params.butteraugli_distance = 0.1 + (100 - quality) * 0.09;
     } else {
-      if (quality >= 30) {
-        params.butteraugli_distance = 0.1 + (100 - quality) * 0.09;
-      } else {
-        params.butteraugli_distance =
-            6.4 + pow(2.5, (30 - quality) / 5.0f) / 6.25f;
-      }
+      params.butteraugli_distance =
+          6.4 + pow(2.5, (30 - quality) / 5.0f) / 6.25f;
     }
   }
+
   if (params.resampling > 1 && !params.already_downsampled)
     jpeg_transcode = false;
 
@@ -687,8 +587,7 @@ jxl::Status CompressArgs::ValidateArgs(const CommandLineParser& cmdline) {
   if (!cmdline.GetOption(opt_color_id)->matched()) {
     // default to RGB for lossless modular
     if (params.modular_mode) {
-      if (params.quality_pair.first != 100 ||
-          params.quality_pair.second != 100) {
+      if (params.butteraugli_distance > 0.f) {
         params.color_transform = jxl::ColorTransform::kXYB;
       } else {
         params.color_transform = jxl::ColorTransform::kNone;
@@ -773,7 +672,7 @@ jxl::Status LoadAll(CompressArgs& args, jxl::ThreadPoolInternal* pool,
 
   if (input_codec == jxl::extras::Codec::kGIF && args.default_settings) {
     args.params.modular_mode = true;
-    args.params.quality_pair.first = args.params.quality_pair.second = 100;
+    args.params.butteraugli_distance = 0;
   }
   if (args.override_bitdepth != 0) {
     if (args.override_bitdepth == 32) {

--- a/tools/fuzzer_corpus.cc
+++ b/tools/fuzzer_corpus.cc
@@ -260,7 +260,6 @@ bool GenerateFile(const char* output_dir, const ImageSpec& spec,
   params.lossy_palette = spec.params.lossy_palette;
   if (spec.params.preview) params.preview = jxl::Override::kOn;
   if (spec.params.noise) params.noise = jxl::Override::kOn;
-  params.quality_pair = {100., 100.};
 
   jxl::AuxOut aux_out;
   jxl::PassesEncoderState passes_encoder_state;
@@ -307,6 +306,7 @@ std::vector<ImageSpec::CjxlParams> CompressParamsList() {
     ImageSpec::CjxlParams params;
     params.modular_mode = true;
     params.color_transform = jxl::ColorTransform::kNone;
+    params.butteraugli_distance = 0.f;
     params.modular_predictor = {jxl::Predictor::Weighted};
     ret.push_back(params);
   }


### PR DESCRIPTION
Get rid of the separate cparams.quality_pair for modular quality, instead use cparams.butteraugli_distance also in modular mode as the main setting that controls lossy quality.

Also taking the opportunity to better calibrate modular and vardct quality and to tweak the quality settings chosen for alpha, dc frames, and patch frames.

## Effect on dc frames

Test corpus: jyrki31.

Before:
```
Encoding      kPixels    Bytes          BPP  E MP/s  D MP/s     Max norm        pnorm       BPP*pnorm   Bugs
------------------------------------------------------------------------------------------------------------
jxl:d0.5        13270  4225280    2.5471813   3.049  22.687   1.12016439   0.37185960  0.947193828701      0
jxl:d1          13270  2680279    1.6157880   3.333  24.225   1.68695998   0.60068375  0.970577588663      0
jxl:d2          13270  1685403    1.0160337   3.511  25.091   2.98979163   0.94922260  0.964442190920      0
jxl:d4          13270  1006130    0.6065386   3.296  17.630   4.82071018   1.50086778  0.910334293335      0
jxl:d5          13270   825027    0.4973619   3.258  16.790   5.96885347   1.76033233  0.875522269601      0
jxl:d6          13270   718021    0.4328541   3.274  16.965   7.37481737   1.97648186  0.855528239885      0
jxl:d8          13270   576361    0.3474553   3.231  16.312   8.18236828   2.35794399  0.819280165669      0
jxl:d10         13270   478064    0.2881976   3.291  16.836   9.00066471   2.74497689  0.791095844090      0
jxl:d15         13270   333269    0.2009090   3.306  15.588  12.30572796   3.70734670  0.744839140403      0
Aggregate:      13270  1004866    0.6057768   3.281  18.822   4.68458678   1.43966693  0.872116784553      0
```

After:
```
Encoding      kPixels    Bytes          BPP  E MP/s  D MP/s     Max norm        pnorm       BPP*pnorm   Bugs
------------------------------------------------------------------------------------------------------------
jxl:d0.5        13270  4225280    2.5471813   2.944  21.976   1.12016439   0.37185960  0.947193828701      0
jxl:d1          13270  2680279    1.6157880   3.214  24.537   1.68695998   0.60068375  0.970577588663      0
jxl:d2          13270  1685403    1.0160337   3.412  23.954   2.98979163   0.94922260  0.964442190920      0
jxl:d4          13270  1006000    0.6064603   3.100  17.009   4.82071018   1.50023616  0.909833619277      0
jxl:d5          13270   829744    0.5002055   3.034  16.796   6.26831722   1.75601021  0.878366021280      0
jxl:d6          13270   717469    0.4325213   3.050  16.571   7.20063066   1.97447910  0.854004287594      0
jxl:d8          13270   567576    0.3421593   3.114  16.126  11.96129036   2.41502386  0.826322957318      0
jxl:d10         13270   462801    0.2789964   3.151  15.609  12.24995804   2.83010974  0.789590537231      0
jxl:d15         13270   312372    0.1883113   3.192  15.758  15.19184494   3.83955014  0.723030821265      0
Aggregate:      13270   992906    0.5985669   3.132  18.407   5.19089891   1.45342633  0.869972882931      0
```

As expected, no changes up to d4 (since dc frame is not used by default at the reasonable distances). At d6 and above, dc is getting quantized somewhat more aggressively, causing somewhat lower file size and worse BA scores.

Same corpus, forcing use of DC frame (`--progressive_dc=1`):

Before
```
Encoding      kPixels    Bytes          BPP  E MP/s  D MP/s     Max norm        pnorm       BPP*pnorm   Bugs
------------------------------------------------------------------------------------------------------------
jxl:d0.5        13270  4076419    2.4574415   2.868  23.149   3.35752273   0.55992564  1.375984499855      0
jxl:d1          13270  2598493    1.5664838   3.047  23.734   3.05902910   0.72088617  1.129256538744      0
jxl:d2          13270  1626196    0.9803412   3.174  23.505   4.37277079   1.02525940  1.005104033914      0
jxl:d4          13270   974254    0.5873224   3.032  16.013   7.08602810   1.55492794  0.913244012317      0
Aggregate:      13270  2024004    1.2201570   3.028  21.325   4.22367544   0.89564368  1.092825955415      0
```

Before without DC frame (default setting, or `--progressive_dc=0`):
```
Encoding      kPixels    Bytes          BPP  E MP/s  D MP/s     Max norm        pnorm       BPP*pnorm   Bugs
------------------------------------------------------------------------------------------------------------
jxl:d0.5        13270  4225280    2.5471813   3.210  24.789   1.12016439   0.37185960  0.947193828701      0
jxl:d1          13270  2680279    1.6157880   3.642  27.371   1.68695998   0.60068375  0.970577588663      0
jxl:d2          13270  1685403    1.0160337   3.860  27.408   2.98979163   0.94922260  0.964442190920      0
jxl:d4          13270  1006130    0.6065386   3.652  18.150   4.82071018   1.50086778  0.910334293335      0
Aggregate:      13270  2093381    1.2619807   3.583  24.103   2.28446560   0.75107593  0.947843324516      0
```

After, without DC frame
(same as before)

After, with DC frame:
```
Encoding      kPixels    Bytes          BPP  E MP/s  D MP/s     Max norm        pnorm       BPP*pnorm   Bugs
------------------------------------------------------------------------------------------------------------
jxl:d0.5        13270  4242703    2.5576847   2.916  24.304   1.11804676   0.37141887  0.949972357422      0
jxl:d1          13270  2709766    1.6335640   3.326  25.279   1.69873714   0.59691134  0.975092893872      0
jxl:d2          13270  1685398    1.0160307   3.482  27.279   3.03871059   0.94602487  0.961190343710      0
jxl:d4          13270   991318    0.5976093   3.203  17.977   4.87749672   1.50688748  0.900530001980      0
Aggregate:      13270  2093498    1.2620508   3.225  23.429   2.30339341   0.74978940  0.946272319641      0
```

This is an improvement in reducing the difference between progressive dc and default dc. Before, when using progressive dc at d0.5-4, the quality would be reduced compared to not using progressive dc.


## Effect on alpha

Corpus: some images with typical (simple) and atypical alpha channels
(DSKoopabird.png  IceAlpha.png  MagnoliaAlpha.png  OwlAlpha.png  PNG_transparency_demonstration_1.png  Tentacle.png)

Before:
```
Encoding      kPixels    Bytes          BPP  E MP/s  D MP/s     Max norm        pnorm       BPP*pnorm   Bugs
------------------------------------------------------------------------------------------------------------
jxl:d0.5         4312  1512075    2.8052136   0.716   9.128   1.53742707   0.28806668  0.808088567049      0
jxl:d1           4312   982706    1.8231240   1.905   9.681   2.02054238   0.51238705  0.934145126738      0
jxl:d2           4312   750726    1.3927529   1.765  10.138   2.71408129   0.81627877  1.136874595409      0
jxl:d4           4312   554410    1.0285459   1.725   6.265   4.22167206   1.29455135  1.331505427199      0
jxl:d5           4312   502537    0.9323106   1.784   7.976   5.61612797   1.49599385  1.394730997335      0
jxl:d6           4312   454038    0.8423349   1.662   7.355   6.22974777   1.66478938  1.402310226102      0
jxl:d8           4312   393579    0.7301709   1.820   8.586   8.04747391   2.03513486  1.485996250061      0
jxl:d10          4312   352089    0.6531983   1.787   7.796   8.30555344   2.37761880  1.553056608251      0
jxl:d15          4312   278271    0.5162506   1.850   8.233  13.85423660   3.22270268  1.663722122184      0
Aggregate:       4312   560291    1.0394561   1.613   8.273   4.71566685   1.22157890  1.269777667986      0
```

After:
```
Encoding      kPixels    Bytes          BPP  E MP/s  D MP/s     Max norm        pnorm       BPP*pnorm   Bugs
------------------------------------------------------------------------------------------------------------
jxl:d0.5         4312  1325567    2.4592025   1.646   8.563   1.52080929   0.31299866  0.769727067172      0
jxl:d1           4312   921287    1.7091790   1.859   9.638   2.04646826   0.52639372  0.899701092296      0
jxl:d2           4312   627094    1.1633898   1.876  10.211   2.90542150   0.85460492  0.994238637795      0
jxl:d4           4312   406411    0.7539769   1.745   9.286   4.33572435   1.34388404  1.013257562595      0
jxl:d5           4312   348156    0.6459018   1.850   8.805   5.60957575   1.55756572  1.006034482542      0
jxl:d6           4312   308216    0.5718048   1.867   9.539   6.34279823   1.74759771  0.999284725903      0
jxl:d8           4312   252541    0.4685161   1.896   8.331   7.95893574   2.14288038  1.003973907632      0
jxl:d10          4312   212921    0.3950127   1.945  10.421   9.24406815   2.50913415  0.991139947665      0
jxl:d15          4312   156160    0.2897093   1.882  10.244  14.97409344   3.43011513  0.993736174085      0
Aggregate:       4312   403010    0.7476677   1.839   9.421   4.86857922   1.28420155  0.960155979691      0
```

At d5 and above we're seeing the combined effects of alpha recalibration and quality changes caused by dc frames.
To look at just the alpha changes, using `--progressive_dc=0`:

Before:
```
Encoding      kPixels    Bytes          BPP  E MP/s  D MP/s     Max norm        pnorm       BPP*pnorm   Bugs
------------------------------------------------------------------------------------------------------------
jxl:d5           4312   505469    0.9377501   1.762   7.622   5.62605810   1.49030902  1.397537462992      0
jxl:d6           4312   457649    0.8490341   1.696   7.904   6.28876114   1.67193001  1.419525549245      0
jxl:d8           4312   397253    0.7369869   1.750   7.999   7.99622440   2.02382964  1.491535998312      0
jxl:d10          4312   355702    0.6599012   1.758   7.684   8.51952457   2.35600102  1.554727869545      0
jxl:d15          4312   282578    0.5242410   1.800   7.713  12.32147217   3.19820398  1.676629520779      0
Aggregate:       4312   391835    0.7269363   1.753   7.783   7.84416010   2.06990304  1.504687734393      0
```

After:
```
Encoding      kPixels    Bytes          BPP  E MP/s  D MP/s     Max norm        pnorm       BPP*pnorm   Bugs
------------------------------------------------------------------------------------------------------------
jxl:d5           4312   350462    0.6501799   1.786   8.287   5.77319860   1.56426392  1.017052955331      0
jxl:d6           4312   312509    0.5797692   1.809   8.903   6.37706280   1.74901726  1.014026321101      0
jxl:d8           4312   258976    0.4804543   1.823   9.368   8.02161217   2.11591930  1.016602613041      0
jxl:d10          4312   221179    0.4103330   1.812   9.504   9.16325188   2.47126345  1.014041057533      0
jxl:d15          4312   167015    0.3098476   1.849  10.691  11.59208870   3.31558754  1.027326709805      0
Aggregate:       4312   253543    0.4703759   1.816   9.317   7.93052675   2.16379720  1.017798079379      0
```

So basically at the high distances we were spending a lot of bits on alpha, which was a bit pointless considering how bad the image looks at those settings anyway.  I think the balance is better now. BPP*pnorm agrees with me.


## Effect on patches

Testing on a corpus of screenshots, i.e. any changes here are caused by patch frames (and dc frames at d5 and above):

Before:
```
Encoding      kPixels    Bytes          BPP  E MP/s  D MP/s     Max norm        pnorm       BPP*pnorm   Bugs
------------------------------------------------------------------------------------------------------------
jxl:d0.5        42351  4796511    0.9060380   1.412   8.611   1.24443281   0.26646314  0.241425735536      0
jxl:d1          42351  3409703    0.6440766   1.742  20.646   1.74433374   0.47014544  0.302809689725      0
jxl:d2          42351  2414860    0.4561555   1.593  18.753   2.85763645   0.70263631  0.320511436207      0
jxl:d4          42351  1655853    0.3127827   1.612  11.711   5.64935589   1.17883863  0.368720363416      0
jxl:d5          42351  1466427    0.2770011   1.440   9.193   8.31781578   1.34140800  0.371571440339      0
jxl:d6          42351  1323410    0.2499858   1.606  11.411   7.72714520   1.53428062  0.383548419069      0
jxl:d8          42351  1121091    0.2117687   1.624  12.568   9.66806793   1.91100433  0.404690977112      0
jxl:d10         42351   965387    0.1823570   1.657   9.928  15.30806541   2.36241135  0.430802238926      0
jxl:d15         42351   722281    0.1364354   1.560  11.614  18.74994469   3.21883643  0.439163344907      0
Aggregate:      42351  1666633    0.3148190   1.580  12.188   5.68983246   1.13409244  0.357033806860      0
```

After:
```
Encoding      kPixels    Bytes          BPP  E MP/s  D MP/s     Max norm        pnorm       BPP*pnorm   Bugs
------------------------------------------------------------------------------------------------------------
jxl:d0.5        42351  4755804    0.8983487   1.354  17.253   1.19672847   0.26600964  0.238969406151      0
jxl:d1          42351  3403130    0.6428350   1.308  17.037   1.74524164   0.46976816  0.301983419387      0
jxl:d2          42351  2419371    0.4570076   1.356  15.981   2.85246658   0.70272768  0.321151915658      0
jxl:d4          42351  1662341    0.3140083   1.319   9.378   5.64935589   1.17990336  0.370499425258      0
jxl:d5          42351  1471585    0.2779754   1.303   9.734   8.22463036   1.33609968  0.371402819281      0
jxl:d6          42351  1322413    0.2497975   1.484  11.006   7.77507591   1.53297450  0.382933203384      0
jxl:d8          42351  1109658    0.2096091   1.306   9.397   9.54998875   1.93390023  0.405363086184      0
jxl:d10         42351   940974    0.1777455   1.432  10.128  14.37252426   2.39441234  0.425596013822      0
jxl:d15         42351   689384    0.1302213   1.482  10.494  17.42778587   3.24166564  0.422134067145      0
Aggregate:      42351  1651077    0.3118805   1.370  11.880   5.56853679   1.13739140  0.354730232378      0
```

## Calibration between vardct and modular

Corpus: jyrki31

Can't easily give a before, since before this change, butteraugli_distance was ignored in modular mode, so e.g. `jxl:d2:m` would produce a lossless result.

After:
```
Encoding      kPixels    Bytes          BPP  E MP/s  D MP/s     Max norm        pnorm       BPP*pnorm   Bugs
------------------------------------------------------------------------------------------------------------
jxl:d0.5        13270  4225280    2.5471813   3.162  22.371   1.12016439   0.37185960  0.947193828701      0
jxl:d0.5:m      13270  4357304    2.6267711   1.092   4.133   1.33741093   0.41659370  1.094296291713      0
jxl:d1          13270  2680279    1.6157880   3.432  24.841   1.68695998   0.60068375  0.970577588663      0
jxl:d1:m        13270  2940698    1.7727798   1.291   5.505   2.08006930   0.63057298  1.117867037547      0
jxl:d2          13270  1685403    1.0160337   3.430  26.267   2.98979163   0.94922260  0.964442190920      0
jxl:d2:m        13270  1941153    1.1702109   1.418   6.513   2.80438733   0.94351157  1.104107521527      0
jxl:d3          13270  1244972    0.7505229   3.415  27.169   3.67112684   1.25033732  0.938406803190      0
jxl:d3:m        13270  1507518    0.9087970   1.432   6.947   3.61631489   1.19441334  1.085479237427      0
jxl:d4          13270  1006000    0.6064603   3.348  18.580   4.82071018   1.50023616  0.909833619277      0
jxl:d4:m        13270  1242272    0.7488952   1.410   6.857   4.29967356   1.41326417  1.058386801338      0
jxl:d5          13270   829744    0.5002055   3.326  17.128   6.26831722   1.75601021  0.878366021280      0
jxl:d5:m        13270  1067734    0.6436762   1.471   7.332   5.16354465   1.60197483  1.031153051948      0
jxl:d6          13270   717469    0.4325213   3.271  17.344   7.20063066   1.97447910  0.854004287594      0
jxl:d6:m        13270   936994    0.5648605   1.475   7.460   6.29212618   1.78853928  1.010275133049      0
jxl:d8          13270   567576    0.3421593   3.382  17.732  11.96129036   2.41502386  0.826322957318      0
jxl:d8:m        13270   754235    0.4546854   1.477   8.353   6.82318020   2.12962639  0.968310123027      0
jxl:d10         13270   462801    0.2789964   3.447  17.385  12.24995804   2.83010974  0.789590537231      0
jxl:d10:m       13270   636998    0.3840099   1.502   8.394  11.09906387   2.46987386  0.948456050857      0
jxl:d15         13270   312372    0.1883113   3.472  17.841  15.19184494   3.83955014  0.723030821265      0
jxl:d15:m       13270   460555    0.2776425   1.557   9.571  11.54364491   3.08007253  0.855158890916      0
Aggregate:      13270  1132487    0.6827124   2.176  11.877   4.75292895   1.38784687  0.947500206608      0
```

Corpus: images with alpha

After:
```
Encoding      kPixels    Bytes          BPP  E MP/s  D MP/s     Max norm        pnorm       BPP*pnorm   Bugs
------------------------------------------------------------------------------------------------------------
jxl:d0.5         4312  1325567    2.4592025   1.783   8.596   1.52080929   0.31299866  0.769727067172      0
jxl:d0.5:m       4312  1501485    2.7855669   0.921   3.855   1.41916966   0.34845237  0.970637398892      0
jxl:d1           4312   921287    1.7091790   1.936  10.040   2.04646826   0.52639372  0.899701092296      0
jxl:d1:m         4312  1061496    1.9692958   1.052   4.547   2.36985159   0.56669264  1.115985463265      0
jxl:d2           4312   627094    1.1633898   1.873   9.619   2.90542150   0.85460492  0.994238637795      0
jxl:d2:m         4312   721274    1.3381133   1.134   5.158   3.74703097   0.87582010  1.171946499352      0
jxl:d3           4312   488448    0.9061726   1.842  10.296   4.34313440   1.12015798  1.015056493106      0
jxl:d3:m         4312   567269    1.0524020   1.046   5.132   4.05800915   1.11154003  1.169786924718      0
jxl:d4           4312   406411    0.7539769   1.791   8.418   4.33572435   1.34388404  1.013257562595      0
jxl:d4:m         4312   469757    0.8714969   1.118   5.665   4.56567049   1.31246552  1.143809674792      0
jxl:d5           4312   348156    0.6459018   1.861   8.832   5.60957575   1.55756572  1.006034482542      0
jxl:d5:m         4312   406660    0.7544389   1.060   5.575   4.73994398   1.49084838  1.124753977055      0
jxl:d6           4312   308216    0.5718048   1.938  10.103   6.34279823   1.74759771  0.999284725903      0
jxl:d6:m         4312   360929    0.6695984   1.132   6.732   5.78056383   1.65341605  1.107124670690      0
jxl:d8           4312   252541    0.4685161   1.931   9.787   7.95893574   2.14288038  1.003973907632      0
jxl:d8:m         4312   296806    0.5506369   1.210   6.505   6.03821850   1.94284303  1.069800980236      0
jxl:d10          4312   212921    0.3950127   1.965   9.053   9.24406815   2.50913415  0.991139947665      0
jxl:d10:m        4312   254826    0.4727552   1.205   7.013   7.05743551   2.19845434  1.039330779536      0
jxl:d15          4312   156160    0.2897093   1.978   9.371  14.97409344   3.43011513  0.993736174085      0
jxl:d15:m        4312   192040    0.3562741   1.220   8.140   9.59277534   2.76785692  0.986115843559      0
Aggregate:       4312   444203    0.8240886   1.445   7.320   4.59299910   1.24357094  1.024812583531      0
```
