### PR TITLE
fix ppm input where bitdepth is not 8 or 16

### DIFF
--- a/lib/extras/dec/pnm.cc
+++ b/lib/extras/dec/pnm.cc
@@ -363,6 +363,7 @@ Status DecodeImagePNM(const Span<const uint8_t> bytes,
   ppf->frames.emplace_back(header.xsize, header.ysize, format);
   auto* frame = &ppf->frames.back();
 
+  frame->color.bitdepth_from_format = false;
   frame->color.flipped_y = header.bits_per_sample == 32;  // PFMs are flipped
   size_t pnm_remaining_size = bytes.data() + bytes.size() - pos;
   if (pnm_remaining_size < frame->color.pixels_size) {

--- a/lib/extras/packed_image.h
+++ b/lib/extras/packed_image.h
@@ -64,6 +64,12 @@ class PackedImage {
   // Whether the y coordinate is flipped (y=0 is the last row).
   bool flipped_y = false;
 
+  // Whether the range is determined by format or by JxlBasicInfo
+  // e.g. if format is UINT16 and JxlBasicInfo bits_per_sample is 10,
+  // then if bitdepth_from_format == true, the range is 0..65535
+  // while if bitdepth_from_format == true, the range is 0..1023.
+  bool bitdepth_from_format = true;
+
   // The number of bytes per row.
   size_t stride;
 

--- a/lib/extras/packed_image_convert.cc
+++ b/lib/extras/packed_image_convert.cc
@@ -107,7 +107,9 @@ Status ConvertPackedPixelFileToCodecInOut(const PackedPixelFile& ppf,
   for (const auto& frame : ppf.frames) {
     JXL_ASSERT(frame.color.pixels() != nullptr);
     size_t frame_bits_per_sample =
-        frame.color.BitsPerChannel(frame.color.format.data_type);
+        (frame.color.bitdepth_from_format
+             ? frame.color.BitsPerChannel(frame.color.format.data_type)
+             : ppf.info.bits_per_sample);
     JXL_ASSERT(frame_bits_per_sample != 0);
     // It is ok for the frame.color.format.num_channels to not match the
     // number of channels on the image.


### PR DESCRIPTION
Currently, e.g. 10-bit ppm files are loaded incorrectly: while the range of values in the ppm is 0..1023, they get interpreted as UINT16 so basically everything becomes very dark.

This solves that.