### PR TITLE
fix missing atomic issue (#1283)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -190,6 +190,9 @@ endif()  # JPEGXL_STATIC
 # Threads
 set(THREADS_PREFER_PTHREAD_FLAG YES)
 find_package(Threads REQUIRED)
+if(CMAKE_USE_PTHREADS_INIT)
+	target_link_libraries(Threads::Threads INTERFACE -pthread)
+endif()
 
 if(JPEGXL_STATIC)
   if (MINGW)

--- a/tools/conformance/CMakeLists.txt
+++ b/tools/conformance/CMakeLists.txt
@@ -4,7 +4,7 @@
 # license that can be found in the LICENSE file.
 
 add_executable(djxl_conformance djxl_conformance.cc)
-target_link_libraries(djxl_conformance jxl_dec)
+target_link_libraries(djxl_conformance jxl_dec -pthread)
 
 if(BUILD_TESTING AND CMAKE_EXECUTABLE_SUFFIX STREQUAL "")
 # Script to validate the tooling.


### PR DESCRIPTION
Due to there is no 1, 2byte atomic instruction in 64bit RISC-V hardware,
the software layer have to emulate relavant function in atomic library

Let's explicitly pass -pthread here to work around pthread builtin since glibc version 2.34
as the "-pthread" option will pull in libatomic for machines like RISC-V

the command of "gcc dumpspecs | grep pthread" will show accordingly in RISC-V:
   pthread:--push-state --as-needed -latomic --pop-state

Signed-off-by: Yixun Lan <dlan@gentoo.org>