### PR TITLE
noise seeding: match frame index of jxli box

### DIFF
--- a/lib/jxl/dec_frame.cc
+++ b/lib/jxl/dec_frame.cc
@@ -265,6 +265,7 @@ Status FrameDecoder::InitFrame(BitReader* JXL_RESTRICT br, ImageBundle* decoded,
   decoded->duration = frame_header_.animation_frame.duration;
 
   if (!frame_header_.nonserialized_is_preview &&
+      (frame_header_.is_last || frame_header_.animation_frame.duration > 0) &&
       (frame_header_.frame_type == kRegularFrame ||
        frame_header_.frame_type == kSkipProgressive)) {
     ++dec_state_->visible_frame_index;


### PR DESCRIPTION
In the `jxli` box as defined in 18181-2, we don't include zero-duration non-last frames in the frame count. If we want to be able to correctly do the noise seeding when doing `jxli` seeking, we have to match that.