### PR TITLE
cjxl_ng: fixing single-frame pngs

### DIFF
--- a/lib/extras/dec/apng.cc
+++ b/lib/extras/dec/apng.cc
@@ -745,7 +745,9 @@ Status DecodeImageAPNG(const Span<const uint8_t> bytes,
     pframe.frame_info.duration = frame.duration;
     pframe.frame_info.layer_info.blend_info.blendmode =
         should_blend ? JXL_BLEND_BLEND : JXL_BLEND_REPLACE;
-    pframe.frame_info.layer_info.have_crop = 1;
+    bool is_full_size = x0 == 0 && y0 == 0 && xsize == ppf->info.xsize &&
+                        ysize == ppf->info.ysize;
+    pframe.frame_info.layer_info.have_crop = is_full_size ? 0 : 1;
     pframe.frame_info.layer_info.blend_info.source = should_blend ? 1 : 0;
     pframe.frame_info.layer_info.blend_info.alpha = 0;
     pframe.frame_info.layer_info.save_as_reference = use_for_next_frame ? 1 : 0;

--- a/tools/cjxl_ng_main.cc
+++ b/tools/cjxl_ng_main.cc
@@ -838,7 +838,6 @@ int main(int argc, char** argv) {
         return EXIT_FAILURE;
       }
     }
-
     for (size_t num_frame = 0; num_frame < ppf.frames.size(); ++num_frame) {
       const jxl::extras::PackedFrame& pframe = ppf.frames[num_frame];
       const jxl::extras::PackedImage& pimage = pframe.color;
@@ -877,17 +876,17 @@ int main(int argc, char** argv) {
           extra_channel_blend_info.clamp = JXL_FALSE;
           JxlEncoderSetExtraChannelBlendInfo(jxl_encoder_frame_settings, 0,
                                              &extra_channel_blend_info);
-
-          enc_status =
-              JxlEncoderAddImageFrame(jxl_encoder_frame_settings, &ppixelformat,
-                                      pimage.pixels(), pimage.pixels_size);
-          if (JXL_ENC_SUCCESS != enc_status) {
-            // TODO(tfish): Fix such status handling throughout.  We should
-            // have more detail available about what went wrong than what we
-            // currently share with the caller.
-            std::cerr << "JxlEncoderAddImageFrame() failed.\n";
-            return EXIT_FAILURE;
-          }
+        }
+        enc_status =
+            JxlEncoderAddImageFrame(jxl_encoder_frame_settings, &ppixelformat,
+                                    pimage.pixels(), pimage.pixels_size);
+        if (JXL_ENC_SUCCESS != enc_status) {
+          // TODO(tfish): Fix such status handling throughout.  We should
+          // have more detail available about what went wrong than what we
+          // currently share with the caller.
+          std::cerr << "JxlEncoderAddImageFrame() failed.\n";
+          return EXIT_FAILURE;
+        }
           // Only set extra channel buffer if is is provided non-interleaved
           if (!pframe.extra_channels.empty()) {
             enc_status = JxlEncoderSetExtraChannelBuffer(
@@ -901,7 +900,6 @@ int main(int argc, char** argv) {
               return EXIT_FAILURE;
             }
           }
-        }
       }
     }
   }


### PR DESCRIPTION
Fixing an issue introduced in #1223. Drive-by: don't assume cropping by default.