### PR TITLE
Fix crash in set_from_bytes fuzzer

### DIFF
--- a/lib/extras/packed_image_convert.cc
+++ b/lib/extras/packed_image_convert.cc
@@ -69,6 +69,9 @@ Status ConvertPackedPixelFileToCodecInOut(const PackedPixelFile& ppf,
   } else {
     JXL_RETURN_IF_ERROR(ConvertExternalToInternalColorEncoding(
         ppf.color_encoding, &io->metadata.m.color_encoding));
+    if (io->metadata.m.color_encoding.ICC().empty()) {
+      return JXL_FAILURE("Failed to serialize ICC");
+    }
   }
 
   // Convert the extra blobs


### PR DESCRIPTION
AdoptWhitePoint error is silenced in ConvertExternalToInternalColorEncoding ->
-> ConvertPackedPixelFileToCodecInOut did not notice ICC was not set ->
-> CHECK triggered.