### PR TITLE
Make sure to only call memcpy when not nullptr

### DIFF
--- a/lib/jxl/blending.cc
+++ b/lib/jxl/blending.cc
@@ -78,7 +78,7 @@ void PerformBlending(const float* const* bg, const float* const* fg,
     } else if (ec_blending[i].mode == PatchBlendMode::kReplace) {
       memcpy(tmp.Row(3 + i), fg[3 + i] + x0, xsize * sizeof(**fg));
     } else if (ec_blending[i].mode == PatchBlendMode::kNone) {
-      memcpy(tmp.Row(3 + i), bg[3 + i] + x0, xsize * sizeof(**fg));
+      if (xsize) memcpy(tmp.Row(3 + i), bg[3 + i] + x0, xsize * sizeof(**fg));
     } else {
       JXL_ABORT("Unreachable");
     }


### PR DESCRIPTION
Fixes test JxlTest.RoundtripAnimationPatches (using ubsan)

  libjxl/lib/jxl/blending.cc:81:13: runtime error: null pointer passed as argument 1, which is declared to never be null