### PR TITLE
Patch frame quant

### DIFF
--- a/lib/jxl/enc_patch_dictionary.cc
+++ b/lib/jxl/enc_patch_dictionary.cc
@@ -710,10 +710,6 @@ void FindBestPatchDictionary(const Image3F& opsin,
   CompressParams cparams = state->cparams;
   // Recursive application of patches could create very weird issues.
   cparams.patches = Override::kOff;
-  // TODO(veluca): possibly change heuristics here.
-  if (!cparams.modular_mode) {
-    cparams.butteraugli_distance *= 0.5f;
-  }
 
   RoundtripPatchFrame(&reference_frame, state, 0, cparams, cms, pool, true);
 

--- a/lib/jxl/jxl_test.cc
+++ b/lib/jxl/jxl_test.cc
@@ -595,7 +595,7 @@ TEST(JxlTest, RoundtripSmallPatchesAlpha) {
   EXPECT_LE(Roundtrip(&io, cparams, dparams, pool, &io2), 2000u);
   EXPECT_THAT(ButteraugliDistance(io, io2, cparams.ba_params, GetJxlCms(),
                                   /*distmap=*/nullptr, pool),
-              IsSlightlyBelow(0.12f));
+              IsSlightlyBelow(0.04f));
 }
 
 TEST(JxlTest, RoundtripSmallPatches) {
@@ -623,7 +623,7 @@ TEST(JxlTest, RoundtripSmallPatches) {
   EXPECT_LE(Roundtrip(&io, cparams, dparams, pool, &io2), 2000u);
   EXPECT_THAT(ButteraugliDistance(io, io2, cparams.ba_params, GetJxlCms(),
                                   /*distmap=*/nullptr, pool),
-              IsSlightlyBelow(0.12f));
+              IsSlightlyBelow(0.04f));
 }
 
 // Test header encoding of original bits per sample


### PR DESCRIPTION
In the case of lossy non-squeeze modular, XYB color quantization was done twice: once with big factors to go to integers, then again by applying integer quantization as if the values are the final squeeze residuals.

This changes it to do XYB color quantization directly by using different LF quant weights.

For the B channel, the quantization that was done before was too aggressive since it ended up using the large factors that make sense for the final (highest freq) squeeze residuals but not when done on every pixel. This instead uses twice the effective quantization for B (or rather B-Y) as for Y, which makes more sense.

## Effect on `-m -R 0`

Note: of course `-m -R 0` is not a good way to do lossy compression, but it does still make sense to have the distance parameter roughly make sense at this setting too.

Before:
```
Encoding         kPixels    Bytes          BPP  E MP/s  D MP/s     Max norm        pnorm   PSNR   QABPP  SmallB  DCT4x8     AFV  DCT8x8    8x16    8x32      16   16x32      32   32x64      64       BPP*pnorm   Bugs
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
jxl:d0.5           13270  4225280    2.5471813   7.262  26.493   1.12016439   0.37185960  44.08   2.574  0.1915 29.5167  0.9101  7.6812 20.0173  0.0000 39.9439  0.0386  2.5541  0.0000  0.0000  0.947193828701      0
jxl:d0.5:m:R0      13270  6888156    4.1524780   1.496   4.052   6.65156317   2.06309910  39.02  18.260  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  8.566973685795      0
jxl:d1             13270  2680279    1.6157880   8.213  29.165   1.68695998   0.60068375  40.42   2.291  0.2464 20.8150  1.1531  5.7728 16.4803  0.0000 38.9234  4.1514 13.3108  0.0000  0.0000  0.970577588663      0
jxl:d1:m:R0        13270  4671429    2.8161392   1.724   4.399  15.60700035   4.30183492  34.50  23.833  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 12.114566064935      0
jxl:d2             13270  1685403    1.0160337   8.342  32.736   2.98979163   0.94922260  37.10   2.375  0.2836 14.5005  1.3248  4.3559 13.1401  0.0000 24.9008 21.7062 20.6414  0.0000  0.0000  0.964442190920      0
jxl:d2:m:R0        13270  3098049    1.8676378   1.985   4.752  26.90851593   8.59061962  29.34  30.718  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 16.044165810199      0
jxl:d3             13270  1244972    0.7505229   7.453  32.249   3.67112684   1.25033732  35.05   2.354  0.2416 11.1946  1.2689  3.7656 11.4145  0.0000 17.3870 31.8378 23.7433  0.0000  0.0000  0.938406803190      0
jxl:d3:m:R0        13270  2416114    1.4565379   2.008   5.687  68.12578583  11.30722730  27.98  29.016  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 16.469405180441      0
jxl:d4             13270  1006000    0.6064603   7.241  20.953   4.82071018   1.50023616  33.80   2.377  0.1775  8.7996  1.1044  3.1820 10.1422  0.0000 13.9377 37.1120 26.3978  0.0000  0.0000  0.909833619277      0
jxl:d4:m:R0        13270  2042780    1.2314760   2.065   6.089  67.54280090  12.96575886  25.14  28.324  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 15.967021393441      0
jxl:d6             13270   717469    0.4325213   6.557  21.471   7.20063066   1.97447910  31.91   2.278  0.1119  6.1640  0.9081  2.4673  8.7215  0.0000 10.7914 41.8036 29.8856  0.0000  0.0000  0.854004287594      0
jxl:d6:m:R0        13270  1577660    0.9510816   2.151   6.518  87.58567047  14.95372177  25.70  24.555  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 14.222209772238      0
jxl:d8             13270   567576    0.3421593   6.719  19.272  11.96129036   2.41502386  30.80   2.319  0.0627  4.4905  0.6969  1.8722  7.5312  0.0000  9.2172 43.7558 33.2114  0.0154  0.0000  0.826322957318      0
jxl:d8:m:R0        13270  1315836    0.7932428   2.265   7.101 102.44889832  17.75104609  22.44  28.819  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 14.080889337364      0
Aggregate:         13270  1929910    1.1634332   3.782  11.753  11.78196907   3.03502877  32.10   7.824  0.1695 11.3518  1.0304  3.7633 11.8577  0.0000 19.1172  9.5999 17.1511  0.0154  0.0000  3.531053252146      0
```

After:
```
Encoding         kPixels    Bytes          BPP  E MP/s  D MP/s     Max norm        pnorm   PSNR   QABPP  SmallB  DCT4x8     AFV  DCT8x8    8x16    8x32      16   16x32      32   32x64      64       BPP*pnorm   Bugs
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
jxl:d0.5           13270  4225280    2.5471813   7.999  27.544   1.12016439   0.37185960  44.08   2.574  0.1915 29.5167  0.9101  7.6812 20.0173  0.0000 39.9439  0.0386  2.5541  0.0000  0.0000  0.947193828701      0
jxl:d0.5:m:R0      13270 11047163    6.6597071   0.907   4.259   1.26874483   0.34432829  51.43   6.798  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  2.293125598712      0
jxl:d1             13270  2680279    1.6157880   8.450  28.043   1.68695998   0.60068375  40.42   2.291  0.2464 20.8150  1.1531  5.7728 16.4803  0.0000 38.9234  4.1514 13.3108  0.0000  0.0000  0.970577588663      0
jxl:d1:m:R0        13270  8072305    4.8663342   1.131   4.307   3.41570759   0.71326874  46.11   7.671  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  3.471004075111      0
jxl:d2             13270  1685403    1.0160337   9.464  31.973   2.98979163   0.94922260  37.10   2.375  0.2836 14.5005  1.3248  4.3559 13.1401  0.0000 24.9008 21.7062 20.6414  0.0000  0.0000  0.964442190920      0
jxl:d2:m:R0        13270  6730092    4.0571902   1.381   5.988   5.43202448   1.53080807  41.04  13.313  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  6.210779554953      0
jxl:d3             13270  1245173    0.7506441   7.462  29.501   3.67112684   1.25043508  35.05   2.353  0.2416 11.2018  1.2689  3.7661 11.4183  0.0000 17.3831 31.8224 23.7511  0.0000  0.0000  0.938631691957      0
jxl:d3:m:R0        13270  6199582    3.7373759   1.354   8.456   9.26739311   2.36716654  37.86  18.333  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  8.846991137981      0
jxl:d4             13270  1006213    0.6065887   7.841  20.307   4.82071018   1.50046479  33.80   2.391  0.1780  8.8015  1.1015  3.1787 10.1480  0.0000 13.9358 37.1274 26.3823  0.0000  0.0000  0.910164942874      0
jxl:d4:m:R0        13270  5114044    3.0829667   1.374   9.547  13.75525570   3.16484256  36.18  19.744  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  9.757104129838      0
jxl:d6             13270   717379    0.4324671   7.341  21.311   7.05387974   1.97490740  31.91   2.284  0.1119  6.1640  0.9086  2.4639  8.7282  0.0000 10.7875 41.8113 29.8779  0.0000  0.0000  0.854082388150      0
jxl:d6:m:R0        13270  3646046    2.1979941   1.878  10.012  22.48182487   4.82970524  32.86  20.788  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 10.615663399800      0
jxl:d8             13270   567459    0.3420888   6.828  18.733  12.11405659   2.41911848  30.80   2.334  0.0622  4.4929  0.6964  1.8756  7.5341  0.0000  9.1979 43.7751 33.2036  0.0154  0.0000  0.827553343238      0
jxl:d8:m:R0        13270  2780864    1.6764250   2.184   9.858  22.39235878   6.37023489  30.21  20.898  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 10.679220795053      0
Aggregate:         13270  2806237    1.6917207   3.326  13.255   5.27475307   1.43990824  37.32   5.775  0.1694 11.3540  1.0300  3.7631 11.8612  0.0000 19.1095  9.6007 17.1492  0.0154  0.0000  2.435922573100      0
```

Before, the result of `-m -R 0` had a significantly lower quality (both BA and PSNR) than regular VarDCT encoding. This meant the quality had to be bumped up for patch frame encoding (see `enc_patch_dictionary.cc`). Now this is no longer needed.

## Effect on patches

Corpus: a set of screenshot images.

Before:
```
Encoding      kPixels    Bytes          BPP  E MP/s  D MP/s     Max norm        pnorm   PSNR   QABPP  SmallB  DCT4x8     AFV  DCT8x8    8x16    8x32      16   16x32      32   32x64      64       BPP*pnorm   Bugs
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
jxl:d0.5        42351  4755804    0.8983487   3.259  27.732   1.19672847   0.26600964  49.84   0.929  2.8402 12.0224  2.6030  2.4520 17.6513  0.0000 10.6265 14.3161  2.6403 12.3698 22.8052  0.238969406151      0
jxl:d1          42351  3403130    0.6428350   3.356  25.307   1.74524164   0.46976816  46.25   0.947  2.3455  9.8232  2.5960  1.7005 14.1149  0.0000 12.0361 18.0143  4.3376 12.4568 22.9020  0.301983419387      0
jxl:d2          42351  2419371    0.4570076   3.098  23.370   2.85246658   0.70272768  42.82   1.092  1.9594  7.8629  2.4650  1.3088 10.8891  0.0000  9.4955 24.4687  6.0301 12.8388 23.0083  0.321151915658      0
jxl:d3          42351  1939913    0.3664403   3.130  24.435   4.48085260   0.93056066  40.63   1.197  1.6744  6.8812  2.3564  1.2337  9.8770  0.0000  7.7208 27.8332  6.9852 12.6406 23.1244  0.340994935705      0
jxl:d4          42351  1662341    0.3140083   3.121  15.615   5.64935589   1.17990336  39.27   1.271  1.3406  6.2814  2.2433  1.0741  9.1096  0.0000  6.9356 29.4967  7.9886 12.6357 23.2211  0.370499425258      0
jxl:d5          42351  1471585    0.2779754   3.188  15.644   8.22463036   1.33609968  37.90   1.480  1.0707  5.8437  2.1164  0.9655  8.6336  0.0000  6.5028 30.4275  8.7019 12.7470 23.3178  0.371402819281      0
jxl:d6          42351  1322413    0.2497975   3.201  14.828   7.77507591   1.53297450  36.90   1.517  0.8639  5.4674  1.9817  0.8892  8.2446  0.0000  6.2592 30.8120  9.2556 12.8098 23.7434  0.382933203384      0
jxl:d8          42351  1109658    0.2096091   3.336  15.664   9.54998875   1.93390023  35.41   1.572  0.5730  4.7916  1.7445  0.7690  7.7251  0.0000  5.7805 31.4104 10.1816 13.3756 23.9755  0.405363086184      0
Aggregate:      42351  2015840    0.3807826   3.210  19.706   4.17380259   0.88663705  40.88   1.228  1.4089  7.0560  2.2446  1.2158 10.3748  0.0000  7.9085 24.9995  6.4933 12.7311 23.2591  0.337615965487      0
```

After:
```
Encoding      kPixels    Bytes          BPP  E MP/s  D MP/s     Max norm        pnorm   PSNR   QABPP  SmallB  DCT4x8     AFV  DCT8x8    8x16    8x32      16   16x32      32   32x64      64       BPP*pnorm   Bugs
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
jxl:d0.5        42351  4732961    0.8940337   2.826  32.624   1.19672847   0.26603949  49.88   0.925  2.7147 12.1198  2.6642  2.4673 18.6220  0.0000 10.3170 13.7371  2.5049 12.3746 22.8052  0.237848279752      0
jxl:d1          42351  3387481    0.6398790   2.894  28.218   1.74569070   0.46969826  46.30   0.943  2.2714  9.8404  2.6250  1.7199 14.7477  0.0000 11.8771 17.6600  4.2216 12.4713 22.8923  0.300550047590      0
jxl:d2          42351  2410514    0.4553346   2.748  26.063   2.84693027   0.70195799  42.93   1.092  1.8951  7.9180  2.4686  1.3161 11.2198  0.0000  9.2634 24.4965  5.9020 12.8775 22.9697  0.319625754268      0
jxl:d3          42351  1934133    0.3653485   2.709  24.970   4.48085260   0.92931546  40.70   1.185  1.6369  6.9519  2.3675  1.2204 10.1221  0.0000  7.5643 27.8465  6.8570 12.6357 23.1244  0.339524002175      0
jxl:d4          42351  1660000    0.3135661   2.812  15.998   5.64935589   1.17974951  39.34   1.289  1.2923  6.3751  2.2430  1.0830  9.3366  0.0000  6.8286 29.5088  7.8073 12.6309 23.2211  0.369929427006      0
jxl:d5          42351  1472108    0.2780742   2.858  17.120   8.24012184   1.33620322  37.98   1.487  1.0377  5.8944  2.1100  0.9885  8.8778  0.0000  6.3294 30.6343  8.3996 12.7276 23.3275  0.371563607164      0
jxl:d6          42351  1323105    0.2499282   2.886  15.925   7.64293194   1.53498133  36.99   1.513  0.8373  5.5194  1.9740  0.8948  8.4534  0.0000  6.1504 30.9812  8.9727 12.8001 23.7434  0.383635151037      0
jxl:d8          42351  1107446    0.2091913   2.859  17.234   9.56027985   1.93704956  35.51   1.605  0.5581  4.8090  1.7357  0.7687  7.8212  0.0000  5.7128 31.6449  9.9447 13.3659 23.9658  0.405213844820      0
Aggregate:      42351  2011159    0.3798982   2.823  21.463   4.16553173   0.88668260  40.96   1.230  1.3641  7.1124  2.2526  1.2234 10.6930  0.0000  7.7519 24.8766  6.3072 12.7324 23.2530  0.336849163133      0
```

0.47% improvement in bpp*pnorm at d1, 0.23% improvement overall. Of course that's specifically for these screenshot images, not in general.