### PR TITLE
pass jpeg_quality to frames

### DIFF
--- a/tools/djxl.cc
+++ b/tools/djxl.cc
@@ -304,6 +304,7 @@ jxl::Status WriteJxlOutput(const DecompressArgs& args, const char* file_out,
       frame_io.SetFromImage(jxl::CopyImage(*io.frames[i].color()),
                             io.frames[i].c_current());
       frame_io.metadata.m = *io.frames[i].metadata();
+      frame_io.jpeg_quality = io.jpeg_quality;
       if (io.frames[i].HasAlpha()) {
         frame_io.Main().SetAlpha(
             jxl::CopyImage(*io.frames[i].alpha()),


### PR DESCRIPTION
Fixes https://github.com/libjxl/libjxl/issues/258. The problem was that the frames don't get the jpeg_quality set correctly, which resulted in horrible quality/or non-working jpeg when decoding animated jxls to a sequence of jpgs