### PR TITLE
Fix q100

### DIFF
--- a/tools/cjxl.cc
+++ b/tools/cjxl.cc
@@ -509,7 +509,9 @@ jxl::Status CompressArgs::ValidateArgs(const CommandLineParser& cmdline) {
       if (jpeg_transcode == false) params.modular_mode = true;
     }
     // Quality settings roughly match libjpeg qualities.
-    if (quality >= 30) {
+    if (quality >= 100) {
+      params.butteraugli_distance = 0;
+    } else if (quality >= 30) {
       params.butteraugli_distance = 0.1 + (100 - quality) * 0.09;
     } else {
       params.butteraugli_distance =


### PR DESCRIPTION
The changes in https://github.com/libjxl/libjxl/pull/1275 accidentally caused `-q 100` to correspond to d0.1, which was not the intention. This makes `cjxl -q 100` lossless again. Another changed behavior is that `cjxl -m` now defaults to the same distance as non-modular encoding (instead of defaulting to lossless), but I think that's OK to keep like that.