### PR TITLE
Build `jxl_extras_dec` only as a shared library if necessary

### DIFF
--- a/lib/jxl_extras.cmake
+++ b/lib/jxl_extras.cmake
@@ -169,10 +169,18 @@ endif() # JPEGXL_ENABLE_OPENEXR
 
 target_compile_definitions(jxl_extras_dec-obj PRIVATE ${JXL_EXTRAS_DEC_PUBLIC_DEFINITIONS})
 
+### Static library.
 add_library(jxl_extras_dec-static STATIC $<TARGET_OBJECTS:jxl_extras_dec-obj>)
 target_compile_definitions(jxl_extras_dec-static PUBLIC ${JXL_EXTRAS_DEC_PUBLIC_DEFINITIONS})
 target_link_libraries(jxl_extras_dec-static PRIVATE ${JXL_EXTRAS_DEC_INTERNAL_LIBRARIES})
 
+### Shared library.
+if (((NOT DEFINED "${TARGET_SUPPORTS_SHARED_LIBS}") OR
+     TARGET_SUPPORTS_SHARED_LIBS) AND NOT JPEGXL_STATIC AND BUILD_SHARED_LIBS)
 add_library(jxl_extras_dec SHARED $<TARGET_OBJECTS:jxl_extras_dec-obj>)
 target_compile_definitions(jxl_extras_dec PUBLIC ${JXL_EXTRAS_DEC_PUBLIC_DEFINITIONS})
 target_link_libraries(jxl_extras_dec PRIVATE ${JXL_EXTRAS_DEC_INTERNAL_LIBRARIES} jxl)
+else()
+add_library(jxl_extras_dec ALIAS jxl_extras_dec-static)
+endif()  # TARGET_SUPPORTS_SHARED_LIBS AND NOT JPEGXL_STATIC AND
+         # BUILD_SHARED_LIBS


### PR DESCRIPTION
This should fix libvips' CIFuzz and OSS-Fuzz integration.
https://github.com/libvips/libvips/runs/5799006301
https://oss-fuzz-build-logs.storage.googleapis.com/index.html#libvips

Alternatively, we could avoid building `jxl_extras_dec` as a shared
library, since it's not being linked against.

(The logic is derived from `jxl_threads.cmake`)