### PR TITLE
Prevent a signed wrap-around when processing utf-8 strings

### DIFF
--- a/lib/jxl/frame_header.h
+++ b/lib/jxl/frame_header.h
@@ -40,7 +40,7 @@ static inline Status VisitNameString(Visitor* JXL_RESTRICT visitor,
     name->resize(name_length);
   }
   for (size_t i = 0; i < name_length; i++) {
-    uint32_t c = (*name)[i];
+    uint32_t c = static_cast<uint8_t>((*name)[i]);
     JXL_QUIET_RETURN_IF_ERROR(visitor->Bits(8, 0, &c));
     (*name)[i] = static_cast<char>(c);
   }


### PR DESCRIPTION
On most arches `char` is a signed integer type. Make sure to cast to a
unsigned char first, so that all values are within range [0, 255]

This should fix the following error:

[...]
./lib/jxl/fields.h:44: JXL_FAILURE: Value 4294967235 too large for 8 bits
[...]

When calling API:

```
JxlEncoderSetFrameName(jxl_encoder_frame_settings, u8"é");
```