### PR TITLE
Disable pixbuf test under MSAN.

### DIFF
--- a/plugins/gdk-pixbuf/CMakeLists.txt
+++ b/plugins/gdk-pixbuf/CMakeLists.txt
@@ -63,14 +63,18 @@ if(BUILD_TESTING AND NOT MINGW)
       set(XVFB_PROGRAM_PREFIX "")
     endif()
 
-    add_test(
-      NAME pixbufloader_test_jxl
-      COMMAND
-        ${XVFB_PROGRAM_PREFIX} $<TARGET_FILE:pixbufloader_test>
-        "${CMAKE_CURRENT_SOURCE_DIR}/loaders_test.cache"
-        "${CMAKE_SOURCE_DIR}/third_party/testdata/jxl/blending/cropped_traffic_light.jxl"
-      WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
-    )
-    set_tests_properties(pixbufloader_test_jxl PROPERTIES SKIP_RETURN_CODE 254)
+    # libX11.so and libgdk-x11-2.0.so are not compiled with MSAN -> report
+    # use-of-uninitialized-value for string some internal string value.
+    if (NOT (SANITIZER STREQUAL "msan"))
+      add_test(
+        NAME pixbufloader_test_jxl
+        COMMAND
+          ${XVFB_PROGRAM_PREFIX} $<TARGET_FILE:pixbufloader_test>
+          "${CMAKE_CURRENT_SOURCE_DIR}/loaders_test.cache"
+          "${CMAKE_SOURCE_DIR}/third_party/testdata/jxl/blending/cropped_traffic_light.jxl"
+        WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+      )
+      set_tests_properties(pixbufloader_test_jxl PROPERTIES SKIP_RETURN_CODE 254)
+    endif()
   endif()  # Gdk_FOUND
 endif()  # BUILD_TESTING


### PR DESCRIPTION
```
xvfb-run -a ./build/plugins/gdk-pixbuf/pixbufloader_test ./plugins/gdk-pixbuf/loaders_test.cache ./third_party/testdata/jxl/blending/cropped_traffic_light.jxl
Uninitialized bytes in __interceptor_strlen at offset 10 inside [0x701000000810, 11)
==3746300==WARNING: MemorySanitizer: use-of-uninitialized-value
    #0 0x7f09809c906e in _XlcAddCT (/lib/x86_64-linux-gnu/libX11.so.6+0x5306e)
    #1 0x7f09809c92f7 in _XlcInitCTInfo (/lib/x86_64-linux-gnu/libX11.so.6+0x532f7)
    #2 0x7f09809cf482  (/lib/x86_64-linux-gnu/libX11.so.6+0x59482)
    #3 0x7f09809ceb62  (/lib/x86_64-linux-gnu/libX11.so.6+0x58b62)
    #4 0x7f09809cf378 in _XlcCreateLC (/lib/x86_64-linux-gnu/libX11.so.6+0x59378)
    #5 0x7f09809f0070 in _XlcUtf8Loader (/lib/x86_64-linux-gnu/libX11.so.6+0x7a070)
    #6 0x7f09809d690d in _XOpenLC (/lib/x86_64-linux-gnu/libX11.so.6+0x6090d)
    #7 0x7f09809d6a58 in XSupportsLocale (/lib/x86_64-linux-gnu/libX11.so.6+0x60a58)
    #8 0x7f098191b5b6  (/lib/x86_64-linux-gnu/libgdk-x11-2.0.so.0+0x625b6)
    #9 0x7f0981920158  (/lib/x86_64-linux-gnu/libgdk-x11-2.0.so.0+0x67158)
    #10 0x7f09818d79ba in gdk_parse_args (/lib/x86_64-linux-gnu/libgdk-x11-2.0.so.0+0x1e9ba)
    #11 0x7f09818d7ba8 in gdk_init_check (/lib/x86_64-linux-gnu/libgdk-x11-2.0.so.0+0x1eba8)
    #12 0x562d08176fb2 in main libjxl/plugins/gdk-pixbuf/pixbufloader_test.cc:26:8
    #13 0x7f0980d617fc in __libc_start_main csu/../csu/libc-start.c:332:16
    #14 0x562d08100219 in _start (libjxl/build/plugins/gdk-pixbuf/pixbufloader_test+0x21219)

  Uninitialized value was created by a heap allocation
    #0 0x562d08124f0d in malloc (libjxl/build/plugins/gdk-pixbuf/pixbufloader_test+0x45f0d)
    #1 0x7f09809c96cd in _XlcCreateDefaultCharSet (/lib/x86_64-linux-gnu/libX11.so.6+0x536cd)

SUMMARY: MemorySanitizer: use-of-uninitialized-value (/lib/x86_64-linux-gnu/libX11.so.6+0x5306e) in _XlcAddCT
```