### PR TITLE
PAM: Do not skip multiple whitespaces after `ENDHDR`

### DIFF
--- a/lib/extras/dec/pnm.cc
+++ b/lib/extras/dec/pnm.cc
@@ -169,7 +169,7 @@ class Parser {
     return true;
   }
 
-  Status MatchString(const char* keyword) {
+  Status MatchString(const char* keyword, bool skipws = true) {
     const uint8_t* ppos = pos_;
     while (*keyword) {
       if (ppos >= end_) return JXL_FAILURE("PAM: unexpected end of input");
@@ -178,14 +178,18 @@ class Parser {
       keyword++;
     }
     pos_ = ppos;
-    JXL_RETURN_IF_ERROR(SkipWhitespace());
+    if (skipws) {
+      JXL_RETURN_IF_ERROR(SkipWhitespace());
+    } else {
+      JXL_RETURN_IF_ERROR(SkipSingleWhitespace());
+    }
     return true;
   }
 
   Status ParseHeaderPAM(HeaderPNM* header, const uint8_t** pos) {
     size_t depth = 3;
     size_t max_val = 255;
-    while (!MatchString("ENDHDR")) {
+    while (!MatchString("ENDHDR", /*skipws=*/false)) {
       JXL_RETURN_IF_ERROR(SkipWhitespace());
       if (MatchString("WIDTH")) {
         JXL_RETURN_IF_ERROR(ParseUnsigned(&header->xsize));


### PR DESCRIPTION
The parser was confusing a whitespace character with the actual first
pixel value.

Fixes the following test cases:

```
% convert -size 512x512 xc:#090909 tab.pam
% convert -size 512x512 xc:#202020 space.pam
% convert -size 512x512 xc:#0A0A0A lf.pam
% convert -size 512x512 xc:#0D0D0D cr.pam
```

```
% for i in tab.pam space.pam lf.pam cr.pam; do cjxl $i $i.jxl; done
Failed to read image tab.pam.
Failed to read image space.pam.
Failed to read image lf.pam.
Failed to read image cr.pam.
```