### PR TITLE
Properly list `cjxl_ng` as part of the tools to be installed

### DIFF
--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -121,6 +121,7 @@ endif()
 if(JPEGXL_ENABLE_TOOLS)
   list(APPEND TOOL_BINARIES
     cjxl
+    cjxl_ng
     djxl
     djxl_ng
     cjpeg_hdr


### PR DESCRIPTION
This will make sure that cjxl_ng is installed after a call to `make
install`.

This reverts partially commit 775d010700bc8bb752f8db3753e9e7246093758f