### PR TITLE
Provide a mechanism to override default testdata location

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -316,6 +316,10 @@ configure_file("${CMAKE_CURRENT_SOURCE_DIR}/LICENSE"
 # Enable tests regardless of where they are defined.
 enable_testing()
 include(CTest)
+# Specify default location of `testdata`:
+if(NOT DEFINED JPEGXL_TEST_DATA_PATH)
+  set(JPEGXL_TEST_DATA_PATH "${PROJECT_SOURCE_DIR}/third_party/testdata")
+endif()
 
 # Libraries.
 add_subdirectory(lib)

--- a/lib/jxl_benchmark.cmake
+++ b/lib/jxl_benchmark.cmake
@@ -34,7 +34,7 @@ if(benchmark_FOUND)
   add_executable(jxl_gbench "${JPEGXL_INTERNAL_SOURCES_GBENCH}" gbench_main.cc)
 
   target_compile_definitions(jxl_gbench PRIVATE
-    -DTEST_DATA_PATH="${PROJECT_SOURCE_DIR}/third_party/testdata")
+    -DTEST_DATA_PATH="${JPEGXL_TEST_DATA_PATH}")
   target_link_libraries(jxl_gbench
     jxl_extras-static
     jxl-static

--- a/lib/jxl_tests.cmake
+++ b/lib/jxl_tests.cmake
@@ -85,7 +85,7 @@ add_library(jxl_testlib-static STATIC ${TESTLIB_FILES})
     ${JPEGXL_COVERAGE_FLAGS}
   )
 target_compile_definitions(jxl_testlib-static PUBLIC
-  -DTEST_DATA_PATH="${PROJECT_SOURCE_DIR}/third_party/testdata")
+  -DTEST_DATA_PATH="${JPEGXL_TEST_DATA_PATH}")
 target_include_directories(jxl_testlib-static PUBLIC
   "${PROJECT_SOURCE_DIR}"
 )

--- a/tools/conformance/CMakeLists.txt
+++ b/tools/conformance/CMakeLists.txt
@@ -14,7 +14,7 @@ if(BASH_PROGRAM)
     NAME conformance_tooling_test
     COMMAND
         ${BASH_PROGRAM} ${CMAKE_CURRENT_SOURCE_DIR}/tooling_test.sh
-        ${CMAKE_BINARY_DIR})
+        ${CMAKE_BINARY_DIR} ${JPEGXL_TEST_DATA_PATH})
   # Skip the test if dependencies are not available.
   set_tests_properties(conformance_tooling_test PROPERTIES SKIP_RETURN_CODE 254)
 endif()

--- a/tools/conformance/tooling_test.sh
+++ b/tools/conformance/tooling_test.sh
@@ -10,6 +10,12 @@
 
 MYDIR=$(dirname $(realpath "$0"))
 
+if [[ $# -eq 2 ]]; then
+    JPEGXL_TEST_DATA_PATH="$2"
+else
+    JPEGXL_TEST_DATA_PATH="${MYDIR}/../../third_party/testdata"
+fi
+
 set -eux
 
 # Temporary files cleanup hooks.
@@ -41,7 +47,7 @@ main() {
     --output="${tmpdir}" \
     --peak_error=0.001 \
     --rmse=0.001 \
-    "${MYDIR}/../../third_party/testdata/jxl/blending/cropped_traffic_light.jxl"
+    "${JPEGXL_TEST_DATA_PATH}/jxl/blending/cropped_traffic_light.jxl"
 
   # List the contents of the corpus dir.
   tree "${tmpdir}" || true


### PR DESCRIPTION
This will allow user to configure libjxl using an existing testdata
location:

```
% cmake -DJPEGXL_TEST_DATA_PATH:PATH=/usr/share/libjxl-testdata .
```