### PR TITLE
deprecate JXL_TYPE_BOOLEAN and JXL_TYPE_UINT32

### DIFF
--- a/lib/extras/dec/pgx.cc
+++ b/lib/extras/dec/pgx.cc
@@ -117,12 +117,10 @@ class Parser {
     // 0xa, or 0xd 0xa.
     JXL_RETURN_IF_ERROR(SkipLineBreak());
 
-    // libjxl currently does use float buffers internally for most parts of the
-    // codec so the actual precision limit for lossless integer encoding is
-    // 24-bit (higher than that starts losing least significant bits in the
-    // conversion to/from float).
-    if (header->bits_per_sample > 24) {
-      return JXL_FAILURE("PGX: >24 bits not yet supported");
+    // TODO(jon): could do up to 24-bit by converting the values to
+    // JXL_TYPE_FLOAT.
+    if (header->bits_per_sample > 16) {
+      return JXL_FAILURE("PGX: >16 bits not yet supported");
     }
     // TODO(lode): support signed integers. This may require changing the way
     // external_image works.
@@ -131,9 +129,7 @@ class Parser {
     }
 
     size_t numpixels = header->xsize * header->ysize;
-    size_t bytes_per_pixel = header->bits_per_sample <= 8    ? 1
-                             : header->bits_per_sample <= 16 ? 2
-                                                             : 4;
+    size_t bytes_per_pixel = header->bits_per_sample <= 8 ? 1 : 2;
     if (pos_ + numpixels * bytes_per_pixel > end_) {
       return JXL_FAILURE("PGX: data too small");
     }
@@ -178,9 +174,7 @@ Status DecodeImagePGX(const Span<const uint8_t> bytes,
   ppf->info.orientation = JXL_ORIENT_IDENTITY;
 
   JxlDataType data_type;
-  if (header.bits_per_sample > 16) {
-    data_type = JXL_TYPE_UINT32;
-  } else if (header.bits_per_sample > 8) {
+  if (header.bits_per_sample > 8) {
     data_type = JXL_TYPE_UINT16;
   } else {
     data_type = JXL_TYPE_UINT8;

--- a/lib/extras/packed_image.h
+++ b/lib/extras/packed_image.h
@@ -79,21 +79,17 @@ class PackedImage {
 
   static size_t BitsPerChannel(JxlDataType data_type) {
     switch (data_type) {
-      case JXL_TYPE_BOOLEAN:
-        return 1;
       case JXL_TYPE_UINT8:
         return 8;
       case JXL_TYPE_UINT16:
         return 16;
-      case JXL_TYPE_UINT32:
-        return 32;
       case JXL_TYPE_FLOAT:
         return 32;
       case JXL_TYPE_FLOAT16:
         return 16;
-        // No default, give compiler error if new type not handled.
+      default:
+        JXL_ABORT("Unhandled JxlDataType");
     }
-    return 0;  // Indicate invalid data type.
   }
 
  private:

--- a/lib/include/jxl/encode.h
+++ b/lib/include/jxl/encode.h
@@ -1058,7 +1058,7 @@ JXL_EXPORT JxlEncoderStatus JxlEncoderSetFrameDistance(
 
 /** DEPRECATED: use JxlEncoderSetFrameDistance instead.
  */
-JXL_EXPORT JxlEncoderStatus
+JXL_EXPORT JXL_DEPRECATED JxlEncoderStatus
 JxlEncoderOptionsSetDistance(JxlEncoderFrameSettings*, float);
 
 /**
@@ -1081,7 +1081,7 @@ JXL_EXPORT JxlEncoderFrameSettings* JxlEncoderFrameSettingsCreate(
 
 /** DEPRECATED: use JxlEncoderFrameSettingsCreate instead.
  */
-JXL_EXPORT JxlEncoderFrameSettings* JxlEncoderOptionsCreate(
+JXL_EXPORT JXL_DEPRECATED JxlEncoderFrameSettings* JxlEncoderOptionsCreate(
     JxlEncoder*, const JxlEncoderFrameSettings*);
 
 /**

--- a/lib/include/jxl/types.h
+++ b/lib/include/jxl/types.h
@@ -16,6 +16,8 @@
 #include <stddef.h>
 #include <stdint.h>
 
+#include "jxl/jxl_export.h"
+
 #if defined(__cplusplus) || defined(c_plusplus)
 extern "C" {
 #endif
@@ -41,27 +43,25 @@ typedef enum {
    * for HDR and wide gamut images when color profile conversion is required. */
   JXL_TYPE_FLOAT = 0,
 
-  /** Use 1-bit packed in uint8_t, first pixel in LSB, padded to uint8_t per
-   * row.
-   * TODO(lode): support first in MSB, other padding.
-   */
-  JXL_TYPE_BOOLEAN,
-
   /** Use type uint8_t. May clip wide color gamut data.
    */
-  JXL_TYPE_UINT8,
+  JXL_TYPE_UINT8 = 2,
 
   /** Use type uint16_t. May clip wide color gamut data.
    */
-  JXL_TYPE_UINT16,
-
-  /** Use type uint32_t. May clip wide color gamut data.
-   */
-  JXL_TYPE_UINT32,
+  JXL_TYPE_UINT16 = 3,
 
   /** Use 16-bit IEEE 754 half-precision floating point values */
-  JXL_TYPE_FLOAT16,
+  JXL_TYPE_FLOAT16 = 5,
 } JxlDataType;
+
+/* DEPRECATED: bit-packed 1-bit data type. Use JXL_TYPE_UINT8 instead.
+ */
+static const int JXL_DEPRECATED JXL_TYPE_BOOLEAN = 1;
+
+/* DEPRECATED: uint32_t data type. Use JXL_TYPE_FLOAT instead.
+ */
+static const int JXL_DEPRECATED JXL_TYPE_UINT32 = 4;
 
 /** Ordering of multi-byte data.
  */

--- a/lib/jxl/butteraugli_wrapper.cc
+++ b/lib/jxl/butteraugli_wrapper.cc
@@ -36,10 +36,6 @@ void SetMetadataFromPixelFormat(const JxlPixelFormat* pixel_format,
       metadata->SetFloat16Samples();
       potential_alpha_bits = 16;
       break;
-    case JXL_TYPE_UINT32:
-      metadata->SetUintSamples(32);
-      potential_alpha_bits = 16;
-      break;
     case JXL_TYPE_UINT16:
       metadata->SetUintSamples(16);
       potential_alpha_bits = 16;
@@ -48,10 +44,8 @@ void SetMetadataFromPixelFormat(const JxlPixelFormat* pixel_format,
       metadata->SetUintSamples(8);
       potential_alpha_bits = 8;
       break;
-    case JXL_TYPE_BOOLEAN:
-      metadata->SetUintSamples(2);
-      potential_alpha_bits = 2;
-      break;
+    default:
+      JXL_ABORT("Unhandled JxlDataType");
   }
   if (pixel_format->num_channels == 2 || pixel_format->num_channels == 4) {
     metadata->SetAlphaBits(potential_alpha_bits);

--- a/lib/jxl/dec_external_image.h
+++ b/lib/jxl/dec_external_image.h
@@ -22,12 +22,11 @@
 namespace jxl {
 
 // Converts ib to interleaved void* pixel buffer with the given format.
-// bits_per_sample: must be 8, 16 or 32, and must be 32 if float_out
-// is true. 1 and 32 int are not yet implemented.
+// bits_per_sample: must be 16 or 32 if float_out is true, and at most 16
+// if it is false. No bit packing is done.
 // num_channels: must be 1, 2, 3 or 4 for gray, gray+alpha, RGB, RGB+alpha.
 // This supports the features needed for the C API and does not perform
 // color space conversion.
-// TODO(lode): support 1-bit output (bits_per_sample == 1)
 // TODO(lode): support rectangle crop.
 // stride_out is output scanline size in bytes, must be >=
 // output_xsize * output_bytes_per_pixel.
@@ -43,14 +42,8 @@ Status ConvertToExternal(const jxl::ImageBundle& ib, size_t bits_per_sample,
 
 // Converts single-channel image to interleaved void* pixel buffer with the
 // given format, with a single channel.
-// bits_per_sample: must be 8, 16 or 32, and must be 32 if float_out
-// is true. 1 and 32 int are not yet implemented.
 // This supports the features needed for the C API to get extra channels.
-// stride_out is output scanline size in bytes, must be >=
-// output_xsize * output_bytes_per_pixel.
-// undo_orientation is an EXIF orientation to undo. Depending on the
-// orientation, the output xsize and ysize are swapped compared to input
-// xsize and ysize.
+// Arguments are similar to the multi-channel function above.
 Status ConvertToExternal(const jxl::ImageF& channel, size_t bits_per_sample,
                          bool float_out, JxlEndianness endianness,
                          size_t stride_out, jxl::ThreadPool* thread_pool,

--- a/lib/jxl/decode.cc
+++ b/lib/jxl/decode.cc
@@ -139,21 +139,17 @@ namespace {
 
 size_t BitsPerChannel(JxlDataType data_type) {
   switch (data_type) {
-    case JXL_TYPE_BOOLEAN:
-      return 1;
     case JXL_TYPE_UINT8:
       return 8;
     case JXL_TYPE_UINT16:
       return 16;
-    case JXL_TYPE_UINT32:
-      return 32;
     case JXL_TYPE_FLOAT:
       return 32;
     case JXL_TYPE_FLOAT16:
       return 16;
-      // No default, give compiler error if new type not handled.
+    default:
+      return 0;  // signals unhandled JxlDataType
   }
-  return 0;  // Indicate invalid data type.
 }
 
 enum class DecoderStage : uint32_t {
@@ -2405,17 +2401,11 @@ JxlDecoderStatus PrepareSizeCheck(const JxlDecoder* dec,
   if (format->num_channels > 4) {
     return JXL_API_ERROR("More than 4 channels not supported");
   }
-  if (format->data_type == JXL_TYPE_BOOLEAN) {
-    return JXL_API_ERROR("Boolean data type not yet supported");
-  }
-  if (format->data_type == JXL_TYPE_UINT32) {
-    return JXL_API_ERROR("uint32 data type not yet supported");
-  }
 
   *bits = BitsPerChannel(format->data_type);
 
   if (*bits == 0) {
-    return JXL_API_ERROR("Invalid data type");
+    return JXL_API_ERROR("Invalid/unsupported data type");
   }
 
   return JXL_DEC_SUCCESS;

--- a/lib/jxl/decode_test.cc
+++ b/lib/jxl/decode_test.cc
@@ -1407,12 +1407,8 @@ std::ostream& operator<<(std::ostream& os, const PixelTestConfig& c) {
     case JXL_TYPE_FLOAT16:
       os << "f16";
       break;
-    case JXL_TYPE_UINT32:
-      os << "u32";
-      break;
-    case JXL_TYPE_BOOLEAN:
-      os << "b";
-      break;
+    default:
+      JXL_ASSERT(false);
   };
   if (jxl::test::GetDataBits(c.data_type) > jxl::kBitsPerByte) {
     if (c.endianness == JXL_NATIVE_ENDIAN) {

--- a/lib/jxl/enc_external_image.cc
+++ b/lib/jxl/enc_external_image.cc
@@ -86,7 +86,6 @@ uint32_t JXL_INLINE Load8(const uint8_t* p) { return *p; }
 
 Status PixelFormatToExternal(const JxlPixelFormat& pixel_format,
                              size_t* bitdepth, bool* float_in) {
-  // TODO(zond): Make this accept uint32.
   if (pixel_format.data_type == JXL_TYPE_FLOAT) {
     *bitdepth = 32;
     *float_in = true;
@@ -100,7 +99,7 @@ Status PixelFormatToExternal(const JxlPixelFormat& pixel_format,
     *bitdepth = 16;
     *float_in = false;
   } else {
-    return JXL_FAILURE("unsupported bitdepth");
+    return JXL_FAILURE("unsupported pixel format data type");
   }
   return true;
 }
@@ -111,20 +110,9 @@ Status ConvertFromExternal(Span<const uint8_t> bytes, size_t xsize,
                            JxlEndianness endianness, ThreadPool* pool,
                            ImageF* channel, bool float_in, size_t align) {
   // TODO(firsching): Avoid code duplication with the function below.
-  if (bits_per_sample < 1 || bits_per_sample > 32) {
-    return JXL_FAILURE("Invalid bits_per_sample value.");
-  }
-  // TODO(deymo): Implement 1-bit per sample as 8 samples per byte. In
-  // any other case we use DivCeil(bits_per_sample, 8) bytes per pixel per
-  // channel.
-  if (bits_per_sample == 1) {
-    return JXL_FAILURE("packed 1-bit per sample is not yet supported");
-  }
-
-  // bytes_per_pixel are only valid for
-  // bits_per_sample > 1.
+  JXL_CHECK(float_in ? bits_per_sample == 16 || bits_per_sample == 32
+                     : bits_per_sample > 0 && bits_per_sample <= 16);
   const size_t bytes_per_pixel = DivCeil(bits_per_sample, jxl::kBitsPerByte);
-
   const size_t last_row_size = xsize * bytes_per_pixel;
   const size_t row_size =
       (align > 1 ? jxl::DivCeil(last_row_size, align) * align : last_row_size);
@@ -153,7 +141,7 @@ Status ConvertFromExternal(Span<const uint8_t> bytes, size_t xsize,
           const size_t y = task;
           size_t i = row_size * task;
           float* JXL_RESTRICT row_out = channel->Row(y);
-          if (bits_per_sample <= 16) {
+          if (bits_per_sample == 16) {
             if (little_endian) {
               for (size_t x = 0; x < xsize; ++x) {
                 row_out[x] = LoadLEFloat16(in + i);
@@ -188,24 +176,14 @@ Status ConvertFromExternal(Span<const uint8_t> bytes, size_t xsize,
           const size_t y = task;
           size_t i = row_size * task;
           float* JXL_RESTRICT row_out = channel->Row(y);
-          // TODO(deymo): add bits_per_sample == 1 case here. Also maybe
-          // implement masking if bits_per_sample is not a multiple of 8.
           if (bits_per_sample <= 8) {
             LoadFloatRow<Load8>(row_out, in + i, mul, xsize, bytes_per_pixel);
-          } else if (bits_per_sample <= 16) {
+          } else {
             if (little_endian) {
               LoadFloatRow<LoadLE16>(row_out, in + i, mul, xsize,
                                      bytes_per_pixel);
             } else {
               LoadFloatRow<LoadBE16>(row_out, in + i, mul, xsize,
-                                     bytes_per_pixel);
-            }
-          } else {
-            if (little_endian) {
-              LoadFloatRow<LoadLE32>(row_out, in + i, mul, xsize,
-                                     bytes_per_pixel);
-            } else {
-              LoadFloatRow<LoadBE32>(row_out, in + i, mul, xsize,
                                      bytes_per_pixel);
             }
           }
@@ -221,9 +199,8 @@ Status ConvertFromExternal(Span<const uint8_t> bytes, size_t xsize,
                            size_t bits_per_sample, JxlEndianness endianness,
                            bool flipped_y, ThreadPool* pool, ImageBundle* ib,
                            bool float_in, size_t align) {
-  if (bits_per_sample < 1 || bits_per_sample > 32) {
-    return JXL_FAILURE("Invalid bits_per_sample value.");
-  }
+  JXL_CHECK(float_in ? bits_per_sample == 16 || bits_per_sample == 32
+                     : bits_per_sample > 0 && bits_per_sample <= 16);
 
   const size_t color_channels = c_current.Channels();
   bool has_alpha = channels == 2 || channels == 4;
@@ -233,8 +210,6 @@ Status ConvertFromExternal(Span<const uint8_t> bytes, size_t xsize,
                        color_channels, channels);
   }
 
-  // bytes_per_channel and bytes_per_pixel are only valid for
-  // bits_per_sample > 1.
   const size_t bytes_per_channel = DivCeil(bits_per_sample, jxl::kBitsPerByte);
   const size_t bytes_per_pixel = channels * bytes_per_channel;
   if (bits_per_sample > 16 && bits_per_sample < 32) {
@@ -281,7 +256,7 @@ Status ConvertFromExternal(Span<const uint8_t> bytes, size_t xsize,
             size_t i =
                 row_size * task + (c * bits_per_sample / jxl::kBitsPerByte);
             float* JXL_RESTRICT row_out = color.PlaneRow(c, y);
-            if (bits_per_sample <= 16) {
+            if (bits_per_sample == 16) {
               if (little_endian) {
                 for (size_t x = 0; x < xsize; ++x) {
                   row_out[x] = LoadLEFloat16(in + i);
@@ -319,24 +294,14 @@ Status ConvertFromExternal(Span<const uint8_t> bytes, size_t xsize,
             const size_t y = get_y(task);
             size_t i = row_size * task + c * bytes_per_channel;
             float* JXL_RESTRICT row_out = color.PlaneRow(c, y);
-            // TODO(deymo): add bits_per_sample == 1 case here. Also maybe
-            // implement masking if bits_per_sample is not a multiple of 8.
             if (bits_per_sample <= 8) {
               LoadFloatRow<Load8>(row_out, in + i, mul, xsize, bytes_per_pixel);
-            } else if (bits_per_sample <= 16) {
+            } else {
               if (little_endian) {
                 LoadFloatRow<LoadLE16>(row_out, in + i, mul, xsize,
                                        bytes_per_pixel);
               } else {
                 LoadFloatRow<LoadBE16>(row_out, in + i, mul, xsize,
-                                       bytes_per_pixel);
-              }
-            } else {
-              if (little_endian) {
-                LoadFloatRow<LoadLE32>(row_out, in + i, mul, xsize,
-                                       bytes_per_pixel);
-              } else {
-                LoadFloatRow<LoadBE32>(row_out, in + i, mul, xsize,
                                        bytes_per_pixel);
               }
             }
@@ -365,7 +330,7 @@ Status ConvertFromExternal(Span<const uint8_t> bytes, size_t xsize,
             size_t i = row_size * task +
                        ((channels - 1) * bits_per_sample / jxl::kBitsPerByte);
             float* JXL_RESTRICT row_out = alpha.Row(y);
-            if (bits_per_sample <= 16) {
+            if (bits_per_sample == 16) {
               if (little_endian) {
                 for (size_t x = 0; x < xsize; ++x) {
                   row_out[x] = LoadLEFloat16(in + i);
@@ -400,24 +365,14 @@ Status ConvertFromExternal(Span<const uint8_t> bytes, size_t xsize,
             const size_t y = get_y(task);
             size_t i = row_size * task + (channels - 1) * bytes_per_channel;
             float* JXL_RESTRICT row_out = alpha.Row(y);
-            // TODO(deymo): add bits_per_sample == 1 case here. Also maybe
-            // implement masking if bits_per_sample is not a multiple of 8.
             if (bits_per_sample <= 8) {
               LoadFloatRow<Load8>(row_out, in + i, mul, xsize, bytes_per_pixel);
-            } else if (bits_per_sample <= 16) {
+            } else {
               if (little_endian) {
                 LoadFloatRow<LoadLE16>(row_out, in + i, mul, xsize,
                                        bytes_per_pixel);
               } else {
                 LoadFloatRow<LoadBE16>(row_out, in + i, mul, xsize,
-                                       bytes_per_pixel);
-              }
-            } else {
-              if (little_endian) {
-                LoadFloatRow<LoadLE32>(row_out, in + i, mul, xsize,
-                                       bytes_per_pixel);
-              } else {
-                LoadFloatRow<LoadBE32>(row_out, in + i, mul, xsize,
                                        bytes_per_pixel);
               }
             }

--- a/lib/jxl/roundtrip_test.cc
+++ b/lib/jxl/roundtrip_test.cc
@@ -51,7 +51,6 @@ jxl::CodecInOut ConvertTestImage(const std::vector<uint8_t>& buf,
         io.metadata.m.SetAlphaBits(8);
         break;
       case JXL_TYPE_UINT16:
-      case JXL_TYPE_UINT32:
       case JXL_TYPE_FLOAT:
       case JXL_TYPE_FLOAT16:
         io.metadata.m.SetAlphaBits(16);


### PR DESCRIPTION
These two sample types are in the enum but were never fully implemented so they couldn't actually be used by applications. It probably is not a great idea to implement them either, for the following reasons:

- Supporting UINT32 as a sample type at the API boundary can give the misleading impression that JPEG XL can losslessly store uint32 samples, which is not true. The spec limits integer bitdepths to what fits in int32 (so 31-bit uint), and the current libjxl implementation uses internal float representations so it is in practice limited to 24-bit uint.
- Saving memory for 1-bit images by having a bit-packed representation at the API boundary is a somewhat futile exercise when we're still internally using 32-bit floats to represent each bit. It's also somewhat arbitrary to support bit packing specifically for the case of 1-bit, but not for e.g. 2-bit or 4-bit, or for e.g. fitting 10-bit RGB in 4 bytes. No bit packing at all keeps things simple. Also the code was assuming that 1-bit is by definition bit-packed, while e.g. for the `pgm`/`ppm` formats, you need non-bitpacked 1-bit (i.e. bytes that are 0 or 1).

This ~~deprecates~~ removes these two sample types and removes the partial implementations.

(original plan was to keep them around in the enum and just deprecate them, but the documentation generator could not handle that, see https://github.com/sphinx-doc/sphinx/issues/10341, so just removing them is the easiest solution — note that no application could actually be really using these, since it would lead to runtime errors in both encoder and decoder)