### PR TITLE
fix pnm output for the non-multiple-of-8 bitdepth cases

### DIFF
--- a/lib/extras/packed_image_convert.cc
+++ b/lib/extras/packed_image_convert.cc
@@ -244,8 +244,11 @@ Status ConvertCodecInOutToPackedPixelFile(const CodecInOut& io,
 
     PackedFrame packed_frame(frame.oriented_xsize(), frame.oriented_ysize(),
                              format);
+    packed_frame.color.bitdepth_from_format = float_out;
     const size_t bits_per_sample =
-        packed_frame.color.BitsPerChannel(pixel_format.data_type);
+        packed_frame.color.bitdepth_from_format
+            ? packed_frame.color.BitsPerChannel(pixel_format.data_type)
+            : ppf->info.bits_per_sample;
     packed_frame.name = frame.name;
     packed_frame.frame_info.name_length = frame.name.size();
     // Color transform


### PR DESCRIPTION
Fixes https://github.com/libjxl/libjxl/issues/1335

PNM output was always writing 8 or 16 bit data, which is of course wrong when putting a maxval in the PNM header that is not 255 or 65535.