### PR TITLE
relax high bitdepth palette restriction and improve lossless float compression

### DIFF
--- a/lib/jxl/enc_modular.cc
+++ b/lib/jxl/enc_modular.cc
@@ -675,6 +675,8 @@ Status ModularFrameEncoder::ComputeEncodingData(
        (do_color && metadata.bit_depth.bits_per_sample > 8))) {
     // single channel palette (like FLIF's ChannelCompact)
     size_t nb_channels = gi.channel.size() - gi.nb_meta_channels;
+    int orig_bitdepth = max_bitdepth;
+    max_bitdepth = 0;
     for (size_t i = 0; i < nb_channels; i++) {
       int min, max;
       compute_minmax(gi.channel[gi.nb_meta_channels + i], &min, &max);
@@ -694,7 +696,11 @@ Status ModularFrameEncoder::ComputeEncodingData(
         // effective bit depth is lower, adjust quantization accordingly
         compute_minmax(gi.channel[gi.nb_meta_channels + i], &min, &max);
         if (max < maxval) maxval = max;
-      }
+        int ch_bitdepth =
+            (max > 0 ? CeilLog2Nonzero(static_cast<uint32_t>(max)) : 0);
+        if (ch_bitdepth > max_bitdepth) max_bitdepth = ch_bitdepth;
+      } else
+        max_bitdepth = orig_bitdepth;
     }
   }
 
@@ -738,7 +744,7 @@ Status ModularFrameEncoder::ComputeEncodingData(
   }
 
   // don't do an RCT if we're short on bits
-  if (cparams.color_transform == ColorTransform::kNone && do_color && !fp &&
+  if (cparams.color_transform == ColorTransform::kNone && do_color &&
       gi.channel.size() - gi.nb_meta_channels >= 3 &&
       max_bitdepth + 1 < level_max_bitdepth) {
     if (cparams.colorspace == 1 ||

--- a/lib/jxl/modular/transform/enc_palette.cc
+++ b/lib/jxl/modular/transform/enc_palette.cc
@@ -179,7 +179,43 @@ Status FwdPaletteIteration(Image &input, uint32_t begin_c, uint32_t end_c,
     size_t lookup_table_size =
         static_cast<int64_t>(maxval) - static_cast<int64_t>(minval) + 1;
     if (lookup_table_size > palette_internal::kMaxPaletteLookupTableSize) {
-      return false;  // too large lookup table
+      // a lookup table would use too much memory, instead use a slower approach
+      // with std::set
+      std::set<pixel_type> chpalette;
+      pixel_type idx = 0;
+      for (size_t y = 0; y < h; y++) {
+        const pixel_type *p = input.channel[begin_c].Row(y);
+        for (size_t x = 0; x < w; x++) {
+          const bool new_color = chpalette.insert(p[x]).second;
+          if (new_color) {
+            idx++;
+            if (idx > (int)nb_colors) return false;
+          }
+        }
+      }
+      JXL_DEBUG_V(6, "Channel %i uses only %i colors.", begin_c, idx);
+      Channel pch(idx, 1);
+      pch.hshift = -1;
+      nb_colors = idx;
+      idx = 0;
+      pixel_type *JXL_RESTRICT p_palette = pch.Row(0);
+      for (pixel_type p : chpalette) {
+        p_palette[idx++] = p;
+      }
+      for (size_t y = 0; y < h; y++) {
+        pixel_type *p = input.channel[begin_c].Row(y);
+        for (size_t x = 0; x < w; x++) {
+          for (idx = 0; p[x] != p_palette[idx] && idx < (int)nb_colors; idx++) {
+          }
+          JXL_DASSERT(idx < (int)nb_colors);
+          p[x] = idx;
+        }
+      }
+      predictor = Predictor::Zero;
+      input.nb_meta_channels++;
+      input.channel.insert(input.channel.begin(), std::move(pch));
+
+      return true;
     }
     lookup.resize(lookup_table_size, 0);
     pixel_type idx = 0;

--- a/lib/jxl/modular/transform/palette.h
+++ b/lib/jxl/modular/transform/palette.h
@@ -84,7 +84,7 @@ static pixel_type GetPaletteValue(const pixel_type *const palette, int index,
     pixel_type result =
         kDeltaPalette[((index + 1) >> 1)][c] * kMultiplier[index & 1];
     if (bit_depth > 8) {
-      result *= static_cast<pixel_type>(1) << (bit_depth - 8);
+      result *= static_cast<pixel_type>(1) << (std::min(bit_depth, 24) - 8);
     }
     return result;
   } else if (palette_size <= index && index < palette_size + kLargeCubeOffset) {

--- a/lib/jxl/modular/transform/transform.cc
+++ b/lib/jxl/modular/transform/transform.cc
@@ -68,9 +68,6 @@ Status Transform::MetaApply(Image &input) {
                   "Transform: kPalette, begin_c=%" PRIu32 ", num_c=%" PRIu32
                   ", nb_colors=%" PRIu32 ", nb_deltas=%" PRIu32,
                   begin_c, num_c, nb_colors, nb_deltas);
-      if (input.bitdepth > 24) {
-        return JXL_FAILURE("Palette is not allowed for bitdepth > 24");
-      }
       return MetaPalette(input, begin_c, begin_c + num_c - 1, nb_colors,
                          nb_deltas, lossy_palette);
     default:


### PR DESCRIPTION
Fixes #1323 

Currently we're not allowing Palette when bitdepth is > 24, but this is a bit overly restrictive. Instead, let's not have such a restriction, but just don't do default delta scaling in this case.

With that restriction relaxed, the encoder can freely use channel palette also in case of float32 images. This PR adds an encode codepath for the case where the lookup table would be too large, doing it the slower way instead.

Also, RCTs are currently not tried in case of float32 (since bitdepth is 32 so there are no spare bits for it), but in case channel palette reduces the effective bitdepth, they can actually be used without issues.

Before, default speed:
Compressed to 16111054 bytes (52.445 bpp).
1920 x 1280, 0.56 MP/s [0.56, 0.56], 1 reps, 4 threads.

After, default speed:
Compressed to 2807063 bytes (9.138 bpp).
1920 x 1280, 0.36 MP/s [0.36, 0.36], 1 reps, 4 threads.

Before, -e 3:
Compressed to 22134261 bytes (72.052 bpp).
1920 x 1280, 9.48 MP/s [9.48, 9.48], 1 reps, 4 threads.

After, -e 3:
Compressed to 3229866 bytes (10.514 bpp).
1920 x 1280, 2.26 MP/s [2.26, 2.26], 1 reps, 4 threads.

Encoding obviously gets slower — transforms are not just skipped, and the implementation of high-bitdepth forward channel palette is quite naive/slow) — but I think the huge difference in compression ratio justifies that.