### PR TITLE
Do not attempt to create a std::string from a null pointer

### DIFF
--- a/lib/jxl/encode.cc
+++ b/lib/jxl/encode.cc
@@ -1454,7 +1454,7 @@ JxlEncoderStatus JxlEncoderSetExtraChannelBlendInfo(
 
 JxlEncoderStatus JxlEncoderSetFrameName(JxlEncoderFrameSettings* frame_settings,
                                         const char* frame_name) {
-  std::string str = frame_name;
+  std::string str = frame_name ? frame_name : "";
   if (str.size() > 1071) {
     return JXL_API_ERROR("frame name can be max 1071 bytes long");
   }


### PR DESCRIPTION
Even if the API clearly document that the user input should be a
c-string (UTF-8), remove an undefined behavior from
JxlEncoderSetFrameName. The implementation does not make any
difference in between a NULL comment and an empty comment anyway.

[...]
Some standard library vendors, such as libstdc++, throw a
std::logic_error when a null pointer is used in the above function
calls, though not when calling std::char_traits::length(). However,
std::logic_error is not a requirement of the C++ Standard, and some
vendors (e.g., libc++ and the Microsoft Visual Studio STL) do not
implement this behavior. For portability, you should not rely on this
behavior.
[...]

Ref:
* https://wiki.sei.cmu.edu/confluence/display/cplusplus/STR51-CPP.+Do+not+attempt+to+create+a+std%3A%3Astring+from+a+null+pointer