### PR TITLE
Avoid use-after-destructor

### DIFF
--- a/lib/jxl/butteraugli_wrapper.cc
+++ b/lib/jxl/butteraugli_wrapper.cc
@@ -116,9 +116,10 @@ void JxlButteraugliApiSetIntensityTarget(JxlButteraugliApi* api, float v) {
 
 void JxlButteraugliApiDestroy(JxlButteraugliApi* api) {
   if (api) {
+    JxlMemoryManager local_memory_manager = api->memory_manager;
     // Call destructor directly since custom free function is used.
     api->~JxlButteraugliApi();
-    jxl::MemoryManagerFree(&api->memory_manager, api);
+    jxl::MemoryManagerFree(&local_memory_manager, api);
   }
 }
 
@@ -200,8 +201,9 @@ float JxlButteraugliResultGetMaxDistance(const JxlButteraugliResult* result) {
 
 void JxlButteraugliResultDestroy(JxlButteraugliResult* result) {
   if (result) {
+    JxlMemoryManager local_memory_manager = result->memory_manager;
     // Call destructor directly since custom free function is used.
     result->~JxlButteraugliResult();
-    jxl::MemoryManagerFree(&result->memory_manager, result);
+    jxl::MemoryManagerFree(&local_memory_manager, result);
   }
 }

--- a/lib/jxl/decode.cc
+++ b/lib/jxl/decode.cc
@@ -760,9 +760,10 @@ JxlDecoder* JxlDecoderCreate(const JxlMemoryManager* memory_manager) {
 
 void JxlDecoderDestroy(JxlDecoder* dec) {
   if (dec) {
+    JxlMemoryManager local_memory_manager = dec->memory_manager;
     // Call destructor directly since custom free function is used.
     dec->~JxlDecoder();
-    jxl::MemoryManagerFree(&dec->memory_manager, dec);
+    jxl::MemoryManagerFree(&local_memory_manager, dec);
   }
 }
 

--- a/lib/jxl/encode.cc
+++ b/lib/jxl/encode.cc
@@ -1054,9 +1054,10 @@ void JxlEncoderReset(JxlEncoder* enc) {
 
 void JxlEncoderDestroy(JxlEncoder* enc) {
   if (enc) {
+    JxlMemoryManager local_memory_manager = enc->memory_manager;
     // Call destructor directly since custom free function is used.
     enc->~JxlEncoder();
-    jxl::MemoryManagerFree(&enc->memory_manager, enc);
+    jxl::MemoryManagerFree(&local_memory_manager, enc);
   }
 }
 

--- a/lib/threads/thread_parallel_runner.cc
+++ b/lib/threads/thread_parallel_runner.cc
@@ -88,9 +88,10 @@ void JxlThreadParallelRunnerDestroy(void* runner_opaque) {
   jpegxl::ThreadParallelRunner* runner =
       reinterpret_cast<jpegxl::ThreadParallelRunner*>(runner_opaque);
   if (runner) {
+    JxlMemoryManager local_memory_manager = runner->memory_manager;
     // Call destructor directly since custom free function is used.
     runner->~ThreadParallelRunner();
-    ThreadMemoryManagerFree(&runner->memory_manager, runner);
+    ThreadMemoryManagerFree(&local_memory_manager, runner);
   }
 }
 


### PR DESCRIPTION
While there is no reason for compiler to do something extraordinary, MSAN has concerns...