### PR TITLE
apply 8x8 ordered dither to uint decode output

### DIFF
--- a/lib/jxl/dec_cache.h
+++ b/lib/jxl/dec_cache.h
@@ -241,6 +241,28 @@ struct GroupDecCache {
   size_t max_block_area_ = 0;
 };
 
+// 8x8 ordered dithering pattern from
+// https://en.wikipedia.org/wiki/Ordered_dithering
+const int8_t kIntegerDither[64] = {
+    0,  32, 8,  40, 2,  34, 10, 42, 48, 16, 56, 24, 50, 18, 58, 26,
+    12, 44, 4,  36, 14, 46, 6,  38, 60, 28, 52, 20, 62, 30, 54, 22,
+    3,  35, 11, 43, 1,  33, 9,  41, 51, 19, 59, 27, 49, 17, 57, 25,
+    15, 47, 7,  39, 13, 45, 5,  37, 63, 31, 55, 23, 61, 29, 53, 21};
+
+struct Ordered8x8Dithering {
+  float dither[64];
+  Ordered8x8Dithering() {
+    for (size_t i = 0; i < 64; i++) {
+      // make the average 0 and the range [-63/128,63/128], so
+      // actual integer values (e.g. lossless) are still rounded correctly
+      dither[i] = kIntegerDither[i] / 64.f - 0.4921875f;
+    }
+  }
+  const float* Row(size_t y) const { return dither + 8 * (y % 8); }
+};
+
+static const struct Ordered8x8Dithering kDither = Ordered8x8Dithering();
+
 }  // namespace jxl
 
 #endif  // LIB_JXL_DEC_CACHE_H_

--- a/lib/jxl/decode_test.cc
+++ b/lib/jxl/decode_test.cc
@@ -3084,8 +3084,11 @@ TEST(DecodeTest, OrientedCroppedFrameTest) {
       }
     }
 
+    // when resampling > 1, after upsampling the sample values are not integers
+    // anymore, and dithering can be different for coalesced vs non-coalesced
     EXPECT_EQ(0u, jxl::test::ComparePixels(frames[0].data(), frames[4].data(),
-                                           oxsize, oysize, format, format));
+                                           oxsize, oysize, format, format,
+                                           resampling > 1 ? 2.01 : 1.0));
   };
 
   for (bool keep_orientation : {true, false}) {

--- a/lib/jxl/test_utils.h
+++ b/lib/jxl/test_utils.h
@@ -592,6 +592,13 @@ size_t ComparePixels(const uint8_t* a, const uint8_t* b, size_t xsize,
     // TODO(lode): Set the required precision back to 11 bits when possible.
     precision = 0.5 * threshold_multiplier / ((1ull << (bits - 1)) - 1ull);
   }
+  // allow dithering to do its thing, e.g. if original is lossless uint16
+  // and we compare against decoded uint8, we don't want to force undithered
+  // output,
+  // e.g. an original value of 50000/65535 ~= 194.5525/255 can be rounded to 195
+  // but with dithering it can be rounded to 194 too, so a max difference of
+  // 0.5/255 is not enough.
+  if (bits_a != bits_b) precision *= 2.0;
   size_t numdiff = 0;
   for (size_t y = 0; y < ysize; y++) {
     for (size_t x = 0; x < xsize; x++) {


### PR DESCRIPTION
When converting the internal float sample values to uint ones (when JXL_TYPE_UINT8 or JXL_TYPE_UINT16 pixel formats are requested), currently this is done simply by picking the nearest integer value.  This can be a problem, especially with 8-bit output on sufficiently bright displays, as noted by @Matt-Gore in https://github.com/libjxl/libjxl/issues/541. It can lead to quite noticeable banding in slow dark gradients.

This adds 8x8 ordered dithering when converting to uint output.  Even just 2x2 or 4x4 dithering already alleviates most of the banding issues, but 8x8 is still very cheap. I couldn't measure any speed difference compared to non-dithered.