### PR TITLE
API only (proposal): set CMS and desired output color encoding in decoder

### DIFF
--- a/lib/include/jxl/decode.h
+++ b/lib/include/jxl/decode.h
@@ -842,7 +842,7 @@ JXL_EXPORT JxlDecoderStatus JxlDecoderGetColorAsICCProfile(
  *     instead.
  */
 // TODO(firsching): deprecate this function once JxlDecoderSetOutputColorProfile
-// is implemted.
+// is implemented.
 JXL_EXPORT JxlDecoderStatus JxlDecoderSetPreferredColorProfile(
     JxlDecoder* dec, const JxlColorEncoding* color_encoding);
 
@@ -897,7 +897,7 @@ JXL_EXPORT JxlDecoderStatus JxlDecoderSetDesiredIntensityTarget(
  * num_color_channels from the basic info is 1, RGB if num_color_channels from
  * the basic info is 3.
  *
- * This function must not be called after JxlDecoderSetCms.
+ * This function must not be called before JxlDecoderSetCms.
  *
  * @param dec decoder orbject
  * @param color_encoding the output color encoding

--- a/lib/include/jxl/decode.h
+++ b/lib/include/jxl/decode.h
@@ -883,9 +883,7 @@ JXL_EXPORT JxlDecoderStatus JxlDecoderSetDesiredIntensityTarget(
  *
  * Can only be set after the @ref JXL_DEC_COLOR_ENCODING event occurred and
  * before any other event occurred, and should be used before getting
- * JXL_COLOR_PROFILE_TARGET_DATA. The color_encoding or ICC profile must be
- * grayscale if num_color_channels from the basic info is 1, RGB if
- * num_color_channels from the basic info is 3.
+ * JXL_COLOR_PROFILE_TARGET_DATA.
  *
  * This function must not be called before JxlDecoderSetCms.
  *

--- a/lib/include/jxl/decode.h
+++ b/lib/include/jxl/decode.h
@@ -877,10 +877,10 @@ JXL_EXPORT JxlDecoderStatus JxlDecoderSetDesiredIntensityTarget(
  * If no CMS has been set with @ref JxlDecoderSetCms, there are two cases:
  *
  * (1) Calling this function with a color encoding will convert XYB images to
- * the desired color encoding. Non-XYB images will not be converted to the
- * desired color space. In this case, if the requested color encoding has a
+ * the desired color encoding. In this case, if the requested color encoding has a
  * narrower gamut, or the white points differ, then the resulting image can have
- * significant color distortion.
+ * significant color distortion. Non-XYB images will not be converted to the
+ * desired color space.
  *
  * (2) Calling this function with an ICC profile will result in an error.
  *

--- a/lib/include/jxl/decode.h
+++ b/lib/include/jxl/decode.h
@@ -830,15 +830,13 @@ JXL_EXPORT JxlDecoderStatus JxlDecoderGetColorAsICCProfile(
 /** Sets the desired output color profile of the decoded image by calling
  * @ref JxlDecoderSetOutputColorProfile, passing on @c color_encoding and
  * setting @c icc_data to NULL. See @ref JxlDecoderSetOutputColorProfile for
- * details. See @ref JxlDecoderSetOutputColorProfile for details.
+ * details.
  *
  * @param dec decoder object
  * @param color_encoding the default color encoding to set
  * @return @ref JXL_DEC_SUCCESS if the preference was set successfully, @ref
  *     JXL_DEC_ERROR otherwise.
  */
-// TODO(firsching): deprecate this function once JxlDecoderSetOutputColorProfile
-// is implemented.
 JXL_EXPORT JxlDecoderStatus JxlDecoderSetPreferredColorProfile(
     JxlDecoder* dec, const JxlColorEncoding* color_encoding);
 
@@ -881,11 +879,11 @@ JXL_EXPORT JxlDecoderStatus JxlDecoderSetDesiredIntensityTarget(
  * (2) Calling this function with an ICC profile will result in an error.
  *
  * If called with an ICC profile (after a call to @ref JxlDecoderSetCms), the
- * ICC profile has to be a valid RGB or grayscale color profile
+ * ICC profile has to be a valid RGB or grayscale color profile.
  *
  * Can only be set after the @ref JXL_DEC_COLOR_ENCODING event occurred and
  * before any other event occurred, and should be used before getting
- * JXL_COLOR_PROFILE_TARGET_DATA The color_encoding or ICC profile must be
+ * JXL_COLOR_PROFILE_TARGET_DATA. The color_encoding or ICC profile must be
  * grayscale if num_color_channels from the basic info is 1, RGB if
  * num_color_channels from the basic info is 3.
  *

--- a/lib/include/jxl/decode.h
+++ b/lib/include/jxl/decode.h
@@ -829,7 +829,7 @@ JXL_EXPORT JxlDecoderStatus JxlDecoderGetColorAsICCProfile(
     const JxlDecoder* dec, const JxlPixelFormat* unused_format,
     JxlColorProfileTarget target, uint8_t* icc_profile, size_t size);
 
-/** Sets the desired output color profile either of the decoded image by calling
+/** Sets the desired output color profile of the decoded image by calling
  * @ref JxlDecoderSetOutputColorProfile, passing on @c color_encoding and
  * setting @c icc_data to NULL. See @ref JxlDecoderSetOutputColorProfile for
  * details.
@@ -860,18 +860,18 @@ JXL_EXPORT JxlDecoderStatus JxlDecoderSetDesiredIntensityTarget(
     JxlDecoder* dec, float desired_intensity_target);
 
 /**
- * Sets the desired output color profile either of the decoded
- * image either from color a color encoding or an ICC profile. Valid calls of
- * this function have either @c color_encoding or @c icc_data set to NULL and
- * @c icc_size must be 0 if and only if @c icc_data is NULL.
+ * Sets the desired output color profile of the decoded image either from a
+ * color encoding or an ICC profile. Valid calls of this function have either @c
+ * color_encoding or @c icc_data set to NULL and @c icc_size must be 0 if and
+ * only if @c icc_data is NULL.
  *
  * Depending of whether a color management system (CMS) has been set the
  * behavior is as follows:
  *
- * If an color management system (CMS) has been set with @ref JxlDecoderSetCms,
- * and the CMS suppports output to the desired color encoding or icc profile,
- * the it will provide the output in that color encoding or icc profile. If the
- * desired color encoding or icc is not supported, then an error will be
+ * If a color management system (CMS) has been set with @ref JxlDecoderSetCms,
+ * and the CMS suppports output to the desired color encoding or ICC profile,
+ * the it will provide the output in that color encoding or ICC profile. If the
+ * desired color encoding or the ICC is not supported, then an error will be
  * returned.
  *
  * If no CMS has been set with @ref JxlDecoderSetCms, there are two cases:

--- a/lib/include/jxl/decode.h
+++ b/lib/include/jxl/decode.h
@@ -876,6 +876,69 @@ JXL_EXPORT JxlDecoderStatus JxlDecoderSetDesiredIntensityTarget(
     JxlDecoder* dec, float desired_intensity_target);
 
 /**
+ * Sets the color management system (CMS) that will be used for color conversion
+ * (if applicable) during decoding. May only be set before starting decoding. If
+ * left unset, the decoder will not do arbitrary color conversions:
+ * JxlDecoderSetPreferredColorProfile can be used, but there is no guarantee
+ * that the decoded image will be returned in the preferred color encoding. If
+ * however a CMS is set using this function, then the function
+ * JxlDecoderSetColorEncoding or JxlDecoderSetICCProfile can be used and the
+ * decoded image will then be guaranteed to be in the requested color encoding.
+ *
+ * Only one of JxlDecoderSetPreferredColorProfile, JxlDecoderSetColorEncoding
+ * and JxlDecoderSetICCProfile should be called. The CMS will not be used in
+ * case JxlDecoderSetPreferredColorProfile is used; in the other two cases
+ * the CMS will be used if the desired conversion cannot be performed by the
+ * decoder. In any case, the color encoding of the decoded image data can be
+ * obtained through JxlDecoderGetColorAsICCProfile with
+ * target=JXL_COLOR_PROFILE_TARGET_DATA. If a desired color encoding was set
+ * with JxlDecoderSetColorEncoding or JxlDecoderSetICCProfile, the resulting ICC
+ * profile will always be equivalent to the desired encoding; if a preferred
+ * color encoding was set with JxlDecoderSetPreferredColorProfile, this will not
+ * necessarily be the case (it will only be the case if the decoder can do the
+ * conversion without using the CMS).
+ *
+ * @param dec decoder object.
+ * @param cms structure representing a CMS implementation. See JxlCmsInterface
+ * for more details.
+ */
+JXL_EXPORT void JxlDecoderSetCms(JxlDecoder* dec, JxlCmsInterface cms);
+
+/**
+ * Sets the desired output color encoding of the decoded image. This function
+ * can only be used if JxlDecoderSetCms was previously set. This is an
+ * alternative to JxlDecoderSetICCProfile and only one of these two must be
+ * used. This one sets the color encoding as a @ref JxlColorEncoding, while the
+ * other sets it as ICC binary data.
+ *
+ * @param dec decoder object.
+ * @param color color encoding. Object owned by the caller and its contents are
+ * copied internally.
+ * @return JXL_DEC_SUCCESS if the operation was successful, JXL_DEC_ERROR
+ * otherwise.
+ */
+JXL_EXPORT JxlDecoderStatus
+JxlDecoderSetColorEncoding(JxlDecoder* dec, const JxlColorEncoding* color);
+
+/**
+ * Sets the desired output color encoding of the decoded image, as an ICC color
+ * profile. This function can only be used if JxlDecoderSetCms was previously
+ * set. The ICC profile has to be a valid RGB color profile (not grayscale or
+ * CMYK). This is an alternative to JxlDecoderSetColorEncoding and only one of
+ * these two must be used. This one sets the color encoding as ICC binary data,
+ * while the other defines it as a @ref JxlColorEncoding.
+ *
+ * @param dec decoder object.
+ * @param icc_profile bytes of the ICC profile
+ * @param size size of the icc_profile buffer in bytes
+ * @return JXL_DEC_SUCCESS if the operation was successful, JXL_DEC_ERROR
+ * otherwise.
+ */
+JXL_EXPORT JxlDecoderStatus JxlDecoderSetICCProfile(JxlDecoder* dec,
+                                                    const uint8_t* icc_profile,
+                                                    size_t size);
+
+/**
  * Returns the minimum size in bytes of the preview image output pixel buffer
  * for the given format. This is the buffer for @ref
  * JxlDecoderSetPreviewOutBuffer. Requires the preview header information is

--- a/lib/include/jxl/decode.h
+++ b/lib/include/jxl/decode.h
@@ -16,8 +16,6 @@
 #include <stddef.h>
 #include <stdint.h>
 
-#include <cstdint>
-
 #include "jxl/cms_interface.h"
 #include "jxl/codestream_header.h"
 #include "jxl/color_encoding.h"
@@ -843,7 +841,9 @@ JXL_EXPORT JxlDecoderStatus JxlDecoderGetColorAsICCProfile(
  * JxlDecoderSetOutputColorProfile (possibly with @c icc_data set to NULL)
  *     instead.
  */
-JXL_DEPRECATED JXL_EXPORT JxlDecoderStatus JxlDecoderSetPreferredColorProfile(
+// TODO(firsching): deprecate this function once JxlDecoderSetOutputColorProfile
+// is implemted.
+JXL_EXPORT JxlDecoderStatus JxlDecoderSetPreferredColorProfile(
     JxlDecoder* dec, const JxlColorEncoding* color_encoding);
 
 /** Requests that the decoder perform tone mapping to the peak display luminance
@@ -885,7 +885,7 @@ JXL_EXPORT JxlDecoderStatus JxlDecoderSetDesiredIntensityTarget(
  * (2) Calling this function with an ICC profile will result in an error.
  *
  * In case @ref JxlDecoderSetOutputColorProfile is used with an ICC profile,
- * (after a in this case required call to @ref JxlDecocderSetCms), the ICC
+ * (after a in this case required call to JxlDecocderSetCms), the ICC
  * profile has to be a valid RGB or grayscale color profile.
  *
  * Can only be set after the @ref JXL_DEC_COLOR_ENCODING event occurred and
@@ -897,7 +897,7 @@ JXL_EXPORT JxlDecoderStatus JxlDecoderSetDesiredIntensityTarget(
  * num_color_channels from the basic info is 1, RGB if num_color_channels from
  * the basic info is 3.
  *
- * This function must not be called after @ref JxlDecoderSetCms.
+ * This function must not be called after JxlDecoderSetCms.
  *
  * @param dec decoder orbject
  * @param color_encoding the output color encoding

--- a/lib/include/jxl/decode.h
+++ b/lib/include/jxl/decode.h
@@ -862,7 +862,8 @@ JXL_EXPORT JxlDecoderStatus JxlDecoderGetColorAsICCProfile(
  * @return @ref JXL_DEC_SUCCESS if the preference was set successfully, @ref
  *     JXL_DEC_ERROR otherwise.
  *
- * @deprecated This function will be removed. Use @ref JxlDecoderSetOutputColorProfile
+ * @deprecated This function will be removed. Use @ref
+ * JxlDecoderSetOutputColorProfile (possibly with @c icc_data set to NUL)
  *     instead.
  */
 JXL_DEPRECATED JXL_EXPORT JxlDecoderStatus JxlDecoderSetPreferredColorProfile(

--- a/lib/include/jxl/decode.h
+++ b/lib/include/jxl/decode.h
@@ -834,17 +834,18 @@ JXL_EXPORT JxlDecoderStatus JxlDecoderGetColorAsICCProfile(
  * No matter what, the @ref JXL_COLOR_PROFILE_TARGET_DATA must still be queried
  * to know the actual data format of the decoded pixels after decoding.
  *
- * The JXL decoder has no color management system (CMS) built in, but can
- * convert XYB color to any of the ones supported by JxlColorEncoding. Note that
- * if the requested color encoding has a narrower gamut, or the white points
- * differ, then the resulting image can have significant color distortion.
- *
- * Can be used with a CMS by setting it via JxlDecoderSetCms, in which case it
- * not only can convert to color profile supported by JxlColorEncoding, but to
- * those supported by the CMS. JxlDecoderSetCms must not be called after
- * JxlDecoderSetPreferredColorProfile, but it can be optionally called before.
- * When JxlDecoderSetCms has been called, JxlDecoderSetPreferredColorProfile is
- * an alternative to JxlDecoderSetICCProfile and only one of these two must be
+ * The JXL decoder can be build with or without a color management system (CMS).
+ * If build without a CMS, there is a build-in way to convert XYB color to any
+ * of the ones supported by JxlColorEncoding. Note that if the requested color
+ * encoding has a narrower gamut, or the white points differ, then the resulting
+ * image can have significant color distortion. To avoid that you can either
+ * build it with a CMS or provide an interface to a CMS by setting it via
+ * JxlDecoderSetCms, in which cases it not only can convert to color profile
+ * supported by JxlColorEncoding, but to those supported by the CMS.
+ * JxlDecoderSetCms must not be called after JxlDecoderSetPreferredColorProfile,
+ * but it can be optionally called before. If build with a CMS, JxlDecoderSetCms
+ * does not need to be called. JxlDecoderSetPreferredColorProfile is an
+ * alternative to JxlDecoderSetICCProfile and only one of these two must be
  * used. This one sets the color encoding as a @ref JxlColorEncoding, while the
  * other sets it as ICC binary data.
  *
@@ -888,10 +889,11 @@ JXL_EXPORT JxlDecoderStatus JxlDecoderSetDesiredIntensityTarget(
 /**
  * Sets the color management system (CMS) that will be used for color conversion
  * (if applicable) during decoding. May only be set before starting decoding. If
- * left unset, the decoder will not do arbitrary color conversions:
- * JxlDecoderSetPreferredColorProfile can be used, but there is no guarantee
- * that the decoded image will be returned in the preferred color encoding. If
- * however a CMS is set using this function, then the function
+ * left unset and libjxl has been build without a CMS  the decoder will not do
+ * arbitrary color conversions: JxlDecoderSetPreferredColorProfile can be used,
+ * but there is no guarantee that the decoded image will be returned in the
+ * preferred color encoding. If however a CMS is set using this function or if
+ * libjxl has been build with a CMS, then the function
  * JxlDecoderSetPreferredColorProfile or JxlDecoderSetICCProfile can be used and
  * the decoded image will then be guaranteed to be in the requested color
  * encoding.
@@ -918,10 +920,12 @@ JXL_EXPORT void JxlDecoderSetCms(JxlDecoder* dec, JxlCmsInterface cms);
 /**
  * Sets the desired output color encoding of the decoded image, as an ICC color
  * profile. This function can only be used if JxlDecoderSetCms was previously
- * set. The ICC profile has to be a valid RGB color profile (not grayscale or
- * CMYK). This is an alternative to JxlDecodeSetPreferredColorEncoding and only
- * one of these two must be used. This one sets the color encoding as ICC binary
- * data, while the other defines it as a @ref JxlColorEncoding.
+ * set. The ICC profile has to be a either a valid RGB color profile (not
+ * grayscale or CMYK) except when the original color encoding is already
+ * grayscale, in which case the ICC profile can be grayscale or RGB. This is an
+ * alternative to JxlDecodeSetPreferredColorEncoding and only one of these two
+ * must be used. This one sets the color encoding as ICC binary data, while the
+ * other defines it as a @ref JxlColorEncoding.
  *
  * @param dec decoder object.
  * @param icc_profile bytes of the ICC profile

--- a/lib/include/jxl/decode.h
+++ b/lib/include/jxl/decode.h
@@ -877,22 +877,18 @@ JXL_EXPORT JxlDecoderStatus JxlDecoderSetDesiredIntensityTarget(
  * If no CMS has been set with @ref JxlDecoderSetCms, there are two cases:
  *
  * (1) Calling this function with a color encoding will convert XYB images to
- * the desired color encoding and will do no conversion. In this case, if the
- * requested color encoding has a narrower gamut, or the white points differ,
- * then the resulting image can have significant color distortion.
+ * the desired color encoding. Non-XYB images will not be converted to the
+ * desired color space. In this case, if the requested color encoding has a
+ * narrower gamut, or the white points differ, then the resulting image can have
+ * significant color distortion.
  *
  * (2) Calling this function with an ICC profile will result in an error.
  *
- *
- * If @ref JxlDecoderSetOutputColorProfile is not used, then for images for
- * which uses_original_profile is false and with ICC color profile, the decoder
- * will choose linear sRGB for color images, linear grayscale for grayscale
- * images.
- *
- * In case this is used with an ICC profile, (after a in this case required call
- * to @ref JxlDecocderSetCms), the ICC profile has to be a either a valid RGB
- * color profile (not grayscale or CMYK) except when the original color encoding
- * is already grayscale, in which case the ICC profile can be grayscale or RGB.
+ * In case @ref JxlDecoderSetOutputColorProfile is used with an ICC profile,
+ * (after a in this case required call to @ref JxlDecocderSetCms), the ICC
+ * profile has to be a either a valid RGB color profile (not grayscale or CMYK)
+ * except when the original color encoding is already grayscale, in which case
+ * the ICC profile can be grayscale or RGB.
  *
  * Can only be set after the @ref JXL_DEC_COLOR_ENCODING event occurred and
  * before any other event occurred, and can affect the result of @ref
@@ -904,7 +900,7 @@ JXL_EXPORT JxlDecoderStatus JxlDecoderSetDesiredIntensityTarget(
  * the basic info is 3.
  *
  *
- * This function must not be called after @ref JxlDecoderSetCms
+ * This function must not be called after @ref JxlDecoderSetCms.
  *
  * @param dec decoder orbject
  * @param color_encoding the output color encoding

--- a/lib/include/jxl/decode.h
+++ b/lib/include/jxl/decode.h
@@ -830,16 +830,12 @@ JXL_EXPORT JxlDecoderStatus JxlDecoderGetColorAsICCProfile(
 /** Sets the desired output color profile of the decoded image by calling
  * @ref JxlDecoderSetOutputColorProfile, passing on @c color_encoding and
  * setting @c icc_data to NULL. See @ref JxlDecoderSetOutputColorProfile for
- * details.
+ * details. See @ref JxlDecoderSetOutputColorProfile for details.
  *
  * @param dec decoder object
  * @param color_encoding the default color encoding to set
  * @return @ref JXL_DEC_SUCCESS if the preference was set successfully, @ref
  *     JXL_DEC_ERROR otherwise.
- *
- * @deprecated This function will be removed. Use @ref
- * JxlDecoderSetOutputColorProfile (possibly with @c icc_data set to NULL)
- *     instead.
  */
 // TODO(firsching): deprecate this function once JxlDecoderSetOutputColorProfile
 // is implemented.
@@ -865,12 +861,12 @@ JXL_EXPORT JxlDecoderStatus JxlDecoderSetDesiredIntensityTarget(
  * color_encoding or @c icc_data set to NULL and @c icc_size must be 0 if and
  * only if @c icc_data is NULL.
  *
- * Depending of whether a color management system (CMS) has been set the
+ * Depending on whether a color management system (CMS) has been set the
  * behavior is as follows:
  *
  * If a color management system (CMS) has been set with @ref JxlDecoderSetCms,
  * and the CMS suppports output to the desired color encoding or ICC profile,
- * the it will provide the output in that color encoding or ICC profile. If the
+ * then it will provide the output in that color encoding or ICC profile. If the
  * desired color encoding or the ICC is not supported, then an error will be
  * returned.
  *
@@ -884,18 +880,14 @@ JXL_EXPORT JxlDecoderStatus JxlDecoderSetDesiredIntensityTarget(
  *
  * (2) Calling this function with an ICC profile will result in an error.
  *
- * In case @ref JxlDecoderSetOutputColorProfile is used with an ICC profile,
- * (after a in this case required call to JxlDecocderSetCms), the ICC
- * profile has to be a valid RGB or grayscale color profile.
+ * If called with an ICC profile (after a call to @ref JxlDecoderSetCms), the
+ * ICC profile has to be a valid RGB or grayscale color profile
  *
  * Can only be set after the @ref JXL_DEC_COLOR_ENCODING event occurred and
- * before any other event occurred, and can affect the result of @ref
- * JXL_COLOR_PROFILE_TARGET_DATA (but not of @ref
- * JXL_COLOR_PROFILE_TARGET_ORIGINAL), so should be used after getting @ref
- * JXL_COLOR_PROFILE_TARGET_ORIGINAL but before getting @ref
- * JXL_COLOR_PROFILE_TARGET_DATA. The color_encoding must be grayscale if
- * num_color_channels from the basic info is 1, RGB if num_color_channels from
- * the basic info is 3.
+ * before any other event occurred, and should be used before getting
+ * JXL_COLOR_PROFILE_TARGET_DATA The color_encoding or ICC profile must be
+ * grayscale if num_color_channels from the basic info is 1, RGB if
+ * num_color_channels from the basic info is 3.
  *
  * This function must not be called before JxlDecoderSetCms.
  *
@@ -903,7 +895,7 @@ JXL_EXPORT JxlDecoderStatus JxlDecoderSetDesiredIntensityTarget(
  * @param color_encoding the output color encoding
  * @param icc_data bytes of the icc profile
  * @param icc_size size of the icc profile in bytes
- * @return @ref JXL_DEC_SUCCESS if the preference was set successfully, @ref
+ * @return @ref JXL_DEC_SUCCESS if the color profile was set successfully, @ref
  *     JXL_DEC_ERROR otherwise.
  */
 JXL_EXPORT JxlDecoderStatus JxlDecoderSetOutputColorProfile(
@@ -923,6 +915,8 @@ JXL_EXPORT JxlDecoderStatus JxlDecoderSetOutputColorProfile(
  * JxlCmsInterface for more details.
  */
 JXL_EXPORT void JxlDecoderSetCms(JxlDecoder* dec, JxlCmsInterface cms);
+// TODO(firsching): add a function JxlDecoderSetDefaultCms() for setting a
+// default in case libjxl is build with an CMS.
 
 /**
  * Returns the minimum size in bytes of the preview image output pixel buffer

--- a/lib/include/jxl/decode.h
+++ b/lib/include/jxl/decode.h
@@ -886,9 +886,7 @@ JXL_EXPORT JxlDecoderStatus JxlDecoderSetDesiredIntensityTarget(
  *
  * In case @ref JxlDecoderSetOutputColorProfile is used with an ICC profile,
  * (after a in this case required call to @ref JxlDecocderSetCms), the ICC
- * profile has to be a either a valid RGB color profile (not grayscale or CMYK)
- * except when the original color encoding is already grayscale, in which case
- * the ICC profile can be grayscale or RGB.
+ * profile has to be a valid RGB or grayscale color profile.
  *
  * Can only be set after the @ref JXL_DEC_COLOR_ENCODING event occurred and
  * before any other event occurred, and can affect the result of @ref

--- a/lib/include/jxl/decode.h
+++ b/lib/include/jxl/decode.h
@@ -829,33 +829,10 @@ JXL_EXPORT JxlDecoderStatus JxlDecoderGetColorAsICCProfile(
     const JxlDecoder* dec, const JxlPixelFormat* unused_format,
     JxlColorProfileTarget target, uint8_t* icc_profile, size_t size);
 
-/** Sets the color profile to use for @ref JXL_COLOR_PROFILE_TARGET_DATA for the
- * special case when the decoder has a choice. This only has effect for a JXL
- * image where uses_original_profile is false. If uses_original_profile is true,
- * this setting is ignored and the decoder uses a profile related to the image.
- * No matter what, the @ref JXL_COLOR_PROFILE_TARGET_DATA must still be queried
- * to know the actual data format of the decoded pixels after decoding.
- *
- * The JXL decoder has no color management system built in, but can convert XYB
- * color to any of the ones supported by JxlColorEncoding. Note that if the
- * requested color encoding has a narrower gamut, or the white points differ,
- * then the resulting image can have significant color distortion.
- *
- * Can only be set after the @ref JXL_DEC_COLOR_ENCODING event occurred and
- * before any other event occurred, and can affect the result of @ref
- * JXL_COLOR_PROFILE_TARGET_DATA (but not of @ref
- * JXL_COLOR_PROFILE_TARGET_ORIGINAL), so should be used after getting @ref
- * JXL_COLOR_PROFILE_TARGET_ORIGINAL but before getting @ref
- * JXL_COLOR_PROFILE_TARGET_DATA. The color_encoding must be grayscale if
- * num_color_channels from the basic info is 1, RGB if num_color_channels from
- * the basic info is 3.
- *
- * If @ref JxlDecoderSetPreferredColorProfile is not used, then for images for
- * which uses_original_profile is false and with ICC color profile, the decoder
- * will choose linear sRGB for color images, linear grayscale for grayscale
- * images. This function only sets a preference, since for other images the
- * decoder has no choice what color profile to use, it is determined by the
- * image.
+/** Sets the desired output color profile either of the decoded image by calling
+ * @ref JxlDecoderSetOutputColorProfile, passing on @c color_encoding and
+ * setting @c icc_data to NULL. See @ref JxlDecoderSetOutputColorProfile for
+ * details.
  *
  * @param dec decoder object
  * @param color_encoding the default color encoding to set
@@ -863,7 +840,7 @@ JXL_EXPORT JxlDecoderStatus JxlDecoderGetColorAsICCProfile(
  *     JXL_DEC_ERROR otherwise.
  *
  * @deprecated This function will be removed. Use @ref
- * JxlDecoderSetOutputColorProfile (possibly with @c icc_data set to NUL)
+ * JxlDecoderSetOutputColorProfile (possibly with @c icc_data set to NULL)
  *     instead.
  */
 JXL_DEPRECATED JXL_EXPORT JxlDecoderStatus JxlDecoderSetPreferredColorProfile(

--- a/lib/include/jxl/decode.h
+++ b/lib/include/jxl/decode.h
@@ -877,10 +877,10 @@ JXL_EXPORT JxlDecoderStatus JxlDecoderSetDesiredIntensityTarget(
  * If no CMS has been set with @ref JxlDecoderSetCms, there are two cases:
  *
  * (1) Calling this function with a color encoding will convert XYB images to
- * the desired color encoding. In this case, if the requested color encoding has a
- * narrower gamut, or the white points differ, then the resulting image can have
- * significant color distortion. Non-XYB images will not be converted to the
- * desired color space.
+ * the desired color encoding. In this case, if the requested color encoding has
+ * a narrower gamut, or the white points differ, then the resulting image can
+ * have significant color distortion. Non-XYB images will not be converted to
+ * the desired color space.
  *
  * (2) Calling this function with an ICC profile will result in an error.
  *
@@ -896,7 +896,6 @@ JXL_EXPORT JxlDecoderStatus JxlDecoderSetDesiredIntensityTarget(
  * JXL_COLOR_PROFILE_TARGET_DATA. The color_encoding must be grayscale if
  * num_color_channels from the basic info is 1, RGB if num_color_channels from
  * the basic info is 3.
- *
  *
  * This function must not be called after @ref JxlDecoderSetCms.
  *
@@ -916,25 +915,8 @@ JXL_EXPORT JxlDecoderStatus JxlDecoderSetOutputColorProfile(
  * conversion (if applicable) during decoding. May only be set before starting
  * decoding and must not be called after @ref JxlDecoderSetOutputColorProfile.
  *
- * If left unset, the decoder will not do arbitrary color conversions:
- * @ref JxlDecoderSetOutputColorProfile can, but only with a color encoding and
- * not with an icc profile and there is no guarantee that the decoded image will
- * be returned in the preferred color encoding. If however a CMS is set using
- * this function, then the function @ref JxlDecoderSetOutputColorProfile can be
- * used and the decoded image will then be guaranteed to be in the requested
- * color encoding.
- *
- * In any case, the color encoding of the decoded image data can be obtained
- * through @ref JxlDecoderGetColorAsICCProfile with
- * target=JXL_COLOR_PROFILE_TARGET_DATA. If a CMS was set with @ref
- * JxlDecoderSetCms and that CMS can do the conversion to a desired color
- * encoding set with
- * @ref JxlDecoderSetOutputColorProfile the resulting ICC profile will always be
- * equivalent to the desired encoding. If no CMS was set with @ref
- * JxlDecoderSetCms and a preferred color encoding was set with
- * @ref JxlDecoderSetOutputColorProfile, this will not necessarily be the case
- * (it will only be the case if the decoder can do the conversion without using
- * the CMS).
+ * See @ref JxlDecoderSetOutputColorProfile for how color conversions are done
+ * depending on whether or not a CMS has been set with @ref JxlDecoderSetCms.
  *
  * @param dec decoder object.
  * @param cms structure representing a CMS implementation. See @ref


### PR DESCRIPTION
No implementation yet, just an API proposal.

The aim is to make uint8 output more useful by allowing applications to let libjxl do the color conversion before conversion to uint8. That way, the uint8 output can be guaranteed to be in display space, and it's no longer necessary to use the float pixel callback and manually do the color management and conversion to uint8.

Open question: in the encode API there's a default cms available, but I guess that here it also has to work in the lightweight decode-only `libjxl_dec` which doesn't include a default cms. We could perhaps allow calling JxlDecoderSetColorEncoding or JxlDecoderSetICCProfile when no explicit cms was set, but only in `libjxl` builds where we can have a default cms (i.e. if you do that when linking with `libjxl_dec`, it will return error).