### PR TITLE
simplify simd unsqueeze

### DIFF
--- a/lib/jxl/modular/transform/squeeze.cc
+++ b/lib/jxl/modular/transform/squeeze.cc
@@ -23,6 +23,7 @@ HWY_BEFORE_NAMESPACE();
 namespace jxl {
 namespace HWY_NAMESPACE {
 
+using hwy::HWY_NAMESPACE::RebindToUnsigned;
 using hwy::HWY_NAMESPACE::ShiftLeft;
 using hwy::HWY_NAMESPACE::ShiftRight;
 
@@ -35,6 +36,7 @@ JXL_INLINE void FastUnsqueeze(const pixel_type *JXL_RESTRICT p_residual,
                               pixel_type *JXL_RESTRICT p_out,
                               pixel_type *p_nout) {
   const HWY_CAPPED(pixel_type, 8) d;
+  const RebindToUnsigned<decltype(d)> du;
   const size_t N = Lanes(d);
   auto onethird = Set(d, 0x55555556);
   for (size_t x = 0; x < 8; x += N) {
@@ -71,9 +73,8 @@ JXL_INLINE void FastUnsqueeze(const pixel_type *JXL_RESTRICT p_residual,
 
     auto diff_minus_tendency = Load(d, p_residual + x);
     auto diff = diff_minus_tendency + tendency;
-    auto out = ShiftRight<1>(
-        ShiftLeft<1>(avg) + diff +
-        IfThenElse(diff < Zero(d), (diff & Set(d, 1)), Neg(diff & Set(d, 1))));
+    auto out = avg + ShiftRight<1>(
+                         diff + BitCast(d, ShiftRight<31>(BitCast(du, diff))));
     Store(out, d, p_out + x);
     Store(out - diff, d, p_nout + x);
   }


### PR DESCRIPTION
Same simplification as in https://github.com/libjxl/libjxl/pull/1358, but in the SIMD unsqueeze path.

It's a very tiny little bit faster this way, almost not measurable.

Before:
4064 x 2704, geomean: 17.34 MP/s [15.22, 18.43], 30 reps, 0 threads.

After:
4064 x 2704, geomean: 17.40 MP/s [15.29, 18.57], 30 reps, 0 threads.

