### PR TITLE
make coverage run all tests, and only build it if it's going to make a report

### DIFF
--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -59,8 +59,6 @@ jobs:
             apt_pkgs: gcovr
             # Coverage builds require a bit more RAM.
             env_test_stack_size: 2048
-            # Exclude roundtrip tests from the unittest coverage.
-            ctest_args: -E '^JxlTest'
           # Build with support for decoding to JPEG bytes disabled. Produces a
           # smaller build if only decoding to pixels is needed.
           - name: release-nojpeg
@@ -149,6 +147,7 @@ jobs:
         restore-keys: |
           ${{ runner.os }}-${{ steps.git-env.outputs.parent }}-${{ matrix.name }}
     - name: Build
+      if: matrix.name != 'coverage' || env.WILL_RUN_TESTS == 'true'
       run: |
         mkdir -p ${CCACHE_DIR}
         echo "max_size = 200M" > ${CCACHE_DIR}/ccache.conf

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -126,7 +126,7 @@ endif()  # WIN32
 # Internal flags for coverage builds:
 if(JPEGXL_ENABLE_COVERAGE)
 set(JPEGXL_COVERAGE_FLAGS
-    -g -O0 -fprofile-arcs -ftest-coverage -DJXL_DISABLE_SLOW_TESTS
+    -g -O0 -fprofile-arcs -ftest-coverage
     -DJXL_ENABLE_ASSERT=0 -DJXL_ENABLE_CHECK=0
 )
 endif()  # JPEGXL_ENABLE_COVERAGE


### PR DESCRIPTION
Coverage reports currently don't include jxl_test and slow tests because of some philosophical distinction between "unit tests" and "roundtrip tests" which I don't think really makes sense.

Also, when not pushing to main, no coverage report is produced (which is intended) but the instrumented code still gets built (which is a waste of time if no report is going to be produced).