### PR TITLE
don't fail to decode when num_patches is explicitly zero

### DIFF
--- a/lib/jxl/dec_patch_dictionary.cc
+++ b/lib/jxl/dec_patch_dictionary.cc
@@ -156,9 +156,6 @@ Status PatchDictionary::Decode(BitReader* br, size_t xsize, size_t ysize,
   if (!decoder.CheckANSFinalState()) {
     return JXL_FAILURE("ANS checksum failure.");
   }
-  if (!HasAny()) {
-    return JXL_FAILURE("Decoded patch dictionary but got none");
-  }
 
   ComputePatchCache();
   return true;


### PR DESCRIPTION
The jxl codestream allows setting the kPatches flag to `true`, so patches will get decoded, and then signaling that num_patches = 0. This is of course silly — it's better to set the kPatches flag to `false` and not waste some bits on signaling an explicit zero — but there's nothing in the spec that forbids it, so the decoder shouldn't fail if this happens.

Of course the current libjxl encoder will not produce silly bitstreams where kPatches=true and num_patches=0, so it's not a practical problem at all at the moment.

(the alternative is explicitly disallowing this in the spec, but I don't see why that would be needed)