### PR TITLE
Do not crash when color type does not match ICC

### DIFF
--- a/lib/extras/packed_image_convert.cc
+++ b/lib/extras/packed_image_convert.cc
@@ -65,6 +65,11 @@ Status ConvertPackedPixelFileToCodecInOut(const PackedPixelFile& ppf,
     if (!io->metadata.m.color_encoding.SetICC(std::move(icc))) {
       fprintf(stderr, "Warning: error setting ICC profile, assuming SRGB");
       io->metadata.m.color_encoding = ColorEncoding::SRGB(is_gray);
+    } else {
+      if (io->metadata.m.color_encoding.IsGray() != is_gray) {
+        // E.g. JPG image has 3 channels, but gray ICC.
+        return JXL_FAILURE("Embedded ICC does not match image color type");
+      }
     }
   } else {
     JXL_RETURN_IF_ERROR(ConvertExternalToInternalColorEncoding(


### PR DESCRIPTION
It is not reasonable to check that in image decoder - this would require
repeated ICC parsing.