### PR TITLE
jxl/color_encoding.h: fix documented PQ standard

### DIFF
--- a/lib/include/jxl/color_encoding.h
+++ b/lib/include/jxl/color_encoding.h
@@ -90,7 +90,7 @@ typedef enum {
   JXL_TRANSFER_FUNCTION_LINEAR = 8,
   /** As specified in IEC 61966-2-1 sRGB */
   JXL_TRANSFER_FUNCTION_SRGB = 13,
-  /** As specified in SMPTE ST 428-1 */
+  /** As specified in SMPTE ST 2084 */
   JXL_TRANSFER_FUNCTION_PQ = 16,
   /** As specified in SMPTE ST 428-1 */
   JXL_TRANSFER_FUNCTION_DCI = 17,


### PR DESCRIPTION
Fixes a copy/paste typo so JXL_TRANSFER_FUNCTION_PQ is
properly documented as coming from SMPTE ST 2084.