### PR TITLE
fix passes test

### DIFF
--- a/lib/jxl/passes_test.cc
+++ b/lib/jxl/passes_test.cc
@@ -97,7 +97,7 @@ TEST(PassesTest, RoundtripMultiGroupPasses) {
   Roundtrip(&io, cparams, dparams, &pool, &io3);
   EXPECT_THAT(ButteraugliDistance(io, io3, cparams.ba_params, GetJxlCms(),
                                   /*distmap=*/nullptr, &pool),
-              IsSlightlyBelow(2.2f));
+              IsSlightlyBelow(2.3f));
 }
 
 TEST(PassesTest, RoundtripLargeFastPasses) {


### PR DESCRIPTION
The new testdata introduced a failing test in
`PassesTest.RoundtripMultiGroupPasses`
which we fix here.