### PR TITLE
Refactor the low memory rendering pipeline and fix patch + noise combination.

### DIFF
--- a/lib/jxl/dec_cache.cc
+++ b/lib/jxl/dec_cache.cc
@@ -89,7 +89,9 @@ Status PassesDecoderState::PreparePipeline(ImageBundle* decoded,
   }
 
   if ((frame_header.flags & FrameHeader::kPatches) != 0) {
-    builder.AddStage(GetPatchesStage(&shared->image_features.patches));
+    builder.AddStage(
+        GetPatchesStage(&shared->image_features.patches,
+                        3 + shared->metadata->m.num_extra_channels));
   }
   if ((frame_header.flags & FrameHeader::kSplines) != 0) {
     builder.AddStage(GetSplineStage(&shared->image_features.splines));

--- a/lib/jxl/image.h
+++ b/lib/jxl/image.h
@@ -300,6 +300,32 @@ class RectT {
   T x1() const { return x0_ + xsize_; }
   T y1() const { return y0_ + ysize_; }
 
+  RectT<T> ShiftLeft(size_t shiftx, size_t shifty) const {
+    return RectT<T>(x0_ * (1 << shiftx), y0_ * (1 << shifty), xsize_ << shiftx,
+                    ysize_ << shifty);
+  }
+  RectT<T> ShiftLeft(size_t shift) const { return ShiftLeft(shift, shift); }
+
+  // Requires x0(), y0() to be multiples of 1<<shiftx, 1<<shifty.
+  RectT<T> CeilShiftRight(size_t shiftx, size_t shifty) const {
+    JXL_ASSERT(x0_ % (1 << shiftx) == 0);
+    JXL_ASSERT(y0_ % (1 << shifty) == 0);
+    return RectT<T>(x0_ / (1 << shiftx), y0_ / (1 << shifty),
+                    DivCeil(xsize_, T{1} << shiftx),
+                    DivCeil(ysize_, T{1} << shifty));
+  }
+  RectT<T> CeilShiftRight(std::pair<size_t, size_t> shift) const {
+    return CeilShiftRight(shift.first, shift.second);
+  }
+  RectT<T> CeilShiftRight(size_t shift) const {
+    return CeilShiftRight(shift, shift);
+  }
+
+  template <typename U>
+  RectT<U> As() const {
+    return RectT<U>(U(x0_), U(y0_), U(xsize_), U(ysize_));
+  }
+
  private:
   // Returns size_max, or whatever is left in [begin, end).
   static constexpr size_t ClampedSize(T begin, size_t size_max, T end) {

--- a/lib/jxl/render_pipeline/low_memory_render_pipeline.cc
+++ b/lib/jxl/render_pipeline/low_memory_render_pipeline.cc
@@ -303,6 +303,17 @@ void LowMemoryRenderPipeline::Init() {
     stages_[i]->SetInputSizes(input_sizes);
   }
 
+  // Check that kInput stages appear after the switch to image dimensions (if
+  // any).
+  for (size_t i = 0; i < stages_.size(); i++) {
+    for (size_t c = 0; c < shifts.size(); c++) {
+      if (stages_[i]->GetChannelMode(c) == RenderPipelineChannelMode::kInput) {
+        JXL_ASSERT(first_image_dim_stage_ == stages_.size() ||
+                   i >= first_image_dim_stage_);
+      }
+    }
+  }
+
   anyc_.resize(stages_.size());
   for (size_t i = 0; i < stages_.size(); i++) {
     for (size_t c = 0; c < shifts.size(); c++) {
@@ -478,6 +489,72 @@ JXL_INLINE void ApplyXMirroring(float* row, ssize_t borderx, ssize_t group_x0,
   }
 }
 
+// Information about where the *output* of each stage is stored.
+class Rows {
+ public:
+  Rows(const std::vector<std::unique_ptr<RenderPipelineStage>>& stages,
+       const Rect data_max_color_channel_rect, int group_data_x_border,
+       int group_data_y_border,
+       const std::vector<std::pair<size_t, size_t>>& group_data_shift,
+       size_t base_color_shift, std::vector<std::vector<ImageF>>& thread_data,
+       std::vector<ImageF>& input_data) {
+    size_t num_stages = stages.size();
+    size_t num_channels = input_data.size();
+
+    JXL_ASSERT(thread_data.size() == num_channels);
+    JXL_ASSERT(group_data_shift.size() == num_channels);
+
+    for (const auto& td : thread_data) {
+      JXL_ASSERT(td.size() == num_stages);
+    }
+
+    rows_.resize(num_stages + 1, std::vector<RowInfo>(num_channels));
+
+    for (size_t i = 0; i < num_stages; i++) {
+      for (size_t c = 0; c < input_data.size(); c++) {
+        if (stages[i]->GetChannelMode(c) == RenderPipelineChannelMode::kInOut) {
+          rows_[i + 1][c].ymod_minus_1 = thread_data[c][i].ysize() - 1;
+          rows_[i + 1][c].base_ptr = thread_data[c][i].Row(0);
+          rows_[i + 1][c].stride = thread_data[c][i].PixelsPerRow();
+        }
+      }
+    }
+
+    for (size_t c = 0; c < input_data.size(); c++) {
+      auto channel_group_data_rect =
+          data_max_color_channel_rect.As<ssize_t>()
+              .Translate(-group_data_x_border, -group_data_y_border)
+              .ShiftLeft(base_color_shift)
+              .CeilShiftRight(group_data_shift[c])
+              .Translate(group_data_x_border - ssize_t(kRenderPipelineXOffset),
+                         group_data_y_border);
+      rows_[0][c].base_ptr = channel_group_data_rect.Row(&input_data[c], 0);
+      rows_[0][c].stride = input_data[c].PixelsPerRow();
+      rows_[0][c].ymod_minus_1 = -1;
+    }
+  }
+
+  // Stage -1 refers to the input data; all other values must be nonnegative and
+  // refer to the data for the output of that stage.
+  JXL_INLINE float* GetBuffer(int stage, int y, size_t c) const {
+    JXL_DASSERT(stage >= -1);
+    const RowInfo& info = rows_[stage + 1][c];
+    return info.base_ptr + ssize_t(info.stride) * (y & info.ymod_minus_1);
+  }
+
+ private:
+  struct RowInfo {
+    // Pointer to beginning of the first row.
+    float* base_ptr;
+    // Modulo value for the y axis minus 1 (ymod is guaranteed to be a power of
+    // 2, which allows efficient mod computation by masking).
+    int ymod_minus_1;
+    // Number of floats per row.
+    size_t stride;
+  };
+  std::vector<std::vector<RowInfo>> rows_;
+};
+
 }  // namespace
 
 void LowMemoryRenderPipeline::RenderRect(size_t thread_id,
@@ -485,65 +562,56 @@ void LowMemoryRenderPipeline::RenderRect(size_t thread_id,
                                          Rect data_max_color_channel_rect,
                                          Rect image_max_color_channel_rect) {
   // For each stage, the rect corresponding to the image area currently being
-  // processed.
+  // processed, in the coordinates of that stage (i.e. with the scaling factor
+  // that that stage has).
   std::vector<Rect> group_rect;
   group_rect.resize(stages_.size());
+  Rect image_area_rect =
+      image_max_color_channel_rect.ShiftLeft(base_color_shift_)
+          .Crop(frame_dimensions_.xsize_upsampled,
+                frame_dimensions_.ysize_upsampled);
   for (size_t i = 0; i < stages_.size(); i++) {
-    size_t x0 = (image_max_color_channel_rect.x0() << base_color_shift_) >>
-                channel_shifts_[i][anyc_[i]].first;
-    size_t x1 = DivCeil(std::min(frame_dimensions_.xsize_upsampled,
-                                 (image_max_color_channel_rect.x0() +
-                                  image_max_color_channel_rect.xsize())
-                                     << base_color_shift_),
-                        1 << channel_shifts_[i][anyc_[i]].first);
-    size_t y0 = (image_max_color_channel_rect.y0() << base_color_shift_) >>
-                channel_shifts_[i][anyc_[i]].second;
-    size_t y1 = DivCeil(std::min(frame_dimensions_.ysize_upsampled,
-                                 (image_max_color_channel_rect.y0() +
-                                  image_max_color_channel_rect.ysize())
-                                     << base_color_shift_),
-                        1 << channel_shifts_[i][anyc_[i]].second);
-    group_rect[i] = Rect(x0, y0, x1 - x0, y1 - y0);
+    group_rect[i] =
+        image_area_rect.CeilShiftRight(channel_shifts_[i][anyc_[i]]);
   }
 
-  struct RowInfo {
-    float* base_ptr;
-    int ymod_minus_1;
-    size_t stride;
-  };
+  ssize_t frame_x0 =
+      first_image_dim_stage_ == stages_.size() ? 0 : frame_origin_.x0;
+  ssize_t frame_y0 =
+      first_image_dim_stage_ == stages_.size() ? 0 : frame_origin_.y0;
+  size_t full_image_xsize = first_image_dim_stage_ == stages_.size()
+                                ? frame_dimensions_.xsize_upsampled
+                                : full_image_xsize_;
+  size_t full_image_ysize = first_image_dim_stage_ == stages_.size()
+                                ? frame_dimensions_.ysize_upsampled
+                                : full_image_ysize_;
 
-  std::vector<std::vector<RowInfo>> rows(
-      stages_.size() + 1, std::vector<RowInfo>(input_data.size()));
-
-  for (size_t i = 0; i < stages_.size(); i++) {
-    for (size_t c = 0; c < input_data.size(); c++) {
-      if (stages_[i]->GetChannelMode(c) == RenderPipelineChannelMode::kInOut) {
-        rows[i + 1][c].ymod_minus_1 = stage_data_[thread_id][c][i].ysize() - 1;
-        rows[i + 1][c].base_ptr = stage_data_[thread_id][c][i].Row(0);
-        rows[i + 1][c].stride = stage_data_[thread_id][c][i].PixelsPerRow();
-      }
-    }
+  // Compute actual x-axis bounds for the current image area in the context of
+  // the full image this frame is part of. As the left boundary may be negative,
+  // we also create the x_pixels_skip value, defined as follows:
+  // - both x_pixels_skip and full_image_x0 are >= 0, and at least one is 0;
+  // - full_image_x0 - x_pixels_skip is the position of the current frame area
+  //   in the full image.
+  ssize_t full_image_x0 = frame_x0 + image_area_rect.x0();
+  ssize_t x_pixels_skip = 0;
+  if (full_image_x0 < 0) {
+    x_pixels_skip = -full_image_x0;
+    full_image_x0 = 0;
   }
+  ssize_t full_image_x1 = frame_x0 + image_area_rect.x1();
+  full_image_x1 = std::min<ssize_t>(full_image_x1, full_image_xsize);
 
-  for (size_t c = 0; c < input_data.size(); c++) {
-    int xoff = int(data_max_color_channel_rect.x0()) -
-               int(LowMemoryRenderPipeline::group_data_x_border_);
-    xoff = xoff * (1 << base_color_shift_) >> channel_shifts_[0][c].first;
-    xoff += LowMemoryRenderPipeline::group_data_x_border_;
-    int yoff = int(data_max_color_channel_rect.y0()) -
-               int(LowMemoryRenderPipeline::group_data_y_border_);
-    yoff = yoff * (1 << base_color_shift_) >> channel_shifts_[0][c].second;
-    yoff += LowMemoryRenderPipeline::group_data_y_border_;
-    rows[0][c].base_ptr =
-        input_data[c].Row(yoff) + xoff - kRenderPipelineXOffset;
-    rows[0][c].stride = input_data[c].PixelsPerRow();
-    rows[0][c].ymod_minus_1 = -1;
-  }
+  // If the current image area is entirely outside of the visible image, there
+  // is no point in proceeding. Note: this uses the assumption that if there is
+  // a stage with observable effects (i.e. a kInput stage), it only appears
+  // after the stage that switches to image dimensions.
+  if (full_image_x1 <= full_image_x0) return;
 
-  auto get_row_buffer = [&](int stage, int y, size_t c) {
-    const RowInfo& info = rows[stage + 1][c];
-    return info.base_ptr + ssize_t(info.stride) * (y & info.ymod_minus_1);
-  };
+  // Data structures to hold information about input/output rows and their
+  // buffers.
+  Rows rows(stages_, data_max_color_channel_rect, group_data_x_border_,
+            group_data_y_border_, channel_shifts_[0], base_color_shift_,
+            stage_data_[thread_id], input_data);
 
   std::vector<RenderPipelineStage::RowInfo> input_rows(first_trailing_stage_ +
                                                        1);
@@ -557,6 +625,51 @@ void LowMemoryRenderPipeline::RenderRect(size_t thread_id,
   RenderPipelineStage::RowInfo output_rows(input_data.size(),
                                            std::vector<float*>(8));
 
+  // Fills in input_rows and output_rows for a given y value (relative to the
+  // start of the group, measured in actual pixels at the appropriate vertical
+  // scaling factor) and a given stage, applying mirroring if necessary. This
+  // function is somewhat inefficient for trailing kInOut or kInput stages,
+  // where just filling the input row once ought to be sufficient.
+  auto prepare_io_rows = [&](int y, size_t i) {
+    ssize_t bordery = stages_[i]->settings_.border_y;
+    size_t shifty = stages_[i]->settings_.shift_y;
+    auto make_row = [&](size_t c, ssize_t iy) {
+      size_t mirrored_y = GetMirroredY(y + iy - bordery, group_rect[i].y0(),
+                                       image_rect_[i].ysize());
+      input_rows[i][c][iy] =
+          rows.GetBuffer(stage_input_for_channel_[i][c], mirrored_y, c);
+      ApplyXMirroring(input_rows[i][c][iy], stages_[i]->settings_.border_x,
+                      group_rect[i].x0(), group_rect[i].xsize(),
+                      image_rect_[i].xsize());
+    };
+    for (size_t c = 0; c < input_data.size(); c++) {
+      RenderPipelineChannelMode mode = stages_[i]->GetChannelMode(c);
+      if (mode == RenderPipelineChannelMode::kIgnored) {
+        continue;
+      }
+      // If we already have rows from a previous iteration, we can just shift
+      // the rows by 1 and insert the new one.
+      if (input_rows[i][c].size() == 2 * size_t(bordery) + 1) {
+        for (ssize_t iy = 0; iy < 2 * bordery; iy++) {
+          input_rows[i][c][iy] = input_rows[i][c][iy + 1];
+        }
+        make_row(c, bordery * 2);
+      } else {
+        input_rows[i][c].resize(2 * bordery + 1);
+        for (ssize_t iy = 0; iy < 2 * bordery + 1; iy++) {
+          make_row(c, iy);
+        }
+      }
+
+      // If necessary, get the output buffers.
+      if (mode == RenderPipelineChannelMode::kInOut) {
+        for (size_t iy = 0; iy < (1u << shifty); iy++) {
+          output_rows[c][iy] = rows.GetBuffer(i, y * (1 << shifty) + iy, c);
+        }
+      }
+    }
+  };
+
   // We pretend that every stage has a vertical shift of 0, i.e. it is as tall
   // as the final image.
   // We call each such row a "virtual" row, because it may or may not correspond
@@ -567,10 +680,9 @@ void LowMemoryRenderPipeline::RenderRect(size_t thread_id,
                                          virtual_ypadding_for_output_.end());
 
   for (int vy = -num_extra_rows;
-       vy < int(group_rect.back().ysize()) + num_extra_rows; vy++) {
+       vy < int(image_area_rect.ysize()) + num_extra_rows; vy++) {
     for (size_t i = 0; i < first_trailing_stage_; i++) {
-      int virtual_y_offset = num_extra_rows - virtual_ypadding_for_output_[i];
-      int stage_vy = vy - virtual_y_offset;
+      int stage_vy = vy - num_extra_rows + virtual_ypadding_for_output_[i];
 
       if (stage_vy % (1 << channel_shifts_[i][anyc_[i]].second) != 0) {
         continue;
@@ -580,8 +692,6 @@ void LowMemoryRenderPipeline::RenderRect(size_t thread_id,
         continue;
       }
 
-      ssize_t bordery = stages_[i]->settings_.border_y;
-      size_t shifty = stages_[i]->settings_.shift_y;
       int y = stage_vy >> channel_shifts_[i][anyc_[i]].second;
 
       ssize_t image_y = ssize_t(group_rect[i].y0()) + y;
@@ -590,96 +700,54 @@ void LowMemoryRenderPipeline::RenderRect(size_t thread_id,
         continue;
       }
 
-      // Get the actual input rows and potentially apply mirroring.
-      for (size_t c = 0; c < input_data.size(); c++) {
-        RenderPipelineChannelMode mode = stages_[i]->GetChannelMode(c);
-        if (mode == RenderPipelineChannelMode::kIgnored) {
-          continue;
-        }
-        auto make_row = [&](ssize_t iy) {
-          size_t mirrored_y = GetMirroredY(y + iy - bordery, group_rect[i].y0(),
-                                           image_rect_[i].ysize());
-          input_rows[i][c][iy] =
-              get_row_buffer(stage_input_for_channel_[i][c], mirrored_y, c);
-          ApplyXMirroring(input_rows[i][c][iy], stages_[i]->settings_.border_x,
-                          group_rect[i].x0(), group_rect[i].xsize(),
-                          image_rect_[i].xsize());
-        };
-        // If we already have rows from a previous iteration, we can just shift
-        // the rows by 1 and insert the new one.
-        if (input_rows[i][c].size() == 2 * size_t(bordery) + 1) {
-          for (ssize_t iy = 0; iy < 2 * bordery; iy++) {
-            input_rows[i][c][iy] = input_rows[i][c][iy + 1];
-          }
-          make_row(bordery * 2);
-        } else {
-          input_rows[i][c].resize(2 * bordery + 1);
-          for (ssize_t iy = 0; iy < 2 * bordery + 1; iy++) {
-            make_row(iy);
-          }
-        }
+      // Get the input/output rows and potentially apply mirroring to the input.
+      prepare_io_rows(y, i);
 
-        // If necessary, get the output buffers.
-        if (mode == RenderPipelineChannelMode::kInOut) {
-          for (size_t iy = 0; iy < (1u << shifty); iy++) {
-            output_rows[c][iy] = get_row_buffer(i, y * (1 << shifty) + iy, c);
-          }
-        }
-      }
       // Produce output rows.
       stages_[i]->ProcessRow(input_rows[i], output_rows,
                              xpadding_for_output_[i], group_rect[i].xsize(),
-                             group_rect[i].x0(), group_rect[i].y0() + y,
-                             thread_id);
+                             group_rect[i].x0(), image_y, thread_id);
     }
 
     // Process trailing stages, i.e. the final set of non-kInOut stages; they
     // all have the same input buffer and no need to use any mirroring.
 
     int y = vy - num_extra_rows;
-    if (y < 0 || y >= ssize_t(frame_dimensions_.ysize_upsampled)) continue;
 
     for (size_t c = 0; c < input_data.size(); c++) {
-      input_rows[first_trailing_stage_][c][0] = get_row_buffer(
-          stage_input_for_channel_[first_trailing_stage_][c], y, c);
+      // Skip pixels that are not part of the actual final image area.
+      input_rows[first_trailing_stage_][c][0] =
+          rows.GetBuffer(stage_input_for_channel_[first_trailing_stage_][c], y,
+                         c) +
+          x_pixels_skip;
     }
 
-    for (size_t i = first_trailing_stage_; i < first_image_dim_stage_; i++) {
-      stages_[i]->ProcessRow(input_rows[first_trailing_stage_], output_rows,
-                             /*xextra=*/0, group_rect[i].xsize(),
-                             group_rect[i].x0(), group_rect[i].y0() + y,
-                             thread_id);
-    }
-
-    if (first_image_dim_stage_ == stages_.size()) continue;
-
-    ssize_t full_image_y =
-        y + frame_origin_.y0 + group_rect[first_image_dim_stage_].y0();
-    if (full_image_y < 0 || full_image_y >= ssize_t(full_image_ysize_)) {
+    // Check that we are not outside of the bounds for the current rendering
+    // rect. Not doing so might result in overwriting some rows that have been
+    // written (or will be written) by other threads.
+    if (y < 0 || y >= ssize_t(image_area_rect.ysize())) {
       continue;
     }
 
-    ssize_t full_image_x0 =
-        frame_origin_.x0 + group_rect[first_image_dim_stage_].x0();
-
-    if (full_image_x0 < 0) {
-      // Skip pixels.
-      for (size_t c = 0; c < input_data.size(); c++) {
-        input_rows[first_trailing_stage_][c][0] -= full_image_x0;
-      }
-      full_image_x0 = 0;
+    // Avoid running pipeline stages on pixels that are outside the full image
+    // area. As trailing stages have no borders, this is a free optimization
+    // (and may be necessary for correctness, as some stages assume coordinates
+    // are within bounds).
+    ssize_t full_image_y = frame_y0 + image_area_rect.y0() + y;
+    if (full_image_y < 0 || full_image_y >= ssize_t(full_image_ysize)) {
+      continue;
     }
-    ssize_t full_image_x1 = frame_origin_.x0 +
-                            group_rect[first_image_dim_stage_].x0() +
-                            group_rect[first_image_dim_stage_].xsize();
-    full_image_x1 = std::min<ssize_t>(full_image_x1, full_image_xsize_);
 
-    if (full_image_x1 <= full_image_x0) continue;
-
-    for (size_t i = first_image_dim_stage_; i < stages_.size(); i++) {
+    for (size_t i = first_trailing_stage_; i < stages_.size(); i++) {
+      // Before the first_image_dim_stage_, coordinates are relative to the
+      // current frame.
+      size_t x0 =
+          i < first_image_dim_stage_ ? full_image_x0 - frame_x0 : full_image_x0;
+      size_t y =
+          i < first_image_dim_stage_ ? full_image_y - frame_y0 : full_image_y;
       stages_[i]->ProcessRow(input_rows[first_trailing_stage_], output_rows,
-                             /*xextra=*/0, full_image_x1 - full_image_x0,
-                             full_image_x0, full_image_y, thread_id);
+                             /*xextra=*/0, full_image_x1 - full_image_x0, x0, y,
+                             thread_id);
     }
   }
 }

--- a/lib/jxl/render_pipeline/render_pipeline_test.cc
+++ b/lib/jxl/render_pipeline/render_pipeline_test.cc
@@ -418,6 +418,26 @@ std::vector<RenderPipelineTestInputSettings> GeneratePipelineTests() {
     all_tests.push_back(settings);
   }
 
+  {
+    RenderPipelineTestInputSettings settings;
+    settings.input_path = "jxl/grayscale_patches.png";
+    settings.xsize = 1011;
+    settings.ysize = 277;
+    settings.cparams.photon_noise_iso = 1000;
+    settings.cparams_descr = "PatchesAndNoise";
+    all_tests.push_back(settings);
+  }
+
+  {
+    RenderPipelineTestInputSettings settings;
+    settings.input_path = "jxl/grayscale_patches.png";
+    settings.xsize = 1011;
+    settings.ysize = 277;
+    settings.cparams.resampling = 2;
+    settings.cparams_descr = "PatchesAndUps2";
+    all_tests.push_back(settings);
+  }
+
   return all_tests;
 }
 

--- a/lib/jxl/render_pipeline/stage_patches.cc
+++ b/lib/jxl/render_pipeline/stage_patches.cc
@@ -9,9 +9,10 @@ namespace jxl {
 namespace {
 class PatchDictionaryStage : public RenderPipelineStage {
  public:
-  explicit PatchDictionaryStage(const PatchDictionary* patches)
+  PatchDictionaryStage(const PatchDictionary* patches, size_t num_channels)
       : RenderPipelineStage(RenderPipelineStage::Settings()),
-        patches_(*patches) {}
+        patches_(*patches),
+        num_channels_(num_channels) {}
 
   void ProcessRow(const RowInfo& input_rows, const RowInfo& output_rows,
                   size_t xextra, size_t xsize, size_t xpos, size_t ypos,
@@ -19,27 +20,29 @@ class PatchDictionaryStage : public RenderPipelineStage {
     PROFILER_ZONE("RenderPatches");
     JXL_ASSERT(xpos == 0 || xpos >= xextra);
     size_t x0 = xpos ? xpos - xextra : 0;
-    std::vector<float*> row_ptrs(input_rows.size());
-    for (size_t i = 0; i < row_ptrs.size(); i++) {
+    std::vector<float*> row_ptrs(num_channels_);
+    for (size_t i = 0; i < num_channels_; i++) {
       row_ptrs[i] = GetInputRow(input_rows, i, 0) + x0 - xpos;
     }
     patches_.AddOneRow(row_ptrs.data(), ypos, x0, xsize + xextra + xpos - x0);
   }
 
   RenderPipelineChannelMode GetChannelMode(size_t c) const final {
-    return RenderPipelineChannelMode::kInPlace;
+    return c < num_channels_ ? RenderPipelineChannelMode::kInPlace
+                             : RenderPipelineChannelMode::kIgnored;
   }
 
   const char* GetName() const override { return "Patches"; }
 
  private:
   const PatchDictionary& patches_;
+  const size_t num_channels_;
 };
 }  // namespace
 
 std::unique_ptr<RenderPipelineStage> GetPatchesStage(
-    const PatchDictionary* patches) {
-  return jxl::make_unique<PatchDictionaryStage>(patches);
+    const PatchDictionary* patches, size_t num_channels) {
+  return jxl::make_unique<PatchDictionaryStage>(patches, num_channels);
 }
 
 }  // namespace jxl

--- a/lib/jxl/render_pipeline/stage_patches.h
+++ b/lib/jxl/render_pipeline/stage_patches.h
@@ -15,7 +15,7 @@ namespace jxl {
 
 // Draws patches if applicable.
 std::unique_ptr<RenderPipelineStage> GetPatchesStage(
-    const PatchDictionary* patches);
+    const PatchDictionary* patches, size_t num_channels);
 
 }  // namespace jxl
 


### PR DESCRIPTION
This PR contains two related commits, one that fixes #1397:

    Fix the patch stage when combined with noise.
    
    The patch stage declared to affect the additional noise channels (which
    it doesn't). Because of this, the pipeline execution got confused about
    the amount of y axis padding that the stage required (as it assumes that
    it is the same for all channels for which it matters), resulting in
    bogus values for the y position and, thus, in patches being moved by 2
    pixels up.

And one that hopefully improves clarity for the rendering pipeline and aids future debugging:

    Refactor the low memory rendering pipeline.
    
    The code should now hopefully be more clear and undestandable.
    
    As a nice side effect, this remove a potential race condition and
    optimizes rendering of frames partially outside the current image.
