### PR TITLE
follow spec regarding shift brackets in multi-pass modular

### DIFF
--- a/lib/jxl/frame_header.cc
+++ b/lib/jxl/frame_header.cc
@@ -120,10 +120,16 @@ Status Passes::VisitFields(Visitor* JXL_RESTRICT visitor) {
     for (uint32_t i = 0; i < num_downsample; ++i) {
       JXL_QUIET_RETURN_IF_ERROR(
           visitor->U32(Val(1), Val(2), Val(4), Val(8), 1, &downsample[i]));
+      if (i > 0 && downsample[i] >= downsample[i - 1]) {
+        return JXL_FAILURE("downsample sequence should be decreasing");
+      }
     }
     for (uint32_t i = 0; i < num_downsample; ++i) {
       JXL_QUIET_RETURN_IF_ERROR(
           visitor->U32(Val(0), Val(1), Val(2), Bits(3), 0, &last_pass[i]));
+      if (i > 0 && last_pass[i] <= last_pass[i - 1]) {
+        return JXL_FAILURE("last_pass sequence should be increasing");
+      }
       if (last_pass[i] >= num_passes) {
         return JXL_FAILURE("last_pass %u >= num_passes %u", last_pass[i],
                            num_passes);

--- a/lib/jxl/frame_header.h
+++ b/lib/jxl/frame_header.h
@@ -262,10 +262,10 @@ struct Passes : public Fields {
 
   void GetDownsamplingBracket(size_t pass, int& minShift, int& maxShift) const {
     maxShift = 2;
-    minShift = 0;
+    minShift = 3;
     for (size_t i = 0;; i++) {
       for (uint32_t j = 0; j < num_downsample; ++j) {
-        if (i <= last_pass[j]) {
+        if (i == last_pass[j]) {
           if (downsample[j] == 8) minShift = 3;
           if (downsample[j] == 4) minShift = 2;
           if (downsample[j] == 2) minShift = 1;
@@ -275,7 +275,6 @@ struct Passes : public Fields {
       if (i == num_passes - 1) minShift = 0;
       if (i == pass) return;
       maxShift = minShift - 1;
-      minShift = 0;
     }
   }
 


### PR DESCRIPTION
See the discussion in https://github.com/libjxl/libjxl/issues/1401

This makes libjxl follow the spec regarding minshift/maxshift for modular passes, bringing the modular part of a pass in sync with the vardct part.

It also adds checks to require that the downscale sequence is strictly decreasing, so [8, 4, 2, 1] is allowed but not [2, 4] or [4, 4]. Also the last_pass sequence is required to be strictly increasing.

These constraints should ensure that all shifts are always covered exactly once (modulo brainos on my end), and should be added to the spec too.

This should not break any bitstreams encoded with "normal" cjxl options (i.e. the ones available in the non-verbose help screen).  It also does not break any bitstreams encoded with "advanced" cjxl options (the ones available in the help screen with one `-v`). It does break bitstreams encoded with "experimental" cjxl options (the ones you only see when doing `-v -v -h`), in particular when using this combination of options: `--progressive_ac --saliency_num_progressive_steps={3,4} -m` (or without the `-m` if they have an alpha channel). Things break in the sense that after this change, the encoder will produce bitstreams that fail to decode by an older decoder, and the decoder will fail to decode bitstreams that were encoded by an older encoder.

The extra checks should not affect any existing bitstreams, nor should they reduce the expressivity of the bitstream in any meaningful way.