### PR TITLE
add missing includes of <atomic> to fix gcc compile

### DIFF
--- a/lib/jxl/enc_image_bundle.cc
+++ b/lib/jxl/enc_image_bundle.cc
@@ -17,6 +17,7 @@
 #include "lib/jxl/fields.h"
 #include "lib/jxl/image_bundle.h"
 #include "lib/jxl/luminance.h"
+#include <atomic>
 
 namespace jxl {
 

--- a/lib/jxl/modular/transform/palette.h
+++ b/lib/jxl/modular/transform/palette.h
@@ -12,6 +12,7 @@
 #include "lib/jxl/modular/encoding/context_predict.h"
 #include "lib/jxl/modular/modular_image.h"
 #include "lib/jxl/modular/transform/transform.h"  // CheckEqualChannels
+#include <atomic>
 
 namespace jxl {
 


### PR DESCRIPTION
detected on aarch64 with gcc-10.3.1

fixes: https://github.com/libjxl/libjxl/issues/1407