### PR TITLE
remove detailed error codes from jpeg data reader; remove max size limit

### DIFF
--- a/lib/jxl/jpeg/jpeg_data.cc
+++ b/lib/jxl/jpeg/jpeg_data.cc
@@ -366,7 +366,6 @@ Status JPEGData::VisitFields(Visitor* visitor) {
   }
   uint32_t tail_data_len = tail_data.size();
   if (!visitor->IsReading() && tail_data_len > 4260096) {
-    error = JPEGReadError::TAIL_DATA_TOO_LARGE;
     return JXL_FAILURE("Tail data too large (max size = 4260096, size = %u).",
                        tail_data_len);
   }

--- a/lib/jxl/jpeg/jpeg_data.h
+++ b/lib/jxl/jpeg/jpeg_data.h
@@ -61,53 +61,6 @@ constexpr uint32_t kJPEGZigZagOrder[64] = {
 };
 /* clang-format on */
 
-enum struct JPEGReadError {
-  OK = 0,
-  SOI_NOT_FOUND,
-  SOF_NOT_FOUND,
-  UNEXPECTED_EOF,
-  MARKER_BYTE_NOT_FOUND,
-  UNSUPPORTED_MARKER,
-  WRONG_MARKER_SIZE,
-  INVALID_PRECISION,
-  INVALID_WIDTH,
-  INVALID_HEIGHT,
-  INVALID_NUMCOMP,
-  INVALID_SAMP_FACTOR,
-  INVALID_START_OF_SCAN,
-  INVALID_END_OF_SCAN,
-  INVALID_SCAN_BIT_POSITION,
-  INVALID_COMPS_IN_SCAN,
-  INVALID_HUFFMAN_INDEX,
-  INVALID_QUANT_TBL_INDEX,
-  INVALID_QUANT_VAL,
-  INVALID_MARKER_LEN,
-  INVALID_SAMPLING_FACTORS,
-  INVALID_HUFFMAN_CODE,
-  INVALID_SYMBOL,
-  NON_REPRESENTABLE_DC_COEFF,
-  NON_REPRESENTABLE_AC_COEFF,
-  INVALID_SCAN,
-  OVERLAPPING_SCANS,
-  INVALID_SCAN_ORDER,
-  EXTRA_ZERO_RUN,
-  DUPLICATE_DRI,
-  DUPLICATE_SOF,
-  WRONG_RESTART_MARKER,
-  DUPLICATE_COMPONENT_ID,
-  COMPONENT_NOT_FOUND,
-  HUFFMAN_TABLE_NOT_FOUND,
-  HUFFMAN_TABLE_ERROR,
-  QUANT_TABLE_NOT_FOUND,
-  EMPTY_DHT,
-  EMPTY_DQT,
-  OUT_OF_BAND_COEFF,
-  EOB_RUN_TOO_LONG,
-  IMAGE_TOO_LARGE,
-  INVALID_QUANT_TBL_PRECISION,
-  TAIL_DATA_TOO_LARGE
-};
-
 // Quantization values for an 8x8 pixel block.
 struct JPEGQuantTable {
   std::array<int32_t, kDCTBlockSize> values;
@@ -211,11 +164,7 @@ enum class AppMarkerType : uint32_t {
 // Represents a parsed jpeg file.
 struct JPEGData : public Fields {
   JPEGData()
-      : width(0),
-        height(0),
-        restart_interval(0),
-        error(JPEGReadError::OK),
-        has_zero_padding_bit(false) {}
+      : width(0), height(0), restart_interval(0), has_zero_padding_bit(false) {}
 
   JXL_FIELDS_NAME(JPEGData)
 #if JPEGXL_ENABLE_TRANSCODE_JPEG
@@ -244,7 +193,6 @@ struct JPEGData : public Fields {
   std::vector<uint8_t> marker_order;
   std::vector<std::vector<uint8_t>> inter_marker_data;
   std::vector<uint8_t> tail_data;
-  JPEGReadError error;
 
   // Extra information required for bit-precise JPEG file reconstruction.
 


### PR DESCRIPTION
Errors during reading jpeg bitstreams caused both a debug string to be printed and an error code enum to be set. However, these error codes are not used anywhere, and I don't think we will want to expose that kind of granularity in the api (if it fails for some reason, it fails, but we don't really need to know why exactly). So this PR gets rid of the error codes in jpeg_data (while keeping the debug strings, of course only in builds that do print them).

Also gets rid of `kBrunsliMaxNumBlocks` which I think was a technical limitation in Brunsli but it no longer applies now (obviously memory will be a problem when trying to recompress a jpeg that large, but any valid jpeg dimensions are also valid jxl dimensions so I don't think we should enforce a lower limit).