### PR TITLE
fix range check for RCT

### DIFF
--- a/lib/include/jxl/encode.h
+++ b/lib/include/jxl/encode.h
@@ -281,7 +281,7 @@ typedef enum {
    */
   JXL_ENC_FRAME_SETTING_COLOR_TRANSFORM = 24,
 
-  /** Reversible color transform for modular encoding: -1=default, 0-48=RCT
+  /** Reversible color transform for modular encoding: -1=default, 0-41=RCT
    * index, e.g. index 0 = none, index 6 = YCoCg.
    * If this option is set to a non-default value, the RCT will be globally
    * applied to the whole frame.

--- a/lib/jxl/encode.cc
+++ b/lib/jxl/encode.cc
@@ -1135,9 +1135,9 @@ JxlEncoderStatus JxlEncoderFrameSettingsSetOption(
       }
       return JXL_ENC_SUCCESS;
     case JXL_ENC_FRAME_SETTING_MODULAR_COLOR_SPACE:
-      if (value < -1 || value > 48) {
+      if (value < -1 || value > 41) {
         return JXL_API_ERROR(frame_settings->enc, JXL_ENC_ERR_API_USAGE,
-                             "Option value has to be in [-1..48]");
+                             "Option value has to be in [-1..41]");
       }
       frame_settings->values.cparams.colorspace = value;
       return JXL_ENC_SUCCESS;

--- a/tools/cjxl.cc
+++ b/tools/cjxl.cc
@@ -418,7 +418,7 @@ void CompressArgs::AddCommandLineOptions(CommandLineParser* cmdline) {
   cmdline->AddOptionValue(
       'C', "colorspace", "K",
       ("[modular encoding] color transform: -1=default, 0=RGB (none), "
-       "1-48=RCT (6=YCoCg, default: try several, depending on speed)"),
+       "1-41=RCT (6=YCoCg, default: try several, depending on speed)"),
       &params.colorspace, &ParseSigned, 1);
 
   opt_m_group_size_id = cmdline->AddOptionValue(

--- a/tools/cjxl_ng_main.cc
+++ b/tools/cjxl_ng_main.cc
@@ -706,10 +706,10 @@ int main(int argc, char** argv) {
           "modular_colorspace", FLAGS_modular_colorspace,
           JXL_ENC_FRAME_SETTING_MODULAR_COLOR_SPACE,
           [](int32_t x) -> std::string {
-            return (-1 <= x && x <= 48)
+            return (-1 <= x && x <= 41)
                        ? ""
                        : "Invalid --modular_colorspace. Valid range is "
-                         "{-1, 0, 1, ..., 48}.\n";
+                         "{-1, 0, 1, ..., 41}.\n";
           });
       process_flag("modular_ma_tree_learning_percent",
                    FLAGS_modular_ma_tree_learning_percent,


### PR DESCRIPTION
The valid range for the rct type is [0,41].
The spec also needs to be updated to require that range.