### PR TITLE
Pin the Windows version for release builds

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -251,7 +251,7 @@ jobs:
 
   windows_build:
     name: Windows Build (vcpkg / ${{ matrix.triplet }})
-    runs-on: [windows-latest]
+    runs-on: [windows-2019]
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
This might work around some of the issues seen with the built binaries.