### PR TITLE
cmake: Do not add static suffix with static libraries in mingw

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -20,6 +20,7 @@ Alex Xu (Hello71) <alex_y_xu@yahoo.ca>
 Alexander Sago <cagelight@gmail.com>
 Andrius Lukas Narbutas <andrius4669@gmail.com>
 Artem Selishchev
+Biswapriyo Nath <nathbappai@gmail.com>
 CanadianBaconBoi <beamconnor@gmail.com>
 Daniel Novomeský <dnovomesky@gmail.com>
 David Burnett <vargolsoft@gmail.com>

--- a/lib/jxl.cmake
+++ b/lib/jxl.cmake
@@ -526,7 +526,7 @@ endif()  # JPEGXL_ENABLE_TCMALLOC
 
 # Install the static library too, but as jxl.a file without the -static except
 # in Windows.
-if (NOT WIN32)
+if (NOT WIN32 OR MINGW)
   set_target_properties(jxl-static PROPERTIES OUTPUT_NAME "jxl")
   set_target_properties(jxl_dec-static PROPERTIES OUTPUT_NAME "jxl_dec")
 endif()

--- a/lib/jxl_threads.cmake
+++ b/lib/jxl_threads.cmake
@@ -40,7 +40,7 @@ set_target_properties(${_target} PROPERTIES
 
 # Always install the library as jxl_threads.{a,so} file without the "-static"
 # suffix, except in Windows.
-if (NOT WIN32)
+if (NOT WIN32 OR MINGW)
   set_target_properties(${_target} PROPERTIES OUTPUT_NAME "jxl_threads")
 endif()
 install(TARGETS ${_target}


### PR DESCRIPTION
This fixes static linking using pkgconfig files in mingw.
Otherwise, linker can not find static library showing this

ld.exe: cannot find -ljxl:No such file or directory
ld.exe: cannot find -ljxl_threads: No such file or directory

Signed-off-by: Biswapriyo Nath <nathbappai@gmail.com>