### PR TITLE
tools: add missing <stdint.h> header to codec_config.h

### DIFF
--- a/tools/codec_config.h
+++ b/tools/codec_config.h
@@ -6,6 +6,7 @@
 #ifndef TOOLS_CODEC_CONFIG_H_
 #define TOOLS_CODEC_CONFIG_H_
 
+#include <stdint.h>
 #include <string>
 
 namespace jpegxl {


### PR DESCRIPTION
Without the change libjxl build fails on this week's gcc-13 snapshot as:

    In file included from /build/libjxl/tools/codec_config.cc:6:
    /build/libjxl/tools/codec_config.h:17:31: error: 'uint32_t' was not declared in this scope
       17 | std::string CodecConfigString(uint32_t lib_version);
          |                               ^~~~~~~~
    /build/libjxl/tools/codec_config.h:10:1: note: 'uint32_t' is defined in header '<cstdint>';
      did you forget to '#include <cstdint>'?
        9 | #include <string>
      +++ |+#include <cstdint>
       10 |