### PR TITLE
pkgconfig: Define JXL_STATIC_DEFINE for static linking

### DIFF
--- a/lib/jxl/libjxl.pc.in
+++ b/lib/jxl/libjxl.pc.in
@@ -10,3 +10,4 @@ Requires.private: @JPEGXL_LIBRARY_REQUIRES@
 Libs: -L${libdir} -ljxl
 Libs.private: -lm
 Cflags: -I${includedir}
+Cflags.private: -DJXL_STATIC_DEFINE

--- a/lib/threads/libjxl_threads.pc.in
+++ b/lib/threads/libjxl_threads.pc.in
@@ -10,3 +10,4 @@ Requires.private: @JPEGXL_THREADS_LIBRARY_REQUIRES@
 Libs: -L${libdir} -ljxl_threads
 Libs.private: -lm
 Cflags: -I${includedir}
+Cflags.private: -DJXL_THREADS_STATIC_DEFINE


### PR DESCRIPTION
Add Cflags.private field with proper defined flags. This
allows for the usage of $(pkgconf --static --cflags libjxl)
to produce the proper CFLAGS for static linking. Relies on
pkgconf rather than pkg-config. Otherwise, static libraries
export APIs with dllimport decorations. And it produces the
following errors while static linking:

ld.exe: decode_progressive.cc:(.text+0x1a): undefined reference to '__imp_JxlDecoderCreate'
ld.exe: decode_progressive.cc:(.text+0x53): undefined reference to '__imp_JxlResizableParallelRunnerCreate'
...
ld.exe: decode_progressive.cc:(.text+0x4f): undefined reference to '__imp_JxlResizableParallelRunnerCreate'
ld.exe: decode_progressive.cc:(.text+0x251): undefined reference to '__imp_JxlResizableParallelRunner'
...

Signed-off-by: Biswapriyo Nath <nathbappai@gmail.com>