### PR TITLE
pkgconfig: link -lstdc++ to Libs.private

### DIFF
--- a/lib/jxl/libjxl.pc.in
+++ b/lib/jxl/libjxl.pc.in
@@ -8,5 +8,5 @@ Description: Loads and saves JPEG XL files
 Version: @JPEGXL_LIBRARY_VERSION@
 Requires.private: @JPEGXL_LIBRARY_REQUIRES@
 Libs: -L${libdir} -ljxl
-Libs.private: -lm
+Libs.private: -lm -lstdc++
 Cflags: -I${includedir}

--- a/lib/threads/libjxl_threads.pc.in
+++ b/lib/threads/libjxl_threads.pc.in
@@ -8,5 +8,5 @@ Description: JPEG XL multi-thread runner using std::threads.
 Version: @JPEGXL_LIBRARY_VERSION@
 Requires.private: @JPEGXL_THREADS_LIBRARY_REQUIRES@
 Libs: -L${libdir} -ljxl_threads
-Libs.private: -lm
+Libs.private: -lm -lstdc++
 Cflags: -I${includedir}


### PR DESCRIPTION
When static linking libjxl with other program like ffmpeg will throw error:
```
../lib/libjxl.a(decode.cc.obj):decode.cc:(.text+0x376): undefined reference to `operator new(unsigned int)'
../lib/libjxl.a(decode.cc.obj):decode.cc:(.text+0x421): undefined reference to `operator delete(void*)'
../lib/libjxl.a(decode.cc.obj):decode.cc:(.text+0x483): undefined reference to `std::__throw_length_error(char const*)'
../lib/libjxl.a(decode.cc.obj):decode.cc:(.text+0x4a1): undefined reference to `__gxx_personality_sj0'
../lib/libjxl.a(decode.cc.obj):decode.cc:(.text+0x5df): undefined reference to `operator delete(void*)'
```
Adding `-lstdc++` to Libs.private fixed it.