### PR TITLE
Fix butteraugli target in AQ loop for resampled images.

### DIFF
--- a/lib/jxl/enc_frame.cc
+++ b/lib/jxl/enc_frame.cc
@@ -1050,6 +1050,9 @@ Status ParamsPostInit(CompressParams* p) {
   if (!p->manual_xyb_factors.empty() && p->manual_xyb_factors.size() != 3) {
     return JXL_FAILURE("Invalid number of XYB quantization factors");
   }
+  if (p->original_butteraugli_distance == -1.0) {
+    p->original_butteraugli_distance = p->butteraugli_distance;
+  }
   if (p->resampling <= 0) {
     p->resampling = 1;
     // For very low bit rates, using 2x2 resampling gives better results on

--- a/lib/jxl/enc_params.h
+++ b/lib/jxl/enc_params.h
@@ -254,6 +254,9 @@ struct CompressParams {
   int ec_resampling = -1;
   // Skip the downsampling before encoding if this is true.
   bool already_downsampled = false;
+  // Butteraugli target distance on the original full size image, this can be
+  // different from butteraugli_distance if resampling was used.
+  float original_butteraugli_distance = -1.0f;
 
   // Codestream level to conform to.
   // -1: don't care


### PR DESCRIPTION
This addresses another problem in Issue #330, namely if
resampling is selected based on butteraugli distance, then
the butteraugli distance is changed to reflect the expected
distortion on the smaller image. But in the AQ loop we
compare the full sized images, so there we have to use the
original butteraugli distance. For everything other than
the butteraugli comparison (initial quantization, etc.) we
still need to use the modified butteraugli distance.

Benchmark results:

```
BEFORE:
Encoding            kPixels    Bytes          BPP  E MP/s  D MP/s     Max norm        pnorm       BPP*pnorm   Bugs
------------------------------------------------------------------------------------------------------------------
jxl:kitten:d25        13270   300537    0.1811767   0.161  17.280  14.90736198   4.32093880  0.782853381548      0
jxl:tortoise:d25      13270   323909    0.1952663   0.123  18.150  12.74440765   4.07513828  0.795737334744      0

AFTER:
Encoding            kPixels    Bytes          BPP  E MP/s  D MP/s     Max norm        pnorm       BPP*pnorm   Bugs
------------------------------------------------------------------------------------------------------------------
jxl:kitten:d25        13270   186024    0.1121433   0.160  17.137  23.99775124   6.33460680  0.710383737470      0
jxl:tortoise:d25      13270   191170    0.1152455   0.126  19.820  23.99775124   6.33459650  0.730033964636      0
```