### PR TITLE
Disable slow AQ search for low butteraugli target with resampling.

### DIFF
--- a/lib/jxl/enc_adaptive_quantization.cc
+++ b/lib/jxl/enc_adaptive_quantization.cc
@@ -734,6 +734,13 @@ void FindBestQuantization(const ImageBundle& linear, const Image3F& opsin,
                           const JxlCmsInterface& cms, ThreadPool* pool,
                           AuxOut* aux_out) {
   const CompressParams& cparams = enc_state->cparams;
+  if (cparams.resampling > 1 &&
+      cparams.original_butteraugli_distance <= 4.0 * cparams.resampling) {
+    // For downsampled opsin image, the butteraugli based adaptive quantization
+    // loop would only make the size bigger without improving the distance much,
+    // so in this case we enable it only for very high butteraugli targets.
+    return;
+  }
   Quantizer& quantizer = enc_state->shared.quantizer;
   ImageI& raw_quant_field = enc_state->shared.raw_quant_field;
   ImageF& quant_field = enc_state->initial_quant_field;

--- a/lib/jxl/jxl_test.cc
+++ b/lib/jxl/jxl_test.cc
@@ -238,12 +238,13 @@ TEST(JxlTest, RoundtripResample2Slow) {
   io.ShrinkTo(io.xsize(), io.ysize());
   CompressParams cparams;
   cparams.resampling = 2;
+  cparams.butteraugli_distance = 10;
   cparams.speed_tier = SpeedTier::kTortoise;
   DecompressParams dparams;
   CodecInOut io2;
-  EXPECT_LE(Roundtrip(&io, cparams, dparams, pool, &io2), 35000u);
+  EXPECT_LE(Roundtrip(&io, cparams, dparams, pool, &io2), 5000u);
   EXPECT_THAT(ComputeDistance2(io.Main(), io2.Main(), GetJxlCms()),
-              IsSlightlyBelow(90));
+              IsSlightlyBelow(250));
 }
 
 TEST(JxlTest, RoundtripResample2MT) {


### PR DESCRIPTION
Benchmark results:

BEFORE:
```
Encoding                         kPixels    Bytes          BPP  E MP/s  D MP/s     Max norm        pnorm       BPP*pnorm   Bugs
-------------------------------------------------------------------------------------------------------------------------------
jxl:tortoise:resampling=2:d1       13270  2561039    1.5439050   0.082  15.676  11.92454147   2.15506849  3.327220929853      0
jxl:tortoise:resampling=2:d4       13270   633621    0.3819741   0.104  15.105  11.97806740   2.75957457  1.054086053395      0
jxl:tortoise:resampling=2:d8       13270   291244    0.1755745   0.112  15.943  13.04184532   4.41013473  0.774307051378      0
jxl:tortoise:resampling=4:d8       13270   211605    0.1275646   0.202  20.137  24.62362862   6.61222334  0.843485865518      0
jxl:tortoise:resampling=4:d16      13270    71034    0.0428224   0.210  21.545  27.48932838   9.63750761  0.412700860763      0
jxl:tortoise:resampling=8:d25      13270    22245    0.0134102   0.210  23.749  49.54417038  16.45530297  0.220669678645      0
```

AFTER:
```
Encoding                         kPixels    Bytes          BPP  E MP/s  D MP/s     Max norm        pnorm       BPP*pnorm   Bugs
-------------------------------------------------------------------------------------------------------------------------------
jxl:tortoise:resampling=2:d1       13270  1033228    0.6228745   0.187  18.059  11.93404388   2.29897906  1.431975382959      0
jxl:tortoise:resampling=2:d4       13270   390681    0.2355194   0.219  15.720  13.84154701   3.74463748  0.881934720248      0
jxl:tortoise:resampling=2:d8       13270   218058    0.1314548   0.239  15.905  23.09692574   5.76916797  0.758384725985      0
jxl:tortoise:resampling=4:d8       13270    72007    0.0434089  12.404  20.352  40.41043472  10.41484712  0.452097376188      0
jxl:tortoise:resampling=4:d16      13270    39673    0.0239166  13.382  20.678  48.01293564  13.83403782  0.330863127435      0
jxl:tortoise:resampling=8:d25      13270    11443    0.0068983  27.863  23.151  73.70134735  21.27699959  0.146775866470      0
```