### PR TITLE
prevent infinite loop in box decoding

### DIFF
--- a/lib/jxl/decode.cc
+++ b/lib/jxl/decode.cc
@@ -2092,7 +2092,8 @@ static JxlDecoderStatus HandleBoxes(JxlDecoder* dec) {
           dec->AdvanceInput(avail_codestream);
         }
 
-        if (dec->file_pos == dec->box_contents_end) {
+        if (dec->file_pos == dec->box_contents_end &&
+            !dec->box_contents_unbounded) {
           dec->box_stage = BoxStage::kHeader;
           continue;
         }

--- a/lib/jxl/decode_test.cc
+++ b/lib/jxl/decode_test.cc
@@ -1727,8 +1727,7 @@ TEST(DecodeTest, ProcessEmptyInputWithBoxes) {
         /*add_intrinsic_size=*/false);
     const int events =
         JXL_DEC_BASIC_INFO | JXL_DEC_FULL_IMAGE | JXL_DEC_COLOR_ENCODING;
-    EXPECT_EQ(JXL_DEC_SUCCESS,
-              JXL_DEC_SUCCESS != JxlDecoderSubscribeEvents(dec, events));
+    EXPECT_EQ(JXL_DEC_SUCCESS, JxlDecoderSubscribeEvents(dec, events));
     EXPECT_EQ(JXL_DEC_NEED_MORE_INPUT, JxlDecoderProcessInput(dec));
     EXPECT_EQ(JXL_DEC_SUCCESS,
               JxlDecoderSetInput(dec, compressed.data(), compressed.size()));
@@ -1742,8 +1741,6 @@ TEST(DecodeTest, ProcessEmptyInputWithBoxes) {
     const size_t remaining = JxlDecoderReleaseInput(dec);
     EXPECT_LE(remaining, compressed.size());
     EXPECT_EQ(JXL_DEC_NEED_MORE_INPUT, JxlDecoderProcessInput(dec));
-    EXPECT_EQ(JXL_DEC_SUCCESS,
-              JxlDecoderSetInput(dec, compressed.data(), compressed.size()));
   }
 }
 

--- a/lib/jxl/decode_test.cc
+++ b/lib/jxl/decode_test.cc
@@ -1741,6 +1741,7 @@ TEST(DecodeTest, ProcessEmptyInputWithBoxes) {
     const size_t remaining = JxlDecoderReleaseInput(dec);
     EXPECT_LE(remaining, compressed.size());
     EXPECT_EQ(JXL_DEC_NEED_MORE_INPUT, JxlDecoderProcessInput(dec));
+    JxlDecoderDestroy(dec);
   }
 }
 


### PR DESCRIPTION
After the commit https://github.com/libjxl/libjxl/commit/5a024e5bf5b9b93da698c7f6cb06abb874b73c4c, the jxl decoder in chrome goes into an infinite loop when trying to decoder a raw jxl image. 
This happens in `HandleBoxes` and more precisely this happens when `dec->avail_in == 0` and` dec->box_stage` switches back and forth between `BoxStage::kHeader` and `BoxStage::kCodestream`.

The proposed changed stops the infinite loop and makes the chrome jxl decoder work again. 
(I haven't run any tests yet..)
