### PR TITLE
Implement kLastPasses progressive detail in the decoder.

### DIFF
--- a/lib/include/jxl/types.h
+++ b/lib/include/jxl/types.h
@@ -120,6 +120,7 @@ typedef char JxlBoxType[4];
  * with smaller or equal value. Currently only the following level of
  * progressive detail is implemented:
  *  - kDC (which implies kFrames)
+ *  - kLastPasses (which implies kDC and kFrames)
  *  - kPasses (which implies kLastPasses, kDC and kFrames)
  */
 typedef enum {

--- a/lib/jxl/dec_frame.cc
+++ b/lib/jxl/dec_frame.cc
@@ -761,13 +761,13 @@ Status FrameDecoder::ProcessSections(const SectionInfo* sections, size_t num,
     section_status[ac_global_sec] = SectionStatus::kDone;
   }
 
-  if (progressive_detail_ >= JxlProgressiveDetail::kPasses) {
-    // Mark that we only want the next pass.
-    size_t num_complete_passes = NumCompletePasses();
+  if (progressive_detail_ >= JxlProgressiveDetail::kLastPasses) {
+    // Mark that we only want the next progression pass.
+    size_t target_complete_passes = NextNumPassesToPause();
     for (size_t i = 0; i < ac_group_sec.size(); i++) {
       desired_num_ac_passes[i] =
           std::min(desired_num_ac_passes[i],
-                   1 + num_complete_passes - decoded_passes_per_ac_group_[i]);
+                   target_complete_passes - decoded_passes_per_ac_group_[i]);
     }
   }
 

--- a/lib/jxl/progressive_split.h
+++ b/lib/jxl/progressive_split.h
@@ -115,7 +115,10 @@ class ProgressiveSplitter {
           min_downsampling_factor != kNoDownsamplingFactor) {
         passes->downsample[passes->num_downsample] = min_downsampling_factor;
         passes->last_pass[passes->num_downsample] = i;
-        passes->num_downsample += 1;
+        if (mode_.passes[i + 1].suitable_for_downsampling_of_at_least <
+            min_downsampling_factor) {
+          passes->num_downsample += 1;
+        }
       }
     }
   }


### PR DESCRIPTION
Added test with 4 intermediate passes, 2 for each downsampling
target. For this I had to fix a bug in progressive_splitter that
filled in the last_pass array of the frame header incorrectly.