### PR TITLE
Implement partial decoding of progressive JXLs in djxl_ng.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
  - decoder API: new function `JxlDecoderSetMultithreadedImageOutCallback`,
    allowing output callbacks to receive more information about the number of
    threads on which they are running.
+ - decoder API: new function `JxlDecoderSkipCurrentFrame` to skip processing
+   the current frame after a progressive detail is reached.
+ - decoder API: new function `JxlDecoderGetIntendedDownsamplingRatio` to get
+   the intended downsampling ratio of progressive setps, based on the
+   information in the frame header.
  - encoder API: added ability to set several encoder options to frames using
    `JxlEncoderFrameSettingsSetOption`
  - encoder API: new functions `JxlEncoderSetFrameHeader` and

--- a/lib/include/jxl/decode.h
+++ b/lib/include/jxl/decode.h
@@ -347,6 +347,20 @@ JXL_EXPORT void JxlDecoderRewind(JxlDecoder* dec);
 JXL_EXPORT void JxlDecoderSkipFrames(JxlDecoder* dec, size_t amount);
 
 /**
+ * Skips processing the current frame. Can be called after frame processing
+ * already started, signaled by a @ref JXL_DEC_NEED_IMAGE_OUT_BUFFER event,
+ * but before the corrsponding @ref JXL_DEC_FULL_IMAGE event. The next signaled
+ * event will be another @ref JXL_DEC_FRAME, or @ref JXL_DEC_SUCCESS if there
+ * are no more frames. If pixel data is required from the already processed part
+ * of the frame, @ref JxlDecoderFlushImage must be called before this.
+ *
+ * @param dec decoder object
+ * @return @ref JXL_DEC_SUCCESS if there is a frame to skip, and @ref
+ *     JXL_DEC_ERROR if the function was not called during frame processing.
+ */
+JXL_EXPORT JxlDecoderStatus JxlDecoderSkipCurrentFrame(JxlDecoder* dec);
+
+/**
  * Get the default pixel format for this decoder.
  *
  * Requires that the decoder can produce JxlBasicInfo.
@@ -1318,6 +1332,16 @@ JXL_EXPORT JxlDecoderStatus JxlDecoderGetBoxSizeRaw(const JxlDecoder* dec,
  */
 JXL_EXPORT JxlDecoderStatus
 JxlDecoderSetProgressiveDetail(JxlDecoder* dec, JxlProgressiveDetail detail);
+
+/**
+ * Returns the intended downsampling ratio for the progressive frame produced
+ * by @ref JxlDecoderFlushImage after the latest @ref JXL_DEC_FRAME_PROGRESSION
+ * event.
+ *
+ * @param dec decoder object
+ * @return The intended downsampling ratio, can be 1, 2, 4 or 8.
+ */
+JXL_EXPORT size_t JxlDecoderGetIntendedDownsamplingRatio(JxlDecoder* dec);
 
 /**
  * Outputs progressive step towards the decoded image so far when only partial

--- a/lib/jxl/frame_header.h
+++ b/lib/jxl/frame_header.h
@@ -279,6 +279,17 @@ struct Passes : public Fields {
     }
   }
 
+  uint32_t GetDownsamplingTargetForCompletedPasses(uint32_t num_p) {
+    if (num_p >= num_passes) return 1;
+    uint32_t retval = 8;
+    for (uint32_t i = 0; i < num_downsample; ++i) {
+      if (num_p > last_pass[i]) {
+        retval = std::min(retval, downsample[i]);
+      }
+    }
+    return retval;
+  }
+
   uint32_t num_passes;      // <= kMaxNumPasses
   uint32_t num_downsample;  // <= num_passes
 


### PR DESCRIPTION
This commit implements the --downsampling flag from djxl.

Added a function to the public API that can retrieve info about
the downsampling / is_last arrays in the frame header.

Added a JxlDecoderSkipCurrentFrame function to the public API
that can jump to the next frame during progressive decoding.