### PR TITLE
Improve documentation of some API functions.

### DIFF
--- a/lib/include/jxl/codestream_header.h
+++ b/lib/include/jxl/codestream_header.h
@@ -175,10 +175,14 @@ typedef struct {
    * (linear if outputting to floating point, nonlinear with standard sRGB
    * transfer function if outputting to unsigned integers) but will not convert
    * it to to the original color profile. The decoder also does not convert to
-   * the target display color profile, but instead will always indicate which
-   * color profile the returned pixel data is encoded in when using @see
-   * JXL_COLOR_PROFILE_TARGET_DATA so that a CMS can be used to convert the
-   * data.
+   * the target display color profile. To convert the pixel data produced by
+   * the decoder to the original color profile, one of the JxlDecoderGetColor*
+   * functions needs to be called with @ref JXL_COLOR_PROFILE_TARGET_DATA to get
+   * the color profile of the decoder output, and then an external CMS can be
+   * used for conversion.
+   * Note that for lossy compression, this should be set to false for most use
+   * cases, and if needed, the image should be converted to the original color
+   * profile after decoding, as described above.
    */
   JXL_BOOL uses_original_profile;
 

--- a/lib/include/jxl/decode.h
+++ b/lib/include/jxl/decode.h
@@ -640,7 +640,7 @@ JXL_EXPORT JxlDecoderStatus JxlDecoderGetExtraChannelName(const JxlDecoder* dec,
 
 /** Defines which color profile to get: the profile from the codestream
  * metadata header, which represents the color profile of the original image,
- * or the color profile from the pixel data received by the decoder. Both are
+ * or the color profile from the pixel data produced by the decoder. Both are
  * the same if the JxlBasicInfo has uses_original_profile set.
  */
 typedef enum {

--- a/lib/include/jxl/encode.h
+++ b/lib/include/jxl/encode.h
@@ -576,12 +576,12 @@ JxlEncoderAddJPEGFrame(const JxlEncoderFrameSettings* frame_settings,
  * If the image has alpha, and alpha is not passed here, it will implicitly be
  * set to all-opaque (an alpha value of 1.0 everywhere).
  *
- * The color profile of the pixels depends on the value of uses_original_profile
- * in the JxlBasicInfo. If true, the pixels are assumed to be encoded in the
- * original profile that is set with JxlEncoderSetColorEncoding or
- * JxlEncoderSetICCProfile. If false, the pixels are assumed to be nonlinear
- * sRGB for integer data types (JXL_TYPE_UINT8, JXL_TYPE_UINT16), and linear
- * sRGB for floating point data types (JXL_TYPE_FLOAT16, JXL_TYPE_FLOAT).
+ * The pixels are assumed to be encoded in the original profile that is set with
+ * JxlEncoderSetColorEncoding or JxlEncoderSetICCProfile. If none of these
+ * functions were used, the pixels are assumed to be nonlinear sRGB for integer
+ * data types (JXL_TYPE_UINT8, JXL_TYPE_UINT16), and linear sRGB for floating
+ * point data types (JXL_TYPE_FLOAT16, JXL_TYPE_FLOAT).
+ *
  * Sample values in floating-point pixel formats are allowed to be outside the
  * nominal range, e.g. to represent out-of-sRGB-gamut colors in the
  * uses_original_profile=false case. They are however not allowed to be NaN or


### PR DESCRIPTION
Add note to uses_original_profile that it should not be used for
lossy compression.

Update the documentation of JxlDecoderAddImageFrame to reflect that
pixel buffer is always expected to be in the color profile that is
set by JxlEncoderSetColorEncoding or JxlEncoderSetICCProfile.