### PR TITLE
Deprecate the --allow_progressive_steps flag from djxl.

### DIFF
--- a/lib/jxl/dec_frame.h
+++ b/lib/jxl/dec_frame.h
@@ -72,7 +72,7 @@ class FrameDecoder {
   // on callers.
   Status InitFrame(BitReader* JXL_RESTRICT br, ImageBundle* decoded,
                    bool is_preview, bool allow_partial_frames,
-                   bool allow_partial_dc_global, bool output_needed);
+                   bool output_needed);
 
   struct SectionInfo {
     BitReader* JXL_RESTRICT br;
@@ -307,7 +307,6 @@ class FrameDecoder {
   ImageBundle* decoded_;
   ModularFrameDecoder modular_frame_decoder_;
   bool allow_partial_frames_;
-  bool allow_partial_dc_global_;
   bool render_spotcolors_ = true;
   bool coalescing_ = true;
 

--- a/lib/jxl/dec_params.h
+++ b/lib/jxl/dec_params.h
@@ -36,11 +36,8 @@ struct DecompressParams {
   // the full size is requested.
   size_t max_downsampling = 1;
 
-  // Try to decode as much as possible of a truncated codestream, but only whole
-  // sections at a time.
+  // Try to decode as much as possible of a truncated codestream.
   bool allow_partial_files = false;
-  // Allow even more progression.
-  bool allow_more_progressive_steps = false;
 
   // Internal test-only setting: whether or not to use the slow rendering
   // pipeline.

--- a/lib/jxl/decode.cc
+++ b/lib/jxl/decode.cc
@@ -1476,7 +1476,7 @@ JxlDecoderStatus JxlDecoderProcessCodestream(JxlDecoder* dec, const uint8_t* in,
 
       jxl::Status status = dec->frame_dec->InitFrame(
           reader.get(), dec->ib.get(), /*is_preview=*/false,
-          /*allow_partial_frames=*/true, /*allow_partial_dc_global=*/false,
+          /*allow_partial_frames=*/true,
           /*output_needed=*/dec->events_wanted & JXL_DEC_FULL_IMAGE);
       if (!status) JXL_API_RETURN_IF_ERROR(status);
 

--- a/tools/djxl.cc
+++ b/tools/djxl.cc
@@ -108,10 +108,12 @@ void DecompressArgs::AddCommandLineOptions(CommandLineParser* cmdline) {
                          "allow decoding of truncated files",
                          &params.allow_partial_files, &SetBooleanTrue);
 
-  cmdline->AddOptionFlag('\0', "allow_more_progressive_steps",
-                         "allow decoding more progressive steps in truncated "
-                         "files. No effect without --allow_partial_files",
-                         &params.allow_more_progressive_steps, &SetBooleanTrue);
+  bool dummy_allow_more_progressive_steps = true;
+  opt_allow_more_progressive_steps = cmdline->AddOptionFlag(
+      '\0', "allow_more_progressive_steps",
+      "DEPRECATED: we always decode as much detail "
+      "as possible if --allow_partial_files is used",
+      &dummy_allow_more_progressive_steps, &SetBooleanTrue);
 
 #if JPEGXL_ENABLE_JPEG
   cmdline->AddOptionFlag(
@@ -148,6 +150,10 @@ jxl::Status DecompressArgs::ValidateArgs(const CommandLineParser& cmdline) {
   if (file_in == nullptr) {
     fprintf(stderr, "Missing INPUT filename.\n");
     return false;
+  }
+
+  if (cmdline.GetOption(opt_allow_more_progressive_steps)->matched()) {
+    fprintf(stderr, "Warning: --allow_more_progressive_steps is deprecated.");
   }
 
 #if JPEGXL_ENABLE_JPEG

--- a/tools/djxl.h
+++ b/tools/djxl.h
@@ -67,6 +67,7 @@ struct DecompressArgs {
 
   // References (ids) of specific options to check if they were matched.
   CommandLineParser::OptionId opt_jpeg_quality_id = -1;
+  CommandLineParser::OptionId opt_allow_more_progressive_steps = -1;
 };
 
 // Decompresses and notifies SpeedStats of elapsed time.

--- a/tools/djxl_ng_main.cc
+++ b/tools/djxl_ng_main.cc
@@ -67,11 +67,6 @@ DEFINE_uint32(downsampling, 0,
 // TODO(firsching): wire this up.
 DEFINE_bool(allow_partial_files, false, "allow decoding of truncated files");
 
-// TODO(firsching): wire this up.
-DEFINE_bool(allow_more_progressive_steps, false,
-            "allow decoding more progressive steps in truncated "
-            "files. No effect without --allow_partial_files");
-
 #if JPEGXL_ENABLE_JPEG
 // TODO(firsching): wire this up.
 DEFINE_bool(


### PR DESCRIPTION
This change has the same effect as if setting --allow_progressive_steps
to the same value as --allow_partial_files.

If the --allow_partial_files is set to true, then we will always
decode and render as much detail as possible.