### PR TITLE
Avoid reading DCT params for custom AFV matrices multiple times.

### DIFF
--- a/lib/jxl/enc_quant_weights.cc
+++ b/lib/jxl/enc_quant_weights.cc
@@ -105,10 +105,9 @@ Status EncodeQuant(const QuantEncoding& encoding, size_t idx, size_t size_x,
           JXL_RETURN_IF_ERROR(F16Coder::Write(
               encoding.afv_weights[c][i] * (i < 6 ? 1.0f / 64 : 1.0f), writer));
         }
-        JXL_RETURN_IF_ERROR(EncodeDctParams(encoding.dct_params, writer));
-        JXL_RETURN_IF_ERROR(
-            EncodeDctParams(encoding.dct_params_afv_4x4, writer));
       }
+      JXL_RETURN_IF_ERROR(EncodeDctParams(encoding.dct_params, writer));
+      JXL_RETURN_IF_ERROR(EncodeDctParams(encoding.dct_params_afv_4x4, writer));
       break;
     }
   }

--- a/lib/jxl/quant_weights.cc
+++ b/lib/jxl/quant_weights.cc
@@ -450,9 +450,9 @@ Status Decode(BitReader* br, QuantEncoding* encoding, size_t required_size_x,
         for (size_t i = 0; i < 6; i++) {
           encoding->afv_weights[c][i] *= 64;
         }
-        JXL_RETURN_IF_ERROR(DecodeDctParams(br, &encoding->dct_params));
-        JXL_RETURN_IF_ERROR(DecodeDctParams(br, &encoding->dct_params_afv_4x4));
       }
+      JXL_RETURN_IF_ERROR(DecodeDctParams(br, &encoding->dct_params));
+      JXL_RETURN_IF_ERROR(DecodeDctParams(br, &encoding->dct_params_afv_4x4));
       break;
     }
     case QuantEncoding::kQuantModeDCT: {


### PR DESCRIPTION
Fixes #1484.

As far as we are aware, no encoder today produces files with custom AFV
matrices, so this fix should be safe.