### PR TITLE
Add tests for rendering partially decoded streams with API.

### DIFF
--- a/lib/jxl/test_utils.h
+++ b/lib/jxl/test_utils.h
@@ -636,6 +636,26 @@ size_t ComparePixels(const uint8_t* a, const uint8_t* b, size_t xsize,
   }
   return numdiff;
 }
+double DistanceRMS(const uint8_t* a, const uint8_t* b, size_t xsize,
+                   size_t ysize, const JxlPixelFormat& format) {
+  // Convert both images to equal full precision for comparison.
+  std::vector<double> a_full = ConvertToRGBA32(a, xsize, ysize, format);
+  std::vector<double> b_full = ConvertToRGBA32(b, xsize, ysize, format);
+  double sum = 0.0;
+  for (size_t y = 0; y < ysize; y++) {
+    double row_sum = 0.0;
+    for (size_t x = 0; x < xsize; x++) {
+      size_t i = (y * xsize + x) * 4;
+      for (size_t c = 0; c < format.num_channels; ++c) {
+        double diff = a_full[i + c] - b_full[i + c];
+        row_sum += diff * diff;
+      }
+    }
+    sum += row_sum;
+  }
+  sum /= (xsize * ysize);
+  return sqrt(sum);
+}
 }  // namespace test
 
 bool operator==(const jxl::PaddedBytes& a, const jxl::PaddedBytes& b) {


### PR DESCRIPTION
The tests only document the current state of API decoding, and
show that rendering on partial input produces new details when
we have a whole group available, but does not produce new details
if we only have part of a group available.
This is the case for both lossy and lossless modes.