### PR TITLE
Improved input handling in the decoder API implementation.

### DIFF
--- a/lib/include/jxl/decode.h
+++ b/lib/include/jxl/decode.h
@@ -189,6 +189,9 @@ typedef enum {
    * "JxlDecoderProcessInput": User extensions of the codestream header. This
    * event occurs max once per image and always later than @ref
    * JXL_DEC_BASIC_INFO and earlier than any pixel data.
+   *
+   * @deprecated The decoder no longer returns this, the header extensions,
+   * if any, are available at the JXL_DEC_BASIC_INFO event.
    */
   JXL_DEC_EXTENSIONS = 0x80,
 
@@ -518,8 +521,6 @@ JXL_EXPORT JxlDecoderStatus JxlDecoderSetCoalescing(JxlDecoder* dec,
  *     TODO(lode): document the input data mechanism
  * @return @ref JXL_DEC_NEED_MORE_INPUT when more input data is necessary.
  * @return @ref JXL_DEC_BASIC_INFO when basic info such as image dimensions is
- *     available and this informative event is subscribed to.
- * @return @ref JXL_DEC_EXTENSIONS when JPEG XL codestream user extensions are
  *     available and this informative event is subscribed to.
  * @return @ref JXL_DEC_COLOR_ENCODING when color profile information is
  *     available and this informative event is subscribed to.

--- a/lib/jxl/dec_file.cc
+++ b/lib/jxl/dec_file.cc
@@ -113,9 +113,12 @@ Status DecodeFile(const DecompressParams& dparams,
 
     if (io->metadata.m.have_preview) {
       JXL_RETURN_IF_ERROR(reader.JumpToByteBoundary());
-      JXL_RETURN_IF_ERROR(DecodeFrame(dparams, &dec_state, pool, &reader,
-                                      &io->preview_frame, io->metadata,
-                                      &io->constraints, /*is_preview=*/true));
+      size_t preview_start = reader.TotalBitsConsumed() / kBitsPerByte;
+      JXL_RETURN_IF_ERROR(
+          DecodeFrame(dparams, &dec_state, pool, file.data() + preview_start,
+                      file.size() - preview_start, &io->preview_frame,
+                      io->metadata, &io->constraints, /*is_preview=*/true));
+      reader.SkipBits(io->preview_frame.decoded_bytes() * kBitsPerByte);
     }
 
     // Only necessary if no ICC and no preview.
@@ -134,12 +137,15 @@ Status DecodeFile(const DecompressParams& dparams,
       // Skip frames that are not displayed.
       bool found_displayed_frame = true;
       do {
+        size_t frame_start = reader.TotalBitsConsumed() / kBitsPerByte;
         dec_ok =
-            DecodeFrame(dparams, &dec_state, pool, &reader, &io->frames.back(),
+            DecodeFrame(dparams, &dec_state, pool, file.data() + frame_start,
+                        file.size() - frame_start, &io->frames.back(),
                         io->metadata, &io->constraints);
+        reader.SkipBits(io->frames.back().decoded_bytes() * kBitsPerByte);
         if (!dparams.allow_partial_files) {
           JXL_RETURN_IF_ERROR(dec_ok);
-        } else if (!dec_ok) {
+        } else if (!reader.AllReadsWithinBounds()) {
           io->frames.pop_back();
           found_displayed_frame = false;
           break;

--- a/lib/jxl/dec_frame.h
+++ b/lib/jxl/dec_frame.h
@@ -42,8 +42,8 @@ Status DecodeFrameHeader(BitReader* JXL_RESTRICT reader,
 // `decoded->metadata` must already be set and must match metadata.m.
 Status DecodeFrame(const DecompressParams& dparams,
                    PassesDecoderState* dec_state, ThreadPool* JXL_RESTRICT pool,
-                   BitReader* JXL_RESTRICT reader, ImageBundle* decoded,
-                   const CodecMetadata& metadata,
+                   const uint8_t* next_in, size_t avail_in,
+                   ImageBundle* decoded, const CodecMetadata& metadata,
                    const SizeConstraints* constraints, bool is_preview = false);
 
 // TODO(veluca): implement "forced drawing".
@@ -129,6 +129,7 @@ class FrameDecoder {
   }
   const std::vector<uint32_t>& SectionSizes() const { return section_sizes_; }
   size_t NumSections() const { return section_sizes_.size(); }
+  uint64_t SumSectionSizes() const { return section_sizes_sum_; }
 
   // TODO(veluca): remove once we remove --downsampling flag.
   void SetMaxPasses(size_t max_passes) { max_passes_ = max_passes; }
@@ -304,6 +305,7 @@ class FrameDecoder {
   ThreadPool* pool_;
   std::vector<uint64_t> section_offsets_;
   std::vector<uint32_t> section_sizes_;
+  uint64_t section_sizes_sum_;
   size_t max_passes_;
   // TODO(veluca): figure out the duplication between these and dec_state_.
   FrameHeader frame_header_;

--- a/lib/jxl/enc_cache.cc
+++ b/lib/jxl/enc_cache.cc
@@ -143,7 +143,6 @@ Status InitializePassesEncoder(const Image3F& opsin, const JxlCmsInterface& cms,
     const Span<const uint8_t> encoded = special_frame->GetSpan();
     enc_state->special_frames.emplace_back(std::move(special_frame));
 
-    BitReader br(encoded);
     ImageBundle decoded(&shared.metadata->m);
     std::unique_ptr<PassesDecoderState> dec_state =
         jxl::make_unique<PassesDecoderState>();
@@ -151,9 +150,14 @@ Status InitializePassesEncoder(const Image3F& opsin, const JxlCmsInterface& cms,
         *shared.metadata,
         ColorEncoding::LinearSRGB(shared.metadata->m.color_encoding.IsGray()),
         /*desired_intensity_target=*/0));
+    const uint8_t* frame_start = encoded.data();
+    size_t encoded_size = encoded.size();
     for (int i = 0; i <= cparams.progressive_dc; ++i) {
-      JXL_CHECK(DecodeFrame({}, dec_state.get(), pool, &br, &decoded,
-                            *shared.metadata, /*constraints=*/nullptr));
+      JXL_CHECK(DecodeFrame({}, dec_state.get(), pool, frame_start,
+                            encoded_size, &decoded, *shared.metadata,
+                            /*constraints=*/nullptr));
+      frame_start += decoded.decoded_bytes();
+      encoded_size -= decoded.decoded_bytes();
     }
     // TODO(lode): shared.frame_header.dc_level should be equal to
     // dec_state.shared->frame_header.dc_level - 1 here, since above we set
@@ -164,7 +168,7 @@ Status InitializePassesEncoder(const Image3F& opsin, const JxlCmsInterface& cms,
         CopyImage(dec_state->shared->dc_frames[shared.frame_header.dc_level]);
     ZeroFillImage(&shared.quant_dc);
     shared.dc = &shared.dc_storage;
-    JXL_CHECK(br.Close());
+    JXL_CHECK(encoded_size == 0);
   } else {
     auto compute_dc_coeffs = [&](int group_index, int /* thread */) {
       modular_frame_encoder->AddVarDCTDC(

--- a/lib/jxl/enc_patch_dictionary.cc
+++ b/lib/jxl/enc_patch_dictionary.cc
@@ -770,7 +770,6 @@ void RoundtripPatchFrame(Image3F* reference_frame,
   const Span<const uint8_t> encoded = special_frame->GetSpan();
   state->special_frames.emplace_back(std::move(special_frame));
   if (subtract) {
-    BitReader br(encoded);
     ImageBundle decoded(&state->shared.metadata->m);
     PassesDecoderState dec_state;
     JXL_CHECK(dec_state.output_encoding_info.Set(
@@ -778,16 +777,22 @@ void RoundtripPatchFrame(Image3F* reference_frame,
         ColorEncoding::LinearSRGB(
             state->shared.metadata->m.color_encoding.IsGray()),
         /*desired_intensity_target=*/0));
-    JXL_CHECK(DecodeFrame({}, &dec_state, pool, &br, &decoded,
-                          *state->shared.metadata, /*constraints=*/nullptr));
+    const uint8_t* frame_start = encoded.data();
+    size_t encoded_size = encoded.size();
+    JXL_CHECK(DecodeFrame({}, &dec_state, pool, frame_start, encoded_size,
+                          &decoded, *state->shared.metadata,
+                          /*constraints=*/nullptr));
+    frame_start += decoded.decoded_bytes();
+    encoded_size -= decoded.decoded_bytes();
     size_t ref_xsize =
         dec_state.shared_storage.reference_frames[idx].storage.color()->xsize();
     // if the frame itself uses patches, we need to decode another frame
     if (!ref_xsize) {
-      JXL_CHECK(DecodeFrame({}, &dec_state, pool, &br, &decoded,
-                            *state->shared.metadata, /*constraints=*/nullptr));
+      JXL_CHECK(DecodeFrame({}, &dec_state, pool, frame_start, encoded_size,
+                            &decoded, *state->shared.metadata,
+                            /*constraints=*/nullptr));
     }
-    JXL_CHECK(br.Close());
+    JXL_CHECK(encoded_size == 0);
     state->shared.reference_frames[idx] =
         std::move(dec_state.shared_storage.reference_frames[idx]);
   } else {

--- a/lib/jxl/frame_header.h
+++ b/lib/jxl/frame_header.h
@@ -279,7 +279,7 @@ struct Passes : public Fields {
     }
   }
 
-  uint32_t GetDownsamplingTargetForCompletedPasses(uint32_t num_p) {
+  uint32_t GetDownsamplingTargetForCompletedPasses(uint32_t num_p) const {
     if (num_p >= num_passes) return 1;
     uint32_t retval = 8;
     for (uint32_t i = 0; i < num_downsample; ++i) {


### PR DESCRIPTION
For JXL_DEC_NEED_MORE_INPUT events, we always consume everything,
except if we are in a signature, box header or the first 4 bytes of
brob/ftyp/jxlp boxes.

For JXL_DEC_BASIC info, we consume input until the end of ImageMetadata,
together with extensions, and we no longer return JXL_DEC_EXTENSIONS.

For JXL_DEC_COLOR_ENCODING, we consume input until end of all headers.

For JXL_DEC_PREVIEW_IMAGE, we consume input until end of preview frame.

For JXL_DEC_FRAME, we consume input until end of frame header.

Still missing is the input handling for the JXL_DEC_FRAME_PROGRESSION
events.