### PR TITLE
README.md: HTTP => HTTPS

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -29,6 +29,7 @@ Don Olmstead <don.j.olmstead@gmail.com>
 Even Rouault <even.rouault@spatialys.com>
 Heiko Becker <heirecka@exherbo.org>
 Jon Sneyers <jon@cloudinary.com>
+Kai Hollberg <Schweinepriester@users.noreply.github.com>
 Kleis Auke Wolthuizen <github@kleisauke.nl>
 L. E. Segovia
 Leo Izen <leo.izen@gmail.com>

--- a/README.md
+++ b/README.md
@@ -168,7 +168,7 @@ format: Cloudinary and Google.
 *   [JPEG XL Format Overview](doc/format_overview.md)
 *   [Introductory paper](https://www.spiedigitallibrary.org/proceedings/Download?fullDOI=10.1117%2F12.2529237) (open-access)
 *   [XL Overview](doc/xl_overview.md) - a brief introduction to the source code modules
-*   [JPEG XL white paper](http://ds.jpeg.org/whitepapers/jpeg-xl-whitepaper.pdf)
+*   [JPEG XL white paper](https://ds.jpeg.org/whitepapers/jpeg-xl-whitepaper.pdf)
 *   [JPEG XL official website](https://jpeg.org/jpegxl)
 *   [JPEG XL community website](https://jpegxl.info)
 


### PR DESCRIPTION
Checked the link, the PDF is available via HTTPS as well:

http://ds.jpeg.org/whitepapers/jpeg-xl-whitepaper.pdf
vs.
https://ds.jpeg.org/whitepapers/jpeg-xl-whitepaper.pdf