### PR TITLE
Improved input handling in the decoder API (part 2).

### DIFF
--- a/lib/jxl/toc.h
+++ b/lib/jxl/toc.h
@@ -13,6 +13,7 @@
 
 #include "lib/jxl/base/compiler_specific.h"
 #include "lib/jxl/base/status.h"
+#include "lib/jxl/coeff_order_fwd.h"
 #include "lib/jxl/dec_bit_reader.h"
 #include "lib/jxl/field_encodings.h"
 
@@ -39,6 +40,10 @@ static JXL_INLINE size_t NumTocEntries(size_t num_groups, size_t num_dc_groups,
   return AcGroupIndex(0, 0, num_groups, num_dc_groups, has_ac_global) +
          num_groups * num_passes;
 }
+
+Status ReadToc(size_t toc_entries, BitReader* JXL_RESTRICT reader,
+               std::vector<uint32_t>* JXL_RESTRICT sizes,
+               std::vector<coeff_order_t>* JXL_RESTRICT permutation);
 
 Status ReadGroupOffsets(size_t toc_entries, BitReader* JXL_RESTRICT reader,
                         std::vector<uint64_t>* JXL_RESTRICT offsets,

--- a/lib/jxl/toc_test.cc
+++ b/lib/jxl/toc_test.cc
@@ -81,7 +81,7 @@ void Roundtrip(size_t num_entries, bool permute, Rng* rng) {
 
 TEST(TocTest, Test) {
   Rng rng(0);
-  for (size_t num_entries = 0; num_entries < 10; ++num_entries) {
+  for (size_t num_entries = 1; num_entries < 10; ++num_entries) {
     for (bool permute : std::vector<bool>{false, true}) {
       Roundtrip(num_entries, permute, &rng);
     }


### PR DESCRIPTION
This is a continuation of PR #1501.

For JXL_DEC_FRAME_PROGRESSION events, we stop at the end of the
section that was required to produce the progression event.

If the caller of the API does not subscribe to the full image output,
the decoder now stops and returns JXL_DEC_SUCCESS at the last event
that was produced from all of the subscribed ones.

Added tests for input handling for one-shot and streaming input.

The decoder now clears the codestream_copy when it advances the
codestream, so we now only use it as a temporary buffer instead of
the copy of the whole codestream.