### PR TITLE
Fix cjxl_ng for inputs with an ICC profile

### DIFF
--- a/tools/cjxl_ng_main.cc
+++ b/tools/cjxl_ng_main.cc
@@ -798,7 +798,6 @@ int main(int argc, char** argv) {
       }
 
       if (!ppf.icc.empty()) {
-        JxlEncoderSetICCProfile(jxl_encoder, ppf.icc.data(), ppf.icc.size());
         if (JXL_ENC_SUCCESS != JxlEncoderSetICCProfile(jxl_encoder,
                                                        ppf.icc.data(),
                                                        ppf.icc.size())) {


### PR DESCRIPTION
`JxlEncoderSetICCProfile` was accidentally called twice.