### PR TITLE
Broader application of JxlDecoderSetPreferredColorProfile.

### DIFF
--- a/lib/include/jxl/decode.h
+++ b/lib/include/jxl/decode.h
@@ -746,22 +746,15 @@ JXL_EXPORT JxlDecoderStatus JxlDecoderGetColorAsICCProfile(
 
 /** Sets the color profile to use for @ref JXL_COLOR_PROFILE_TARGET_DATA for the
  * special case when the decoder has a choice. This only has effect for a JXL
- * image where uses_original_profile is false, and the original color profile is
- * encoded as an ICC color profile rather than a JxlColorEncoding with known
- * enum values. In most other cases (uses uses_original_profile is true, or the
- * color profile is already given as a JxlColorEncoding), this setting is
- * ignored and the decoder uses a profile related to the image.
+ * image where uses_original_profile is false. If uses_original_profile is true,
+ * this setting is ignored and the decoder uses a profile related to the image.
  * No matter what, the @ref JXL_COLOR_PROFILE_TARGET_DATA must still be queried
  * to know the actual data format of the decoded pixels after decoding.
  *
- * The intended use case of this function is for cases where you are using
- * a color management system to parse the original ICC color profile
- * (@ref JXL_COLOR_PROFILE_TARGET_ORIGINAL), from this you know that the ICC
- * profile represents one of the color profiles supported by JxlColorEncoding
- * (such as sRGB, PQ or HLG): in that case it is beneficial (but not necessary)
- * to use @ref JxlDecoderSetPreferredColorProfile to match the parsed profile.
  * The JXL decoder has no color management system built in, but can convert XYB
- * color to any of the ones supported by JxlColorEncoding.
+ * color to any of the ones supported by JxlColorEncoding. Note that if the
+ * requested color encoding has a narrower gamut, or the white points differ,
+ * then the resulting image can have significant color distortion.
  *
  * Can only be set after the @ref JXL_DEC_COLOR_ENCODING event occurred and
  * before any other event occurred, and can affect the result of @ref

--- a/lib/jxl/dec_file.cc
+++ b/lib/jxl/dec_file.cc
@@ -106,10 +106,12 @@ Status DecodeFile(const DecompressParams& dparams,
     }
 
     PassesDecoderState dec_state;
-    JXL_RETURN_IF_ERROR(dec_state.output_encoding_info.Set(
-        io->metadata,
-        ColorEncoding::LinearSRGB(io->metadata.m.color_encoding.IsGray()),
-        dparams.desired_intensity_target));
+    JXL_RETURN_IF_ERROR(
+        dec_state.output_encoding_info.SetFromMetadata(io->metadata));
+    if (dparams.desired_intensity_target > 0) {
+      dec_state.output_encoding_info.desired_intensity_target =
+          dparams.desired_intensity_target;
+    }
 
     if (io->metadata.m.have_preview) {
       JXL_RETURN_IF_ERROR(reader.JumpToByteBoundary());

--- a/lib/jxl/dec_frame.h
+++ b/lib/jxl/dec_frame.h
@@ -64,9 +64,6 @@ class FrameDecoder {
   }
   void SetRenderSpotcolors(bool rsc) { render_spotcolors_ = rsc; }
   void SetCoalescing(bool c) { coalescing_ = c; }
-  void SetDesiredIntensityTarget(float desired_intensity_target) {
-    desired_intensity_target_ = desired_intensity_target;
-  }
 
   // Read FrameHeader and table of contents from the given BitReader.
   // Also checks frame dimensions for their limits, and sets the output
@@ -218,7 +215,8 @@ class FrameDecoder {
     if (decoded_->metadata()->xyb_encoded &&
         dec_state_->output_encoding_info.color_encoding.IsSRGB() &&
         dec_state_->output_encoding_info.all_default_opsin &&
-        dec_state_->output_encoding_info.desired_intensity_target == 0 &&
+        dec_state_->output_encoding_info.desired_intensity_target ==
+            dec_state_->output_encoding_info.orig_intensity_target &&
         HasFastXYBTosRGB8() && frame_header_.needs_color_transform()) {
       dec_state_->fast_xyb_srgb8_conversion = true;
     }
@@ -313,7 +311,6 @@ class FrameDecoder {
   bool allow_partial_frames_;
   bool render_spotcolors_ = true;
   bool coalescing_ = true;
-  float desired_intensity_target_ = 0.f;
 
   std::vector<uint8_t> processed_section_;
   std::vector<uint8_t> decoded_passes_per_ac_group_;

--- a/lib/jxl/dec_xyb.cc
+++ b/lib/jxl/dec_xyb.cc
@@ -196,89 +196,31 @@ void OpsinParams::Init(float intensity_target) {
   }
 }
 
-Status OutputEncodingInfo::Set(const CodecMetadata& metadata,
-                               const ColorEncoding& default_enc,
-                               float desired_intensity_target) {
-  const auto& im = metadata.transform_data.opsin_inverse_matrix;
-  float inverse_matrix[9];
-  memcpy(inverse_matrix, im.inverse_matrix, sizeof(inverse_matrix));
-  orig_intensity_target = metadata.m.IntensityTarget();
-  float encoding_intensity_target = orig_intensity_target;
-  this->desired_intensity_target = desired_intensity_target;
-  orig_color_encoding = metadata.m.color_encoding;
-  if (metadata.m.xyb_encoded) {
-    color_encoding = default_enc;
-    // Figure out if we can output to this color encoding.
-    do {
-      if (!orig_color_encoding.HaveFields()) break;
-      // TODO(veluca): keep in sync with dec_reconstruct.cc
-      if (!orig_color_encoding.tf.IsPQ() && !orig_color_encoding.tf.IsSRGB() &&
-          !orig_color_encoding.tf.IsGamma() &&
-          !orig_color_encoding.tf.IsLinear() &&
-          !orig_color_encoding.tf.IsHLG() && !orig_color_encoding.tf.IsDCI() &&
-          !orig_color_encoding.tf.Is709()) {
-        break;
-      }
-      if (orig_color_encoding.tf.IsGamma()) {
-        inverse_gamma = orig_color_encoding.tf.GetGamma();
-      }
-      if (orig_color_encoding.tf.IsDCI()) {
-        inverse_gamma = 1.0f / 2.6f;
-      }
-      if (orig_color_encoding.IsGray() &&
-          orig_color_encoding.white_point != WhitePoint::kD65) {
-        // TODO(veluca): figure out what should happen here.
-        break;
-      }
+bool CanOutputToColorEncoding(const ColorEncoding& c_desired) {
+  if (!c_desired.HaveFields()) {
+    return false;
+  }
+  // TODO(veluca): keep in sync with dec_reconstruct.cc
+  if (!c_desired.tf.IsPQ() && !c_desired.tf.IsSRGB() &&
+      !c_desired.tf.IsGamma() && !c_desired.tf.IsLinear() &&
+      !c_desired.tf.IsHLG() && !c_desired.tf.IsDCI() && !c_desired.tf.Is709()) {
+    return false;
+  }
+  if (c_desired.IsGray() && c_desired.white_point != WhitePoint::kD65) {
+    // TODO(veluca): figure out what should happen here.
+    return false;
+  }
+  return true;
+}
 
-      if ((orig_color_encoding.primaries != Primaries::kSRGB ||
-           orig_color_encoding.white_point != WhitePoint::kD65) &&
-          !orig_color_encoding.IsGray()) {
-        all_default_opsin = false;
-        float srgb_to_xyzd50[9];
-        const auto& srgb = ColorEncoding::SRGB(/*is_gray=*/false);
-        JXL_CHECK(PrimariesToXYZD50(
-            srgb.GetPrimaries().r.x, srgb.GetPrimaries().r.y,
-            srgb.GetPrimaries().g.x, srgb.GetPrimaries().g.y,
-            srgb.GetPrimaries().b.x, srgb.GetPrimaries().b.y,
-            srgb.GetWhitePoint().x, srgb.GetWhitePoint().y, srgb_to_xyzd50));
-        float original_to_xyz[3][3];
-        JXL_RETURN_IF_ERROR(PrimariesToXYZ(
-            orig_color_encoding.GetPrimaries().r.x,
-            orig_color_encoding.GetPrimaries().r.y,
-            orig_color_encoding.GetPrimaries().g.x,
-            orig_color_encoding.GetPrimaries().g.y,
-            orig_color_encoding.GetPrimaries().b.x,
-            orig_color_encoding.GetPrimaries().b.y,
-            orig_color_encoding.GetWhitePoint().x,
-            orig_color_encoding.GetWhitePoint().y, &original_to_xyz[0][0]));
-        memcpy(luminances, original_to_xyz[1], sizeof luminances);
-        float adapt_to_d50[9];
-        JXL_RETURN_IF_ERROR(AdaptToXYZD50(orig_color_encoding.GetWhitePoint().x,
-                                          orig_color_encoding.GetWhitePoint().y,
-                                          adapt_to_d50));
-        float xyzd50_to_original[9];
-        MatMul(adapt_to_d50, &original_to_xyz[0][0], 3, 3, 3,
-               xyzd50_to_original);
-        JXL_RETURN_IF_ERROR(Inv3x3Matrix(xyzd50_to_original));
-        float srgb_to_original[9];
-        MatMul(xyzd50_to_original, srgb_to_xyzd50, 3, 3, 3, srgb_to_original);
-        MatMul(srgb_to_original, im.inverse_matrix, 3, 3, 3, inverse_matrix);
-      }
-      color_encoding = orig_color_encoding;
-      color_encoding_is_original = true;
-      if (color_encoding.tf.IsPQ()) {
-        encoding_intensity_target = 10000;
-      }
-    } while (false);
-  } else {
-    color_encoding = metadata.m.color_encoding;
-  }
-  if (std::abs(encoding_intensity_target - 255.0) > 0.1f || !im.all_default) {
-    all_default_opsin = false;
-  }
-  InitSIMDInverseMatrix(inverse_matrix, opsin_params.inverse_opsin_matrix,
-                        encoding_intensity_target);
+Status OutputEncodingInfo::SetFromMetadata(const CodecMetadata& metadata) {
+  orig_color_encoding = metadata.m.color_encoding;
+  orig_intensity_target = metadata.m.IntensityTarget();
+  desired_intensity_target = orig_intensity_target;
+  const auto& im = metadata.transform_data.opsin_inverse_matrix;
+  memcpy(orig_inverse_matrix, im.inverse_matrix, sizeof(orig_inverse_matrix));
+  default_transform = im.all_default;
+  xyb_encoded = metadata.m.xyb_encoded;
   std::copy(std::begin(im.opsin_biases), std::end(im.opsin_biases),
             opsin_params.opsin_biases);
   for (int i = 0; i < 3; ++i) {
@@ -287,6 +229,81 @@ Status OutputEncodingInfo::Set(const CodecMetadata& metadata,
   opsin_params.opsin_biases_cbrt[3] = opsin_params.opsin_biases[3] = 1;
   std::copy(std::begin(im.quant_biases), std::end(im.quant_biases),
             opsin_params.quant_biases);
+  bool orig_ok = CanOutputToColorEncoding(orig_color_encoding);
+  bool orig_grey = orig_color_encoding.IsGray();
+  return SetColorEncoding(!xyb_encoded || orig_ok
+                              ? orig_color_encoding
+                              : ColorEncoding::LinearSRGB(orig_grey));
+}
+
+Status OutputEncodingInfo::MaybeSetColorEncoding(const ColorEncoding& color) {
+  if (!xyb_encoded || !CanOutputToColorEncoding(color)) {
+    return false;
+  }
+  return SetColorEncoding(color);
+}
+
+Status OutputEncodingInfo::SetColorEncoding(const ColorEncoding& c_desired) {
+  color_encoding = c_desired;
+  color_encoding_is_original = orig_color_encoding.SameColorEncoding(c_desired);
+
+  // Compute the opsin inverse matrix and luminances based on primaries and
+  // white point.
+  float inverse_matrix[9];
+  bool inverse_matrix_is_default = default_transform;
+  memcpy(inverse_matrix, orig_inverse_matrix, sizeof(inverse_matrix));
+  constexpr float kSRGBLuminances[3] = {0.2126, 0.7152, 0.0722};
+  memcpy(luminances, kSRGBLuminances, sizeof(luminances));
+  if ((c_desired.primaries != Primaries::kSRGB ||
+       c_desired.white_point != WhitePoint::kD65) &&
+      !c_desired.IsGray()) {
+    float srgb_to_xyzd50[9];
+    const auto& srgb = ColorEncoding::SRGB(/*is_gray=*/false);
+    JXL_CHECK(PrimariesToXYZD50(
+        srgb.GetPrimaries().r.x, srgb.GetPrimaries().r.y,
+        srgb.GetPrimaries().g.x, srgb.GetPrimaries().g.y,
+        srgb.GetPrimaries().b.x, srgb.GetPrimaries().b.y,
+        srgb.GetWhitePoint().x, srgb.GetWhitePoint().y, srgb_to_xyzd50));
+    float original_to_xyz[3][3];
+    JXL_RETURN_IF_ERROR(PrimariesToXYZ(
+        c_desired.GetPrimaries().r.x, c_desired.GetPrimaries().r.y,
+        c_desired.GetPrimaries().g.x, c_desired.GetPrimaries().g.y,
+        c_desired.GetPrimaries().b.x, c_desired.GetPrimaries().b.y,
+        c_desired.GetWhitePoint().x, c_desired.GetWhitePoint().y,
+        &original_to_xyz[0][0]));
+    memcpy(luminances, original_to_xyz[1], sizeof luminances);
+    if (xyb_encoded) {
+      float adapt_to_d50[9];
+      JXL_RETURN_IF_ERROR(AdaptToXYZD50(c_desired.GetWhitePoint().x,
+                                        c_desired.GetWhitePoint().y,
+                                        adapt_to_d50));
+      float xyzd50_to_original[9];
+      MatMul(adapt_to_d50, &original_to_xyz[0][0], 3, 3, 3, xyzd50_to_original);
+      JXL_RETURN_IF_ERROR(Inv3x3Matrix(xyzd50_to_original));
+      float srgb_to_original[9];
+      MatMul(xyzd50_to_original, srgb_to_xyzd50, 3, 3, 3, srgb_to_original);
+      MatMul(srgb_to_original, orig_inverse_matrix, 3, 3, 3, inverse_matrix);
+      inverse_matrix_is_default = false;
+    }
+  }
+
+  // The internal XYB color space uses absolute luminance, so we scale back the
+  // opsin inverse matrix to relative luminance where 1.0 corresponds to the
+  // original intensity target, or to absolute luminance for PQ, where 1.0
+  // corresponds to 10000 nits.
+  if (xyb_encoded) {
+    float intensity_target =
+        (c_desired.tf.IsPQ() ? 10000 : orig_intensity_target);
+    InitSIMDInverseMatrix(inverse_matrix, opsin_params.inverse_opsin_matrix,
+                          intensity_target);
+    all_default_opsin = (std::abs(intensity_target - 255.0) <= 0.1f &&
+                         inverse_matrix_is_default);
+  }
+
+  // Set the inverse gamma based on color space transfer function.
+  inverse_gamma = (c_desired.tf.IsGamma() ? c_desired.tf.GetGamma()
+                   : c_desired.tf.IsDCI() ? 1.0f / 2.6f
+                                          : 1.0);
   return true;
 }
 

--- a/lib/jxl/dec_xyb.h
+++ b/lib/jxl/dec_xyb.h
@@ -29,27 +29,39 @@ struct OpsinParams {
 };
 
 struct OutputEncodingInfo {
+  //
+  // Fields depending only on image metadata
+  //
   ColorEncoding orig_color_encoding;
+  // Used for the HLG OOTF and PQ tone mapping.
+  float orig_intensity_target;
+  // Opsin inverse matrix taken from the metadata.
+  float orig_inverse_matrix[9];
+  bool default_transform;
+  bool xyb_encoded;
+  //
+  // Fields depending on output color encoding
+  //
   ColorEncoding color_encoding;
-  // Used for Gamma and DCI transfer functions.
-  float inverse_gamma;
+  bool color_encoding_is_original;
   // Contains an opsin matrix that converts to the primaries of the output
   // encoding.
   OpsinParams opsin_params;
-  // default_enc is used for xyb encoded image with ICC profile, in other
-  // cases it has no effect. Use linear sRGB or grayscale if ICC profile is
-  // not matched (not parsed or no matching ColorEncoding exists)
-  Status Set(const CodecMetadata& metadata, const ColorEncoding& default_enc,
-             float desired_intensity_target);
-  bool all_default_opsin = true;
-  bool color_encoding_is_original = false;
+  bool all_default_opsin;
+  // Used for Gamma and DCI transfer functions.
+  float inverse_gamma;
   // Luminances of color_encoding's primaries, used for the HLG inverse OOTF and
   // for PQ tone mapping.
   // Default to sRGB's.
-  float luminances[3] = {0.2126, 0.7152, 0.0722};
-  // Also used for the HLG inverse OOTF and PQ tone mapping.
-  float orig_intensity_target;
+  float luminances[3];
+  // Used for the HLG inverse OOTF and PQ tone mapping.
   float desired_intensity_target;
+
+  Status SetFromMetadata(const CodecMetadata& metadata);
+  Status MaybeSetColorEncoding(const ColorEncoding& c_desired);
+
+ private:
+  Status SetColorEncoding(const ColorEncoding& c_desired);
 };
 
 // Converts `inout` (not padded) from opsin to linear sRGB in-place. Called from

--- a/lib/jxl/enc_adaptive_quantization.cc
+++ b/lib/jxl/enc_adaptive_quantization.cc
@@ -1071,11 +1071,8 @@ ImageBundle RoundtripImage(const Image3F& opsin, PassesEncoderState* enc_state,
   PROFILER_ZONE("enc roundtrip");
   std::unique_ptr<PassesDecoderState> dec_state =
       jxl::make_unique<PassesDecoderState>();
-  JXL_CHECK(dec_state->output_encoding_info.Set(
-      *enc_state->shared.metadata,
-      ColorEncoding::LinearSRGB(
-          enc_state->shared.metadata->m.color_encoding.IsGray()),
-      /*desired_intensity_target=*/0));
+  JXL_CHECK(dec_state->output_encoding_info.SetFromMetadata(
+      *enc_state->shared.metadata));
   dec_state->shared = &enc_state->shared;
   JXL_ASSERT(opsin.ysize() % kBlockDim == 0);
 

--- a/lib/jxl/enc_cache.cc
+++ b/lib/jxl/enc_cache.cc
@@ -146,10 +146,8 @@ Status InitializePassesEncoder(const Image3F& opsin, const JxlCmsInterface& cms,
     ImageBundle decoded(&shared.metadata->m);
     std::unique_ptr<PassesDecoderState> dec_state =
         jxl::make_unique<PassesDecoderState>();
-    JXL_CHECK(dec_state->output_encoding_info.Set(
-        *shared.metadata,
-        ColorEncoding::LinearSRGB(shared.metadata->m.color_encoding.IsGray()),
-        /*desired_intensity_target=*/0));
+    JXL_CHECK(
+        dec_state->output_encoding_info.SetFromMetadata(*shared.metadata));
     const uint8_t* frame_start = encoded.data();
     size_t encoded_size = encoded.size();
     for (int i = 0; i <= cparams.progressive_dc; ++i) {

--- a/lib/jxl/enc_patch_dictionary.cc
+++ b/lib/jxl/enc_patch_dictionary.cc
@@ -772,11 +772,8 @@ void RoundtripPatchFrame(Image3F* reference_frame,
   if (subtract) {
     ImageBundle decoded(&state->shared.metadata->m);
     PassesDecoderState dec_state;
-    JXL_CHECK(dec_state.output_encoding_info.Set(
-        *state->shared.metadata,
-        ColorEncoding::LinearSRGB(
-            state->shared.metadata->m.color_encoding.IsGray()),
-        /*desired_intensity_target=*/0));
+    JXL_CHECK(dec_state.output_encoding_info.SetFromMetadata(
+        *state->shared.metadata));
     const uint8_t* frame_start = encoded.data();
     size_t encoded_size = encoded.size();
     JXL_CHECK(DecodeFrame({}, &dec_state, pool, frame_start, encoded_size,

--- a/lib/jxl/render_pipeline/stage_from_linear.cc
+++ b/lib/jxl/render_pipeline/stage_from_linear.cc
@@ -155,7 +155,7 @@ std::unique_ptr<RenderPipelineStage> GetFromLinearStage(
   } else if (output_encoding_info.color_encoding.tf.IsHLG()) {
     return MakeFromLinearStage(
         OpHlg(output_encoding_info.luminances,
-              output_encoding_info.orig_intensity_target));
+              output_encoding_info.desired_intensity_target));
   } else if (output_encoding_info.color_encoding.tf.Is709()) {
     return MakeFromLinearStage(MakePerChannelOp(Op709()));
   } else if (output_encoding_info.color_encoding.tf.IsGamma() ||

--- a/lib/jxl/render_pipeline/stage_tone_mapping.cc
+++ b/lib/jxl/render_pipeline/stage_tone_mapping.cc
@@ -24,8 +24,12 @@ class ToneMappingStage : public RenderPipelineStage {
   explicit ToneMappingStage(OutputEncodingInfo output_encoding_info)
       : RenderPipelineStage(RenderPipelineStage::Settings()),
         output_encoding_info_(std::move(output_encoding_info)) {
+    if (output_encoding_info_.desired_intensity_target ==
+        output_encoding_info_.orig_intensity_target) {
+      // No tone mapping requested.
+      return;
+    }
     if (output_encoding_info_.orig_color_encoding.tf.IsPQ() &&
-        0 < output_encoding_info_.desired_intensity_target &&
         output_encoding_info_.desired_intensity_target <
             output_encoding_info_.orig_intensity_target) {
       tone_mapper_storage_ = AllocateArray(sizeof(ToneMapper));

--- a/lib/jxl/render_pipeline/stage_tone_mapping.h
+++ b/lib/jxl/render_pipeline/stage_tone_mapping.h
@@ -21,7 +21,7 @@ namespace jxl {
 // Tone maps the image if appropriate. It must be in linear space and
 // `output_encoding_info.luminances` must contain the luminance for the
 // primaries of that space. It must also be encoded such that (1, 1, 1)
-// represents `output_encoding_info.intensity_target` nits, unless
+// represents `output_encoding_info.orig_intensity_target` nits, unless
 // `output_encoding_info.color_encoding.tf.IsPQ()`, in which case (1, 1, 1) must
 // represent 10000 nits. This corresponds to what XYBStage outputs. After this
 // stage, (1, 1, 1) will represent

--- a/lib/jxl/test_utils.h
+++ b/lib/jxl/test_utils.h
@@ -220,6 +220,7 @@ static inline ColorEncoding ColorEncodingFromDescriptor(
   c.primaries = desc.primaries;
   c.tf.SetTransferFunction(desc.tf);
   c.rendering_intent = desc.rendering_intent;
+  JXL_CHECK(c.CreateICC());
   return c;
 }
 


### PR DESCRIPTION
This change enables JxlDecoderSetPreferredColorProfile in cases
where the image is xyb encoded and the original color encoding
is not given by an ICC profile.

Added tests for converting back to original profile and to convert
between color profiles given by enums.

Implemented the --color_space flag in djxl_ng using this new functionality.