### PR TITLE
Add explantion about uploading .jxl images

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -27,3 +27,11 @@ If applicable, add screenshots or example input/output images to help explain yo
 
 **Additional context**
 Add any other context about the problem here.
+
+<!--
+Currently github does not allow uploading files that end in `.jxl`, but when you
+rename them for example as `image.jxl.jpg`, it will be possible to upload them
+and also view them in browser that are configured to support it.
+
+See https://github.com/orgs/github-community/discussions/18139
+-->


### PR DESCRIPTION
This modifies the issue templates to encourage users to
upload .jxl images as .jxl.jpg, in order to be able to upload them
(and viewing them) instead of uploading them as .jxl.gz, where
viewing is not possible.