### PR TITLE
djxl_ng: allow apng extension

### DIFF
--- a/lib/extras/enc/encode.cc
+++ b/lib/extras/enc/encode.cc
@@ -59,7 +59,7 @@ std::unique_ptr<Encoder> Encoder::FromExtension(std::string extension) {
       extension.begin(), extension.end(), extension.begin(),
       [](char c) { return std::tolower(c, std::locale::classic()); });
 #if JPEGXL_ENABLE_APNG
-  if (extension == ".png") return GetAPNGEncoder();
+  if (extension == ".png" || extension == ".apng") return GetAPNGEncoder();
 #endif
 
 #if JPEGXL_ENABLE_JPEG


### PR DESCRIPTION
This is a fix for https://github.com/libjxl/libjxl/issues/1517, at least for `djxl_ng`.