### PR TITLE
Handle extra channels and metadata boxes in djxl_ng.

### DIFF
--- a/lib/extras/codec.cc
+++ b/lib/extras/codec.cc
@@ -109,8 +109,9 @@ Status Encode(const CodecInOut& io, const extras::Codec codec,
       }
       JXL_RETURN_IF_ERROR(extras::ConvertCodecInOutToPackedPixelFile(
           io, format, c_desired, pool, &ppf));
-      JXL_RETURN_IF_ERROR(extras::EncodeImagePNM(
-          ppf, bits_per_sample, pool, /*frame_index=*/0, &bytes_vector));
+      JXL_RETURN_IF_ERROR(
+          extras::EncodeImagePNM(ppf.frames[0].color, ppf.info.orientation,
+                                 bits_per_sample, &bytes_vector));
       bytes->assign(bytes_vector.data(),
                     bytes_vector.data() + bytes_vector.size());
       return true;

--- a/lib/extras/enc/encode.h
+++ b/lib/extras/enc/encode.h
@@ -28,6 +28,9 @@ struct EncodedImage {
   // more sequential bitstreams.
   std::vector<std::vector<uint8_t>> bitstreams;
 
+  // For each extra channel one or more sequential bitstreams.
+  std::vector<std::vector<std::vector<uint8_t>>> extra_channel_bitstreams;
+
   // If the format does not support embedding color profiles into the bitstreams
   // above, it will be present here, to be written as a separate file. If it
   // does support them, this field will be empty.

--- a/lib/extras/enc/pnm.h
+++ b/lib/extras/enc/pnm.h
@@ -13,11 +13,6 @@
 
 #include "lib/extras/enc/encode.h"
 #include "lib/extras/packed_image.h"
-#include "lib/jxl/base/data_parallel.h"
-#include "lib/jxl/base/padded_bytes.h"
-#include "lib/jxl/base/status.h"
-#include "lib/jxl/codec_in_out.h"
-#include "lib/jxl/color_encoding_internal.h"
 
 namespace jxl {
 namespace extras {
@@ -26,10 +21,8 @@ std::unique_ptr<Encoder> GetPGMEncoder();
 std::unique_ptr<Encoder> GetPPMEncoder();
 std::unique_ptr<Encoder> GetPFMEncoder();
 
-// Transforms from io->c_current to `c_desired` and encodes into `bytes`.
-Status EncodeImagePNM(const PackedPixelFile& ppf, size_t bits_per_sample,
-                      ThreadPool* pool, size_t frame_index,
-                      std::vector<uint8_t>* bytes);
+Status EncodeImagePNM(const PackedImage& image, JxlOrientation orientation,
+                      size_t bits_per_sample, std::vector<uint8_t>* bytes);
 
 }  // namespace extras
 }  // namespace jxl

--- a/lib/extras/packed_image.h
+++ b/lib/extras/packed_image.h
@@ -77,6 +77,11 @@ class PackedImage {
   JxlPixelFormat format;
   size_t pixels_size;
 
+  size_t pixel_stride() const {
+    return (BitsPerChannel(format.data_type) * format.num_channels /
+            jxl::kBitsPerByte);
+  }
+
   static size_t BitsPerChannel(JxlDataType data_type) {
     switch (data_type) {
       case JXL_TYPE_UINT8:
@@ -140,11 +145,8 @@ class PackedPixelFile {
 
   // The extra channel metadata information.
   struct PackedExtraChannel {
-    PackedExtraChannel(const JxlExtraChannelInfo& ec_info,
-                       const std::string& name)
-        : ec_info(ec_info), name(name) {}
-
     JxlExtraChannelInfo ec_info;
+    size_t index;
     std::string name;
   };
   std::vector<PackedExtraChannel> extra_channels_info;


### PR DESCRIPTION
Extra channels (other then first alpha) are written as separate
images. This is currently implemented only for the pnm encoder.