### PR TITLE
new metric: XYB MSSSIM

### DIFF
--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -221,12 +221,14 @@ if(${JPEGXL_ENABLE_DEVTOOLS})
     ssimulacra_main
     xyb_range
     jxl_from_tree
+    xybmsssim
   )
 
   add_executable(fuzzer_corpus fuzzer_corpus.cc)
 
   add_executable(ssimulacra_main ssimulacra_main.cc ssimulacra.cc)
   add_executable(butteraugli_main butteraugli_main.cc)
+  add_executable(xybmsssim xybmsssim.cc)
   add_executable(decode_and_encode decode_and_encode.cc)
   add_executable(display_to_hlg hdr/display_to_hlg.cc)
   add_executable(pq_to_hlg hdr/pq_to_hlg.cc)

--- a/tools/xybmsssim.cc
+++ b/tools/xybmsssim.cc
@@ -1,0 +1,286 @@
+// Copyright (c) the JPEG XL Project Authors. All rights reserved.
+//
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// Multi-Scale SSIM in XYB color space
+
+#include "tools/xybmsssim.h"
+
+#include <stdio.h>
+
+#include <cmath>
+
+#include "lib/extras/codec.h"
+#include "lib/jxl/color_management.h"
+#include "lib/jxl/enc_color_management.h"
+#include "lib/jxl/enc_xyb.h"
+#include "lib/jxl/gauss_blur.h"
+#include "lib/jxl/image_ops.h"
+
+namespace xybmsssim {
+namespace {
+
+using jxl::Image3F;
+using jxl::ImageF;
+
+static const float kC1 = 0.0001f;
+static const float kC2 = 0.0004f;
+static const int kNumScales = 6;
+
+Image3F Downsample(const Image3F& in, size_t fx, size_t fy) {
+  const size_t out_xsize = (in.xsize() + fx - 1) / fx;
+  const size_t out_ysize = (in.ysize() + fy - 1) / fy;
+  Image3F out(out_xsize, out_ysize);
+  const float normalize = 1.0f / (fx * fy);
+  for (size_t c = 0; c < 3; ++c) {
+    for (size_t oy = 0; oy < out_ysize; ++oy) {
+      float* JXL_RESTRICT row_out = out.PlaneRow(c, oy);
+      for (size_t ox = 0; ox < out_xsize; ++ox) {
+        float sum = 0.0f;
+        for (size_t iy = 0; iy < fy; ++iy) {
+          for (size_t ix = 0; ix < fx; ++ix) {
+            const size_t x = std::min(ox * fx + ix, in.xsize() - 1);
+            const size_t y = std::min(oy * fy + iy, in.ysize() - 1);
+            sum += in.PlaneRow(c, y)[x];
+          }
+        }
+        row_out[ox] = sum * normalize;
+      }
+    }
+  }
+  return out;
+}
+
+void Multiply(const Image3F& a, const Image3F& b, Image3F* mul) {
+  for (size_t c = 0; c < 3; ++c) {
+    for (size_t y = 0; y < a.ysize(); ++y) {
+      const float* JXL_RESTRICT in1 = a.PlaneRow(c, y);
+      const float* JXL_RESTRICT in2 = b.PlaneRow(c, y);
+      float* JXL_RESTRICT out = mul->PlaneRow(c, y);
+      for (size_t x = 0; x < a.xsize(); ++x) {
+        out[x] = in1[x] * in2[x];
+      }
+    }
+  }
+}
+
+// Temporary storage for Gaussian blur, reused for multiple images.
+class Blur {
+ public:
+  Blur(const size_t xsize, const size_t ysize)
+      : rg_(jxl::CreateRecursiveGaussian(1.5)), temp_(xsize, ysize) {}
+
+  void operator()(const ImageF& in, ImageF* JXL_RESTRICT out) {
+    jxl::ThreadPool* null_pool = nullptr;
+    FastGaussian(rg_, in, null_pool, &temp_, out);
+  }
+
+  Image3F operator()(const Image3F& in) {
+    Image3F out(in.xsize(), in.ysize());
+    operator()(in.Plane(0), &out.Plane(0));
+    operator()(in.Plane(1), &out.Plane(1));
+    operator()(in.Plane(2), &out.Plane(2));
+    return out;
+  }
+
+  // Allows reusing across scales.
+  void ShrinkTo(const size_t xsize, const size_t ysize) {
+    temp_.ShrinkTo(xsize, ysize);
+  }
+
+ private:
+  hwy::AlignedUniquePtr<jxl::RecursiveGaussian> rg_;
+  ImageF temp_;
+};
+
+void SSIMMap(const Image3F& m1, const Image3F& m2, const Image3F& s11,
+             const Image3F& s22, const Image3F& s12, Image3F* out,
+             double* plane_averages) {
+  const double onePerPixels = 1.0 / (out->ysize() * out->xsize());
+  for (size_t c = 0; c < 3; ++c) {
+    double sum1[4] = {0.0};
+    for (size_t y = 0; y < out->ysize(); ++y) {
+      const float* JXL_RESTRICT row_m1 = m1.PlaneRow(c, y);
+      const float* JXL_RESTRICT row_m2 = m2.PlaneRow(c, y);
+      const float* JXL_RESTRICT row_s11 = s11.PlaneRow(c, y);
+      const float* JXL_RESTRICT row_s22 = s22.PlaneRow(c, y);
+      const float* JXL_RESTRICT row_s12 = s12.PlaneRow(c, y);
+      float* JXL_RESTRICT row_out = out->PlaneRow(c, y);
+      for (size_t x = 0; x < out->xsize(); ++x) {
+        float mu1 = row_m1[x];
+        float mu2 = row_m2[x];
+        float mu11 = mu1 * mu1;
+        float mu22 = mu2 * mu2;
+        float mu12 = mu1 * mu2;
+        float nom_m = 2 * mu12 + kC1;
+        float nom_s = 2 * (row_s12[x] - mu12) + kC2;
+        float denom_m = mu11 + mu22 + kC1;
+        float denom_s = (row_s11[x] - mu11) + (row_s22[x] - mu22) + kC2;
+        row_out[x] = 1.f - ((nom_m * nom_s) / (denom_m * denom_s));
+        double d2 = row_out[x];
+        sum1[0] += d2;
+        d2 *= d2;
+        sum1[1] += d2;
+        d2 *= d2;
+        sum1[2] += d2;
+        d2 *= d2;
+        sum1[3] += d2;
+      }
+    }
+    for (int i = 0; i < 4; ++i) {
+      double e = pow(onePerPixels * sum1[i], 1.0 / (1.0 * (1 << i)));
+      plane_averages[c * 4 + i] = e;
+    }
+  }
+}
+
+}  // namespace
+
+double Msssim::Score() const {
+  double ssim = 0.0;
+  const double weight[72 * 2 + 2] = {
+      0.021973116402930787,  -11.523616782747345,    -147.37059822708056,
+      -1.6143866083529559,   -39.003437698173244,    -31.77851289789551,
+      -49.9672868154597,     62.78586191436433,      -11.053513167403734,
+      -25.25525534752599,    -11.415621837152546,    -23.38918350888089,
+      718.4310147320011,     -1023.9555732634483,    13.575607877577777,
+      141.50928115232477,    -16.788153923948656,    -11.14813741602568,
+      -16.743372236131428,   -11.11197562810807,     -19.316636306695123,
+      -20.138778296356875,   -19.477270281874418,    7.614588849564161,
+      0.07063913261015303,   227.040974959351,       313.52827186664183,
+      54.37789467869065,     322.4617307612118,      -11.04667377598248,
+      -20.540074595777423,   -29.548527190845817,    -0.9328007883120797,
+      -28.272946227881985,   16.672112311471277,     -11.526153821254828,
+      0.0009536336122358943, -0.0024173620930892925, 0.00276134245313746,
+      -19.675262442378354,   -0.33481507050708403,   -28.164158014477607,
+      -22.653668830863715,   -18.153649722461513,    -16.415731256266568,
+      35.61593605404771,     -32.39618248697417,     -241.4545530623837,
+      -17.340979714640063,   46381.62732487409,      -17.629683220501953,
+      13080.751179399924,    -0.18398984292625342,   -20.732735069582514,
+      -21.019782851043495,   -10.563109909082382,    -0.030149429486623774,
+      -26.798577154623352,   -36.8686653964214,      -15.645312144949866,
+      -30.865582183753954,   -0.004469813254280001,  -0.016411462368678867,
+      222311.65551417434,    0.01898423014962192,    -30.503711598127694,
+      -0.14054091135601224,  23.851160727703203,     0.03056930762289608,
+      -16.818967502698584,   -27.16862823681399,     -19.621844143993187,
+      16.5611193910485,      -1.116156823452251,     -0.677777124861732,
+      -1.2492563529750185,   9.677625317807392,      7.1531846932376375,
+      27.54129929386308,     -0.2633102031643941,    -1.3272962342215187,
+      51.000093303695444,    -1.1102844310813411,    11.913941162288666,
+      17.494045423192453,    -0.7914956525753191,    24.446457083956567,
+      -0.44272175599737584,  0.16384944378708885,    -1.1211940846283721,
+      8.132191144243372,     -1.6563024399769932,    -0.9166303361655113,
+      -0.8103546757732437,   -0.808317399866697,     -0.9795764111692445,
+      12.173967812437901,    25.044499271495702,     13.101551006910066,
+      -1.1463247029072159,   -0.4222594330259958,    -1.132327957487064,
+      9.363842191435552,     38.83335743612862,      -1.0998677284469365,
+      9.561955730070371,     -0.8577540499265555,    10.164679872122045,
+      5.174164800803601,     6.980151957954371,      4.564248527942422,
+      -0.6468187230353699,   10.614172148130983,     9.031116407927799,
+      18.089446230343704,    -0.7325871691753574,    18.634836028802297,
+      -1.1128013178866873,   26.168040233780744,     7.181927080200893,
+      -0.7596683767842739,   6.249875147821439,      -1.15666833927224,
+      8.594112201346285,     6.411467686728347,      -1.5457033203228143,
+      -1.1859673880665245,   -1.1153019963530784,    8.267647945954227,
+      18.25883548652105,     7.201468614200209,      10.006791677877976,
+      -1.0073087931737255,   6.048253005305727,      5.27839167059301,
+      9.086796676752908,     13.262383047279133,     -1.1512776806463452,
+      8.558057521289651,     -1.0737872485390612,    8.022981622712607,
+      16.08638451276799,     13.65961727400643,      15.093366785654075,
+      -0.06491732157830722,  0.3337168175410301};
+
+  for (size_t c = 0; c < 3; ++c) {
+    for (size_t scale = 0; scale < scales.size(); ++scale) {
+      for (size_t n = 0; n < 4; n++) {
+        size_t idx = scale * 12 + c * 4 + n;
+        ssim += std::max(-10.0, 1.0 + weight[idx]) *
+                pow(std::abs(scales[scale].avg_ssim[c * 4 + n]),
+                    std::max(0.125, std::min(weight[72 + idx] + 1.0, 8.0)));
+      }
+    }
+  }
+  ssim = 100.0 - (1.0 + weight[145]) * pow(std::abs(ssim), 1.0 + weight[144]);
+
+  //  if (ssim < 0) ssim = 0;
+  //  if (ssim > 100) ssim = 100;
+  return ssim;
+}
+
+Msssim ComputeMSSSIM(jxl::Image3F& img1, jxl::Image3F& img2) {
+  Msssim msssim;
+
+  Image3F mul(img1.xsize(), img1.ysize());
+  Blur blur(img1.xsize(), img1.ysize());
+
+  for (int scale = 0; scale < kNumScales; scale++) {
+    if (img1.xsize() < 8 || img1.ysize() < 8) {
+      break;
+    }
+    if (scale) {
+      img1 = Downsample(img1, 2, 2);
+      img2 = Downsample(img2, 2, 2);
+    }
+    mul.ShrinkTo(img1.xsize(), img2.ysize());
+    blur.ShrinkTo(img1.xsize(), img2.ysize());
+
+    Multiply(img1, img1, &mul);
+    Image3F sigma1_sq = blur(mul);
+
+    Multiply(img2, img2, &mul);
+    Image3F sigma2_sq = blur(mul);
+
+    Multiply(img1, img2, &mul);
+    Image3F sigma12 = blur(mul);
+
+    Image3F mu1 = blur(img1);
+    Image3F mu2 = blur(img2);
+    // Reuse mul as "ssim_map".
+    MsssimScale sscale;
+    SSIMMap(mu1, mu2, sigma1_sq, sigma2_sq, sigma12, &mul, sscale.avg_ssim);
+    msssim.scales.push_back(sscale);
+  }
+  return msssim;
+}
+
+namespace {
+
+int PrintUsage(char** argv) {
+  fprintf(stderr, "Usage: %s orig.png distorted.png\n", argv[0]);
+  return 1;
+}
+
+int Run(int argc, char** argv) {
+  if (argc != 3) return PrintUsage(argv);
+
+  jxl::CodecInOut io1;
+  jxl::CodecInOut io2;
+  JXL_CHECK(SetFromFile(argv[1], jxl::extras::ColorHints(), &io1));
+  JXL_CHECK(SetFromFile(argv[2], jxl::extras::ColorHints(), &io2));
+  JXL_CHECK(io1.TransformTo(jxl::ColorEncoding::LinearSRGB(io1.Main().IsGray()),
+                            jxl::GetJxlCms()));
+  JXL_CHECK(io2.TransformTo(jxl::ColorEncoding::LinearSRGB(io2.Main().IsGray()),
+                            jxl::GetJxlCms()));
+
+  if (io1.xsize() != io2.xsize() || io1.ysize() != io2.ysize()) {
+    fprintf(stderr, "Image size mismatch\n");
+    return 1;
+  }
+  if (io1.xsize() < 8 || io1.ysize() < 8) {
+    fprintf(stderr, "Minimum image size is 8x8 pixels\n");
+    return 1;
+  }
+  jxl::Image3F orig(io1.xsize(), io1.ysize());
+  jxl::ToXYB(io1.Main(), nullptr, &orig, jxl::GetJxlCms(), nullptr);
+  jxl::Image3F dist(io2.xsize(), io2.ysize());
+  jxl::ToXYB(io2.Main(), nullptr, &dist, jxl::GetJxlCms(), nullptr);
+
+  Msssim msssim = ComputeMSSSIM(orig, dist);
+  printf("%.8f\n", msssim.Score());
+  return 0;
+}
+
+}  // namespace
+}  // namespace xybmsssim
+
+int main(int argc, char** argv) { return xybmsssim::Run(argc, argv); }

--- a/tools/xybmsssim.h
+++ b/tools/xybmsssim.h
@@ -1,0 +1,30 @@
+// Copyright (c) the JPEG XL Project Authors. All rights reserved.
+//
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+#ifndef TOOLS_XYBMSSSIM_H_
+#define TOOLS_XYBMSSSIM_H_
+
+#include <vector>
+
+#include "lib/jxl/image.h"
+
+namespace xybmsssim {
+
+struct MsssimScale {
+  double avg_ssim[3 * 4];
+};
+
+struct Msssim {
+  std::vector<MsssimScale> scales;
+
+  double Score() const;
+};
+
+// expects input images in XYB space
+Msssim ComputeMSSSIM(jxl::Image3F& orig, jxl::Image3F& distorted);
+
+}  // namespace xybmsssim
+
+#endif  // TOOLS_XYBMSSSIM_H_


### PR DESCRIPTION
Multi-scale SSIM in XYB colorspace, using a weighted sum of powers of the 1,2,4,8 norms.
Weights were obtained by running Nelder-Mead simplex optimization using 80% of the DMOS scores, obtained in a recent Cloudinary subjective experiment  (~16k scores from 201 original images out of ~20k scores from 250 originals).

Metric performance on the remaing 20% of the data (separated by original image, so these results are for ~4k distorted images from 49 originals images not used for optimization):

subset | metric | Kendall correlation | Spearman correlation | Pearson correlation
----|----|--|--|--
all | PSNR | 0.35041115466124867 | 0.500406463539444 | 0.5002062683589741
all | BA-3norm | -0.613996798587313 | -0.8083629111562226 | -0.7537523619824422
all | BA-2norm | -0.6213339726237509 | -0.8168069461808429 | -0.7824049704635682
all | ssimulacra | -0.5763120312023206 | -0.7714789388746107 | -0.766859005271729
all | DSSIM | -0.6523558376090376 | -0.84562564877755 | -0.793440499142467
all | VMAF | 0.5549847687105102 | 0.7516154310230944 | 0.7166543502509799
all | XYB-MSSSIM | 0.6936901286836596 | 0.881431553743505 | 0.872509218023444
all | SSIM | 0.45028155974687606 | 0.6289293798985657 | 0.5488220831966164
mozjpeg | PSNR | 0.509670161131236 | 0.7004095776619754 | 0.665815783072121
mozjpeg | BA-3norm | -0.7260581560668993 | -0.9021204392345801 | -0.8314182034598971
mozjpeg | BA-2norm | -0.7369851489662721 | -0.9102150007481695 | -0.8564176578909608
mozjpeg | ssimulacra | -0.6982376408972683 | -0.8807888682629363 | -0.8606616755578758
mozjpeg | DSSIM | -0.7809725832977631 | -0.9359597784840379 | -0.8933960359613262
mozjpeg | VMAF | 0.7441114486832545 | 0.9114521466811746 | 0.8926980479523794
mozjpeg | XYB-MSSSIM | 0.7631847802787072 | 0.93075089064365 | 0.9332980785704679
mozjpeg | SSIM | 0.6594574122187176 | 0.846706982213639 | 0.8013164423143488
libjxl | PSNR | 0.4000547579773945 | 0.5698995148445875 | 0.5535970342660336
libjxl | BA-3norm | -0.7519022976012445 | -0.9201341220378885 | -0.8975067975449603
libjxl | BA-2norm | -0.7402585834748687 | -0.9113712537653874 | -0.8839107448986914
libjxl | ssimulacra | -0.6048496143806517 | -0.7992134283579517 | -0.7703007154055456
libjxl | DSSIM | -0.6956313518352701 | -0.8806601111931741 | -0.7959176988040749
libjxl | VMAF | 0.6546611712028725 | 0.8433572256060708 | 0.7808014320504519
libjxl | XYB-MSSSIM | 0.7263449756198855 | 0.9089162823570408 | 0.8995532983988134
libjxl | SSIM | 0.48392680826367906 | 0.6687458022697321 | 0.5939912547009625
cld_jp2 | PSNR | 0.2920164710892895 | 0.42285198235084087 | 0.4259422648672662
cld_jp2 | BA-3norm | -0.593540473830155 | -0.7932659355093769 | -0.7215163753264658
cld_jp2 | BA-2norm | -0.6132684666566013 | -0.8121785361759581 | -0.7540922859750483
cld_jp2 | ssimulacra | -0.5096398146831989 | -0.7063880344581207 | -0.7136569549576678
cld_jp2 | DSSIM | -0.6491169301103007 | -0.8454145590199218 | -0.8000625657956654
cld_jp2 | VMAF | 0.5947979529967309 | 0.7905412791179862 | 0.7700123155561784
cld_jp2 | XYB-MSSSIM | 0.69125278939688 | 0.8826134958393677 | 0.8697144106774636
cld_jp2 | SSIM | 0.4040734079285154 | 0.5753421849628731 | 0.547537167885176
cld_heic | PSNR | 0.35407273368164344 | 0.5029109634089227 | 0.5033675046793947
cld_heic | BA-3norm | -0.6452029737380403 | -0.838785977654267 | -0.8231418301372707
cld_heic | BA-2norm | -0.658383964524169 | -0.8509736945521661 | -0.8401422531369683
cld_heic | ssimulacra | -0.6104364792288848 | -0.8037251247330868 | -0.7963300042037179
cld_heic | DSSIM | -0.6670233862077505 | -0.8559903849788374 | -0.7916430047920574
cld_heic | VMAF | 0.6091575316080524 | 0.8059872373450657 | 0.7728616939737741
cld_heic | XYB-MSSSIM | 0.6861814995483811 | 0.8742894914494073 | 0.857345652134505
cld_heic | SSIM | 0.461337687452346 | 0.637415155211364 | 0.5999274455570998
AVIF | PSNR | 0.2615607698507881 | 0.3761411202917834 | 0.3652916063885287
AVIF | BA-3norm | -0.5877076706779695 | -0.7827262620630606 | -0.7025243424336484
AVIF | BA-2norm | -0.5916186062178653 | -0.7890323109655084 | -0.7393227428806718
AVIF | ssimulacra | -0.5036036630296609 | -0.6942514923335538 | -0.6957423078337769
AVIF | DSSIM | -0.6103971474133896 | -0.8062744603239833 | -0.7452048094186174
AVIF | VMAF | 0.54943116427831 | 0.7429748636471627 | 0.7274873257703117
AVIF | XYB-MSSSIM | 0.672080317913586 | 0.8600198597862051 | 0.849507615901608
AVIF | SSIM | 0.43453251944363186 | 0.6082465480298491 | 0.5330257953176616
cld_webp | PSNR | 0.32195676012453356 | 0.4594858858015214 | 0.45871591824412117
cld_webp | BA-3norm | -0.5963968303962388 | -0.7787278019759695 | -0.7457858453038633
cld_webp | BA-2norm | -0.6135106739969538 | -0.7985915963586011 | -0.7849221103621511
cld_webp | ssimulacra | -0.6058197539209699 | -0.7977522347924692 | -0.7696630348693037
cld_webp | DSSIM | -0.6746668910086651 | -0.8575624479936117 | -0.7963805614932778
cld_webp | VMAF | 0.5827882318703691 | 0.7809925671018564 | 0.7392928807950685
cld_webp | XYB-MSSSIM | 0.6993479401533106 | 0.8836230225733462 | 0.875579500446377
cld_webp | SSIM | 0.4883528057363038 | 0.6675873199708439 | 0.5961147548159399
