### PR TITLE
Add informative flags to djxl_ng and make output file optional.

### DIFF
--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -62,10 +62,11 @@ set(TOOL_BINARIES)
 add_library(jxl_tool STATIC EXCLUDE_FROM_ALL
   cmdline.cc
   codec_config.cc
+  speed_stats.cc
   tool_version.cc
 )
 target_compile_options(jxl_tool PUBLIC "${JPEGXL_INTERNAL_FLAGS}")
-target_link_libraries(jxl_tool jxl-static)
+target_link_libraries(jxl_tool hwy)
 
 target_include_directories(jxl_tool
   PUBLIC "${PROJECT_SOURCE_DIR}")
@@ -130,7 +131,6 @@ if(JPEGXL_ENABLE_TOOLS)
   # Main compressor.
   add_executable(cjxl
     cjxl.cc
-    speed_stats.cc
     cjxl_main.cc
   )
   target_link_libraries(cjxl
@@ -161,9 +161,9 @@ if(JPEGXL_ENABLE_TOOLS)
   )
   target_link_libraries(djxl_ng
     jxl_dec
-    jxl_gflags
-    jxl_threads
     jxl_extras-static
+    jxl_threads
+    jxl_tool
   )
 
   add_executable(cjpeg_hdr
@@ -178,7 +178,6 @@ if(JPEGXL_ENABLE_TOOLS)
   # Main decompressor.
   add_library(djxltool STATIC
     djxl.cc
-    speed_stats.cc
   )
   target_link_libraries(djxltool
     box
@@ -256,8 +255,6 @@ if(${JPEGXL_ENABLE_BENCHMARK} AND JPEGXL_ENABLE_TOOLS)
     benchmark/benchmark_codec_custom.h
     benchmark/benchmark_codec_jxl.cc
     benchmark/benchmark_codec_jxl.h
-    speed_stats.cc
-    speed_stats.h
     ../third_party/dirent.cc
   )
   target_link_libraries(benchmark_xl Threads::Threads)

--- a/tools/args.h
+++ b/tools/args.h
@@ -40,43 +40,6 @@ static inline bool ParseOverride(const char* arg, jxl::Override* out) {
   return JXL_FAILURE("Args");
 }
 
-static inline bool ParseUnsigned(const char* arg, size_t* out) {
-  char* end;
-  *out = static_cast<size_t>(strtoull(arg, &end, 0));
-  if (end[0] != '\0') {
-    fprintf(stderr, "Unable to interpret as unsigned integer: %s.\n", arg);
-    return JXL_FAILURE("Args");
-  }
-  return true;
-}
-
-static inline bool ParseUint32(const char* arg, uint32_t* out) {
-  size_t value = 0;
-  bool ret = ParseUnsigned(arg, &value);
-  if (ret) *out = value;
-  return ret;
-}
-
-static inline bool ParseSigned(const char* arg, int* out) {
-  char* end;
-  *out = static_cast<int>(strtol(arg, &end, 0));
-  if (end[0] != '\0') {
-    fprintf(stderr, "Unable to interpret as signed integer: %s.\n", arg);
-    return JXL_FAILURE("Args");
-  }
-  return true;
-}
-
-static inline bool ParseFloat(const char* arg, float* out) {
-  char* end;
-  *out = static_cast<float>(strtod(arg, &end));
-  if (end[0] != '\0') {
-    fprintf(stderr, "Unable to interpret as float: %s.\n", arg);
-    return JXL_FAILURE("Args");
-  }
-  return true;
-}
-
 static inline bool ParseFloatPair(const char* arg,
                                   std::pair<float, float>* out) {
   int parsed = sscanf(arg, "%f,%f", &out->first, &out->second);
@@ -86,16 +49,6 @@ static inline bool ParseFloatPair(const char* arg,
     fprintf(stderr,
             "Unable to interpret as float pair separated by a comma: %s.\n",
             arg);
-    return JXL_FAILURE("Args");
-  }
-  return true;
-}
-
-static inline bool ParseDouble(const char* arg, double* out) {
-  char* end;
-  *out = static_cast<double>(strtod(arg, &end));
-  if (end[0] != '\0') {
-    fprintf(stderr, "Unable to interpret as double: %s.\n", arg);
     return JXL_FAILURE("Args");
   }
   return true;
@@ -132,23 +85,8 @@ static inline bool ParsePredictor(const char* arg, jxl::Predictor* out) {
   return true;
 }
 
-static inline bool ParseString(const char* arg, std::string* out) {
-  out->assign(arg);
-  return true;
-}
-
 static inline bool ParseCString(const char* arg, const char** out) {
   *out = arg;
-  return true;
-}
-
-static inline bool SetBooleanTrue(bool* out) {
-  *out = true;
-  return true;
-}
-
-static inline bool SetBooleanFalse(bool* out) {
-  *out = false;
   return true;
 }
 

--- a/tools/cmdline.h
+++ b/tools/cmdline.h
@@ -13,8 +13,6 @@
 #include <string>
 #include <vector>
 
-#include "lib/jxl/base/status.h"
-
 namespace jpegxl {
 namespace tools {
 
@@ -97,7 +95,6 @@ class CommandLineParser {
   }
 
   const CmdOptionInterface* GetOption(OptionId id) const {
-    JXL_ASSERT(id < options_.size());
     return options_[id].get();
   }
 
@@ -315,6 +312,72 @@ class CommandLineParser {
   // stderr.
   bool help_ = false;
 };
+
+//
+// Common parsers for AddOptionValue and AddOptionFlag
+//
+
+static inline bool ParseSigned(const char* arg, int* out) {
+  char* end;
+  *out = static_cast<int>(strtol(arg, &end, 0));
+  if (end[0] != '\0') {
+    fprintf(stderr, "Unable to interpret as signed integer: %s.\n", arg);
+    return false;
+  }
+  return true;
+}
+
+static inline bool ParseUnsigned(const char* arg, size_t* out) {
+  char* end;
+  *out = static_cast<size_t>(strtoull(arg, &end, 0));
+  if (end[0] != '\0') {
+    fprintf(stderr, "Unable to interpret as unsigned integer: %s.\n", arg);
+    return false;
+  }
+  return true;
+}
+
+static inline bool ParseUint32(const char* arg, uint32_t* out) {
+  size_t value = 0;
+  bool ret = ParseUnsigned(arg, &value);
+  if (ret) *out = value;
+  return ret;
+}
+
+static inline bool ParseFloat(const char* arg, float* out) {
+  char* end;
+  *out = static_cast<float>(strtod(arg, &end));
+  if (end[0] != '\0') {
+    fprintf(stderr, "Unable to interpret as float: %s.\n", arg);
+    return false;
+  }
+  return true;
+}
+
+static inline bool ParseDouble(const char* arg, double* out) {
+  char* end;
+  *out = static_cast<double>(strtod(arg, &end));
+  if (end[0] != '\0') {
+    fprintf(stderr, "Unable to interpret as double: %s.\n", arg);
+    return false;
+  }
+  return true;
+}
+
+static inline bool ParseString(const char* arg, std::string* out) {
+  out->assign(arg);
+  return true;
+}
+
+static inline bool SetBooleanTrue(bool* out) {
+  *out = true;
+  return true;
+}
+
+static inline bool SetBooleanFalse(bool* out) {
+  *out = false;
+  return true;
+}
 
 }  // namespace tools
 }  // namespace jpegxl

--- a/tools/codec_config.cc
+++ b/tools/codec_config.cc
@@ -7,7 +7,6 @@
 
 #include <hwy/targets.h>
 
-#include "lib/jxl/base/status.h"
 #include "tools/tool_version.h"
 
 namespace jpegxl {
@@ -45,8 +44,9 @@ std::string CodecConfigString(uint32_t lib_version) {
     config += ',';
     saw_target = true;
   }
-  JXL_ASSERT(saw_target);
-  (void)saw_target;
+  if (!saw_target) {
+    config += "no targets found,";
+  }
   config.resize(config.size() - 1);  // remove trailing comma
   config += "]";
 

--- a/tools/speed_stats.cc
+++ b/tools/speed_stats.cc
@@ -17,12 +17,13 @@ namespace jpegxl {
 namespace tools {
 
 void SpeedStats::NotifyElapsed(double elapsed_seconds) {
-  JXL_ASSERT(elapsed_seconds > 0.0);
-  elapsed_.push_back(elapsed_seconds);
+  if (elapsed_seconds > 0.0) {
+    elapsed_.push_back(elapsed_seconds);
+  }
 }
 
-jxl::Status SpeedStats::GetSummary(SpeedStats::Summary* s) {
-  if (elapsed_.empty()) return JXL_FAILURE("Didn't call NotifyElapsed");
+bool SpeedStats::GetSummary(SpeedStats::Summary* s) {
+  if (elapsed_.empty()) return false;
 
   s->min = *std::min_element(elapsed_.begin(), elapsed_.end());
   s->max = *std::max_element(elapsed_.begin(), elapsed_.end());
@@ -83,18 +84,18 @@ std::string SummaryStat(double value, const char* unit,
   const double value_min = value / s.max;
   const double value_max = value / s.min;
 
-  int ret = snprintf(stat_str, sizeof(stat_str), ",%s %.2f %s/s [%.2f, %.2f]",
-                     s.type, value_tendency, unit, value_min, value_max);
-  (void)ret;  // ret is unused when JXL_ASSERT is disabled.
-  JXL_ASSERT(ret < static_cast<int>(sizeof(stat_str)));
+  snprintf(stat_str, sizeof(stat_str), ",%s %.2f %s/s [%.2f, %.2f]", s.type,
+           value_tendency, unit, value_min, value_max);
   return stat_str;
 }
 
 }  // namespace
 
-jxl::Status SpeedStats::Print(size_t worker_threads) {
+bool SpeedStats::Print(size_t worker_threads) {
   Summary s;
-  JXL_RETURN_IF_ERROR(GetSummary(&s));
+  if (!GetSummary(&s)) {
+    return false;
+  }
   std::string mps_stats = SummaryStat(xsize_ * ysize_ * 1e-6, "MP", s);
   std::string mbs_stats = SummaryStat(file_size_ * 1e-6, "MB", s);
 

--- a/tools/speed_stats.h
+++ b/tools/speed_stats.h
@@ -11,8 +11,6 @@
 
 #include <vector>
 
-#include "lib/jxl/base/status.h"
-
 namespace jpegxl {
 namespace tools {
 
@@ -32,7 +30,7 @@ class SpeedStats {
   };
 
   // Non-const, may sort elapsed_.
-  jxl::Status GetSummary(Summary* summary);
+  bool GetSummary(Summary* summary);
 
   // Sets the image size to allow computing MP/s values.
   void SetImageSize(size_t xsize, size_t ysize) {
@@ -45,7 +43,7 @@ class SpeedStats {
 
   // Calls GetSummary and prints megapixels/sec. SetImageSize() must be called
   // once before this can be used.
-  jxl::Status Print(size_t worker_threads);
+  bool Print(size_t worker_threads);
 
  private:
   std::vector<double> elapsed_;


### PR DESCRIPTION
This change implements the --quiet and --print_read_bytes flag from
djxl and in case of missing output filename it calls the decoder
loop but discards the results.