### PR TITLE
Replace ICC profiles with an enum representation when appropriate

### DIFF
--- a/lib/jxl/encode.cc
+++ b/lib/jxl/encode.cc
@@ -627,6 +627,11 @@ JxlEncoderStatus JxlEncoderSetICCProfile(JxlEncoder* enc,
   if (!enc->intensity_target_set) {
     jxl::SetIntensityTarget(&enc->metadata.m);
   }
+
+  if (!enc->basic_info.uses_original_profile) {
+    enc->metadata.m.color_encoding.DecideIfWantICC();
+  }
+
   return JXL_ENC_SUCCESS;
 }
 

--- a/lib/jxl/roundtrip_test.cc
+++ b/lib/jxl/roundtrip_test.cc
@@ -729,7 +729,7 @@ TEST(RoundtripTest, TestICCProfile) {
   jxl::test::JxlBasicInfoSetFromPixelFormat(&basic_info, &format);
   basic_info.xsize = xsize;
   basic_info.ysize = ysize;
-  basic_info.uses_original_profile = JXL_FALSE;
+  basic_info.uses_original_profile = JXL_TRUE;
   EXPECT_EQ(JXL_ENC_SUCCESS, JxlEncoderSetBasicInfo(enc, &basic_info));
 
   EXPECT_EQ(JXL_ENC_SUCCESS,


### PR DESCRIPTION
Legacy `cjxl` already does this. This brings this behavior to the API and `cjxl_ng` as well.