### PR TITLE
Fix build with `-DJPEGXL_ENABLE_TOOLS=0`

### DIFF
--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -393,7 +393,7 @@ add_subdirectory(box)
 add_subdirectory(conformance)
 
 
-if ("${JPEGXL_EMSCRIPTEN}")
+if (JPEGXL_ENABLE_TOOLS AND JPEGXL_EMSCRIPTEN)
 # WASM API facade.
 add_executable(jxl_emcc jxl_emcc.cc)
 target_link_libraries(jxl_emcc
@@ -421,14 +421,7 @@ set_target_properties(jxl_emcc PROPERTIES LINK_FLAGS "\
     _jxlProcessInput\
   ]\"\
 ")
-else()
-add_executable(jxl_emcc jxl_emcc.cc)
-target_link_libraries(jxl_emcc
-    jxl-static
-    jxl_extras-static
-    jxl_threads-static
-)
-endif ()  # JPEGXL_EMSCRIPTEN
+endif ()  # JPEGXL_ENABLE_TOOLS AND JPEGXL_EMSCRIPTEN
 
 if(JPEGXL_ENABLE_JNI)
 find_package(JNI QUIET)


### PR DESCRIPTION
This should fix libvips' CIFuzz and OSS-Fuzz integration. See:
https://oss-fuzz-build-logs.storage.googleapis.com/log-3e7b1372-e642-4766-8b82-58e70c3cd9c6.txt

Resolves: https://github.com/libjxl/libjxl/issues/1564.