### PR TITLE
Set a minimum butteraugli distance in vardct mode.

### DIFF
--- a/lib/jxl/enc_frame.cc
+++ b/lib/jxl/enc_frame.cc
@@ -1050,6 +1050,9 @@ Status ParamsPostInit(CompressParams* p) {
   if (!p->manual_xyb_factors.empty() && p->manual_xyb_factors.size() != 3) {
     return JXL_FAILURE("Invalid number of XYB quantization factors");
   }
+  if (!p->modular_mode && p->butteraugli_distance == 0.0) {
+    p->butteraugli_distance = kMinButteraugliDistance;
+  }
   if (p->original_butteraugli_distance == -1.0) {
     p->original_butteraugli_distance = p->butteraugli_distance;
   }

--- a/tools/benchmark/benchmark_codec_jxl.cc
+++ b/tools/benchmark/benchmark_codec_jxl.cc
@@ -116,7 +116,9 @@ class JxlCodec : public ImageCodec {
       std::istringstream parser(param.substr(kEcResamplingPrefix.size()));
       parser >> cparams_.ec_resampling;
     } else if (ImageCodec::ParseParam(param)) {
-      // Nothing to do.
+      if (param[0] == 'd' && butteraugli_target_ == 0.0) {
+        cparams_.SetLossless();
+      }
     } else if (param == "uint8") {
       uint8_ = true;
     } else if (param[0] == 'u') {


### PR DESCRIPTION
Additionally, activate lossless mode in benchmark for d0.0.

Fixes #1568