### PR TITLE
Fix bit cost accounting in AuxOut.

### DIFF
--- a/lib/jxl/aux_out.h
+++ b/lib/jxl/aux_out.h
@@ -37,72 +37,54 @@ namespace jxl {
 enum {
   kLayerHeader = 0,
   kLayerTOC,
+  kLayerDictionary,
+  kLayerSplines,
   kLayerNoise,
   kLayerQuant,
-  kLayerDequantTables,
-  kLayerOrder,
+  kLayerModularTree,
+  kLayerModularGlobal,
   kLayerDC,
+  kLayerModularDcGroup,
   kLayerControlFields,
+  kLayerOrder,
   kLayerAC,
   kLayerACTokens,
-  kLayerDictionary,
-  kLayerDots,
-  kLayerSplines,
-  kLayerLossless,
-  kLayerModularGlobal,
-  kLayerModularDcGroup,
   kLayerModularAcGroup,
-  kLayerModularTree,
-  kLayerAlpha,
-  kLayerDepth,
-  kLayerExtraChannels,
   kNumImageLayers
 };
 
 static inline const char* LayerName(size_t layer) {
   switch (layer) {
     case kLayerHeader:
-      return "headers";
+      return "Headers";
     case kLayerTOC:
       return "TOC";
+    case kLayerDictionary:
+      return "Patches";
+    case kLayerSplines:
+      return "Splines";
     case kLayerNoise:
-      return "noise";
+      return "Noise";
     case kLayerQuant:
-      return "quantizer";
-    case kLayerDequantTables:
-      return "quant tables";
-    case kLayerOrder:
-      return "order";
+      return "Quantizer";
+    case kLayerModularTree:
+      return "ModularTree";
+    case kLayerModularGlobal:
+      return "ModularGlobal";
     case kLayerDC:
       return "DC";
+    case kLayerModularDcGroup:
+      return "ModularDcGroup";
     case kLayerControlFields:
       return "ControlFields";
+    case kLayerOrder:
+      return "CoeffOrder";
     case kLayerAC:
-      return "AC";
+      return "ACHistograms";
     case kLayerACTokens:
       return "ACTokens";
-    case kLayerDictionary:
-      return "dictionary";
-    case kLayerDots:
-      return "dots";
-    case kLayerSplines:
-      return "splines";
-    case kLayerLossless:
-      return "lossless";
-    case kLayerModularGlobal:
-      return "modularGlobal";
-    case kLayerModularDcGroup:
-      return "modularDcGroup";
     case kLayerModularAcGroup:
-      return "modularAcGroup";
-    case kLayerModularTree:
-      return "modularTree";
-    case kLayerAlpha:
-      return "alpha";
-    case kLayerDepth:
-      return "depth";
-    case kLayerExtraChannels:
-      return "extra channels";
+      return "ModularAcGroup";
     default:
       JXL_ABORT("Invalid layer %d\n", static_cast<int>(layer));
   }
@@ -170,6 +152,14 @@ struct AuxOut {
   }
 
   void Print(size_t num_inputs) const;
+
+  size_t TotalBits() const {
+    size_t total = 0;
+    for (const auto& layer : layers) {
+      total += layer.total_bits;
+    }
+    return total;
+  }
 
   template <typename T>
   void DumpImage(const char* label, const Image3<T>& image) const {

--- a/lib/jxl/enc_ans.cc
+++ b/lib/jxl/enc_ans.cc
@@ -442,20 +442,24 @@ size_t BuildAndStoreANSEncodingData(
     {
       std::vector<uint8_t> depths(alphabet_size);
       std::vector<uint16_t> bits(alphabet_size);
-      BitWriter tmp_writer;
-      BitWriter* w = writer ? writer : &tmp_writer;
-      size_t start = w->BitsWritten();
-      BitWriter::Allotment allotment(
-          w, 8 * alphabet_size + 8);  // safe upper bound
-      BuildAndStoreHuffmanTree(histo.data(), alphabet_size, depths.data(),
-                               bits.data(), w);
-      ReclaimAndCharge(w, &allotment, 0, /*aux_out=*/nullptr);
-
+      if (writer == nullptr) {
+        BitWriter tmp_writer;
+        BitWriter::Allotment allotment(
+            &tmp_writer, 8 * alphabet_size + 8);  // safe upper bound
+        BuildAndStoreHuffmanTree(histo.data(), alphabet_size, depths.data(),
+                                 bits.data(), &tmp_writer);
+        ReclaimAndCharge(&tmp_writer, &allotment, 0, /*aux_out=*/nullptr);
+        cost = tmp_writer.BitsWritten();
+      } else {
+        size_t start = writer->BitsWritten();
+        BuildAndStoreHuffmanTree(histo.data(), alphabet_size, depths.data(),
+                                 bits.data(), writer);
+        cost = writer->BitsWritten() - start;
+      }
       for (size_t i = 0; i < alphabet_size; i++) {
         info[i].bits = depths[i] == 0 ? 0 : bits[i];
         info[i].depth = depths[i];
       }
-      cost = w->BitsWritten() - start;
     }
     // Estimate data cost.
     for (size_t i = 0; i < alphabet_size; i++) {
@@ -719,7 +723,8 @@ class HistogramBuilder {
         }
       }
       if (writer != nullptr) {
-        EncodeContextMap(*context_map, clustered_histograms.size(), writer);
+        EncodeContextMap(*context_map, clustered_histograms.size(), writer,
+                         layer, aux_out);
       }
     }
     if (aux_out != nullptr) {

--- a/lib/jxl/enc_bit_writer.h
+++ b/lib/jxl/enc_bit_writer.h
@@ -38,10 +38,6 @@ struct BitWriter {
   BitWriter(BitWriter&&) = default;
   BitWriter& operator=(BitWriter&&) = default;
 
-  explicit BitWriter(PaddedBytes&& donor)
-      : bits_written_(donor.size() * kBitsPerByte),
-        storage_(std::move(donor)) {}
-
   size_t BitsWritten() const { return bits_written_; }
 
   Span<const uint8_t> GetSpan() const {
@@ -60,8 +56,11 @@ struct BitWriter {
     return std::move(storage_);
   }
 
+ private:
   // Must be byte-aligned before calling.
   void AppendByteAligned(const Span<const uint8_t>& span);
+
+ public:
   // NOTE: no allotment needed, the other BitWriters have already been charged.
   void AppendByteAligned(const BitWriter& other);
   void AppendByteAligned(const std::vector<std::unique_ptr<BitWriter>>& others);

--- a/lib/jxl/enc_cache.cc
+++ b/lib/jxl/enc_cache.cc
@@ -134,9 +134,15 @@ Status InitializePassesEncoder(const Image3F& opsin, const JxlCmsInterface& cms,
     dc_frame_info.dc_level = shared.frame_header.dc_level + 1;
     dc_frame_info.ib_needs_color_transform = false;
     dc_frame_info.save_before_color_transform = true;  // Implicitly true
+    AuxOut dc_aux_out;
     JXL_CHECK(EncodeFrame(cparams, dc_frame_info, shared.metadata, ib,
                           state.get(), cms, pool, special_frame.get(),
-                          nullptr));
+                          aux_out ? &dc_aux_out : nullptr));
+    if (aux_out) {
+      for (const auto& l : dc_aux_out.layers) {
+        aux_out->layers[kLayerDC].Assimilate(l);
+      }
+    }
     const Span<const uint8_t> encoded = special_frame->GetSpan();
     enc_state->special_frames.emplace_back(std::move(special_frame));
 

--- a/lib/jxl/enc_context_map.cc
+++ b/lib/jxl/enc_context_map.cc
@@ -56,7 +56,8 @@ std::vector<uint8_t> MoveToFrontTransform(const std::vector<uint8_t>& v) {
 }  // namespace
 
 void EncodeContextMap(const std::vector<uint8_t>& context_map,
-                      size_t num_histograms, BitWriter* writer) {
+                      size_t num_histograms, BitWriter* writer, size_t layer,
+                      AuxOut* aux_out) {
   if (num_histograms == 1) {
     // Simple code
     writer->Write(1, 1);
@@ -100,7 +101,7 @@ void EncodeContextMap(const std::vector<uint8_t>& context_map,
     writer->Write(1, 0);
     writer->Write(1, use_mtf);  // Use/don't use MTF.
     BuildAndEncodeHistograms(params, 1, tokens, &codes, &dummy_context_map,
-                             writer, 0, nullptr);
+                             writer, layer, aux_out);
     WriteTokens(tokens[0], codes, dummy_context_map, writer);
   }
 }
@@ -132,7 +133,7 @@ void EncodeBlockCtxMap(const BlockCtxMap& block_ctx_map, BitWriter* writer,
   for (uint32_t i : qft) {
     JXL_CHECK(U32Coder::Write(kQFThresholdDist, i - 1, writer));
   }
-  EncodeContextMap(ctx_map, block_ctx_map.num_ctxs, writer);
+  EncodeContextMap(ctx_map, block_ctx_map.num_ctxs, writer, kLayerAC, aux_out);
   ReclaimAndCharge(writer, &allotment, kLayerAC, aux_out);
 }
 

--- a/lib/jxl/enc_context_map.h
+++ b/lib/jxl/enc_context_map.h
@@ -24,7 +24,8 @@ static const size_t kClustersLimit = 128;
 // Encodes the given context map to the bit stream. The number of different
 // histogram ids is given by num_histograms.
 void EncodeContextMap(const std::vector<uint8_t>& context_map,
-                      size_t num_histograms, BitWriter* writer);
+                      size_t num_histograms, BitWriter* writer, size_t layer,
+                      AuxOut* aux_out);
 
 void EncodeBlockCtxMap(const BlockCtxMap& block_ctx_map, BitWriter* writer,
                        AuxOut* aux_out);

--- a/lib/jxl/enc_file.cc
+++ b/lib/jxl/enc_file.cc
@@ -170,7 +170,9 @@ Status EncodeFile(const CompressParams& params, const CodecInOut* io,
   }
 
   // Each frame should start on byte boundaries.
+  BitWriter::Allotment allotment(&writer, 8);
   writer.ZeroPadToByte();
+  ReclaimAndCharge(&writer, &allotment, kLayerHeader, aux_out);
 
   if (cparams.progressive_mode || cparams.qprogressive_mode) {
     if (cparams.saliency_map != nullptr) {

--- a/lib/jxl/enc_patch_dictionary.h
+++ b/lib/jxl/enc_patch_dictionary.h
@@ -102,7 +102,7 @@ void FindBestPatchDictionary(const Image3F& opsin,
 void RoundtripPatchFrame(Image3F* reference_frame,
                          PassesEncoderState* JXL_RESTRICT state, int idx,
                          CompressParams& cparams, const JxlCmsInterface& cms,
-                         ThreadPool* pool, bool subtract);
+                         ThreadPool* pool, AuxOut* aux_out, bool subtract);
 
 }  // namespace jxl
 

--- a/lib/jxl/jxl_test.cc
+++ b/lib/jxl/jxl_test.cc
@@ -71,7 +71,7 @@ TEST(JxlTest, HeaderSize) {
     CodecInOut io2;
     AuxOut aux_out;
     Roundtrip(&io, cparams, {}, pool, &io2, &aux_out);
-    EXPECT_LE(aux_out.layers[kLayerHeader].total_bits, 34u);
+    EXPECT_LE(aux_out.layers[kLayerHeader].total_bits, 41u);
   }
 
   {
@@ -82,7 +82,7 @@ TEST(JxlTest, HeaderSize) {
     io.Main().SetAlpha(std::move(alpha), /*alpha_is_premultiplied=*/false);
     AuxOut aux_out;
     Roundtrip(&io, cparams, {}, pool, &io2, &aux_out);
-    EXPECT_LE(aux_out.layers[kLayerHeader].total_bits, 46u);
+    EXPECT_LE(aux_out.layers[kLayerHeader].total_bits, 49u);
   }
 }
 

--- a/lib/jxl/modular/encoding/encoding.cc
+++ b/lib/jxl/modular/encoding/encoding.cc
@@ -591,13 +591,13 @@ Status ModularGenericDecompress(BitReader *br, Image &image,
 #endif
   GroupHeader local_header;
   if (header == nullptr) header = &local_header;
+  size_t bit_pos = br->TotalBitsConsumed();
   auto dec_status = ModularDecode(br, image, *header, group_id, options, tree,
                                   code, ctx_map, allow_truncated_group);
   if (!allow_truncated_group) JXL_RETURN_IF_ERROR(dec_status);
   if (dec_status.IsFatalError()) return dec_status;
   if (undo_transforms) image.undo_transforms(header->wp_header);
   if (image.error) return JXL_FAILURE("Corrupt file. Aborting.");
-  size_t bit_pos = br->TotalBitsConsumed();
   JXL_DEBUG_V(4,
               "Modular-decoded a %" PRIuS "x%" PRIuS " nbchans=%" PRIuS
               " image from %" PRIuS " bytes",

--- a/tools/benchmark/benchmark_stats.cc
+++ b/tools/benchmark/benchmark_stats.cc
@@ -166,6 +166,13 @@ void BenchmarkStats::Assimilate(const BenchmarkStats& victim) {
 void BenchmarkStats::PrintMoreStats() const {
   if (Args()->print_more_stats) {
     jxl_stats.Print();
+    size_t total_bits = jxl_stats.aux_out.TotalBits();
+    size_t compressed_bits = total_compressed_size * kBitsPerByte;
+    if (total_bits != compressed_bits) {
+      printf("Total layer bits: %" PRIuS " vs total compressed bits: %" PRIuS
+             "  (%.2f%% accounted for)\n",
+             total_bits, compressed_bits, total_bits * 100.0 / compressed_bits);
+    }
   }
   if (Args()->print_distance_percentiles) {
     std::vector<float> sorted = distances;


### PR DESCRIPTION
The whole DC frame is added to kLayerDC, the whole patch reference
frame is added to kLayerDictionary, the padding bits between frames
are added to kLayerHeader, and the context map encoding is added
to the layer it was called from.

With these changes now the sum of layer bits is equal the sum of
compressed bits, and there is a warning added to benchmark stats
if it breaks again in the future.

The number and order of layers is also changed to reflect the current
state of the format.

Experiment on 31 images to see how much of bitsream is DC for some
bitrates:

```
Distance      BPP      DC%
--------------------------
d1.0        1.616    11.7%
d2.0        1.016    16.5%
d4.0        0.607    22.9%
d6.0        0.432    26.3%
d8.0        0.342    29.8%
d12.0       0.230    37.3%
d16.0       0.179    42.5%
```