### PR TITLE
Fixes for fuzzer bugs.

### DIFF
--- a/lib/jxl/dec_group.cc
+++ b/lib/jxl/dec_group.cc
@@ -241,8 +241,10 @@ Status DecodeGroupImpl(GetBlock* JXL_RESTRICT get_block,
     r[i] =
         Rect(block_rect.x0() >> hshift[i], block_rect.y0() >> vshift[i],
              block_rect.xsize() >> hshift[i], block_rect.ysize() >> vshift[i]);
-    JXL_ASSERT(r[i].IsInside({0, 0, dec_state->shared->dc->Plane(i).xsize(),
-                              dec_state->shared->dc->Plane(i).ysize()}));
+    if (!r[i].IsInside({0, 0, dec_state->shared->dc->Plane(i).xsize(),
+                        dec_state->shared->dc->Plane(i).ysize()})) {
+      return JXL_FAILURE("Frame dimensions are too big for the image.");
+    }
   }
 
   for (size_t by = 0; by < ysize_blocks; ++by) {

--- a/lib/jxl/dec_modular.h
+++ b/lib/jxl/dec_modular.h
@@ -8,6 +8,8 @@
 
 #include <stddef.h>
 
+#include <string>
+
 #include "lib/jxl/aux_out_fwd.h"
 #include "lib/jxl/base/data_parallel.h"
 #include "lib/jxl/base/status.h"
@@ -81,6 +83,7 @@ struct ModularStreamId {
   static size_t Num(const FrameDimensions& frame_dim, size_t passes) {
     return ModularAC(0, passes).ID(frame_dim);
   }
+  std::string DebugString() const;
 };
 
 class ModularFrameDecoder {
@@ -92,7 +95,8 @@ class ModularFrameDecoder {
                      int maxShift, const ModularStreamId& stream, bool zerofill,
                      PassesDecoderState* dec_state,
                      RenderPipelineInput* render_pipeline_input,
-                     ImageBundle* output, bool allow_truncated);
+                     ImageBundle* output, bool allow_truncated,
+                     bool* should_run_pipeline = nullptr);
   // Decodes a VarDCT DC group (`group_id`) from the given `reader`.
   Status DecodeVarDCTDC(size_t group_id, BitReader* reader,
                         PassesDecoderState* dec_state);

--- a/lib/jxl/frame_header.cc
+++ b/lib/jxl/frame_header.cc
@@ -446,7 +446,8 @@ std::string FrameHeader::DebugString() const {
   if (custom_size_or_origin) {
     os << ",xs=" << frame_size.xsize;
     os << ",ys=" << frame_size.ysize;
-    if (frame_type == FrameType::kRegularFrame) {
+    if (frame_type == FrameType::kRegularFrame ||
+        frame_type == FrameType::kSkipProgressive) {
       os << ",x0=" << frame_origin.x0;
       os << ",y0=" << frame_origin.y0;
     }

--- a/lib/jxl/modular/encoding/encoding.cc
+++ b/lib/jxl/modular/encoding/encoding.cc
@@ -603,6 +603,7 @@ Status ModularGenericDecompress(BitReader *br, Image &image,
               " image from %" PRIuS " bytes",
               image.w, image.h, image.channel.size(),
               (br->TotalBitsConsumed() - bit_pos) / 8);
+  JXL_DEBUG_V(5, "Modular image: %s", image.DebugString().c_str());
   (void)bit_pos;
 #ifdef JXL_ENABLE_ASSERT
   // Check that after applying all transforms we are back to the requested image

--- a/lib/jxl/modular/modular_image.cc
+++ b/lib/jxl/modular/modular_image.cc
@@ -5,6 +5,8 @@
 
 #include "lib/jxl/modular/modular_image.h"
 
+#include <sstream>
+
 #include "lib/jxl/base/status.h"
 #include "lib/jxl/common.h"
 #include "lib/jxl/modular/transform/transform.h"
@@ -56,6 +58,20 @@ Image Image::clone() {
     c.channel.push_back(std::move(a));
   }
   return c;
+}
+
+std::string Image::DebugString() const {
+  std::ostringstream os;
+  os << w << "x" << h << " depth: " << bitdepth;
+  if (!channel.empty()) {
+    os << " channels:";
+    for (size_t i = 0; i < channel.size(); ++i) {
+      os << " " << channel[i].w << "x" << channel[i].h
+         << "(shift: " << channel[i].hshift << "," << channel[i].vshift << ")";
+      if (i < nb_meta_channels) os << "*";
+    }
+  }
+  return os.str();
 }
 
 }  // namespace jxl

--- a/lib/jxl/modular/modular_image.h
+++ b/lib/jxl/modular/modular_image.h
@@ -11,6 +11,7 @@
 #include <stdio.h>
 #include <string.h>
 
+#include <string>
 #include <utility>
 #include <vector>
 
@@ -101,6 +102,8 @@ class Image {
 
   void undo_transforms(const weighted::Header& wp_header,
                        jxl::ThreadPool* pool = nullptr);
+
+  std::string DebugString() const;
 };
 
 }  // namespace jxl

--- a/lib/jxl/render_pipeline/render_pipeline.cc
+++ b/lib/jxl/render_pipeline/render_pipeline.cc
@@ -108,9 +108,9 @@ void RenderPipeline::InputReady(
     const std::vector<std::pair<ImageF*, Rect>>& buffers) {
   JXL_DASSERT(group_id < group_completed_passes_.size());
   group_completed_passes_[group_id]++;
-  for (const auto& buf : buffers) {
-    (void)buf;
-    JXL_CHECK_IMAGE_INITIALIZED(*buf.first, buf.second);
+  for (size_t i = 0; i < buffers.size(); ++i) {
+    (void)i;
+    JXL_CHECK_PLANE_INITIALIZED(*buffers[i].first, buffers[i].second, i);
   }
 
   ProcessBuffers(group_id, thread_id);

--- a/lib/jxl/render_pipeline/simple_render_pipeline.cc
+++ b/lib/jxl/render_pipeline/simple_render_pipeline.cc
@@ -63,7 +63,7 @@ void SimpleRenderPipeline::ProcessBuffers(size_t group_id, size_t thread_id) {
   for (size_t c = 0; c < channel_data_.size(); c++) {
     Rect r = MakeChannelRect(group_id, c);
     (void)r;
-    JXL_CHECK_IMAGE_INITIALIZED(channel_data_[c], r);
+    JXL_CHECK_PLANE_INITIALIZED(channel_data_[c], r, c);
   }
 
   if (PassesWithAllInput() <= processed_passes_) return;
@@ -202,9 +202,10 @@ void SimpleRenderPipeline::ProcessBuffers(size_t group_id, size_t thread_id) {
                              1 << channel_shifts_[next_stage][c].second);
       channel_data_[c].ShrinkTo(xsize + 2 * kRenderPipelineXOffset,
                                 ysize + 2 * kRenderPipelineXOffset);
-      JXL_CHECK_IMAGE_INITIALIZED(
+      JXL_CHECK_PLANE_INITIALIZED(
           channel_data_[c],
-          Rect(kRenderPipelineXOffset, kRenderPipelineXOffset, xsize, ysize));
+          Rect(kRenderPipelineXOffset, kRenderPipelineXOffset, xsize, ysize),
+          c);
     }
 
     if (stage->SwitchToImageDimensions()) {

--- a/lib/jxl/render_pipeline/stage_epf.cc
+++ b/lib/jxl/render_pipeline/stage_epf.cc
@@ -93,7 +93,7 @@ class EPF0Stage : public RenderPipelineStage {
       if (row_sigma[bx] < kMinSigma) {
         for (size_t c = 0; c < 3; c++) {
           auto px = Load(df, rows[c][3 + 0] + x);
-          Store(px, df, GetOutputRow(output_rows, c, 0) + x);
+          StoreU(px, df, GetOutputRow(output_rows, c, 0) + x);
         }
         continue;
       }
@@ -146,9 +146,9 @@ class EPF0Stage : public RenderPipelineStage {
 #else
       auto inv_w = ApproximateReciprocal(w);
 #endif
-      Store(X * inv_w, df, GetOutputRow(output_rows, 0, 0) + x);
-      Store(Y * inv_w, df, GetOutputRow(output_rows, 1, 0) + x);
-      Store(B * inv_w, df, GetOutputRow(output_rows, 2, 0) + x);
+      StoreU(X * inv_w, df, GetOutputRow(output_rows, 0, 0) + x);
+      StoreU(Y * inv_w, df, GetOutputRow(output_rows, 1, 0) + x);
+      StoreU(B * inv_w, df, GetOutputRow(output_rows, 2, 0) + x);
     }
   }
 

--- a/lib/jxl/render_pipeline/stage_from_linear.cc
+++ b/lib/jxl/render_pipeline/stage_from_linear.cc
@@ -102,7 +102,6 @@ class FromLinearStage : public RenderPipelineStage {
                   size_t xextra, size_t xsize, size_t xpos, size_t ypos,
                   size_t thread_id) const final {
     PROFILER_ZONE("FromLinear");
-
     const HWY_FULL(float) d;
     const size_t xsize_v = RoundUpTo(xsize, Lanes(d));
     float* JXL_RESTRICT row0 = GetInputRow(input_rows, 0, 0);
@@ -115,13 +114,13 @@ class FromLinearStage : public RenderPipelineStage {
     msan::UnpoisonMemory(row1 + xsize, sizeof(float) * (xsize_v - xsize));
     msan::UnpoisonMemory(row2 + xsize, sizeof(float) * (xsize_v - xsize));
     for (ssize_t x = -xextra; x < (ssize_t)(xsize + xextra); x += Lanes(d)) {
-      auto r = Load(d, row0 + x);
-      auto g = Load(d, row1 + x);
-      auto b = Load(d, row2 + x);
+      auto r = LoadU(d, row0 + x);
+      auto g = LoadU(d, row1 + x);
+      auto b = LoadU(d, row2 + x);
       op_.Transform(d, &r, &g, &b);
-      Store(r, d, row0 + x);
-      Store(g, d, row1 + x);
-      Store(b, d, row2 + x);
+      StoreU(r, d, row0 + x);
+      StoreU(g, d, row1 + x);
+      StoreU(b, d, row2 + x);
     }
     msan::PoisonMemory(row0 + xsize, sizeof(float) * (xsize_v - xsize));
     msan::PoisonMemory(row1 + xsize, sizeof(float) * (xsize_v - xsize));

--- a/lib/jxl/render_pipeline/stage_noise.cc
+++ b/lib/jxl/render_pipeline/stage_noise.cc
@@ -123,17 +123,17 @@ void AddNoiseToRGB(const D d, const Vec<D> rnd_noise_r,
   const auto green_noise = kRGNCorr * rnd_noise_g * noise_strength_g +
                            kRGCorr * rnd_noise_cor * noise_strength_g;
 
-  auto vx = Load(d, out_x);
-  auto vy = Load(d, out_y);
-  auto vb = Load(d, out_b);
+  auto vx = LoadU(d, out_x);
+  auto vy = LoadU(d, out_y);
+  auto vb = LoadU(d, out_b);
 
   vx += red_noise - green_noise + Set(d, ytox) * (red_noise + green_noise);
   vy += red_noise + green_noise;
   vb += Set(d, ytob) * (red_noise + green_noise);
 
-  Store(vx, d, out_x);
-  Store(vy, d, out_y);
-  Store(vb, d, out_b);
+  StoreU(vx, d, out_x);
+  StoreU(vy, d, out_y);
+  StoreU(vb, d, out_b);
 }
 
 class AddNoiseStage : public RenderPipelineStage {
@@ -180,16 +180,16 @@ class AddNoiseStage : public RenderPipelineStage {
     msan::UnpoisonMemory(row_x + xsize, (xsize_v - xsize) * sizeof(float));
     msan::UnpoisonMemory(row_y + xsize, (xsize_v - xsize) * sizeof(float));
     for (size_t x = 0; x < xsize_v; x += Lanes(d)) {
-      const auto vx = Load(d, row_x + x);
-      const auto vy = Load(d, row_y + x);
+      const auto vx = LoadU(d, row_x + x);
+      const auto vy = LoadU(d, row_y + x);
       const auto in_g = vy - vx;
       const auto in_r = vy + vx;
       const auto noise_strength_g = NoiseStrength(noise_model, in_g * half);
       const auto noise_strength_r = NoiseStrength(noise_model, in_r * half);
-      const auto addit_rnd_noise_red = Load(d, row_rnd_r + x) * norm_const;
-      const auto addit_rnd_noise_green = Load(d, row_rnd_g + x) * norm_const;
+      const auto addit_rnd_noise_red = LoadU(d, row_rnd_r + x) * norm_const;
+      const auto addit_rnd_noise_green = LoadU(d, row_rnd_g + x) * norm_const;
       const auto addit_rnd_noise_correlated =
-          Load(d, row_rnd_c + x) * norm_const;
+          LoadU(d, row_rnd_c + x) * norm_const;
       AddNoiseToRGB(D(), addit_rnd_noise_red, addit_rnd_noise_green,
                     addit_rnd_noise_correlated, noise_strength_g,
                     noise_strength_r, ytox, ytob, row_x + x, row_y + x,
@@ -241,7 +241,7 @@ class ConvolveNoiseStage : public RenderPipelineStage {
       float* JXL_RESTRICT row_out = GetOutputRow(output_rows, c, 0);
       for (ssize_t x = -RoundUpTo(xextra, Lanes(d));
            x < (ssize_t)(xsize + xextra); x += Lanes(d)) {
-        const auto p00 = Load(d, rows[2] + x);
+        const auto p00 = LoadU(d, rows[2] + x);
         auto others = Zero(d);
         for (ssize_t i = -2; i <= 2; i++) {
           others += LoadU(d, rows[0] + x + i);
@@ -255,7 +255,7 @@ class ConvolveNoiseStage : public RenderPipelineStage {
         others += LoadU(d, rows[2] + x + 2);
         // 4 * (1 - box kernel)
         auto pixels = MulAdd(others, Set(d, 0.16), p00 * Set(d, -3.84));
-        Store(pixels, d, row_out + x);
+        StoreU(pixels, d, row_out + x);
       }
     }
   }

--- a/lib/jxl/render_pipeline/stage_to_linear.cc
+++ b/lib/jxl/render_pipeline/stage_to_linear.cc
@@ -124,13 +124,13 @@ class ToLinearStage : public RenderPipelineStage {
     msan::UnpoisonMemory(row1 + xsize, sizeof(float) * (xsize_v - xsize));
     msan::UnpoisonMemory(row2 + xsize, sizeof(float) * (xsize_v - xsize));
     for (ssize_t x = -xextra; x < (ssize_t)(xsize + xextra); x += Lanes(d)) {
-      auto r = Load(d, row0 + x);
-      auto g = Load(d, row1 + x);
-      auto b = Load(d, row2 + x);
+      auto r = LoadU(d, row0 + x);
+      auto g = LoadU(d, row1 + x);
+      auto b = LoadU(d, row2 + x);
       op_.Transform(d, &r, &g, &b);
-      Store(r, d, row0 + x);
-      Store(g, d, row1 + x);
-      Store(b, d, row2 + x);
+      StoreU(r, d, row0 + x);
+      StoreU(g, d, row1 + x);
+      StoreU(b, d, row2 + x);
     }
     msan::PoisonMemory(row0 + xsize, sizeof(float) * (xsize_v - xsize));
     msan::PoisonMemory(row1 + xsize, sizeof(float) * (xsize_v - xsize));

--- a/lib/jxl/render_pipeline/stage_tone_mapping.cc
+++ b/lib/jxl/render_pipeline/stage_tone_mapping.cc
@@ -83,9 +83,9 @@ class ToneMappingStage : public RenderPipelineStage {
     msan::UnpoisonMemory(row1 + xsize, sizeof(float) * (xsize_v - xsize));
     msan::UnpoisonMemory(row2 + xsize, sizeof(float) * (xsize_v - xsize));
     for (ssize_t x = -xextra; x < (ssize_t)(xsize + xextra); x += Lanes(d)) {
-      auto r = Load(d, row0 + x);
-      auto g = Load(d, row1 + x);
-      auto b = Load(d, row2 + x);
+      auto r = LoadU(d, row0 + x);
+      auto g = LoadU(d, row1 + x);
+      auto b = LoadU(d, row2 + x);
       if (tone_mapper_ || hlg_ootf_) {
         r *= Set(d, to_intensity_target_);
         g *= Set(d, to_intensity_target_);
@@ -103,9 +103,9 @@ class ToneMappingStage : public RenderPipelineStage {
         g *= Set(d, from_desired_intensity_target_);
         b *= Set(d, from_desired_intensity_target_);
       }
-      Store(r, d, row0 + x);
-      Store(g, d, row1 + x);
-      Store(b, d, row2 + x);
+      StoreU(r, d, row0 + x);
+      StoreU(g, d, row1 + x);
+      StoreU(b, d, row2 + x);
     }
     msan::PoisonMemory(row0 + xsize, sizeof(float) * (xsize_v - xsize));
     msan::PoisonMemory(row1 + xsize, sizeof(float) * (xsize_v - xsize));

--- a/lib/jxl/render_pipeline/stage_write.cc
+++ b/lib/jxl/render_pipeline/stage_write.cc
@@ -53,20 +53,20 @@ void StoreRGBA(D d, V r, V g, V b, V a, bool alpha, size_t n, size_t extra,
   // TODO(veluca): implement this for x86.
   size_t mul = alpha ? 4 : 3;
   HWY_ALIGN uint8_t bytes[16];
-  Store(r, d, bytes);
+  StoreU(r, d, bytes);
   for (size_t i = 0; i < n; i++) {
     buf[mul * i] = bytes[i];
   }
-  Store(g, d, bytes);
+  StoreU(g, d, bytes);
   for (size_t i = 0; i < n; i++) {
     buf[mul * i + 1] = bytes[i];
   }
-  Store(b, d, bytes);
+  StoreU(b, d, bytes);
   for (size_t i = 0; i < n; i++) {
     buf[mul * i + 2] = bytes[i];
   }
   if (alpha) {
-    Store(a, d, bytes);
+    StoreU(a, d, bytes);
     for (size_t i = 0; i < n; i++) {
       buf[4 * i + 3] = bytes[i];
     }
@@ -115,10 +115,10 @@ class WriteToU8Stage : public RenderPipelineStage {
     }
 
     for (ssize_t x = 0; x < x1; x += Lanes(d)) {
-      auto rf = Clamp(zero, Load(d, row_in_r + x), one) * mul;
-      auto gf = Clamp(zero, Load(d, row_in_g + x), one) * mul;
-      auto bf = Clamp(zero, Load(d, row_in_b + x), one) * mul;
-      auto af = row_in_a ? Clamp(zero, Load(d, row_in_a + x), one) * mul
+      auto rf = Clamp(zero, LoadU(d, row_in_r + x), one) * mul;
+      auto gf = Clamp(zero, LoadU(d, row_in_g + x), one) * mul;
+      auto bf = Clamp(zero, LoadU(d, row_in_b + x), one) * mul;
+      auto af = row_in_a ? Clamp(zero, LoadU(d, row_in_a + x), one) * mul
                          : Set(d, 255.0f);
       auto r8 = U8FromU32(BitCast(du, NearestInt(rf)));
       auto g8 = U8FromU32(BitCast(du, NearestInt(gf)));


### PR DESCRIPTION
* Initialize full image area with RenderPadding if frame is outside image
* Use unaligned store/load in all stages
* Only run per-group render pipeline if modular could decode something