### PR TITLE
Use pixel_type_w for intermediate unsqueeze calculations.

### DIFF
--- a/lib/jxl/dec_context_map.cc
+++ b/lib/jxl/dec_context_map.cc
@@ -37,8 +37,8 @@ void InverseMoveToFrontTransform(uint8_t* v, int v_len) {
   }
 }
 
-bool VerifyContextMap(const std::vector<uint8_t>& context_map,
-                      const size_t num_htrees) {
+Status VerifyContextMap(const std::vector<uint8_t>& context_map,
+                        const size_t num_htrees) {
   std::vector<bool> have_htree(num_htrees);
   size_t num_found = 0;
   for (const uint8_t htree : context_map) {
@@ -58,8 +58,8 @@ bool VerifyContextMap(const std::vector<uint8_t>& context_map,
 
 }  // namespace
 
-bool DecodeContextMap(std::vector<uint8_t>* context_map, size_t* num_htrees,
-                      BitReader* input) {
+Status DecodeContextMap(std::vector<uint8_t>* context_map, size_t* num_htrees,
+                        BitReader* input) {
   bool is_simple = input->ReadFixedBits<1>();
   if (is_simple) {
     int bits_per_entry = input->ReadFixedBits<2>();

--- a/lib/jxl/dec_context_map.h
+++ b/lib/jxl/dec_context_map.h
@@ -22,8 +22,8 @@ constexpr size_t kMaxClusters = 256;
 // context_map->size() must be the number of possible context ids.
 // Sets *num_htrees to the number of different histogram ids in
 // *context_map.
-bool DecodeContextMap(std::vector<uint8_t>* context_map, size_t* num_htrees,
-                      BitReader* input);
+Status DecodeContextMap(std::vector<uint8_t>* context_map, size_t* num_htrees,
+                        BitReader* input);
 
 }  // namespace jxl
 

--- a/lib/jxl/dec_modular.cc
+++ b/lib/jxl/dec_modular.cc
@@ -242,6 +242,8 @@ Status ModularFrameDecoder::DecodeGlobalInfo(BitReader* reader,
       all_same_shift = false;
   }
 
+  JXL_DEBUG_V(6, "DecodeGlobalInfo: full_image (w/o transforms) %s",
+              gi.DebugString().c_str());
   ModularOptions options;
   options.max_chan_size = frame_dim.group_dim;
   options.group_dim = frame_dim.group_dim;
@@ -272,6 +274,8 @@ Status ModularFrameDecoder::DecodeGlobalInfo(BitReader* reader,
     }
   }
   full_image = std::move(gi);
+  JXL_DEBUG_V(6, "DecodeGlobalInfo: full_image (with transforms) %s",
+              full_image.DebugString().c_str());
   return dec_status;
 }
 

--- a/lib/jxl/modular/encoding/context_predict.h
+++ b/lib/jxl/modular/encoding/context_predict.h
@@ -62,7 +62,7 @@ struct State {
   pixel_type_w pred = 0;  // *before* removing the added bits.
   std::vector<uint32_t> pred_errors[kNumPredictors];
   std::vector<int32_t> error;
-  Header header;
+  const Header header;
 
   // Allows to approximate division by a number from 1 to 64.
   uint32_t divlookup[64];

--- a/lib/jxl/modular/modular_image.cc
+++ b/lib/jxl/modular/modular_image.cc
@@ -62,9 +62,9 @@ Image Image::clone() {
 
 std::string Image::DebugString() const {
   std::ostringstream os;
-  os << w << "x" << h << " depth: " << bitdepth;
+  os << w << "x" << h << ", depth: " << bitdepth;
   if (!channel.empty()) {
-    os << " channels:";
+    os << ", channels:";
     for (size_t i = 0; i < channel.size(); ++i) {
       os << " " << channel[i].w << "x" << channel[i].h
          << "(shift: " << channel[i].hshift << "," << channel[i].vshift << ")";

--- a/lib/jxl/modular/transform/squeeze.cc
+++ b/lib/jxl/modular/transform/squeeze.cc
@@ -114,15 +114,15 @@ Status InvHSqueeze(Image &input, uint32_t c, uint32_t rc, ThreadPool *pool) {
     const pixel_type *JXL_RESTRICT p_avg = chin.Row(y);
     pixel_type *JXL_RESTRICT p_out = chout.Row(y);
     for (size_t x = x0; x < chin_residual.w; x++) {
-      pixel_type diff_minus_tendency = p_residual[x];
-      pixel_type avg = p_avg[x];
-      pixel_type next_avg = (x + 1 < chin.w ? p_avg[x + 1] : avg);
-      pixel_type left = (x ? p_out[(x << 1) - 1] : avg);
-      pixel_type tendency = SmoothTendency(left, avg, next_avg);
-      pixel_type diff = diff_minus_tendency + tendency;
-      pixel_type A = avg + (diff / 2);
+      pixel_type_w diff_minus_tendency = p_residual[x];
+      pixel_type_w avg = p_avg[x];
+      pixel_type_w next_avg = (x + 1 < chin.w ? p_avg[x + 1] : avg);
+      pixel_type_w left = (x ? p_out[(x << 1) - 1] : avg);
+      pixel_type_w tendency = SmoothTendency(left, avg, next_avg);
+      pixel_type_w diff = diff_minus_tendency + tendency;
+      pixel_type_w A = avg + (diff / 2);
       p_out[(x << 1)] = A;
-      pixel_type B = A - diff;
+      pixel_type_w B = A - diff;
       p_out[(x << 1) + 1] = B;
     }
     if (chout.w & 1) p_out[chout.w - 1] = p_avg[chin.w - 1];
@@ -243,13 +243,13 @@ Status InvVSqueeze(Image &input, uint32_t c, uint32_t rc, ThreadPool *pool) {
       }
 #endif
       for (; x < w; x++) {
-        pixel_type avg = p_avg[x];
-        pixel_type next_avg = p_navg[x];
-        pixel_type top = p_pout[x];
-        pixel_type tendency = SmoothTendency(top, avg, next_avg);
-        pixel_type diff_minus_tendency = p_residual[x];
-        pixel_type diff = diff_minus_tendency + tendency;
-        pixel_type out = avg + (diff / 2);
+        pixel_type_w avg = p_avg[x];
+        pixel_type_w next_avg = p_navg[x];
+        pixel_type_w top = p_pout[x];
+        pixel_type_w tendency = SmoothTendency(top, avg, next_avg);
+        pixel_type_w diff_minus_tendency = p_residual[x];
+        pixel_type_w diff = diff_minus_tendency + tendency;
+        pixel_type_w out = avg + (diff / 2);
         p_out[x] = out;
         // If the chin_residual.h == chin.h, the output has an even number
         // of rows so the next line is fine. Otherwise, this loop won't
@@ -450,6 +450,8 @@ Status MetaSqueeze(Image &image, std::vector<SqueezeParams> *parameters) {
 
       image.channel.insert(image.channel.begin() + offset + (c - beginc),
                            std::move(dummy));
+      JXL_DEBUG_V(8, "MetaSqueeze applied, current image: %s",
+                  image.DebugString().c_str());
     }
   }
   return true;

--- a/lib/jxl/modular/transform/transform.cc
+++ b/lib/jxl/modular/transform/transform.cc
@@ -39,8 +39,7 @@ Status Transform::Inverse(Image &input, const weighted::Header &wp_header,
 }
 
 Status Transform::MetaApply(Image &input) {
-  JXL_DEBUG_V(6, "Input channels (%" PRIuS ", %" PRIuS " meta): ",
-              input.channel.size(), input.nb_meta_channels);
+  JXL_DEBUG_V(6, "MetaApply input: %s", input.DebugString().c_str());
   switch (id) {
     case TransformId::kRCT:
       JXL_DEBUG_V(2, "Transform: kRCT, rct_type=%" PRIu32, rct_type);


### PR DESCRIPTION
This fixes the signed integer overflow found by fuzzers, and relies only
on int64_t to int32_t integer casting.