### PR TITLE
lcms2: add a fallback for determining primaries

### DIFF
--- a/lib/jxl/enc_color_management.cc
+++ b/lib/jxl/enc_color_management.cc
@@ -613,8 +613,15 @@ Status ProfileEquivalentToICC(const cmsContext context, const Profile& profile1,
 JXL_MUST_USE_RESULT cmsCIEXYZ UnadaptedWhitePoint(const cmsContext context,
                                                   const Profile& profile,
                                                   const ColorEncoding& c) {
-  cmsCIEXYZ XYZ = {1.0, 1.0, 1.0};
+  const cmsCIEXYZ* white_point = static_cast<const cmsCIEXYZ*>(
+      cmsReadTag(profile.get(), cmsSigMediaWhitePointTag));
+  if (white_point != nullptr &&
+      cmsReadTag(profile.get(), cmsSigChromaticAdaptationTag) == nullptr) {
+    // No chromatic adaptation matrix: the white point is already unadapted.
+    return *white_point;
+  }
 
+  cmsCIEXYZ XYZ = {1.0, 1.0, 1.0};
   Profile profile_xyz;
   if (!CreateProfileXYZ(context, &profile_xyz)) return XYZ;
   // Array arguments are one per profile.
@@ -637,8 +644,8 @@ JXL_MUST_USE_RESULT cmsCIEXYZ UnadaptedWhitePoint(const cmsContext context,
   return XYZ;
 }
 
-Status IdentifyPrimaries(const Profile& profile, const cmsCIEXYZ& wp_unadapted,
-                         ColorEncoding* c) {
+Status IdentifyPrimaries(const cmsContext context, const Profile& profile,
+                         const cmsCIEXYZ& wp_unadapted, ColorEncoding* c) {
   if (!c->HasPrimaries()) return true;
   if (ColorSpaceFromProfile(profile) == ColorSpace::kUnknown) return true;
 
@@ -649,8 +656,34 @@ Status IdentifyPrimaries(const Profile& profile, const cmsCIEXYZ& wp_unadapted,
       cmsReadTag(profile.get(), cmsSigGreenColorantTag));
   const cmsCIEXYZ* adapted_b = static_cast<const cmsCIEXYZ*>(
       cmsReadTag(profile.get(), cmsSigBlueColorantTag));
+
+  cmsCIEXYZ converted_rgb[3];
   if (adapted_r == nullptr || adapted_g == nullptr || adapted_b == nullptr) {
-    return JXL_FAILURE("Failed to retrieve colorants");
+    // No colorant tag, determine the XYZ coordinates of the primaries by
+    // converting from the colorspace.
+    Profile profile_xyz;
+    if (!CreateProfileXYZ(context, &profile_xyz)) {
+      return JXL_FAILURE("Failed to retrieve colorants");
+    }
+    // Array arguments are one per profile.
+    cmsHPROFILE profiles[2] = {profile.get(), profile_xyz.get()};
+    cmsUInt32Number intents[2] = {INTENT_RELATIVE_COLORIMETRIC,
+                                  INTENT_RELATIVE_COLORIMETRIC};
+    cmsBool black_compensation[2] = {0, 0};
+    cmsFloat64Number adaption[2] = {0.0, 0.0};
+    // Only transforming three pixels, so skip expensive optimizations.
+    cmsUInt32Number flags = cmsFLAGS_NOOPTIMIZE | cmsFLAGS_HIGHRESPRECALC;
+    Transform xform(cmsCreateExtendedTransform(
+        context, 2, profiles, black_compensation, intents, adaption, nullptr, 0,
+        Type64(*c), TYPE_XYZ_DBL, flags));
+    if (!xform) return JXL_FAILURE("Failed to retrieve colorants");
+
+    const cmsFloat64Number in[9] = {1.0, 0.0, 0.0, 0.0, 1.0,
+                                    0.0, 0.0, 0.0, 1.0};
+    cmsDoTransform(xform.get(), in, &converted_rgb->X, 3);
+    adapted_r = &converted_rgb[0];
+    adapted_g = &converted_rgb[1];
+    adapted_b = &converted_rgb[2];
   }
 
   // TODO(janwas): no longer assume Bradford and D50.
@@ -869,7 +902,7 @@ Status ColorEncoding::SetFieldsFromICC() {
   JXL_RETURN_IF_ERROR(SetWhitePoint(CIExyFromXYZ(wp_unadapted)));
 
   // Relies on color_space.
-  JXL_RETURN_IF_ERROR(IdentifyPrimaries(profile, wp_unadapted, this));
+  JXL_RETURN_IF_ERROR(IdentifyPrimaries(context, profile, wp_unadapted, this));
 
   // Relies on color_space/white point/primaries being set already.
   DetectTransferFunction(context, profile, this);


### PR DESCRIPTION
The fallback is what the skcms branch does in all cases.

Also align the white point detection logic with the skcms version.