### PR TITLE
Disable progressive dc for the fastest modes.

### DIFF
--- a/lib/jxl/enc_frame.cc
+++ b/lib/jxl/enc_frame.cc
@@ -1089,9 +1089,11 @@ Status EncodeFrame(const CompressParams& cparams_orig,
                          cparams.progressive_dc);
     }
     cparams.progressive_dc = 0;
-    // Enable progressive_dc for lower qualities.
-    if (cparams.butteraugli_distance >=
-        kMinButteraugliDistanceForProgressiveDc) {
+    // Enable progressive_dc for lower qualities, except for fast speeds where
+    // the modular encoder uses fixed tree.
+    if (cparams.speed_tier <= SpeedTier::kCheetah &&
+        cparams.butteraugli_distance >=
+            kMinButteraugliDistanceForProgressiveDc) {
       cparams.progressive_dc = 1;
     }
   }


### PR DESCRIPTION
Benchmark before:
```
Encoding      kPixels    Bytes          BPP  E MP/s  D MP/s     Max norm        pnorm       BPP*pnorm   Bugs
------------------------------------------------------------------------------------------------------------
jxl:1:d4.5      13270  1264112    0.7620613  18.634   8.117   4.83199263   1.71316856  1.305539512384      0
jxl:1:d8        13270   856537    0.5163575  20.078   8.037   6.49864912   2.45349616  1.266881165285      0
jxl:1:d16       13270   574334    0.3462333  20.631   8.217  11.38341045   3.64709596  1.262746248261      0
jxl:2:d4.5      13270  1217573    0.7340056  17.392   7.963   4.83199263   1.71316856  1.257475335028      0
jxl:2:d8        13270   813016    0.4901212  18.448   8.291   6.49864912   2.45349616  1.202510408162      0
jxl:2:d16       13270   535015    0.3225302  19.199   8.235  11.38341045   3.64709596  1.176298432643      0
jxl:3:d4.5      13270  1188366    0.7163984  14.470   7.618   4.83199263   1.71316856  1.227311162440      0
jxl:3:d8        13270   792053    0.4774838  14.887   7.413   6.49864912   2.45349616  1.171504590704      0
jxl:3:d16       13270   516482    0.3113577  16.794   7.934  11.38341045   3.64709596  1.135551278166      0
Aggregate:      13270   815834    0.4918199  17.717   7.976   7.09698546   2.48414851  1.221753789834      0
```

Benchmark after:
```
Encoding      kPixels    Bytes          BPP  E MP/s  D MP/s     Max norm        pnorm       BPP*pnorm   Bugs
------------------------------------------------------------------------------------------------------------
jxl:1:d4.5      13270  1062761    0.6406782  18.641   8.161   4.59679651   1.72622102  1.105952255064      0
jxl:1:d8        13270   687567    0.4144951  19.610   8.408   6.54634523   2.45428229  1.017287967452      0
jxl:1:d16       13270   437330    0.2636414  20.071   8.767  10.91654015   3.60297315  0.949892952802      0
jxl:2:d4.5      13270  1062308    0.6404052  19.238   8.394   4.59679651   1.72622102  1.105480844868      0
jxl:2:d8        13270   687176    0.4142594  19.027   8.459   6.54634523   2.45428229  1.016709464419      0
jxl:2:d16       13270   436975    0.2634274  22.182   8.342  10.91654015   3.60297315  0.949121882905      0
jxl:3:d4.5      13270   967485    0.5832418  18.446   8.187   4.59679651   1.72622102  1.006804180329      0
jxl:3:d8        13270   606094    0.3653796  19.129   8.461   6.54634523   2.45428229  0.896744802099      0
jxl:3:d16       13270   367137    0.2213260  21.441   8.439  10.91654015   3.60297315  0.797431799815      0
Aggregate:      13270   654192    0.3943752  19.719   8.400   6.89995725   2.48062232  0.978295988676      0
```