### PR TITLE
Don't undo per-group global transforms in modular FinalizeDecoding.

### DIFF
--- a/lib/jxl/dec_modular.cc
+++ b/lib/jxl/dec_modular.cc
@@ -691,9 +691,7 @@ Status ModularFrameDecoder::FinalizeDecoding(PassesDecoderState* dec_state,
 
   // Undo the global transforms
   gi.undo_transforms(global_header.wp_header, pool);
-  for (auto t : global_transform) {
-    JXL_RETURN_IF_ERROR(t.Inverse(gi, global_header.wp_header));
-  }
+  JXL_DASSERT(global_transform.empty());
   if (gi.error) return JXL_FAILURE("Undoing transforms failed");
 
   for (size_t i = 0; i < dec_state->shared->frame_dim.num_groups; i++) {


### PR DESCRIPTION
This is a no-op becuase if we have global transforms pushed to the
group level, then we also drop the full image and there is no
FinalizeDecoding stage.