### PR TITLE
cjxl_ng: change default effort

### DIFF
--- a/tools/cjxl_ng_main.cc
+++ b/tools/cjxl_ng_main.cc
@@ -138,7 +138,7 @@ struct CompressArgs {
     cmdline->AddOptionValue(
         'e', "effort", "EFFORT",
         "Encoder effort setting. Range: 1 .. 9.\n"
-        "     Default: 3. Higher number is more effort (slower).",
+        "     Default: 7. Higher number is more effort (slower).",
         &effort, &ParseUnsigned, -1);
 
     cmdline->AddOptionValue(
@@ -468,7 +468,7 @@ struct CompressArgs {
   int32_t codestream_level = -1;
   int32_t responsive = -1;
   float distance = 1.0;
-  size_t effort = 3;
+  size_t effort = 7;
   size_t brotli_effort = 9;
   std::string frame_indexing;
 


### PR DESCRIPTION
We change the default effort to match what is currently done in cjxl.
There it is speed tier "squirrel", which corresponds to effort 7.