### PR TITLE
Do not build third_party tests for ASAN/MSAN

### DIFF
--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -183,6 +183,9 @@ jobs:
       env:
         SKIP_TEST: 1
         CMAKE_CXX_FLAGS: ${{ matrix.cxxflags }}
+    - name: Build stats
+      run: |
+        awk '!/^#/ {total[$4]+=($2-$1);cntr[$4]+=1} END {for (key in total) print total[key]/cntr[key] " " key}' build/.ninja_log | sort -n | tail -n 25
     - name: ccache stats
       run: ccache --show-stats
     - name: Build stats ${{ matrix.name }}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -326,8 +326,10 @@ endif ()  # !MSVC
 
 include(GNUInstallDirs)
 
+# Separately build/configure testing frameworks and other third_party libraries
+# to allow disabling tests in those libraries.
+include(third_party/testing.cmake)
 add_subdirectory(third_party)
-
 # Copy the JXL license file to the output build directory.
 configure_file("${CMAKE_CURRENT_SOURCE_DIR}/LICENSE"
                ${PROJECT_BINARY_DIR}/LICENSE.jpeg-xl COPYONLY)

--- a/third_party/CMakeLists.txt
+++ b/third_party/CMakeLists.txt
@@ -12,73 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Enable tests in third_party/ as well.
-enable_testing()
-include(CTest)
-
-if(BUILD_TESTING)
-# Add GTest from source and alias it to what the find_package(GTest) workflow
-# defines. Omitting googletest/ directory would require it to be available in
-# the base system instead, but it would work just fine. This makes packages
-# using GTest and calling find_package(GTest) actually work.
-if (EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/googletest/CMakeLists.txt" AND
-    NOT JPEGXL_FORCE_SYSTEM_GTEST)
-  add_subdirectory(googletest EXCLUDE_FROM_ALL)
-
-  set(GTEST_ROOT "${CMAKE_CURRENT_SOURCE_DIR}/googletest/googletest")
-  set(GTEST_INCLUDE_DIR "$<TARGET_PROPERTY:INCLUDE_DIRECTORIES,gtest>"
-      CACHE STRING "")
-  set(GMOCK_INCLUDE_DIR "$<TARGET_PROPERTY:INCLUDE_DIRECTORIES,gmock>")
-  set(GTEST_LIBRARY "$<TARGET_FILE:gtest>")
-  set(GTEST_MAIN_LIBRARY "$<TARGET_FILE:gtest_main>")
-  add_library(GTest::GTest ALIAS gtest)
-  add_library(GTest::Main ALIAS gtest_main)
-
-  set_target_properties(gtest PROPERTIES POSITION_INDEPENDENT_CODE TRUE)
-  set_target_properties(gmock PROPERTIES POSITION_INDEPENDENT_CODE TRUE)
-  set_target_properties(gtest_main PROPERTIES POSITION_INDEPENDENT_CODE TRUE)
-  set_target_properties(gmock_main PROPERTIES POSITION_INDEPENDENT_CODE TRUE)
-
-  # googletest doesn't compile clean with clang-cl (-Wundef)
-  if (WIN32 AND CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
-    set_target_properties(gtest PROPERTIES COMPILE_FLAGS "-Wno-error")
-    set_target_properties(gmock PROPERTIES COMPILE_FLAGS "-Wno-error")
-    set_target_properties(gtest_main PROPERTIES COMPILE_FLAGS "-Wno-error")
-    set_target_properties(gmock_main PROPERTIES COMPILE_FLAGS "-Wno-error")
-  endif ()
-  configure_file("${CMAKE_CURRENT_SOURCE_DIR}/googletest/LICENSE"
-                 ${PROJECT_BINARY_DIR}/LICENSE.googletest COPYONLY)
-else()
-  if(JPEGXL_DEP_LICENSE_DIR)
-    configure_file("${JPEGXL_DEP_LICENSE_DIR}/googletest/copyright"
-                   ${PROJECT_BINARY_DIR}/LICENSE.googletest COPYONLY)
-  endif()  # JPEGXL_DEP_LICENSE_DIR
+if((SANITIZER STREQUAL "asan") OR (SANITIZER STREQUAL "msan"))
+  set(BUILD_TESTING OFF)
 endif()
-find_package(GTest)
-if (NOT GTEST_FOUND)
-  set(BUILD_TESTING OFF CACHE BOOL "Build tests" FORCE)
-  message(SEND_ERROR "GTest not found. Install googletest package "
-          "(libgtest-dev) in the system or download googletest to "
-          "third_party/googletest from https://github.com/google/googletest ."
-          "To disable tests instead re-run cmake with -DBUILD_TESTING=OFF.")
-endif()  # NOT GTEST_FOUND
-
-# Look for gmock in the system too.
-if (NOT DEFINED GMOCK_INCLUDE_DIR)
-  find_path(
-      GMOCK_INCLUDE_DIR "gmock/gmock.h"
-      HINTS ${GTEST_INCLUDE_DIRS})
-  if (NOT GMOCK_INCLUDE_DIR)
-    set(BUILD_TESTING OFF CACHE BOOL "Build tests" FORCE)
-    message(SEND_ERROR "GMock not found. Install googletest package "
-            "(libgmock-dev) in the system or download googletest to "
-            "third_party/googletest from https://github.com/google/googletest ."
-            "To disable tests instead re-run cmake with -DBUILD_TESTING=OFF.")
-  else()
-    message(STATUS "Found GMock: ${GMOCK_INCLUDE_DIR}")
-  endif()  # NOT GMOCK_INCLUDE_DIR
-endif()  # NOT DEFINED GMOCK_INCLUDE_DIR
-endif()  # BUILD_TESTING
 
 # Highway
 set(HWY_SYSTEM_GTEST ON CACHE INTERNAL "")
@@ -215,4 +151,3 @@ if (JPEGXL_ENABLE_SJPEG)
   configure_file("${CMAKE_CURRENT_SOURCE_DIR}/sjpeg/COPYING"
                  ${PROJECT_BINARY_DIR}/LICENSE.sjpeg COPYONLY)
 endif ()
-

--- a/third_party/testing.cmake
+++ b/third_party/testing.cmake
@@ -1,0 +1,83 @@
+# Copyright (c) the JPEG XL Project
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Enable tests in third_party/ as well.
+enable_testing()
+include(CTest)
+
+set(SOURCE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/third_party")
+
+if(BUILD_TESTING)
+# Add GTest from source and alias it to what the find_package(GTest) workflow
+# defines. Omitting googletest/ directory would require it to be available in
+# the base system instead, but it would work just fine. This makes packages
+# using GTest and calling find_package(GTest) actually work.
+if (EXISTS "${SOURCE_DIR}/googletest/CMakeLists.txt" AND
+    NOT JPEGXL_FORCE_SYSTEM_GTEST)
+  add_subdirectory(third_party/googletest EXCLUDE_FROM_ALL)
+
+  set(GTEST_ROOT "${SOURCE_DIR}/googletest/googletest")
+  set(GTEST_INCLUDE_DIR "$<TARGET_PROPERTY:INCLUDE_DIRECTORIES,gtest>"
+      CACHE STRING "")
+  set(GMOCK_INCLUDE_DIR "$<TARGET_PROPERTY:INCLUDE_DIRECTORIES,gmock>")
+  set(GTEST_LIBRARY "$<TARGET_FILE:gtest>")
+  set(GTEST_MAIN_LIBRARY "$<TARGET_FILE:gtest_main>")
+  add_library(GTest::GTest ALIAS gtest)
+  add_library(GTest::Main ALIAS gtest_main)
+
+  set_target_properties(gtest PROPERTIES POSITION_INDEPENDENT_CODE TRUE)
+  set_target_properties(gmock PROPERTIES POSITION_INDEPENDENT_CODE TRUE)
+  set_target_properties(gtest_main PROPERTIES POSITION_INDEPENDENT_CODE TRUE)
+  set_target_properties(gmock_main PROPERTIES POSITION_INDEPENDENT_CODE TRUE)
+
+  # googletest doesn't compile clean with clang-cl (-Wundef)
+  if (WIN32 AND CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
+    set_target_properties(gtest PROPERTIES COMPILE_FLAGS "-Wno-error")
+    set_target_properties(gmock PROPERTIES COMPILE_FLAGS "-Wno-error")
+    set_target_properties(gtest_main PROPERTIES COMPILE_FLAGS "-Wno-error")
+    set_target_properties(gmock_main PROPERTIES COMPILE_FLAGS "-Wno-error")
+  endif ()
+  configure_file("${SOURCE_DIR}/googletest/LICENSE"
+                 ${PROJECT_BINARY_DIR}/LICENSE.googletest COPYONLY)
+else()
+  if(JPEGXL_DEP_LICENSE_DIR)
+    configure_file("${JPEGXL_DEP_LICENSE_DIR}/googletest/copyright"
+                   ${PROJECT_BINARY_DIR}/LICENSE.googletest COPYONLY)
+  endif()  # JPEGXL_DEP_LICENSE_DIR
+endif()
+find_package(GTest)
+if (NOT GTEST_FOUND)
+  set(BUILD_TESTING OFF CACHE BOOL "Build tests" FORCE)
+  message(SEND_ERROR "GTest not found. Install googletest package "
+          "(libgtest-dev) in the system or download googletest to "
+          "third_party/googletest from https://github.com/google/googletest ."
+          "To disable tests instead re-run cmake with -DBUILD_TESTING=OFF.")
+endif()  # NOT GTEST_FOUND
+
+# Look for gmock in the system too.
+if (NOT DEFINED GMOCK_INCLUDE_DIR)
+  find_path(
+      GMOCK_INCLUDE_DIR "gmock/gmock.h"
+      HINTS ${GTEST_INCLUDE_DIRS})
+  if (NOT GMOCK_INCLUDE_DIR)
+    set(BUILD_TESTING OFF CACHE BOOL "Build tests" FORCE)
+    message(SEND_ERROR "GMock not found. Install googletest package "
+            "(libgmock-dev) in the system or download googletest to "
+            "third_party/googletest from https://github.com/google/googletest ."
+            "To disable tests instead re-run cmake with -DBUILD_TESTING=OFF.")
+  else()
+    message(STATUS "Found GMock: ${GMOCK_INCLUDE_DIR}")
+  endif()  # NOT GMOCK_INCLUDE_DIR
+endif()  # NOT DEFINED GMOCK_INCLUDE_DIR
+endif()  # BUILD_TESTING


### PR DESCRIPTION
Hopefully will shave 15min of build time.

Drive-by: report compile time