### PR TITLE
cjxl_ng: improve container handling

### DIFF
--- a/tools/cjxl_ng_main.cc
+++ b/tools/cjxl_ng_main.cc
@@ -790,7 +790,7 @@ int main(int argc, char** argv) {
       }
     };
 
-    { // Processing tuning flags.
+    {  // Processing tuning flags.
       process_bool_flag("modular", args.modular, JXL_ENC_FRAME_SETTING_MODULAR);
       process_bool_flag("keep_invisible", args.keep_invisible,
                         JXL_ENC_FRAME_SETTING_KEEP_INVISIBLE);


### PR DESCRIPTION
This unifies the two boolean "container" and the "strip" into a three-state flag "container".
We move the `PrintMode` to a place after the state of container is known and also print this information in the end.