### PR TITLE
add `JxlEncoderFrameSettingsSetFloatOption`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,8 +31,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
  - decoder API: new function `JxlDecoderGetIntendedDownsamplingRatio` to get
    the intended downsampling ratio of progressive setps, based on the
    information in the frame header.
- - encoder API: added ability to set several encoder options to frames using
-   `JxlEncoderFrameSettingsSetOption`
+ - encoder API: added ability to set several encoder int options to frames
+   using `JxlEncoderFrameSettingsSetOption`.
+ - encoder API: added ability to set several encoder float options to frames
+   using `JxlEncoderFrameSettingsSetFloatOption`.
  - encoder API: new functions `JxlEncoderSetFrameHeader` and
    `JxlEncoderSetExtraChannelBlendInfo` to set animation
    and blending parameters of the frame, and `JxlEncoderInitFrameHeader` and

--- a/lib/include/jxl/encode.h
+++ b/lib/include/jxl/encode.h
@@ -913,6 +913,24 @@ JXL_EXPORT JxlEncoderStatus JxlEncoderFrameSettingsSetOption(
     JxlEncoderFrameSettings* frame_settings, JxlEncoderFrameSettingId option,
     int64_t value);
 
+/**
+ * Sets a frame-specific option of float type to the encoder options.
+ * The JxlEncoderFrameSettingId argument determines which option is set.
+ *
+ * @param frame_settings set of options and metadata for this frame. Also
+ * includes reference to the encoder object.
+ * @param option ID of the option to set.
+ * @param value Float value to set for this option.
+ * @return JXL_ENC_SUCCESS if the operation was successful, JXL_ENC_ERROR in
+ * case of an error, such as invalid or unknown option id, or invalid integer
+ * value for the given option. If an error is returned, the state of the
+ * JxlEncoderFrameSettings object is still valid and is the same as before this
+ * function was called.
+ */
+JXL_EXPORT JxlEncoderStatus JxlEncoderFrameSettingsSetFloatOption(
+    JxlEncoderFrameSettings* frame_settings, JxlEncoderFrameSettingId option,
+    float value);
+
 /** Forces the encoder to use the box-based container format (BMFF) even
  * when not necessary.
  *

--- a/lib/jxl/encode_test.cc
+++ b/lib/jxl/encode_test.cc
@@ -404,10 +404,10 @@ TEST(EncodeTest, frame_settingsTest) {
     JxlEncoderFrameSettings* frame_settings =
         JxlEncoderFrameSettingsCreate(enc.get(), NULL);
     EXPECT_EQ(JXL_ENC_SUCCESS,
-              JxlEncoderFrameSettingsSetOption(
-                  frame_settings, JXL_ENC_FRAME_SETTING_PHOTON_NOISE, 1777));
+              JxlEncoderFrameSettingsSetFloatOption(
+                  frame_settings, JXL_ENC_FRAME_SETTING_PHOTON_NOISE, 1777.777));
     VerifyFrameEncoding(enc.get(), frame_settings);
-    EXPECT_EQ(1777.0f, enc->last_used_cparams.photon_noise_iso);
+    EXPECT_NEAR(1777.777f, enc->last_used_cparams.photon_noise_iso, 1E-6);
   }
 
   {
@@ -416,13 +416,13 @@ TEST(EncodeTest, frame_settingsTest) {
     JxlEncoderFrameSettings* frame_settings =
         JxlEncoderFrameSettingsCreate(enc.get(), NULL);
     EXPECT_EQ(JXL_ENC_SUCCESS,
-              JxlEncoderFrameSettingsSetOption(
+              JxlEncoderFrameSettingsSetFloatOption(
                   frame_settings,
-                  JXL_ENC_FRAME_SETTING_CHANNEL_COLORS_GLOBAL_PERCENT, 55));
+                  JXL_ENC_FRAME_SETTING_CHANNEL_COLORS_GLOBAL_PERCENT, 55.0f));
     EXPECT_EQ(JXL_ENC_SUCCESS,
-              JxlEncoderFrameSettingsSetOption(
+              JxlEncoderFrameSettingsSetFloatOption(
                   frame_settings,
-                  JXL_ENC_FRAME_SETTING_CHANNEL_COLORS_GROUP_PERCENT, 25));
+                  JXL_ENC_FRAME_SETTING_CHANNEL_COLORS_GROUP_PERCENT, 25.0f));
     EXPECT_EQ(JXL_ENC_SUCCESS,
               JxlEncoderFrameSettingsSetOption(
                   frame_settings, JXL_ENC_FRAME_SETTING_PALETTE_COLORS, 70000));
@@ -430,9 +430,9 @@ TEST(EncodeTest, frame_settingsTest) {
               JxlEncoderFrameSettingsSetOption(
                   frame_settings, JXL_ENC_FRAME_SETTING_LOSSY_PALETTE, 1));
     VerifyFrameEncoding(enc.get(), frame_settings);
-    EXPECT_EQ(55.0f,
-              enc->last_used_cparams.channel_colors_pre_transform_percent);
-    EXPECT_EQ(25.0f, enc->last_used_cparams.channel_colors_percent);
+    EXPECT_NEAR(55.0f,
+              enc->last_used_cparams.channel_colors_pre_transform_percent, 1E-6);
+    EXPECT_NEAR(25.0f, enc->last_used_cparams.channel_colors_percent, 1E-6);
     EXPECT_EQ(70000, enc->last_used_cparams.palette_colors);
     EXPECT_EQ(true, enc->last_used_cparams.lossy_palette);
   }
@@ -453,9 +453,9 @@ TEST(EncodeTest, frame_settingsTest) {
               JxlEncoderFrameSettingsSetOption(
                   frame_settings, JXL_ENC_FRAME_SETTING_MODULAR_PREDICTOR, 14));
     EXPECT_EQ(JXL_ENC_SUCCESS,
-              JxlEncoderFrameSettingsSetOption(
+              JxlEncoderFrameSettingsSetFloatOption(
                   frame_settings,
-                  JXL_ENC_FRAME_SETTING_MODULAR_MA_TREE_LEARNING_PERCENT, 77));
+                  JXL_ENC_FRAME_SETTING_MODULAR_MA_TREE_LEARNING_PERCENT, 77.0f));
     EXPECT_EQ(
         JXL_ENC_SUCCESS,
         JxlEncoderFrameSettingsSetOption(
@@ -464,7 +464,7 @@ TEST(EncodeTest, frame_settingsTest) {
     EXPECT_EQ(30, enc->last_used_cparams.colorspace);
     EXPECT_EQ(2, enc->last_used_cparams.modular_group_size_shift);
     EXPECT_EQ(jxl::Predictor::Best, enc->last_used_cparams.options.predictor);
-    EXPECT_EQ(0.77f, enc->last_used_cparams.options.nb_repeats);
+    EXPECT_NEAR(0.77f, enc->last_used_cparams.options.nb_repeats, 1E-6);
     EXPECT_EQ(7, enc->last_used_cparams.options.max_properties);
   }
 

--- a/lib/jxl/encode_test.cc
+++ b/lib/jxl/encode_test.cc
@@ -403,9 +403,10 @@ TEST(EncodeTest, frame_settingsTest) {
     EXPECT_NE(nullptr, enc.get());
     JxlEncoderFrameSettings* frame_settings =
         JxlEncoderFrameSettingsCreate(enc.get(), NULL);
-    EXPECT_EQ(JXL_ENC_SUCCESS,
-              JxlEncoderFrameSettingsSetFloatOption(
-                  frame_settings, JXL_ENC_FRAME_SETTING_PHOTON_NOISE, 1777.777));
+    EXPECT_EQ(
+        JXL_ENC_SUCCESS,
+        JxlEncoderFrameSettingsSetFloatOption(
+            frame_settings, JXL_ENC_FRAME_SETTING_PHOTON_NOISE, 1777.777));
     VerifyFrameEncoding(enc.get(), frame_settings);
     EXPECT_NEAR(1777.777f, enc->last_used_cparams.photon_noise_iso, 1E-6);
   }
@@ -431,7 +432,8 @@ TEST(EncodeTest, frame_settingsTest) {
                   frame_settings, JXL_ENC_FRAME_SETTING_LOSSY_PALETTE, 1));
     VerifyFrameEncoding(enc.get(), frame_settings);
     EXPECT_NEAR(55.0f,
-              enc->last_used_cparams.channel_colors_pre_transform_percent, 1E-6);
+                enc->last_used_cparams.channel_colors_pre_transform_percent,
+                1E-6);
     EXPECT_NEAR(25.0f, enc->last_used_cparams.channel_colors_percent, 1E-6);
     EXPECT_EQ(70000, enc->last_used_cparams.palette_colors);
     EXPECT_EQ(true, enc->last_used_cparams.lossy_palette);
@@ -452,10 +454,11 @@ TEST(EncodeTest, frame_settingsTest) {
     EXPECT_EQ(JXL_ENC_SUCCESS,
               JxlEncoderFrameSettingsSetOption(
                   frame_settings, JXL_ENC_FRAME_SETTING_MODULAR_PREDICTOR, 14));
-    EXPECT_EQ(JXL_ENC_SUCCESS,
-              JxlEncoderFrameSettingsSetFloatOption(
-                  frame_settings,
-                  JXL_ENC_FRAME_SETTING_MODULAR_MA_TREE_LEARNING_PERCENT, 77.0f));
+    EXPECT_EQ(
+        JXL_ENC_SUCCESS,
+        JxlEncoderFrameSettingsSetFloatOption(
+            frame_settings,
+            JXL_ENC_FRAME_SETTING_MODULAR_MA_TREE_LEARNING_PERCENT, 77.0f));
     EXPECT_EQ(
         JXL_ENC_SUCCESS,
         JxlEncoderFrameSettingsSetOption(

--- a/tools/cjxl_ng_main.cc
+++ b/tools/cjxl_ng_main.cc
@@ -20,6 +20,7 @@
 #include <sstream>
 #include <string>
 #include <thread>
+#include <type_traits>
 #include <vector>
 
 #include "jxl/codestream_header.h"
@@ -314,9 +315,9 @@ struct CompressArgs {
         'I', "iterations", "F",
         "[modular encoding] Fraction of pixels used to learn MA trees as "
         "a percentage. -1 = default, 0 = no MA and fast decode, 50 = "
-        "default value, 100 = all, values above 100 are also permitted. "
+        "default value, 100 = all."
         "Higher values use more encoder memory.",
-        &modular_ma_tree_learning_percent, &ParseSigned, 2);
+        &modular_ma_tree_learning_percent, &ParseFloat, 2);
 
     cmdline->AddOptionValue(
         'C', "modular_colorspace", "K",
@@ -366,7 +367,7 @@ struct CompressArgs {
         "colors is smaller than this percentage of range. "
         "Use 0-100 to set an explicit percentage, -1 to use the encoder "
         "default.",
-        &modular_channel_colors_global_percent, &ParseSigned, 2);
+        &modular_channel_colors_global_percent, &ParseFloat, 2);
 
     cmdline->AddOptionValue(
         'Y', "post-compact", "PERCENT",
@@ -374,7 +375,7 @@ struct CompressArgs {
         "number "
         "of colors is smaller than this percentage of range. Use 0-100 to set "
         "an explicit percentage, -1 to use the encoder default.",
-        &modular_channel_colors_group_percent, &ParseSigned, 2);
+        &modular_channel_colors_group_percent, &ParseFloat, 2);
 
     cmdline->AddOptionValue('\0', "codestream_level", "K",
                             "The codestream level. Either `-1`, `5` or `10`.",
@@ -463,11 +464,11 @@ struct CompressArgs {
   int32_t modular_group_size = -1;
   int32_t modular_predictor = -1;
   int32_t modular_colorspace = -1;
-  int32_t modular_channel_colors_global_percent = -1;
-  int32_t modular_channel_colors_group_percent = -1;
+  float modular_channel_colors_global_percent = -1.f;
+  float modular_channel_colors_group_percent = -1.f;
   int32_t modular_palette_colors = -1;
   int32_t modular_nb_prev_channels = -1;
-  int32_t modular_ma_tree_learning_percent = -1;
+  float modular_ma_tree_learning_percent = -1.f;
   float photon_noise_iso = 0;
   int32_t codestream_level = -1;
   int32_t responsive = -1;
@@ -563,14 +564,18 @@ bool WriteFile(const std::vector<uint8_t>& bytes, const char* filename) {
   return true;
 }
 
-void SetFlagFrameOptionOrDie(const char* flag_name, int64_t flag_value,
+template <typename T>
+void SetFlagFrameOptionOrDie(const char* flag_name, T flag_value,
                              JxlEncoderFrameSettings* frame_settings,
                              JxlEncoderFrameSettingId encoder_option) {
   if (JXL_ENC_SUCCESS !=
-      JxlEncoderFrameSettingsSetOption(frame_settings, encoder_option,
-                                       static_cast<int64_t>(flag_value))) {
-    std::cerr << "Setting encoder option from flag -- " << flag_name
-              << "failed." << std::endl;
+      (std::is_same<T, float>::value
+           ? JxlEncoderFrameSettingsSetFloatOption(frame_settings,
+                                                   encoder_option, flag_value)
+           : JxlEncoderFrameSettingsSetOption(frame_settings, encoder_option,
+                                              flag_value))) {
+    std::cerr << "Setting encoder option from flag --" << flag_name
+              << " failed." << std::endl;
     exit(EXIT_FAILURE);
   }
 }
@@ -617,6 +622,7 @@ void SetDistanceFromFlags(JxlEncoderFrameSettings* jxl_encoder_frame_settings,
 }
 
 using flag_check_fn = std::function<std::string(int64_t)>;
+using flag_check_float_fn = std::function<std::string(float)>;
 
 bool IsJPG(const jxl::PaddedBytes& image_data) {
   return (image_data.size() >= 2 && image_data[0] == 0xFF &&
@@ -784,6 +790,19 @@ int main(int argc, char** argv) {
       SetFlagFrameOptionOrDie(flag_name, flag_value, jxl_encoder_frame_settings,
                               encoder_option);
     };
+    auto process_float_flag = [&jxl_encoder_frame_settings](
+                                  const char* flag_name, float flag_value,
+                                  JxlEncoderFrameSettingId encoder_option,
+                                  const flag_check_float_fn& flag_check) {
+      std::string error = flag_check(flag_value);
+      if (!error.empty()) {
+        std::cerr << "Invalid flag value for --" << flag_name << ": " << error
+                  << std::endl;
+        exit(EXIT_FAILURE);
+      }
+      SetFlagFrameOptionOrDie(flag_name, flag_value, jxl_encoder_frame_settings,
+                              encoder_option);
+    };
 
     auto process_bool_flag = [&jxl_encoder_frame_settings](
                                  const char* flag_name,
@@ -877,8 +896,6 @@ int main(int argc, char** argv) {
                                 ? ""
                                 : "Valid values are {-1, 1, 2, 4, 8}.\n";
                    });
-      // TODO(firsching): change JxlEncoderFrameSettingsSetOption to take float
-      // for JXL_ENC_FRAME_SETTING_PHOTON_NOISE.
       SetFlagFrameOptionOrDie("photon_noise_iso", args.photon_noise_iso,
                               jxl_encoder_frame_settings,
                               JXL_ENC_FRAME_SETTING_PHOTON_NOISE);
@@ -975,14 +992,15 @@ int main(int argc, char** argv) {
                        : "Invalid --modular_colorspace. Valid range is "
                          "{-1, 0, 1, ..., 41}.\n";
           });
-      process_flag(
+      process_float_flag(
           "modular_ma_tree_learning_percent",
           args.modular_ma_tree_learning_percent,
           JXL_ENC_FRAME_SETTING_MODULAR_MA_TREE_LEARNING_PERCENT,
-          [](int64_t x) -> std::string {
-            return -1 <= x ? ""
-                           : "Invalid --modular_ma_tree_learning_percent, must "
-                             "be -1 or non-negative\n";
+          [](float x) -> std::string {
+            return -1 <= x && x <= 100
+                       ? ""
+                       : "Invalid --modular_ma_tree_learning_percent, Valid"
+                         "rang is [-1, 100].\n";
           });
       process_flag("modular_nb_prev_channels", args.modular_nb_prev_channels,
                    JXL_ENC_FRAME_SETTING_MODULAR_NB_PREV_CHANNELS,
@@ -1003,27 +1021,27 @@ int main(int argc, char** argv) {
                                     : "Invalid --modular_palette_colors, must "
                                       "be -1 or non-negative\n";
                    });
-      process_flag(
+      process_float_flag(
           "modular_channel_colors_global_percent",
           args.modular_channel_colors_global_percent,
           JXL_ENC_FRAME_SETTING_CHANNEL_COLORS_GLOBAL_PERCENT,
-          [](int64_t x) -> std::string {
+          [](float x) -> std::string {
             return (-1 <= x && x <= 100)
                        ? ""
                        : "Invalid --modular_channel_colors_global_percent. "
                          "Valid "
-                         "range is {-1, 0, 1, ..., 100}.\n";
+                         "range is [-1, 100].\n";
           });
-      process_flag(
+      process_float_flag(
           "modular_channel_colors_group_percent",
           args.modular_channel_colors_group_percent,
           JXL_ENC_FRAME_SETTING_CHANNEL_COLORS_GROUP_PERCENT,
-          [](int64_t x) -> std::string {
+          [](float x) -> std::string {
             return (-1 <= x && x <= 100)
                        ? ""
                        : "Invalid --modular_channel_colors_group_percent. "
                          "Valid "
-                         "range is {-1, 0, 1, ..., 100}.\n";
+                         "range is [-1, 100].\n";
           });
     }
 


### PR DESCRIPTION
Some of the values that are currently set via
`JxlEncoderFrameSettingsSetOption` are floats, which are cast back and
forth to int64_t in between. We add a way of letting them be floats at
all times.