### PR TITLE
Do not unpremultiply-alpha by default

### DIFF
--- a/lib/extras/dec/jxl.h
+++ b/lib/extras/dec/jxl.h
@@ -52,7 +52,7 @@ struct JXLDecompressParams {
   // Whether to use the image callback or the image buffer to get the output.
   bool use_image_callback = true;
   // Whether to unpremultiply colors for associated alpha channels.
-  bool unpremultiply_alpha = true;
+  bool unpremultiply_alpha = false;
 };
 
 bool DecodeImageJXL(const uint8_t* bytes, size_t bytes_size,

--- a/lib/include/jxl/decode.h
+++ b/lib/include/jxl/decode.h
@@ -521,8 +521,7 @@ JxlDecoderSetKeepOrientation(JxlDecoder* dec, JXL_BOOL skip_reorientation);
  * The colors will be unpremultiplied based on the alpha channel. This function
  * has no effect if the image does not have an associated alpha channel.
  *
- * By default, this option is enabled, and the returned pixel data is
- * unpremultiplied.
+ * By default, this option is disabled, and the returned pixel data "as is".
  *
  * This function must be called at the beginning, before decoding is performed.
  *

--- a/lib/jxl/dec_external_image.h
+++ b/lib/jxl/dec_external_image.h
@@ -39,7 +39,7 @@ Status ConvertToExternal(const jxl::ImageBundle& ib, size_t bits_per_sample,
                          jxl::ThreadPool* thread_pool, void* out_image,
                          size_t out_size, const PixelCallback& out_callback,
                          jxl::Orientation undo_orientation,
-                         bool unpremul_alpha = true);
+                         bool unpremul_alpha = false);
 
 // Converts single-channel image to interleaved void* pixel buffer with the
 // given format, with a single channel.

--- a/lib/jxl/decode.cc
+++ b/lib/jxl/decode.cc
@@ -752,7 +752,7 @@ void JxlDecoderReset(JxlDecoder* dec) {
 
   dec->thread_pool.reset();
   dec->keep_orientation = false;
-  dec->unpremul_alpha = true;
+  dec->unpremul_alpha = false;
   dec->render_spotcolors = true;
   dec->coalescing = true;
   dec->desired_intensity_target = 0;

--- a/lib/jxl/image_bundle.cc
+++ b/lib/jxl/image_bundle.cc
@@ -8,7 +8,6 @@
 #include <limits>
 #include <utility>
 
-#include "lib/jxl/alpha.h"
 #include "lib/jxl/base/byte_order.h"
 #include "lib/jxl/base/padded_bytes.h"
 #include "lib/jxl/base/printf_macros.h"
@@ -117,32 +116,6 @@ void ImageBundle::SetAlpha(ImageF&& alpha, bool alpha_is_premultiplied) {
   }
   // num_extra_channels is automatically set in visitor
   VerifySizes();
-}
-void ImageBundle::PremultiplyAlpha() {
-  if (!HasAlpha()) return;
-  if (!HasColor()) return;
-  const ExtraChannelInfo* eci = metadata_->Find(ExtraChannel::kAlpha);
-  if (eci->alpha_associated) return;  // already premultiplied
-  JXL_CHECK(color_.ysize() == alpha()->ysize());
-  JXL_CHECK(color_.xsize() == alpha()->xsize());
-  for (size_t y = 0; y < color_.ysize(); y++) {
-    ::jxl::PremultiplyAlpha(color_.PlaneRow(0, y), color_.PlaneRow(1, y),
-                            color_.PlaneRow(2, y), alpha()->Row(y),
-                            color_.xsize());
-  }
-}
-void ImageBundle::UnpremultiplyAlpha() {
-  if (!HasAlpha()) return;
-  if (!HasColor()) return;
-  const ExtraChannelInfo* eci = metadata_->Find(ExtraChannel::kAlpha);
-  if (!eci->alpha_associated) return;  // already unpremultiplied
-  JXL_CHECK(color_.ysize() == alpha()->ysize());
-  JXL_CHECK(color_.xsize() == alpha()->xsize());
-  for (size_t y = 0; y < color_.ysize(); y++) {
-    ::jxl::UnpremultiplyAlpha(color_.PlaneRow(0, y), color_.PlaneRow(1, y),
-                              color_.PlaneRow(2, y), alpha()->Row(y),
-                              color_.xsize());
-  }
 }
 
 void ImageBundle::SetExtraChannels(std::vector<ImageF>&& extra_channels) {

--- a/lib/jxl/image_bundle.h
+++ b/lib/jxl/image_bundle.h
@@ -170,10 +170,6 @@ class ImageBundle {
     const ExtraChannelInfo* eci = metadata_->Find(ExtraChannel::kAlpha);
     return (eci == nullptr) ? false : eci->alpha_associated;
   }
-  // Premultiply alpha (if it isn't already premultiplied)
-  void PremultiplyAlpha();
-  // Unpremultiply alpha (if it isn't already non-premultiplied)
-  void UnpremultiplyAlpha();
   const ImageF& alpha() const;
   ImageF* alpha();
 

--- a/lib/jxl/jxl_test.cc
+++ b/lib/jxl/jxl_test.cc
@@ -858,8 +858,12 @@ TEST(JxlTest, RoundtripAlphaPremultiplied) {
   CompressParams cparams;
   cparams.butteraugli_distance = 1.0;
 
-  io.PremultiplyAlpha();
+  EXPECT_FALSE(io.Main().AlphaIsPremultiplied());
+  EXPECT_TRUE(io.PremultiplyAlpha());
   EXPECT_TRUE(io.Main().AlphaIsPremultiplied());
+
+  EXPECT_FALSE(io_nopremul.Main().AlphaIsPremultiplied());
+
   PassesEncoderState enc_state;
   AuxOut* aux_out = nullptr;
   PaddedBytes compressed;
@@ -886,12 +890,14 @@ TEST(JxlTest, RoundtripAlphaPremultiplied) {
         EXPECT_TRUE(test::DecodeFile(dparams, compressed, &io2, pool));
 
         EXPECT_LE(compressed.size(), 10000u);
+        EXPECT_EQ(unpremul_alpha, !io2.Main().AlphaIsPremultiplied());
         if (!unpremul_alpha) {
           EXPECT_THAT(
               ButteraugliDistance(io, io2, cparams.ba_params, GetJxlCms(),
                                   /*distmap=*/nullptr, pool),
               IsSlightlyBelow(1.25));
-          io2.Main().UnpremultiplyAlpha();
+          EXPECT_TRUE(io2.UnpremultiplyAlpha());
+          EXPECT_FALSE(io2.Main().AlphaIsPremultiplied());
         }
         EXPECT_THAT(ButteraugliDistance(io_nopremul, io2, cparams.ba_params,
                                         GetJxlCms(),


### PR DESCRIPTION
This is generally bad idea to have alpha premultiplied (in storage format).
Unpremultiplying can cause very low precision results, and the result for
pixels with alpha == 0 is a separate discussion topic.