### PR TITLE
Fix float32 small/large cube implicit palette value scaling.

### DIFF
--- a/lib/jxl/modular/transform/enc_palette.cc
+++ b/lib/jxl/modular/transform/enc_palette.cc
@@ -340,7 +340,7 @@ Status FwdPaletteIteration(Image &input, uint32_t begin_c, uint32_t end_c,
   pixel_type *JXL_RESTRICT p_palette = pch.Row(0);
   intptr_t onerow = pch.plane.PixelsPerRow();
   intptr_t onerow_image = input.channel[begin_c].plane.PixelsPerRow();
-  const int bit_depth = input.bitdepth;
+  const int bit_depth = std::min(input.bitdepth, 24);
 
   if (lossy) {
     for (uint32_t i = 0; i < nb_deltas; i++) {

--- a/lib/jxl/modular/transform/palette.h
+++ b/lib/jxl/modular/transform/palette.h
@@ -86,7 +86,7 @@ static pixel_type GetPaletteValue(const pixel_type *const palette, int index,
     pixel_type result =
         kDeltaPalette[((index + 1) >> 1)][c] * kMultiplier[index & 1];
     if (bit_depth > 8) {
-      result *= static_cast<pixel_type>(1) << (std::min(bit_depth, 24) - 8);
+      result *= static_cast<pixel_type>(1) << (bit_depth - 8);
     }
     return result;
   } else if (palette_size <= index && index < palette_size + kLargeCubeOffset) {
@@ -141,7 +141,7 @@ static Status InvPalette(Image &input, uint32_t begin_c, uint32_t nb_colors,
   const pixel_type *JXL_RESTRICT p_palette = input.channel[0].Row(0);
   intptr_t onerow = input.channel[0].plane.PixelsPerRow();
   intptr_t onerow_image = input.channel[c0].plane.PixelsPerRow();
-  const int bit_depth = input.bitdepth;
+  const int bit_depth = std::min(input.bitdepth, 24);
 
   if (w == 0) {
     // Nothing to do.


### PR DESCRIPTION
This is analogous to how implicit delta palette value scaling is
defined for float32 palette.

This fixes an integer overflow bug found by oss-fuzz that was
introduced by #1341.