### PR TITLE
tools/cjxl_main: correctly report modular mode for lossless

### DIFF
--- a/tools/cjxl_main.cc
+++ b/tools/cjxl_main.cc
@@ -487,7 +487,9 @@ struct CompressArgs {
 
 const char* ModeFromArgs(const CompressArgs& args) {
   if (args.lossless_jpeg) return "JPEG";
-  if (args.modular == jxl::Override::kOn) return "Modular";
+  if (args.modular == jxl::Override::kOn || args.distance == 0 ||
+      args.quality == 100)
+    return "Modular";
   return "VarDCT";
 }
 


### PR DESCRIPTION
cjxl should correctly report that it is using modular mode when a
user specifies distance=0 or quality=100. It already uses modular,
but until this commit it reported VarDCT incorrectly.

Fixes #1627.