### PR TITLE
Add tighter memory usage limits on patch dictionary.

### DIFF
--- a/lib/jxl/dec_patch_dictionary.h
+++ b/lib/jxl/dec_patch_dictionary.h
@@ -78,25 +78,12 @@ struct PatchBlending {
 // Position and size of the patch in the reference frame.
 struct PatchReferencePosition {
   size_t ref, x0, y0, xsize, ysize;
-  bool operator<(const PatchReferencePosition& oth) const {
-    return std::make_tuple(ref, x0, y0, xsize, ysize) <
-           std::make_tuple(oth.ref, oth.x0, oth.y0, oth.xsize, oth.ysize);
-  }
-  bool operator==(const PatchReferencePosition& oth) const {
-    return !(*this < oth) && !(oth < *this);
-  }
 };
 
 struct PatchPosition {
   // Position of top-left corner of the patch in the image.
   size_t x, y;
-  // Different blend mode for color and extra channels.
-  std::vector<PatchBlending> blending;
-  PatchReferencePosition ref_pos;
-  bool operator<(const PatchPosition& oth) const {
-    return std::make_tuple(ref_pos, x, y) <
-           std::make_tuple(oth.ref_pos, oth.x, oth.y);
-  }
+  size_t ref_pos_idx;
 };
 
 struct PassesSharedState;
@@ -135,7 +122,10 @@ class PatchDictionary {
 
   const PassesSharedState* shared_;
   std::vector<PatchPosition> positions_;
+  std::vector<PatchReferencePosition> ref_positions_;
+  std::vector<PatchBlending> blendings_;
 
+  // TODO(szabadka) Limit the size of these vectors or use an interval tree.
   // Patch occurrences sorted by y.
   std::vector<size_t> sorted_patches_;
   // Index of the first patch for each y value.

--- a/lib/jxl/enc_patch_dictionary.h
+++ b/lib/jxl/enc_patch_dictionary.h
@@ -81,13 +81,12 @@ class PatchDictionaryEncoder {
                      size_t layer, AuxOut* aux_out);
 
   static void SetPositions(PatchDictionary* pdic,
-                           std::vector<PatchPosition> positions) {
-    if (pdic->positions_.empty()) {
-      pdic->positions_ = std::move(positions);
-    } else {
-      pdic->positions_.insert(pdic->positions_.end(), positions.begin(),
-                              positions.end());
-    }
+                           std::vector<PatchPosition> positions,
+                           std::vector<PatchReferencePosition> ref_positions,
+                           std::vector<PatchBlending> blendings) {
+    pdic->positions_ = std::move(positions);
+    pdic->ref_positions_ = std::move(ref_positions);
+    pdic->blendings_ = std::move(blendings);
     pdic->ComputePatchCache();
   }
 


### PR DESCRIPTION
The vector of patch positions is broken up into three
vectors: reference positions, patch positions (with indexes into
the reference positions vector) and blending infos. Each vector's
size is limited in the decoder, giving a combined upper bound on
the memory usage (currently 1.5GB).

I will fix the memory usage of the structures used for looking up
patches that insersect a certain row in a separate PR.