### PR TITLE
Make JXL library build for arm-none-eabi

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -39,6 +39,7 @@ Maarten DB <anonymous.maarten@gmail.com>
 Marcin Konicki <ahwayakchih@gmail.com>
 Martin Strunz
 Mathieu Malaterre <mathieu.malaterre@gmail.com>
+Mikk Leini <mikk.leini@krakul.eu>
 Misaki Kasumi <misakikasumi@outlook.com>
 Petr Diblík
 Pieter Wuille

--- a/lib/jxl/ans_common.cc
+++ b/lib/jxl/ans_common.cc
@@ -12,11 +12,11 @@
 
 namespace jxl {
 
-std::vector<int> CreateFlatHistogram(int length, int total_count) {
+std::vector<int32_t> CreateFlatHistogram(int length, int total_count) {
   JXL_ASSERT(length > 0);
   JXL_ASSERT(length <= total_count);
   const int count = total_count / length;
-  std::vector<int> result(length, count);
+  std::vector<int32_t> result(length, count);
   const int rem_counts = total_count % length;
   for (int i = 0; i < rem_counts; ++i) {
     ++result[i];
@@ -48,7 +48,7 @@ std::vector<int> CreateFlatHistogram(int length, int total_count) {
 // underfull nor overfull, and represents exactly two symbols. The overfull
 // entry might be either overfull or underfull, and is pushed into the
 // corresponding stack.
-void InitAliasTable(std::vector<int> distribution, uint32_t range,
+void InitAliasTable(std::vector<int32_t> distribution, uint32_t range,
                     size_t log_alpha_size, AliasTable::Entry* JXL_RESTRICT a) {
   while (!distribution.empty() && distribution.back() == 0) {
     distribution.pop_back();

--- a/lib/jxl/ans_common.h
+++ b/lib/jxl/ans_common.h
@@ -32,7 +32,7 @@ static JXL_INLINE uint32_t GetPopulationCountPrecision(uint32_t logcount,
 // Returns a histogram where the counts are positive, differ by at most 1,
 // and add up to total_count. The bigger counts (if any) are at the beginning
 // of the histogram.
-std::vector<int> CreateFlatHistogram(int length, int total_count);
+std::vector<int32_t> CreateFlatHistogram(int length, int total_count);
 
 // An alias table implements a mapping from the [0, ANS_TAB_SIZE) range into
 // the [0, ANS_MAX_ALPHABET_SIZE) range, satisfying the following conditions:
@@ -135,7 +135,7 @@ struct AliasTable {
 };
 
 // Computes an alias table for a given distribution.
-void InitAliasTable(std::vector<int> distribution, uint32_t range,
+void InitAliasTable(std::vector<int32_t> distribution, uint32_t range,
                     size_t log_alpha_size, AliasTable::Entry* JXL_RESTRICT a);
 
 }  // namespace jxl

--- a/lib/jxl/base/random.h
+++ b/lib/jxl/base/random.h
@@ -20,7 +20,8 @@
 namespace jxl {
 struct Rng {
   explicit Rng(size_t seed)
-      : s{0x94D049BB133111EBull, 0xBF58476D1CE4E5B9ull + seed} {}
+      : s{static_cast<uint64_t>(0x94D049BB133111EBull),
+          static_cast<uint64_t>(0xBF58476D1CE4E5B9ull) + seed} {}
 
   // Xorshift128+ adapted from xorshift128+-inl.h
   uint64_t operator()() {

--- a/lib/jxl/dec_ans.cc
+++ b/lib/jxl/dec_ans.cc
@@ -48,7 +48,7 @@ inline int DecodeVarLenUint16(BitReader* input) {
   return 0;
 }
 
-Status ReadHistogram(int precision_bits, std::vector<int>* counts,
+Status ReadHistogram(int precision_bits, std::vector<int32_t>* counts,
                      BitReader* input) {
   int simple_code = input->ReadBits(1);
   if (simple_code == 1) {
@@ -228,7 +228,7 @@ Status DecodeANSCodes(const size_t num_histograms,
     AliasTable::Entry* alias_tables =
         reinterpret_cast<AliasTable::Entry*>(result->alias_tables.get());
     for (size_t c = 0; c < num_histograms; ++c) {
-      std::vector<int> counts;
+      std::vector<int32_t> counts;
       if (!ReadHistogram(ANS_LOG_TAB_SIZE, &counts, in)) {
         return JXL_FAILURE("Invalid histogram bitstream.");
       }

--- a/lib/jxl/dec_modular.cc
+++ b/lib/jxl/dec_modular.cc
@@ -451,11 +451,11 @@ Status ModularFrameDecoder::DecodeAcMetadata(size_t group_id, BitReader* reader,
   uint32_t local_used_acs = 0;
   for (size_t iy = 0; iy < r.ysize(); iy++) {
     size_t y = r.y0() + iy;
-    int* row_qf = r.Row(&dec_state->shared_storage.raw_quant_field, iy);
+    int32_t* row_qf = r.Row(&dec_state->shared_storage.raw_quant_field, iy);
     uint8_t* row_epf = r.Row(&dec_state->shared_storage.epf_sharpness, iy);
-    int* row_in_1 = image.channel[2].plane.Row(0);
-    int* row_in_2 = image.channel[2].plane.Row(1);
-    int* row_in_3 = image.channel[3].plane.Row(iy);
+    int32_t* row_in_1 = image.channel[2].plane.Row(0);
+    int32_t* row_in_2 = image.channel[2].plane.Row(1);
+    int32_t* row_in_3 = image.channel[3].plane.Row(iy);
     for (size_t ix = 0; ix < r.xsize(); ix++) {
       size_t x = r.x0() + ix;
       int sharpness = row_in_3[ix];
@@ -492,8 +492,8 @@ Status ModularFrameDecoder::DecodeAcMetadata(size_t group_id, BitReader* reader,
       }
       JXL_RETURN_IF_ERROR(
           ac_strategy.SetNoBoundsCheck(x, y, AcStrategy::Type(row_in_1[num])));
-      row_qf[ix] =
-          1 + std::max(0, std::min(Quantizer::kQuantMax - 1, row_in_2[num]));
+      row_qf[ix] = 1 + std::max<int32_t>(0, std::min(Quantizer::kQuantMax - 1,
+                                                     row_in_2[num]));
       num++;
     }
   }
@@ -755,7 +755,7 @@ Status ModularFrameDecoder::DecodeQuantTable(
   encoding->qraw.qtable->resize(required_size_x * required_size_y * 3);
   for (size_t c = 0; c < 3; c++) {
     for (size_t y = 0; y < required_size_y; y++) {
-      int* JXL_RESTRICT row = image.channel[c].Row(y);
+      int32_t* JXL_RESTRICT row = image.channel[c].Row(y);
       for (size_t x = 0; x < required_size_x; x++) {
         (*encoding->qraw.qtable)[c * required_size_x * required_size_y +
                                  y * required_size_x + x] = row[x];

--- a/lib/jxl/enc_chroma_from_luma.cc
+++ b/lib/jxl/enc_chroma_from_luma.cc
@@ -163,7 +163,8 @@ void InitDCStorage(size_t num_blocks, ImageF* dc_values) {
   }
 }
 
-void ComputeDC(const ImageF& dc_values, bool fast, int* dc_x, int* dc_b) {
+void ComputeDC(const ImageF& dc_values, bool fast, int32_t* dc_x,
+               int32_t* dc_b) {
   constexpr float kDistanceMultiplierDC = 1e-5f;
   const float* JXL_RESTRICT dc_values_yx = dc_values.Row(0);
   const float* JXL_RESTRICT dc_values_x = dc_values.Row(1);

--- a/lib/jxl/enc_coeff_order.cc
+++ b/lib/jxl/enc_coeff_order.cc
@@ -73,7 +73,8 @@ void ComputeCoeffOrder(SpeedTier speed, const ACImage& acs,
   if (used_orders != 0) {
     uint64_t threshold =
         (std::numeric_limits<uint64_t>::max() >> 32) * block_fraction;
-    uint64_t s[2] = {0x94D049BB133111EBull, 0xBF58476D1CE4E5B9ull};
+    uint64_t s[2] = {static_cast<uint64_t>(0x94D049BB133111EBull),
+                     static_cast<uint64_t>(0xBF58476D1CE4E5B9ull)};
     // Xorshift128+ adapted from xorshift128+-inl.h
     auto use_sample = [&]() {
       auto s1 = s[0];

--- a/lib/jxl/enc_frame.cc
+++ b/lib/jxl/enc_frame.cc
@@ -604,7 +604,7 @@ class LossyFrameEncoder {
     std::vector<int> qt(192);
     for (size_t c = 0; c < 3; c++) {
       size_t jpeg_c = jpeg_c_map[c];
-      const int* quant =
+      const int32_t* quant =
           jpeg_data.quant[jpeg_data.components[jpeg_c].quant_idx].values.data();
 
       dcquantization[c] = 255 * 8.0f / quant[0];
@@ -629,7 +629,7 @@ class LossyFrameEncoder {
     shared.quantizer.RecomputeFromGlobalScale();
 
     // Per-block dequant scaling should be 1.
-    FillImage(static_cast<int>(shared.quantizer.InvGlobalScale()),
+    FillImage(static_cast<int32_t>(shared.quantizer.InvGlobalScale()),
               &shared.raw_quant_field);
 
     std::vector<int32_t> scaled_qtable(192);

--- a/lib/jxl/enc_modular.cc
+++ b/lib/jxl/enc_modular.cc
@@ -680,7 +680,7 @@ Status ModularFrameEncoder::ComputeEncodingData(
     int orig_bitdepth = max_bitdepth;
     max_bitdepth = 0;
     for (size_t i = 0; i < nb_channels; i++) {
-      int min, max;
+      int32_t min, max;
       compute_minmax(gi.channel[gi.nb_meta_channels + i], &min, &max);
       int64_t colors = max - min + 1;
       JXL_DEBUG_V(10, "Channel %" PRIuS ": range=%i..%i", i, min, max);
@@ -1360,7 +1360,7 @@ Status ModularFrameEncoder::PrepareStreamParams(const Rect& rect,
       // single channel palette (like FLIF's ChannelCompact)
       size_t nb_channels = gi.channel.size() - gi.nb_meta_channels;
       for (size_t i = 0; i < nb_channels; i++) {
-        int min, max;
+        int32_t min, max;
         compute_minmax(gi.channel[gi.nb_meta_channels + i], &min, &max);
         int colors = max - min + 1;
         JXL_DEBUG_V(10, "Channel %" PRIuS ": range=%i..%i", i, min, max);
@@ -1675,11 +1675,11 @@ void ModularFrameEncoder::AddACMetadata(size_t group_index, bool jpeg_transcode,
   size_t num = 0;
   for (size_t y = 0; y < r.ysize(); y++) {
     AcStrategyRow row_acs = enc_state->shared.ac_strategy.ConstRow(r, y);
-    const int* row_qf = r.ConstRow(enc_state->shared.raw_quant_field, y);
+    const int32_t* row_qf = r.ConstRow(enc_state->shared.raw_quant_field, y);
     const uint8_t* row_epf = r.ConstRow(enc_state->shared.epf_sharpness, y);
-    int* out_acs = image.channel[2].plane.Row(0);
-    int* out_qf = image.channel[2].plane.Row(1);
-    int* row_out_epf = image.channel[3].plane.Row(y);
+    int32_t* out_acs = image.channel[2].plane.Row(0);
+    int32_t* out_qf = image.channel[2].plane.Row(1);
+    int32_t* row_out_epf = image.channel[3].plane.Row(y);
     for (size_t x = 0; x < r.xsize(); x++) {
       row_out_epf[x] = row_epf[x];
       if (!row_acs[x].IsFirstBlock()) continue;
@@ -1707,7 +1707,7 @@ void ModularFrameEncoder::EncodeQuantTable(
   Image image(size_x, size_y, 8, 3);
   for (size_t c = 0; c < 3; c++) {
     for (size_t y = 0; y < size_y; y++) {
-      int* JXL_RESTRICT row = image.channel[c].Row(y);
+      int32_t* JXL_RESTRICT row = image.channel[c].Row(y);
       for (size_t x = 0; x < size_x; x++) {
         row[x] = (*encoding.qraw.qtable)[c * size_x * size_y + y * size_x + x];
       }
@@ -1727,7 +1727,7 @@ void ModularFrameEncoder::AddQuantTable(size_t size_x, size_t size_y,
   image = Image(size_x, size_y, 8, 3);
   for (size_t c = 0; c < 3; c++) {
     for (size_t y = 0; y < size_y; y++) {
-      int* JXL_RESTRICT row = image.channel[c].Row(y);
+      int32_t* JXL_RESTRICT row = image.channel[c].Row(y);
       for (size_t x = 0; x < size_x; x++) {
         row[x] = (*encoding.qraw.qtable)[c * size_x * size_y + y * size_x + x];
       }

--- a/lib/jxl/epf.cc
+++ b/lib/jxl/epf.cc
@@ -62,7 +62,7 @@ void ComputeSigma(const Rect& block_rect, PassesDecoderState* state) {
     const uint8_t* JXL_RESTRICT sharpness_row =
         block_rect.ConstRow(state->shared->epf_sharpness, by);
     AcStrategyRow acs_row = ac_strategy.ConstRow(block_rect, by);
-    const int* const JXL_RESTRICT row_quant =
+    const int32_t* const JXL_RESTRICT row_quant =
         block_rect.ConstRow(state->shared->raw_quant_field, by);
 
     for (size_t bx = 0; bx < block_rect.xsize(); bx++) {

--- a/lib/jxl/modular/encoding/enc_encoding.cc
+++ b/lib/jxl/modular/encoding/enc_encoding.cc
@@ -87,7 +87,8 @@ void GatherTreeData(const Image &image, pixel_type chan, size_t group_id,
   }
   uint64_t threshold =
       (std::numeric_limits<uint64_t>::max() >> 32) * pixel_fraction;
-  uint64_t s[2] = {0x94D049BB133111EBull, 0xBF58476D1CE4E5B9ull};
+  uint64_t s[2] = {static_cast<uint64_t>(0x94D049BB133111EBull),
+                   static_cast<uint64_t>(0xBF58476D1CE4E5B9ull)};
   // Xorshift128+ adapted from xorshift128+-inl.h
   auto use_sample = [&]() {
     auto s1 = s[0];

--- a/lib/jxl/modular/encoding/enc_ma.cc
+++ b/lib/jxl/modular/encoding/enc_ma.cc
@@ -504,7 +504,7 @@ void ComputeBestTree(TreeSamples &tree_samples, float threshold,
    tree);
 }
 
-constexpr int TreeSamples::kPropertyRange;
+constexpr int32_t TreeSamples::kPropertyRange;
 constexpr uint32_t TreeSamples::kDedupEntryUnused;
 
 Status TreeSamples::SetPredictor(Predictor predictor,
@@ -722,12 +722,12 @@ void TreeSamples::ThreeShuffle(size_t a, size_t b, size_t c) {
 }
 
 namespace {
-std::vector<int> QuantizeHistogram(const std::vector<uint32_t> &histogram,
-                                   size_t num_chunks) {
+std::vector<int32_t> QuantizeHistogram(const std::vector<uint32_t> &histogram,
+                                       size_t num_chunks) {
   if (histogram.empty()) return {};
   // TODO(veluca): selecting distinct quantiles is likely not the best
   // way to go about this.
-  std::vector<int> thresholds;
+  std::vector<int32_t> thresholds;
   size_t sum = std::accumulate(histogram.begin(), histogram.end(), 0LU);
   size_t cumsum = 0;
   size_t threshold = 0;
@@ -741,8 +741,8 @@ std::vector<int> QuantizeHistogram(const std::vector<uint32_t> &histogram,
   return thresholds;
 }
 
-std::vector<int> QuantizeSamples(const std::vector<int32_t> &samples,
-                                 size_t num_chunks) {
+std::vector<int32_t> QuantizeSamples(const std::vector<int32_t> &samples,
+                                     size_t num_chunks) {
   if (samples.empty()) return {};
   int min = *std::min_element(samples.begin(), samples.end());
   constexpr int kRange = 512;
@@ -752,7 +752,7 @@ std::vector<int> QuantizeSamples(const std::vector<int32_t> &samples,
     uint32_t sample_offset = std::min(std::max(s, -kRange), kRange) - min;
     counts[sample_offset]++;
   }
-  std::vector<int> thresholds = QuantizeHistogram(counts, num_chunks);
+  std::vector<int32_t> thresholds = QuantizeHistogram(counts, num_chunks);
   for (auto &v : thresholds) v += min;
   return thresholds;
 }
@@ -810,15 +810,15 @@ void TreeSamples::PreQuantizeProperties(
     return QuantizeHistogram(group_pixel_count, max_property_values);
   };
   auto quantize_coordinate = [&]() {
-    std::vector<int> quantized;
+    std::vector<int32_t> quantized;
     quantized.reserve(max_property_values - 1);
     for (size_t i = 0; i + 1 < max_property_values; i++) {
       quantized.push_back((i + 1) * 256 / max_property_values - 1);
     }
     return quantized;
   };
-  std::vector<int> abs_pixel_thr;
-  std::vector<int> pixel_thr;
+  std::vector<int32_t> abs_pixel_thr;
+  std::vector<int32_t> pixel_thr;
   auto quantize_pixel_property = [&]() {
     if (pixel_thr.empty()) {
       pixel_thr = QuantizeSamples(pixel_samples, max_property_values);
@@ -833,8 +833,8 @@ void TreeSamples::PreQuantizeProperties(
     }
     return abs_pixel_thr;
   };
-  std::vector<int> abs_diff_thr;
-  std::vector<int> diff_thr;
+  std::vector<int32_t> abs_diff_thr;
+  std::vector<int32_t> diff_thr;
   auto quantize_diff_property = [&]() {
     if (diff_thr.empty()) {
       diff_thr = QuantizeSamples(diff_samples, max_property_values);
@@ -851,16 +851,16 @@ void TreeSamples::PreQuantizeProperties(
   };
   auto quantize_wp = [&]() {
     if (max_property_values < 32) {
-      return std::vector<int>{-127, -63, -31, -15, -7, -3, -1, 0,
-                              1,    3,   7,   15,  31, 63, 127};
+      return std::vector<int32_t>{-127, -63, -31, -15, -7, -3, -1, 0,
+                                  1,    3,   7,   15,  31, 63, 127};
     }
     if (max_property_values < 64) {
-      return std::vector<int>{-255, -191, -127, -95, -63, -47, -31, -23,
-                              -15,  -11,  -7,   -5,  -3,  -1,  0,   1,
-                              3,    5,    7,    11,  15,  23,  31,  47,
-                              63,   95,   127,  191, 255};
+      return std::vector<int32_t>{-255, -191, -127, -95, -63, -47, -31, -23,
+                                  -15,  -11,  -7,   -5,  -3,  -1,  0,   1,
+                                  3,    5,    7,    11,  15,  23,  31,  47,
+                                  63,   95,   127,  191, 255};
     }
-    return std::vector<int>{
+    return std::vector<int32_t>{
         -255, -223, -191, -159, -127, -111, -95, -79, -63, -55, -47,
         -39,  -31,  -27,  -23,  -19,  -15,  -13, -11, -9,  -7,  -6,
         -5,   -4,   -3,   -2,   -1,   0,    1,   2,   3,   4,   5,

--- a/lib/jxl/modular/encoding/enc_ma.h
+++ b/lib/jxl/modular/encoding/enc_ma.h
@@ -114,13 +114,13 @@ struct TreeSamples {
   // Property values, quantized to at most 256 distinct values.
   std::vector<std::vector<uint8_t>> props;
   // Decompactification info for `props`.
-  std::vector<std::vector<int>> compact_properties;
+  std::vector<std::vector<int32_t>> compact_properties;
   // List of properties to use.
   std::vector<uint32_t> props_to_use;
   // List of predictors to use.
   std::vector<Predictor> predictors;
   // Mapping property value -> quantized property value.
-  static constexpr int kPropertyRange = 511;
+  static constexpr int32_t kPropertyRange = 511;
   std::vector<std::vector<uint8_t>> property_mapping;
   // Number of samples seen.
   size_t num_samples = 0;

--- a/lib/jxl/modular/transform/palette.h
+++ b/lib/jxl/modular/transform/palette.h
@@ -154,7 +154,7 @@ static Status InvPalette(Image &input, uint32_t begin_c, uint32_t nb_colors,
             const size_t y = task;
             pixel_type *p = input.channel[c0].Row(y);
             for (size_t x = 0; x < w; x++) {
-              const int index = Clamp1(p[x], 0, (pixel_type)palette.w - 1);
+              const int index = Clamp1<int>(p[x], 0, (pixel_type)palette.w - 1);
               p[x] = palette_internal::GetPaletteValue(
                   p_palette, index, /*c=*/0,
                   /*palette_size=*/palette.w,

--- a/lib/jxl/quantizer.cc
+++ b/lib/jxl/quantizer.cc
@@ -19,9 +19,9 @@
 
 namespace jxl {
 
-static const int kDefaultQuant = 64;
+static const int32_t kDefaultQuant = 64;
 
-constexpr int Quantizer::kQuantMax;
+constexpr int32_t Quantizer::kQuantMax;
 
 Quantizer::Quantizer(const DequantMatrices* dequant)
     : Quantizer(dequant, kDefaultQuant, kGlobalScaleDenom / kDefaultQuant) {}
@@ -109,7 +109,7 @@ void Quantizer::SetQuantField(const float quant_dc, const ImageF& qf,
 void Quantizer::SetQuant(float quant_dc, float quant_ac,
                          ImageI* JXL_RESTRICT raw_quant_field) {
   ComputeGlobalScaleAndQuant(quant_dc, quant_ac, 0);
-  int val = ClampVal(quant_ac * inv_global_scale_ + 0.5f);
+  int32_t val = ClampVal(quant_ac * inv_global_scale_ + 0.5f);
   FillImage(val, raw_quant_field);
 }
 

--- a/lib/jxl/quantizer.h
+++ b/lib/jxl/quantizer.h
@@ -68,10 +68,11 @@ class Quantizer {
   explicit Quantizer(const DequantMatrices* dequant);
   Quantizer(const DequantMatrices* dequant, int quant_dc, int global_scale);
 
-  static constexpr int kQuantMax = 256;
+  static constexpr int32_t kQuantMax = 256;
 
-  static JXL_INLINE int ClampVal(float val) {
-    return static_cast<int>(std::max(1.0f, std::min<float>(val, kQuantMax)));
+  static JXL_INLINE int32_t ClampVal(float val) {
+    return static_cast<int32_t>(
+        std::max(1.0f, std::min<float>(val, kQuantMax)));
   }
 
   float ScaleGlobalScale(const float scale) {

--- a/lib/jxl/render_pipeline/stage_noise.cc
+++ b/lib/jxl/render_pipeline/stage_noise.cc
@@ -22,7 +22,7 @@ using hwy::HWY_NAMESPACE::ShiftRight;
 using hwy::HWY_NAMESPACE::Vec;
 
 using D = HWY_CAPPED(float, kBlockDim);
-using DI = hwy::HWY_NAMESPACE::Rebind<int, D>;
+using DI = hwy::HWY_NAMESPACE::Rebind<int32_t, D>;
 using DI8 = hwy::HWY_NAMESPACE::Repartition<uint8_t, D>;
 
 // [0, max_value]


### PR DESCRIPTION
Fixing #1534

arm-none-eabi-g++ declares "int32_t" as "long int" which makes it incompatible with "int" in C++ so the code using template classes does not compile. This pull request fixes those incompatibilities by changing some "int" types to "int32_t". It is just a minimum change to make the static library compile and link. Not all "int" are changed to "int32_t". Examples and tools are not touched either. Tools can't be cross-compiled as such anyway.

Important local modification required: Highway library does not have a bare-metal ARM support so it guesses the target is a POSIX system and uses "clock_gettime" function. That won't compile. So "hwy/nanobenchmark.cc" and "hwy/nanobenchmark.h" have to be commented out from the "third_party\highway\CMakeLIsts.txt".

Exact used compiler: [Arm GNU Toolchain](https://developer.arm.com/Tools%20and%20Software/GNU%20Toolchain) 11.2-2022.02 AArch32 bare-metal target (arm-none-eabi).

CMake arguments for cross-compiling under WSL:

```
cmake
 -DCMAKE_BUILD_TYPE=Debug
 -DCMAKE_MAKE_PROGRAM=/usr/bin/ninja
 -DCMAKE_C_COMPILER=/opt/gcc-arm-11.2/bin/arm-none-eabi-gcc
 -DCMAKE_CXX_COMPILER=/opt/gcc-arm-11.2/bin/arm-none-eabi-g++
 -DCMAKE_SYSTEM_NAME=Generic
 -DCMAKE_SYSTEM_PROCESSOR=arm
 -DCMAKE_TRY_COMPILE_TARGET_TYPE=STATIC_LIBRARY
 -DJPEGXL_ENABLE_TOOLS=OFF
 -DJPEGXL_ENABLE_BENCHMARK=OFF
 -DJPEGXL_ENABLE_EXAMPLES=OFF
 -DJPEGXL_ENABLE_DOXYGEN=OFF
 -DJPEGXL_ENABLE_MANPAGES=OFF
 -DJPEGXL_STATIC=ON
 -DHWY_ENABLE_EXAMPLES=OFF
 -G Ninja
 -S ./libjxl -B ./cmake-build-debug-wsl-arm-gcc
```

Build target is "jxl-static".

It is not tested (run on target) in exactly such configuration. When testing it on Cortex M7, a few more things had to be cut out. The purpose of building it for arm-none-eabi is to help spot the type incompatibilities. Maybe someday a proper support for bare metal ARM is added (into JXL and Highway).