### PR TITLE
Implement compressing to a specific bitrate.

### DIFF
--- a/lib/jxl/aux_out.cc
+++ b/lib/jxl/aux_out.cc
@@ -25,6 +25,12 @@ void AuxOut::Print(size_t num_inputs) const {
 
   printf("Average butteraugli iters: %10.2f\n",
          num_butteraugli_iters * 1.0 / num_inputs);
+  if (min_quant_rescale != 1.0 || max_quant_rescale != 1.0) {
+    printf("quant rescale range: %f .. %f\n", min_quant_rescale,
+           max_quant_rescale);
+    printf("bitrate error range: %.3f%% .. %.3f%%\n",
+           100.0f * min_bitrate_error, 100.0f * max_bitrate_error);
+  }
 
   for (size_t i = 0; i < layers.size(); ++i) {
     if (layers[i].total_bits != 0) {

--- a/lib/jxl/aux_out.h
+++ b/lib/jxl/aux_out.h
@@ -149,6 +149,10 @@ struct AuxOut {
       dc_pred_usage[i] += victim.dc_pred_usage[i];
       dc_pred_usage_xb[i] += victim.dc_pred_usage_xb[i];
     }
+    max_quant_rescale = std::max(max_quant_rescale, victim.max_quant_rescale);
+    min_quant_rescale = std::min(min_quant_rescale, victim.min_quant_rescale);
+    max_bitrate_error = std::max(max_bitrate_error, victim.max_bitrate_error);
+    min_bitrate_error = std::min(min_bitrate_error, victim.min_bitrate_error);
   }
 
   void Print(size_t num_inputs) const;
@@ -274,6 +278,11 @@ struct AuxOut {
   std::array<uint32_t, 8> dc_pred_usage_xb = {{0}};
 
   int num_butteraugli_iters = 0;
+
+  float max_quant_rescale = 1.0f;
+  float min_quant_rescale = 1.0f;
+  float min_bitrate_error = 0.0f;
+  float max_bitrate_error = 0.0f;
 
   // If not empty, additional debugging information (e.g. debug images) is
   // saved in files with this prefix.

--- a/lib/jxl/enc_heuristics.cc
+++ b/lib/jxl/enc_heuristics.cc
@@ -164,19 +164,6 @@ void FindBestBlockEntropyModel(PassesEncoderState& enc_state) {
       *std::max_element(ctx_map.begin(), ctx_map.end()) + 1;
 }
 
-// Returns the target size based on whether bitrate or direct targetsize is
-// given.
-size_t TargetSize(const CompressParams& cparams,
-                  const FrameDimensions& frame_dim) {
-  if (cparams.target_size > 0) {
-    return cparams.target_size;
-  }
-  if (cparams.target_bitrate > 0.0) {
-    return 0.5 + cparams.target_bitrate * frame_dim.xsize * frame_dim.ysize /
-                     kBitsPerByte;
-  }
-  return 0;
-}
 }  // namespace
 
 void FindBestDequantMatrices(const CompressParams& cparams,
@@ -772,12 +759,7 @@ Status DefaultEncoderHeuristics::LossyFrameHeuristics(
     PadImageToBlockMultipleInPlace(opsin);
   }
 
-  const FrameDimensions& frame_dim = enc_state->shared.frame_dim;
-  size_t target_size = TargetSize(cparams, frame_dim);
-  size_t opsin_target_size = target_size;
-  if (cparams.target_size > 0 || cparams.target_bitrate > 0.0) {
-    cparams.target_size = opsin_target_size;
-  } else if (cparams.butteraugli_distance < 0) {
+  if (cparams.butteraugli_distance < 0) {
     return JXL_FAILURE("Expected non-negative distance");
   }
 

--- a/lib/jxl/enc_params.h
+++ b/lib/jxl/enc_params.h
@@ -256,6 +256,8 @@ struct CompressParams {
   // different from butteraugli_distance if resampling was used.
   float original_butteraugli_distance = -1.0f;
 
+  float quant_ac_rescale = 1.0;
+
   // Codestream level to conform to.
   // -1: don't care
   int level = -1;

--- a/lib/jxl/enc_quant_weights.cc
+++ b/lib/jxl/enc_quant_weights.cc
@@ -175,6 +175,14 @@ void DequantMatricesSetCustomDC(DequantMatrices* matrices, const float* dc) {
   JXL_CHECK(br.Close());
 }
 
+void DequantMatricesScaleDC(DequantMatrices* matrices, const float scale) {
+  float dc[3];
+  for (size_t c = 0; c < 3; ++c) {
+    dc[c] = matrices->InvDCQuant(c) * (1.0f / scale);
+  }
+  DequantMatricesSetCustomDC(matrices, dc);
+}
+
 void DequantMatricesSetCustom(DequantMatrices* matrices,
                               const std::vector<QuantEncoding>& encodings,
                               ModularFrameEncoder* encoder) {

--- a/lib/jxl/enc_quant_weights.h
+++ b/lib/jxl/enc_quant_weights.h
@@ -20,6 +20,8 @@ Status DequantMatricesEncodeDC(const DequantMatrices* matrices,
 // precision.
 void DequantMatricesSetCustomDC(DequantMatrices* matrices, const float* dc);
 
+void DequantMatricesScaleDC(DequantMatrices* matrices, const float scale);
+
 void DequantMatricesSetCustom(DequantMatrices* matrices,
                               const std::vector<QuantEncoding>& encodings,
                               ModularFrameEncoder* encoder);

--- a/lib/jxl/quantizer.cc
+++ b/lib/jxl/quantizer.cc
@@ -70,7 +70,7 @@ void Quantizer::ComputeGlobalScaleAndQuant(float quant_dc, float quant_median,
 }
 
 void Quantizer::SetQuantFieldRect(const ImageF& qf, const Rect& rect,
-                                  ImageI* JXL_RESTRICT raw_quant_field) {
+                                  ImageI* JXL_RESTRICT raw_quant_field) const {
   for (size_t y = 0; y < rect.ysize(); ++y) {
     const float* JXL_RESTRICT row_qf = rect.ConstRow(qf, y);
     int32_t* JXL_RESTRICT row_qi = rect.Row(raw_quant_field, y);

--- a/lib/jxl/quantizer.h
+++ b/lib/jxl/quantizer.h
@@ -74,6 +74,14 @@ class Quantizer {
     return static_cast<int>(std::max(1.0f, std::min<float>(val, kQuantMax)));
   }
 
+  float ScaleGlobalScale(const float scale) {
+    int new_global_scale = static_cast<int>(global_scale_ * scale + 0.5f);
+    float scale_out = new_global_scale * 1.0f / global_scale_;
+    global_scale_ = new_global_scale;
+    RecomputeFromGlobalScale();
+    return scale_out;
+  }
+
   // Recomputes other derived fields after global_scale_ has changed.
   void RecomputeFromGlobalScale() {
     global_scale_float_ = global_scale_ * (1.0 / kGlobalScaleDenom);
@@ -93,7 +101,7 @@ class Quantizer {
   JXL_INLINE float InvGlobalScale() const { return inv_global_scale_; }
 
   void SetQuantFieldRect(const ImageF& qf, const Rect& rect,
-                         ImageI* JXL_RESTRICT raw_quant_field);
+                         ImageI* JXL_RESTRICT raw_quant_field) const;
 
   void SetQuantField(float quant_dc, const ImageF& qf,
                      ImageI* JXL_RESTRICT raw_quant_field);

--- a/tools/benchmark/benchmark_codec.cc
+++ b/tools/benchmark/benchmark_codec.cc
@@ -94,7 +94,6 @@ Status ImageCodec::ParseParam(const std::string& param) {
     }
     return true;
   } else if (param[0] == 'r') {
-    butteraugli_target_ = -1.0;
     ba_params_.hf_asymmetry = args_.ba_params.hf_asymmetry;
     bitrate_target_ = strtof(param.substr(1).c_str(), nullptr);
     return true;


### PR DESCRIPTION
This is currently rather slow (about 5x slowdown), but it is only used in the
benchmark. There is a new jxl codec param 'nr' for "normalize bitrate" and it
sets a bitrate target for each image by looking at the jpeg:95 compressed size
of the image and the target butteraugli distance.

The target bitrate it achieved by scaling the AC quantization interval lengths
by setting a custom global_scale in the quantizer. This way all other heuristic
choices are preserved.