### PR TITLE
Tweak quant field quantization heuristics.

### DIFF
--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -209,7 +209,7 @@ jobs:
           exit 1
         fi
         # Test that the built binaries run.
-        echo -e -n "PF\n1 1\n-1.0\nrrrrggggbbbb" > test.pfm
+        echo -e -n "PF\n1 1\n-1.0\n\0\0\x80\x3f\0\0\x80\x3f\0\0\x80\x3f" > test.pfm
         build-example/encode_oneshot test.pfm test.jxl
         build-example/encode_oneshot_static test.pfm test-static.jxl
         build-example/decode_oneshot test.jxl dec.pfm dec.icc

--- a/lib/jxl/decode_test.cc
+++ b/lib/jxl/decode_test.cc
@@ -1641,7 +1641,7 @@ TEST(DecodeTest, PixelTestWithICCProfileLossy) {
   jxl::ButteraugliParams ba;
   EXPECT_THAT(ButteraugliDistance(io0, io1, ba, jxl::GetJxlCms(),
                                   /*distmap=*/nullptr, nullptr),
-              IsSlightlyBelow(0.77f));
+              IsSlightlyBelow(0.775f));
 
   JxlDecoderDestroy(dec);
 }

--- a/lib/jxl/enc_ac_strategy.h
+++ b/lib/jxl/enc_ac_strategy.h
@@ -56,10 +56,6 @@ struct ACSConfig {
     JXL_DASSERT(quant_field_row[by * quant_field_stride + bx] > 0);
     return quant_field_row[by * quant_field_stride + bx];
   }
-  void SetQuant(size_t bx, size_t by, float value) const {
-    JXL_DASSERT(value > 0);
-    quant_field_row[by * quant_field_stride + bx] = value;
-  }
 };
 
 struct AcStrategyHeuristics {

--- a/lib/jxl/enc_heuristics.cc
+++ b/lib/jxl/enc_heuristics.cc
@@ -841,6 +841,7 @@ Status DefaultEncoderHeuristics::LossyFrameHeuristics(
     enc_state->initial_quant_field = InitialQuantField(
         butteraugli_distance_for_iqf, *opsin, shared.frame_dim, pool, 1.0f,
         &enc_state->initial_quant_masking);
+    quantizer.SetQuantField(quant_dc, enc_state->initial_quant_field, nullptr);
   }
 
   // TODO(veluca): do something about animations.

--- a/lib/jxl/encode_test.cc
+++ b/lib/jxl/encode_test.cc
@@ -220,7 +220,7 @@ void VerifyFrameEncoding(size_t xsize, size_t ysize, JxlEncoder* enc,
 #if JXL_HIGH_PRECISION
       1.8);
 #else
-      4.8);
+      8.0);
 #endif
 }
 

--- a/lib/jxl/jxl_test.cc
+++ b/lib/jxl/jxl_test.cc
@@ -170,7 +170,7 @@ TEST(JxlTest, RoundtripSmallD1) {
     EXPECT_THAT(
         ButteraugliDistance(io_dim, io_out, cparams.ba_params, GetJxlCms(),
                             /*distmap=*/nullptr, pool),
-        IsSlightlyBelow(1.5));
+        IsSlightlyBelow(1.1));
     EXPECT_EQ(io_dim.metadata.m.IntensityTarget(),
               io_out.metadata.m.IntensityTarget());
   }
@@ -457,7 +457,7 @@ TEST(JxlTest, RoundtripLargeFast) {
   cparams.speed_tier = SpeedTier::kSquirrel;
 
   CodecInOut io2;
-  EXPECT_LE(Roundtrip(&io, cparams, {}, &pool, &io2), 450000u);
+  EXPECT_LE(Roundtrip(&io, cparams, {}, &pool, &io2), 450500u);
 }
 
 TEST(JxlTest, RoundtripDotsForceEpf) {
@@ -1459,7 +1459,7 @@ TEST(JxlTest, RoundtripAnimationPatches) {
   // >10 with broken patches
   EXPECT_THAT(ButteraugliDistance(io, io2, cparams.ba_params, GetJxlCms(),
                                   /*distmap=*/nullptr, pool),
-              IsSlightlyBelow(1.5));
+              IsSlightlyBelow(1.2));
 }
 
 #endif  // JPEGXL_ENABLE_GIF
@@ -1700,10 +1700,10 @@ TEST(JxlTest, RoundtripProgressive) {
   cparams.responsive = true;
   cparams.progressive_mode = true;
   CodecInOut io2;
-  EXPECT_LE(Roundtrip(&io, cparams, {}, &pool, &io2), 61000u);
+  EXPECT_LE(Roundtrip(&io, cparams, {}, &pool, &io2), 61600u);
   EXPECT_THAT(ButteraugliDistance(io, io2, cparams.ba_params, GetJxlCms(),
                                   /*distmap=*/nullptr, &pool),
-              IsSlightlyBelow(1.2f));
+              IsSlightlyBelow(1.17f));
 }
 
 TEST(JxlTest, RoundtripProgressiveLevel2Slow) {

--- a/lib/jxl/quantizer.cc
+++ b/lib/jxl/quantizer.cc
@@ -39,7 +39,7 @@ Quantizer::Quantizer(const DequantMatrices* dequant, int quant_dc,
 void Quantizer::ComputeGlobalScaleAndQuant(float quant_dc, float quant_median,
                                            float quant_median_absd) {
   // Target value for the median value in the quant field.
-  const float kQuantFieldTarget = 3.80987740592518214386f;
+  const float kQuantFieldTarget = 5;
   // We reduce the median of the quant field by the median absolute deviation:
   // higher resolution on highly varying quant fields.
   float scale = kGlobalScaleDenom * (quant_median - quant_median_absd) /
@@ -49,9 +49,9 @@ void Quantizer::ComputeGlobalScaleAndQuant(float quant_dc, float quant_median,
   if (scale > (1 << 15)) scale = 1 << 15;
   int new_global_scale = static_cast<int>(scale);
   // Ensure that quant_dc_ will always be at least
-  // kGlobalScaleDenom/kGlobalScaleNumerator.
+  // 0.625 * kGlobalScaleDenom/kGlobalScaleNumerator = 10.
   const int scaled_quant_dc =
-      static_cast<int>(quant_dc * kGlobalScaleNumerator);
+      static_cast<int>(quant_dc * kGlobalScaleNumerator * 1.6);
   if (new_global_scale > scaled_quant_dc) {
     new_global_scale = scaled_quant_dc;
     if (new_global_scale <= 0) new_global_scale = 1;
@@ -83,7 +83,6 @@ void Quantizer::SetQuantFieldRect(const ImageF& qf, const Rect& rect,
 
 void Quantizer::SetQuantField(const float quant_dc, const ImageF& qf,
                               ImageI* JXL_RESTRICT raw_quant_field) {
-  JXL_CHECK(SameSize(*raw_quant_field, qf));
   std::vector<float> data(qf.xsize() * qf.ysize());
   for (size_t y = 0; y < qf.ysize(); ++y) {
     const float* JXL_RESTRICT row_qf = qf.Row(y);
@@ -103,7 +102,10 @@ void Quantizer::SetQuantField(const float quant_dc, const ImageF& qf,
                    deviations.end());
   const float quant_median_absd = deviations[deviations.size() / 2];
   ComputeGlobalScaleAndQuant(quant_dc, quant_median, quant_median_absd);
-  SetQuantFieldRect(qf, Rect(qf), raw_quant_field);
+  if (raw_quant_field) {
+    JXL_CHECK(SameSize(*raw_quant_field, qf));
+    SetQuantFieldRect(qf, Rect(qf), raw_quant_field);
+  }
 }
 
 void Quantizer::SetQuant(float quant_dc, float quant_ac,

--- a/lib/jxl/quantizer_test.cc
+++ b/lib/jxl/quantizer_test.cc
@@ -42,7 +42,7 @@ TEST(QuantizerTest, BitStreamRoundtripSameQuant) {
   EXPECT_TRUE(quantizer1.Encode(&writer, 0, nullptr));
   writer.ZeroPadToByte();
   const size_t bits_written = writer.BitsWritten();
-  Quantizer quantizer2(&dequant, qxsize, qysize);
+  Quantizer quantizer2(&dequant);
   BitReader reader(writer.GetSpan());
   EXPECT_TRUE(quantizer2.Decode(&reader));
   EXPECT_TRUE(reader.JumpToByteBoundary());
@@ -66,7 +66,7 @@ TEST(QuantizerTest, BitStreamRoundtripRandomQuant) {
   EXPECT_TRUE(quantizer1.Encode(&writer, 0, nullptr));
   writer.ZeroPadToByte();
   const size_t bits_written = writer.BitsWritten();
-  Quantizer quantizer2(&dequant, qxsize, qysize);
+  Quantizer quantizer2(&dequant);
   BitReader reader(writer.GetSpan());
   EXPECT_TRUE(quantizer2.Decode(&reader));
   EXPECT_TRUE(reader.JumpToByteBoundary());


### PR DESCRIPTION
0.22% improvement in BPP*pnorm for squirrel:d1.

Benchmark before:
```
Encoding      kPixels    Bytes          BPP  E MP/s  D MP/s     Max norm        pnorm       BPP*pnorm   Bugs
------------------------------------------------------------------------------------------------------------
jxl:d1          13270  2680179    1.6157277   2.512  20.071   1.68695998   0.60068375  0.970541376851      0
jxl:d2          13270  1685303    1.0159735   2.642  19.665   2.98979163   0.94922260  0.964384967681      0
jxl:d4          13270  1006113    0.6065284   2.546  12.674   4.82071018   1.50046479  0.910074488374      0
jxl:d8          13270   567359    0.3420285   2.433  12.211  12.11405659   2.41911848  0.827407508324      0
jxl:5:d1        13270  2666994    1.6077792   4.184  17.521   1.82699859   0.60483250  0.972437112514      0
jxl:5:d2        13270  1665393    1.0039709   4.226  17.959   2.74670744   0.95214332  0.955924141264      0
jxl:5:d4        13270   982919    0.5925460   4.328  10.138   4.80737257   1.52272321  0.902283610033      0
jxl:5:d8        13270   550188    0.3316771   4.209  10.147  11.92240238   2.47004662  0.819257891848      0
```

Benchmark after:
```
Encoding      kPixels    Bytes          BPP  E MP/s  D MP/s     Max norm        pnorm       BPP*pnorm   Bugs
------------------------------------------------------------------------------------------------------------
jxl:d1          13270  2680681    1.6160303   2.525  19.920   1.68643832   0.59921631  0.968351725465      0
jxl:d2          13270  1683846    1.0150951   2.679  19.748   3.07402134   0.94835722  0.962672788308      0
jxl:d4          13270  1001868    0.6039693   2.522  12.649   5.01221323   1.50586731  0.909497646855      0
jxl:d8          13270   564516    0.3403146   2.390  12.022  11.99684715   2.41557013  0.822053864115      0
jxl:5:d1        13270  2667583    1.6081343   4.005  17.191   1.79556513   0.60369989  0.970830489445      0
jxl:5:d2        13270  1664759    1.0035887   4.085  16.882   2.66829967   0.95186780  0.955283724013      0
jxl:5:d4        13270   979116    0.5902534   4.144   9.767   4.82719278   1.52841810  0.902154019047      0
jxl:5:d8        13270   547555    0.3300898   4.083  10.275  11.94434738   2.46383268  0.813286061870      0
```