### PR TITLE
Remove djxl's dependence on libjxl internals.

### DIFF
--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -104,7 +104,7 @@ jobs:
         cp tools/conformance/conformance.py build/tools/conformance
         cp tools/conformance/lcms2.py build/tools/conformance
         cp build/tools/djxl build/tools/conformance
-        cp build/libjxl_dec.so.0.7.0 build/tools/conformance
+        cp build/libjxl.so.0.7.0 build/tools/conformance
         cp build/libjxl_threads.so.0.7.0 build/tools/conformance
       env:
         SKIP_TEST: 1
@@ -115,7 +115,7 @@ jobs:
           build/tools/conformance/conformance.py
           build/tools/conformance/lcms2.py
           build/tools/conformance/djxl
-          build/tools/conformance/libjxl_dec.so.0.7.0
+          build/tools/conformance/libjxl.so.0.7.0
           build/tools/conformance/libjxl_threads.so.0.7.0
     - name: ccache stats
       run: ccache --show-stats
@@ -148,7 +148,7 @@ jobs:
     - name: Run conformance tests
       run: |
         chmod +x djxl
-        ln -s libjxl_dec.so.0.7.0 libjxl_dec.so.0.7
+        ln -s libjxl.so.0.7.0 libjxl.so.0.7
         ln -s libjxl_threads.so.0.7.0 libjxl_threads.so.0.7
         export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:`pwd`
         python conformance.py \

--- a/lib/extras/codec.cc
+++ b/lib/extras/codec.cc
@@ -68,66 +68,59 @@ Status Encode(const CodecInOut& io, const extras::Codec codec,
   if (io.Main().IsJPEG()) {
     JXL_WARNING("Writing JPEG data as pixels");
   }
-
-  extras::PackedPixelFile ppf;
   JxlPixelFormat format = {
       0,  // num_channels is ignored by the converter
-      bits_per_sample <= 8 ? JXL_TYPE_UINT8 : JXL_TYPE_UINT16,
-      JXL_NATIVE_ENDIAN, 0};
-  std::vector<uint8_t> bytes_vector;
+      bits_per_sample <= 8 ? JXL_TYPE_UINT8 : JXL_TYPE_UINT16, JXL_BIG_ENDIAN,
+      0};
   const bool floating_point = bits_per_sample > 16;
-  extras::EncodedImage encoded_image;
+  std::unique_ptr<extras::Encoder> encoder;
+  std::ostringstream os;
   switch (codec) {
     case extras::Codec::kPNG:
 #if JPEGXL_ENABLE_APNG
-      format.endianness = JXL_BIG_ENDIAN;
-      JXL_RETURN_IF_ERROR(extras::ConvertCodecInOutToPackedPixelFile(
-          io, format, c_desired, pool, &ppf));
-      JXL_RETURN_IF_ERROR(
-          extras::GetAPNGEncoder()->Encode(ppf, &encoded_image, pool));
-      JXL_ASSERT(encoded_image.bitstreams.size() == 1);
-      *bytes = encoded_image.bitstreams[0];
-      return true;
+      encoder = extras::GetAPNGEncoder();
+      break;
 #else
       return JXL_FAILURE("JPEG XL was built without (A)PNG support");
 #endif
     case extras::Codec::kJPG:
 #if JPEGXL_ENABLE_JPEG
-      return EncodeImageJPG(&io,
-                            io.use_sjpeg ? extras::JpegEncoder::kSJpeg
-                                         : extras::JpegEncoder::kLibJpeg,
-                            io.jpeg_quality, YCbCrChromaSubsampling(), pool,
-                            bytes);
+      format.data_type = JXL_TYPE_UINT8;
+      encoder = extras::GetJPEGEncoder();
+      os << io.jpeg_quality;
+      encoder->SetOption("q", os.str());
+      break;
 #else
       return JXL_FAILURE("JPEG XL was built without JPEG support");
 #endif
     case extras::Codec::kPNM:
-
-      // Choose native for PFM; PGM/PPM require big-endian (N/A for PBM)
-      format.endianness = floating_point ? JXL_NATIVE_ENDIAN : JXL_BIG_ENDIAN;
-      if (floating_point) {
+      if (io.Main().HasAlpha()) {
+        encoder = extras::GetPAMEncoder();
+      } else if (io.Main().IsGray()) {
+        encoder = extras::GetPGMEncoder();
+      } else if (!floating_point) {
+        encoder = extras::GetPPMEncoder();
+      } else {
         format.data_type = JXL_TYPE_FLOAT;
+        format.endianness = JXL_NATIVE_ENDIAN;
+        encoder = extras::GetPFMEncoder();
       }
       if (!c_desired.IsSRGB()) {
         JXL_WARNING(
-            "PNM encoder cannot store custom ICC profile; decoder\n"
+            "PNM encoder cannot store custom ICC profile; decoder "
             "will need hint key=color_space to get the same values");
       }
-      JXL_RETURN_IF_ERROR(extras::ConvertCodecInOutToPackedPixelFile(
-          io, format, c_desired, pool, &ppf));
-      JXL_RETURN_IF_ERROR(
-          extras::EncodeImagePNM(ppf.frames[0].color, ppf.info.orientation,
-                                 bits_per_sample, &bytes_vector));
-      bytes->assign(bytes_vector.data(),
-                    bytes_vector.data() + bytes_vector.size());
-      return true;
+      break;
     case extras::Codec::kPGX:
-      return JXL_FAILURE("Encoding CodecInOut to PGX is not implemented");
+      encoder = extras::GetPGXEncoder();
+      break;
     case extras::Codec::kGIF:
       return JXL_FAILURE("Encoding to GIF is not implemented");
     case extras::Codec::kEXR:
 #if JPEGXL_ENABLE_EXR
-      return extras::EncodeImageEXR(&io, c_desired, pool, bytes);
+      format.data_type = JXL_TYPE_FLOAT;
+      encoder = extras::GetEXREncoder();
+      break;
 #else
       return JXL_FAILURE("JPEG XL was built without OpenEXR support");
 #endif
@@ -135,7 +128,19 @@ Status Encode(const CodecInOut& io, const extras::Codec codec,
       return JXL_FAILURE("Cannot encode using Codec::kUnknown");
   }
 
-  return JXL_FAILURE("Invalid codec");
+  if (encoder.get() == nullptr) {
+    return JXL_FAILURE("Invalid codec.");
+  }
+
+  extras::PackedPixelFile ppf;
+  JXL_RETURN_IF_ERROR(
+      ConvertCodecInOutToPackedPixelFile(io, format, c_desired, pool, &ppf));
+  extras::EncodedImage encoded_image;
+  JXL_RETURN_IF_ERROR(encoder->Encode(ppf, &encoded_image, pool));
+  JXL_ASSERT(encoded_image.bitstreams.size() == 1);
+  *bytes = encoded_image.bitstreams[0];
+
+  return true;
 }
 
 Status EncodeToFile(const CodecInOut& io, const ColorEncoding& c_desired,

--- a/lib/extras/enc/encode.h
+++ b/lib/extras/enc/encode.h
@@ -58,6 +58,11 @@ class Encoder {
     return options_;
   }
 
+  Status VerifyBasicInfo(const JxlBasicInfo& info) const;
+
+  Status VerifyPackedImage(const PackedImage& image,
+                           const JxlBasicInfo& info) const;
+
  private:
   std::unordered_map<std::string, std::string> options_;
 };

--- a/lib/extras/enc/exr.h
+++ b/lib/extras/enc/exr.h
@@ -8,24 +8,14 @@
 
 // Encodes OpenEXR images in memory.
 
+#include <memory>
+
 #include "lib/extras/enc/encode.h"
-#include "lib/extras/packed_image.h"
-#include "lib/jxl/base/data_parallel.h"
-#include "lib/jxl/base/padded_bytes.h"
-#include "lib/jxl/base/span.h"
-#include "lib/jxl/base/status.h"
-#include "lib/jxl/codec_in_out.h"
-#include "lib/jxl/color_encoding_internal.h"
 
 namespace jxl {
 namespace extras {
 
 std::unique_ptr<Encoder> GetEXREncoder();
-
-// Transforms from io->c_current to `c_desired` (with the transfer function set
-// to linear as that is the OpenEXR convention) and encodes into `bytes`.
-Status EncodeImageEXR(const CodecInOut* io, const ColorEncoding& c_desired,
-                      ThreadPool* pool, std::vector<uint8_t>* bytes);
 
 }  // namespace extras
 }  // namespace jxl

--- a/lib/extras/enc/jpg.cc
+++ b/lib/extras/enc/jpg.cc
@@ -16,17 +16,8 @@
 #include <utility>
 #include <vector>
 
-#include "lib/extras/packed_image_convert.h"
-#include "lib/jxl/base/compiler_specific.h"
+#include "lib/extras/exif.h"
 #include "lib/jxl/base/status.h"
-#include "lib/jxl/color_encoding_internal.h"
-#include "lib/jxl/common.h"
-#include "lib/jxl/dec_external_image.h"
-#include "lib/jxl/enc_color_management.h"
-#include "lib/jxl/enc_image_bundle.h"
-#include "lib/jxl/exif.h"
-#include "lib/jxl/image.h"
-#include "lib/jxl/image_bundle.h"
 #include "lib/jxl/sanitizers.h"
 #if JPEGXL_ENABLE_SJPEG
 #include "sjpeg.h"
@@ -46,8 +37,21 @@ constexpr unsigned char kExifSignature[6] = {0x45, 0x78, 0x69,
                                              0x66, 0x00, 0x00};
 constexpr int kExifMarker = JPEG_APP0 + 1;
 
+enum class JpegEncoder {
+  kLibJpeg,
+  kSJpeg,
+};
+
+bool IsSRGBEncoding(const JxlColorEncoding& c) {
+  return ((c.color_space == JXL_COLOR_SPACE_RGB ||
+           c.color_space == JXL_COLOR_SPACE_GRAY) &&
+          c.primaries == JXL_PRIMARIES_SRGB &&
+          c.white_point == JXL_WHITE_POINT_D65 &&
+          c.transfer_function == JXL_TRANSFER_FUNCTION_SRGB);
+}
+
 void WriteICCProfile(jpeg_compress_struct* const cinfo,
-                     const PaddedBytes& icc) {
+                     const std::vector<uint8_t>& icc) {
   constexpr size_t kMaxIccBytesInMarker =
       kMaxBytesInMarker - sizeof kICCSignature - 2;
   const int num_markers =
@@ -82,23 +86,34 @@ void WriteExif(jpeg_compress_struct* const cinfo,
   }
 }
 
-Status SetChromaSubsampling(const YCbCrChromaSubsampling& chroma_subsampling,
+Status SetChromaSubsampling(const std::string& subsampling,
                             jpeg_compress_struct* const cinfo) {
-  for (size_t i = 0; i < 3; i++) {
-    cinfo->comp_info[i].h_samp_factor =
-        1 << (chroma_subsampling.MaxHShift() -
-              chroma_subsampling.HShift(i < 2 ? i ^ 1 : i));
-    cinfo->comp_info[i].v_samp_factor =
-        1 << (chroma_subsampling.MaxVShift() -
-              chroma_subsampling.VShift(i < 2 ? i ^ 1 : i));
+  const std::pair<const char*,
+                  std::pair<std::array<uint8_t, 3>, std::array<uint8_t, 3>>>
+      options[] = {{"444", {{{1, 1, 1}}, {{1, 1, 1}}}},
+                   {"420", {{{2, 1, 1}}, {{2, 1, 1}}}},
+                   {"422", {{{2, 1, 1}}, {{1, 1, 1}}}},
+                   {"440", {{{1, 1, 1}}, {{2, 1, 1}}}}};
+  for (const auto& option : options) {
+    if (subsampling == option.first) {
+      for (size_t i = 0; i < 3; i++) {
+        cinfo->comp_info[i].h_samp_factor = option.second.first[i];
+        cinfo->comp_info[i].v_samp_factor = option.second.second[i];
+      }
+      return true;
+    }
   }
-  return true;
+  return false;
 }
 
-Status EncodeWithLibJpeg(const ImageBundle& ib, std::vector<uint8_t> exif,
-                         size_t quality,
-                         const YCbCrChromaSubsampling& chroma_subsampling,
+Status EncodeWithLibJpeg(const PackedImage& image, const JxlBasicInfo& info,
+                         const std::vector<uint8_t>& icc,
+                         std::vector<uint8_t> exif, size_t quality,
+                         const std::string& chroma_subsampling,
                          std::vector<uint8_t>* bytes) {
+  if (BITS_IN_JSAMPLE != 8 || sizeof(JSAMPLE) != 1) {
+    return JXL_FAILURE("Only 8 bit JSAMPLE is supported.");
+  }
   jpeg_compress_struct cinfo;
   // cinfo is initialized by libjpeg, which we are not instrumenting with
   // msan.
@@ -109,15 +124,10 @@ Status EncodeWithLibJpeg(const ImageBundle& ib, std::vector<uint8_t> exif,
   unsigned char* buffer = nullptr;
   unsigned long size = 0;
   jpeg_mem_dest(&cinfo, &buffer, &size);
-  cinfo.image_width = ib.oriented_xsize();
-  cinfo.image_height = ib.oriented_ysize();
-  if (ib.IsGray()) {
-    cinfo.input_components = 1;
-    cinfo.in_color_space = JCS_GRAYSCALE;
-  } else {
-    cinfo.input_components = 3;
-    cinfo.in_color_space = JCS_RGB;
-  }
+  cinfo.image_width = image.xsize;
+  cinfo.image_height = image.ysize;
+  cinfo.input_components = info.num_color_channels;
+  cinfo.in_color_space = info.num_color_channels == 1 ? JCS_GRAYSCALE : JCS_RGB;
   jpeg_set_defaults(&cinfo);
   cinfo.optimize_coding = TRUE;
   if (cinfo.input_components == 3) {
@@ -125,8 +135,8 @@ Status EncodeWithLibJpeg(const ImageBundle& ib, std::vector<uint8_t> exif,
   }
   jpeg_set_quality(&cinfo, quality, TRUE);
   jpeg_start_compress(&cinfo, TRUE);
-  if (!ib.IsSRGB()) {
-    WriteICCProfile(&cinfo, ib.c_current().ICC());
+  if (!icc.empty()) {
+    WriteICCProfile(&cinfo, icc);
   }
   if (!exif.empty()) {
     ResetExifOrientation(exif);
@@ -135,16 +145,11 @@ Status EncodeWithLibJpeg(const ImageBundle& ib, std::vector<uint8_t> exif,
   if (cinfo.input_components > 3 || cinfo.input_components < 0)
     return JXL_FAILURE("invalid numbers of components");
 
-  size_t stride =
-      ib.oriented_xsize() * cinfo.input_components * sizeof(JSAMPLE);
-  std::vector<uint8_t> raw_bytes(stride * ib.oriented_ysize());
-  JXL_RETURN_IF_ERROR(ConvertToExternal(
-      ib, BITS_IN_JSAMPLE, /*float_out=*/false, cinfo.input_components,
-      JXL_BIG_ENDIAN, stride, nullptr, raw_bytes.data(), raw_bytes.size(),
-      /*out_callback=*/{}, ib.metadata()->GetOrientation()));
-
-  for (size_t y = 0; y < ib.oriented_ysize(); ++y) {
-    JSAMPROW row[] = {raw_bytes.data() + y * stride};
+  std::vector<uint8_t> raw_bytes(image.pixels_size);
+  memcpy(&raw_bytes[0], reinterpret_cast<const uint8_t*>(image.pixels()),
+         image.pixels_size);
+  for (size_t y = 0; y < info.ysize; ++y) {
+    JSAMPROW row[] = {raw_bytes.data() + y * image.stride};
 
     jpeg_write_scanlines(&cinfo, row, 1);
   }
@@ -159,40 +164,34 @@ Status EncodeWithLibJpeg(const ImageBundle& ib, std::vector<uint8_t> exif,
   return true;
 }
 
-Status EncodeWithSJpeg(const ImageBundle& ib, std::vector<uint8_t> exif,
-                       size_t quality,
-                       const YCbCrChromaSubsampling& chroma_subsampling,
+Status EncodeWithSJpeg(const PackedImage& image, const JxlBasicInfo& info,
+                       const std::vector<uint8_t>& icc,
+                       std::vector<uint8_t> exif, size_t quality,
+                       const std::string& chroma_subsampling,
                        std::vector<uint8_t>* bytes) {
 #if !JPEGXL_ENABLE_SJPEG
   return JXL_FAILURE("JPEG XL was built without sjpeg support");
 #else
   sjpeg::EncoderParam param(quality);
-  if (!ib.IsSRGB()) {
-    param.iccp.assign(ib.metadata()->color_encoding.ICC().begin(),
-                      ib.metadata()->color_encoding.ICC().end());
+  if (!icc.empty()) {
+    param.iccp.assign(icc.begin(), icc.end());
   }
   if (!exif.empty()) {
     ResetExifOrientation(exif);
     param.exif.assign(exif.begin(), exif.end());
   }
-  if (chroma_subsampling.Is444()) {
+  if (chroma_subsampling == "444") {
     param.yuv_mode = SJPEG_YUV_444;
-  } else if (chroma_subsampling.Is420()) {
+  } else if (chroma_subsampling == "420") {
     param.yuv_mode = SJPEG_YUV_SHARP;
   } else {
     return JXL_FAILURE("sjpeg does not support this chroma subsampling mode");
   }
-  size_t stride = ib.oriented_xsize() * 3;
-  std::vector<uint8_t> rgb(ib.xsize() * ib.ysize() * 3);
-  JXL_RETURN_IF_ERROR(
-      ConvertToExternal(ib, 8, /*float_out=*/false, 3, JXL_BIG_ENDIAN, stride,
-                        nullptr, rgb.data(), rgb.size(),
-                        /*out_callback=*/{}, ib.metadata()->GetOrientation()));
-
+  size_t stride = info.xsize * 3;
+  const uint8_t* pixels = reinterpret_cast<const uint8_t*>(image.pixels());
   std::string output;
-  JXL_RETURN_IF_ERROR(sjpeg::Encode(rgb.data(), ib.oriented_xsize(),
-                                    ib.oriented_ysize(), stride, param,
-                                    &output));
+  JXL_RETURN_IF_ERROR(
+      sjpeg::Encode(pixels, image.xsize, image.ysize, stride, param, &output));
   bytes->assign(
       reinterpret_cast<const uint8_t*>(output.data()),
       reinterpret_cast<const uint8_t*>(output.data() + output.size()));
@@ -200,54 +199,36 @@ Status EncodeWithSJpeg(const ImageBundle& ib, std::vector<uint8_t> exif,
 #endif
 }
 
-Status EncodeImageJPG(const ImageBundle& ib, std::vector<uint8_t> exif,
-                      JpegEncoder encoder, size_t quality,
-                      YCbCrChromaSubsampling chroma_subsampling,
+Status EncodeImageJPG(const PackedImage& image, const JxlBasicInfo& info,
+                      const std::vector<uint8_t>& icc,
+                      std::vector<uint8_t> exif, JpegEncoder encoder,
+                      size_t quality, const std::string& chroma_subsampling,
                       ThreadPool* pool, std::vector<uint8_t>* bytes) {
-  if (ib.HasAlpha()) {
+  if (image.format.data_type != JXL_TYPE_UINT8) {
+    return JXL_FAILURE("Unsupported pixel data type");
+  }
+  if (info.alpha_bits > 0) {
     return JXL_FAILURE("alpha is not supported");
   }
   if (quality > 100) {
     return JXL_FAILURE("please specify a 0-100 JPEG quality");
   }
 
-  const ImageBundle* transformed;
-  ImageMetadata metadata = *ib.metadata();
-  ImageBundle ib_store(&metadata);
-  JXL_RETURN_IF_ERROR(TransformIfNeeded(
-      ib, metadata.color_encoding, GetJxlCms(), pool, &ib_store, &transformed));
-
   switch (encoder) {
     case JpegEncoder::kLibJpeg:
-      JXL_RETURN_IF_ERROR(EncodeWithLibJpeg(ib, std::move(exif), quality,
-                                            chroma_subsampling, bytes));
+      JXL_RETURN_IF_ERROR(EncodeWithLibJpeg(image, info, icc, std::move(exif),
+                                            quality, chroma_subsampling,
+                                            bytes));
       break;
     case JpegEncoder::kSJpeg:
-      JXL_RETURN_IF_ERROR(EncodeWithSJpeg(ib, std::move(exif), quality,
-                                          chroma_subsampling, bytes));
+      JXL_RETURN_IF_ERROR(EncodeWithSJpeg(image, info, icc, std::move(exif),
+                                          quality, chroma_subsampling, bytes));
       break;
     default:
       return JXL_FAILURE("tried to use an unknown JPEG encoder");
   }
 
   return true;
-}
-
-Status ParseChromaSubsampling(const std::string& param,
-                              YCbCrChromaSubsampling* subsampling) {
-  const std::pair<const char*,
-                  std::pair<std::array<uint8_t, 3>, std::array<uint8_t, 3>>>
-      options[] = {{"444", {{{1, 1, 1}}, {{1, 1, 1}}}},
-                   {"420", {{{2, 1, 1}}, {{2, 1, 1}}}},
-                   {"422", {{{2, 1, 1}}, {{1, 1, 1}}}},
-                   {"440", {{{1, 1, 1}}, {{2, 1, 1}}}}};
-  for (const auto& option : options) {
-    if (param == option.first) {
-      return subsampling->Set(option.second.first.data(),
-                              option.second.second.data());
-    }
-  }
-  return false;
 }
 
 class JPEGEncoder : public Encoder {
@@ -265,6 +246,7 @@ class JPEGEncoder : public Encoder {
   }
   Status Encode(const PackedPixelFile& ppf, EncodedImage* encoded_image,
                 ThreadPool* pool = nullptr) const override {
+    JXL_RETURN_IF_ERROR(VerifyBasicInfo(ppf.info));
     const auto& options = this->options();
     int quality = 100;
     auto it_quality = options.find("q");
@@ -272,11 +254,10 @@ class JPEGEncoder : public Encoder {
       std::istringstream is(it_quality->second);
       JXL_RETURN_IF_ERROR(static_cast<bool>(is >> quality));
     }
-    YCbCrChromaSubsampling chroma_subsampling;
+    std::string chroma_subsampling = "444";
     auto it_chroma_subsampling = options.find("chroma_subsampling");
     if (it_chroma_subsampling != options.end()) {
-      JXL_RETURN_IF_ERROR(ParseChromaSubsampling(it_chroma_subsampling->second,
-                                                 &chroma_subsampling));
+      chroma_subsampling = it_chroma_subsampling->second;
     }
     JpegEncoder jpeg_encoder = JpegEncoder::kLibJpeg;
     auto it_encoder = options.find("jpeg_encoder");
@@ -290,16 +271,18 @@ class JPEGEncoder : public Encoder {
                            it_encoder->second.c_str());
       }
     }
-    CodecInOut io;
-    JXL_RETURN_IF_ERROR(ConvertPackedPixelFileToCodecInOut(ppf, pool, &io));
-    encoded_image->icc = ppf.icc;
+    std::vector<uint8_t> icc;
+    if (!IsSRGBEncoding(ppf.color_encoding)) {
+      icc = ppf.icc;
+    }
     encoded_image->bitstreams.clear();
-    encoded_image->bitstreams.reserve(io.frames.size());
-    for (const ImageBundle& ib : io.frames) {
+    encoded_image->bitstreams.reserve(ppf.frames.size());
+    for (const auto& frame : ppf.frames) {
+      JXL_RETURN_IF_ERROR(VerifyPackedImage(frame.color, ppf.info));
       encoded_image->bitstreams.emplace_back();
-      JXL_RETURN_IF_ERROR(EncodeImageJPG(ib, ppf.metadata.exif, jpeg_encoder,
-                                         quality, chroma_subsampling, pool,
-                                         &encoded_image->bitstreams.back()));
+      JXL_RETURN_IF_ERROR(EncodeImageJPG(
+          frame.color, ppf.info, icc, ppf.metadata.exif, jpeg_encoder, quality,
+          chroma_subsampling, pool, &encoded_image->bitstreams.back()));
     }
     return true;
   }
@@ -309,13 +292,6 @@ class JPEGEncoder : public Encoder {
 
 std::unique_ptr<Encoder> GetJPEGEncoder() {
   return jxl::make_unique<JPEGEncoder>();
-}
-
-Status EncodeImageJPG(const CodecInOut* io, JpegEncoder encoder, size_t quality,
-                      YCbCrChromaSubsampling chroma_subsampling,
-                      ThreadPool* pool, std::vector<uint8_t>* bytes) {
-  return EncodeImageJPG(io->Main(), io->blobs.exif, encoder, quality,
-                        chroma_subsampling, pool, bytes);
 }
 
 }  // namespace extras

--- a/lib/extras/enc/jpg.h
+++ b/lib/extras/enc/jpg.h
@@ -8,29 +8,14 @@
 
 // Encodes JPG pixels and metadata in memory.
 
-#include <stdint.h>
+#include <memory>
 
 #include "lib/extras/enc/encode.h"
-#include "lib/jxl/base/data_parallel.h"
-#include "lib/jxl/base/padded_bytes.h"
-#include "lib/jxl/base/span.h"
-#include "lib/jxl/base/status.h"
-#include "lib/jxl/codec_in_out.h"
 
 namespace jxl {
 namespace extras {
 
-enum class JpegEncoder {
-  kLibJpeg,
-  kSJpeg,
-};
-
 std::unique_ptr<Encoder> GetJPEGEncoder();
-
-// Encodes into `bytes`.
-Status EncodeImageJPG(const CodecInOut* io, JpegEncoder encoder, size_t quality,
-                      YCbCrChromaSubsampling chroma_subsampling,
-                      ThreadPool* pool, std::vector<uint8_t>* bytes);
 
 }  // namespace extras
 }  // namespace jxl

--- a/lib/extras/enc/npy.cc
+++ b/lib/extras/enc/npy.cc
@@ -284,6 +284,7 @@ class NumPyEncoder : public Encoder {
  public:
   Status Encode(const PackedPixelFile& ppf, EncodedImage* encoded_image,
                 ThreadPool* pool = nullptr) const override {
+    JXL_RETURN_IF_ERROR(VerifyBasicInfo(ppf.info));
     GenerateMetadata(ppf, &encoded_image->metadata);
     encoded_image->bitstreams.emplace_back();
     if (!WriteNPYArray(ppf, &encoded_image->bitstreams.back())) {

--- a/lib/extras/enc/pnm.h
+++ b/lib/extras/enc/pnm.h
@@ -10,9 +10,9 @@
 
 // TODO(janwas): workaround for incorrect Win64 codegen (cause unknown)
 #include <hwy/highway.h>
+#include <memory>
 
 #include "lib/extras/enc/encode.h"
-#include "lib/extras/packed_image.h"
 
 namespace jxl {
 namespace extras {
@@ -21,9 +21,6 @@ std::unique_ptr<Encoder> GetPAMEncoder();
 std::unique_ptr<Encoder> GetPGMEncoder();
 std::unique_ptr<Encoder> GetPPMEncoder();
 std::unique_ptr<Encoder> GetPFMEncoder();
-
-Status EncodeImagePNM(const PackedImage& image, JxlOrientation orientation,
-                      size_t bits_per_sample, std::vector<uint8_t>* bytes);
 
 }  // namespace extras
 }  // namespace jxl

--- a/lib/extras/exif.cc
+++ b/lib/extras/exif.cc
@@ -1,0 +1,55 @@
+// Copyright (c) the JPEG XL Project Authors. All rights reserved.
+//
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+#include "lib/extras/exif.h"
+
+#include "lib/jxl/base/byte_order.h"
+
+namespace jxl {
+
+constexpr uint16_t kExifOrientationTag = 274;
+
+void ResetExifOrientation(std::vector<uint8_t>& exif) {
+  if (exif.size() < 12) return;  // not enough bytes for a valid exif blob
+  bool bigendian;
+  uint8_t* t = exif.data();
+  if (LoadLE32(t) == 0x2A004D4D) {
+    bigendian = true;
+  } else if (LoadLE32(t) == 0x002A4949) {
+    bigendian = false;
+  } else {
+    return;  // not a valid tiff header
+  }
+  t += 4;
+  uint32_t offset = (bigendian ? LoadBE32(t) : LoadLE32(t));
+  if (exif.size() < 12 + offset + 2 || offset < 8) return;
+  t += offset - 4;
+  uint16_t nb_tags = (bigendian ? LoadBE16(t) : LoadLE16(t));
+  t += 2;
+  while (nb_tags > 0) {
+    if (t + 12 >= exif.data() + exif.size()) return;
+    uint16_t tag = (bigendian ? LoadBE16(t) : LoadLE16(t));
+    t += 2;
+    if (tag == kExifOrientationTag) {
+      uint16_t type = (bigendian ? LoadBE16(t) : LoadLE16(t));
+      t += 2;
+      uint32_t count = (bigendian ? LoadBE32(t) : LoadLE32(t));
+      t += 4;
+      if (type == 3 && count == 1) {
+        if (bigendian) {
+          StoreBE16(1, t);
+        } else {
+          StoreLE16(1, t);
+        }
+      }
+      return;
+    } else {
+      t += 10;
+      nb_tags--;
+    }
+  }
+}
+
+}  // namespace jxl

--- a/lib/extras/exif.h
+++ b/lib/extras/exif.h
@@ -1,0 +1,20 @@
+// Copyright (c) the JPEG XL Project Authors. All rights reserved.
+//
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+#ifndef LIB_EXTRAS_EXIF_H_
+#define LIB_EXTRAS_EXIF_H_
+
+#include <stdint.h>
+
+#include <vector>
+
+namespace jxl {
+
+// Sets the Exif orientation to the identity, to avoid repeated orientation
+void ResetExifOrientation(std::vector<uint8_t>& exif);
+
+}  // namespace jxl
+
+#endif  // LIB_EXTRAS_EXIF_H_

--- a/lib/extras/packed_image.h
+++ b/lib/extras/packed_image.h
@@ -32,26 +32,6 @@ class PackedImage {
  public:
   PackedImage(size_t xsize, size_t ysize, const JxlPixelFormat& format)
       : PackedImage(xsize, ysize, format, CalcStride(format, xsize)) {}
-  PackedImage(size_t xsize, size_t ysize, const JxlPixelFormat& format,
-              size_t stride)
-      : xsize(xsize),
-        ysize(ysize),
-        stride(stride),
-        format(format),
-        pixels_size(ysize * stride),
-        pixels_(malloc(std::max<size_t>(1, pixels_size)), free) {}
-  // Construct the image using the passed pixel buffer. The buffer is owned by
-  // this object and released with free().
-  PackedImage(size_t xsize, size_t ysize, const JxlPixelFormat& format,
-              void* pixels, size_t pixels_size)
-      : xsize(xsize),
-        ysize(ysize),
-        stride(CalcStride(format, xsize)),
-        format(format),
-        pixels_size(pixels_size),
-        pixels_(pixels, free) {
-    JXL_ASSERT(pixels_size >= stride * ysize);
-  }
 
   // The interleaved pixels as defined in the storage format.
   void* pixels() const { return pixels_.get(); }
@@ -59,15 +39,6 @@ class PackedImage {
   // The image size in pixels.
   size_t xsize;
   size_t ysize;
-
-  // Whether the y coordinate is flipped (y=0 is the last row).
-  bool flipped_y = false;
-
-  // Whether the range is determined by format or by JxlBasicInfo
-  // e.g. if format is UINT16 and JxlBasicInfo bits_per_sample is 10,
-  // then if bitdepth_from_format == true, the range is 0..65535
-  // while if bitdepth_from_format == false, the range is 0..1023.
-  bool bitdepth_from_format = true;
 
   // The number of bytes per row.
   size_t stride;
@@ -97,6 +68,15 @@ class PackedImage {
   }
 
  private:
+  PackedImage(size_t xsize, size_t ysize, const JxlPixelFormat& format,
+              size_t stride)
+      : xsize(xsize),
+        ysize(ysize),
+        stride(stride),
+        format(format),
+        pixels_size(ysize * stride),
+        pixels_(malloc(std::max<size_t>(1, pixels_size)), free) {}
+
   static size_t CalcStride(const JxlPixelFormat& format, size_t xsize) {
     size_t stride = xsize * (BitsPerChannel(format.data_type) *
                              format.num_channels / jxl::kBitsPerByte);

--- a/lib/jxl/codec_in_out.h
+++ b/lib/jxl/codec_in_out.h
@@ -210,7 +210,6 @@ class CodecInOut {
 
   std::vector<ImageBundle> frames;  // size=1 if !metadata.have_animation
 
-  bool use_sjpeg = false;
   // If the image should be written to a JPEG, use this quality for encoding.
   size_t jpeg_quality;
 };

--- a/lib/jxl/decode_test.cc
+++ b/lib/jxl/decode_test.cc
@@ -18,8 +18,8 @@
 #include "jxl/resizable_parallel_runner_cxx.h"
 #include "jxl/thread_parallel_runner_cxx.h"
 #include "jxl/types.h"
+#include "lib/extras/codec.h"
 #include "lib/extras/dec/color_description.h"
-#include "lib/extras/enc/jpg.h"
 #include "lib/jxl/base/byte_order.h"
 #include "lib/jxl/base/file_io.h"
 #include "lib/jxl/base/padded_bytes.h"
@@ -230,14 +230,14 @@ PaddedBytes CreateTestJXLCodestream(Span<const uint8_t> pixels, size_t xsize,
   EXPECT_TRUE(ConvertFromExternal(
       pixels, xsize, ysize, color_encoding, num_channels,
       /*alpha_is_premultiplied=*/false, /*bits_per_sample=*/16, JXL_BIG_ENDIAN,
-      /*flipped_y=*/false, &pool, &io.Main(), /*float_in=*/false, /*align=*/0));
+      &pool, &io.Main(), /*float_in=*/false, /*align=*/0));
   jxl::PaddedBytes jpeg_data;
   if (params.jpeg_codestream != nullptr) {
 #if JPEGXL_ENABLE_JPEG
     std::vector<uint8_t> jpeg_bytes;
-    EXPECT_TRUE(EncodeImageJPG(&io, jxl::extras::JpegEncoder::kLibJpeg,
-                               /*quality=*/70, jxl::YCbCrChromaSubsampling(),
-                               &pool, &jpeg_bytes));
+    io.jpeg_quality = 70;
+    EXPECT_TRUE(Encode(io, extras::Codec::kJPG, io.metadata.m.color_encoding,
+                       /*bits_per_sample=*/8, &jpeg_bytes, &pool));
     params.jpeg_codestream->append(jpeg_bytes.data(),
                                    jpeg_bytes.data() + jpeg_bytes.size());
     EXPECT_TRUE(jxl::jpeg::DecodeImageJPG(
@@ -1297,12 +1297,12 @@ TEST_P(DecodeTestParam, PixelTest) {
     if (config.include_alpha) io.metadata.m.SetAlphaBits(16);
     io.SetSize(config.xsize, config.ysize);
 
-    EXPECT_TRUE(ConvertFromExternal(
-        bytes, config.xsize, config.ysize, color_encoding,
-        config.output_channels,
-        /*alpha_is_premultiplied=*/false, 16, JXL_BIG_ENDIAN,
-        /*flipped_y=*/false, nullptr, &io.Main(), /*float_in=*/false,
-        /*align=*/0));
+    EXPECT_TRUE(ConvertFromExternal(bytes, config.xsize, config.ysize,
+                                    color_encoding, config.output_channels,
+                                    /*alpha_is_premultiplied=*/false, 16,
+                                    JXL_BIG_ENDIAN, nullptr, &io.Main(),
+                                    /*float_in=*/false,
+                                    /*align=*/0));
 
     for (size_t i = 0; i < pixels.size(); i++) pixels[i] = 0;
     EXPECT_TRUE(ConvertToExternal(
@@ -1620,12 +1620,12 @@ TEST(DecodeTest, PixelTestWithICCProfileLossy) {
   jxl::Span<const uint8_t> span0(pixels.data(), pixels.size());
   jxl::CodecInOut io0;
   io0.SetSize(xsize, ysize);
-  EXPECT_TRUE(ConvertFromExternal(
-      span0, xsize, ysize, color_encoding0, /*channels=*/3,
-      /*alpha_is_premultiplied=*/false, /*bits_per_sample=*/16,
-      format_orig.endianness,
-      /*flipped_y=*/false, /*pool=*/nullptr, &io0.Main(), /*float_in=*/false,
-      /*align=*/0));
+  EXPECT_TRUE(
+      ConvertFromExternal(span0, xsize, ysize, color_encoding0, /*channels=*/3,
+                          /*alpha_is_premultiplied=*/false,
+                          /*bits_per_sample=*/16, format_orig.endianness,
+                          /*pool=*/nullptr, &io0.Main(), /*float_in=*/false,
+                          /*align=*/0));
 
   jxl::ColorEncoding color_encoding1;
   EXPECT_TRUE(color_encoding1.SetICC(std::move(icc)));
@@ -1635,8 +1635,8 @@ TEST(DecodeTest, PixelTestWithICCProfileLossy) {
   EXPECT_TRUE(ConvertFromExternal(span1, xsize, ysize, color_encoding1,
                                   channels, /*alpha_is_premultiplied=*/false,
                                   /*bits_per_sample=*/32, format.endianness,
-                                  /*flipped_y=*/false, /*pool=*/nullptr,
-                                  &io1.Main(), /*float_in=*/true, /*align=*/0));
+                                  /*pool=*/nullptr, &io1.Main(),
+                                  /*float_in=*/true, /*align=*/0));
 
   jxl::ButteraugliParams ba;
   EXPECT_THAT(ButteraugliDistance(io0, io1, ba, jxl::GetJxlCms(),
@@ -1682,7 +1682,7 @@ double ButteraugliDistance(size_t xsize, size_t ysize,
       jxl::Span<const uint8_t>(pixels_in.data(), pixels_in.size()), xsize,
       ysize, color_in, color_in.Channels(),
       /*alpha_is_premultiplied=*/false,
-      /*bits_per_sample=*/16, JXL_BIG_ENDIAN, /*flipped_y=*/false,
+      /*bits_per_sample=*/16, JXL_BIG_ENDIAN,
       /*pool=*/nullptr, &in.Main(), /*float_in=*/false, /*align=*/0));
   jxl::CodecInOut out;
   out.metadata.m.color_encoding = color_out;
@@ -1691,7 +1691,7 @@ double ButteraugliDistance(size_t xsize, size_t ysize,
       jxl::Span<const uint8_t>(pixels_out.data(), pixels_out.size()), xsize,
       ysize, color_out, color_out.Channels(),
       /*alpha_is_premultiplied=*/false,
-      /*bits_per_sample=*/16, JXL_BIG_ENDIAN, /*flipped_y=*/false,
+      /*bits_per_sample=*/16, JXL_BIG_ENDIAN,
       /*pool=*/nullptr, &out.Main(), /*float_in=*/false, /*align=*/0));
   return ButteraugliDistance(in, out, jxl::ButteraugliParams(),
                              jxl::GetJxlCms(), nullptr, nullptr);
@@ -1871,7 +1871,7 @@ TEST(DecodeTest, PixelTestOpaqueSrgbLossy) {
         span0, xsize, ysize, color_encoding0, /*channels=*/3,
         /*alpha_is_premultiplied=*/false, /*bits_per_sample=*/16,
         format_orig.endianness,
-        /*flipped_y=*/false, /*pool=*/nullptr, &io0.Main(), /*float_in=*/false,
+        /*pool=*/nullptr, &io0.Main(), /*float_in=*/false,
         /*align=*/0));
 
     jxl::ColorEncoding color_encoding1 = jxl::ColorEncoding::SRGB(false);
@@ -1880,8 +1880,8 @@ TEST(DecodeTest, PixelTestOpaqueSrgbLossy) {
     EXPECT_TRUE(ConvertFromExternal(span1, xsize, ysize, color_encoding1,
                                     channels, /*alpha_is_premultiplied=*/false,
                                     /*bits_per_sample=*/8, format.endianness,
-                                    /*flipped_y=*/false, /*pool=*/nullptr,
-                                    &io1.Main(), /*float_in=*/false,
+                                    /*pool=*/nullptr, &io1.Main(),
+                                    /*float_in=*/false,
                                     /*align=*/0));
 
     jxl::ButteraugliParams ba;
@@ -1927,7 +1927,7 @@ TEST(DecodeTest, PixelTestOpaqueSrgbLossyNoise) {
         span0, xsize, ysize, color_encoding0, /*channels=*/3,
         /*alpha_is_premultiplied=*/false, /*bits_per_sample=*/16,
         format_orig.endianness,
-        /*flipped_y=*/false, /*pool=*/nullptr, &io0.Main(), /*float_in=*/false,
+        /*pool=*/nullptr, &io0.Main(), /*float_in=*/false,
         /*align=*/0));
 
     jxl::ColorEncoding color_encoding1 = jxl::ColorEncoding::SRGB(false);
@@ -1936,8 +1936,8 @@ TEST(DecodeTest, PixelTestOpaqueSrgbLossyNoise) {
     EXPECT_TRUE(ConvertFromExternal(span1, xsize, ysize, color_encoding1,
                                     channels, /*alpha_is_premultiplied=*/false,
                                     /*bits_per_sample=*/8, format.endianness,
-                                    /*flipped_y=*/false, /*pool=*/nullptr,
-                                    &io1.Main(), /*float_in=*/false,
+                                    /*pool=*/nullptr, &io1.Main(),
+                                    /*float_in=*/false,
                                     /*align=*/0));
 
     jxl::ButteraugliParams ba;
@@ -2444,7 +2444,7 @@ TEST(DecodeTest, AnimationTest) {
         jxl::Span<const uint8_t>(frames[i].data(), frames[i].size()), xsize,
         ysize, jxl::ColorEncoding::SRGB(/*is_gray=*/false), /*channels=*/3,
         /*alpha_is_premultiplied=*/false, /*bits_per_sample=*/16,
-        JXL_BIG_ENDIAN, /*flipped_y=*/false, /*pool=*/nullptr, &bundle,
+        JXL_BIG_ENDIAN, /*pool=*/nullptr, &bundle,
         /*float_in=*/false, /*align=*/0));
     bundle.duration = frame_durations[i];
     io.frames.push_back(std::move(bundle));
@@ -2548,7 +2548,7 @@ TEST(DecodeTest, AnimationTestStreaming) {
         jxl::Span<const uint8_t>(frames[i].data(), frames[i].size()), xsize,
         ysize, jxl::ColorEncoding::SRGB(/*is_gray=*/false), /*channels=*/3,
         /*alpha_is_premultiplied=*/false, /*bits_per_sample=*/16,
-        JXL_BIG_ENDIAN, /*flipped_y=*/false, /*pool=*/nullptr, &bundle,
+        JXL_BIG_ENDIAN, /*pool=*/nullptr, &bundle,
         /*float_in=*/false, /*align=*/0));
     bundle.duration = frame_durations[i];
     io.frames.push_back(std::move(bundle));
@@ -2767,7 +2767,7 @@ TEST(DecodeTest, SkipCurrentFrameTest) {
         jxl::Span<const uint8_t>(frames[i].data(), frames[i].size()), xsize,
         ysize, jxl::ColorEncoding::SRGB(/*is_gray=*/false), /*channels=*/3,
         /*alpha_is_premultiplied=*/false, /*bits_per_sample=*/16,
-        JXL_BIG_ENDIAN, /*flipped_y=*/false, /*pool=*/nullptr, &bundle,
+        JXL_BIG_ENDIAN, /*pool=*/nullptr, &bundle,
         /*float_in=*/false, /*align=*/0));
     bundle.duration = frame_durations[i];
     io.frames.push_back(std::move(bundle));
@@ -2883,7 +2883,7 @@ TEST(DecodeTest, SkipFrameTest) {
         jxl::Span<const uint8_t>(frames[i].data(), frames[i].size()), xsize,
         ysize, jxl::ColorEncoding::SRGB(/*is_gray=*/false), /*channels=*/3,
         /*alpha_is_premultiplied=*/false, /*bits_per_sample=*/16,
-        JXL_BIG_ENDIAN, /*flipped_y=*/false, /*pool=*/nullptr, &bundle,
+        JXL_BIG_ENDIAN, /*pool=*/nullptr, &bundle,
         /*float_in=*/false, /*align=*/0));
     bundle.duration = frame_durations[i];
     io.frames.push_back(std::move(bundle));
@@ -3020,8 +3020,8 @@ TEST(DecodeTest, SkipFrameWithBlendingTest) {
           xsize, ysize, jxl::ColorEncoding::SRGB(/*is_gray=*/false),
           /*channels=*/3,
           /*alpha_is_premultiplied=*/false, /*bits_per_sample=*/16,
-          JXL_BIG_ENDIAN, /*flipped_y=*/false, /*pool=*/nullptr,
-          &bundle_internal, /*float_in=*/false, /*align=*/0));
+          JXL_BIG_ENDIAN, /*pool=*/nullptr, &bundle_internal,
+          /*float_in=*/false, /*align=*/0));
       bundle_internal.duration = 0;
       bundle_internal.use_for_next_frame = true;
       io.frames.push_back(std::move(bundle_internal));
@@ -3036,7 +3036,7 @@ TEST(DecodeTest, SkipFrameWithBlendingTest) {
         jxl::Span<const uint8_t>(frame.data(), frame.size()), xsize, ysize,
         jxl::ColorEncoding::SRGB(/*is_gray=*/false), /*channels=*/3,
         /*alpha_is_premultiplied=*/false, /*bits_per_sample=*/16,
-        JXL_BIG_ENDIAN, /*flipped_y=*/false, /*pool=*/nullptr, &bundle,
+        JXL_BIG_ENDIAN, /*pool=*/nullptr, &bundle,
         /*float_in=*/false, /*align=*/0));
     bundle.duration = frame_durations[i];
     // Create some variation in which frames depend on which.
@@ -3247,8 +3247,8 @@ TEST(DecodeTest, SkipFrameWithAlphaBlendingTest) {
           xsize / 2, ysize / 2, jxl::ColorEncoding::SRGB(/*is_gray=*/false),
           /*channels=*/4,
           /*alpha_is_premultiplied=*/false, /*bits_per_sample=*/16,
-          JXL_BIG_ENDIAN, /*flipped_y=*/false, /*pool=*/nullptr,
-          &bundle_internal, /*float_in=*/false, /*align=*/0));
+          JXL_BIG_ENDIAN, /*pool=*/nullptr, &bundle_internal,
+          /*float_in=*/false, /*align=*/0));
       bundle_internal.duration = 0;
       bundle_internal.use_for_next_frame = true;
       bundle_internal.origin = {13, 17};
@@ -3268,7 +3268,7 @@ TEST(DecodeTest, SkipFrameWithAlphaBlendingTest) {
         jxl::Span<const uint8_t>(frame.data(), frame.size()), cropxsize,
         cropysize, jxl::ColorEncoding::SRGB(/*is_gray=*/false), /*channels=*/4,
         /*alpha_is_premultiplied=*/false, /*bits_per_sample=*/16,
-        JXL_BIG_ENDIAN, /*flipped_y=*/false, /*pool=*/nullptr, &bundle,
+        JXL_BIG_ENDIAN, /*pool=*/nullptr, &bundle,
         /*float_in=*/false, /*align=*/0));
     bundle.duration = 5 + i;
     frame_durations_nc.push_back(5 + i);
@@ -3532,7 +3532,7 @@ TEST(DecodeTest, OrientedCroppedFrameTest) {
           cropysize, jxl::ColorEncoding::SRGB(/*is_gray=*/false),
           /*channels=*/4,
           /*alpha_is_premultiplied=*/false, /*bits_per_sample=*/16,
-          JXL_BIG_ENDIAN, /*flipped_y=*/false, /*pool=*/nullptr, &bundle,
+          JXL_BIG_ENDIAN, /*pool=*/nullptr, &bundle,
           /*float_in=*/false, /*align=*/0));
       bundle.origin = {cropx0, cropy0};
       bundle.use_for_next_frame = true;
@@ -4616,7 +4616,7 @@ TEST_P(DecodeProgressiveTest, ProgressiveEventTest) {
         jxl::Span<const uint8_t>(pixels.data(), pixels.size()), xsize, ysize,
         color_encoding, num_channels,
         /*alpha_is_premultiplied=*/false,
-        /*bits_per_sample=*/16, JXL_BIG_ENDIAN, /*flipped_y=*/false,
+        /*bits_per_sample=*/16, JXL_BIG_ENDIAN,
         /*pool=*/nullptr, &io.Main(), /*float_in=*/false, /*align=*/0));
     jxl::TestCodestreamParams params;
     if (lossless) {
@@ -4738,7 +4738,7 @@ TEST_P(DecodeProgressiveTest, ProgressiveEventTest) {
             jxl::Span<const uint8_t>(passes[p].data(), passes[p].size()), xsize,
             ysize, color_encoding, num_channels,
             /*alpha_is_premultiplied=*/false, /*bits_per_sample=*/16,
-            JXL_BIG_ENDIAN, /*flipped_y=*/false,
+            JXL_BIG_ENDIAN,
             /*pool=*/nullptr, &io1.Main(), /*float_in=*/false,
             /*align=*/0));
         distances[p] = ButteraugliDistance(io, io1, ba, jxl::GetJxlCms(),

--- a/lib/jxl/enc_external_image.h
+++ b/lib/jxl/enc_external_image.h
@@ -32,8 +32,8 @@ Status ConvertFromExternal(Span<const uint8_t> bytes, size_t xsize,
                            size_t ysize, const ColorEncoding& c_current,
                            size_t channels, bool alpha_is_premultiplied,
                            size_t bits_per_sample, JxlEndianness endianness,
-                           bool flipped_y, ThreadPool* pool, ImageBundle* ib,
-                           bool float_in, size_t align);
+                           ThreadPool* pool, ImageBundle* ib, bool float_in,
+                           size_t align);
 Status BufferToImageF(const JxlPixelFormat& pixel_format, size_t xsize,
                       size_t ysize, const void* buffer, size_t size,
                       ThreadPool* pool, ImageF* channel);

--- a/lib/jxl/enc_external_image_gbench.cc
+++ b/lib/jxl/enc_external_image_gbench.cc
@@ -31,7 +31,6 @@ void BM_EncExternalImage_ConvertImageRGBA(benchmark::State& state) {
           /*channels=*/4,
           /*alpha_is_premultiplied=*/false,
           /*bits_per_sample=*/8, JXL_NATIVE_ENDIAN,
-          /*flipped_y=*/false,
           /*pool=*/nullptr, &ib, /*float_in=*/false, /*align=*/0));
     }
   }

--- a/lib/jxl/enc_external_image_test.cc
+++ b/lib/jxl/enc_external_image_test.cc
@@ -30,18 +30,18 @@ TEST(ExternalImageTest, InvalidSize) {
       Span<const uint8_t>(buf, 10), /*xsize=*/10, /*ysize=*/100,
       /*c_current=*/ColorEncoding::SRGB(), /*channels=*/4,
       /*alpha_is_premultiplied=*/false, /*bits_per_sample=*/16, JXL_BIG_ENDIAN,
-      /*flipped_y=*/false, nullptr, &ib, /*float_in=*/false, /*align=*/0));
+      nullptr, &ib, /*float_in=*/false, /*align=*/0));
   EXPECT_FALSE(ConvertFromExternal(
       Span<const uint8_t>(buf, sizeof(buf) - 1), /*xsize=*/10, /*ysize=*/100,
       /*c_current=*/ColorEncoding::SRGB(), /*channels=*/4,
       /*alpha_is_premultiplied=*/false, /*bits_per_sample=*/16, JXL_BIG_ENDIAN,
-      /*flipped_y=*/false, nullptr, &ib, /*float_in=*/false, /*align=*/0));
-  EXPECT_TRUE(ConvertFromExternal(
-      Span<const uint8_t>(buf, sizeof(buf)), /*xsize=*/10,
-      /*ysize=*/100, /*c_current=*/ColorEncoding::SRGB(),
-      /*channels=*/4, /*alpha_is_premultiplied=*/false,
-      /*bits_per_sample=*/16, JXL_BIG_ENDIAN,
-      /*flipped_y=*/false, nullptr, &ib, /*float_in=*/false, /*align=*/0));
+      nullptr, &ib, /*float_in=*/false, /*align=*/0));
+  EXPECT_TRUE(
+      ConvertFromExternal(Span<const uint8_t>(buf, sizeof(buf)), /*xsize=*/10,
+                          /*ysize=*/100, /*c_current=*/ColorEncoding::SRGB(),
+                          /*channels=*/4, /*alpha_is_premultiplied=*/false,
+                          /*bits_per_sample=*/16, JXL_BIG_ENDIAN, nullptr, &ib,
+                          /*float_in=*/false, /*align=*/0));
 }
 #endif
 
@@ -56,12 +56,12 @@ TEST(ExternalImageTest, AlphaMissing) {
 
   // has_alpha is true but the ImageBundle has no alpha. Alpha channel should
   // be ignored.
-  EXPECT_TRUE(ConvertFromExternal(
-      Span<const uint8_t>(buf, sizeof(buf)), xsize, ysize,
-      /*c_current=*/ColorEncoding::SRGB(),
-      /*channels=*/4, /*alpha_is_premultiplied=*/false,
-      /*bits_per_sample=*/8, JXL_BIG_ENDIAN,
-      /*flipped_y=*/false, nullptr, &ib, /*float_in=*/false, /*align=*/0));
+  EXPECT_TRUE(
+      ConvertFromExternal(Span<const uint8_t>(buf, sizeof(buf)), xsize, ysize,
+                          /*c_current=*/ColorEncoding::SRGB(),
+                          /*channels=*/4, /*alpha_is_premultiplied=*/false,
+                          /*bits_per_sample=*/8, JXL_BIG_ENDIAN, nullptr, &ib,
+                          /*float_in=*/false, /*align=*/0));
   EXPECT_FALSE(ib.HasAlpha());
 }
 

--- a/lib/jxl/exif.cc
+++ b/lib/jxl/exif.cc
@@ -67,23 +67,4 @@ void InterpretExif(const std::vector<uint8_t>& exif, CodecMetadata* metadata) {
   }
 }
 
-void ResetExifOrientation(std::vector<uint8_t>& exif) {
-  bool bigendian;
-  if (!IsExif(exif, &bigendian)) return;
-  size_t o_pos = FindExifTagPosition(exif, kExifOrientationTag);
-  if (o_pos) {
-    uint8_t* t = exif.data() + o_pos;
-    uint16_t type = (bigendian ? LoadBE16(t) : LoadLE16(t));
-    t += 2;
-    uint32_t count = (bigendian ? LoadBE32(t) : LoadLE32(t));
-    t += 4;
-    if (type == 3 && count == 1) {
-      if (bigendian)
-        StoreBE16(1, t);
-      else
-        StoreLE16(1, t);
-    }
-  }
-}
-
 }  // namespace jxl

--- a/lib/jxl/exif.h
+++ b/lib/jxl/exif.h
@@ -19,9 +19,6 @@ namespace jxl {
 // as a no-op.
 void InterpretExif(const std::vector<uint8_t>& exif, CodecMetadata* metadata);
 
-// Sets the Exif orientation to the identity, to avoid repeated orientation
-void ResetExifOrientation(std::vector<uint8_t>& exif);
-
 }  // namespace jxl
 
 #endif  // LIB_JXL_EXIF_H_

--- a/lib/jxl/frame_header.h
+++ b/lib/jxl/frame_header.h
@@ -92,8 +92,8 @@ struct YCbCrChromaSubsampling : public Fields {
   uint8_t MaxHShift() const { return maxhs_; }
   uint8_t MaxVShift() const { return maxvs_; }
 
-  uint8_t RawHShift(size_t c) { return kHShift[channel_mode_[c]]; }
-  uint8_t RawVShift(size_t c) { return kVShift[channel_mode_[c]]; }
+  uint8_t RawHShift(size_t c) const { return kHShift[channel_mode_[c]]; }
+  uint8_t RawVShift(size_t c) const { return kVShift[channel_mode_[c]]; }
 
   // Uses JPEG channel order (Y, Cb, Cr).
   Status Set(const uint8_t* hsample, const uint8_t* vsample) {

--- a/lib/jxl/roundtrip_test.cc
+++ b/lib/jxl/roundtrip_test.cc
@@ -101,7 +101,7 @@ jxl::CodecInOut ConvertTestImage(const std::vector<uint8_t>& buf,
       color_encoding, pixel_format.num_channels,
       /*alpha_is_premultiplied=*/false,
       /*bits_per_sample=*/bitdepth, pixel_format.endianness,
-      /*flipped_y=*/false, /*pool=*/nullptr, &io.Main(), float_in,
+      /*pool=*/nullptr, &io.Main(), float_in,
       /*align=*/0));
   return io;
 }

--- a/lib/jxl/test_utils.h
+++ b/lib/jxl/test_utils.h
@@ -307,7 +307,7 @@ jxl::CodecInOut SomeTestImageToCodecInOut(const std::vector<uint8_t>& buf,
       jxl::Span<const uint8_t>(buf.data(), buf.size()), xsize, ysize,
       jxl::ColorEncoding::SRGB(/*is_gray=*/num_channels < 3), num_channels,
       /*alpha_is_premultiplied=*/false, /*bits_per_sample=*/16, JXL_BIG_ENDIAN,
-      /*flipped_y=*/false, /*pool=*/nullptr,
+      /*pool=*/nullptr,
       /*ib=*/&io.Main(), /*float_in=*/false, 0));
   return io;
 }

--- a/lib/jxl_tests.cmake
+++ b/lib/jxl_tests.cmake
@@ -125,8 +125,6 @@ foreach (TESTFILE IN LISTS TEST_FILES)
   )
   target_link_libraries(${TESTNAME}
     box
-    jxl-static
-    jxl_threads-static
     jxl_extras-static
     jxl_testlib-static
     gmock

--- a/lib/lib.gni
+++ b/lib/lib.gni
@@ -466,6 +466,8 @@ libjxl_extras_sources = [
     "extras/enc/pgx.h",
     "extras/enc/pnm.cc",
     "extras/enc/pnm.h",
+    "extras/exif.cc",
+    "extras/exif.h",
     "extras/hlg.cc",
     "extras/hlg.h",
     "extras/packed_image.h",

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -58,18 +58,19 @@ endif()  # JPEGXL_ENABLE_VIEWERS
 
 # Tools are added conditionally below.
 set(TOOL_BINARIES)
+# Tools that depend on jxl internal functions.
+set(INTERNAL_TOOL_BINARIES)
 
 add_library(jxl_tool STATIC EXCLUDE_FROM_ALL
   cmdline.cc
   codec_config.cc
   speed_stats.cc
+  file_io.cc
   tool_version.cc
 )
 target_compile_options(jxl_tool PUBLIC "${JPEGXL_INTERNAL_FLAGS}")
+target_include_directories(jxl_tool PUBLIC "${PROJECT_SOURCE_DIR}")
 target_link_libraries(jxl_tool hwy)
-
-target_include_directories(jxl_tool
-  PUBLIC "${PROJECT_SOURCE_DIR}")
 
 # The JPEGXL_VERSION is set from the builders.
 if(NOT DEFINED JPEGXL_VERSION OR JPEGXL_VERSION STREQUAL "")
@@ -120,49 +121,32 @@ else()
 endif()
 
 if(JPEGXL_ENABLE_TOOLS)
-  list(APPEND TOOL_BINARIES
-    cjxl
-    cjpeg_hdr
-    jxlinfo
-  )
-
   # Main compressor.
-  add_executable(cjxl
-    cjxl_main.cc
-  )
+  add_executable(cjxl cjxl_main.cc)
   target_link_libraries(cjxl
     jxl
-    jxl_extras_dec-static
-    jxl_threads
-    hwy
-  )
-  target_include_directories(cjxl PRIVATE "${PROJECT_SOURCE_DIR}")
-  if(JPEGXL_EMSCRIPTEN)
-    set_target_properties(cjxl PROPERTIES LINK_FLAGS "-s USE_LIBPNG=1")
-  endif()
-
-  add_executable(djxl
-    djxl_main.cc
-  )
-  target_link_libraries(djxl
-    jxl_extras-static
+    jxl_extras_codec-static
     jxl_threads
     jxl_tool
   )
+  list(APPEND TOOL_BINARIES cjxl)
 
-  add_executable(cjpeg_hdr
-    cjpeg_hdr.cc
+  # Main decompressor.
+  add_executable(djxl djxl_main.cc)
+  target_link_libraries(djxl
+    jxl
+    jxl_extras_codec-static
+    jxl_threads
+    jxl_tool
   )
-  target_link_libraries(cjpeg_hdr
-    jxl-static
-    jxl_extras-static
-    jxl_threads-static
-  )
+  list(APPEND TOOL_BINARIES djxl)
 
-  add_executable(jxlinfo
-    jxlinfo.c
-  )
+  add_executable(cjpeg_hdr cjpeg_hdr.cc)
+  list(APPEND INTERNAL_TOOL_BINARIES cjpeg_hdr)
+
+  add_executable(jxlinfo jxlinfo.c)
   target_link_libraries(jxlinfo jxl)
+  list(APPEND TOOL_BINARIES jxlinfo)
 
   if(NOT SANITIZER STREQUAL "none")
     # Linking a C test binary with the C++ JPEG XL implementation when using
@@ -175,7 +159,7 @@ endif()  # JPEGXL_ENABLE_TOOLS
 
 # Other developer tools.
 if(JPEGXL_ENABLE_DEVTOOLS)
-  list(APPEND TOOL_BINARIES
+  list(APPEND INTERNAL_TOOL_BINARIES
     fuzzer_corpus
     butteraugli_main
     decode_and_encode
@@ -207,7 +191,7 @@ endif()  # JPEGXL_ENABLE_DEVTOOLS
 
 # Benchmark tools.
 if(JPEGXL_ENABLE_BENCHMARK AND JPEGXL_ENABLE_TOOLS)
-  list(APPEND TOOL_BINARIES
+  list(APPEND INTERNAL_TOOL_BINARIES
     benchmark_xl
   )
 
@@ -284,20 +268,20 @@ if(JPEGXL_ENABLE_BENCHMARK AND JPEGXL_ENABLE_TOOLS)
 endif()  # JPEGXL_ENABLE_BENCHMARK
 
 # All tool binaries depend on "jxl" library and the tool helpers.
+foreach(BINARY IN LISTS INTERNAL_TOOL_BINARIES)
+  target_link_libraries("${BINARY}"
+    jxl_extras-static
+    jxl_tool
+  )
+endforeach()
+
+list(APPEND TOOL_BINARIES ${INTERNAL_TOOL_BINARIES})
+
 foreach(BINARY IN LISTS TOOL_BINARIES)
-  target_include_directories("${BINARY}" PRIVATE "${PROJECT_SOURCE_DIR}")
-  target_link_libraries("${BINARY}" jxl-static jxl_extras-static jxl_threads-static jxl_tool)
   if(JPEGXL_EMSCRIPTEN)
     set_target_properties(${BINARY} PROPERTIES LINK_FLAGS "-s USE_LIBPNG=1")
   endif()
 endforeach()
-
-if(JPEGXL_ENABLE_TOOLS)
-  list(APPEND TOOL_BINARIES djxl)
-  if(JPEGXL_EMSCRIPTEN)
-    set_target_properties(djxl PROPERTIES LINK_FLAGS "-s USE_LIBPNG=1")
-  endif()
-endif()
 
 install(TARGETS ${TOOL_BINARIES} RUNTIME DESTINATION "${CMAKE_INSTALL_BINDIR}")
 message(STATUS "Building tools: ${TOOL_BINARIES}")
@@ -335,9 +319,7 @@ foreach(FUZZER IN LISTS FUZZER_BINARIES)
     )
   else()
     target_link_libraries("${BINARY}"
-      jxl-static
       jxl_extras-static
-      jxl_threads-static
       jxl_tool
     )
   endif()
@@ -389,9 +371,7 @@ if (JPEGXL_ENABLE_TOOLS AND JPEGXL_EMSCRIPTEN)
 # WASM API facade.
 add_executable(jxl_emcc jxl_emcc.cc)
 target_link_libraries(jxl_emcc
-    jxl-static
     jxl_extras-static
-    jxl_threads-static
 )
 set_target_properties(jxl_emcc PROPERTIES LINK_FLAGS "\
   -O3\

--- a/tools/benchmark/benchmark_codec_avif.cc
+++ b/tools/benchmark/benchmark_codec_avif.cc
@@ -324,7 +324,7 @@ class AvifCodec : public ImageCodec {
                                   rgb_image.height * rgb_image.rowBytes),
               rgb_image.width, rgb_image.height, color, (has_alpha ? 4 : 3),
               /*alpha_is_premultiplied=*/false, rgb_image.depth,
-              JXL_NATIVE_ENDIAN, /*flipped_y=*/false, pool, &ib,
+              JXL_NATIVE_ENDIAN, pool, &ib,
               /*float_in=*/false, /*align=*/0));
           io->frames.push_back(std::move(ib));
           io->dec_pixels += rgb_image.width * rgb_image.height;

--- a/tools/benchmark/benchmark_codec_webp.cc
+++ b/tools/benchmark/benchmark_codec_webp.cc
@@ -40,11 +40,10 @@ Status FromSRGB(const size_t xsize, const size_t ysize, const bool is_gray,
   const ColorEncoding& c = ColorEncoding::SRGB(is_gray);
   const size_t bits_per_sample = (is_16bit ? 2 : 1) * kBitsPerByte;
   const Span<const uint8_t> span(pixels, end - pixels);
-  return ConvertFromExternal(span, xsize, ysize, c,
-                             (is_gray ? 1 : 3) + (has_alpha ? 1 : 0),
-                             alpha_is_premultiplied, bits_per_sample,
-                             endianness, /*flipped_y=*/false, pool, ib,
-                             /*float_in=*/false, /*align=*/0);
+  return ConvertFromExternal(
+      span, xsize, ysize, c, (is_gray ? 1 : 3) + (has_alpha ? 1 : 0),
+      alpha_is_premultiplied, bits_per_sample, endianness, pool, ib,
+      /*float_in=*/false, /*align=*/0);
 }
 
 struct WebPArgs {

--- a/tools/file_io.cc
+++ b/tools/file_io.cc
@@ -1,0 +1,75 @@
+// Copyright (c) the JPEG XL Project Authors. All rights reserved.
+//
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+#include "tools/file_io.h"
+
+#include <errno.h>
+#include <limits.h>
+#include <stdio.h>
+#include <string.h>
+
+namespace jpegxl {
+namespace tools {
+
+bool ReadFile(const char* filename, std::vector<uint8_t>* out) {
+  FILE* file = fopen(filename, "rb");
+  if (!file) {
+    return false;
+  }
+
+  if (fseek(file, 0, SEEK_END) != 0) {
+    fclose(file);
+    return false;
+  }
+
+  long size = ftell(file);
+  // Avoid invalid file or directory.
+  if (size >= LONG_MAX || size < 0) {
+    fclose(file);
+    return false;
+  }
+
+  if (fseek(file, 0, SEEK_SET) != 0) {
+    fclose(file);
+    return false;
+  }
+
+  out->resize(size);
+  size_t readsize = fread(out->data(), 1, size, file);
+  if (fclose(file) != 0) {
+    return false;
+  }
+
+  return readsize == static_cast<size_t>(size);
+}
+
+bool WriteFile(const char* filename, const std::vector<uint8_t>& bytes) {
+  FILE* file = fopen(filename, "wb");
+  if (!file) {
+    fprintf(stderr,
+            "Could not open %s for writing\n"
+            "Error: %s",
+            filename, strerror(errno));
+    return false;
+  }
+  if (fwrite(bytes.data(), 1, bytes.size(), file) != bytes.size()) {
+    fprintf(stderr,
+            "Could not write to file\n"
+            "Error: %s",
+            strerror(errno));
+    return false;
+  }
+  if (fclose(file) != 0) {
+    fprintf(stderr,
+            "Could not close file\n"
+            "Error: %s",
+            strerror(errno));
+    return false;
+  }
+  return true;
+}
+
+}  // namespace tools
+}  // namespace jpegxl

--- a/tools/file_io.h
+++ b/tools/file_io.h
@@ -1,0 +1,23 @@
+// Copyright (c) the JPEG XL Project Authors. All rights reserved.
+//
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+#ifndef TOOLS_FILE_IO_H_
+#define TOOLS_FILE_IO_H_
+
+#include <stdint.h>
+
+#include <vector>
+
+namespace jpegxl {
+namespace tools {
+
+bool ReadFile(const char* filename, std::vector<uint8_t>* out);
+
+bool WriteFile(const char* filename, const std::vector<uint8_t>& bytes);
+
+}  // namespace tools
+}  // namespace jpegxl
+
+#endif  // TOOLS_FILE_IO_H_

--- a/tools/fuzzer_corpus.cc
+++ b/tools/fuzzer_corpus.cc
@@ -23,7 +23,7 @@
 #include <vector>
 
 #if JPEGXL_ENABLE_JPEG
-#include "lib/extras/enc/jpg.h"
+#include "lib/extras/codec.h"
 #endif
 #include "lib/jxl/aux_out.h"
 #include "lib/jxl/base/data_parallel.h"
@@ -220,8 +220,8 @@ bool GenerateFile(const char* output_dir, const ImageSpec& spec,
         span, spec.width, spec.height, io.metadata.m.color_encoding,
         bytes_per_pixel / bytes_per_sample,
         /*alpha_is_premultiplied=*/spec.alpha_is_premultiplied,
-        io.metadata.m.bit_depth.bits_per_sample, JXL_LITTLE_ENDIAN,
-        false /* flipped_y */, nullptr, &ib, /*float_in=*/false, /*align=*/0));
+        io.metadata.m.bit_depth.bits_per_sample, JXL_LITTLE_ENDIAN, nullptr,
+        &ib, /*float_in=*/false, /*align=*/0));
     io.frames.push_back(std::move(ib));
   }
 
@@ -233,9 +233,11 @@ bool GenerateFile(const char* output_dir, const ImageSpec& spec,
     // If this image is supposed to be a reconstructible JPEG, collect the JPEG
     // metadata and encode it in the beginning of the compressed bytes.
     std::vector<uint8_t> jpeg_bytes;
-    JXL_RETURN_IF_ERROR(EncodeImageJPG(
-        &io, jxl::extras::JpegEncoder::kLibJpeg, /*quality=*/70,
-        jxl::YCbCrChromaSubsampling(), /*pool=*/nullptr, &jpeg_bytes));
+    io.jpeg_quality = 70;
+    JXL_RETURN_IF_ERROR(jxl::Encode(io, jxl::extras::Codec::kJPG,
+                                    io.metadata.m.color_encoding,
+                                    /*bits_per_sample=*/8, &jpeg_bytes,
+                                    /*pool=*/nullptr));
     JXL_RETURN_IF_ERROR(jxl::jpeg::DecodeImageJPG(
         jxl::Span<const uint8_t>(jpeg_bytes.data(), jpeg_bytes.size()), &io));
     jxl::PaddedBytes jpeg_data;


### PR DESCRIPTION
Size of djxl binary decreased from 62 MB to 3.7 MB.

All encoder functions work directly on ppf, there is no conversion to
CodecInOut, this allows djxl to be only dynamically linked to jxl library.

There are also some simplifications to the ppf structure: flipped_y parameter
was removed, now pnm encoder and decoder do the flipping on the fly, and
bitdepth_from_format was also removed since the decoders always set this
correctly for unsigned formats, and it is ignored for float formats anyway.

The basic info and ppf frame sanity checks were moved to an Encoder method
and are used by all the encoders.

Now ppf / codecio conversions only happen in tests and the benchmark.