### PR TITLE
tsc_timer.h: sync with nanobenchmark.cc from Highway

### DIFF
--- a/lib/profiler/tsc_timer.h
+++ b/lib/profiler/tsc_timer.h
@@ -101,6 +101,9 @@ static HWY_INLINE HWY_MAYBE_UNUSED Ticks TicksBefore() {
   Ticks t;
 #if HWY_ARCH_PPC && defined(__GLIBC__)
   asm volatile("mfspr %0, %1" : "=r"(t) : "i"(268));
+#elif HWY_ARCH_ARM_A64 && !HWY_COMPILER_MSVC
+  // pmccntr_el0 is privileged but cntvct_el0 is accessible in Linux and QEMU.
+  asm volatile("mrs %0, cntvct_el0" : "=r"(t));
 #elif HWY_ARCH_X86 && HWY_COMPILER_MSVC
   hwy::LoadFence();
   HWY_FENCE;
@@ -120,7 +123,7 @@ static HWY_INLINE HWY_MAYBE_UNUSED Ticks TicksBefore() {
       // "cc" = flags modified by SHL.
       : "rdx", "memory", "cc");
 #elif HWY_ARCH_RVV
-  asm volatile("rdcycle %0" : "=r"(t));
+  asm volatile("rdtime %0" : "=r"(t));
 #elif defined(_WIN32) || defined(_WIN64)
   LARGE_INTEGER counter;
   (void)QueryPerformanceCounter(&counter);
@@ -141,6 +144,9 @@ static HWY_INLINE HWY_MAYBE_UNUSED Ticks TicksAfter() {
   Ticks t;
 #if HWY_ARCH_PPC && defined(__GLIBC__)
   asm volatile("mfspr %0, %1" : "=r"(t) : "i"(268));
+#elif HWY_ARCH_ARM_A64 && !HWY_COMPILER_MSVC
+  // pmccntr_el0 is privileged but cntvct_el0 is accessible in Linux and QEMU.
+  asm volatile("mrs %0, cntvct_el0" : "=r"(t));
 #elif HWY_ARCH_X86 && HWY_COMPILER_MSVC
   HWY_FENCE;
   unsigned aux;


### PR DESCRIPTION
This file was originally originated from nanobenchmark.cc on the
Highway project. Re-syncing this file ensures that the improvements
from commit google/highway@a884393 and google/highway@12ca8ff are
incorporated.

---

Note that I did not sync commit google/highway@1ac50ad, as
`JPEGXL_ENABLE_PROFILER` is not enabled by default. I think(?) we
can safely assume that `RDTSCP` on x86 is available, when users
explicitly enable that option.

/cc @jan-wassenberg