### PR TITLE
tsc_timer.h: avoid conflict with SerializationStatus::ERROR on Windows

### DIFF
--- a/lib/profiler/tsc_timer.h
+++ b/lib/profiler/tsc_timer.h
@@ -19,6 +19,9 @@
 #ifndef NOMINMAX
 #define NOMINMAX
 #endif  // NOMINMAX
+#ifndef NOGDI
+#define NOGDI
+#endif  // NOGDI
 #include <windows.h>
 // Undef macros to avoid collisions
 #undef LoadFence


### PR DESCRIPTION
`wingdi.h` defines `ERROR` to `0`, which would conflict with the `ERROR`
enum member in `SerializationStatus`. Fix this by defining `NOGDI`
prior including `windows.h`, to avoid the GDI defines and routines.

---

This fixes compilation on Windows when building with 
`-DJPEGXL_ENABLE_PROFILER=ON`. Here's a simple Dockerfile to
 reproduce this issue:
<details>
  <summary>Dockerfile</summary>
  
```Dockerfile
# Build with:
# docker build --build-arg ARCH=x86_64 -t llvm-mingw .
# docker run --rm llvm-mingw tar -cf - /packaging | tar -xvf -
FROM mstorsjo/llvm-mingw:latest

# Supported architectures: x86_64, i686, aarch64 and armv7
ARG ARCH=x86_64

# Install git
RUN apt-get update -qq && \
    apt-get install -qqy --no-install-recommends git && \
    apt-get clean -y && \
    rm -rf /var/lib/apt/lists/*

WORKDIR /build

# Clone libjxl
RUN git clone --depth 1 --recursive https://github.com/libjxl/libjxl.git

# Enable optimizations and link-time garbage collection
ENV \
  CFLAGS="-O3 -fdata-sections -ffunction-sections" \
  CXXFLAGS="-O3 -fdata-sections -ffunction-sections" \
  LDFLAGS="-Wl,--gc-sections -Wl,-s"

WORKDIR /build/libjxl/build-$ARCH

# Cross-compile libjxl for Windows
RUN cmake \
      -DCMAKE_BUILD_TYPE=Release \
      -DJPEGXL_STATIC=ON \
      -DJPEGXL_ENABLE_PROFILER=ON \
      -DBUILD_TESTING=OFF \
      -DCMAKE_INSTALL_PREFIX="/packaging" \
      -DCMAKE_C_COMPILER=$ARCH-w64-mingw32-clang \
      -DCMAKE_CXX_COMPILER=$ARCH-w64-mingw32-clang++ \
      -DCMAKE_SYSTEM_NAME=Windows \
      -DCMAKE_SYSTEM_PROCESSOR=$ARCH \
      .. && \
    cmake --build . -- -j$(nproc) && \
    cmake --install .

# /build/libjxl/lib/jxl/jpeg/dec_jpeg_serialization_state.h:68:5: error: expected identifier
#     ERROR,
#     ^
# /opt/llvm-mingw/x86_64-w64-mingw32/include/wingdi.h:75:15: note: expanded from macro 'ERROR'
# #define ERROR 0
#               ^
```
</details>