### PR TITLE
Ignore empty stream images while learning modular tree.

### DIFF
--- a/lib/jxl/enc_cache.cc
+++ b/lib/jxl/enc_cache.cc
@@ -139,6 +139,9 @@ Status InitializePassesEncoder(const Image3F& opsin, const JxlCmsInterface& cms,
     dc_frame_info.ib_needs_color_transform = false;
     dc_frame_info.save_before_color_transform = true;  // Implicitly true
     AuxOut dc_aux_out;
+    if (aux_out) {
+      dc_aux_out.debug_prefix = aux_out->debug_prefix;
+    }
     JXL_CHECK(EncodeFrame(cparams, dc_frame_info, shared.metadata, ib,
                           state.get(), cms, pool, special_frame.get(),
                           aux_out ? &dc_aux_out : nullptr));

--- a/lib/jxl/enc_modular.cc
+++ b/lib/jxl/enc_modular.cc
@@ -956,10 +956,12 @@ Status ModularFrameEncoder::ComputeEncodingData(
 
   JXL_RETURN_IF_ERROR(ValidateChannelDimensions(gi, stream_options_[0]));
 
-  return PrepareEncoding(pool, enc_state->heuristics.get(), aux_out);
+  return PrepareEncoding(frame_header, pool, enc_state->heuristics.get(),
+                         aux_out);
 }
 
-Status ModularFrameEncoder::PrepareEncoding(ThreadPool* pool,
+Status ModularFrameEncoder::PrepareEncoding(const FrameHeader& frame_header,
+                                            ThreadPool* pool,
                                             EncoderHeuristics* heuristics,
                                             AuxOut* aux_out) {
   if (!tree_.empty()) return true;
@@ -981,9 +983,7 @@ Status ModularFrameEncoder::PrepareEncoding(ThreadPool* pool,
       size_t start = tree_splits_[chunk];
       size_t stop = tree_splits_[chunk + 1];
       for (size_t i = start; i < stop; i++) {
-        for (const Channel& c : stream_images_[i].channel) {
-          if (c.w && c.h) has_pixels = true;
-        }
+        if (!stream_images_[i].empty()) has_pixels = true;
       }
       if (has_pixels) {
         useful_splits.push_back(tree_splits_[chunk]);
@@ -1003,6 +1003,8 @@ Status ModularFrameEncoder::PrepareEncoding(ThreadPool* pool,
           size_t total_pixels = 0;
           uint32_t start = useful_splits[chunk];
           uint32_t stop = useful_splits[chunk + 1];
+          while (start < stop && stream_images_[start].empty()) ++start;
+          while (start < stop && stream_images_[stop - 1].empty()) --stop;
           uint32_t max_c = 0;
           if (stream_options_[start].tree_kind !=
               ModularOptions::TreeKind::kLearn) {
@@ -1089,7 +1091,12 @@ Status ModularFrameEncoder::PrepareEncoding(ThreadPool* pool,
   tree_ = std::move(decoded_tree);
 
   if (WantDebugOutput(aux_out)) {
-    PrintTree(tree_, aux_out->debug_prefix + "/global_tree");
+    if (frame_header.dc_level > 0) {
+      PrintTree(tree_, aux_out->debug_prefix + "/dc_frame_level" +
+                           std::to_string(frame_header.dc_level) + "_tree");
+    } else {
+      PrintTree(tree_, aux_out->debug_prefix + "/global_tree");
+    }
   }
 
   image_widths_.resize(num_streams);

--- a/lib/jxl/enc_modular.h
+++ b/lib/jxl/enc_modular.h
@@ -63,7 +63,8 @@ class ModularFrameEncoder {
   std::vector<uint8_t> extra_dc_precision;
 
  private:
-  Status PrepareEncoding(ThreadPool* pool, EncoderHeuristics* heuristics,
+  Status PrepareEncoding(const FrameHeader& frame_header, ThreadPool* pool,
+                         EncoderHeuristics* heuristics,
                          AuxOut* aux_out = nullptr);
   Status PrepareStreamParams(const Rect& rect, const CompressParams& cparams,
                              int minShift, int maxShift,

--- a/lib/jxl/modular/modular_image.h
+++ b/lib/jxl/modular/modular_image.h
@@ -98,6 +98,13 @@ class Image {
   Image& operator=(Image&& other) noexcept;
   Image(Image&& other) noexcept = default;
 
+  bool empty() const {
+    for (const auto& ch : channel) {
+      if (ch.w && ch.h) return false;
+    }
+    return true;
+  }
+
   Image clone();
 
   void undo_transforms(const weighted::Header& wp_header,


### PR DESCRIPTION
This occurs currently in dc frames where we have a (g>0)
top-level split, but the only non-empty stream is
the modular global (for small enough images).

Benchmark before:
```
Encoding      kPixels    Bytes          BPP  E MP/s  D MP/s     Max norm        pnorm       BPP*pnorm   Bugs
------------------------------------------------------------------------------------------------------------
jxl:d1          13270  2680680    1.6160297   2.527  20.140   1.68643689   0.59921594  0.968350771923      0
jxl:d5          13270   827864    0.4990722   2.378  11.477   8.16946983   1.76535380  0.881038980710      0
jxl:d8          13270   564527    0.3403213   2.488  11.155  11.99684238   2.41556748  0.822068981129      0
Aggregate:      13270  1078027    0.6498811   2.464  13.712   5.48795203   1.36713509  0.888475308236      0
```

Benchmark after:
```
Encoding      kPixels    Bytes          BPP  E MP/s  D MP/s     Max norm        pnorm       BPP*pnorm   Bugs
------------------------------------------------------------------------------------------------------------
jxl:d1          13270  2680680    1.6160297   2.521  19.656   1.68643689   0.59921594  0.968350771923      0
jxl:d5          13270   827783    0.4990234   2.353  11.200   8.16946983   1.76535380  0.880952777956      0
jxl:d8          13270   564455    0.3402779   2.396  10.780  11.99684238   2.41556748  0.821964134121      0
Aggregate:      13270  1077946    0.6498323   2.422  13.338   5.48795203   1.36713509  0.888408557971      0
```