### PR TITLE
Increase quantization in flat 8x8 blocks.

### DIFF
--- a/lib/jxl/enc_group.cc
+++ b/lib/jxl/enc_group.cc
@@ -42,13 +42,13 @@ using hwy::HWY_NAMESPACE::Round;
 
 // NOTE: caller takes care of extracting quant from rect of RawQuantField.
 void QuantizeBlockAC(const Quantizer& quantizer, const bool error_diffusion,
-                     size_t c, int32_t quant, float qm_multiplier,
-                     size_t quant_kind, size_t xsize, size_t ysize,
-                     const float* JXL_RESTRICT block_in,
+                     size_t c, float qm_multiplier, size_t quant_kind,
+                     size_t xsize, size_t ysize,
+                     const float* JXL_RESTRICT block_in, int32_t* quant,
                      int32_t* JXL_RESTRICT block_out) {
   PROFILER_FUNC;
   const float* JXL_RESTRICT qm = quantizer.InvDequantMatrix(quant_kind, c);
-  const float qac = quantizer.Scale() * quant;
+  float qac = quantizer.Scale() * (*quant);
   // Not SIMD-fied for now.
   float thres[4] = {0.58f, 0.635f, 0.66f, 0.7f};
   if (c == 0) {
@@ -118,7 +118,8 @@ retry:
       const size_t hfix = (static_cast<size_t>(y >= ysize * kBlockDim / 2) * 2 +
                            static_cast<size_t>(x >= xsize * kBlockDim / 2));
       const float val = block_in[pos] * (qm[pos] * qac * qm_multiplier);
-      float v = (std::abs(val) < thres[hfix]) ? 0 : rintf(val);
+      const float v = (std::abs(val) < thres[hfix]) ? 0 : rintf(val);
+      block_out[pos] = static_cast<int32_t>(v);
       const float error = std::abs(val) - std::abs(v);
       hfError[hfix] += error * error;
       if (hfMaxError[hfix] < error) {
@@ -128,7 +129,6 @@ retry:
       if (v != 0.0f) {
         hfNonZeros[hfix] += std::abs(v);
       }
-      block_out[pos] = static_cast<int32_t>(rintf(v));
     }
   }
   if (c != 1) return;
@@ -151,6 +151,29 @@ retry:
     }
   }
   if (goretry) goto retry;
+  if (quant_kind == AcStrategy::Type::DCT) {
+    // If this 8x8 block is too flat, increase the adaptive quantization level
+    // a bit to reduce visible block boundaries and requantize the block.
+    if (hfNonZeros[0] + hfNonZeros[1] + hfNonZeros[2] + hfNonZeros[3] < 11) {
+      *quant *= 5;
+      *quant /= 4;
+      qac = quantizer.Scale() * (*quant);
+      for (size_t y = 0; y < kBlockDim; y++) {
+        for (size_t x = 0; x < kBlockDim; x++) {
+          if (x < 1 && y < 1) {
+            continue;
+          }
+          const size_t pos = y * kBlockDim + x;
+          const size_t hfix = (static_cast<size_t>(y >= kBlockDim / 2) * 2 +
+                               static_cast<size_t>(x >= kBlockDim / 2));
+          const float val = block_in[pos] * (qm[pos] * qac * qm_multiplier);
+          const float v = (std::abs(val) < thres[hfix]) ? 0 : rintf(val);
+          block_out[pos] = static_cast<int32_t>(v);
+        }
+      }
+    }
+    return;
+  }
   for (int i = 1; i < 4; ++i) {
     if (hfError[i] >= hfErrorLimit && hfNonZeros[i] == 0) {
       const size_t pos = hfMaxErrorIx[i];
@@ -163,13 +186,13 @@ retry:
 
 // NOTE: caller takes care of extracting quant from rect of RawQuantField.
 void QuantizeRoundtripYBlockAC(const Quantizer& quantizer,
-                               const bool error_diffusion, int32_t quant,
-                               size_t quant_kind, size_t xsize, size_t ysize,
-                               const float* JXL_RESTRICT biases,
+                               const bool error_diffusion, size_t quant_kind,
+                               size_t xsize, size_t ysize,
+                               const float* JXL_RESTRICT biases, int32_t* quant,
                                float* JXL_RESTRICT inout,
                                int32_t* JXL_RESTRICT quantized) {
-  QuantizeBlockAC(quantizer, error_diffusion, 1, quant, 1.0f, quant_kind, xsize,
-                  ysize, inout, quantized);
+  QuantizeBlockAC(quantizer, error_diffusion, 1, 1.0f, quant_kind, xsize, ysize,
+                  inout, quant, quantized);
 
   PROFILER_ZONE("enc quant adjust bias");
   const float* JXL_RESTRICT dequant_matrix =
@@ -177,7 +200,7 @@ void QuantizeRoundtripYBlockAC(const Quantizer& quantizer,
 
   HWY_CAPPED(float, kDCTBlockSize) df;
   HWY_CAPPED(int32_t, kDCTBlockSize) di;
-  const auto inv_qac = Set(df, quantizer.inv_quant_ac(quant));
+  const auto inv_qac = Set(df, quantizer.inv_quant_ac(*quant));
   for (size_t k = 0; k < kDCTBlockSize * xsize * ysize; k += Lanes(df)) {
     const auto quant = Load(di, quantized + k);
     const auto adj_quant = AdjustQuantBias(di, 1, quant, biases);
@@ -203,7 +226,7 @@ void ComputeCoefficients(size_t group_idx, PassesEncoderState* enc_state,
   const size_t dc_stride = static_cast<size_t>(dc->PixelsPerRow());
   const size_t opsin_stride = static_cast<size_t>(opsin.PixelsPerRow());
 
-  const ImageI& full_quant_field = enc_state->shared.raw_quant_field;
+  ImageI& full_quant_field = enc_state->shared.raw_quant_field;
   const CompressParams& cparams = enc_state->cparams;
 
   // TODO(veluca): consider strategies to reduce this memory.
@@ -233,8 +256,8 @@ void ComputeCoefficients(size_t group_idx, PassesEncoderState* enc_state,
     size_t offset = 0;
 
     for (size_t by = 0; by < ysize_blocks; ++by) {
-      const int32_t* JXL_RESTRICT row_quant_ac =
-          block_group_rect.ConstRow(full_quant_field, by);
+      int32_t* JXL_RESTRICT row_quant_ac =
+          block_group_rect.Row(&full_quant_field, by);
       size_t ty = by / kColorTileDimInBlocks;
       const int8_t* JXL_RESTRICT row_cmap[3] = {
           cmap_rect.ConstRow(enc_state->shared.cmap.ytox_map, ty),
@@ -272,15 +295,15 @@ void ComputeCoefficients(size_t group_idx, PassesEncoderState* enc_state,
           size_t size = kDCTBlockSize * xblocks * yblocks;
 
           // DCT Y channel, roundtrip-quantize it and set DC.
-          const int32_t quant_ac = row_quant_ac[bx];
+          int32_t quant_ac = row_quant_ac[bx];
           TransformFromPixels(acs.Strategy(), opsin_rows[1] + bx * kBlockDim,
                               opsin_stride, coeffs_in + size, scratch_space);
           DCFromLowestFrequencies(acs.Strategy(), coeffs_in + size,
                                   dc_rows[1] + bx, dc_stride);
-          QuantizeRoundtripYBlockAC(
-              enc_state->shared.quantizer, error_diffusion, quant_ac,
-              acs.RawStrategy(), xblocks, yblocks, kDefaultQuantBias,
-              coeffs_in + size, quantized + size);
+          QuantizeRoundtripYBlockAC(enc_state->shared.quantizer,
+                                    error_diffusion, acs.RawStrategy(), xblocks,
+                                    yblocks, kDefaultQuantBias, &quant_ac,
+                                    coeffs_in + size, quantized + size);
 
           // DCT X and B channels
           for (size_t c : {0, 2}) {
@@ -303,14 +326,15 @@ void ComputeCoefficients(size_t group_idx, PassesEncoderState* enc_state,
           // Quantize X and B channels and set DC.
           for (size_t c : {0, 2}) {
             QuantizeBlockAC(enc_state->shared.quantizer, error_diffusion, c,
-                            quant_ac,
                             c == 0 ? enc_state->x_qm_multiplier
                                    : enc_state->b_qm_multiplier,
                             acs.RawStrategy(), xblocks, yblocks,
-                            coeffs_in + c * size, quantized + c * size);
+                            coeffs_in + c * size, &quant_ac,
+                            quantized + c * size);
             DCFromLowestFrequencies(acs.Strategy(), coeffs_in + c * size,
                                     dc_rows[c] + bx, dc_stride);
           }
+          row_quant_ac[bx] = quant_ac;
           enc_state->progressive_splitter.SplitACCoefficients(
               quantized, size, acs, bx, by, offset, coeffs);
           offset += size;


### PR DESCRIPTION
Benchmark results with all 8x8 blocks:

Before
```
Encoding      kPixels    Bytes          BPP  E MP/s  D MP/s     Max norm        pnorm       BPP*pnorm   Bugs
------------------------------------------------------------------------------------------------------------
jxl:d1          13270  2723911    1.6420912   1.810  16.222   1.74343252   0.65861527  1.081506359483      0
jxl:d2          13270  1706943    1.0290190   1.857  14.973   2.94722962   1.08186301  1.113257580031      0
jxl:d4          13270  1000052    0.6028746   1.782   9.602   5.04913187   1.77373730  1.069341081351      0
```

After:
```
Encoding      kPixels    Bytes          BPP  E MP/s  D MP/s     Max norm        pnorm       BPP*pnorm   Bugs
------------------------------------------------------------------------------------------------------------
jxl:d1          13270  2755241    1.6609783   2.096  17.783   1.73951459   0.64075941  1.064287489864      0
jxl:d2          13270  1740389    1.0491817   2.147  16.969   2.95925331   1.04322046  1.094527792322      0
jxl:d4          13270  1047406    0.6314216   2.062  10.975   5.06505680   1.67949491  1.060469345796      0
```

Benchmark results with normal AC strategy:

Before
```
Encoding      kPixels    Bytes          BPP  E MP/s  D MP/s     Max norm        pnorm       BPP*pnorm   Bugs
------------------------------------------------------------------------------------------------------------
jxl:d1          13270  2680680    1.6160297   2.319  17.152   1.68643689   0.59921594  0.968350771923      0
jxl:d2          13270  1683824    1.0150819   2.409  17.450   3.07402062   0.94836343  0.962666511883      0
jxl:d4          13270  1001875    0.6039735   2.295  10.250   5.01221323   1.50586670  0.909503632879      0
```

After
```
Encoding      kPixels    Bytes          BPP  E MP/s  D MP/s     Max norm        pnorm       BPP*pnorm   Bugs
------------------------------------------------------------------------------------------------------------
jxl:d1          13270  2682080    1.6168737   2.431  18.466   1.68643689   0.59894225  0.968413965890      0
jxl:d2          13270  1685344    1.0159982   2.575  18.422   3.07402062   0.94758179  0.962741367927      0
jxl:d4          13270  1004383    0.6054855   2.411  10.610   5.01221752   1.50244186  0.909706712628      0
```