### PR TITLE
Use the same minimum distance parameter for slow and fast clustering.

### DIFF
--- a/lib/jxl/enc_ans.cc
+++ b/lib/jxl/enc_ans.cc
@@ -703,9 +703,8 @@ class HistogramBuilder {
     if (histograms_.size() > 1) {
       if (!ans_fuzzer_friendly_) {
         std::vector<uint32_t> histogram_symbols;
-        ClusterHistograms(params, histograms_, histograms_.size(),
-                          kClustersLimit, &clustered_histograms,
-                          &histogram_symbols);
+        ClusterHistograms(params, histograms_, kClustersLimit,
+                          &clustered_histograms, &histogram_symbols);
         for (size_t c = 0; c < histograms_.size(); ++c) {
           (*context_map)[c] = static_cast<uint8_t>(histogram_symbols[c]);
         }

--- a/lib/jxl/enc_cluster.cc
+++ b/lib/jxl/enc_cluster.cc
@@ -84,60 +84,44 @@ float HistogramDistance(const Histogram& a, const Histogram& b) {
 
 // First step of a k-means clustering with a fancy distance metric.
 void FastClusterHistograms(const std::vector<Histogram>& in,
-                           const size_t num_contexts_in, size_t max_histograms,
-                           float min_distance, std::vector<Histogram>* out,
+                           size_t max_histograms, std::vector<Histogram>* out,
                            std::vector<uint32_t>* histogram_symbols) {
   PROFILER_FUNC;
+  out->clear();
+  out->reserve(max_histograms);
+  histogram_symbols->clear();
+  histogram_symbols->resize(in.size(), max_histograms);
+
+  std::vector<float> dists(in.size(), std::numeric_limits<float>::max());
   size_t largest_idx = 0;
-  std::vector<uint32_t> nonempty_histograms;
-  nonempty_histograms.reserve(in.size());
-  for (size_t i = 0; i < num_contexts_in; i++) {
-    if (in[i].total_count_ == 0) continue;
+  for (size_t i = 0; i < in.size(); i++) {
+    if (in[i].total_count_ == 0) {
+      (*histogram_symbols)[i] = 0;
+      dists[i] = 0.0f;
+      continue;
+    }
     HistogramEntropy(in[i]);
     if (in[i].total_count_ > in[largest_idx].total_count_) {
       largest_idx = i;
     }
-    nonempty_histograms.push_back(i);
   }
-  // No symbols.
-  if (nonempty_histograms.empty()) {
-    out->resize(1);
-    histogram_symbols->clear();
-    histogram_symbols->resize(in.size(), 0);
-    return;
-  }
-  largest_idx = std::find(nonempty_histograms.begin(),
-                          nonempty_histograms.end(), largest_idx) -
-                nonempty_histograms.begin();
-  size_t num_contexts = nonempty_histograms.size();
-  out->clear();
-  out->reserve(max_histograms);
-  std::vector<float> dists(num_contexts, std::numeric_limits<float>::max());
-  histogram_symbols->clear();
-  histogram_symbols->resize(in.size(), max_histograms);
 
-  while (out->size() < max_histograms && out->size() < num_contexts) {
-    (*histogram_symbols)[nonempty_histograms[largest_idx]] = out->size();
-    out->push_back(in[nonempty_histograms[largest_idx]]);
+  constexpr float kMinDistanceForDistinct = 48.0f;
+  while (out->size() < max_histograms) {
+    (*histogram_symbols)[largest_idx] = out->size();
+    out->push_back(in[largest_idx]);
+    dists[largest_idx] = 0.0f;
     largest_idx = 0;
-    for (size_t i = 0; i < num_contexts; i++) {
-      dists[i] = std::min(
-          HistogramDistance(in[nonempty_histograms[i]], out->back()), dists[i]);
-      // Avoid repeating histograms
-      if ((*histogram_symbols)[nonempty_histograms[i]] != max_histograms) {
-        continue;
-      }
+    for (size_t i = 0; i < in.size(); i++) {
+      if (dists[i] == 0.0f) continue;
+      dists[i] = std::min(HistogramDistance(in[i], out->back()), dists[i]);
       if (dists[i] > dists[largest_idx]) largest_idx = i;
     }
-    if (dists[largest_idx] < min_distance) break;
+    if (dists[largest_idx] < kMinDistanceForDistinct) break;
   }
 
-  for (size_t i = 0; i < num_contexts_in; i++) {
+  for (size_t i = 0; i < in.size(); i++) {
     if ((*histogram_symbols)[i] != max_histograms) continue;
-    if (in[i].total_count_ == 0) {
-      (*histogram_symbols)[i] = 0;
-      continue;
-    }
     size_t best = 0;
     float best_dist = HistogramDistance(in[i], (*out)[best]);
     for (size_t j = 1; j < out->size(); j++) {
@@ -198,25 +182,19 @@ void HistogramReindex(std::vector<Histogram>* out,
 // placed in 'out', and for each index in 'in', *histogram_symbols will
 // indicate which of the 'out' histograms is the best approximation.
 void ClusterHistograms(const HistogramParams params,
-                       const std::vector<Histogram>& in,
-                       const size_t num_contexts, size_t max_histograms,
+                       const std::vector<Histogram>& in, size_t max_histograms,
                        std::vector<Histogram>* out,
                        std::vector<uint32_t>* histogram_symbols) {
-  constexpr float kMinDistanceForDistinctFast = 64.0f;
-  constexpr float kMinDistanceForDistinctBest = 16.0f;
   max_histograms = std::min(max_histograms, params.max_histograms);
+  max_histograms = std::min(max_histograms, in.size());
   if (params.clustering == HistogramParams::ClusteringType::kFastest) {
-    HWY_DYNAMIC_DISPATCH(FastClusterHistograms)
-    (in, num_contexts, 4, kMinDistanceForDistinctFast, out, histogram_symbols);
-  } else if (params.clustering == HistogramParams::ClusteringType::kFast) {
-    HWY_DYNAMIC_DISPATCH(FastClusterHistograms)
-    (in, num_contexts, max_histograms, kMinDistanceForDistinctFast, out,
-     histogram_symbols);
-  } else {
-    PROFILER_FUNC;
-    HWY_DYNAMIC_DISPATCH(FastClusterHistograms)
-    (in, num_contexts, max_histograms, kMinDistanceForDistinctBest, out,
-     histogram_symbols);
+    max_histograms = std::min(max_histograms, static_cast<size_t>(4));
+  }
+
+  HWY_DYNAMIC_DISPATCH(FastClusterHistograms)
+  (in, max_histograms, out, histogram_symbols);
+
+  if (params.clustering == HistogramParams::ClusteringType::kBest) {
     for (size_t i = 0; i < out->size(); i++) {
       (*out)[i].entropy_ =
           ANSPopulationCost((*out)[i].data_.data(), (*out)[i].data_.size());

--- a/lib/jxl/enc_cluster.h
+++ b/lib/jxl/enc_cluster.h
@@ -53,8 +53,7 @@ struct Histogram {
 };
 
 void ClusterHistograms(HistogramParams params, const std::vector<Histogram>& in,
-                       size_t num_contexts, size_t max_histograms,
-                       std::vector<Histogram>* out,
+                       size_t max_histograms, std::vector<Histogram>* out,
                        std::vector<uint32_t>* histogram_symbols);
 }  // namespace jxl
 

--- a/lib/jxl/jxl_test.cc
+++ b/lib/jxl/jxl_test.cc
@@ -1713,7 +1713,7 @@ TEST(JxlTest, RoundtripProgressive) {
   cparams.responsive = true;
   cparams.progressive_mode = true;
   CodecInOut io2;
-  EXPECT_LE(Roundtrip(&io, cparams, {}, &pool, &io2), 61600u);
+  EXPECT_LE(Roundtrip(&io, cparams, {}, &pool, &io2), 61700u);
   EXPECT_THAT(ButteraugliDistance(io, io2, cparams.ba_params, GetJxlCms(),
                                   /*distmap=*/nullptr, &pool),
               IsSlightlyBelow(1.17f));


### PR DESCRIPTION
The slow clustering will just attempt to merge some more clusters from the
output of the fast clustering. This seemingly works better than trying to
produce more clusters with a lower minimum distance parameter and then trying
to merge those.

Drive-by: simplify the implementation of fast clustering.

Benchmark before:
```
Encoding      kPixels    Bytes          BPP  E MP/s  D MP/s     Max norm        pnorm       BPP*pnorm   Bugs
------------------------------------------------------------------------------------------------------------
jxl:d1          13270  2680680    1.6160297   1.935  14.626   1.68643689   0.59921594  0.968350771923      0
jxl:d4          13270  1001875    0.6039735   1.915   8.464   5.01221323   1.50586670  0.909503632879      0
jxl:9:d1        13270  2609859    1.5733358   0.080  16.044   1.34425843   0.60213251  0.947356618624      0
jxl:9:d4        13270   916163    0.5523026   0.148   8.566   4.58943462   1.61853789  0.893922748194      0
Aggregate:      13270  1591886    0.9596579   0.457  11.421   2.68726439   0.96838089  0.929314377063      0
```

Benchmark after:
```
Encoding      kPixels    Bytes          BPP  E MP/s  D MP/s     Max norm        pnorm       BPP*pnorm   Bugs
------------------------------------------------------------------------------------------------------------
jxl:d1          13270  2680245    1.6157675   1.957  14.792   1.68643689   0.59921594  0.968193635455      0
jxl:d4          13270  1001661    0.6038445   1.954   8.746   5.01221323   1.50586670  0.909309363357      0
jxl:9:d1        13270  2603698    1.5696216   0.136  15.077   1.34425843   0.60213251  0.945120228027      0
jxl:9:d4        13270   912039    0.5498165   0.161   8.694   4.58943462   1.61853789  0.889898860072      0
Aggregate:      13270  1589003    0.9579199   0.538  11.411   2.68726439   0.96838089  0.927631310067      0
```