### PR TITLE
Move progressive splitter setup to EncodeFrame.

### DIFF
--- a/lib/jxl/decode_test.cc
+++ b/lib/jxl/decode_test.cc
@@ -2778,8 +2778,7 @@ TEST(DecodeTest, SkipCurrentFrameTest) {
   jxl::AuxOut aux_out;
   jxl::PaddedBytes compressed;
   jxl::PassesEncoderState enc_state;
-  jxl::PassDefinition passes[] = {
-      {2, 0, false, 4}, {4, 0, false, 4}, {8, 2, false, 2}, {8, 0, false, 1}};
+  jxl::PassDefinition passes[] = {{2, 0, 4}, {4, 0, 4}, {8, 2, 2}, {8, 0, 1}};
   jxl::ProgressiveMode progressive_mode{passes};
   enc_state.progressive_splitter.SetProgressiveMode(progressive_mode);
   EXPECT_TRUE(jxl::EncodeFile(cparams, &io, &enc_state, &compressed,
@@ -4624,11 +4623,8 @@ TEST_P(DecodeProgressiveTest, ProgressiveEventTest) {
     } else {
       params.cparams.butteraugli_distance = 0.5f;
     }
-    jxl::PassDefinition passes[] = {{2, 0, false, 4},
-                                    {4, 0, false, 4},
-                                    {8, 2, false, 2},
-                                    {8, 1, false, 2},
-                                    {8, 0, false, 1}};
+    jxl::PassDefinition passes[] = {
+        {2, 0, 4}, {4, 0, 4}, {8, 2, 2}, {8, 1, 2}, {8, 0, 1}};
     const int kNumPasses = 5;
     jxl::ProgressiveMode progressive_mode{passes};
     params.progressive_mode = &progressive_mode;

--- a/lib/jxl/enc_file.cc
+++ b/lib/jxl/enc_file.cc
@@ -28,42 +28,6 @@ namespace jxl {
 
 namespace {
 
-// DC + 'Very Low Frequency'
-PassDefinition progressive_passes_dc_vlf[] = {
-    {/*num_coefficients=*/2, /*shift=*/0, /*salient_only=*/false,
-     /*suitable_for_downsampling_of_at_least=*/4}};
-
-PassDefinition progressive_passes_dc_lf[] = {
-    {/*num_coefficients=*/2, /*shift=*/0, /*salient_only=*/false,
-     /*suitable_for_downsampling_of_at_least=*/4},
-    {/*num_coefficients=*/3, /*shift=*/0, /*salient_only=*/false,
-     /*suitable_for_downsampling_of_at_least=*/2}};
-
-PassDefinition progressive_passes_dc_lf_salient_ac[] = {
-    {/*num_coefficients=*/2, /*shift=*/0, /*salient_only=*/false,
-     /*suitable_for_downsampling_of_at_least=*/4},
-    {/*num_coefficients=*/3, /*shift=*/0, /*salient_only=*/false,
-     /*suitable_for_downsampling_of_at_least=*/2},
-    {/*num_coefficients=*/8, /*shift=*/0, /*salient_only=*/true,
-     /*suitable_for_downsampling_of_at_least=*/0}};
-
-PassDefinition progressive_passes_dc_lf_salient_ac_other_ac[] = {
-    {/*num_coefficients=*/2, /*shift=*/0, /*salient_only=*/false,
-     /*suitable_for_downsampling_of_at_least=*/4},
-    {/*num_coefficients=*/3, /*shift=*/0, /*salient_only=*/false,
-     /*suitable_for_downsampling_of_at_least=*/2},
-    {/*num_coefficients=*/8, /*shift=*/0, /*salient_only=*/true,
-     /*suitable_for_downsampling_of_at_least=*/0},
-    {/*num_coefficients=*/8, /*shift=*/0, /*salient_only=*/false,
-     /*suitable_for_downsampling_of_at_least=*/0}};
-
-PassDefinition progressive_passes_dc_quant_ac_full_ac[] = {
-    {/*num_coefficients=*/8, /*shift=*/1, /*salient_only=*/false,
-     /*suitable_for_downsampling_of_at_least=*/2},
-    {/*num_coefficients=*/8, /*shift=*/0, /*salient_only=*/false,
-     /*suitable_for_downsampling_of_at_least=*/0},
-};
-
 Status PrepareCodecMetadataFromIO(const CompressParams& cparams,
                                   const CodecInOut* io,
                                   CodecMetadata* metadata) {
@@ -172,47 +136,6 @@ Status EncodeFile(const CompressParams& params, const CodecInOut* io,
   BitWriter::Allotment allotment(&writer, 8);
   writer.ZeroPadToByte();
   ReclaimAndCharge(&writer, &allotment, kLayerHeader, aux_out);
-
-  if (cparams.progressive_mode || cparams.qprogressive_mode) {
-    if (cparams.saliency_map != nullptr) {
-      passes_enc_state->progressive_splitter.SetSaliencyMap(
-          cparams.saliency_map);
-    }
-    passes_enc_state->progressive_splitter.SetSaliencyThreshold(
-        cparams.saliency_threshold);
-    if (cparams.qprogressive_mode) {
-      passes_enc_state->progressive_splitter.SetProgressiveMode(
-          ProgressiveMode{progressive_passes_dc_quant_ac_full_ac});
-    } else {
-      switch (cparams.saliency_num_progressive_steps) {
-        case 1:
-          passes_enc_state->progressive_splitter.SetProgressiveMode(
-              ProgressiveMode{progressive_passes_dc_vlf});
-          break;
-        case 2:
-          passes_enc_state->progressive_splitter.SetProgressiveMode(
-              ProgressiveMode{progressive_passes_dc_lf});
-          break;
-        case 3:
-          passes_enc_state->progressive_splitter.SetProgressiveMode(
-              ProgressiveMode{progressive_passes_dc_lf_salient_ac});
-          break;
-        case 4:
-          if (cparams.saliency_threshold == 0.0f) {
-            // No need for a 4th pass if saliency-threshold regards everything
-            // as salient.
-            passes_enc_state->progressive_splitter.SetProgressiveMode(
-                ProgressiveMode{progressive_passes_dc_lf_salient_ac});
-          } else {
-            passes_enc_state->progressive_splitter.SetProgressiveMode(
-                ProgressiveMode{progressive_passes_dc_lf_salient_ac_other_ac});
-          }
-          break;
-        default:
-          return JXL_FAILURE("Invalid saliency_num_progressive_steps.");
-      }
-    }
-  }
 
   for (size_t i = 0; i < io->frames.size(); i++) {
     FrameInfo info;

--- a/lib/jxl/enc_frame.cc
+++ b/lib/jxl/enc_frame.cc
@@ -69,6 +69,22 @@
 namespace jxl {
 namespace {
 
+PassDefinition progressive_passes_dc_vlf_lf_full_ac[] = {
+    {/*num_coefficients=*/2, /*shift=*/0,
+     /*suitable_for_downsampling_of_at_least=*/4},
+    {/*num_coefficients=*/3, /*shift=*/0,
+     /*suitable_for_downsampling_of_at_least=*/2},
+    {/*num_coefficients=*/8, /*shift=*/0,
+     /*suitable_for_downsampling_of_at_least=*/0},
+};
+
+PassDefinition progressive_passes_dc_quant_ac_full_ac[] = {
+    {/*num_coefficients=*/8, /*shift=*/1,
+     /*suitable_for_downsampling_of_at_least=*/2},
+    {/*num_coefficients=*/8, /*shift=*/0,
+     /*suitable_for_downsampling_of_at_least=*/0},
+};
+
 void ClusterGroups(PassesEncoderState* enc_state) {
   if (enc_state->shared.frame_header.passes.num_passes > 1) {
     // TODO(veluca): implement this for progressive modes.
@@ -1126,6 +1142,14 @@ Status EncodeFrame(const CompressParams& cparams_orig,
   ib.VerifyMetadata();
 
   passes_enc_state->special_frames.clear();
+
+  if (cparams.qprogressive_mode) {
+    passes_enc_state->progressive_splitter.SetProgressiveMode(
+        ProgressiveMode{progressive_passes_dc_quant_ac_full_ac});
+  } else if (cparams.progressive_mode) {
+    passes_enc_state->progressive_splitter.SetProgressiveMode(
+        ProgressiveMode{progressive_passes_dc_vlf_lf_full_ac});
+  }
 
   JXL_RETURN_IF_ERROR(ParamsPostInit(&cparams));
 

--- a/lib/jxl/enc_params.h
+++ b/lib/jxl/enc_params.h
@@ -174,29 +174,6 @@ struct CompressParams {
   // Default: on for lossless, off for lossy
   Override keep_invisible = Override::kDefault;
 
-  // Progressive-mode saliency.
-  //
-  // How many progressive saliency-encoding steps to perform.
-  // - 1: Encode only DC and lowest-frequency AC. Does not need a saliency-map.
-  // - 2: Encode only DC+LF, dropping all HF AC data.
-  //      Does not need a saliency-map.
-  // - 3: Encode DC+LF+{salient HF}, dropping all non-salient HF data.
-  // - 4: Encode DC+LF+{salient HF}+{other HF}.
-  // - 5: Encode DC+LF+{quantized HF}+{low HF bits}.
-  size_t saliency_num_progressive_steps = 3;
-  // Every saliency-heatmap cell with saliency >= threshold will be considered
-  // as 'salient'. The default value of 0.0 will consider every AC-block
-  // as salient, hence not require a saliency-map, and not actually generate
-  // a 4th progressive step.
-  float saliency_threshold = 0.0f;
-  // Saliency-map (owned by caller).
-  ImageF* saliency_map = nullptr;
-
-  // Input and output file name. Will be used to provide pluggable saliency
-  // extractor with paths.
-  const char* file_in = nullptr;
-  const char* file_out = nullptr;
-
   // Currently unused as of 2020-01.
   bool clear_metadata = false;
 

--- a/lib/jxl/encode_test.cc
+++ b/lib/jxl/encode_test.cc
@@ -392,7 +392,8 @@ TEST(EncodeTest, frame_settingsTest) {
     EXPECT_EQ(JXL_ENC_SUCCESS,
               JxlEncoderFrameSettingsSetOption(
                   frame_settings, JXL_ENC_FRAME_SETTING_PROGRESSIVE_DC, 2));
-    VerifyFrameEncoding(enc.get(), frame_settings);
+    VerifyFrameEncoding(63, 129, enc.get(), frame_settings, 2750,
+                        /*lossy_use_original_profile=*/false);
     EXPECT_EQ(false, enc->last_used_cparams.responsive);
     EXPECT_EQ(true, enc->last_used_cparams.progressive_mode);
     EXPECT_EQ(2, enc->last_used_cparams.progressive_dc);

--- a/lib/jxl/progressive_split.cc
+++ b/lib/jxl/progressive_split.cc
@@ -15,31 +15,6 @@
 
 namespace jxl {
 
-bool ProgressiveSplitter::SuperblockIsSalient(size_t row_start,
-                                              size_t col_start, size_t num_rows,
-                                              size_t num_cols) const {
-  if (saliency_map_ == nullptr || saliency_map_->xsize() == 0 ||
-      saliency_threshold_ == 0.0) {
-    // If we do not have a saliency-map, or the threshold says to include
-    // every block, we straightaway classify the superblock as 'salient'.
-    return true;
-  }
-  const size_t row_end = std::min(saliency_map_->ysize(), row_start + num_rows);
-  const size_t col_end = std::min(saliency_map_->xsize(), col_start + num_cols);
-  for (size_t num_row = row_start; num_row < row_end; num_row++) {
-    const float* JXL_RESTRICT map_row = saliency_map_->ConstRow(num_row);
-    for (size_t num_col = col_start; num_col < col_end; num_col++) {
-      if (map_row[num_col] >= saliency_threshold_) {
-        // One of the blocks covered by this superblock is above the saliency
-        // threshold.
-        return true;
-      }
-    }
-  }
-  // We did not see any block above the saliency threshold.
-  return false;
-}
-
 template <typename T>
 void ProgressiveSplitter::SplitACCoefficients(
     const T* JXL_RESTRICT block, size_t size, const AcStrategy& acs, size_t bx,
@@ -57,7 +32,6 @@ void ProgressiveSplitter::SplitACCoefficients(
     return;
   }
   size_t ncoeffs_all_done_from_earlier_passes = 1;
-  size_t previous_pass_salient_only = false;
 
   int previous_pass_shift = 0;
   for (size_t num_pass = 0; num_pass < mode_.num_passes; num_pass++) {  // pass
@@ -65,32 +39,19 @@ void ProgressiveSplitter::SplitACCoefficients(
     for (size_t c = 0; c < 3; c++) {
       memset(output[num_pass][c] + offset, 0, size * sizeof(T));
     }
-    const bool current_pass_salient_only = mode_.passes[num_pass].salient_only;
     const int pass_shift = mode_.passes[num_pass].shift;
     size_t frame_ncoeffs = mode_.passes[num_pass].num_coefficients;
     for (size_t c = 0; c < 3; c++) {  // color-channel
       size_t xsize = acs.covered_blocks_x();
       size_t ysize = acs.covered_blocks_y();
       CoefficientLayout(&ysize, &xsize);
-      if (current_pass_salient_only || previous_pass_salient_only) {
-        // Current or previous pass is salient-only.
-        const bool superblock_is_salient =
-            SuperblockIsSalient(by, bx, ysize, xsize);
-        if (current_pass_salient_only != superblock_is_salient) {
-          // Current pass is salient-only, but block is not salient,
-          // OR last pass was salient-only, and block is salient
-          // (hence was already included in last pass).
-          continue;
-        }
-      }
       for (size_t y = 0; y < ysize * frame_ncoeffs; y++) {    // superblk-y
         for (size_t x = 0; x < xsize * frame_ncoeffs; x++) {  // superblk-x
           size_t pos = y * xsize * kBlockDim + x;
           if (x < xsize * ncoeffs_all_done_from_earlier_passes &&
               y < ysize * ncoeffs_all_done_from_earlier_passes) {
             // This coefficient was already included in an earlier pass,
-            // which included a genuinely smaller set of coefficients
-            // (= is not about saliency-splitting).
+            // which included a genuinely smaller set of coefficients.
             continue;
           }
           T v = block[c * size + pos];
@@ -104,15 +65,12 @@ void ProgressiveSplitter::SplitACCoefficients(
         }  // superblk-x
       }    // superblk-y
     }      // color-channel
-    if (!current_pass_salient_only) {
-      // We just finished a non-salient pass.
-      // Hence, we are now guaranteed to have included all coeffs up to
-      // frame_ncoeffs in every block, unless the current pass is shifted.
-      if (mode_.passes[num_pass].shift == 0) {
-        ncoeffs_all_done_from_earlier_passes = frame_ncoeffs;
-      }
+    // We just finished a pass.
+    // Hence, we are now guaranteed to have included all coeffs up to
+    // frame_ncoeffs in every block, unless the current pass is shifted.
+    if (mode_.passes[num_pass].shift == 0) {
+      ncoeffs_all_done_from_earlier_passes = frame_ncoeffs;
     }
-    previous_pass_salient_only = current_pass_salient_only;
     previous_pass_shift = mode_.passes[num_pass].shift;
   }  // num_pass
 }

--- a/lib/jxl/progressive_split.h
+++ b/lib/jxl/progressive_split.h
@@ -41,10 +41,6 @@ struct PassDefinition {
   // How much to shift the encoded values by, with rounding.
   size_t shift;
 
-  // Whether or not we should include only salient blocks.
-  // TODO(veluca): ignored for now.
-  bool salient_only;
-
   // If specified, this indicates that if the requested downsampling factor is
   // sufficiently high, then it is fine to stop decoding after this pass.
   // By default, passes are not marked as being suitable for any downsampling.
@@ -53,9 +49,9 @@ struct PassDefinition {
 
 struct ProgressiveMode {
   size_t num_passes = 1;
-  PassDefinition passes[kMaxNumPasses] = {PassDefinition{
-      /*num_coefficients=*/8, /*shift=*/0, /*salient_only=*/false,
-      /*suitable_for_downsampling_of_at_least=*/1}};
+  PassDefinition passes[kMaxNumPasses] = {
+      PassDefinition{/*num_coefficients=*/8, /*shift=*/0,
+                     /*suitable_for_downsampling_of_at_least=*/1}};
 
   ProgressiveMode() = default;
 
@@ -65,13 +61,10 @@ struct ProgressiveMode {
     num_passes = nump;
     PassDefinition previous_pass{
         /*num_coefficients=*/1, /*shift=*/0,
-        /*salient_only=*/false,
         /*suitable_for_downsampling_of_at_least=*/kNoDownsamplingFactor};
     size_t last_downsampling_factor = kNoDownsamplingFactor;
     for (size_t i = 0; i < nump; i++) {
       JXL_ASSERT(p[i].num_coefficients > previous_pass.num_coefficients ||
-                 (p[i].num_coefficients == previous_pass.num_coefficients &&
-                  !p[i].salient_only && previous_pass.salient_only) ||
                  (p[i].num_coefficients == previous_pass.num_coefficients &&
                   p[i].shift < previous_pass.shift));
       JXL_ASSERT(p[i].suitable_for_downsampling_of_at_least ==
@@ -89,14 +82,6 @@ struct ProgressiveMode {
 class ProgressiveSplitter {
  public:
   void SetProgressiveMode(ProgressiveMode mode) { mode_ = mode; }
-
-  void SetSaliencyMap(const ImageF* saliency_map) {
-    saliency_map_ = saliency_map;
-  }
-
-  void SetSaliencyThreshold(float threshold) {
-    saliency_threshold_ = threshold;
-  }
 
   size_t GetNumPasses() const { return mode_.num_passes; }
 
@@ -130,13 +115,7 @@ class ProgressiveSplitter {
                            T* JXL_RESTRICT output[kMaxNumPasses][3]);
 
  private:
-  bool SuperblockIsSalient(size_t row_start, size_t col_start, size_t num_rows,
-                           size_t num_cols) const;
   ProgressiveMode mode_;
-
-  // Not owned, must remain valid.
-  const ImageF* saliency_map_ = nullptr;
-  float saliency_threshold_ = 0.0;
 };
 
 extern template void ProgressiveSplitter::SplitACCoefficients<int32_t>(

--- a/tools/cjxl_main.cc
+++ b/tools/cjxl_main.cc
@@ -424,9 +424,6 @@ struct CompressArgs {
   size_t num_reps = 1;
   float intensity_target = 0;
 
-  // Filename for the user provided saliency-map.
-  std::string saliency_map_filename;
-
   // Whether to perform lossless transcoding with kVarDCT or kJPEG encoding.
   // If true, attempts to load JPEG coefficients instead of pixels.
   // Reset to false if input image is not a JPEG.


### PR DESCRIPTION
The custom saliency map support was removed since it is not possible
to set through the API (and there are no tests for it either).