### PR TITLE
tests: Make sure libjxl0.7 can still be found

### DIFF
--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -353,6 +353,13 @@ add_test(
   COMMAND libjxl_test
   WORKING_DIRECTORY $<TARGET_FILE_DIR:jxl>
 )
+# if user decide to set CMAKE_SKIP_RPATH:BOOL=ON make sure libjxl.so.0.7 can
+# still be found:
+if(UNIX AND CMAKE_SKIP_RPATH)
+  set_property(TEST LibraryCLinkageTest PROPERTY ENVIRONMENT
+     LD_LIBRARY_PATH=${CMAKE_CURRENT_BINARY_DIR}/..
+     )
+endif()
 
 endif()  # BUILD_TESTING AND TARGET jxl AND NOT JPEGXL_EMSCRIPTEN
 


### PR DESCRIPTION
In some cases user may set CMAKE_SKIP_RPATH:BOOL=ON in which case we
must indicate explicitly where to find libjxl dynamic library.

Reverse cherry-pick from v0.7.x (PR #1711)