### PR TITLE
Add Paint.NET to the supported image editors list

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -41,6 +41,7 @@ Martin Strunz
 Mathieu Malaterre <mathieu.malaterre@gmail.com>
 Mikk Leini <mikk.leini@krakul.eu>
 Misaki Kasumi <misakikasumi@outlook.com>
+Nicholas Hayes <0xC0000054@users.noreply.github.com>
 Petr Diblík
 Pieter Wuille
 roland-rollo

--- a/doc/software_support.md
+++ b/doc/software_support.md
@@ -43,6 +43,7 @@ Please add missing software to this list.
 
 - [GIMP (since 2.99.8)](https://www.gimp.org/news/2021/10/20/gimp-2-99-8-released/); plugin for older versions available in libjxl repo
 - [Krita](https://invent.kde.org/graphics/krita/-/commit/13e5d2e5b9f0eac5c8064b7767f0b62264a0797b)
+- [Paint.NET](https://www.getpaint.net/index.html); supported since 4.3.12 - requires a [plugin](https://github.com/0xC0000054/pdn-jpegxl) to be downloaded and installed.
 - Photoshop: no plugin available yet, no official support yet
 
 ## Image viewers


### PR DESCRIPTION
The user needs to download and install a plugin for JPEG XL support.