### PR TITLE
Improve 'custom' codec in benchmark.

### DIFF
--- a/lib/extras/codec.cc
+++ b/lib/extras/codec.cc
@@ -105,11 +105,6 @@ Status Encode(const CodecInOut& io, const extras::Codec codec,
         format.endianness = JXL_NATIVE_ENDIAN;
         encoder = extras::GetPFMEncoder();
       }
-      if (!c_desired.IsSRGB()) {
-        JXL_WARNING(
-            "PNM encoder cannot store custom ICC profile; decoder "
-            "will need hint key=color_space to get the same values");
-      }
       break;
     case extras::Codec::kPGX:
       encoder = extras::GetPGXEncoder();
@@ -135,6 +130,7 @@ Status Encode(const CodecInOut& io, const extras::Codec codec,
   extras::PackedPixelFile ppf;
   JXL_RETURN_IF_ERROR(
       ConvertCodecInOutToPackedPixelFile(io, format, c_desired, pool, &ppf));
+  ppf.info.bits_per_sample = bits_per_sample;
   extras::EncodedImage encoded_image;
   JXL_RETURN_IF_ERROR(encoder->Encode(ppf, &encoded_image, pool));
   JXL_ASSERT(encoded_image.bitstreams.size() == 1);

--- a/lib/jxl/base/file_io.h
+++ b/lib/jxl/base/file_io.h
@@ -133,7 +133,8 @@ template <typename ContainerType>
 static inline Status WriteFile(const ContainerType& bytes,
                                const std::string& pathname) {
   FileWrapper f(pathname, "wb");
-  if (f == nullptr) return JXL_FAILURE("Failed to open file for writing");
+  if (f == nullptr)
+    return JXL_FAILURE("Failed to open file for writing: %s", pathname.c_str());
 
   size_t pos = 0;
   while (pos < bytes.size()) {

--- a/tools/benchmark/benchmark_args.cc
+++ b/tools/benchmark/benchmark_args.cc
@@ -17,6 +17,7 @@
 #include "lib/jxl/base/status.h"
 #include "lib/jxl/color_encoding_internal.h"
 #include "lib/jxl/color_management.h"
+#include "tools/benchmark/benchmark_codec_custom.h"  // for AddCommand..
 #include "tools/benchmark/benchmark_codec_jpeg.h"  // for AddCommand..
 #include "tools/benchmark/benchmark_codec_jxl.h"
 #if JPEGXL_ENABLE_APNG
@@ -210,6 +211,7 @@ Status BenchmarkArgs::AddCommandLineOptions() {
       "Distance numbers and compression speeds shown in the table are invalid.",
       false);
 
+  if (!AddCommandLineOptionsCustomCodec(this)) return false;
   if (!AddCommandLineOptionsJxlCodec(this)) return false;
 #ifdef BENCHMARK_JPEG
   if (!AddCommandLineOptionsJPEGCodec(this)) return false;

--- a/tools/benchmark/benchmark_codec_custom.h
+++ b/tools/benchmark/benchmark_codec_custom.h
@@ -40,6 +40,7 @@
 namespace jxl {
 
 ImageCodec* CreateNewCustomCodec(const BenchmarkArgs& args);
+Status AddCommandLineOptionsCustomCodec(BenchmarkArgs* args);
 
 }  // namespace jxl
 

--- a/tools/benchmark/benchmark_utils.h
+++ b/tools/benchmark/benchmark_utils.h
@@ -28,7 +28,8 @@ class TemporaryFile final {
 };
 
 Status RunCommand(const std::string& command,
-                  const std::vector<std::string>& arguments);
+                  const std::vector<std::string>& arguments,
+                  bool quiet = false);
 
 }  // namespace jxl
 


### PR DESCRIPTION
Add options to prepare input of custom codec in arbitrary file
format and colorspace.

Add option to suppress custom codec stdin/stdout.

Fix endianness of pfm headers and check correct endianness
of ppf when encoding into ppm/pgm.