### PR TITLE
Add codespace that use ubuntu and emsdk container.

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,26 @@
+FROM mcr.microsoft.com/vscode/devcontainers/base:ubuntu-20.04
+
+RUN apt-get update && \
+    apt install -y \
+        ccache \
+        clang-7 \
+        cmake \
+        doxygen \
+        libbenchmark-dev \
+        libbenchmark-tools \
+        libbrotli-dev \
+        libgdk-pixbuf2.0-dev \
+        libgif-dev \
+        libgtest-dev \
+        libgtk2.0-dev  \
+        libjpeg-dev \
+        libopenexr-dev \
+        libpng-dev \
+        libwebp-dev \
+        ninja-build \
+        pkg-config \
+        xdg-utils \
+        xvfb
+
+ENV CC=clang-7
+ENV CXX=clang++-7

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,3 +1,8 @@
+# Copyright (c) the JPEG XL Project Authors. All rights reserved.
+#
+# Use of this source code is governed by a BSD-style
+# license that can be found in the LICENSE file.
+
 FROM mcr.microsoft.com/vscode/devcontainers/base:ubuntu-20.04
 
 RUN apt-get update && \

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,16 @@
+{
+  "build": {
+    "dockerfile": "Dockerfile"
+  },
+  "onCreateCommand": "./deps.sh && SKIP_TEST=1 ./ci.sh debug",
+  "remoteEnv": { 
+    "PATH": "${containerEnv:PATH}:${containerWorkspaceFolder}/build/tools"
+  },
+  "customizations": {
+    "vscode": {
+      "settings": {
+        "extensions.ignoreRecommendations": true
+      }
+    }
+  }
+}

--- a/.devcontainer/emsdk/Dockerfile
+++ b/.devcontainer/emsdk/Dockerfile
@@ -1,0 +1,11 @@
+FROM emscripten/emsdk:3.1.20
+
+RUN apt-get update && \
+    apt install -y \
+        doxygen \
+        ninja-build \
+        pkg-config
+
+ENV CC=emcc
+ENV CXX=em++
+ENV BUILD_TARGET=wasm32

--- a/.devcontainer/emsdk/Dockerfile
+++ b/.devcontainer/emsdk/Dockerfile
@@ -1,3 +1,8 @@
+# Copyright (c) the JPEG XL Project Authors. All rights reserved.
+#
+# Use of this source code is governed by a BSD-style
+# license that can be found in the LICENSE file.
+
 FROM emscripten/emsdk:3.1.20
 
 RUN apt-get update && \

--- a/.devcontainer/emsdk/devcontainer.json
+++ b/.devcontainer/emsdk/devcontainer.json
@@ -1,0 +1,13 @@
+{
+  "build": {
+    "dockerfile": "Dockerfile"
+  },
+  "onCreateCommand": "./deps.sh && SKIP_TEST=1 ./ci.sh release",
+  "customizations": {
+    "vscode": {
+      "settings": {
+        "extensions.ignoreRecommendations": true
+      }
+    }
+  }
+}


### PR DESCRIPTION
This PR adds two GitHub Codespaces. The default (in the `.decontainer`) is an ubuntu container. And the other one uses an emsdk container to make it possible to test emsdk changes. People with access to GitHub Codespaces could use this to work on this library and quickly test a change in the browser without requiring to set up a local development environment. The `onCreateCommand` can be part of the created container by configuring a pre-build codespace. And then when the codespace starts the commands are already executed. For the emsdk codespace I was unable to use `./ci.sh debug` because this resulted in a SIGKILL so I used release for now. The `onCreateCommand` part is optional but I thought it would be nice that the binaries are already pre-build in the codespace. This can then be used by someone to check a possible bug with the pre-build tools.