### PR TITLE
Added missing check for JPEGXL_BUNDLE_LIBPNG in wasm build.

### DIFF
--- a/third_party/CMakeLists.txt
+++ b/third_party/CMakeLists.txt
@@ -100,7 +100,7 @@ if (JPEGXL_ENABLE_VIEWERS OR NOT JPEGXL_ENABLE_SKCMS)
 endif()
 
 # libpng
-if (JPEGXL_EMSCRIPTEN)
+if (JPEGXL_BUNDLE_LIBPNG AND JPEGXL_EMSCRIPTEN)
   if (NOT EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/libpng/CMakeLists.txt")
   message(FATAL_ERROR "Please run ${PROJECT_SOURCE_DIR}/deps.sh to fetch the "
           "build dependencies.")


### PR DESCRIPTION
This PR adds a missing check for `JPEGXL_BUNDLE_LIBPNG` for the wasm build. This now results in this error message when `-DJPEGXL_BUNDLE_LIBPNG=OFF` is used:

```
CMake Error at third_party/CMakeLists.txt:105 (message):
  Please run /workspaces/libjxl/deps.sh to fetch the build dependencies.
```

This error doesn't happen during the normal ci build but can be reproduced in the ci build with the following patch (tested in a codespace from #1725):

```patch
diff --git a/ci.sh b/ci.sh
index 06b73fd8..bca1052c 100755
--- a/ci.sh
+++ b/ci.sh
@@ -384,6 +384,7 @@ cmake_configure() {
         -DSJPEG_ENABLE_SIMD=OFF
         # Building shared libs is not very useful for WASM.
         -DBUILD_SHARED_LIBS=OFF
+        -DJPEGXL_BUNDLE_LIBPNG=OFF
       )
     fi
     args+=(
```
