### PR TITLE
Implement decoding to a scaled XYB space.

### DIFF
--- a/lib/jxl/color_encoding_internal.cc
+++ b/lib/jxl/color_encoding_internal.cc
@@ -636,6 +636,7 @@ Status ConvertExternalToInternalColorEncoding(const JxlColorEncoding& external,
     }
   }
   CustomTransferFunction tf;
+  tf.nonserialized_color_space = internal->GetColorSpace();
   if (external.transfer_function == JXL_TRANSFER_FUNCTION_GAMMA) {
     JXL_RETURN_IF_ERROR(tf.SetGamma(external.gamma));
   } else {

--- a/lib/jxl/color_management.h
+++ b/lib/jxl/color_management.h
@@ -28,6 +28,8 @@ enum class ExtraTF {
   kSRGB,
 };
 
+// NOTE: for XYB colorspace, the created profile can be used to transform a
+// *scaled* XYB image (created by ScaleXYB()) to another colorspace.
 Status MaybeCreateProfile(const ColorEncoding& c,
                           PaddedBytes* JXL_RESTRICT icc);
 

--- a/lib/jxl/color_management_test.cc
+++ b/lib/jxl/color_management_test.cc
@@ -18,6 +18,7 @@
 #include "lib/jxl/base/file_io.h"
 #include "lib/jxl/base/thread_pool_internal.h"
 #include "lib/jxl/enc_color_management.h"
+#include "lib/jxl/enc_xyb.h"
 #include "lib/jxl/image_test_utils.h"
 #include "lib/jxl/test_utils.h"
 #include "lib/jxl/testdata.h"
@@ -313,6 +314,91 @@ TEST_F(ColorManagementTest, HlgOotf) {
   ASSERT_TRUE(grayscale_transform.Run(0, &grayscale_hlg_value,
                                       &linear_grayscale_value));
   EXPECT_THAT(linear_grayscale_value, FloatNear(0.203, 1e-3));
+}
+
+TEST_F(ColorManagementTest, XYBProfile) {
+  ColorEncoding c_xyb;
+  c_xyb.SetColorSpace(ColorSpace::kXYB);
+  c_xyb.rendering_intent = RenderingIntent::kPerceptual;
+  ASSERT_TRUE(c_xyb.CreateICC());
+  ColorEncoding c_native = ColorEncoding::LinearSRGB(false);
+
+  static const size_t kGridDim = 17;
+  static const size_t kNumColors = kGridDim * kGridDim * kGridDim;
+  const JxlCmsInterface& cms = GetJxlCms();
+  ColorSpaceTransform xform(cms);
+  ASSERT_TRUE(
+      xform.Init(c_xyb, c_native, kDefaultIntensityTarget, kNumColors, 1));
+
+  ImageMetadata metadata;
+  metadata.color_encoding = c_native;
+  ImageBundle ib(&metadata);
+  Image3F native(kNumColors, 1);
+  float mul = 1.0f / (kGridDim - 1);
+  for (size_t ir = 0, x = 0; ir < kGridDim; ++ir) {
+    for (size_t ig = 0; ig < kGridDim; ++ig) {
+      for (size_t ib = 0; ib < kGridDim; ++ib, ++x) {
+        native.PlaneRow(0, 0)[x] = ir * mul;
+        native.PlaneRow(1, 0)[x] = ig * mul;
+        native.PlaneRow(2, 0)[x] = ib * mul;
+      }
+    }
+  }
+  ib.SetFromImage(std::move(native), c_native);
+  const Image3F& in = *ib.color();
+  Image3F opsin(kNumColors, 1);
+  ToXYB(ib, nullptr, &opsin, cms, nullptr);
+
+  Image3F opsin2 = CopyImage(opsin);
+  ScaleXYB(&opsin2);
+
+  float* src = xform.BufSrc(0);
+  for (size_t i = 0; i < kNumColors; ++i) {
+    for (size_t c = 0; c < 3; ++c) {
+      src[3 * i + c] = opsin2.PlaneRow(c, 0)[i];
+    }
+  }
+
+  float* dst = xform.BufDst(0);
+  ASSERT_TRUE(xform.Run(0, src, dst));
+
+  Image3F out(kNumColors, 1);
+  for (size_t i = 0; i < kNumColors; ++i) {
+    for (size_t c = 0; c < 3; ++c) {
+      out.PlaneRow(c, 0)[i] = dst[3 * i + c];
+    }
+  }
+
+  auto debug_print_color = [&](size_t i) {
+    printf(
+        "(%f, %f, %f) -> (%9.6f, %f, %f) -> (%f, %f, %f) -> "
+        "(%9.6f, %9.6f, %9.6f)",
+        in.PlaneRow(0, 0)[i], in.PlaneRow(1, 0)[i], in.PlaneRow(2, 0)[i],
+        opsin.PlaneRow(0, 0)[i], opsin.PlaneRow(1, 0)[i],
+        opsin.PlaneRow(2, 0)[i], opsin2.PlaneRow(0, 0)[i],
+        opsin2.PlaneRow(1, 0)[i], opsin2.PlaneRow(2, 0)[i],
+        out.PlaneRow(0, 0)[i], out.PlaneRow(1, 0)[i], out.PlaneRow(2, 0)[i]);
+  };
+
+  float max_err[3] = {};
+  size_t max_err_i[3] = {};
+  for (size_t i = 0; i < kNumColors; ++i) {
+    for (size_t c = 0; c < 3; ++c) {
+      // debug_print_color(i); printf("\n");
+      float err = std::abs(in.PlaneRow(c, 0)[i] - out.PlaneRow(c, 0)[i]);
+      if (err > max_err[c]) {
+        max_err[c] = err;
+        max_err_i[c] = i;
+      }
+    }
+  }
+  static float kMaxError[3] = {8e-4, 4e-4, 5e-4};
+  printf("Maximum errors:\n");
+  for (size_t c = 0; c < 3; ++c) {
+    debug_print_color(max_err_i[c]);
+    printf("    %f\n", max_err[c]);
+    EXPECT_LT(max_err[c], kMaxError[c]);
+  }
 }
 
 }  // namespace

--- a/lib/jxl/dec_cache.cc
+++ b/lib/jxl/dec_cache.cc
@@ -159,8 +159,11 @@ Status PassesDecoderState::PreparePipeline(ImageBundle* decoded,
     if (frame_header.color_transform == ColorTransform::kYCbCr) {
       builder.AddStage(GetYCbCrStage());
     } else if (frame_header.color_transform == ColorTransform::kXYB) {
-      builder.AddStage(GetXYBStage(output_encoding_info.opsin_params));
-      linear = true;
+      builder.AddStage(GetXYBStage(output_encoding_info));
+      if (output_encoding_info.color_encoding.GetColorSpace() !=
+          ColorSpace::kXYB) {
+        linear = true;
+      }
     }  // Nothing to do for kNone.
 
     if (options.coalescing && NeedsBlending(this)) {

--- a/lib/jxl/dec_xyb.cc
+++ b/lib/jxl/dec_xyb.cc
@@ -239,6 +239,12 @@ Status OutputEncodingInfo::SetFromMetadata(const CodecMetadata& metadata) {
 
 Status OutputEncodingInfo::MaybeSetColorEncoding(
     const ColorEncoding& c_desired) {
+  if (c_desired.GetColorSpace() == ColorSpace::kXYB &&
+      ((color_encoding.GetColorSpace() == ColorSpace::kRGB &&
+        color_encoding.primaries != Primaries::kSRGB) ||
+       color_encoding.tf.IsPQ())) {
+    return false;
+  }
   if (!xyb_encoded || !CanOutputToColorEncoding(c_desired)) {
     return false;
   }

--- a/lib/jxl/decode.cc
+++ b/lib/jxl/decode.cc
@@ -2730,14 +2730,13 @@ JxlDecoderStatus JxlDecoderSetPreferredColorProfile(
       dec->image_out_buffer_set && dec->image_out_format.num_channels < 3) {
     return JXL_API_ERROR("Number of channels is too low for color output");
   }
-  if (color_encoding->color_space == JXL_COLOR_SPACE_UNKNOWN ||
-      color_encoding->color_space == JXL_COLOR_SPACE_XYB) {
-    return JXL_API_ERROR("only RGB or grayscale output supported");
+  if (color_encoding->color_space == JXL_COLOR_SPACE_UNKNOWN) {
+    return JXL_API_ERROR("Unknown output colorspace");
   }
-
   jxl::ColorEncoding c_out;
   JXL_API_RETURN_IF_ERROR(
       ConvertExternalToInternalColorEncoding(*color_encoding, &c_out));
+  JXL_API_RETURN_IF_ERROR(!c_out.ICC().empty());
   auto& output_encoding = dec->passes_state->output_encoding_info;
   if (!c_out.SameColorEncoding(output_encoding.color_encoding)) {
     JXL_API_RETURN_IF_ERROR(output_encoding.MaybeSetColorEncoding(c_out));

--- a/lib/jxl/enc_xyb.cc
+++ b/lib/jxl/enc_xyb.cc
@@ -353,6 +353,18 @@ const ImageBundle* ToXYB(const ImageBundle& in, ThreadPool* pool,
   return HWY_DYNAMIC_DISPATCH(ToXYB)(in, pool, xyb, cms, linear_storage);
 }
 
+void ScaleXYB(Image3F* opsin) {
+  jxl::SubtractFrom(opsin->Plane(1), &opsin->Plane(2));
+  for (size_t y = 0; y < opsin->ysize(); y++) {
+    for (size_t c = 0; c < 3; ++c) {
+      float* row = opsin->PlaneRow(c, y);
+      for (size_t x = 0; x < opsin->xsize(); x++) {
+        row[x] = (row[x] + kScaledXYBOffset[c]) * kScaledXYBScale[c];
+      }
+    }
+  }
+}
+
 HWY_EXPORT(RgbToYcbcr);
 Status RgbToYcbcr(const ImageF& r_plane, const ImageF& g_plane,
                   const ImageF& b_plane, ImageF* y_plane, ImageF* cb_plane,

--- a/lib/jxl/enc_xyb.h
+++ b/lib/jxl/enc_xyb.h
@@ -27,6 +27,10 @@ const ImageBundle* ToXYB(const ImageBundle& in, ThreadPool* pool,
                          Image3F* JXL_RESTRICT xyb, const JxlCmsInterface& cms,
                          ImageBundle* JXL_RESTRICT linear = nullptr);
 
+// Transforms each color component of the given XYB image into the [0.0, 1.0]
+// interval with an affine transform.
+void ScaleXYB(Image3F* opsin);
+
 // Bt.601 to match JPEG/JFIF. Outputs _signed_ YCbCr values suitable for DCT,
 // see F.1.1.3 of T.81 (because our data type is float, there is no need to add
 // a bias to make the values unsigned).

--- a/lib/jxl/opsin_params.h
+++ b/lib/jxl/opsin_params.h
@@ -69,6 +69,18 @@ static const float kNegOpsinAbsorbanceBiasRGB[4] = {
     -kOpsinAbsorbanceBias[0], -kOpsinAbsorbanceBias[1],
     -kOpsinAbsorbanceBias[2], 1.0f};
 
+static const float kScaledXYBOffset[3] = {
+    0.015386134f,
+    0.0f,
+    0.27770459f,
+};
+
+static const float kScaledXYBScale[3] = {
+    22.995788804f,
+    1.183000077f,
+    1.502141333f,
+};
+
 }  // namespace jxl
 
 #endif  // LIB_JXL_OPSIN_PARAMS_H_

--- a/lib/jxl/render_pipeline/stage_xyb.cc
+++ b/lib/jxl/render_pipeline/stage_xyb.cc
@@ -11,6 +11,7 @@
 #include <hwy/highway.h>
 
 #include "lib/jxl/dec_xyb-inl.h"
+#include "lib/jxl/opsin_params.h"
 #include "lib/jxl/sanitizers.h"
 
 HWY_BEFORE_NAMESPACE();
@@ -19,9 +20,11 @@ namespace HWY_NAMESPACE {
 
 class XYBStage : public RenderPipelineStage {
  public:
-  explicit XYBStage(const OpsinParams& opsin_params)
+  explicit XYBStage(const OutputEncodingInfo& output_encoding_info)
       : RenderPipelineStage(RenderPipelineStage::Settings()),
-        opsin_params_(opsin_params) {}
+        opsin_params_(output_encoding_info.opsin_params),
+        output_is_xyb_(output_encoding_info.color_encoding.GetColorSpace() ==
+                       ColorSpace::kXYB) {}
 
   void ProcessRow(const RowInfo& input_rows, const RowInfo& output_rows,
                   size_t xextra, size_t xsize, size_t xpos, size_t ypos,
@@ -42,18 +45,38 @@ class XYBStage : public RenderPipelineStage {
     msan::UnpoisonMemory(row2 + xsize, sizeof(float) * (xsize_v - xsize));
     // TODO(eustas): when using frame origin, addresses might be unaligned;
     //               making them aligned will void performance penalty.
-    for (ssize_t x = -xextra; x < (ssize_t)(xsize + xextra); x += Lanes(d)) {
-      const auto in_opsin_x = LoadU(d, row0 + x);
-      const auto in_opsin_y = LoadU(d, row1 + x);
-      const auto in_opsin_b = LoadU(d, row2 + x);
-      auto r = Undefined(d);
-      auto g = Undefined(d);
-      auto b = Undefined(d);
-      XybToRgb(d, in_opsin_x, in_opsin_y, in_opsin_b, opsin_params_, &r, &g,
-               &b);
-      StoreU(r, d, row0 + x);
-      StoreU(g, d, row1 + x);
-      StoreU(b, d, row2 + x);
+    if (output_is_xyb_) {
+      const auto scale_x = Set(d, kScaledXYBScale[0]);
+      const auto scale_y = Set(d, kScaledXYBScale[1]);
+      const auto scale_bmy = Set(d, kScaledXYBScale[2]);
+      const auto offset_x = Set(d, kScaledXYBOffset[0]);
+      const auto offset_y = Set(d, kScaledXYBOffset[1]);
+      const auto offset_bmy = Set(d, kScaledXYBOffset[2]);
+      for (ssize_t x = -xextra; x < (ssize_t)(xsize + xextra); x += Lanes(d)) {
+        const auto in_x = LoadU(d, row0 + x);
+        const auto in_y = LoadU(d, row1 + x);
+        const auto in_b = LoadU(d, row2 + x);
+        auto out_x = Mul(Add(in_x, offset_x), scale_x);
+        auto out_y = Mul(Add(in_y, offset_y), scale_y);
+        auto out_b = Mul(Add(Sub(in_b, in_y), offset_bmy), scale_bmy);
+        StoreU(out_x, d, row0 + x);
+        StoreU(out_y, d, row1 + x);
+        StoreU(out_b, d, row2 + x);
+      }
+    } else {
+      for (ssize_t x = -xextra; x < (ssize_t)(xsize + xextra); x += Lanes(d)) {
+        const auto in_opsin_x = LoadU(d, row0 + x);
+        const auto in_opsin_y = LoadU(d, row1 + x);
+        const auto in_opsin_b = LoadU(d, row2 + x);
+        auto r = Undefined(d);
+        auto g = Undefined(d);
+        auto b = Undefined(d);
+        XybToRgb(d, in_opsin_x, in_opsin_y, in_opsin_b, opsin_params_, &r, &g,
+                 &b);
+        StoreU(r, d, row0 + x);
+        StoreU(g, d, row1 + x);
+        StoreU(b, d, row2 + x);
+      }
     }
     msan::PoisonMemory(row0 + xsize, sizeof(float) * (xsize_v - xsize));
     msan::PoisonMemory(row1 + xsize, sizeof(float) * (xsize_v - xsize));
@@ -69,11 +92,12 @@ class XYBStage : public RenderPipelineStage {
 
  private:
   const OpsinParams opsin_params_;
+  const bool output_is_xyb_;
 };
 
 std::unique_ptr<RenderPipelineStage> GetXYBStage(
-    const OpsinParams& opsin_params) {
-  return jxl::make_unique<XYBStage>(opsin_params);
+    const OutputEncodingInfo& output_encoding_info) {
+  return jxl::make_unique<XYBStage>(output_encoding_info);
 }
 
 // NOLINTNEXTLINE(google-readability-namespace-comments)
@@ -87,8 +111,8 @@ namespace jxl {
 HWY_EXPORT(GetXYBStage);
 
 std::unique_ptr<RenderPipelineStage> GetXYBStage(
-    const OpsinParams& opsin_params) {
-  return HWY_DYNAMIC_DISPATCH(GetXYBStage)(opsin_params);
+    const OutputEncodingInfo& output_encoding_info) {
+  return HWY_DYNAMIC_DISPATCH(GetXYBStage)(output_encoding_info);
 }
 
 namespace {

--- a/lib/jxl/render_pipeline/stage_xyb.h
+++ b/lib/jxl/render_pipeline/stage_xyb.h
@@ -14,7 +14,7 @@ namespace jxl {
 
 // Converts the color channels from XYB to linear with appropriate primaries.
 std::unique_ptr<RenderPipelineStage> GetXYBStage(
-    const OpsinParams& output_encoding_info);
+    const OutputEncodingInfo& output_encoding_info);
 
 // Gets a stage to convert with fixed point arithmetic from XYB to sRGB8 and
 // write to a uint8 buffer.

--- a/lib/jxl/test_utils.h
+++ b/lib/jxl/test_utils.h
@@ -232,9 +232,11 @@ static inline ColorEncoding ColorEncodingFromDescriptor(
     const ColorEncodingDescriptor& desc) {
   ColorEncoding c;
   c.SetColorSpace(desc.color_space);
-  c.white_point = desc.white_point;
-  c.primaries = desc.primaries;
-  c.tf.SetTransferFunction(desc.tf);
+  if (desc.color_space != ColorSpace::kXYB) {
+    c.white_point = desc.white_point;
+    c.primaries = desc.primaries;
+    c.tf.SetTransferFunction(desc.tf);
+  }
   c.rendering_intent = desc.rendering_intent;
   JXL_CHECK(c.CreateICC());
   return c;


### PR DESCRIPTION
Add the XYB profile created by sboukortt@ and veluca93@ that describes
a transformed version of the XYB space that is inside the unit cube for
sRGB colors.

Implement decoding into this modified XYB space by the API and thus
enable saving JXL files to XYB jpegs or PNGs.