### PR TITLE
Unify the pixel callback and image buffer write stages.

### DIFF
--- a/lib/jxl/base/byte_order.h
+++ b/lib/jxl/base/byte_order.h
@@ -9,6 +9,7 @@
 #include <stdint.h>
 #include <string.h>  // memcpy
 
+#include "jxl/types.h"
 #include "lib/jxl/base/compiler_specific.h"
 
 #if JXL_COMPILER_MSVC
@@ -35,6 +36,11 @@ static inline bool IsLittleEndian() {
   return byte == 1;
 }
 #endif
+
+static inline bool SwapEndianness(JxlEndianness endianness) {
+  return ((endianness == JXL_BIG_ENDIAN && IsLittleEndian()) ||
+          (endianness == JXL_LITTLE_ENDIAN && !IsLittleEndian()));
+}
 
 #if JXL_COMPILER_MSVC
 #define JXL_BSWAP16(x) _byteswap_ushort(x)

--- a/lib/jxl/dec_cache.cc
+++ b/lib/jxl/dec_cache.cc
@@ -138,22 +138,16 @@ Status PassesDecoderState::PreparePipeline(ImageBundle* decoded,
     }
   }
 
-  size_t width = options.coalescing
-                     ? frame_header.nonserialized_metadata->xsize()
-                     : shared->frame_dim.xsize_upsampled;
-  size_t height = options.coalescing
-                      ? frame_header.nonserialized_metadata->ysize()
-                      : shared->frame_dim.ysize_upsampled;
-
   if (fast_xyb_srgb8_conversion) {
     JXL_ASSERT(!NeedsBlending(this));
     JXL_ASSERT(!frame_header.CanBeReferenced() ||
                frame_header.save_before_color_transform);
     JXL_ASSERT(!options.render_spotcolors ||
                !decoded->metadata()->Find(ExtraChannel::kSpotColor));
-    builder.AddStage(GetFastXYBTosRGB8Stage(rgb_output, rgb_stride, width,
-                                            height, rgb_output_is_rgba,
-                                            has_alpha, alpha_c));
+    bool is_rgba = (format.num_channels == 4);
+    uint8_t* rgb_output = reinterpret_cast<uint8_t*>(image_buffer);
+    builder.AddStage(GetFastXYBTosRGB8Stage(rgb_output, stride, width, height,
+                                            is_rgba, has_alpha, alpha_c));
   } else {
     bool linear = false;
     if (frame_header.color_transform == ColorTransform::kYCbCr) {
@@ -218,15 +212,10 @@ Status PassesDecoderState::PreparePipeline(ImageBundle* decoded,
       linear = false;
     }
 
-    if (pixel_callback.IsPresent()) {
-      builder.AddStage(GetWriteToPixelCallbackStage(
-          pixel_callback, width, height, output_channels, has_alpha,
-          unpremul_alpha, alpha_c, swap_endianness, undo_orientation,
-          output_data_type));
-    } else if (rgb_output) {
-      builder.AddStage(GetWriteToU8Stage(rgb_output, rgb_stride, height,
-                                         rgb_output_is_rgba, has_alpha,
-                                         alpha_c));
+    if (pixel_callback.IsPresent() || image_buffer) {
+      builder.AddStage(GetWriteToOutputStage(
+          pixel_callback, image_buffer, width, height, stride, format,
+          has_alpha, unpremul_alpha, alpha_c, undo_orientation));
     } else {
       builder.AddStage(GetWriteToImageBundleStage(
           decoded, output_encoding_info.color_encoding));

--- a/lib/jxl/dec_cache.h
+++ b/lib/jxl/dec_cache.h
@@ -77,36 +77,28 @@ struct PassesDecoderState {
   // Sigma values for EPF.
   ImageF sigma;
 
-  // RGB8 output buffer. If not nullptr, image data will be written to this
-  // buffer instead of being written to the output ImageBundle. The image data
-  // is assumed to have the stride given by `rgb_stride`, hence row `i` starts
-  // at position `i * rgb_stride`.
-  uint8_t* rgb_output;
-  size_t rgb_stride = 0;
-
-  size_t output_channels;
-  JxlDataType output_data_type;
+  // Pixel buffer for image output.
+  void* image_buffer;
+  // Image dimensions before applying undo_orientation.
+  size_t width;
+  size_t height;
+  // Length of a row of image_buffer in bytes (based on oriented width).
+  size_t stride;
+  // Callback for line-by-line output.
+  PixelCallback pixel_callback;
+  // Pixel format of the output pixels, used for buffer and callback output.
+  JxlPixelFormat format;
 
   // Whether to use int16 float-XYB-to-uint8-srgb conversion.
   bool fast_xyb_srgb8_conversion;
 
-  // If true, rgb_output or callback output is RGBA using 4 instead of 3 bytes
-  // per pixel.
-  bool rgb_output_is_rgba;
   // If true, the RGBA output will be unpremultiplied before writing to the
-  // output callback (the output buffer case is handled in ConvertToExternal).
+  // output.
   bool unpremul_alpha;
 
-  bool swap_endianness;
+  // The render pipeline will apply this orientation to bring the image to the
+  // intended display orientation.
   Orientation undo_orientation;
-
-  // Callback for line-by-line output.
-  PixelCallback pixel_callback;
-
-  // Buffer of upsampling * kApplyImageFeaturesTileDim ones.
-  std::vector<float> opaque_alpha;
-  // One row per thread
-  std::vector<std::vector<float>> pixel_callback_rows;
 
   // Used for seeding noise.
   size_t visible_frame_index = 0;
@@ -142,15 +134,13 @@ struct PassesDecoderState {
     b_dm_multiplier =
         std::pow(1 / (1.25f), shared->frame_header.b_qm_scale - 2.0f);
 
-    rgb_output = nullptr;
-    rgb_output_is_rgba = false;
-    output_channels = 3;
-    output_data_type = JXL_TYPE_FLOAT;
-    unpremul_alpha = false;
-    swap_endianness = false;
-    undo_orientation = Orientation::kIdentity;
-    fast_xyb_srgb8_conversion = false;
     pixel_callback = PixelCallback();
+    image_buffer = nullptr;
+
+    fast_xyb_srgb8_conversion = false;
+    unpremul_alpha = false;
+    undo_orientation = Orientation::kIdentity;
+
     used_acs = 0;
 
     upsampler8x = GetUpsamplingStage(shared->metadata->transform_data, 0, 3);

--- a/lib/jxl/dec_frame.h
+++ b/lib/jxl/dec_frame.h
@@ -172,73 +172,60 @@ class FrameDecoder {
                                          : std::numeric_limits<size_t>::max());
   }
 
-  void MaybeSetUnpremultiplyAlpha(bool unpremul_alpha) {
+  // Sets the pixel callback or image buffer where the pixels will be decoded.
+  // This is not supported for all images. If it succeeds, HasRGBBuffer() will
+  // return true.
+  // If it does not succeed, the image is decoded to the ImageBundle passed to
+  // InitFrame instead.
+  //
+  // @param undo_orientation: if true, indicates the frame decoder should apply
+  // the exif orientation to bring the image to the intended display
+  // orientation.
+  void SetImageOutput(const PixelCallback& pixel_callback, void* image_buffer,
+                      size_t xsize, size_t ysize, JxlPixelFormat format,
+                      bool unpremul_alpha, bool undo_orientation) const {
+    dec_state_->pixel_callback = pixel_callback;
+    dec_state_->image_buffer = image_buffer;
+    dec_state_->width = xsize;
+    dec_state_->height = ysize;
+    dec_state_->format = format;
+    dec_state_->stride =
+        (xsize * BytesPerChannel(format.data_type) * format.num_channels);
+    if (format.align > 1) {
+      dec_state_->stride =
+          (jxl::DivCeil(dec_state_->stride, format.align) * format.align);
+    }
     const jxl::ExtraChannelInfo* alpha =
         decoded_->metadata()->Find(jxl::ExtraChannel::kAlpha);
     if (alpha && alpha->alpha_associated && unpremul_alpha) {
       dec_state_->unpremul_alpha = true;
     }
-  }
-
-  // Sets the buffer to which uint8 sRGB pixels will be decoded. This is not
-  // supported for all images. If it succeeds, HasRGBBuffer() will return true.
-  // If it does not succeed, the image is decoded to the ImageBundle passed to
-  // InitFrame instead.
-  // If an output callback is set, this function *may not* be called.
-  //
-  // @param undo_orientation: if true, indicates the frame decoder should apply
-  // the exif orientation to bring the image to the intended display
-  // orientation. Performing this operation is not yet supported, so this
-  // results in not setting the buffer if the image has a non-identity EXIF
-  // orientation. When outputting to the ImageBundle, no orientation is undone.
-  void MaybeSetRGB8OutputBuffer(uint8_t* rgb_output, size_t stride,
-                                bool is_rgba, bool undo_orientation) const {
-    if (!CanDoLowMemoryPath(undo_orientation) || dec_state_->unpremul_alpha) {
-      return;
+    if (undo_orientation) {
+      dec_state_->undo_orientation = decoded_->metadata()->GetOrientation();
+      if (static_cast<int>(dec_state_->undo_orientation) > 4) {
+        std::swap(dec_state_->width, dec_state_->height);
+      }
     }
-    dec_state_->rgb_output = rgb_output;
-    dec_state_->rgb_output_is_rgba = is_rgba;
-    dec_state_->rgb_stride = stride;
-    JXL_ASSERT(!dec_state_->pixel_callback.IsPresent());
 #if !JXL_HIGH_PRECISION
-    if (decoded_->metadata()->xyb_encoded &&
+    if (dec_state_->image_buffer && (format.data_type == JXL_TYPE_UINT8) &&
+        (format.num_channels >= 3) && !dec_state_->unpremul_alpha &&
+        (dec_state_->undo_orientation == Orientation::kIdentity) &&
+        decoded_->metadata()->xyb_encoded &&
         dec_state_->output_encoding_info.color_encoding.IsSRGB() &&
         dec_state_->output_encoding_info.all_default_opsin &&
-        dec_state_->output_encoding_info.desired_intensity_target ==
-            dec_state_->output_encoding_info.orig_intensity_target &&
+        (dec_state_->output_encoding_info.desired_intensity_target ==
+         dec_state_->output_encoding_info.orig_intensity_target) &&
         HasFastXYBTosRGB8() && frame_header_.needs_color_transform()) {
       dec_state_->fast_xyb_srgb8_conversion = true;
     }
 #endif
   }
 
-  // Same as MaybeSetRGB8OutputBuffer, but with a float callback. This is not
-  // supported for all images. If it succeeds, HasRGBBuffer() will return true.
-  // If it does not succeed, the image is decoded to the ImageBundle passed to
-  // InitFrame instead.
-  // If a RGB8 output buffer is set, this function *may not* be called.
-  //
-  // @param undo_orientation: if true, indicates the frame decoder should apply
-  // the exif orientation to bring the image to the intended display
-  // orientation.
-  void SetCallback(const PixelCallback& pixel_callback, size_t num_channels,
-                   bool unpremul_alpha, bool undo_orientation,
-                   bool swap_endianness, JxlDataType data_type) const {
-    dec_state_->pixel_callback = pixel_callback;
-    dec_state_->output_channels = num_channels;
-    dec_state_->undo_orientation = undo_orientation
-                                       ? decoded_->metadata()->GetOrientation()
-                                       : Orientation::kIdentity;
-    dec_state_->swap_endianness = swap_endianness;
-    dec_state_->output_data_type = data_type;
-    JXL_ASSERT(dec_state_->rgb_output == nullptr);
-  }
-
   // Returns true if the rgb output buffer passed by MaybeSetRGB8OutputBuffer
   // has been/will be populated by Flush() / FinalizeFrame(), or if a pixel
   // callback has been used.
   bool HasRGBBuffer() const {
-    return dec_state_->rgb_output != nullptr ||
+    return dec_state_->image_buffer != nullptr ||
            dec_state_->pixel_callback.IsPresent();
   }
 
@@ -280,15 +267,10 @@ class FrameDecoder {
     return thread;
   }
 
-  // If the image has default exif orientation (or has an orientation but should
-  // not be undone) and no blending, the current frame cannot be referenced by
-  // future frames, there are no spot colors to be rendered, and alpha is not
-  // premultiplied, then low memory options can be used
-  // (uint8 output buffer or float pixel callback).
-  // TODO(veluca): reduce this set of restrictions.
-  bool CanDoLowMemoryPath(bool undo_orientation) const {
-    return !(undo_orientation &&
-             decoded_->metadata()->GetOrientation() != Orientation::kIdentity);
+  static size_t BytesPerChannel(JxlDataType data_type) {
+    return (data_type == JXL_TYPE_UINT8   ? 1u
+            : data_type == JXL_TYPE_FLOAT ? 4u
+                                          : 2u);
   }
 
   PassesDecoderState* dec_state_;

--- a/lib/jxl/decode.cc
+++ b/lib/jxl/decode.cc
@@ -894,20 +894,19 @@ JxlDecoderStatus JxlDecoderSetCoalescing(JxlDecoder* dec, JXL_BOOL coalescing) {
 
 namespace {
 // helper function to get the dimensions of the current image buffer
-void GetCurrentDimensions(const JxlDecoder* dec, size_t& xsize, size_t& ysize,
-                          bool oriented) {
+void GetCurrentDimensions(const JxlDecoder* dec, size_t& xsize, size_t& ysize) {
   if (dec->frame_header->nonserialized_is_preview) {
     xsize = dec->metadata.oriented_preview_xsize(dec->keep_orientation);
     ysize = dec->metadata.oriented_preview_ysize(dec->keep_orientation);
     return;
   }
-  xsize = dec->metadata.oriented_xsize(dec->keep_orientation || !oriented);
-  ysize = dec->metadata.oriented_ysize(dec->keep_orientation || !oriented);
+  xsize = dec->metadata.oriented_xsize(dec->keep_orientation);
+  ysize = dec->metadata.oriented_ysize(dec->keep_orientation);
   if (!dec->coalescing) {
     const auto frame_dim = dec->frame_header->ToFrameDimensions();
     xsize = frame_dim.xsize_upsampled;
     ysize = frame_dim.ysize_upsampled;
-    if (!dec->keep_orientation && oriented &&
+    if (!dec->keep_orientation &&
         static_cast<int>(dec->metadata.m.GetOrientation()) > 4) {
       std::swap(xsize, ysize);
     }
@@ -1075,7 +1074,7 @@ JxlDecoderStatus JxlDecoderReadAllHeaders(JxlDecoder* dec) {
 
 static size_t GetStride(const JxlDecoder* dec, const JxlPixelFormat& format) {
   size_t xsize, ysize;
-  GetCurrentDimensions(dec, xsize, ysize, true);
+  GetCurrentDimensions(dec, xsize, ysize);
   size_t stride = xsize * (BitsPerChannel(format.data_type) *
                            format.num_channels / jxl::kBitsPerByte);
   if (format.align > 1) {
@@ -1464,37 +1463,15 @@ JxlDecoderStatus JxlDecoderProcessCodestream(JxlDecoder* dec) {
         }
       }
 
-      dec->frame_dec->MaybeSetUnpremultiplyAlpha(dec->unpremul_alpha);
-
-      if (dec->image_out_buffer_set && !!dec->image_out_buffer &&
-          dec->image_out_format.data_type == JXL_TYPE_UINT8 &&
-          dec->image_out_format.num_channels >= 3 &&
-          dec->extra_channel_output.empty()) {
-        bool is_rgba = dec->image_out_format.num_channels == 4;
-        dec->frame_dec->MaybeSetRGB8OutputBuffer(
-            reinterpret_cast<uint8_t*>(dec->image_out_buffer),
-            GetStride(dec, dec->image_out_format), is_rgba,
-            !dec->keep_orientation);
-      }
-
-      const bool little_endian =
-          dec->image_out_format.endianness == JXL_LITTLE_ENDIAN ||
-          (dec->image_out_format.endianness == JXL_NATIVE_ENDIAN &&
-           IsLittleEndian());
-      bool swap_endianness = little_endian != IsLittleEndian();
-
-      // TODO(lode): Support more formats than just native endian float32 for
-      // the low-memory callback path
-      if (dec->image_out_buffer_set && !!dec->image_out_init_callback &&
-          !!dec->image_out_run_callback &&
-          dec->extra_channel_output.empty()) {
-        dec->frame_dec->SetCallback(
+      if (dec->image_out_buffer_set && dec->extra_channel_output.empty()) {
+        size_t xsize, ysize;
+        GetCurrentDimensions(dec, xsize, ysize);
+        dec->frame_dec->SetImageOutput(
             PixelCallback{
                 dec->image_out_init_callback, dec->image_out_run_callback,
                 dec->image_out_destroy_callback, dec->image_out_init_opaque},
-            dec->image_out_format.num_channels, dec->unpremul_alpha,
-            !dec->keep_orientation, swap_endianness,
-            dec->image_out_format.data_type);
+            reinterpret_cast<uint8_t*>(dec->image_out_buffer), xsize, ysize,
+            dec->image_out_format, dec->unpremul_alpha, !dec->keep_orientation);
       }
 
       size_t next_num_passes_to_pause = dec->frame_dec->NextNumPassesToPause();
@@ -2465,7 +2442,7 @@ JXL_EXPORT JxlDecoderStatus JxlDecoderImageOutBufferSize(
     return JXL_API_ERROR("Number of channels is too low for color output");
   }
   size_t xsize, ysize;
-  GetCurrentDimensions(dec, xsize, ysize, true);
+  GetCurrentDimensions(dec, xsize, ysize);
   size_t row_size =
       jxl::DivCeil(xsize * format->num_channels * bits, jxl::kBitsPerByte);
   if (format->align > 1) {
@@ -2526,7 +2503,7 @@ JxlDecoderStatus JxlDecoderExtraChannelBufferSize(const JxlDecoder* dec,
   if (status != JXL_DEC_SUCCESS) return status;
 
   size_t xsize, ysize;
-  GetCurrentDimensions(dec, xsize, ysize, true);
+  GetCurrentDimensions(dec, xsize, ysize);
   size_t row_size =
       jxl::DivCeil(xsize * num_channels * bits, jxl::kBitsPerByte);
   if (format->align > 1) {
@@ -2635,7 +2612,7 @@ JxlDecoderStatus JxlDecoderGetFrameHeader(const JxlDecoder* dec,
   header->name_length = dec->frame_header->name.size();
   header->is_last = dec->frame_header->is_last;
   size_t xsize, ysize;
-  GetCurrentDimensions(dec, xsize, ysize, true);
+  GetCurrentDimensions(dec, xsize, ysize);
   header->layer_info.xsize = xsize;
   header->layer_info.ysize = ysize;
   if (!dec->coalescing && dec->frame_header->custom_size_or_origin) {

--- a/lib/jxl/decode_test.cc
+++ b/lib/jxl/decode_test.cc
@@ -170,11 +170,46 @@ void AppendTestBox(const char* type, const char* contents, size_t contents_size,
   bytes->append(contents_u, contents_u + contents_size);
 }
 
+enum PreviewMode {
+  kNoPreview,
+  kSmallPreview,
+  kBigPreview,
+  kNumPreviewModes,
+};
+
+void GeneratePreview(PreviewMode preview_mode, ImageBundle* ib) {
+  if (preview_mode == kSmallPreview) {
+    ib->ShrinkTo(ib->xsize() / 7, ib->ysize() / 7);
+  } else if (preview_mode == kBigPreview) {
+    auto upsample7 = [&](const ImageF& in, ImageF* out) {
+      for (size_t y = 0; y < out->ysize(); ++y) {
+        for (size_t x = 0; x < out->xsize(); ++x) {
+          out->Row(y)[x] = in.ConstRow(y / 7)[x / 7];
+        }
+      }
+    };
+    Image3F preview(ib->xsize() * 7, ib->ysize() * 7);
+    for (size_t c = 0; c < 3; ++c) {
+      upsample7(ib->color()->Plane(c), &preview.Plane(c));
+    }
+    std::vector<ImageF> extra_channels;
+    for (size_t i = 0; i < ib->extra_channels().size(); ++i) {
+      ImageF ec(ib->xsize() * 7, ib->ysize() * 7);
+      upsample7(ib->extra_channels()[i], &ec);
+      extra_channels.emplace_back(std::move(ec));
+    }
+    ib->RemoveColor();
+    ib->ClearExtraChannels();
+    ib->SetFromImage(std::move(preview), ib->c_current());
+    ib->SetExtraChannels(std::move(extra_channels));
+  }
+}
+
 struct TestCodestreamParams {
   CompressParams cparams;
   CodeStreamBoxFormat box_format = kCSBF_None;
   JxlOrientation orientation = JXL_ORIENT_IDENTITY;
-  bool add_preview = false;
+  PreviewMode preview_mode = kNoPreview;
   bool add_intrinsic_size = false;
   bool add_icc_profile = false;
   float intensity_target = 0.0;
@@ -250,9 +285,9 @@ PaddedBytes CreateTestJXLCodestream(Span<const uint8_t> pixels, size_t xsize,
         "unable to create reconstructible JPEG without JPEG support enabled");
 #endif  // JPEGXL_ENABLE_JPEG
   }
-  if (params.add_preview) {
+  if (params.preview_mode) {
     io.preview_frame = io.Main().Copy();
-    io.preview_frame.ShrinkTo(xsize / 7, ysize / 7);
+    GeneratePreview(params.preview_mode, &io.preview_frame);
     io.metadata.m.have_preview = true;
     EXPECT_TRUE(io.metadata.m.preview_size.Set(io.preview_frame.xsize(),
                                                io.preview_frame.ysize()));
@@ -1219,7 +1254,7 @@ struct PixelTestConfig {
   bool include_alpha;
   size_t xsize;
   size_t ysize;
-  bool add_preview;
+  jxl::PreviewMode preview_mode;
   bool add_intrinsic_size;
   // Output format.
   JxlEndianness endianness;
@@ -1262,7 +1297,7 @@ TEST_P(DecodeTestParam, PixelTest) {
   params.cparams.ec_resampling = config.upsampling;
   params.box_format = config.add_container;
   params.orientation = config.orientation;
-  params.add_preview = config.add_preview;
+  params.preview_mode = config.preview_mode;
   params.add_intrinsic_size = config.add_intrinsic_size;
   jxl::PaddedBytes compressed = jxl::CreateTestJXLCodestream(
       jxl::Span<const uint8_t>(pixels.data(), pixels.size()), config.xsize,
@@ -1360,16 +1395,16 @@ std::vector<PixelTestConfig> GeneratePixelTests() {
       {JXL_BIG_ENDIAN, JXL_TYPE_FLOAT},
   };
 
-  auto make_test = [&](ChannelInfo ch, size_t xsize, size_t ysize, bool preview,
-                       bool intrinsic_size, CodeStreamBoxFormat box,
-                       JxlOrientation orientation, bool keep_orientation,
-                       OutputFormat format, bool use_callback,
-                       bool set_buffer_early, bool resizable_runner,
-                       size_t upsampling) {
+  auto make_test = [&](ChannelInfo ch, size_t xsize, size_t ysize,
+                       jxl::PreviewMode preview_mode, bool intrinsic_size,
+                       CodeStreamBoxFormat box, JxlOrientation orientation,
+                       bool keep_orientation, OutputFormat format,
+                       bool use_callback, bool set_buffer_early,
+                       bool resizable_runner, size_t upsampling) {
     PixelTestConfig c;
     c.grayscale = ch.grayscale;
     c.include_alpha = ch.include_alpha;
-    c.add_preview = preview;
+    c.preview_mode = preview_mode;
     c.add_intrinsic_size = intrinsic_size;
     c.xsize = xsize;
     c.ysize = ysize;
@@ -1391,7 +1426,7 @@ std::vector<PixelTestConfig> GeneratePixelTests() {
     for (int use_callback = 0; use_callback <= 1; use_callback++) {
       for (size_t upsampling : {1, 2, 4, 8}) {
         for (OutputFormat fmt : out_formats) {
-          make_test(ch, 301, 33, /*add_preview=*/false,
+          make_test(ch, 301, 33, jxl::kNoPreview,
                     /*add_intrinsic_size=*/false,
                     CodeStreamBoxFormat::kCSBF_None, JXL_ORIENT_IDENTITY,
                     /*keep_orientation=*/false, fmt, use_callback,
@@ -1403,7 +1438,7 @@ std::vector<PixelTestConfig> GeneratePixelTests() {
   }
   // Test codestream formats.
   for (size_t box = 1; box < kCSBF_NUM_ENTRIES; ++box) {
-    make_test(ch_info[0], 77, 33, /*add_preview=*/false,
+    make_test(ch_info[0], 77, 33, jxl::kNoPreview,
               /*add_intrinsic_size=*/false, (CodeStreamBoxFormat)box,
               JXL_ORIENT_IDENTITY,
               /*keep_orientation=*/false, out_formats[0],
@@ -1411,9 +1446,13 @@ std::vector<PixelTestConfig> GeneratePixelTests() {
               /*set_buffer_early=*/false, /*resizable_runner=*/false, 1);
   }
   // Test previews.
-  for (int add_preview = 0; add_preview <= 1; add_preview++) {
-    make_test(ch_info[0], 77, 33, add_preview, /*add_intrinsic_size=*/false,
-              CodeStreamBoxFormat::kCSBF_None, JXL_ORIENT_IDENTITY,
+  for (int preview_mode = 0; preview_mode < jxl::kNumPreviewModes;
+       preview_mode++) {
+    // if (preview_mode == jxl::kBigPreview &&
+    //	ch_info[0].output_channels != 3) continue;
+    make_test(ch_info[0], 77, 33, (jxl::PreviewMode)preview_mode,
+              /*add_intrinsic_size=*/false, CodeStreamBoxFormat::kCSBF_None,
+              JXL_ORIENT_IDENTITY,
               /*keep_orientation=*/false, out_formats[0],
               /*use_callback=*/false, /*set_buffer_early=*/false,
               /*resizable_runner=*/false, 1);
@@ -1421,14 +1460,14 @@ std::vector<PixelTestConfig> GeneratePixelTests() {
   // Test intrinsic sizes.
   for (int add_intrinsic_size = 0; add_intrinsic_size <= 1;
        add_intrinsic_size++) {
-    make_test(ch_info[0], 55, 34, /*add_preview=*/false, add_intrinsic_size,
+    make_test(ch_info[0], 55, 34, jxl::kNoPreview, add_intrinsic_size,
               CodeStreamBoxFormat::kCSBF_None, JXL_ORIENT_IDENTITY,
               /*keep_orientation=*/false, out_formats[0],
               /*use_callback=*/false, /*set_buffer_early=*/false,
               /*resizable_runner=*/false, 1);
   }
   // Test setting buffers early.
-  make_test(ch_info[0], 300, 33, /*add_preview=*/false,
+  make_test(ch_info[0], 300, 33, jxl::kNoPreview,
             /*add_intrinsic_size=*/false, CodeStreamBoxFormat::kCSBF_None,
             JXL_ORIENT_IDENTITY,
             /*keep_orientation=*/false, out_formats[0],
@@ -1437,7 +1476,7 @@ std::vector<PixelTestConfig> GeneratePixelTests() {
 
   // Test using the resizable runner
   for (size_t i = 0; i < 4; i++) {
-    make_test(ch_info[0], 300 << i, 33 << i, /*add_preview=*/false,
+    make_test(ch_info[0], 300 << i, 33 << i, jxl::kNoPreview,
               /*add_intrinsic_size=*/false, CodeStreamBoxFormat::kCSBF_None,
               JXL_ORIENT_IDENTITY,
               /*keep_orientation=*/false, out_formats[0],
@@ -1451,7 +1490,7 @@ std::vector<PixelTestConfig> GeneratePixelTests() {
       for (int use_callback = 0; use_callback <= 1; use_callback++) {
         for (ChannelInfo ch : ch_info) {
           for (OutputFormat fmt : out_formats) {
-            make_test(ch, 280, 12, /*add_preview=*/false,
+            make_test(ch, 280, 12, jxl::kNoPreview,
                       /*add_intrinsic_size=*/false,
                       CodeStreamBoxFormat::kCSBF_None,
                       static_cast<JxlOrientation>(orientation),
@@ -1502,7 +1541,8 @@ std::ostream& operator<<(std::ostream& os, const PixelTestConfig& c) {
     os << "Box";
     os << (size_t)c.add_container;
   }
-  if (c.add_preview) os << "Preview";
+  if (c.preview_mode == jxl::kSmallPreview) os << "Preview";
+  if (c.preview_mode == jxl::kBigPreview) os << "BigPreview";
   if (c.add_intrinsic_size) os << "IntrinicSize";
   if (c.use_callback) os << "Callback";
   if (c.set_buffer_early) os << "EarlyBuffer";
@@ -2323,85 +2363,76 @@ TEST(DecodeTest, PreviewTest) {
   size_t xsize = 77, ysize = 120;
   std::vector<uint8_t> pixels = jxl::test::GetSomeTestImage(xsize, ysize, 3, 0);
 
-  jxl::TestCodestreamParams params;
-  params.add_preview = true;
-  jxl::PaddedBytes compressed = jxl::CreateTestJXLCodestream(
-      jxl::Span<const uint8_t>(pixels.data(), pixels.size()), xsize, ysize, 3,
-      params);
+  for (jxl::PreviewMode mode : {jxl::kSmallPreview, jxl::kBigPreview}) {
+    jxl::TestCodestreamParams params;
+    params.preview_mode = mode;
 
-  JxlPixelFormat format = {3, JXL_TYPE_UINT8, JXL_LITTLE_ENDIAN, 0};
+    jxl::PaddedBytes compressed = jxl::CreateTestJXLCodestream(
+        jxl::Span<const uint8_t>(pixels.data(), pixels.size()), xsize, ysize, 3,
+        params);
 
-  JxlDecoder* dec = JxlDecoderCreate(NULL);
-  const uint8_t* next_in = compressed.data();
-  size_t avail_in = compressed.size();
+    JxlPixelFormat format = {3, JXL_TYPE_UINT8, JXL_LITTLE_ENDIAN, 0};
 
-  EXPECT_EQ(JXL_DEC_SUCCESS,
-            JxlDecoderSubscribeEvents(
-                dec, JXL_DEC_BASIC_INFO | JXL_DEC_PREVIEW_IMAGE));
-  EXPECT_EQ(JXL_DEC_SUCCESS, JxlDecoderSetInput(dec, next_in, avail_in));
+    JxlDecoder* dec = JxlDecoderCreate(NULL);
+    const uint8_t* next_in = compressed.data();
+    size_t avail_in = compressed.size();
 
-  EXPECT_EQ(JXL_DEC_BASIC_INFO, JxlDecoderProcessInput(dec));
-  JxlBasicInfo info;
-  EXPECT_EQ(JXL_DEC_SUCCESS, JxlDecoderGetBasicInfo(dec, &info));
-  size_t buffer_size;
-  EXPECT_EQ(JXL_DEC_SUCCESS,
-            JxlDecoderPreviewOutBufferSize(dec, &format, &buffer_size));
+    EXPECT_EQ(JXL_DEC_SUCCESS,
+              JxlDecoderSubscribeEvents(
+                  dec, JXL_DEC_BASIC_INFO | JXL_DEC_PREVIEW_IMAGE));
+    EXPECT_EQ(JXL_DEC_SUCCESS, JxlDecoderSetInput(dec, next_in, avail_in));
 
-  // GetSomeTestImage is hardcoded to use a top-left cropped preview with
-  // floor of 1/7th of the size
-  size_t xsize_preview = (xsize / 7);
-  size_t ysize_preview = (ysize / 7);
-  EXPECT_EQ(xsize_preview, info.preview.xsize);
-  EXPECT_EQ(ysize_preview, info.preview.ysize);
-  EXPECT_EQ(xsize_preview * ysize_preview * 3, buffer_size);
+    EXPECT_EQ(JXL_DEC_BASIC_INFO, JxlDecoderProcessInput(dec));
+    JxlBasicInfo info;
+    EXPECT_EQ(JXL_DEC_SUCCESS, JxlDecoderGetBasicInfo(dec, &info));
+    size_t buffer_size;
+    EXPECT_EQ(JXL_DEC_SUCCESS,
+              JxlDecoderPreviewOutBufferSize(dec, &format, &buffer_size));
 
-  EXPECT_EQ(JXL_DEC_NEED_PREVIEW_OUT_BUFFER, JxlDecoderProcessInput(dec));
+    jxl::ColorEncoding c_srgb = jxl::ColorEncoding::SRGB(false);
+    jxl::CodecInOut io0;
+    EXPECT_TRUE(jxl::ConvertFromExternal(
+        jxl::Span<const uint8_t>(pixels.data(), pixels.size()), xsize, ysize,
+        c_srgb, 3, /*alpha_is_premultiplied=*/false, /*bits_per_sample=*/16,
+        JXL_BIG_ENDIAN, /*pool=*/nullptr, &io0.Main(),
+        /*float_in=*/false, /*align=*/0));
+    GeneratePreview(params.preview_mode, &io0.Main());
 
-  std::vector<uint8_t> preview(xsize_preview * ysize_preview * 3);
-  EXPECT_EQ(JXL_DEC_SUCCESS, JxlDecoderSetPreviewOutBuffer(
-                                 dec, &format, preview.data(), preview.size()));
+    size_t xsize_preview = io0.Main().xsize();
+    size_t ysize_preview = io0.Main().ysize();
+    EXPECT_EQ(xsize_preview, info.preview.xsize);
+    EXPECT_EQ(ysize_preview, info.preview.ysize);
+    EXPECT_EQ(xsize_preview * ysize_preview * 3, buffer_size);
 
-  EXPECT_EQ(JXL_DEC_PREVIEW_IMAGE, JxlDecoderProcessInput(dec));
+    EXPECT_EQ(JXL_DEC_NEED_PREVIEW_OUT_BUFFER, JxlDecoderProcessInput(dec));
 
-  jxl::Image3F preview0(xsize_preview, ysize_preview);
-  jxl::Image3F preview1(xsize_preview, ysize_preview);
+    std::vector<uint8_t> preview(buffer_size);
+    EXPECT_EQ(JXL_DEC_SUCCESS,
+              JxlDecoderSetPreviewOutBuffer(dec, &format, preview.data(),
+                                            preview.size()));
 
-  // For preview0, the original: top-left crop the preview image the way
-  // GetSomeTestImage does.
-  for (size_t y = 0; y < ysize_preview; y++) {
-    for (size_t x = 0; x < xsize_preview; x++) {
-      preview0.PlaneRow(0, y)[x] =
-          (1.f / 255) * (pixels[(y * xsize + x) * 6 + 0]);
-      preview0.PlaneRow(1, y)[x] =
-          (1.f / 255) * (pixels[(y * xsize + x) * 6 + 2]);
-      preview0.PlaneRow(2, y)[x] =
-          (1.f / 255) * (pixels[(y * xsize + x) * 6 + 4]);
-      preview1.PlaneRow(0, y)[x] =
-          (1.f / 255) * (preview[(y * xsize_preview + x) * 3 + 0]);
-      preview1.PlaneRow(1, y)[x] =
-          (1.f / 255) * (preview[(y * xsize_preview + x) * 3 + 1]);
-      preview1.PlaneRow(2, y)[x] =
-          (1.f / 255) * (preview[(y * xsize_preview + x) * 3 + 2]);
-    }
+    EXPECT_EQ(JXL_DEC_PREVIEW_IMAGE, JxlDecoderProcessInput(dec));
+
+    jxl::CodecInOut io1;
+    EXPECT_TRUE(jxl::ConvertFromExternal(
+        jxl::Span<const uint8_t>(preview.data(), preview.size()), xsize_preview,
+        ysize_preview, c_srgb, 3, /*alpha_is_premultiplied=*/false,
+        /*bits_per_sample=*/8, JXL_LITTLE_ENDIAN,
+        /*pool=*/nullptr, &io1.Main(), /*float_in=*/false, /*align=*/0));
+
+    jxl::ButteraugliParams ba;
+    // TODO(lode): this ButteraugliDistance silently returns 0 (dangerous for
+    // tests) if xsize or ysize is < 8, no matter how different the images, a
+    // tiny size that could happen for a preview. ButteraugliDiffmap does
+    // support smaller than 8x8, but jxl's ButteraugliDistance does not. Perhaps
+    // move butteraugli's <8x8 handling from ButteraugliDiffmap to
+    // ButteraugliComparator::Diffmap in butteraugli.cc.
+    EXPECT_LE(ButteraugliDistance(io0, io1, ba, jxl::GetJxlCms(),
+                                  /*distmap=*/nullptr, nullptr),
+              mode == jxl::kSmallPreview ? 0.7f : 1.2f);
+
+    JxlDecoderDestroy(dec);
   }
-
-  jxl::CodecInOut io0;
-  io0.SetFromImage(std::move(preview0), jxl::ColorEncoding::SRGB(false));
-  jxl::CodecInOut io1;
-  io1.SetFromImage(std::move(preview1), jxl::ColorEncoding::SRGB(false));
-
-  jxl::ButteraugliParams ba;
-  // TODO(lode): this ButteraugliDistance silently returns 0 (dangerous for
-  // tests) if xsize or ysize is < 8, no matter how different the images, a tiny
-  // size that could happen for a preview. ButteraugliDiffmap does support
-  // smaller than 8x8, but jxl's ButteraugliDistance does not. Perhaps move
-  // butteraugli's <8x8 handling from ButteraugliDiffmap to
-  // ButteraugliComparator::Diffmap in butteraugli.cc.
-  EXPECT_LE(ButteraugliDistance(io0, io1, ba, jxl::GetJxlCms(),
-                                /*distmap=*/nullptr, nullptr),
-            0.6f);
-
-  JxlDecoderDestroy(dec);
 }
 
 TEST(DecodeTest, AlignTest) {
@@ -3867,7 +3898,7 @@ TEST(DecodeTest, ProgressionTest) {
       jxl::test::GetSomeTestImage(xsize, ysize, num_channels, 0);
   jxl::TestCodestreamParams params;
   params.cparams.progressive_dc = 1;
-  params.add_preview = true;
+  params.preview_mode = jxl::kSmallPreview;
   jxl::PaddedBytes data = jxl::CreateTestJXLCodestream(
       jxl::Span<const uint8_t>(pixels.data(), pixels.size()), xsize, ysize,
       num_channels, params);
@@ -3947,7 +3978,7 @@ TEST(DecodeTest, InputHandlingTestOneShot) {
     printf("Testing with box format %d\n", i);
     jxl::TestCodestreamParams params;
     params.cparams.progressive_dc = 1;
-    params.add_preview = true;
+    params.preview_mode = jxl::kSmallPreview;
     params.box_format = (CodeStreamBoxFormat)i;
     jxl::PaddedBytes data = jxl::CreateTestJXLCodestream(
         jxl::Span<const uint8_t>(pixels.data(), pixels.size()), xsize, ysize,
@@ -4042,7 +4073,7 @@ TEST(DecodeTest, JXL_TRANSCODE_JPEG_TEST(InputHandlingTestJPEGOneshot)) {
     jxl::TestCodestreamParams params;
     params.cparams.color_transform = jxl::ColorTransform::kNone;
     params.jpeg_codestream = &jpeg_codestream;
-    params.add_preview = true;
+    params.preview_mode = jxl::kSmallPreview;
     params.box_format = (CodeStreamBoxFormat)i;
     jxl::PaddedBytes data = jxl::CreateTestJXLCodestream(
         jxl::Span<const uint8_t>(pixels.data(), pixels.size()), xsize, ysize,
@@ -4133,7 +4164,7 @@ TEST(DecodeTest, InputHandlingTestStreaming) {
     jxl::TestCodestreamParams params;
     params.cparams.progressive_dc = 1;
     params.box_format = (CodeStreamBoxFormat)i;
-    params.add_preview = true;
+    params.preview_mode = jxl::kSmallPreview;
     jxl::PaddedBytes data = jxl::CreateTestJXLCodestream(
         jxl::Span<const uint8_t>(pixels.data(), pixels.size()), xsize, ysize,
         num_channels, params);
@@ -4228,7 +4259,7 @@ TEST(DecodeTest, FlushTest) {
   std::vector<uint8_t> pixels =
       jxl::test::GetSomeTestImage(xsize, ysize, num_channels, 0);
   jxl::TestCodestreamParams params;
-  params.add_preview = true;
+  params.preview_mode = jxl::kSmallPreview;
   jxl::PaddedBytes data = jxl::CreateTestJXLCodestream(
       jxl::Span<const uint8_t>(pixels.data(), pixels.size()), xsize, ysize,
       num_channels, params);
@@ -4303,7 +4334,7 @@ TEST(DecodeTest, FlushTestImageOutCallback) {
   std::vector<uint8_t> pixels =
       jxl::test::GetSomeTestImage(xsize, ysize, num_channels, 0);
   jxl::TestCodestreamParams params;
-  params.add_preview = true;
+  params.preview_mode = jxl::kSmallPreview;
   jxl::PaddedBytes data = jxl::CreateTestJXLCodestream(
       jxl::Span<const uint8_t>(pixels.data(), pixels.size()), xsize, ysize,
       num_channels, params);
@@ -4389,7 +4420,7 @@ TEST(DecodeTest, FlushTestLossyProgressiveAlpha) {
   std::vector<uint8_t> pixels =
       jxl::test::GetSomeTestImage(xsize, ysize, num_channels, 0);
   jxl::TestCodestreamParams params;
-  params.add_preview = true;
+  params.preview_mode = jxl::kSmallPreview;
   jxl::PaddedBytes data = jxl::CreateTestJXLCodestream(
       jxl::Span<const uint8_t>(pixels.data(), pixels.size()), xsize, ysize,
       num_channels, params);
@@ -4461,7 +4492,7 @@ TEST(DecodeTest, FlushTestLossyProgressiveAlphaUpsampling) {
   jxl::TestCodestreamParams params;
   params.cparams.resampling = 2;
   params.cparams.ec_resampling = 4;
-  params.add_preview = true;
+  params.preview_mode = jxl::kSmallPreview;
   jxl::PaddedBytes data = jxl::CreateTestJXLCodestream(
       jxl::Span<const uint8_t>(pixels.data(), pixels.size()), xsize, ysize,
       num_channels, params);
@@ -4536,7 +4567,7 @@ TEST(DecodeTest, FlushTestLosslessProgressiveAlpha) {
   params.cparams.SetLossless();
   params.cparams.speed_tier = jxl::SpeedTier::kThunder;
   params.cparams.responsive = 1;
-  params.add_preview = true;
+  params.preview_mode = jxl::kSmallPreview;
   jxl::PaddedBytes data = jxl::CreateTestJXLCodestream(
       jxl::Span<const uint8_t>(pixels.data(), pixels.size()), xsize, ysize,
       num_channels, params);
@@ -4817,7 +4848,7 @@ TEST(DecodeTest, JXL_TRANSCODE_JPEG_TEST(JPEGReconstructTestCodestream)) {
   params.cparams.color_transform = jxl::ColorTransform::kNone;
   params.box_format = kCSBF_Single;
   params.jpeg_codestream = &jpeg_codestream;
-  params.add_preview = true;
+  params.preview_mode = jxl::kSmallPreview;
   jxl::PaddedBytes compressed = jxl::CreateTestJXLCodestream(
       jxl::Span<const uint8_t>(pixels.data(), pixels.size()), xsize, ysize,
       channels, params);

--- a/lib/jxl/render_pipeline/stage_write.h
+++ b/lib/jxl/render_pipeline/stage_write.h
@@ -20,18 +20,11 @@ std::unique_ptr<RenderPipelineStage> GetWriteToImageBundleStage(
 // Gets a stage to write color channels to an Image3F.
 std::unique_ptr<RenderPipelineStage> GetWriteToImage3FStage(Image3F* image);
 
-// Gets a stage to write to a uint8 buffer.
-std::unique_ptr<RenderPipelineStage> GetWriteToU8Stage(uint8_t* rgb,
-                                                       size_t stride,
-                                                       size_t height, bool rgba,
-                                                       bool has_alpha,
-                                                       size_t alpha_c);
-
-// Gets a stage to write to a pixel callback.
-std::unique_ptr<RenderPipelineStage> GetWriteToPixelCallbackStage(
-    const PixelCallback& pixel_callback, size_t width, size_t height,
-    size_t num_channels, bool has_alpha, bool unpremul_alpha, size_t alpha_c,
-    bool swap_endianness, Orientation undo_orientation, JxlDataType data_type);
+// Gets a stage to write to a pixel callback or image buffer.
+std::unique_ptr<RenderPipelineStage> GetWriteToOutputStage(
+    const PixelCallback& pixel_callback, void* buffer, size_t width,
+    size_t height, size_t stride, JxlPixelFormat format, bool has_alpha,
+    bool unpremul_alpha, size_t alpha_c, Orientation undo_orientation);
 
 }  // namespace jxl
 


### PR DESCRIPTION
This enables low memory code-path for all image buffer cases with the exception of extra channels.