### PR TITLE
Add target-bitrate mode to the xyb-jpeg encoder.

### DIFF
--- a/lib/extras/encode_jpeg.h
+++ b/lib/extras/encode_jpeg.h
@@ -16,8 +16,8 @@
 namespace jxl {
 namespace extras {
 
-Status EncodeJpeg(const ImageBundle& input, float distance, ThreadPool* pool,
-                  std::vector<uint8_t>* compressed);
+Status EncodeJpeg(const ImageBundle& input, size_t target_size, float distance,
+                  ThreadPool* pool, std::vector<uint8_t>* compressed);
 
 }  // namespace extras
 }  // namespace jxl

--- a/tools/benchmark/benchmark_args.cc
+++ b/tools/benchmark/benchmark_args.cc
@@ -129,6 +129,7 @@ Status BenchmarkArgs::AddCommandLineOptions() {
   AddDouble(&mul_output, "mul_output",
             "If nonzero, multiplies linear sRGB by this and clamps to 255",
             0.0);
+  AddFlag(&save_heatmap, "save_heatmap", "Saves the heatmap images.", true);
   AddDouble(&heatmap_good, "heatmap_good",
             "If greater than zero, use this as the good "
             "threshold for creating heatmap images.",
@@ -144,6 +145,11 @@ Status BenchmarkArgs::AddCommandLineOptions() {
           "Base64-encode the images in the HTML report rather than use "
           "external file names. May cause very large HTML data size.",
           false);
+  AddFlag(&html_report_use_decompressed, "html_report_use_decompressed",
+          "Show the compressed image as decompressed to --output_extension.",
+          true);
+  AddFlag(&html_report_add_heatmap, "html_report_add_heatmap",
+          "Add heatmaps to the image comparisons.", false);
 
   AddFlag(
       &markdown, "markdown",

--- a/tools/benchmark/benchmark_args.h
+++ b/tools/benchmark/benchmark_args.h
@@ -126,8 +126,11 @@ struct BenchmarkArgs {
   double heatmap_good;
   double heatmap_bad;
 
+  bool save_heatmap;
   bool write_html_report;
   bool html_report_self_contained;
+  bool html_report_use_decompressed;
+  bool html_report_add_heatmap;
   bool markdown;
   bool more_columns;
 


### PR DESCRIPTION
Benchmark results:
```
Encoding                   kPixels    Bytes          BPP  E MP/s  D MP/s     Max norm        pnorm       BPP*pnorm   Bugs
-------------------------------------------------------------------------------------------------------------------------
jpeg:q80                     13270  3185957    1.9206325  46.057 124.259   3.88049626   0.98219334  1.886432478371      0
jpeg:libjxl:d1.0:nr:q80      13270  3185856    1.9205716   1.553  55.073   2.05721784   0.71286332  1.369105080770      0
```

Images can be viewed at the following links:
https://storage.googleapis.com/jxl-quality/eval/61297ec/index.jpeg_q80.html 
https://storage.googleapis.com/jxl-quality/eval/61297ec/index.jpeg_libjxl_d1.0_nr_q80.html