### PR TITLE
Subsample the blue channel in XYB jpegs.

### DIFF
--- a/lib/jxl/image.cc
+++ b/lib/jxl/image.cc
@@ -175,12 +175,13 @@ Image3F PadImageMirror(const Image3F& in, const size_t xborder,
   return out;
 }
 
-void PadImageToBlockMultipleInPlace(Image3F* JXL_RESTRICT in) {
+void PadImageToBlockMultipleInPlace(Image3F* JXL_RESTRICT in,
+                                    size_t block_dim) {
   PROFILER_FUNC;
   const size_t xsize_orig = in->xsize();
   const size_t ysize_orig = in->ysize();
-  const size_t xsize = RoundUpToBlockDim(xsize_orig);
-  const size_t ysize = RoundUpToBlockDim(ysize_orig);
+  const size_t xsize = RoundUpTo(xsize_orig, block_dim);
+  const size_t ysize = RoundUpTo(ysize_orig, block_dim);
   // Expands image size to the originally-allocated size.
   in->ShrinkTo(xsize, ysize);
   for (size_t c = 0; c < 3; c++) {

--- a/lib/jxl/image_ops.h
+++ b/lib/jxl/image_ops.h
@@ -795,7 +795,8 @@ Image3F PadImageMirror(const Image3F& in, size_t xborder, size_t yborder);
 
 // Same as above, but operates in-place. Assumes that the `in` image was
 // allocated large enough.
-void PadImageToBlockMultipleInPlace(Image3F* JXL_RESTRICT in);
+void PadImageToBlockMultipleInPlace(Image3F* JXL_RESTRICT in,
+                                    size_t block_dim = kBlockDim);
 
 // Downsamples an image by a given factor.
 void DownsampleImage(Image3F* opsin, size_t factor);


### PR DESCRIPTION
Benchmark before:
```
Encoding                   kPixels    Bytes          BPP  E MP/s  D MP/s     Max norm        pnorm       BPP*pnorm   Bugs
-------------------------------------------------------------------------------------------------------------------------
jpeg:libjxl:d1.0:nr:q80      13270  3185856    1.9205716   0.836  31.438   2.05721784   0.71286332  1.369105080770      0
```

Images:
https://storage.googleapis.com/jxl-quality/eval/61297ec/index.jpeg_libjxl_d1.0_nr_q80.html

Benchmark after:
```
Encoding                   kPixels    Bytes          BPP  E MP/s  D MP/s     Max norm        pnorm       BPP*pnorm   Bugs
-------------------------------------------------------------------------------------------------------------------------
jpeg:libjxl:d1.0:nr:q80      13270  3185255    1.9202093   1.195  51.755   2.06744123   0.70402018  1.351866109571      0
```

Images:
https://storage.googleapis.com/jxl-quality/eval/1e41328/index.jpeg_libjxl_d1.0_nr_q80.html