### PR TITLE
cjxl: improve quality to distance calculation

### DIFF
--- a/tools/cjxl_main.cc
+++ b/tools/cjxl_main.cc
@@ -564,7 +564,7 @@ void SetDistanceFromFlags(JxlEncoderFrameSettings* jxl_encoder_frame_settings,
     double distance = args->quality >= 100 ? 0.0
                       : args->quality >= 30
                           ? 0.1 + (100 - args->quality) * 0.09
-                          : 6.4 + pow(2.5, (30 - args->quality) / 5.0) / 6.25;
+                          : 6.24 + pow(2.5, (30 - args->quality) / 5.0) / 6.25;
     args->distance = distance;
     distance_set = true;
   }


### PR DESCRIPTION
We change a detail in the calculation going from quality to distance: now it is continous near the value 30, corresponding to distance 6.4.