### PR TITLE
cjxl: fix check for resampling flag

### DIFF
--- a/tools/cjxl_main.cc
+++ b/tools/cjxl_main.cc
@@ -831,14 +831,14 @@ int main(int argc, char** argv) {
       process_flag("resampling", args.resampling,
                    JXL_ENC_FRAME_SETTING_RESAMPLING,
                    [](int64_t x) -> std::string {
-                     return (x == -1 || x == 1 || x == 4 || x == 8)
+                     return (x == -1 || x == 1 || x == 2 || x == 4 || x == 8)
                                 ? ""
                                 : "Valid values are {-1, 1, 2, 4, 8}.\n";
                    });
       process_flag("ec_resampling", args.ec_resampling,
                    JXL_ENC_FRAME_SETTING_EXTRA_CHANNEL_RESAMPLING,
                    [](int64_t x) -> std::string {
-                     return (x == -1 || x == 1 || x == 4 || x == 8)
+                     return (x == -1 || x == 1 || x == 2 || x == 4 || x == 8)
                                 ? ""
                                 : "Valid values are {-1, 1, 2, 4, 8}.\n";
                    });


### PR DESCRIPTION
Fixes #1755 both for --resampling and --ec_resampling.