### PR TITLE
Convert more tests to use ppf input + alpha bit depth bugfix.

### DIFF
--- a/lib/extras/enc/jxl.cc
+++ b/lib/extras/enc/jxl.cc
@@ -140,17 +140,20 @@ bool EncodeImageJXL(const JXLCompressParams& params, const PackedPixelFile& ppf,
       if (num_alpha_channels > 0) {
         JxlExtraChannelInfo extra_channel_info;
         JxlEncoderInitExtraChannelInfo(JXL_CHANNEL_ALPHA, &extra_channel_info);
-        if (JXL_ENC_SUCCESS !=
-            JxlEncoderSetExtraChannelInfo(enc, 0, &extra_channel_info)) {
-          fprintf(stderr, "JxlEncoderSetExtraChannelInfo() failed.\n");
-          return false;
-        }
+        extra_channel_info.bits_per_sample = ppf.info.alpha_bits;
+        extra_channel_info.exponent_bits_per_sample =
+            ppf.info.alpha_exponent_bits;
         if (params.premultiply != -1) {
           if (params.premultiply != 0 && params.premultiply != 1) {
             fprintf(stderr, "premultiply must be one of: -1, 0, 1.\n");
             return false;
           }
           extra_channel_info.alpha_premultiplied = params.premultiply;
+        }
+        if (JXL_ENC_SUCCESS !=
+            JxlEncoderSetExtraChannelInfo(enc, 0, &extra_channel_info)) {
+          fprintf(stderr, "JxlEncoderSetExtraChannelInfo() failed.\n");
+          return false;
         }
         // We take the extra channel blend info frame_info, but don't do
         // clamping.

--- a/lib/jxl/test_image.h
+++ b/lib/jxl/test_image.h
@@ -242,7 +242,7 @@ class TestImage {
   }
 
   TestImage& SetDimensions(size_t xsize, size_t ysize) {
-    if (xsize < ppf_.info.xsize && ysize < ppf_.info.ysize) {
+    if (xsize <= ppf_.info.xsize && ysize <= ppf_.info.ysize) {
       for (auto& frame : ppf_.frames) {
         CropLayerInfo(xsize, ysize, &frame.frame_info.layer_info);
         CropImage(xsize, ysize, &frame.color);
@@ -344,6 +344,19 @@ class TestImage {
         FillPackedImage(ppf().extra_channels_info[i].ec_info, seed + 1 + i,
                         &frame().extra_channels[i]);
       }
+    }
+
+    void SetValue(size_t y, size_t x, size_t c, float val) {
+      const extras::PackedImage& color = frame().color;
+      JxlPixelFormat format = color.format;
+      JXL_CHECK(y < ppf().info.ysize);
+      JXL_CHECK(x < ppf().info.xsize);
+      JXL_CHECK(c < format.num_channels);
+      size_t pwidth = extras::PackedImage::BitsPerChannel(format.data_type) / 8;
+      size_t idx = ((y * color.xsize + x) * format.num_channels + c) * pwidth;
+      uint8_t* pixels = reinterpret_cast<uint8_t*>(frame().color.pixels());
+      uint8_t* p = pixels + idx;
+      StoreValue(val, ppf().info, frame().color.format, &p);
     }
 
    private:


### PR DESCRIPTION
The new test framework detected a bug in cjxl where we would ignore the 16-bit alpha bit-depth and fall back to 8 bit precision.