### PR TITLE
Add jxl-roundtrip based jpeg decoder to benchmark.

### DIFF
--- a/tools/butteraugli_main.cc
+++ b/tools/butteraugli_main.cc
@@ -75,7 +75,7 @@ Status RunButteraugli(const char* pathname1, const char* pathname2,
 
   ImageF distmap;
   ButteraugliParams ba_params;
-  ba_params.hf_asymmetry = 0.8f;
+  ba_params.hf_asymmetry = 1.0f;
   ba_params.xmul = 1.0f;
   ba_params.intensity_target = intensity_target;
   const float distance = ButteraugliDistance(io1.Main(), io2.Main(), ba_params,


### PR DESCRIPTION
The hf_assymetry of the butteraugli_main tool was changed to match that of benchmark_xl.

Benchmark results:
```
Encoding           kPixels    Bytes          BPP  E MP/s  D MP/s     Max norm        pnorm       BPP*pnorm   Bugs
-----------------------------------------------------------------------------------------------------------------
jpeg:q95             13270  7112433    4.2876819  18.423  45.517   1.72006321   0.48375988  2.074208483263      0
jpeg:q95:djxl8       13270  7112433    4.2876819  17.420   2.787   1.62978482   0.45445552  1.948560710939      0
jpeg:q95:djxl16      13270  7112433    4.2876819  14.434   2.842   1.62876725   0.44648875  1.914401746589      0
```