### PR TITLE
Don't use chroma-from-luma for jxl-roundtrip jpeg decoding.

### DIFF
--- a/tools/benchmark/benchmark_codec_jpeg.cc
+++ b/tools/benchmark/benchmark_codec_jpeg.cc
@@ -127,6 +127,7 @@ class JPEGCodec : public ImageCodec {
     extras::PackedPixelFile ppf;
     if (use_jxl_decoder_) {
       extras::JXLCompressParams cparams;
+      cparams.AddOption(JXL_ENC_FRAME_SETTING_JPEG_RECON_CFL, 0);
       std::vector<uint8_t> jpeg_bytes(compressed.data(),
                                       compressed.data() + compressed.size());
       const double start = Now();


### PR DESCRIPTION
Benchmark before:
```
Encoding           kPixels    Bytes          BPP  E MP/s  D MP/s     Max norm        pnorm       BPP*pnorm   Bugs
-----------------------------------------------------------------------------------------------------------------
jpeg:q95:djxl8       13270  7112433    4.2876819  17.679   2.856   1.62978482   0.45445552  1.948560710939      0
jpeg:q95:djxl16      13270  7112433    4.2876819  16.533   2.858   1.62876725   0.44648875  1.914401746589      0
```

Benchmark after:
```
Encoding           kPixels    Bytes          BPP  E MP/s  D MP/s     Max norm        pnorm       BPP*pnorm   Bugs
-----------------------------------------------------------------------------------------------------------------
jpeg:q95:djxl8       13270  7112433    4.2876819  18.117   3.494   1.63743067   0.44661786  1.914955293952      0
jpeg:q95:djxl16      13270  7112433    4.2876819  16.691   3.185   1.61143291   0.43850905  1.880187337450      0
```