### PR TITLE
Also include version.h in the encode header file.

### DIFF
--- a/lib/include/jxl/encode.h
+++ b/lib/include/jxl/encode.h
@@ -18,6 +18,7 @@
 #include "jxl/jxl_export.h"
 #include "jxl/memory_manager.h"
 #include "jxl/parallel_runner.h"
+#include "jxl/version.h"
 
 #if defined(__cplusplus) || defined(c_plusplus)
 extern "C" {


### PR DESCRIPTION
In the PR #834 the version header file was added to `decode.h` because `decode.cc` uses these defines. Can this also be added to the `encode.h` header file since `encode.cc` also uses these defines?