### PR TITLE
Add separate data type and bit depth argument to image converter.

### DIFF
--- a/lib/extras/packed_image_convert.cc
+++ b/lib/extras/packed_image_convert.cc
@@ -58,10 +58,8 @@ Status ConvertPackedFrameToImageBundle(const JxlBasicInfo& info,
 
   JXL_RETURN_IF_ERROR(ConvertFromExternal(
       span, frame.color.xsize, frame.color.ysize, io.metadata.m.color_encoding,
-      frame.color.format.num_channels,
       /*alpha_is_premultiplied=*/info.alpha_premultiplied,
-      frame_bits_per_sample, frame.color.format.endianness, pool, bundle,
-      /*float_in=*/float_in, /*align=*/0));
+      frame_bits_per_sample, frame.color.format, pool, bundle));
 
   bundle->extra_channels().resize(io.metadata.m.extra_channel_info.size());
   for (size_t i = 0; i < frame.extra_channels.size(); i++) {

--- a/lib/jxl/decode_test.cc
+++ b/lib/jxl/decode_test.cc
@@ -259,13 +259,15 @@ PaddedBytes CreateTestJXLCodestream(Span<const uint8_t> pixels, size_t xsize,
   if (params.intensity_target != 0) {
     io.metadata.m.SetIntensityTarget(params.intensity_target);
   }
+  JxlPixelFormat format = {static_cast<uint32_t>(num_channels), JXL_TYPE_UINT16,
+                           JXL_BIG_ENDIAN, 0};
   // Make the grayscale-ness of the io metadata color_encoding and the packed
   // image match.
   io.metadata.m.color_encoding = color_encoding;
-  EXPECT_TRUE(ConvertFromExternal(
-      pixels, xsize, ysize, color_encoding, num_channels,
-      /*alpha_is_premultiplied=*/false, /*bits_per_sample=*/16, JXL_BIG_ENDIAN,
-      &pool, &io.Main(), /*float_in=*/false, /*align=*/0));
+  EXPECT_TRUE(ConvertFromExternal(pixels, xsize, ysize, color_encoding,
+                                  /*alpha_is_premultiplied=*/false,
+                                  /*bits_per_sample=*/16, format, &pool,
+                                  &io.Main()));
   jxl::PaddedBytes jpeg_data;
   if (params.jpeg_codestream != nullptr) {
 #if JPEGXL_ENABLE_JPEG
@@ -1334,11 +1336,9 @@ TEST_P(DecodeTestParam, PixelTest) {
     io.SetSize(config.xsize, config.ysize);
 
     EXPECT_TRUE(ConvertFromExternal(bytes, config.xsize, config.ysize,
-                                    color_encoding, orig_channels,
+                                    color_encoding,
                                     /*alpha_is_premultiplied=*/false, 16,
-                                    JXL_BIG_ENDIAN, nullptr, &io.Main(),
-                                    /*float_in=*/false,
-                                    /*align=*/0));
+                                    format_orig, nullptr, &io.Main()));
 
     for (size_t i = 0; i < pixels.size(); i++) pixels[i] = 0;
     EXPECT_TRUE(ConvertToExternal(
@@ -1662,12 +1662,10 @@ TEST(DecodeTest, PixelTestWithICCProfileLossy) {
   jxl::Span<const uint8_t> span0(pixels.data(), pixels.size());
   jxl::CodecInOut io0;
   io0.SetSize(xsize, ysize);
-  EXPECT_TRUE(
-      ConvertFromExternal(span0, xsize, ysize, color_encoding0, /*channels=*/3,
-                          /*alpha_is_premultiplied=*/false,
-                          /*bits_per_sample=*/16, format_orig.endianness,
-                          /*pool=*/nullptr, &io0.Main(), /*float_in=*/false,
-                          /*align=*/0));
+  EXPECT_TRUE(ConvertFromExternal(span0, xsize, ysize, color_encoding0,
+                                  /*alpha_is_premultiplied=*/false,
+                                  /*bits_per_sample=*/16, format_orig,
+                                  /*pool=*/nullptr, &io0.Main()));
 
   jxl::ColorEncoding color_encoding1;
   EXPECT_TRUE(color_encoding1.SetICC(std::move(icc)));
@@ -1675,10 +1673,9 @@ TEST(DecodeTest, PixelTestWithICCProfileLossy) {
   jxl::CodecInOut io1;
   io1.SetSize(xsize, ysize);
   EXPECT_TRUE(ConvertFromExternal(span1, xsize, ysize, color_encoding1,
-                                  channels, /*alpha_is_premultiplied=*/false,
-                                  /*bits_per_sample=*/32, format.endianness,
-                                  /*pool=*/nullptr, &io1.Main(),
-                                  /*float_in=*/true, /*align=*/0));
+                                  /*alpha_is_premultiplied=*/false,
+                                  /*bits_per_sample=*/32, format,
+                                  /*pool=*/nullptr, &io1.Main()));
 
   jxl::ButteraugliParams ba;
   EXPECT_THAT(ButteraugliDistance(io0, io1, ba, jxl::GetJxlCms(),
@@ -1720,21 +1717,25 @@ double ButteraugliDistance(size_t xsize, size_t ysize,
   jxl::CodecInOut in;
   in.metadata.m.color_encoding = color_in;
   in.metadata.m.SetIntensityTarget(intensity_in);
+  JxlPixelFormat format_in = {static_cast<uint32_t>(color_in.Channels()),
+                              JXL_TYPE_UINT16, JXL_BIG_ENDIAN, 0};
   EXPECT_TRUE(jxl::ConvertFromExternal(
       jxl::Span<const uint8_t>(pixels_in.data(), pixels_in.size()), xsize,
-      ysize, color_in, color_in.Channels(),
+      ysize, color_in,
       /*alpha_is_premultiplied=*/false,
-      /*bits_per_sample=*/16, JXL_BIG_ENDIAN,
-      /*pool=*/nullptr, &in.Main(), /*float_in=*/false, /*align=*/0));
+      /*bits_per_sample=*/16, format_in,
+      /*pool=*/nullptr, &in.Main()));
   jxl::CodecInOut out;
   out.metadata.m.color_encoding = color_out;
   out.metadata.m.SetIntensityTarget(intensity_out);
+  JxlPixelFormat format_out = {static_cast<uint32_t>(color_out.Channels()),
+                               JXL_TYPE_UINT16, JXL_BIG_ENDIAN, 0};
   EXPECT_TRUE(jxl::ConvertFromExternal(
       jxl::Span<const uint8_t>(pixels_out.data(), pixels_out.size()), xsize,
-      ysize, color_out, color_out.Channels(),
+      ysize, color_out,
       /*alpha_is_premultiplied=*/false,
-      /*bits_per_sample=*/16, JXL_BIG_ENDIAN,
-      /*pool=*/nullptr, &out.Main(), /*float_in=*/false, /*align=*/0));
+      /*bits_per_sample=*/16, format_out,
+      /*pool=*/nullptr, &out.Main()));
   return ButteraugliDistance(in, out, jxl::ButteraugliParams(),
                              jxl::GetJxlCms(), nullptr, nullptr);
 }
@@ -1924,22 +1925,18 @@ TEST(DecodeTest, PixelTestOpaqueSrgbLossy) {
     jxl::Span<const uint8_t> span0(pixels.data(), pixels.size());
     jxl::CodecInOut io0;
     io0.SetSize(xsize, ysize);
-    EXPECT_TRUE(ConvertFromExternal(
-        span0, xsize, ysize, color_encoding0, /*channels=*/3,
-        /*alpha_is_premultiplied=*/false, /*bits_per_sample=*/16,
-        format_orig.endianness,
-        /*pool=*/nullptr, &io0.Main(), /*float_in=*/false,
-        /*align=*/0));
+    EXPECT_TRUE(ConvertFromExternal(span0, xsize, ysize, color_encoding0,
+                                    /*alpha_is_premultiplied=*/false,
+                                    /*bits_per_sample=*/16, format_orig,
+                                    /*pool=*/nullptr, &io0.Main()));
 
     jxl::ColorEncoding color_encoding1 = jxl::ColorEncoding::SRGB(false);
     jxl::Span<const uint8_t> span1(pixels2.data(), pixels2.size());
     jxl::CodecInOut io1;
     EXPECT_TRUE(ConvertFromExternal(span1, xsize, ysize, color_encoding1,
-                                    channels, /*alpha_is_premultiplied=*/false,
-                                    /*bits_per_sample=*/8, format.endianness,
-                                    /*pool=*/nullptr, &io1.Main(),
-                                    /*float_in=*/false,
-                                    /*align=*/0));
+                                    /*alpha_is_premultiplied=*/false,
+                                    /*bits_per_sample=*/8, format,
+                                    /*pool=*/nullptr, &io1.Main()));
 
     jxl::ButteraugliParams ba;
     EXPECT_THAT(ButteraugliDistance(io0, io1, ba, jxl::GetJxlCms(),
@@ -1980,22 +1977,18 @@ TEST(DecodeTest, PixelTestOpaqueSrgbLossyNoise) {
     jxl::Span<const uint8_t> span0(pixels.data(), pixels.size());
     jxl::CodecInOut io0;
     io0.SetSize(xsize, ysize);
-    EXPECT_TRUE(ConvertFromExternal(
-        span0, xsize, ysize, color_encoding0, /*channels=*/3,
-        /*alpha_is_premultiplied=*/false, /*bits_per_sample=*/16,
-        format_orig.endianness,
-        /*pool=*/nullptr, &io0.Main(), /*float_in=*/false,
-        /*align=*/0));
+    EXPECT_TRUE(ConvertFromExternal(span0, xsize, ysize, color_encoding0,
+                                    /*alpha_is_premultiplied=*/false,
+                                    /*bits_per_sample=*/16, format_orig,
+                                    /*pool=*/nullptr, &io0.Main()));
 
     jxl::ColorEncoding color_encoding1 = jxl::ColorEncoding::SRGB(false);
     jxl::Span<const uint8_t> span1(pixels2.data(), pixels2.size());
     jxl::CodecInOut io1;
     EXPECT_TRUE(ConvertFromExternal(span1, xsize, ysize, color_encoding1,
-                                    channels, /*alpha_is_premultiplied=*/false,
-                                    /*bits_per_sample=*/8, format.endianness,
-                                    /*pool=*/nullptr, &io1.Main(),
-                                    /*float_in=*/false,
-                                    /*align=*/0));
+                                    /*alpha_is_premultiplied=*/false,
+                                    /*bits_per_sample=*/8, format,
+                                    /*pool=*/nullptr, &io1.Main()));
 
     jxl::ButteraugliParams ba;
     EXPECT_THAT(ButteraugliDistance(io0, io1, ba, jxl::GetJxlCms(),
@@ -2360,7 +2353,7 @@ TEST(DecodeTest, DCNotGettableTest) {
 TEST(DecodeTest, PreviewTest) {
   size_t xsize = 77, ysize = 120;
   std::vector<uint8_t> pixels = jxl::test::GetSomeTestImage(xsize, ysize, 3, 0);
-
+  JxlPixelFormat format_orig = {3, JXL_TYPE_UINT16, JXL_BIG_ENDIAN, 0};
   for (jxl::PreviewMode mode : {jxl::kSmallPreview, jxl::kBigPreview}) {
     jxl::TestCodestreamParams params;
     params.preview_mode = mode;
@@ -2391,9 +2384,8 @@ TEST(DecodeTest, PreviewTest) {
     jxl::CodecInOut io0;
     EXPECT_TRUE(jxl::ConvertFromExternal(
         jxl::Span<const uint8_t>(pixels.data(), pixels.size()), xsize, ysize,
-        c_srgb, 3, /*alpha_is_premultiplied=*/false, /*bits_per_sample=*/16,
-        JXL_BIG_ENDIAN, /*pool=*/nullptr, &io0.Main(),
-        /*float_in=*/false, /*align=*/0));
+        c_srgb, /*alpha_is_premultiplied=*/false, /*bits_per_sample=*/16,
+        format_orig, /*pool=*/nullptr, &io0.Main()));
     GeneratePreview(params.preview_mode, &io0.Main());
 
     size_t xsize_preview = io0.Main().xsize();
@@ -2414,9 +2406,9 @@ TEST(DecodeTest, PreviewTest) {
     jxl::CodecInOut io1;
     EXPECT_TRUE(jxl::ConvertFromExternal(
         jxl::Span<const uint8_t>(preview.data(), preview.size()), xsize_preview,
-        ysize_preview, c_srgb, 3, /*alpha_is_premultiplied=*/false,
-        /*bits_per_sample=*/8, JXL_LITTLE_ENDIAN,
-        /*pool=*/nullptr, &io1.Main(), /*float_in=*/false, /*align=*/0));
+        ysize_preview, c_srgb, /*alpha_is_premultiplied=*/false,
+        /*bits_per_sample=*/8, format,
+        /*pool=*/nullptr, &io1.Main()));
 
     jxl::ButteraugliParams ba;
     // TODO(lode): this ButteraugliDistance silently returns 0 (dangerous for
@@ -2490,10 +2482,9 @@ TEST(DecodeTest, AnimationTest) {
 
     EXPECT_TRUE(ConvertFromExternal(
         jxl::Span<const uint8_t>(frames[i].data(), frames[i].size()), xsize,
-        ysize, jxl::ColorEncoding::SRGB(/*is_gray=*/false), /*channels=*/3,
-        /*alpha_is_premultiplied=*/false, /*bits_per_sample=*/16,
-        JXL_BIG_ENDIAN, /*pool=*/nullptr, &bundle,
-        /*float_in=*/false, /*align=*/0));
+        ysize, jxl::ColorEncoding::SRGB(/*is_gray=*/false),
+        /*alpha_is_premultiplied=*/false, /*bits_per_sample=*/16, format,
+        /*pool=*/nullptr, &bundle));
     bundle.duration = frame_durations[i];
     io.frames.push_back(std::move(bundle));
   }
@@ -2594,10 +2585,9 @@ TEST(DecodeTest, AnimationTestStreaming) {
 
     EXPECT_TRUE(ConvertFromExternal(
         jxl::Span<const uint8_t>(frames[i].data(), frames[i].size()), xsize,
-        ysize, jxl::ColorEncoding::SRGB(/*is_gray=*/false), /*channels=*/3,
-        /*alpha_is_premultiplied=*/false, /*bits_per_sample=*/16,
-        JXL_BIG_ENDIAN, /*pool=*/nullptr, &bundle,
-        /*float_in=*/false, /*align=*/0));
+        ysize, jxl::ColorEncoding::SRGB(/*is_gray=*/false),
+        /*alpha_is_premultiplied=*/false, /*bits_per_sample=*/16, format,
+        /*pool=*/nullptr, &bundle));
     bundle.duration = frame_durations[i];
     io.frames.push_back(std::move(bundle));
   }
@@ -2813,10 +2803,9 @@ TEST(DecodeTest, SkipCurrentFrameTest) {
 
     EXPECT_TRUE(ConvertFromExternal(
         jxl::Span<const uint8_t>(frames[i].data(), frames[i].size()), xsize,
-        ysize, jxl::ColorEncoding::SRGB(/*is_gray=*/false), /*channels=*/3,
-        /*alpha_is_premultiplied=*/false, /*bits_per_sample=*/16,
-        JXL_BIG_ENDIAN, /*pool=*/nullptr, &bundle,
-        /*float_in=*/false, /*align=*/0));
+        ysize, jxl::ColorEncoding::SRGB(/*is_gray=*/false),
+        /*alpha_is_premultiplied=*/false, /*bits_per_sample=*/16, format,
+        /*pool=*/nullptr, &bundle));
     bundle.duration = frame_durations[i];
     io.frames.push_back(std::move(bundle));
   }
@@ -2928,10 +2917,9 @@ TEST(DecodeTest, SkipFrameTest) {
 
     EXPECT_TRUE(ConvertFromExternal(
         jxl::Span<const uint8_t>(frames[i].data(), frames[i].size()), xsize,
-        ysize, jxl::ColorEncoding::SRGB(/*is_gray=*/false), /*channels=*/3,
-        /*alpha_is_premultiplied=*/false, /*bits_per_sample=*/16,
-        JXL_BIG_ENDIAN, /*pool=*/nullptr, &bundle,
-        /*float_in=*/false, /*align=*/0));
+        ysize, jxl::ColorEncoding::SRGB(/*is_gray=*/false),
+        /*alpha_is_premultiplied=*/false, /*bits_per_sample=*/16, format,
+        /*pool=*/nullptr, &bundle));
     bundle.duration = frame_durations[i];
     io.frames.push_back(std::move(bundle));
   }
@@ -3065,10 +3053,8 @@ TEST(DecodeTest, SkipFrameWithBlendingTest) {
           jxl::Span<const uint8_t>(frame_internal.data(),
                                    frame_internal.size()),
           xsize, ysize, jxl::ColorEncoding::SRGB(/*is_gray=*/false),
-          /*channels=*/3,
-          /*alpha_is_premultiplied=*/false, /*bits_per_sample=*/16,
-          JXL_BIG_ENDIAN, /*pool=*/nullptr, &bundle_internal,
-          /*float_in=*/false, /*align=*/0));
+          /*alpha_is_premultiplied=*/false, /*bits_per_sample=*/16, format,
+          /*pool=*/nullptr, &bundle_internal));
       bundle_internal.duration = 0;
       bundle_internal.use_for_next_frame = true;
       io.frames.push_back(std::move(bundle_internal));
@@ -3081,10 +3067,9 @@ TEST(DecodeTest, SkipFrameWithBlendingTest) {
     jxl::ImageBundle bundle(&io.metadata.m);
     EXPECT_TRUE(ConvertFromExternal(
         jxl::Span<const uint8_t>(frame.data(), frame.size()), xsize, ysize,
-        jxl::ColorEncoding::SRGB(/*is_gray=*/false), /*channels=*/3,
-        /*alpha_is_premultiplied=*/false, /*bits_per_sample=*/16,
-        JXL_BIG_ENDIAN, /*pool=*/nullptr, &bundle,
-        /*float_in=*/false, /*align=*/0));
+        jxl::ColorEncoding::SRGB(/*is_gray=*/false),
+        /*alpha_is_premultiplied=*/false, /*bits_per_sample=*/16, format,
+        /*pool=*/nullptr, &bundle));
     bundle.duration = frame_durations[i];
     // Create some variation in which frames depend on which.
     if (i != 3 && i != 9 && i != 10) {
@@ -3292,10 +3277,8 @@ TEST(DecodeTest, SkipFrameWithAlphaBlendingTest) {
           jxl::Span<const uint8_t>(frame_internal.data(),
                                    frame_internal.size()),
           xsize / 2, ysize / 2, jxl::ColorEncoding::SRGB(/*is_gray=*/false),
-          /*channels=*/4,
-          /*alpha_is_premultiplied=*/false, /*bits_per_sample=*/16,
-          JXL_BIG_ENDIAN, /*pool=*/nullptr, &bundle_internal,
-          /*float_in=*/false, /*align=*/0));
+          /*alpha_is_premultiplied=*/false, /*bits_per_sample=*/16, format,
+          /*pool=*/nullptr, &bundle_internal));
       bundle_internal.duration = 0;
       bundle_internal.use_for_next_frame = true;
       bundle_internal.origin = {13, 17};
@@ -3313,10 +3296,9 @@ TEST(DecodeTest, SkipFrameWithAlphaBlendingTest) {
     jxl::ImageBundle bundle(&io.metadata.m);
     EXPECT_TRUE(ConvertFromExternal(
         jxl::Span<const uint8_t>(frame.data(), frame.size()), cropxsize,
-        cropysize, jxl::ColorEncoding::SRGB(/*is_gray=*/false), /*channels=*/4,
-        /*alpha_is_premultiplied=*/false, /*bits_per_sample=*/16,
-        JXL_BIG_ENDIAN, /*pool=*/nullptr, &bundle,
-        /*float_in=*/false, /*align=*/0));
+        cropysize, jxl::ColorEncoding::SRGB(/*is_gray=*/false),
+        /*alpha_is_premultiplied=*/false, /*bits_per_sample=*/16, format,
+        /*pool=*/nullptr, &bundle));
     bundle.duration = 5 + i;
     frame_durations_nc.push_back(5 + i);
     frame_durations_c.push_back(5 + i);
@@ -3577,10 +3559,8 @@ TEST(DecodeTest, OrientedCroppedFrameTest) {
       EXPECT_TRUE(ConvertFromExternal(
           jxl::Span<const uint8_t>(frame.data(), frame.size()), cropxsize,
           cropysize, jxl::ColorEncoding::SRGB(/*is_gray=*/false),
-          /*channels=*/4,
-          /*alpha_is_premultiplied=*/false, /*bits_per_sample=*/16,
-          JXL_BIG_ENDIAN, /*pool=*/nullptr, &bundle,
-          /*float_in=*/false, /*align=*/0));
+          /*alpha_is_premultiplied=*/false, /*bits_per_sample=*/16, format,
+          /*pool=*/nullptr, &bundle));
       bundle.origin = {cropx0, cropy0};
       bundle.use_for_next_frame = true;
       io.frames.push_back(std::move(bundle));
@@ -4657,14 +4637,15 @@ TEST_P(DecodeProgressiveTest, ProgressiveEventTest) {
     }
     std::vector<uint8_t> pixels =
         jxl::test::GetSomeTestImage(xsize, ysize, num_channels, 0);
+    JxlPixelFormat format = {num_channels, JXL_TYPE_UINT16, JXL_BIG_ENDIAN, 0};
     jxl::ColorEncoding color_encoding = jxl::ColorEncoding::SRGB(false);
     jxl::CodecInOut io;
     EXPECT_TRUE(jxl::ConvertFromExternal(
         jxl::Span<const uint8_t>(pixels.data(), pixels.size()), xsize, ysize,
-        color_encoding, num_channels,
+        color_encoding,
         /*alpha_is_premultiplied=*/false,
-        /*bits_per_sample=*/16, JXL_BIG_ENDIAN,
-        /*pool=*/nullptr, &io.Main(), /*float_in=*/false, /*align=*/0));
+        /*bits_per_sample=*/16, format,
+        /*pool=*/nullptr, &io.Main()));
     jxl::TestCodestreamParams params;
     if (lossless) {
       params.cparams.SetLossless();
@@ -4679,7 +4660,6 @@ TEST_P(DecodeProgressiveTest, ProgressiveEventTest) {
     jxl::PaddedBytes data = jxl::CreateTestJXLCodestream(
         jxl::Span<const uint8_t>(pixels.data(), pixels.size()), xsize, ysize,
         num_channels, params);
-    JxlPixelFormat format = {num_channels, JXL_TYPE_UINT16, JXL_BIG_ENDIAN, 0};
 
     for (size_t increment : {(size_t)1, data.size()}) {
       printf(
@@ -4780,11 +4760,9 @@ TEST_P(DecodeProgressiveTest, ProgressiveEventTest) {
         jxl::CodecInOut io1;
         EXPECT_TRUE(jxl::ConvertFromExternal(
             jxl::Span<const uint8_t>(passes[p].data(), passes[p].size()), xsize,
-            ysize, color_encoding, num_channels,
-            /*alpha_is_premultiplied=*/false, /*bits_per_sample=*/16,
-            JXL_BIG_ENDIAN,
-            /*pool=*/nullptr, &io1.Main(), /*float_in=*/false,
-            /*align=*/0));
+            ysize, color_encoding,
+            /*alpha_is_premultiplied=*/false, /*bits_per_sample=*/16, format,
+            /*pool=*/nullptr, &io1.Main()));
         distances[p] = ButteraugliDistance(io, io1, ba, jxl::GetJxlCms(),
                                            nullptr, nullptr);
         if (p == kNumPasses) break;

--- a/lib/jxl/enc_external_image.cc
+++ b/lib/jxl/enc_external_image.cc
@@ -107,19 +107,30 @@ Status PixelFormatToExternal(const JxlPixelFormat& pixel_format,
 
 Status ConvertFromExternal(Span<const uint8_t> bytes, size_t xsize,
                            size_t ysize, size_t bits_per_sample,
-                           JxlEndianness endianness, ThreadPool* pool,
-                           ImageF* channel, bool float_in, size_t align) {
-  // TODO(firsching): Avoid code duplication with the function below.
+                           JxlPixelFormat format, size_t c, ThreadPool* pool,
+                           ImageF* channel) {
+  size_t format_bitdepth;
+  bool float_in;
+  JXL_RETURN_IF_ERROR(
+      PixelFormatToExternal(format, &format_bitdepth, &float_in));
+  size_t bytes_per_channel = format_bitdepth / kBitsPerByte;
+  size_t bytes_per_pixel = format.num_channels * bytes_per_channel;
+  size_t pixel_offset = c * bytes_per_channel;
+
   JXL_CHECK(float_in ? bits_per_sample == 16 || bits_per_sample == 32
                      : bits_per_sample > 0 && bits_per_sample <= 16);
-  const size_t bytes_per_pixel = DivCeil(bits_per_sample, jxl::kBitsPerByte);
   const size_t last_row_size = xsize * bytes_per_pixel;
+  const size_t align = format.align;
   const size_t row_size =
       (align > 1 ? jxl::DivCeil(last_row_size, align) * align : last_row_size);
   const size_t bytes_to_read = row_size * (ysize - 1) + last_row_size;
   if (xsize == 0 || ysize == 0) return JXL_FAILURE("Empty image");
   if (bytes.size() < bytes_to_read) {
-    return JXL_FAILURE("Buffer size is too small");
+    return JXL_FAILURE("Buffer size is too small, expected: %" PRIuS
+                       " got: %" PRIuS " (Image: %" PRIuS "x%" PRIuS
+                       "x%u, bitdepth: %" PRIuS ")",
+                       bytes_to_read, bytes.size(), xsize, ysize,
+                       format.num_channels, format_bitdepth);
   }
   JXL_ASSERT(channel->xsize() == xsize);
   JXL_ASSERT(channel->ysize() == ysize);
@@ -130,8 +141,8 @@ Status ConvertFromExternal(Span<const uint8_t> bytes, size_t xsize,
   }
 
   const bool little_endian =
-      endianness == JXL_LITTLE_ENDIAN ||
-      (endianness == JXL_NATIVE_ENDIAN && IsLittleEndian());
+      format.endianness == JXL_LITTLE_ENDIAN ||
+      (format.endianness == JXL_NATIVE_ENDIAN && IsLittleEndian());
 
   const uint8_t* const in = bytes.data();
   if (float_in) {
@@ -139,7 +150,7 @@ Status ConvertFromExternal(Span<const uint8_t> bytes, size_t xsize,
         pool, 0, static_cast<uint32_t>(ysize), ThreadPool::NoInit,
         [&](const uint32_t task, size_t /*thread*/) {
           const size_t y = task;
-          size_t i = row_size * task;
+          size_t i = row_size * task + pixel_offset;
           float* JXL_RESTRICT row_out = channel->Row(y);
           if (bits_per_sample == 16) {
             if (little_endian) {
@@ -174,7 +185,7 @@ Status ConvertFromExternal(Span<const uint8_t> bytes, size_t xsize,
         pool, 0, static_cast<uint32_t>(ysize), ThreadPool::NoInit,
         [&](const uint32_t task, size_t /*thread*/) {
           const size_t y = task;
-          size_t i = row_size * task;
+          size_t i = row_size * task + pixel_offset;
           float* JXL_RESTRICT row_out = channel->Row(y);
           if (bits_per_sample <= 8) {
             LoadFloatRow<Load8>(row_out, in + i, mul, xsize, bytes_per_pixel);
@@ -195,187 +206,39 @@ Status ConvertFromExternal(Span<const uint8_t> bytes, size_t xsize,
 }
 Status ConvertFromExternal(Span<const uint8_t> bytes, size_t xsize,
                            size_t ysize, const ColorEncoding& c_current,
-                           size_t channels, bool alpha_is_premultiplied,
-                           size_t bits_per_sample, JxlEndianness endianness,
-                           ThreadPool* pool, ImageBundle* ib, bool float_in,
-                           size_t align) {
-  JXL_CHECK(float_in ? bits_per_sample == 16 || bits_per_sample == 32
-                     : bits_per_sample > 0 && bits_per_sample <= 16);
-
+                           bool alpha_is_premultiplied, size_t bits_per_sample,
+                           JxlPixelFormat format, ThreadPool* pool,
+                           ImageBundle* ib) {
   const size_t color_channels = c_current.Channels();
-  bool has_alpha = channels == 2 || channels == 4;
-  if (channels < color_channels) {
+  bool has_alpha = format.num_channels == 2 || format.num_channels == 4;
+  if (format.num_channels < color_channels) {
     return JXL_FAILURE("Expected %" PRIuS
-                       " color channels, received only %" PRIuS " channels",
-                       color_channels, channels);
+                       " color channels, received only %u channels",
+                       color_channels, format.num_channels);
   }
-
-  const size_t bytes_per_channel = DivCeil(bits_per_sample, jxl::kBitsPerByte);
-  const size_t bytes_per_pixel = channels * bytes_per_channel;
   if (bits_per_sample > 16 && bits_per_sample < 32) {
     return JXL_FAILURE("not supported, try bits_per_sample=32");
   }
 
-  const size_t last_row_size = xsize * bytes_per_pixel;
-  const size_t row_size =
-      (align > 1 ? jxl::DivCeil(last_row_size, align) * align : last_row_size);
-  const size_t bytes_to_read = row_size * (ysize - 1) + last_row_size;
-  if (xsize == 0 || ysize == 0) return JXL_FAILURE("Empty image");
-  if (bytes.size() < bytes_to_read) {
-    return JXL_FAILURE(
-        "Buffer size is too small: expected at least %" PRIuS
-        " bytes (= %" PRIuS " * %" PRIuS " * %" PRIuS "), got %" PRIuS " bytes",
-        bytes_to_read, xsize, ysize, bytes_per_pixel, bytes.size());
-  }
-  // Too large buffer is likely an application bug, so also fail for that.
-  // Do allow padding to stride in last row though.
-  if (bytes.size() > row_size * ysize) {
-    return JXL_FAILURE(
-        "Buffer size is too large: expected at most %" PRIuS " bytes (= %" PRIuS
-        " * %" PRIuS " * %" PRIuS "), got %" PRIuS " bytes",
-        row_size * ysize, xsize, ysize, bytes_per_pixel, bytes.size());
-  }
-  const bool little_endian =
-      endianness == JXL_LITTLE_ENDIAN ||
-      (endianness == JXL_NATIVE_ENDIAN && IsLittleEndian());
-
-  const uint8_t* const in = bytes.data();
-
   Image3F color(xsize, ysize);
-
-  if (float_in) {
-    for (size_t c = 0; c < color_channels; ++c) {
-      JXL_RETURN_IF_ERROR(RunOnPool(
-          pool, 0, static_cast<uint32_t>(ysize), ThreadPool::NoInit,
-          [&](const uint32_t task, size_t /*thread*/) {
-            const size_t y = task;
-            size_t i =
-                row_size * task + (c * bits_per_sample / jxl::kBitsPerByte);
-            float* JXL_RESTRICT row_out = color.PlaneRow(c, y);
-            if (bits_per_sample == 16) {
-              if (little_endian) {
-                for (size_t x = 0; x < xsize; ++x) {
-                  row_out[x] = LoadLEFloat16(in + i);
-                  i += bytes_per_pixel;
-                }
-              } else {
-                for (size_t x = 0; x < xsize; ++x) {
-                  row_out[x] = LoadBEFloat16(in + i);
-                  i += bytes_per_pixel;
-                }
-              }
-            } else {
-              if (little_endian) {
-                for (size_t x = 0; x < xsize; ++x) {
-                  row_out[x] = LoadLEFloat(in + i);
-                  i += bytes_per_pixel;
-                }
-              } else {
-                for (size_t x = 0; x < xsize; ++x) {
-                  row_out[x] = LoadBEFloat(in + i);
-                  i += bytes_per_pixel;
-                }
-              }
-            }
-          },
-          "ConvertRGBFloat"));
-    }
-  } else {
-    // Multiplier to convert from the integer range to floating point 0-1 range.
-    float mul = 1. / ((1ull << bits_per_sample) - 1);
-    for (size_t c = 0; c < color_channels; ++c) {
-      JXL_RETURN_IF_ERROR(RunOnPool(
-          pool, 0, static_cast<uint32_t>(ysize), ThreadPool::NoInit,
-          [&](const uint32_t task, size_t /*thread*/) {
-            const size_t y = task;
-            size_t i = row_size * task + c * bytes_per_channel;
-            float* JXL_RESTRICT row_out = color.PlaneRow(c, y);
-            if (bits_per_sample <= 8) {
-              LoadFloatRow<Load8>(row_out, in + i, mul, xsize, bytes_per_pixel);
-            } else {
-              if (little_endian) {
-                LoadFloatRow<LoadLE16>(row_out, in + i, mul, xsize,
-                                       bytes_per_pixel);
-              } else {
-                LoadFloatRow<LoadBE16>(row_out, in + i, mul, xsize,
-                                       bytes_per_pixel);
-              }
-            }
-          },
-          "ConvertRGBUint"));
-    }
+  for (size_t c = 0; c < color_channels; ++c) {
+    JXL_RETURN_IF_ERROR(ConvertFromExternal(bytes, xsize, ysize,
+                                            bits_per_sample, format, c, pool,
+                                            &color.Plane(c)));
   }
-
   if (color_channels == 1) {
     CopyImageTo(color.Plane(0), &color.Plane(1));
     CopyImageTo(color.Plane(0), &color.Plane(2));
   }
-
   ib->SetFromImage(std::move(color), c_current);
 
   // Passing an interleaved image with an alpha channel to an image that doesn't
   // have alpha channel just discards the passed alpha channel.
   if (has_alpha && ib->HasAlpha()) {
     ImageF alpha(xsize, ysize);
-
-    if (float_in) {
-      JXL_RETURN_IF_ERROR(RunOnPool(
-          pool, 0, static_cast<uint32_t>(ysize), ThreadPool::NoInit,
-          [&](const uint32_t task, size_t /*thread*/) {
-            const size_t y = task;
-            size_t i = row_size * task +
-                       ((channels - 1) * bits_per_sample / jxl::kBitsPerByte);
-            float* JXL_RESTRICT row_out = alpha.Row(y);
-            if (bits_per_sample == 16) {
-              if (little_endian) {
-                for (size_t x = 0; x < xsize; ++x) {
-                  row_out[x] = LoadLEFloat16(in + i);
-                  i += bytes_per_pixel;
-                }
-              } else {
-                for (size_t x = 0; x < xsize; ++x) {
-                  row_out[x] = LoadBEFloat16(in + i);
-                  i += bytes_per_pixel;
-                }
-              }
-            } else {
-              if (little_endian) {
-                for (size_t x = 0; x < xsize; ++x) {
-                  row_out[x] = LoadLEFloat(in + i);
-                  i += bytes_per_pixel;
-                }
-              } else {
-                for (size_t x = 0; x < xsize; ++x) {
-                  row_out[x] = LoadBEFloat(in + i);
-                  i += bytes_per_pixel;
-                }
-              }
-            }
-          },
-          "ConvertAlphaFloat"));
-    } else {
-      float mul = 1. / ((1ull << bits_per_sample) - 1);
-      JXL_RETURN_IF_ERROR(RunOnPool(
-          pool, 0, static_cast<uint32_t>(ysize), ThreadPool::NoInit,
-          [&](const uint32_t task, size_t /*thread*/) {
-            const size_t y = task;
-            size_t i = row_size * task + (channels - 1) * bytes_per_channel;
-            float* JXL_RESTRICT row_out = alpha.Row(y);
-            if (bits_per_sample <= 8) {
-              LoadFloatRow<Load8>(row_out, in + i, mul, xsize, bytes_per_pixel);
-            } else {
-              if (little_endian) {
-                LoadFloatRow<LoadLE16>(row_out, in + i, mul, xsize,
-                                       bytes_per_pixel);
-              } else {
-                LoadFloatRow<LoadBE16>(row_out, in + i, mul, xsize,
-                                       bytes_per_pixel);
-              }
-            }
-          },
-          "ConvertAlphaUint"));
-    }
-
+    JXL_RETURN_IF_ERROR(
+        ConvertFromExternal(bytes, xsize, ysize, bits_per_sample, format,
+                            format.num_channels - 1, pool, &alpha));
     ib->SetAlpha(std::move(alpha), alpha_is_premultiplied);
   } else if (!has_alpha && ib->HasAlpha()) {
     // if alpha is not passed, but it is expected, then assume
@@ -399,8 +262,7 @@ Status BufferToImageF(const JxlPixelFormat& pixel_format, size_t xsize,
 
   JXL_RETURN_IF_ERROR(ConvertFromExternal(
       jxl::Span<const uint8_t>(static_cast<const uint8_t*>(buffer), size),
-      xsize, ysize, bitdepth, pixel_format.endianness, pool, channel, float_in,
-      pixel_format.align));
+      xsize, ysize, bitdepth, pixel_format, 0, pool, channel));
 
   return true;
 }
@@ -417,9 +279,8 @@ Status BufferToImageBundle(const JxlPixelFormat& pixel_format, uint32_t xsize,
 
   JXL_RETURN_IF_ERROR(ConvertFromExternal(
       jxl::Span<const uint8_t>(static_cast<const uint8_t*>(buffer), size),
-      xsize, ysize, c_current, pixel_format.num_channels,
-      /*alpha_is_premultiplied=*/false, bitdepth, pixel_format.endianness, pool,
-      ib, float_in, pixel_format.align));
+      xsize, ysize, c_current,
+      /*alpha_is_premultiplied=*/false, bitdepth, pixel_format, pool, ib));
   ib->VerifyMetadata();
 
   return true;

--- a/lib/jxl/enc_external_image.h
+++ b/lib/jxl/enc_external_image.h
@@ -23,17 +23,16 @@
 namespace jxl {
 Status ConvertFromExternal(Span<const uint8_t> bytes, size_t xsize,
                            size_t ysize, size_t bits_per_sample,
-                           JxlEndianness endianness, ThreadPool* pool,
-                           ImageF* channel, bool float_in, size_t align);
+                           JxlPixelFormat format, size_t c, ThreadPool* pool,
+                           ImageF* channel);
 
 // Convert an interleaved pixel buffer to the internal ImageBundle
 // representation. This is the opposite of ConvertToExternal().
 Status ConvertFromExternal(Span<const uint8_t> bytes, size_t xsize,
                            size_t ysize, const ColorEncoding& c_current,
-                           size_t channels, bool alpha_is_premultiplied,
-                           size_t bits_per_sample, JxlEndianness endianness,
-                           ThreadPool* pool, ImageBundle* ib, bool float_in,
-                           size_t align);
+                           bool alpha_is_premultiplied, size_t bits_per_sample,
+                           JxlPixelFormat format, ThreadPool* pool,
+                           ImageBundle* ib);
 Status BufferToImageF(const JxlPixelFormat& pixel_format, size_t xsize,
                       size_t ysize, const void* buffer, size_t size,
                       ThreadPool* pool, ImageF* channel);

--- a/lib/jxl/enc_external_image_gbench.cc
+++ b/lib/jxl/enc_external_image_gbench.cc
@@ -21,17 +21,16 @@ void BM_EncExternalImage_ConvertImageRGBA(benchmark::State& state) {
   ImageBundle ib(&im);
 
   std::vector<uint8_t> interleaved(xsize * ysize * 4);
-
+  JxlPixelFormat format = {4, JXL_TYPE_UINT8, JXL_NATIVE_ENDIAN, 0};
   for (auto _ : state) {
     for (size_t i = 0; i < kNumIter; ++i) {
       JXL_CHECK(ConvertFromExternal(
           Span<const uint8_t>(interleaved.data(), interleaved.size()), xsize,
           ysize,
           /*c_current=*/ColorEncoding::SRGB(),
-          /*channels=*/4,
           /*alpha_is_premultiplied=*/false,
-          /*bits_per_sample=*/8, JXL_NATIVE_ENDIAN,
-          /*pool=*/nullptr, &ib, /*float_in=*/false, /*align=*/0));
+          /*bits_per_sample=*/8, format,
+          /*pool=*/nullptr, &ib));
     }
   }
 

--- a/lib/jxl/enc_external_image_test.cc
+++ b/lib/jxl/enc_external_image_test.cc
@@ -25,23 +25,23 @@ TEST(ExternalImageTest, InvalidSize) {
   im.SetAlphaBits(8);
   ImageBundle ib(&im);
 
+  JxlPixelFormat format = {4, JXL_TYPE_UINT16, JXL_BIG_ENDIAN, 0};
   const uint8_t buf[10 * 100 * 8] = {};
   EXPECT_FALSE(ConvertFromExternal(
       Span<const uint8_t>(buf, 10), /*xsize=*/10, /*ysize=*/100,
-      /*c_current=*/ColorEncoding::SRGB(), /*channels=*/4,
-      /*alpha_is_premultiplied=*/false, /*bits_per_sample=*/16, JXL_BIG_ENDIAN,
-      nullptr, &ib, /*float_in=*/false, /*align=*/0));
+      /*c_current=*/ColorEncoding::SRGB(),
+      /*alpha_is_premultiplied=*/false, /*bits_per_sample=*/16, format, nullptr,
+      &ib));
   EXPECT_FALSE(ConvertFromExternal(
       Span<const uint8_t>(buf, sizeof(buf) - 1), /*xsize=*/10, /*ysize=*/100,
-      /*c_current=*/ColorEncoding::SRGB(), /*channels=*/4,
-      /*alpha_is_premultiplied=*/false, /*bits_per_sample=*/16, JXL_BIG_ENDIAN,
-      nullptr, &ib, /*float_in=*/false, /*align=*/0));
+      /*c_current=*/ColorEncoding::SRGB(),
+      /*alpha_is_premultiplied=*/false, /*bits_per_sample=*/16, format, nullptr,
+      &ib));
   EXPECT_TRUE(
       ConvertFromExternal(Span<const uint8_t>(buf, sizeof(buf)), /*xsize=*/10,
                           /*ysize=*/100, /*c_current=*/ColorEncoding::SRGB(),
-                          /*channels=*/4, /*alpha_is_premultiplied=*/false,
-                          /*bits_per_sample=*/16, JXL_BIG_ENDIAN, nullptr, &ib,
-                          /*float_in=*/false, /*align=*/0));
+                          /*alpha_is_premultiplied=*/false,
+                          /*bits_per_sample=*/16, format, nullptr, &ib));
 }
 #endif
 
@@ -54,14 +54,14 @@ TEST(ExternalImageTest, AlphaMissing) {
   const size_t ysize = 20;
   const uint8_t buf[xsize * ysize * 4] = {};
 
+  JxlPixelFormat format = {4, JXL_TYPE_UINT8, JXL_BIG_ENDIAN, 0};
   // has_alpha is true but the ImageBundle has no alpha. Alpha channel should
   // be ignored.
-  EXPECT_TRUE(
-      ConvertFromExternal(Span<const uint8_t>(buf, sizeof(buf)), xsize, ysize,
-                          /*c_current=*/ColorEncoding::SRGB(),
-                          /*channels=*/4, /*alpha_is_premultiplied=*/false,
-                          /*bits_per_sample=*/8, JXL_BIG_ENDIAN, nullptr, &ib,
-                          /*float_in=*/false, /*align=*/0));
+  EXPECT_TRUE(ConvertFromExternal(Span<const uint8_t>(buf, sizeof(buf)), xsize,
+                                  ysize,
+                                  /*c_current=*/ColorEncoding::SRGB(),
+                                  /*alpha_is_premultiplied=*/false,
+                                  /*bits_per_sample=*/8, format, nullptr, &ib));
   EXPECT_FALSE(ib.HasAlpha());
 }
 

--- a/lib/jxl/test_utils.h
+++ b/lib/jxl/test_utils.h
@@ -297,12 +297,14 @@ jxl::CodecInOut SomeTestImageToCodecInOut(const std::vector<uint8_t>& buf,
   io.metadata.m.SetAlphaBits(16);
   io.metadata.m.color_encoding = jxl::ColorEncoding::SRGB(
       /*is_gray=*/num_channels == 1 || num_channels == 2);
+  JxlPixelFormat format = {static_cast<uint32_t>(num_channels), JXL_TYPE_UINT16,
+                           JXL_BIG_ENDIAN, 0};
   EXPECT_TRUE(ConvertFromExternal(
       jxl::Span<const uint8_t>(buf.data(), buf.size()), xsize, ysize,
-      jxl::ColorEncoding::SRGB(/*is_gray=*/num_channels < 3), num_channels,
-      /*alpha_is_premultiplied=*/false, /*bits_per_sample=*/16, JXL_BIG_ENDIAN,
+      jxl::ColorEncoding::SRGB(/*is_gray=*/num_channels < 3),
+      /*alpha_is_premultiplied=*/false, /*bits_per_sample=*/16, format,
       /*pool=*/nullptr,
-      /*ib=*/&io.Main(), /*float_in=*/false, 0));
+      /*ib=*/&io.Main()));
   return io;
 }
 

--- a/tools/benchmark/benchmark_codec_avif.cc
+++ b/tools/benchmark/benchmark_codec_avif.cc
@@ -318,14 +318,17 @@ class AvifCodec : public ImageCodec {
         JXL_RETURN_IF_AVIF_ERROR(avifImageYUVToRGB(decoder->image, &rgb_image));
         const double start_convert_image = Now();
         {
+          JxlPixelFormat format = {
+              (has_alpha ? 4u : 3u),
+              (rgb_image.depth <= 8 ? JXL_TYPE_UINT8 : JXL_TYPE_UINT16),
+              JXL_NATIVE_ENDIAN, 0};
           ImageBundle ib(&io->metadata.m);
           JXL_RETURN_IF_ERROR(ConvertFromExternal(
               Span<const uint8_t>(rgb_image.pixels,
                                   rgb_image.height * rgb_image.rowBytes),
-              rgb_image.width, rgb_image.height, color, (has_alpha ? 4 : 3),
-              /*alpha_is_premultiplied=*/false, rgb_image.depth,
-              JXL_NATIVE_ENDIAN, pool, &ib,
-              /*float_in=*/false, /*align=*/0));
+              rgb_image.width, rgb_image.height, color,
+              /*alpha_is_premultiplied=*/false, rgb_image.depth, format, pool,
+              &ib));
           io->frames.push_back(std::move(ib));
           io->dec_pixels += rgb_image.width * rgb_image.height;
         }

--- a/tools/benchmark/benchmark_codec_webp.cc
+++ b/tools/benchmark/benchmark_codec_webp.cc
@@ -39,11 +39,12 @@ Status FromSRGB(const size_t xsize, const size_t ysize, const bool is_gray,
                 ImageBundle* ib) {
   const ColorEncoding& c = ColorEncoding::SRGB(is_gray);
   const size_t bits_per_sample = (is_16bit ? 2 : 1) * kBitsPerByte;
+  const uint32_t num_channels = (is_gray ? 1 : 3) + (has_alpha ? 1 : 0);
+  JxlDataType data_type = is_16bit ? JXL_TYPE_UINT16 : JXL_TYPE_UINT8;
+  JxlPixelFormat format = {num_channels, data_type, endianness, 0};
   const Span<const uint8_t> span(pixels, end - pixels);
-  return ConvertFromExternal(
-      span, xsize, ysize, c, (is_gray ? 1 : 3) + (has_alpha ? 1 : 0),
-      alpha_is_premultiplied, bits_per_sample, endianness, pool, ib,
-      /*float_in=*/false, /*align=*/0);
+  return ConvertFromExternal(span, xsize, ysize, c, alpha_is_premultiplied,
+                             bits_per_sample, format, pool, ib);
 }
 
 struct WebPArgs {

--- a/tools/fuzzer_corpus.cc
+++ b/tools/fuzzer_corpus.cc
@@ -214,14 +214,15 @@ bool GenerateFile(const char* output_dir, const ImageSpec& spec,
         }
       }
     }
-
+    uint32_t num_channels = bytes_per_pixel / bytes_per_sample;
+    JxlDataType data_type =
+        bytes_per_sample == 1 ? JXL_TYPE_UINT8 : JXL_TYPE_UINT16;
+    JxlPixelFormat format = {num_channels, data_type, JXL_LITTLE_ENDIAN, 0};
     const jxl::Span<const uint8_t> span(img_data.data(), img_data.size());
     JXL_RETURN_IF_ERROR(ConvertFromExternal(
         span, spec.width, spec.height, io.metadata.m.color_encoding,
-        bytes_per_pixel / bytes_per_sample,
         /*alpha_is_premultiplied=*/spec.alpha_is_premultiplied,
-        io.metadata.m.bit_depth.bits_per_sample, JXL_LITTLE_ENDIAN, nullptr,
-        &ib, /*float_in=*/false, /*align=*/0));
+        io.metadata.m.bit_depth.bits_per_sample, format, nullptr, &ib));
     io.frames.push_back(std::move(ib));
   }
 


### PR DESCRIPTION
This is a preparation to accept buffers with zero-padding in most significant bits.

By default the bit depth is the full bit depth of the format data type, so the behavior is unchanged.