### PR TITLE
Add API functions for setting input/output bit depth.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Added
+ - encoder API: new function `JxlEncoderSetFrameBitDepth` to set the bit depth
+   of the input buffer.
+ - decoder API: new function `JxlDecoderSetImageBitDepth` to set the bit depth
+   of the output buffer.
+
 ## [0.7] - 2022-07-21
 
 ### Added

--- a/lib/extras/dec/jxl.h
+++ b/lib/extras/dec/jxl.h
@@ -53,6 +53,9 @@ struct JXLDecompressParams {
   bool use_image_callback = true;
   // Whether to unpremultiply colors for associated alpha channels.
   bool unpremultiply_alpha = false;
+
+  // Controls the effective bit depth of the output pixels.
+  JxlBitDepth output_bitdepth = {JXL_BIT_DEPTH_FROM_PIXEL_FORMAT, 0, 0};
 };
 
 bool DecodeImageJXL(const uint8_t* bytes, size_t bytes_size,

--- a/lib/extras/decode_jpeg.cc
+++ b/lib/extras/decode_jpeg.cc
@@ -204,6 +204,8 @@ std::unique_ptr<RenderPipeline> PreparePipeline(
   }
   ImageOutput main_output;
   main_output.format = output->format;
+  main_output.bits_per_sample =
+      PackedImage::BitsPerChannel(output->format.data_type);
   main_output.buffer = reinterpret_cast<uint8_t*>(output->pixels());
   main_output.buffer_size = output->pixels_size;
   main_output.stride = output->stride;

--- a/lib/extras/enc/jxl.h
+++ b/lib/extras/enc/jxl.h
@@ -49,6 +49,8 @@ struct JXLCompressParams {
   size_t override_bitdepth = 0;
   int32_t codestream_level = -1;
   int32_t premultiply = -1;
+  // Override input buffer interpretation.
+  JxlBitDepth input_bitdepth = {JXL_BIT_DEPTH_FROM_PIXEL_FORMAT, 0, 0};
   // If runner_opaque is set, the decoder uses this parallel runner.
   JxlParallelRunner runner = JxlThreadParallelRunner;
   void* runner_opaque = nullptr;

--- a/lib/include/jxl/decode.h
+++ b/lib/include/jxl/decode.h
@@ -1450,6 +1450,21 @@ JXL_EXPORT size_t JxlDecoderGetIntendedDownsamplingRatio(JxlDecoder* dec);
  */
 JXL_EXPORT JxlDecoderStatus JxlDecoderFlushImage(JxlDecoder* dec);
 
+/**
+ * Sets the bit depth of the output buffer or callback.
+ *
+ * Can be called after @ref JxlDecoderSetImageOutBuffer or @ref
+ * JxlDecoderSetImageOutCallback. For float pixel data types, only the default
+ * @ref JXL_BIT_DEPTH_FROM_PIXEL_FORMAT setting is supported.
+ *
+ * @param dec decoder object
+ * @param bit_depth the bit depth setting of the pixel output
+ * @return @ref JXL_DEC_SUCCESS on success, @ref JXL_DEC_ERROR on error, such as
+ *     incompatible custom bit depth and pixel data type.
+ */
+JXL_EXPORT JxlDecoderStatus
+JxlDecoderSetImageOutBitDepth(JxlDecoder* dec, const JxlBitDepth* bit_depth);
+
 #if defined(__cplusplus) || defined(c_plusplus)
 }
 #endif

--- a/lib/include/jxl/encode.h
+++ b/lib/include/jxl/encode.h
@@ -516,6 +516,22 @@ JXL_EXPORT JxlEncoderStatus JxlEncoderSetFrameName(
     JxlEncoderFrameSettings* frame_settings, const char* frame_name);
 
 /**
+ * Sets the bit depth of the input buffer.
+ *
+ * For float pixel formats, only the default JXL_BIT_DEPTH_FROM_PIXEL_FORMAT
+ * setting is allowed, while for unsigned pixel formats,
+ * JXL_BIT_DEPTH_FROM_CODESTREAM setting is also allowed. See the comment on
+ * @ref JxlEncoderAddImageFrame for the effects of the bit depth setting.
+
+ * @param frame_settings set of options and metadata for this frame. Also
+ * includes reference to the encoder object.
+ * @param bit_depth the bit depth setting of the pixel input
+ * @return JXL_ENC_SUCCESS on success, JXL_ENC_ERROR on error
+ */
+JXL_EXPORT JxlEncoderStatus JxlEncoderSetFrameBitDepth(
+    JxlEncoderFrameSettings* frame_settings, const JxlBitDepth* bit_depth);
+
+/**
  * Sets the buffer to read JPEG encoded bytes from for the next frame to encode.
  *
  * If JxlEncoderSetBasicInfo has not yet been called, calling
@@ -556,15 +572,22 @@ JxlEncoderAddJPEGFrame(const JxlEncoderFrameSettings* frame_settings,
  * - JXL_TYPE_FLOAT, with nominal range 0..1
  *
  * Note: the sample data type in pixel_format is allowed to be different from
- * what is described in the JxlBasicInfo. The type in pixel_format describes the
- * format of the uncompressed pixel buffer. The bits_per_sample and
- * exponent_bits_per_sample in the JxlBasicInfo describes what will actually be
- * encoded in the JPEG XL codestream. For example, to encode a 12-bit image, you
- * would set bits_per_sample to 12, and you could use e.g. JXL_TYPE_UINT16
- * (where the values are rescaled to 16-bit, i.e. multiplied by 65535/4095) or
- * JXL_TYPE_FLOAT (where the values are rescaled to 0..1, i.e. multiplied
- * by 1.f/4095.f). While it is allowed, it is obviously not recommended to use a
- * pixel_format with lower precision than what is specified in the JxlBasicInfo.
+ * what is described in the JxlBasicInfo. The type in pixel_format, together
+ * with an optional @ref JxlBitDepth parameter set by @ref
+ * JxlEncoderSetFrameBitDepth describes the format of the uncompressed pixel
+ * buffer. The bits_per_sample and exponent_bits_per_sample in the JxlBasicInfo
+ * describes what will actually be encoded in the JPEG XL codestream.
+ * For example, to encode a 12-bit image, you would set bits_per_sample to 12,
+ * while the input frame buffer can be in the following formats:
+ *  - if pixel format is in JXL_TYPE_UINT16 with default bit depth setting
+ *    (i.e. JXL_BIT_DEPTH_FROM_PIXEL_FORMAT), input sample values are rescaled
+ *    to 16-bit, i.e. multiplied by 65535/4095;
+ *  - if pixel format is in JXL_TYPE_UINT16 with JXL_BIT_DEPTH_FROM_CODESTREAM
+ *    bit depth setting, input sample values are provided unscaled;
+ *  - if pixel format is in JXL_TYPE_FLOAT, input sample values are rescaled
+ *    to 0..1, i.e.  multiplied by 1.f/4095.f.
+ * While it is allowed, it is obviously not recommended to use a pixel_format
+ * with lower precision than what is specified in the JxlBasicInfo.
  *
  * We support interleaved channels as described by the JxlPixelFormat:
  * - single-channel data, e.g. grayscale

--- a/lib/include/jxl/types.h
+++ b/lib/include/jxl/types.h
@@ -111,6 +111,43 @@ typedef struct {
   size_t align;
 } JxlPixelFormat;
 
+/** Settings for the interpretation of the input and output buffers.
+ */
+typedef enum {
+  /** This is the default setting, where the encoder expects the input pixels
+   * to use the full range of the pixel format data type (e.g. for UINT16, the
+   * input range is 0 .. 65535 and the value 65535 is mapped to 1.0 when
+   * converting to float), and the decoder uses the full range to output
+   * pixels. If the bit depth in the basic info is different from this, the
+   * encoder expects the values to be rescaled accordingly (e.g multiplied by
+   * 65535/4095 for a 12-bit image using UINT16 input data type). */
+  JXL_BIT_DEPTH_FROM_PIXEL_FORMAT = 0,
+
+  /** If this setting is selected, the encoder expects the input pixels to be
+   * in the range defined by the bits_per_sample value of the basic info (e.g.
+   * for 12-bit images using UINT16 input data types, the allowed range is
+   * 0 .. 4095 and the value 4095 is mapped to 1.0 when converting to float),
+   * and the decoder outputs pixels in this range. */
+  JXL_BIT_DEPTH_FROM_CODESTREAM = 1,
+
+  /** This setting can only be used in the decoder to select a custom range for
+   * pixel output */
+  JXL_BIT_DEPTH_CUSTOM = 2,
+} JxlBitDepthType;
+
+/** Data type for describing the interpretation of the input and output buffers
+ * in terms of the range of allowed input and output pixel values. */
+typedef struct {
+  /** Bit depth setting, see comment on @ref JxlBitDepthType */
+  JxlBitDepthType type;
+
+  /** Custom bits per sample */
+  uint32_t bits_per_sample;
+
+  /** Custom exponent bits per sample */
+  uint32_t exponent_bits_per_sample;
+} JxlBitDepth;
+
 /** Data type holding the 4-character type name of an ISOBMFF box.
  */
 typedef char JxlBoxType[4];

--- a/lib/jxl/dec_cache.h
+++ b/lib/jxl/dec_cache.h
@@ -59,6 +59,8 @@ struct PixelCallback {
 struct ImageOutput {
   // Pixel format of the output pixels, used for buffer and callback output.
   JxlPixelFormat format;
+  // Output bit depth for unsigned data types, used for float to int conversion.
+  size_t bits_per_sample;
   // Callback for line-by-line output.
   PixelCallback callback;
   // Pixel buffer for image output.

--- a/lib/jxl/dec_frame.h
+++ b/lib/jxl/dec_frame.h
@@ -179,11 +179,12 @@ class FrameDecoder {
   // orientation.
   void SetImageOutput(const PixelCallback& pixel_callback, void* image_buffer,
                       size_t image_buffer_size, size_t xsize, size_t ysize,
-                      JxlPixelFormat format, bool unpremul_alpha,
-                      bool undo_orientation) const {
+                      JxlPixelFormat format, size_t bits_per_sample,
+                      bool unpremul_alpha, bool undo_orientation) const {
     dec_state_->width = xsize;
     dec_state_->height = ysize;
     dec_state_->main_output.format = format;
+    dec_state_->main_output.bits_per_sample = bits_per_sample;
     dec_state_->main_output.callback = pixel_callback;
     dec_state_->main_output.buffer = image_buffer;
     dec_state_->main_output.buffer_size = image_buffer_size;
@@ -217,9 +218,10 @@ class FrameDecoder {
   }
 
   void AddExtraChannelOutput(void* buffer, size_t buffer_size, size_t xsize,
-                             JxlPixelFormat format) {
+                             JxlPixelFormat format, size_t bits_per_sample) {
     ImageOutput out;
     out.format = format;
+    out.bits_per_sample = bits_per_sample;
     out.buffer = buffer;
     out.buffer_size = buffer_size;
     out.stride = GetStride(xsize, format);

--- a/lib/jxl/encode_internal.h
+++ b/lib/jxl/encode_internal.h
@@ -108,6 +108,7 @@ typedef struct JxlEncoderFrameSettingsValuesStruct {
   JxlFrameHeader header;
   std::vector<JxlBlendInfo> extra_channel_blend_info;
   std::string frame_name;
+  JxlBitDepth image_bit_depth;
   bool frame_index_box = false;
 } JxlEncoderFrameSettingsValues;
 

--- a/lib/jxl/test_image.h
+++ b/lib/jxl/test_image.h
@@ -186,10 +186,10 @@ void FillPackedImage(const T& info, uint16_t seed, extras::PackedImage* image) {
       // put some shape in there for visual debugging
       if ((x - circle_x) * (x - circle_x) + (y - circle_y) * (y - circle_y) <
           circle_r * circle_r) {
-        r = ((65535 - x * y) ^ seed) * imul16;
-        g = ((x << 8) + y + seed) * imul16;
-        b = ((y << 8) + x * seed) * imul16;
-        a = (32768 + x * 256 - y) * imul16;
+        r = std::min(1.0f, ((65535 - x * y) ^ seed) * imul16);
+        g = std::min(1.0f, ((x << 8) + y + seed) * imul16);
+        b = std::min(1.0f, ((y << 8) + x * seed) * imul16);
+        a = std::min(1.0f, (32768 + x * 256 - y) * imul16);
       } else if (x > rect_x0 && x < rect_x1 && y > rect_y0 && y < rect_y1) {
         r = rngf(1.0f);
         g = rngf(1.0f);
@@ -205,7 +205,7 @@ void FillPackedImage(const T& info, uint16_t seed, extras::PackedImage* image) {
         StoreValue(r, info, format, &out);
         StoreValue(g, info, format, &out);
         StoreValue(b, info, format, &out);
-      } else if (format.num_channels == 3) {
+      } else if (format.num_channels == 4) {
         StoreValue(r, info, format, &out);
         StoreValue(g, info, format, &out);
         StoreValue(b, info, format, &out);


### PR DESCRIPTION
This addresses part of the issue in #1763.

For the encoder the two choices are using the bit depth of the pixel format (a.k.a. repeating higher bits in lower bits), or to use the bit deth from basic info (a.k.a. zero-padding higher bits). For the decoder there is an additional option to use a custom bit depth.