### PR TITLE
Custom codec on Windows: adding the command-line options should return true, not false

### DIFF
--- a/tools/benchmark/benchmark_codec_custom.cc
+++ b/tools/benchmark/benchmark_codec_custom.cc
@@ -214,7 +214,7 @@ ImageCodec* CreateNewCustomCodec(const BenchmarkArgs& args) {
 namespace jxl {
 
 ImageCodec* CreateNewCustomCodec(const BenchmarkArgs& args) { return nullptr; }
-Status AddCommandLineOptionsCustomCodec(BenchmarkArgs* args) { return false; }
+Status AddCommandLineOptionsCustomCodec(BenchmarkArgs* args) { return true; }
 
 }  // namespace jxl
 


### PR DESCRIPTION
Adding the options succeeds since there are none to add.