### PR TITLE
make butteraugli slightly more sensitive to low freq errors

### DIFF
--- a/lib/jxl/butteraugli/butteraugli.cc
+++ b/lib/jxl/butteraugli/butteraugli.cc
@@ -322,9 +322,9 @@ template <class D, class V>
 HWY_INLINE void XybLowFreqToVals(const D d, const V& x, const V& y,
                                  const V& b_arg, V* HWY_RESTRICT valx,
                                  V* HWY_RESTRICT valy, V* HWY_RESTRICT valb) {
-  static const double xmuli = 32.2217497012;
-  static const double ymuli = 13.7697791434;
-  static const double bmuli = 47.504615728;
+  static const double xmuli = 33.832837186260;
+  static const double ymuli = 14.458268100570;
+  static const double bmuli = 49.87984651440;
   static const double y_to_b_muli = -0.362267051518;
   const V xmul = Set(d, xmuli);
   const V ymul = Set(d, ymuli);
@@ -1078,7 +1078,7 @@ void DiffPrecompute(const ImageF& xyb, float mul, float bias_arg, ImageF* out) {
 // std::log(80.0) / std::log(255.0);
 constexpr float kIntensityTargetNormalizationHack = 0.79079917404f;
 static const float kInternalGoodQualityThreshold =
-    17.8f * kIntensityTargetNormalizationHack;
+    17.83f * kIntensityTargetNormalizationHack;
 static const float kGlobalScale = 1.0 / kInternalGoodQualityThreshold;
 
 void StoreMin3(const float v, float& min0, float& min1, float& min2) {

--- a/lib/jxl/modular_test.cc
+++ b/lib/jxl/modular_test.cc
@@ -147,7 +147,7 @@ TEST(ModularTest, RoundtripLossyDeltaPaletteWP) {
   cparams.ba_params.intensity_target = 80.0f;
   EXPECT_THAT(ButteraugliDistance(io, io_out, cparams.ba_params, GetJxlCms(),
                                   /*distmap=*/nullptr, pool),
-              IsSlightlyBelow(10.0));
+              IsSlightlyBelow(10.1));
 }
 
 TEST(ModularTest, RoundtripLossy) {


### PR DESCRIPTION
Butteraugli-only change. Makes the metric slightly more sensitive to DC errors.

Before, with `--progressive_dc=0`:
```
Encoding      kPixels    Bytes          BPP  E MP/s  D MP/s     Max norm        pnorm       BPP*pnorm   Bugs
------------------------------------------------------------------------------------------------------------
jxl:d0.5        13270  4230132    2.5501063   6.833  71.506   1.07251453   0.37361494  0.952757824848      0
jxl:d1          13270  2695661    1.6250609   7.499  71.163   1.69329262   0.60141074  0.977329093760      0
jxl:d2          13270  1682981    1.0145737   8.544  69.546   3.01595855   0.94927374  0.963108133887      0
jxl:d3          13270  1253173    0.7554668   7.188  65.433   3.69493628   1.24221990  0.938455926169      0
jxl:d4          13270  1012015    0.6100864   6.958  37.313   4.97912407   1.49359852  0.911224093480      0
jxl:d4.49       13270   928374    0.5596640   6.924  39.452   5.43311691   1.60781689  0.899837165214      0
jxl:d4.5        13270   927117    0.5589062   7.696  39.721   5.35581255   1.60915199  0.899364997075      0
jxl:d5          13270   859668    0.5182450   7.081  35.237   5.72150421   1.71738366  0.890025514387      0
jxl:d6          13270   751072    0.4527787   7.452  37.727   6.21766376   1.92028371  0.869463466296      0
jxl:d8          13270   605853    0.3652344   7.272  34.333   7.18107176   2.31364031  0.845020945395      0
Aggregate:      13270  1234109    0.7439739   7.330  47.764   3.86769448   1.22822560  0.913767832394      0
```

After:
```
Encoding      kPixels    Bytes          BPP  E MP/s  D MP/s     Max norm        pnorm       BPP*pnorm   Bugs
------------------------------------------------------------------------------------------------------------
jxl:d0.5        13270  4230132    2.5501063   6.953  62.089   1.07075775   0.37354307  0.952574538746      0
jxl:d1          13270  2695661    1.6250609   8.154  71.330   1.69066322   0.60121030  0.977003367091      0
jxl:d2          13270  1682981    1.0145737   9.240  74.497   3.01102424   0.94896466  0.962794548686      0
jxl:d3          13270  1253173    0.7554668   7.727  68.570   3.69197154   1.24192752  0.938235043417      0
jxl:d4          13270  1012015    0.6100864   7.686  41.892   4.98539543   1.49342448  0.911117914664      0
jxl:d4.49       13270   928374    0.5596640   7.627  37.956   5.43043661   1.60771532  0.899780317958      0
jxl:d4.5        13270   927117    0.5589062   7.760  39.908   5.35170126   1.60904025  0.899302543849      0
jxl:d5          13270   859668    0.5182450   7.873  38.591   5.72473764   1.71735565  0.890011000374      0
jxl:d6          13270   751072    0.4527787   7.879  38.975   6.21732950   1.92046573  0.869545883378      0
jxl:d8          13270   605853    0.3652344   8.107  38.167   7.17651081   2.31397713  0.845143966670      0
Aggregate:      13270  1234109    0.7439739   7.882  49.159   3.86546724   1.22808905  0.913666238381      0
```

Before, with `--progressive_dc=1`:
```
Encoding      kPixels    Bytes          BPP  E MP/s  D MP/s     Max norm        pnorm       BPP*pnorm   Bugs
------------------------------------------------------------------------------------------------------------
jxl:d0.5        13270  4236102    2.5537053   5.998  60.987   1.06784666   0.37395081  0.954960174315      0
jxl:d1          13270  2707730    1.6323366   7.063  68.209   1.69371367   0.59756288  0.975423773746      0
jxl:d2          13270  1684348    1.0153977   7.593  73.381   2.98379230   0.94571682  0.960278723433      0
jxl:d3          13270  1236975    0.7457020   6.708  65.851   3.95146799   1.25057027  0.932552720094      0
jxl:d4          13270   989439    0.5964766   6.716  38.996   4.99962425   1.50736245  0.899106396324      0
jxl:d4.49       13270   901761    0.5436205   6.916  39.802   7.28441811   1.65685682  0.900701315752      0
jxl:d4.5        13270   900648    0.5429495   6.840  38.888   7.28848457   1.65888942  0.900693227635      0
jxl:d5          13270   830208    0.5004853   6.910  40.952   8.17646980   1.76089867  0.881303812206      0
jxl:d6          13270   717568    0.4325810   6.506  36.455   7.03566551   1.96750227  0.851104086308      0
jxl:d8          13270   567120    0.3418844   7.097  38.713  11.99683952   2.40447040  0.822051013200      0
Aggregate:      13270  1205626    0.7268033   6.823  48.371   4.56224210   1.24739973  0.906614200268      0
```

After:
```
Encoding      kPixels    Bytes          BPP  E MP/s  D MP/s     Max norm        pnorm       BPP*pnorm   Bugs
------------------------------------------------------------------------------------------------------------
jxl:d0.5        13270  4236102    2.5537053   5.839  65.267   1.06631088   0.37419582  0.955585838383      0
jxl:d1          13270  2707730    1.6323366   6.894  63.715   1.69117558   0.59767584  0.975608164764      0
jxl:d2          13270  1684348    1.0153977   7.471  70.469   2.97935128   0.94591274  0.960477666363      0
jxl:d3          13270  1236975    0.7457020   6.740  65.913   3.95714688   1.25106763  0.932923597449      0
jxl:d4          13270   989439    0.5964766   6.744  40.684   5.00354862   1.50838382  0.899715618651      0
jxl:d4.49       13270   901761    0.5436205   6.917  41.691   7.28115034   1.65819455  0.901428533882      0
jxl:d4.5        13270   900648    0.5429495   6.845  40.062   7.28517866   1.66022550  0.901418648387      0
jxl:d5          13270   830208    0.5004853   6.955  37.827   8.16854095   1.76249866  0.882104582765      0
jxl:d6          13270   717568    0.4325810   7.039  38.647   7.04228687   1.96973230  0.852068752922      0
jxl:d8          13270   567120    0.3418844   6.706  37.822  12.01802254   2.40786540  0.823211708158      0
Aggregate:      13270  1205626    0.7268033   6.804  48.537   4.56161467   1.24829696  0.907266308484      0
```
