### PR TITLE
Use zero-padded input/output buffers by default for PNM files.

### DIFF
--- a/tools/cjxl_main.cc
+++ b/tools/cjxl_main.cc
@@ -872,6 +872,9 @@ void ProcessFlags(const jxl::extras::Codec codec,
   params->override_bitdepth = args->override_bitdepth;
   params->codestream_level = args->codestream_level;
   params->premultiply = args->premultiply;
+  if (codec == jxl::extras::Codec::kPNM) {
+    params->input_bitdepth.type = JXL_BIT_DEPTH_FROM_CODESTREAM;
+  }
 }
 
 }  // namespace tools


### PR DESCRIPTION
If a PNM file is compressed by cjxl / produced by djxl, the JXL_BIT_DEPTH_FROM_CODESTREAM option is set by default.

Additionally, djxl now implements the --bits_per_sample option for choosing an arbitrary bit depth for unsigned output types.

Added unit tests and end-to-end roundtrip tests for bit-exact pnm file reconstruction for lossless mode.