### PR TITLE
cjxl: modify quality-to-distance map

### DIFF
--- a/lib/jxl/encode.cc
+++ b/lib/jxl/encode.cc
@@ -962,7 +962,8 @@ JxlEncoderStatus JxlEncoderSetFrameDistance(
     JxlEncoderFrameSettings* frame_settings, float distance) {
   if (distance < 0.f || distance > 25.f) {
     return JXL_API_ERROR(frame_settings->enc, JXL_ENC_ERR_API_USAGE,
-                         "Distance has to be in [0.0..25.0]");
+                         "Distance has to be in [0.0..25.0] (corresponding to "
+                         "quality in [0.0..100.0])");
   }
   if (distance > 0.f && distance < 0.01f) {
     distance = 0.01f;

--- a/plugins/gimp/file-jxl-save.cc
+++ b/plugins/gimp/file-jxl-save.cc
@@ -520,8 +520,8 @@ bool JpegXlSaveOpts::UpdateQuality() {
 
   if (distance < 0.1) {
     qual = 100;
-  } else if (distance > 6.56) {
-    qual = 30 - 5 * log(abs(6.25 * distance - 40)) / log(2.5);
+  } else if (distance > 6.4) {
+    qual = -5.0 / 53.0 * sqrt(6360.0 * distance - 39975.0) + 1725.0 / 53.0;
     lossless = false;
   } else {
     qual = 100 - (distance - 0.1) / 0.09;
@@ -544,11 +544,11 @@ bool JpegXlSaveOpts::UpdateDistance() {
   if (quality >= 30) {
     dist = 0.1 + (100 - quality) * 0.09;
   } else {
-    dist = 6.4 + pow(2.5, (30 - quality) / 5.0) / 6.25;
+    dist = 53.0 / 3000.0 * quality * quality - 23.0 / 20.0 * quality + 25.0;
   }
 
-  if (dist > 15) {
-    distance = 15;
+  if (dist > 25) {
+    distance = 25;
   } else {
     distance = dist;
   }

--- a/tools/cjxl_main.cc
+++ b/tools/cjxl_main.cc
@@ -122,17 +122,20 @@ struct CompressArgs {
         "    0.0 = mathematically lossless. Default for already-lossy input "
         "(JPEG/GIF).\n"
         "    1.0 = visually lossless. Default for other input.\n"
-        "    Recommended range: 0.5 .. 3.0. Mutually exclusive with --quality.",
+        "    Recommended range: 0.5 .. 3.0. Allowed range: 0.0 ... 25.0.\n"
+        "    Mutually exclusive with --quality.",
         &distance, &ParseFloat);
 
     // High-level options
     opt_quality_id = cmdline->AddOptionValue(
         'q', "quality", "QUALITY",
-        "Quality setting (is remapped to --distance). Range: -inf .. 100.\n"
+        "Quality setting (is remapped to --distance)."
         "    100 = mathematically lossless. Default for already-lossy input "
         "(JPEG/GIF).\n"
-        "    Other input gets encoded as per --distance default.\n"
-        "    Positive quality values roughly match libjpeg quality.\n"
+        "    Other input gets encoded as per --distance default,\n"
+        "    which corresponds to quality 90.\n"
+        "    Quality values roughly match libjpeg quality.\n"
+        "    Recommended range: 68 .. 96. Allowed range: 0 .. 100.\n"
         "    Mutually exclusive with --distance.",
         &quality, &ParseFloat);
 
@@ -630,7 +633,8 @@ void SetDistanceFromFlags(CommandLineParser* cmdline, CompressArgs* args,
     double distance = args->quality >= 100 ? 0.0
                       : args->quality >= 30
                           ? 0.1 + (100 - args->quality) * 0.09
-                          : 6.24 + pow(2.5, (30 - args->quality) / 5.0) / 6.25;
+                          : 53.0 / 3000.0 * args->quality * args->quality -
+                                23.0 / 20.0 * args->quality + 25.0;
     args->distance = distance;
     distance_set = true;
   }


### PR DESCRIPTION
Fixes #1741
This slighlty changes how qualities below 30 are mapped to distance. Now we use a quadratic map with two properties:
 - 0 is mapped to 25
 - the first derivative at 30 agrees with the linear map for values above 30.