### PR TITLE
Disable progressive dc by default; adjust DC/AC balance and progressive DC precision

### DIFF
--- a/lib/jxl/butteraugli/butteraugli.cc
+++ b/lib/jxl/butteraugli/butteraugli.cc
@@ -322,9 +322,9 @@ template <class D, class V>
 HWY_INLINE void XybLowFreqToVals(const D d, const V& x, const V& y,
                                  const V& b_arg, V* HWY_RESTRICT valx,
                                  V* HWY_RESTRICT valy, V* HWY_RESTRICT valb) {
-  static const double xmuli = 32.2217497012;
-  static const double ymuli = 13.7697791434;
-  static const double bmuli = 47.504615728;
+  static const double xmuli = 33.832837186260;
+  static const double ymuli = 14.458268100570;
+  static const double bmuli = 49.87984651440;
   static const double y_to_b_muli = -0.362267051518;
   const V xmul = Set(d, xmuli);
   const V ymul = Set(d, ymuli);
@@ -1078,7 +1078,7 @@ void DiffPrecompute(const ImageF& xyb, float mul, float bias_arg, ImageF* out) {
 // std::log(80.0) / std::log(255.0);
 constexpr float kIntensityTargetNormalizationHack = 0.79079917404f;
 static const float kInternalGoodQualityThreshold =
-    17.8f * kIntensityTargetNormalizationHack;
+    17.83f * kIntensityTargetNormalizationHack;
 static const float kGlobalScale = 1.0 / kInternalGoodQualityThreshold;
 
 void StoreMin3(const float v, float& min0, float& min1, float& min2) {

--- a/lib/jxl/enc_adaptive_quantization.cc
+++ b/lib/jxl/enc_adaptive_quantization.cc
@@ -734,8 +734,8 @@ ImageF TileDistMap(const ImageF& distmap, int tile_size, int margin,
 }
 
 constexpr float kDcQuantPow = 0.66f;
-static const float kDcQuant = 1.0f;
-static const float kAcQuant = 0.8294f;
+static const float kDcQuant = 1.1f;
+static const float kAcQuant = 0.8f;
 
 void FindBestQuantization(const ImageBundle& linear, const Image3F& opsin,
                           PassesEncoderState* enc_state,

--- a/lib/jxl/enc_cache.cc
+++ b/lib/jxl/enc_cache.cc
@@ -93,10 +93,12 @@ Status InitializePassesEncoder(const Image3F& opsin, const JxlCmsInterface& cms,
     // and kModular for the smallest DC (first in the bitstream)
     if (cparams.progressive_dc == 0) {
       cparams.modular_mode = true;
-      // TODO(jon): tweak mapping from image dist to dist for modular DC
+      cparams.speed_tier =
+          SpeedTier(std::max(static_cast<int>(SpeedTier::kTortoise),
+                             static_cast<int>(cparams.speed_tier) - 1));
       cparams.butteraugli_distance =
           std::max(kMinButteraugliDistance,
-                   enc_state->cparams.butteraugli_distance * 0.03f);
+                   enc_state->cparams.butteraugli_distance * 0.02f);
     } else {
       cparams.max_error_mode = true;
       for (size_t c = 0; c < 3; c++) {

--- a/lib/jxl/enc_frame.cc
+++ b/lib/jxl/enc_frame.cc
@@ -1159,13 +1159,6 @@ Status EncodeFrame(const CompressParams& cparams_orig,
                          cparams.progressive_dc);
     }
     cparams.progressive_dc = 0;
-    // Enable progressive_dc for lower qualities, except for fast speeds where
-    // the modular encoder uses fixed tree.
-    if (cparams.speed_tier <= SpeedTier::kCheetah &&
-        cparams.butteraugli_distance >=
-            kMinButteraugliDistanceForProgressiveDc) {
-      cparams.progressive_dc = 1;
-    }
   }
   if (cparams.ec_resampling < cparams.resampling) {
     cparams.ec_resampling = cparams.resampling;

--- a/lib/jxl/enc_params.h
+++ b/lib/jxl/enc_params.h
@@ -246,13 +246,12 @@ struct CompressParams {
 static constexpr float kMinButteraugliForDynamicAR = 0.5f;
 static constexpr float kMinButteraugliForDots = 3.0f;
 static constexpr float kMinButteraugliToSubtractOriginalPatches = 3.0f;
-static constexpr float kMinButteraugliDistanceForProgressiveDc = 4.5f;
 
 // Always off
 static constexpr float kMinButteraugliForNoise = 99.0f;
 
 // Minimum butteraugli distance the encoder accepts.
-static constexpr float kMinButteraugliDistance = 0.01f;
+static constexpr float kMinButteraugliDistance = 0.001f;
 
 // Tile size for encoder-side processing. Must be equal to color tile dim in the
 // current implementation.

--- a/lib/jxl/encode_test.cc
+++ b/lib/jxl/encode_test.cc
@@ -218,9 +218,9 @@ void VerifyFrameEncoding(size_t xsize, size_t ysize, JxlEncoder* enc,
   EXPECT_LE(
       ComputeDistance2(input_io.Main(), decoded_io.Main(), jxl::GetJxlCms()),
 #if JXL_HIGH_PRECISION
-      1.8);
+      1.84);
 #else
-      8.0);
+      8.7);
 #endif
 }
 

--- a/lib/jxl/jxl_test.cc
+++ b/lib/jxl/jxl_test.cc
@@ -118,7 +118,7 @@ TEST(JxlTest, RoundtripSmallD1) {
 
   {
     PackedPixelFile ppf_out;
-    EXPECT_NEAR(Roundtrip(t.ppf(), {}, {}, pool, &ppf_out), 759, 10);
+    EXPECT_NEAR(Roundtrip(t.ppf(), {}, {}, pool, &ppf_out), 776, 10);
     EXPECT_THAT(ButteraugliDistance(t.ppf(), ppf_out), IsSlightlyBelow(1.0));
   }
 
@@ -145,7 +145,7 @@ TEST(JxlTest, RoundtripResample2) {
   cparams.AddOption(JXL_ENC_FRAME_SETTING_EFFORT, 3);  // kFalcon
 
   PackedPixelFile ppf_out;
-  EXPECT_EQ(Roundtrip(t.ppf(), cparams, {}, pool, &ppf_out), 16723);
+  EXPECT_EQ(Roundtrip(t.ppf(), cparams, {}, pool, &ppf_out), 16439);
   EXPECT_THAT(ComputeDistance2(t.ppf(), ppf_out), IsSlightlyBelow(90));
 }
 
@@ -162,7 +162,7 @@ TEST(JxlTest, RoundtripResample2Slow) {
   cparams.distance = 10.0;
 
   PackedPixelFile ppf_out;
-  EXPECT_NEAR(Roundtrip(t.ppf(), cparams, {}, pool, &ppf_out), 4118, 80);
+  EXPECT_NEAR(Roundtrip(t.ppf(), cparams, {}, pool, &ppf_out), 3988, 80);
   EXPECT_THAT(ComputeDistance2(t.ppf(), ppf_out), IsSlightlyBelow(250));
 }
 
@@ -178,7 +178,7 @@ TEST(JxlTest, RoundtripResample2MT) {
   cparams.AddOption(JXL_ENC_FRAME_SETTING_EFFORT, 3);  // kFalcon
 
   PackedPixelFile ppf_out;
-  EXPECT_NEAR(Roundtrip(t.ppf(), cparams, {}, &pool, &ppf_out), 195202, 10);
+  EXPECT_NEAR(Roundtrip(t.ppf(), cparams, {}, &pool, &ppf_out), 190111, 10);
   EXPECT_THAT(ComputeDistance2(t.ppf(), ppf_out), IsSlightlyBelow(340));
 }
 
@@ -199,8 +199,8 @@ TEST(JxlTest, RoundtripOutOfOrderProcessing) {
   cparams.AddOption(JXL_ENC_FRAME_SETTING_EPF, 3);
 
   PackedPixelFile ppf_out;
-  EXPECT_NEAR(Roundtrip(t.ppf(), cparams, {}, &pool, &ppf_out), 21931, 50);
-  EXPECT_LE(ButteraugliDistance(t.ppf(), ppf_out), 1.5);
+  EXPECT_NEAR(Roundtrip(t.ppf(), cparams, {}, &pool, &ppf_out), 23015, 50);
+  EXPECT_LE(ButteraugliDistance(t.ppf(), ppf_out), 1.3);
 }
 
 TEST(JxlTest, RoundtripOutOfOrderProcessingBorder) {
@@ -219,7 +219,7 @@ TEST(JxlTest, RoundtripOutOfOrderProcessingBorder) {
   cparams.AddOption(JXL_ENC_FRAME_SETTING_RESAMPLING, 2);
 
   PackedPixelFile ppf_out;
-  EXPECT_NEAR(Roundtrip(t.ppf(), cparams, {}, &pool, &ppf_out), 10486, 40);
+  EXPECT_NEAR(Roundtrip(t.ppf(), cparams, {}, &pool, &ppf_out), 9609, 40);
   EXPECT_LE(ButteraugliDistance(t.ppf(), ppf_out), 2.8);
 }
 
@@ -234,7 +234,7 @@ TEST(JxlTest, RoundtripResample4) {
   cparams.AddOption(JXL_ENC_FRAME_SETTING_RESAMPLING, 4);
 
   PackedPixelFile ppf_out;
-  EXPECT_NEAR(Roundtrip(t.ppf(), cparams, {}, pool, &ppf_out), 5652, 20);
+  EXPECT_NEAR(Roundtrip(t.ppf(), cparams, {}, pool, &ppf_out), 5569, 20);
   EXPECT_THAT(ButteraugliDistance(t.ppf(), ppf_out), IsSlightlyBelow(22));
 }
 
@@ -267,8 +267,8 @@ TEST(JxlTest, RoundtripUnalignedD2) {
   cparams.distance = 2.0;
 
   PackedPixelFile ppf_out;
-  EXPECT_EQ(Roundtrip(t.ppf(), cparams, {}, pool, &ppf_out), 504);
-  EXPECT_THAT(ButteraugliDistance(t.ppf(), ppf_out), IsSlightlyBelow(1.7));
+  EXPECT_EQ(Roundtrip(t.ppf(), cparams, {}, pool, &ppf_out), 482);
+  EXPECT_THAT(ButteraugliDistance(t.ppf(), ppf_out), IsSlightlyBelow(1.72));
 }
 
 TEST(JxlTest, RoundtripMultiGroup) {
@@ -292,9 +292,9 @@ TEST(JxlTest, RoundtripMultiGroup) {
   };
 
   auto run_kitten = std::async(std::launch::async, test, SpeedTier::kKitten,
-                               1.0f, 54644u, 11);
+                               1.0f, 52860u, 11);
   auto run_wombat = std::async(std::launch::async, test, SpeedTier::kWombat,
-                               2.0f, 33421u, 18);
+                               2.0f, 32037u, 18.5);
 }
 
 TEST(JxlTest, RoundtripRGBToGrayscale) {
@@ -350,7 +350,7 @@ TEST(JxlTest, RoundtripLargeFast) {
 
   PackedPixelFile ppf_out;
   // TODO(szabadka) Investigate size difference on SCALAR build.
-  EXPECT_NEAR(Roundtrip(t.ppf(), cparams, {}, &pool, &ppf_out), 445625, 500);
+  EXPECT_NEAR(Roundtrip(t.ppf(), cparams, {}, &pool, &ppf_out), 446370, 500);
   EXPECT_THAT(ComputeDistance2(t.ppf(), ppf_out), IsSlightlyBelow(90));
 }
 
@@ -368,7 +368,7 @@ TEST(JxlTest, RoundtripDotsForceEpf) {
 
   PackedPixelFile ppf_out;
   // TODO(szabadka) Investigate size difference on SCALAR build.
-  EXPECT_NEAR(Roundtrip(t.ppf(), cparams, {}, &pool, &ppf_out), 39200, 130);
+  EXPECT_NEAR(Roundtrip(t.ppf(), cparams, {}, &pool, &ppf_out), 38360, 130);
   EXPECT_THAT(ComputeDistance2(t.ppf(), ppf_out), IsSlightlyBelow(18));
 }
 
@@ -448,7 +448,7 @@ TEST(JxlTest, RoundtripSmallNL) {
   t.SetDimensions(xsize, ysize);
 
   PackedPixelFile ppf_out;
-  EXPECT_NEAR(Roundtrip(t.ppf(), {}, {}, pool, &ppf_out), 759, 10);
+  EXPECT_NEAR(Roundtrip(t.ppf(), {}, {}, pool, &ppf_out), 776, 10);
   EXPECT_THAT(ButteraugliDistance(t.ppf(), ppf_out), IsSlightlyBelow(1.0));
 }
 
@@ -465,7 +465,7 @@ TEST(JxlTest, RoundtripNoGaborishNoAR) {
 
   PackedPixelFile ppf_out;
   // TODO(szabadka) Investigate size difference on SCALAR build.
-  EXPECT_NEAR(Roundtrip(t.ppf(), cparams, {}, pool, &ppf_out), 37180, 100);
+  EXPECT_NEAR(Roundtrip(t.ppf(), cparams, {}, pool, &ppf_out), 36541, 100);
   EXPECT_THAT(ButteraugliDistance(t.ppf(), ppf_out), IsSlightlyBelow(2.0));
 }
 
@@ -483,7 +483,7 @@ TEST(JxlTest, RoundtripSmallNoGaborish) {
   cparams.AddOption(JXL_ENC_FRAME_SETTING_GABORISH, 0);
 
   PackedPixelFile ppf_out;
-  EXPECT_EQ(Roundtrip(t.ppf(), cparams, {}, pool, &ppf_out), 819);
+  EXPECT_EQ(Roundtrip(t.ppf(), cparams, {}, pool, &ppf_out), 812);
   EXPECT_THAT(ButteraugliDistance(t.ppf(), ppf_out), IsSlightlyBelow(1.2));
 }
 
@@ -509,8 +509,8 @@ TEST(JxlTest, RoundtripSmallPatchesAlpha) {
   cparams.distance = 0.1f;
 
   PackedPixelFile ppf_out;
-  EXPECT_NEAR(Roundtrip(t.ppf(), cparams, {}, pool, &ppf_out), 573, 15);
-  EXPECT_THAT(ButteraugliDistance(t.ppf(), ppf_out), IsSlightlyBelow(0.02f));
+  EXPECT_NEAR(Roundtrip(t.ppf(), cparams, {}, pool, &ppf_out), 550, 15);
+  EXPECT_THAT(ButteraugliDistance(t.ppf(), ppf_out), IsSlightlyBelow(0.021f));
 }
 
 TEST(JxlTest, RoundtripSmallPatches) {
@@ -534,8 +534,8 @@ TEST(JxlTest, RoundtripSmallPatches) {
   cparams.distance = 0.1f;
 
   PackedPixelFile ppf_out;
-  EXPECT_NEAR(Roundtrip(t.ppf(), cparams, {}, pool, &ppf_out), 477, 10);
-  EXPECT_THAT(ButteraugliDistance(t.ppf(), ppf_out), IsSlightlyBelow(0.02f));
+  EXPECT_NEAR(Roundtrip(t.ppf(), cparams, {}, pool, &ppf_out), 455, 10);
+  EXPECT_THAT(ButteraugliDistance(t.ppf(), ppf_out), IsSlightlyBelow(0.021f));
 }
 
 // TODO(szabadka) Add encoder and decoder API functions that accept frame
@@ -811,7 +811,7 @@ TEST(JxlTest, RoundtripAlphaResampling) {
   cparams.AddOption(JXL_ENC_FRAME_SETTING_EXTRA_CHANNEL_RESAMPLING, 2);
 
   PackedPixelFile ppf_out;
-  EXPECT_NEAR(Roundtrip(t.ppf(), cparams, {}, pool, &ppf_out), 12203, 30);
+  EXPECT_NEAR(Roundtrip(t.ppf(), cparams, {}, pool, &ppf_out), 12149, 30);
   EXPECT_THAT(ButteraugliDistance(t.ppf(), ppf_out), IsSlightlyBelow(4.9));
 }
 
@@ -829,7 +829,7 @@ TEST(JxlTest, RoundtripAlphaResamplingOnlyAlpha) {
   cparams.AddOption(JXL_ENC_FRAME_SETTING_EXTRA_CHANNEL_RESAMPLING, 2);
 
   PackedPixelFile ppf_out;
-  EXPECT_NEAR(Roundtrip(t.ppf(), cparams, {}, pool, &ppf_out), 30278, 40);
+  EXPECT_NEAR(Roundtrip(t.ppf(), cparams, {}, pool, &ppf_out), 29949, 40);
   EXPECT_THAT(ButteraugliDistance(t.ppf(), ppf_out), IsSlightlyBelow(1.85));
 }
 
@@ -1072,7 +1072,7 @@ TEST(JxlTest, RoundtripDots) {
   cparams.distance = 0.04;
 
   PackedPixelFile ppf_out;
-  EXPECT_NEAR(Roundtrip(t.ppf(), cparams, {}, pool, &ppf_out), 255124, 800);
+  EXPECT_NEAR(Roundtrip(t.ppf(), cparams, {}, pool, &ppf_out), 251328, 800);
   EXPECT_THAT(ButteraugliDistance(t.ppf(), ppf_out), IsSlightlyBelow(0.3));
 }
 
@@ -1092,7 +1092,7 @@ TEST(JxlTest, RoundtripNoise) {
   cparams.AddOption(JXL_ENC_FRAME_SETTING_NOISE, 1);
 
   PackedPixelFile ppf_out;
-  EXPECT_NEAR(Roundtrip(t.ppf(), cparams, {}, pool, &ppf_out), 39033, 100);
+  EXPECT_NEAR(Roundtrip(t.ppf(), cparams, {}, pool, &ppf_out), 38200, 100);
   EXPECT_THAT(ButteraugliDistance(t.ppf(), ppf_out), IsSlightlyBelow(1.6));
 }
 
@@ -1377,8 +1377,8 @@ TEST(JxlTest, RoundtripProgressive) {
   cparams.AddOption(JXL_ENC_FRAME_SETTING_RESPONSIVE, 1);
 
   PackedPixelFile ppf_out;
-  EXPECT_NEAR(Roundtrip(t.ppf(), cparams, {}, &pool, &ppf_out), 59940, 50);
-  EXPECT_THAT(ButteraugliDistance(t.ppf(), ppf_out), IsSlightlyBelow(1.23));
+  EXPECT_NEAR(Roundtrip(t.ppf(), cparams, {}, &pool, &ppf_out), 62373, 50);
+  EXPECT_THAT(ButteraugliDistance(t.ppf(), ppf_out), IsSlightlyBelow(1.26));
 }
 
 TEST(JxlTest, RoundtripProgressiveLevel2Slow) {
@@ -1394,8 +1394,8 @@ TEST(JxlTest, RoundtripProgressiveLevel2Slow) {
   cparams.AddOption(JXL_ENC_FRAME_SETTING_RESPONSIVE, 1);
 
   PackedPixelFile ppf_out;
-  EXPECT_NEAR(Roundtrip(t.ppf(), cparams, {}, &pool, &ppf_out), 69852, 50);
-  EXPECT_THAT(ButteraugliDistance(t.ppf(), ppf_out), IsSlightlyBelow(1.1));
+  EXPECT_NEAR(Roundtrip(t.ppf(), cparams, {}, &pool, &ppf_out), 67956, 50);
+  EXPECT_THAT(ButteraugliDistance(t.ppf(), ppf_out), IsSlightlyBelow(1.13));
 }
 
 TEST(JxlTest, RoundtripUnsignedCustomBitdepthLossless) {

--- a/lib/jxl/modular_test.cc
+++ b/lib/jxl/modular_test.cc
@@ -147,7 +147,7 @@ TEST(ModularTest, RoundtripLossyDeltaPaletteWP) {
   cparams.ba_params.intensity_target = 80.0f;
   EXPECT_THAT(ButteraugliDistance(io, io_out, cparams.ba_params, GetJxlCms(),
                                   /*distmap=*/nullptr, pool),
-              IsSlightlyBelow(10.0));
+              IsSlightlyBelow(10.1));
 }
 
 TEST(ModularTest, RoundtripLossy) {

--- a/lib/jxl/passes_test.cc
+++ b/lib/jxl/passes_test.cc
@@ -68,7 +68,7 @@ TEST(PassesTest, RoundtripUnalignedPasses) {
   Roundtrip(&io, cparams, {}, pool, &io2);
   EXPECT_THAT(ButteraugliDistance(io, io2, cparams.ba_params, GetJxlCms(),
                                   /*distmap=*/nullptr, pool),
-              IsSlightlyBelow(1.6));
+              IsSlightlyBelow(1.72));
 }
 
 TEST(PassesTest, RoundtripMultiGroupPasses) {


### PR DESCRIPTION
Butteraugli numbers are with a butteraugli as in https://github.com/libjxl/libjxl/pull/1822.

Currently, `progressive_dc=1` has somewhat lower DC precision than `progressive_dc=0`, causing a discontinuity at d4.5:

```
Encoding      kPixels    Bytes          BPP  E MP/s  D MP/s     Max norm        pnorm       BPP*pnorm   Bugs
------------------------------------------------------------------------------------------------------------
jxl:d0.5        13270  4230132    2.5501063   6.500  50.978   1.07075775   0.37354307  0.952574538746      0
jxl:d1          13270  2695661    1.6250609   7.318  65.233   1.69066322   0.60121030  0.977003367091      0
jxl:d2          13270  1682981    1.0145737   7.896  64.650   3.01102424   0.94896466  0.962794548686      0
jxl:d3          13270  1253173    0.7554668   7.002  63.525   3.69197154   1.24192752  0.938235043417      0
jxl:d4          13270  1012015    0.6100864   7.273  37.927   4.98539543   1.49342448  0.911117914664      0
jxl:d4.49       13270   928374    0.5596640   7.001  36.067   5.43043661   1.60771532  0.899780317958      0
jxl:d4.5        13270   900648    0.5429495   5.900  37.258   7.28517866   1.66022550  0.901418648387      0
jxl:d5          13270   830208    0.5004853   6.197  37.317   8.16854095   1.76249866  0.882104582765      0
jxl:d6          13270   717568    0.4325810   6.551  36.311   7.04228687   1.96973230  0.852068752922      0
jxl:d8          13270   567120    0.3418844   6.243  32.537  12.01802254   2.40786540  0.823211708158      0
jxl:d10         13270   461878    0.2784400   6.533  34.720  12.48957634   2.80455396  0.780900042570      0
jxl:d12         13270   385601    0.2324569   6.331  32.506  12.79455566   3.24981950  0.755443104533      0
Aggregate:      13270  1017022    0.6131049   6.707  42.491   5.25004834   1.44133083  0.883686963798      0
```

As you can see, there's a slight drop in both size and quality between d4.49 and d4.5 (and for some other metrics like SSIMULACRA2 and PSNR-HVS, the drop in quality is bigger than what pnorm suggests).

Also, forcing `progressive_dc=1 `at d3 and d4 produces files that are smaller but worse than when using non-progressive dc:
```
Encoding      kPixels    Bytes          BPP  E MP/s  D MP/s     Max norm        pnorm       BPP*pnorm   Bugs
------------------------------------------------------------------------------------------------------------
jxl:d3          13270  1236975    0.7457020   6.311  63.384   3.95714688   1.25106763  0.932923597449      0
jxl:d4          13270   989439    0.5964766   6.127  34.809   5.00354862   1.50838382  0.899715618651      0
```
while forcing `progressive_dc=0` at d >= 4.5 produces files that are larger and better:
```
Encoding      kPixels    Bytes          BPP  E MP/s  D MP/s     Max norm        pnorm       BPP*pnorm   Bugs
------------------------------------------------------------------------------------------------------------
jxl:d4.5        13270   927117    0.5589062   8.009  39.004   5.35170126   1.60904025  0.899302543849      0
jxl:d5          13270   859668    0.5182450   7.908  36.840   5.72473764   1.71735565  0.890011000374      0
jxl:d6          13270   751072    0.4527787   8.003  38.553   6.21732950   1.92046573  0.869545883378      0
jxl:d8          13270   605853    0.3652344   8.168  35.082   7.17651081   2.31397713  0.845143966670      0
jxl:d10         13270   504644    0.3042212   8.306  35.899   8.04223824   2.69142440  0.818788378418      0
jxl:d12         13270   430102    0.2592841   7.887  35.285  10.43673992   3.11513306  0.807704371140      0
Aggregate:      13270  1049158    0.6324777   7.914  45.228   4.46337606   1.41681489  0.896103808182      0
```

It's not good that switching between progressive dc and non-progressive dc causes differences in quality and filesize that are so large, so this needed to be recalibrated.


This pull request does three things:
- Stop switching by default to progressive dc at d4.5, i.e. keep using the same dc approach everywhere. This avoids a discontinuity and also avoids the slight drop in encode and decode speed that comes with progressive dc.
- Adjust the overall balance between AC and DC (slightly lower AC quality, slightly higher DC quality).
- Bump up the quality of progressive dc so it matches that of the default non-progressive dc. Also encode progressive dc using a slower speed setting; this makes encoding with that option slower but it's now an opt-in thing only so I think that's OK.

This  is what the new default behavior looks like:

```
Encoding      kPixels    Bytes          BPP  E MP/s  D MP/s     Max norm        pnorm       BPP*pnorm   Bugs
------------------------------------------------------------------------------------------------------------
jxl:d0.5        13270  4160820    2.5083221   7.235  70.975   1.05807507   0.37959224  0.952139599816      0
jxl:d1          13270  2647364    1.5959454   8.313  73.612   1.77005208   0.61177727  0.976363123907      0
jxl:d2          13270  1649611    0.9944568   8.972  71.096   2.94739962   0.96637524  0.961018411713      0
jxl:d3          13270  1229477    0.7411819   7.579  64.534   3.59213662   1.26319101  0.936254257832      0
jxl:d4          13270   994532    0.5995469   7.756  40.871   4.76617241   1.51805943  0.910147762935      0
jxl:d4.49       13270   914727    0.5514370   7.659  40.050   5.24246264   1.63118619  0.899496347112      0
jxl:d4.5        13270   913127    0.5504724   7.733  37.347   5.27911806   1.63461552  0.899810740199      0
jxl:d5          13270   846274    0.5101705   7.749  38.532   5.77727699   1.74357325  0.889519690305      0
jxl:d6          13270   741006    0.4467104   7.836  38.011   6.34842682   1.95741822  0.874399138574      0
jxl:d8          13270   600193    0.3618223   7.872  36.405   7.88257933   2.35311323  0.851408774486      0
jxl:d10         13270   501622    0.3023994   8.080  36.606   8.53741455   2.73764120  0.827861093955      0
jxl:d12         13270   427971    0.2579994   7.889  36.290  11.21195507   3.15591321  0.814223742975      0
Aggregate:      13270  1034338    0.6235437   7.879  46.560   4.51823539   1.44018010  0.898015266280      0
```

So the discontinuity at d4.5 of course disappears; at d < 4.5 the quality remains more or less the same as it was (typically a bit better maxnorm, a bit worse pnorm), but the bpp goes down a bit so overall it's a small improvement. At d >= 4.5 the quality improves compared to previous default behavior (and gets slightly worse than with the previous `--progressive_dc=0` behavior). In terms of maxnorm it looks a lot better now at those higher distances.

In terms of calibration between the new default behavior (non-progressive dc) and `--progressive_dc=1`, these are the results for `--progressive_dc=1`:

```
Encoding      kPixels    Bytes          BPP  E MP/s  D MP/s     Max norm        pnorm       BPP*pnorm   Bugs
------------------------------------------------------------------------------------------------------------
jxl:d0.5        13270  4181514    2.5207973   4.898  64.971   1.06629586   0.37921457  0.955923067377      0
jxl:d1          13270  2689419    1.6212980   5.666  64.188   1.77027094   0.60496604  0.980830204553      0
jxl:d2          13270  1680963    1.0133571   6.082  66.126   2.98178077   0.95236136  0.965082167022      0
jxl:d3          13270  1245349    0.7507502   5.306  61.626   3.80780554   1.25311922  0.940779485146      0
jxl:d4          13270   999924    0.6027974   5.619  37.473   4.68146181   1.50829806  0.909198128748      0
jxl:d4.49       13270   912689    0.5502084   5.310  37.929   5.20363474   1.62392643  0.893497902263      0
jxl:d4.5        13270   911333    0.5493909   5.609  38.838   5.20781898   1.62517214  0.892854796952      0
jxl:d5          13270   842753    0.5080479   5.642  37.955   5.73266411   1.73670341  0.882328552231      0
jxl:d6          13270   733337    0.4420872   5.859  38.406   6.88496637   1.95322215  0.863494566138      0
jxl:d8          13270   583570    0.3518012   5.768  34.140   7.87201786   2.35354553  0.827980161123      0
jxl:d10         13270   479142    0.2888475   6.039  35.424   9.83065701   2.75145264  0.794750212609      0
jxl:d12         13270   403597    0.2433057   6.248  34.962  10.46600056   3.17278266  0.771956133694      0
Aggregate:      13270  1026305    0.6187010   5.659  44.345   4.58768210   1.43454368  0.887553579358      0
```


So both in filesize and quality, the difference between `progressive_dc=0` (default) and `progressive_dc=1` is now smaller.

According to pnorm, it might still be worthwhile to switch at around d7 or so, but I think it's better to just avoid the discontinuity in speed and quality caused by changing default settings at specific distance points.