### PR TITLE
fix jxl_from_tree ambiguous call to make_unique

### DIFF
--- a/tools/jxl_from_tree.cc
+++ b/tools/jxl_from_tree.cc
@@ -467,7 +467,7 @@ int JxlFromTree(const char* in, const char* out, const char* tree_out) {
 
   while (true) {
     PassesEncoderState enc_state;
-    enc_state.heuristics = make_unique<Heuristics>(tree);
+    enc_state.heuristics = jxl::make_unique<Heuristics>(tree);
     enc_state.shared.image_features.splines =
         SplinesFromSplineData(spline_data, enc_state.shared.cmap);
 


### PR DESCRIPTION
when using in cmake,
tools\jxl_from_tree.cc(470,56): error C2668: 'jxl::make_unique': ambiguous call to overloaded function