### PR TITLE
Make cjxl output Exif/xml/jumb boxes

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -18,6 +18,7 @@ Google LLC <*@google.com>
 # Individuals:
 Alex Xu (Hello71) <alex_y_xu@yahoo.ca>
 Alexander Sago <cagelight@gmail.com>
+Alistair Barrow
 Andrius Lukas Narbutas <andrius4669@gmail.com>
 Aous Naman <aous@unsw.edu.au>
 Artem Selishchev

--- a/lib/extras/dec/jxl.cc
+++ b/lib/extras/dec/jxl.cc
@@ -516,6 +516,14 @@ bool DecodeImageJXL(const uint8_t* bytes, size_t bytes_size,
     }
   }
   boxes.FinalizeOutput();
+  // Encoded Exif has a 4-byte offset, but for processing we expect the TIFF
+  // header at the start of the data.
+  constexpr uint8_t zero32[] = {0, 0, 0, 0};
+  if (ppf->metadata.exif.size() >= 4 &&
+      memcmp(ppf->metadata.exif.data(), zero32, 4) == 0) {
+    ppf->metadata.exif.erase(ppf->metadata.exif.begin(),
+                             ppf->metadata.exif.begin() + 4);
+  }
   if (jpeg_bytes != nullptr) {
     if (!can_reconstruct_jpeg) return false;
     size_t used_jpeg_output =

--- a/lib/extras/dec/jxl.cc
+++ b/lib/extras/dec/jxl.cc
@@ -11,6 +11,7 @@
 #include "lib/extras/dec/color_description.h"
 #include "lib/extras/enc/encode.h"
 #include "lib/jxl/base/printf_macros.h"
+#include "lib/jxl/exif.h"
 
 namespace jxl {
 namespace extras {
@@ -516,13 +517,27 @@ bool DecodeImageJXL(const uint8_t* bytes, size_t bytes_size,
     }
   }
   boxes.FinalizeOutput();
-  // Encoded Exif has a 4-byte offset, but for processing we expect the TIFF
-  // header at the start of the data.
-  constexpr uint8_t zero32[] = {0, 0, 0, 0};
-  if (ppf->metadata.exif.size() >= 4 &&
-      memcmp(ppf->metadata.exif.data(), zero32, 4) == 0) {
-    ppf->metadata.exif.erase(ppf->metadata.exif.begin(),
-                             ppf->metadata.exif.begin() + 4);
+  if (!ppf->metadata.exif.empty()) {
+    // Verify that Exif box has a valid TIFF header at the specified offset.
+    // Discard bytes preceding the header.
+    if (ppf->metadata.exif.size() >= 4) {
+      uint32_t offset = LoadBE32(ppf->metadata.exif.data());
+      if (offset <= ppf->metadata.exif.size() - 8) {
+        std::vector<uint8_t> exif(ppf->metadata.exif.begin() + 4 + offset,
+                                  ppf->metadata.exif.end());
+        bool bigendian;
+        if (IsExif(exif, &bigendian)) {
+          ppf->metadata.exif = std::move(exif);
+        } else {
+          fprintf(stderr, "Warning: invalid TIFF header in Exif\n");
+        }
+      } else {
+        fprintf(stderr, "Warning: invalid Exif offset: %" PRIu32 "\n", offset);
+      }
+    } else {
+      fprintf(stderr, "Warning: invalid Exif length: %" PRIuS "\n",
+              ppf->metadata.exif.size());
+    }
   }
   if (jpeg_bytes != nullptr) {
     if (!can_reconstruct_jpeg) return false;

--- a/lib/extras/enc/apng.cc
+++ b/lib/extras/enc/apng.cc
@@ -101,7 +101,11 @@ class BlobsWriterPNG {
       // identity to avoid repeated orientation.
       std::vector<uint8_t> exif = blobs.exif;
       ResetExifOrientation(exif);
-      // By convention, the data is prefixed with "Exif\0\0"
+      // By convention, the data is prefixed with "Exif\0\0" when stored in
+      // the legacy (and non-standard) "Raw profile type exif" text chunk
+      // currently used here.
+      // TODO: Store Exif data in an eXIf chunk instead, which always begins
+      // with the TIFF header.
       if (exif.size() >= sizeof kExifSignature &&
           memcmp(exif.data(), kExifSignature, sizeof kExifSignature) != 0) {
         exif.insert(exif.begin(), kExifSignature,
@@ -113,6 +117,7 @@ class BlobsWriterPNG {
       JXL_RETURN_IF_ERROR(EncodeBase16("iptc", blobs.iptc, strings));
     }
     if (!blobs.xmp.empty()) {
+      // TODO: Store XMP data in an "XML:com.adobe.xmp" text chunk instead.
       JXL_RETURN_IF_ERROR(EncodeBase16("xmp", blobs.xmp, strings));
     }
     return true;

--- a/lib/extras/enc/jxl.cc
+++ b/lib/extras/enc/jxl.cc
@@ -157,7 +157,7 @@ bool EncodeImageJXL(const JXLCompressParams& params, const PackedPixelFile& ppf,
         if (!box.bytes.empty() &&
             JXL_ENC_SUCCESS != JxlEncoderAddBox(enc, box.type, box.bytes.data(),
                                                 box.bytes.size(),
-                                                /*compress_box=*/JXL_FALSE)) {
+                                                params.compress_boxes)) {
           fprintf(stderr, "JxlEncoderAddBox() failed (%s).\n", box.type);
           return false;
         }

--- a/lib/extras/enc/jxl.cc
+++ b/lib/extras/enc/jxl.cc
@@ -6,6 +6,7 @@
 #include "lib/extras/enc/jxl.h"
 
 #include "jxl/encode_cxx.h"
+#include "lib/jxl/exif.h"
 
 namespace jxl {
 namespace extras {
@@ -57,12 +58,10 @@ bool EncodeImageJXL(const JXLCompressParams& params, const PackedPixelFile& ppf,
     return false;
   }
 
-  bool use_container = params.use_container;
-  if (!ppf.metadata.exif.empty() || !ppf.metadata.xmp.empty() ||
-      !ppf.metadata.jumbf.empty() || !ppf.metadata.iptc.empty() ||
-      (jpeg_bytes && params.jpeg_store_metadata)) {
-    use_container = true;
-  }
+  bool use_boxes = !ppf.metadata.exif.empty() || !ppf.metadata.xmp.empty() ||
+                   !ppf.metadata.jumbf.empty() || !ppf.metadata.iptc.empty();
+  bool use_container = params.use_container || use_boxes ||
+                       (jpeg_bytes && params.jpeg_store_metadata);
 
   if (JXL_ENC_SUCCESS !=
       JxlEncoderUseContainer(enc, static_cast<int>(use_container))) {
@@ -129,6 +128,41 @@ bool EncodeImageJXL(const JXLCompressParams& params, const PackedPixelFile& ppf,
         fprintf(stderr, "JxlEncoderSetColorEncoding() failed.\n");
         return false;
       }
+    }
+
+    if (use_boxes) {
+      if (JXL_ENC_SUCCESS != JxlEncoderUseBoxes(enc)) {
+        fprintf(stderr, "JxlEncoderUseBoxes() failed.\n");
+        return false;
+      }
+      // Prepend 4 zero bytes to exif for tiff header offset
+      std::vector<uint8_t> exif_with_offset;
+      bool bigendian;
+      if (IsExif(ppf.metadata.exif, &bigendian)) {
+        exif_with_offset.resize(ppf.metadata.exif.size() + 4);
+        memcpy(exif_with_offset.data() + 4, ppf.metadata.exif.data(),
+               ppf.metadata.exif.size());
+      }
+      const struct BoxInfo {
+        const char* type;
+        const std::vector<uint8_t>& bytes;
+      } boxes[] = {
+          {"Exif", exif_with_offset},
+          {"xml ", ppf.metadata.xmp},
+          {"jumb", ppf.metadata.jumbf},
+          {"xml ", ppf.metadata.iptc},
+      };
+      for (size_t i = 0; i < sizeof boxes / sizeof *boxes; ++i) {
+        const BoxInfo& box = boxes[i];
+        if (!box.bytes.empty() &&
+            JXL_ENC_SUCCESS != JxlEncoderAddBox(enc, box.type, box.bytes.data(),
+                                                box.bytes.size(),
+                                                /*compress_box=*/JXL_FALSE)) {
+          fprintf(stderr, "JxlEncoderAddBox() failed (%s).\n", box.type);
+          return false;
+        }
+      }
+      JxlEncoderCloseBoxes(enc);
     }
 
     for (size_t num_frame = 0; num_frame < ppf.frames.size(); ++num_frame) {

--- a/lib/extras/enc/jxl.h
+++ b/lib/extras/enc/jxl.h
@@ -42,6 +42,8 @@ struct JXLCompressParams {
   bool use_container = false;
   // Whether to enable/disable byte-exact jpeg reconstruction for jpeg inputs.
   bool jpeg_store_metadata = true;
+  // Whether to create brob boxes.
+  bool compress_boxes = true;
   // Upper bound on the intensity level present in the image in nits (zero means
   // that the library chooses a default).
   float intensity_target = 0;

--- a/lib/include/jxl/encode.h
+++ b/lib/include/jxl/encode.h
@@ -339,6 +339,13 @@ typedef enum {
    */
   JXL_ENC_FRAME_SETTING_BROTLI_EFFORT = 32,
 
+  /** Enables or disables brotli compression of metadata boxes derived from
+   * a JPEG frame when using JxlEncoderAddJPEGFrame. This has no effect on boxes
+   * added using JxlEncoderAddBox.
+   * -1 = default, 0 = disable compression, 1 = enable compression.
+   */
+  JXL_ENC_FRAME_SETTING_JPEG_COMPRESS_BOXES = 33,
+
   /** Enum value not to be used as an option. This value is added to force the
    * C compiler to have the enum to take a known size.
    */

--- a/lib/jxl/enc_params.h
+++ b/lib/jxl/enc_params.h
@@ -188,6 +188,9 @@ struct CompressParams {
   // allowing reconstruction of the original JPEG.
   bool force_cfl_jpeg_recompression = true;
 
+  // Use brotli compression for any boxes derived from a JPEG frame.
+  bool jpeg_compress_boxes = true;
+
   // Set the noise to what it would approximately be if shooting at the nominal
   // exposure for a given ISO setting on a 35mm camera.
   float photon_noise_iso = 0;

--- a/lib/jxl/encode.cc
+++ b/lib/jxl/encode.cc
@@ -1001,6 +1001,7 @@ JxlEncoderStatus JxlEncoderFrameSettingsSetOption(
     case JXL_ENC_FRAME_SETTING_QPROGRESSIVE_AC:
     case JXL_ENC_FRAME_SETTING_LOSSY_PALETTE:
     case JXL_ENC_FRAME_SETTING_JPEG_RECON_CFL:
+    case JXL_ENC_FRAME_SETTING_JPEG_COMPRESS_BOXES:
       if (value < -1 || value > 1) {
         return JXL_API_ERROR(
             frame_settings->enc, JXL_ENC_ERR_API_USAGE,
@@ -1215,6 +1216,9 @@ JxlEncoderStatus JxlEncoderFrameSettingsSetOption(
       return JXL_API_ERROR(frame_settings->enc, JXL_ENC_ERR_NOT_SUPPORTED,
                            "Float option, try setting it with "
                            "JxlEncoderFrameSettingsSetFloatOption");
+    case JXL_ENC_FRAME_SETTING_JPEG_COMPRESS_BOXES:
+      frame_settings->values.cparams.jpeg_compress_boxes = value;
+      return JXL_ENC_SUCCESS;
     default:
       return JXL_API_ERROR(frame_settings->enc, JXL_ENC_ERR_NOT_SUPPORTED,
                            "Unknown option");
@@ -1303,6 +1307,7 @@ JxlEncoderStatus JxlEncoderFrameSettingsSetFloatOption(
     case JXL_ENC_FRAME_INDEX_BOX:
     case JXL_ENC_FRAME_SETTING_BROTLI_EFFORT:
     case JXL_ENC_FRAME_SETTING_FILL_ENUM:
+    case JXL_ENC_FRAME_SETTING_JPEG_COMPRESS_BOXES:
       return JXL_API_ERROR(frame_settings->enc, JXL_ENC_ERR_NOT_SUPPORTED,
                            "Int option, try setting it with "
                            "JxlEncoderFrameSettingsSetOption");
@@ -1503,17 +1508,19 @@ JxlEncoderStatus JxlEncoderAddJPEGFrame(
     memcpy(exif.data() + 4, io.blobs.exif.data(), io.blobs.exif.size());
     JxlEncoderUseBoxes(frame_settings->enc);
     JxlEncoderAddBox(frame_settings->enc, "Exif", exif.data(), exif_size,
-                     /*compress_box=*/JXL_TRUE);
+                     frame_settings->values.cparams.jpeg_compress_boxes);
   }
   if (!io.blobs.xmp.empty()) {
     JxlEncoderUseBoxes(frame_settings->enc);
     JxlEncoderAddBox(frame_settings->enc, "xml ", io.blobs.xmp.data(),
-                     io.blobs.xmp.size(), /*compress_box=*/JXL_TRUE);
+                     io.blobs.xmp.size(),
+                     frame_settings->values.cparams.jpeg_compress_boxes);
   }
   if (!io.blobs.jumbf.empty()) {
     JxlEncoderUseBoxes(frame_settings->enc);
     JxlEncoderAddBox(frame_settings->enc, "jumb", io.blobs.jumbf.data(),
-                     io.blobs.jumbf.size(), /*compress_box=*/JXL_TRUE);
+                     io.blobs.jumbf.size(),
+                     frame_settings->values.cparams.jpeg_compress_boxes);
   }
   if (frame_settings->enc->store_jpeg_metadata) {
     jxl::jpeg::JPEGData data_in = *io.Main().jpeg_data;

--- a/tools/cjxl_main.cc
+++ b/tools/cjxl_main.cc
@@ -146,6 +146,12 @@ struct CompressArgs {
         &effort, &ParseUnsigned, -1);
 
     cmdline->AddOptionValue(
+        '\0', "compress_boxes", "0|1",
+        "Disable/enable Brotli compression for metadata boxes "
+        "(not provided = default, 0 = disable, 1 = enable).",
+        &compress_boxes, &ParseOverride, 1);
+
+    cmdline->AddOptionValue(
         '\0', "brotli_effort", "B_EFFORT",
         "Brotli effort setting. Range: 0 .. 11.\n"
         "    Default: 9. Higher number is more effort (slower).",
@@ -454,6 +460,7 @@ struct CompressArgs {
   jxl::Override patches = jxl::Override::kDefault;
   jxl::Override gaborish = jxl::Override::kDefault;
   jxl::Override group_order = jxl::Override::kDefault;
+  jxl::Override compress_boxes = jxl::Override::kDefault;
 
   size_t faster_decoding = 0;
   int64_t resampling = -1;
@@ -876,6 +883,7 @@ void ProcessFlags(const jxl::extras::Codec codec,
   params->override_bitdepth = args->override_bitdepth;
   params->codestream_level = args->codestream_level;
   params->premultiply = args->premultiply;
+  params->compress_boxes = args->compress_boxes == jxl::Override::kOn;
   if (codec == jxl::extras::Codec::kPNM) {
     params->input_bitdepth.type = JXL_BIT_DEPTH_FROM_CODESTREAM;
   }

--- a/tools/cjxl_main.cc
+++ b/tools/cjxl_main.cc
@@ -866,6 +866,8 @@ void ProcessFlags(const jxl::extras::Codec codec,
   if (jpeg_bytes) {
     ProcessBoolFlag(args->jpeg_reconstruction_cfl,
                     JXL_ENC_FRAME_SETTING_JPEG_RECON_CFL, params);
+    ProcessBoolFlag(args->compress_boxes,
+                    JXL_ENC_FRAME_SETTING_JPEG_COMPRESS_BOXES, params);
   }
   // Set per-frame options.
   for (size_t num_frame = 0; num_frame < ppf.frames.size(); ++num_frame) {
@@ -883,7 +885,7 @@ void ProcessFlags(const jxl::extras::Codec codec,
   params->override_bitdepth = args->override_bitdepth;
   params->codestream_level = args->codestream_level;
   params->premultiply = args->premultiply;
-  params->compress_boxes = args->compress_boxes == jxl::Override::kOn;
+  params->compress_boxes = args->compress_boxes != jxl::Override::kOff;
   if (codec == jxl::extras::Codec::kPNM) {
     params->input_bitdepth.type = JXL_BIT_DEPTH_FROM_CODESTREAM;
   }


### PR DESCRIPTION
This brings back a cjxl feature from before cjxl_ng: Exif/XMP/IPTC/JUMBF metadata from the input will be preserved as corresponding ISO BMFF boxes in the output.

Without this change, cjxl reads the metadata, reports that it has read the metadata, and forces the JXL container format... but never actually writes any boxes.

Tested with Exif and XMP metadata. `./ci.sh release` ran with no issues.

(This is my first ever PR. Hopefully I'm doing this right!)