### PR TITLE
Compute optimal dequant biases assuming Laplacian AC distribution.

### DIFF
--- a/lib/extras/dec_group_jpeg.h
+++ b/lib/extras/dec_group_jpeg.h
@@ -18,8 +18,13 @@
 namespace jxl {
 namespace extras {
 
-void DecodeJpegBlock(const int16_t* qblock, size_t c,
+void GatherBlockStats(const int16_t* coeffs, const size_t coeffs_size,
+                      int32_t* JXL_RESTRICT nonzeros,
+                      int32_t* JXL_RESTRICT sumabs);
+
+void DecodeJpegBlock(const int16_t* qblock,
                      const float* JXL_RESTRICT dequant_matrices,
+                     const float* JXL_RESTRICT biases,
                      float* JXL_RESTRICT scratch_space,
                      float* JXL_RESTRICT output, size_t output_stride);
 


### PR DESCRIPTION
Based on article by J. R. Price and M. Rabbani from 2000.

Benchmark before:
```
Encoding                 kPixels    Bytes          BPP  E MP/s  D MP/s     Max norm        pnorm       BPP*pnorm   Bugs
-----------------------------------------------------------------------------------------------------------------------
jpeg:q95:djxl8             13270  7112433    4.2876819  54.804 104.038   1.63272071   0.44628983  1.913548813406      0
jpeg:q95:yuv420:djxl8      13270  5230427    3.1531274  81.308 140.788   6.06236982   0.78961033  2.489741937504      0
jpeg:libjxl:djxl8          13270  3197015    1.9272988  19.081  84.911   2.19547820   0.70263982  1.354196861688      0
```

Benchmark after:
```
Encoding                 kPixels    Bytes          BPP  E MP/s  D MP/s     Max norm        pnorm       BPP*pnorm   Bugs
-----------------------------------------------------------------------------------------------------------------------
jpeg:q95:djxl8             13270  7112433    4.2876819  54.394 101.044   1.41126788   0.42871893  1.838210386950      0
jpeg:q95:yuv420:djxl8      13270  5230427    3.1531274  81.098 140.151   6.03857374   0.77685715  2.449529533303      0
jpeg:libjxl:djxl8          13270  3197015    1.9272988  19.056  83.773   2.23333597   0.70076511  1.350583733701      0
```