### PR TITLE
jni/Decoder: add byte buffer wrapper

### DIFF
--- a/tools/jni/org/jpeg/jpegxl/wrapper/Decoder.java
+++ b/tools/jni/org/jpeg/jpegxl/wrapper/Decoder.java
@@ -32,7 +32,14 @@ public class Decoder {
     return new ImageData(basicInfo.width, basicInfo.height, pixels, icc, pixelFormat);
   }
 
-  // TODO(eustas): accept byte-array as input.
+  public static StreamInfo decodeInfo(byte[] data) {
+    return decodeInfo(ByteBuffer.wrap(data));
+  }
+
+  public static StreamInfo decodeInfo(byte[] data, int offset, int length) {
+    return decodeInfo(ByteBuffer.wrap(data, offset, length));
+  }
+
   public static StreamInfo decodeInfo(Buffer data) {
     return DecoderJni.getBasicInfo(data, null);
   }


### PR DESCRIPTION
Removes the TODO by implementing a byte buffer wrapper convenience method.