### PR TITLE
Encode intrinsic dimensions

### DIFF
--- a/lib/include/jxl/codestream_header.h
+++ b/lib/include/jxl/codestream_header.h
@@ -71,15 +71,6 @@ typedef struct {
   uint32_t ysize;
 } JxlPreviewHeader;
 
-/** The intrinsic size header */
-typedef struct {
-  /** Intrinsic width in pixels */
-  uint32_t xsize;
-
-  /** Intrinsic height in pixels */
-  uint32_t ysize;
-} JxlIntrinsicSizeHeader;
-
 /** The codestream animation header, optionally present in the beginning of
  * the codestream, and if it is it applies to all animation frames, unlike
  * JxlFrameHeader which applies to an individual frame.

--- a/lib/jxl/encode.cc
+++ b/lib/jxl/encode.cc
@@ -762,6 +762,18 @@ JxlEncoderStatus JxlEncoderSetBasicInfo(JxlEncoder* enc,
   enc->metadata.m.modular_16_bit_buffer_sufficient =
       (!info->uses_original_profile || info->bits_per_sample <= 12) &&
       info->alpha_bits <= 12;
+  if ((info->intrinsic_xsize > 0 || info->intrinsic_ysize > 0) &&
+      (info->intrinsic_xsize != info->xsize ||
+       info->intrinsic_ysize != info->ysize)) {
+    if (info->intrinsic_xsize > (1ull << 30ull) ||
+        info->intrinsic_ysize > (1ull << 30ull) ||
+        !enc->metadata.m.intrinsic_size.Set(info->intrinsic_xsize,
+                                            info->intrinsic_ysize)) {
+      return JXL_API_ERROR(enc, JXL_ENC_ERR_API_USAGE,
+                           "Invalid intrinsic dimensions");
+    }
+    enc->metadata.m.have_intrinsic_size = true;
+  }
 
   // The number of extra channels includes the alpha channel, so for example and
   // RGBA with no other extra channels, has exactly num_extra_channels == 1

--- a/lib/jxl/encode_test.cc
+++ b/lib/jxl/encode_test.cc
@@ -890,6 +890,8 @@ TEST(EncodeTest, BasicInfoTest) {
   basic_info.min_nits = 5.0;
   basic_info.linear_below = 12.7;
   basic_info.orientation = JXL_ORIENT_ROTATE_90_CW;
+  basic_info.intrinsic_xsize = 88;
+  basic_info.intrinsic_ysize = 99;
   basic_info.animation.tps_numerator = 55;
   basic_info.animation.tps_denominator = 77;
   basic_info.animation.num_loops = 10;
@@ -945,6 +947,8 @@ TEST(EncodeTest, BasicInfoTest) {
       EXPECT_EQ(basic_info.uses_original_profile,
                 basic_info2.uses_original_profile);
       EXPECT_EQ(basic_info.orientation, basic_info2.orientation);
+      EXPECT_EQ(basic_info.intrinsic_xsize, basic_info2.intrinsic_xsize);
+      EXPECT_EQ(basic_info.intrinsic_ysize, basic_info2.intrinsic_ysize);
       EXPECT_EQ(basic_info.num_color_channels, basic_info2.num_color_channels);
       // TODO(lode): also test num_extra_channels, but currently there may be a
       // mismatch between 0 and 1 if there is alpha, until encoder support for


### PR DESCRIPTION
This makes the encoder store the `intrinsic_xsize` and `intrinsic_ysize` from JxlBasicInfo. Setting these previously had no effect.

Tests:
Encoded the same 80x30 image using several different settings for intrinsic_xsize and intrinsic_ysize:

```
Intrinsic dimensions       Encoder error
----------------------------------------
0x0 (unset)                None

80x30 (= xsize/ysize)      None

123x111                    None

123x0                      ./lib/jxl/headers.cc:66: JXL_FAILURE: Empty image
                           ./lib/jxl/encode.cc:773: Invalid intrinsic dimensions
                            
80x1073741824 (1<<30)*     None

80x1073741825              ./lib/jxl/encode.cc:773: Invalid intrinsic dimensions
```
(*There's an explicit check for this maximum, because otherwise it doesn't fail until JxlEncoderProcessOutput.)

Output files:

```bash
for F in 0x0.jxl 80x30.jxl 123x111.jxl 80x1073741824.jxl; do
  printf '%-60s: ' "$(sha1sum "$F")"
  jxlinfo -v "$F" | grep Intrinsic
done
```
```
9a2f7b8ce206f436e1791716c95be3a8af7715b4  0x0.jxl           : Intrinsic dimensions: 80x30
9a2f7b8ce206f436e1791716c95be3a8af7715b4  80x30.jxl         : Intrinsic dimensions: 80x30
ed2b257ed5d2af9352a55ab9067579bc2dff7640  123x111.jxl       : Intrinsic dimensions: 123x111
d65a2dd549b97c701c17fd6732d051ff81dfbed5  80x1073741824.jxl : Intrinsic dimensions: 80x1073741824
```
