### PR TITLE
Dont save MCU coding state if there are enough bytes in buffer.

### DIFF
--- a/lib/extras/decode_jpeg.cc
+++ b/lib/extras/decode_jpeg.cc
@@ -30,6 +30,11 @@ constexpr int kJpegHuffmanAlphabetSize = 256;
 constexpr int kMaxQuantTables = 4;
 constexpr int kJpegDCAlphabetSize = 12;
 constexpr int kMaxDimPixels = 65535;
+// Max 14 block per MCU (when 1 channel is subsampled)
+// Max 64 nonzero coefficients per block
+// Max 16 symbol bits plus 11 extra bits per nonzero symbol
+// Max 2 bytes per 8 bits (worst case is all bytes are escaped 0xff)
+constexpr int kMaxMCUByteSize = 6048;
 constexpr uint8_t kIccProfileTag[12] = "ICC_PROFILE";
 
 constexpr int kJpegHuffmanRootTableBits = 8;
@@ -1219,7 +1224,9 @@ JpegDecoder::Status JpegDecoder::ProcessScan(const uint8_t* data, size_t len,
     if (codestream_bits_ahead_ > 0) {
       br.ReadBits(codestream_bits_ahead_);
     }
-    SaveMCUCodingState();
+    if (start_pos + kMaxMCUByteSize > len) {
+      SaveMCUCodingState();
+    }
 
     // Decode one MCU.
     bool scan_ok = true;


### PR DESCRIPTION
Benchmark before:
```
Encoding                 kPixels    Bytes          BPP  E MP/s  D MP/s     Max norm        pnorm       BPP*pnorm   Bugs
-----------------------------------------------------------------------------------------------------------------------
jpeg:q90:djxl8             13270  4838710    2.9169834  65.817 112.747   2.17603183   0.62092407  1.811225220808      0
jpeg:yuv420:q90:djxl8      13270  3660915    2.2069577  96.322 164.534   6.05725956   0.91959307  2.029503031911      0
jpeg:libjxl:djxl8          13270  3197015    1.9272988  19.046  79.233   2.25490046   0.70510193  1.358942071174      0
```

Benchmark after:
```
Encoding                 kPixels    Bytes          BPP  E MP/s  D MP/s     Max norm        pnorm       BPP*pnorm   Bugs
-----------------------------------------------------------------------------------------------------------------------
jpeg:q90:djxl8             13270  4838710    2.9169834  66.330 118.045   2.17603183   0.62092407  1.811225220808      0
jpeg:yuv420:q90:djxl8      13270  3660915    2.2069577  96.814 169.467   6.05725956   0.91959307  2.029503031911      0
jpeg:libjxl:djxl8          13270  3197015    1.9272988  18.882  82.873   2.25490046   0.70510193  1.358942071174      0
```