### PR TITLE
tools/libjxl_test.c: avoid function declaration without prototype

### DIFF
--- a/tools/libjxl_test.c
+++ b/tools/libjxl_test.c
@@ -9,7 +9,7 @@
 
 #include "jxl/decode.h"
 
-int main() {
+int main(void) {
   if (!JxlDecoderVersion()) return 1;
   JxlDecoder* dec = JxlDecoderCreate(NULL);
   if (!dec) return 1;


### PR DESCRIPTION
Avoid declaring int main() without a prototype as this is deprecated in all versions of C.