### PR TITLE
fast_lossless: rename FastLosslessEncode

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -43,6 +43,7 @@ Mathieu Malaterre <mathieu.malaterre@gmail.com>
 Mikk Leini <mikk.leini@krakul.eu>
 Misaki Kasumi <misakikasumi@outlook.com>
 Nicholas Hayes <0xC0000054@users.noreply.github.com>
+Nigel Tao <nigeltao@golang.org>
 Petr Diblík
 Pieter Wuille
 roland-rollo

--- a/experimental/fast_lossless/fast_lossless.cc
+++ b/experimental/fast_lossless/fast_lossless.cc
@@ -20,6 +20,8 @@
 #error "system not known to be little endian"
 #endif
 
+namespace {
+
 struct BitWriter {
   void Allocate(size_t maximum_bit_size) {
     assert(data == nullptr);
@@ -143,10 +145,10 @@ struct PrefixCode {
   static void ComputeCodeLengths(uint64_t* freqs, size_t n, size_t limit,
                                  uint8_t* nbits) {
     if (n <= 1) return;
-    assert(n <= (1 << limit));
+    assert(n <= (1u << limit));
     assert(n <= 32);
-    int parent[64] = {};
-    int height[64] = {};
+    unsigned int parent[64] = {};
+    unsigned int height[64] = {};
     using QElem = std::pair<uint64_t, size_t>;
     std::priority_queue<QElem, std::vector<QElem>, std::greater<QElem>> q;
     // Standard Huffman code construction. On failure (i.e. if going beyond the
@@ -1088,8 +1090,8 @@ void PrepareDCGlobalPalette(bool is_single_group, size_t width, size_t height,
   encoder.code = &code;
   int16_t p[4][32 + 1024] = {};
   uint8_t prgba[4];
-  int i = 0;
-  int have_zero = 0;
+  size_t i = 0;
+  size_t have_zero = 0;
   if (palette[pcolors_real - 1] == 0) have_zero = 1;
   for (; i < pcolors; i++) {
     if (i < pcolors_real) {
@@ -1184,7 +1186,7 @@ size_t LLEnc(const unsigned char* rgba, size_t width, size_t stride,
     if (palette[0] == 1) palette[0] = 0;
     bool have_color = false;
     uint8_t minG = 255, maxG = 0;
-    for (int k = 0; k < kHashSize; k++) {
+    for (uint32_t k = 0; k < kHashSize; k++) {
       if (palette[k] == 0) continue;
       uint8_t p[4];
       memcpy(p, &palette[k], 4);
@@ -1297,7 +1299,9 @@ size_t LLEnc(const unsigned char* rgba, size_t width, size_t stride,
     PrepareDCGlobalPalette(onegroup, width, height, hcode, palette, pcolors,
                            &group_data[0][0]);
   }
+#ifdef _OPENMP
 #pragma omp parallel for
+#endif
   for (size_t g = 0; g < num_groups_y * num_groups_x; g++) {
     size_t xg = g % num_groups_x;
     size_t yg = g / num_groups_x;
@@ -1324,9 +1328,20 @@ size_t LLEnc(const unsigned char* rgba, size_t width, size_t stride,
   return writer.bytes_written;
 }
 
-size_t FastLosslessEncode(const unsigned char* rgba, size_t width,
-                          size_t stride, size_t height, size_t nb_chans,
-                          size_t bitdepth, int effort, unsigned char** output) {
+}  // namespace
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+size_t JxlFastLosslessEncode(const unsigned char* rgba,
+                             size_t width,
+                             size_t stride,
+                             size_t height,
+                             size_t nb_chans,
+                             size_t bitdepth,
+                             int effort,
+                             unsigned char** output) {
   assert(bitdepth <= 12);
   assert(bitdepth > 0);
   assert(nb_chans <= 4);
@@ -1360,3 +1375,7 @@ size_t FastLosslessEncode(const unsigned char* rgba, size_t width,
   }
   return 0;
 }
+
+#ifdef __cplusplus
+}  // extern "C"
+#endif

--- a/experimental/fast_lossless/fast_lossless.cc
+++ b/experimental/fast_lossless/fast_lossless.cc
@@ -1334,13 +1334,9 @@ size_t LLEnc(const unsigned char* rgba, size_t width, size_t stride,
 extern "C" {
 #endif
 
-size_t JxlFastLosslessEncode(const unsigned char* rgba,
-                             size_t width,
-                             size_t stride,
-                             size_t height,
-                             size_t nb_chans,
-                             size_t bitdepth,
-                             int effort,
+size_t JxlFastLosslessEncode(const unsigned char* rgba, size_t width,
+                             size_t stride, size_t height, size_t nb_chans,
+                             size_t bitdepth, int effort,
                              unsigned char** output) {
   assert(bitdepth <= 12);
   assert(bitdepth > 0);

--- a/experimental/fast_lossless/fast_lossless.h
+++ b/experimental/fast_lossless/fast_lossless.h
@@ -7,8 +7,21 @@
 #define FAST_LOSSLESS_H
 #include <stdlib.h>
 
-size_t FastLosslessEncode(const unsigned char* rgba, size_t width,
-                          size_t row_stride, size_t height, size_t nb_chans,
-                          size_t bitdepth, int effort, unsigned char** output);
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+size_t JxlFastLosslessEncode(const unsigned char* rgba,
+                             size_t width,
+                             size_t row_stride,
+                             size_t height,
+                             size_t nb_chans,
+                             size_t bitdepth,
+                             int effort,
+                             unsigned char** output);
+
+#ifdef __cplusplus
+}  // extern "C"
+#endif
 
 #endif

--- a/experimental/fast_lossless/fast_lossless.h
+++ b/experimental/fast_lossless/fast_lossless.h
@@ -11,13 +11,9 @@
 extern "C" {
 #endif
 
-size_t JxlFastLosslessEncode(const unsigned char* rgba,
-                             size_t width,
-                             size_t row_stride,
-                             size_t height,
-                             size_t nb_chans,
-                             size_t bitdepth,
-                             int effort,
+size_t JxlFastLosslessEncode(const unsigned char* rgba, size_t width,
+                             size_t row_stride, size_t height, size_t nb_chans,
+                             size_t bitdepth, int effort,
                              unsigned char** output);
 
 #ifdef __cplusplus

--- a/experimental/fast_lossless/fast_lossless_main.cc
+++ b/experimental/fast_lossless/fast_lossless_main.cc
@@ -51,8 +51,8 @@ int main(int argc, char** argv) {
   auto start = std::chrono::high_resolution_clock::now();
   for (size_t _ = 0; _ < num_reps; _++) {
     free(encoded);
-    encoded_size = FastLosslessEncode(png, width, stride, height, nb_chans,
-                                      bitdepth, effort, &encoded);
+    encoded_size = JxlFastLosslessEncode(png, width, stride, height, nb_chans,
+                                         bitdepth, effort, &encoded);
   }
   auto stop = std::chrono::high_resolution_clock::now();
   if (num_reps > 1) {


### PR DESCRIPTION
Adding a "Jxl" prefix disambiguates it when combining it with e.g. a fast PNG encoder or fast WebP encoder. Some lines were subsequently re-formatted to fit within 80 columns.

Also wrap an "extern C" around that function.

Also wrap an anonymous namespace around the implementation, so that the fjxl BitWriter doesn't conflict with e.g. fpnge's BitWriter.

Also fix some -Wunknown-pragmas and -Wsign-compare g++ warnings.

Fixes #1855