### PR TITLE
XYB-jpeg: jpeg-specific clustering and more progression.

### DIFF
--- a/lib/extras/encode_jpeg.cc
+++ b/lib/extras/encode_jpeg.cc
@@ -193,9 +193,34 @@ void AddJpegScanInfos(const std::vector<ProgressiveScan>& scans,
   }
 }
 
+float HistogramCost(const Histogram& histo) {
+  std::vector<uint32_t> counts(jpeg::kJpegHuffmanAlphabetSize + 1);
+  std::vector<uint8_t> depths(jpeg::kJpegHuffmanAlphabetSize + 1);
+  for (size_t i = 0; i < jpeg::kJpegHuffmanAlphabetSize; ++i) {
+    counts[i] = histo.data_[i];
+  }
+  counts[jpeg::kJpegHuffmanAlphabetSize] = 1;
+  CreateHuffmanTree(counts.data(), counts.size(),
+                    jpeg::kJpegHuffmanMaxBitLength, &depths[0]);
+  size_t header_bits = (1 + jpeg::kJpegHuffmanMaxBitLength) * 8;
+  size_t data_bits = 0;
+  for (size_t i = 0; i < jpeg::kJpegHuffmanAlphabetSize; ++i) {
+    if (depths[i] > 0) {
+      header_bits += 8;
+      data_bits += counts[i] * depths[i];
+    }
+  }
+  return header_bits + data_bits;
+}
+
+struct JpegClusteredHistograms {
+  std::vector<Histogram> histograms;
+  std::vector<uint32_t> histogram_indexes;
+  std::vector<uint32_t> slot_ids;
+};
+
 void ClusterJpegHistograms(const std::vector<jpeg::HuffmanCodeTable>& jpeg_in,
-                           size_t max_histograms, std::vector<Histogram>* out,
-                           std::vector<uint32_t>* histogram_indexes) {
+                           JpegClusteredHistograms* clusters) {
   std::vector<Histogram> histograms;
   for (const auto& t : jpeg_in) {
     Histogram histo;
@@ -206,17 +231,70 @@ void ClusterJpegHistograms(const std::vector<jpeg::HuffmanCodeTable>& jpeg_in,
     }
     histograms.push_back(histo);
   }
-  // TODO(szabadka): Use a JPEG-specific version of the clustering algorithm.
-  HistogramParams params;
-  ClusterHistograms(params, histograms, max_histograms, out, histogram_indexes);
+  clusters->histogram_indexes.resize(histograms.size());
+  std::vector<uint32_t> slot_histograms;
+  std::vector<float> slot_costs;
+  for (size_t i = 0; i < histograms.size(); ++i) {
+    const Histogram& cur = histograms[i];
+    if (cur.total_count_ == 0) {
+      continue;
+    }
+    float best_cost = HistogramCost(cur);
+    size_t best_slot = slot_histograms.size();
+    for (size_t j = 0; j < slot_histograms.size(); ++j) {
+      size_t prev_idx = slot_histograms[j];
+      const Histogram& prev = clusters->histograms[prev_idx];
+      Histogram combined;
+      combined.AddHistogram(prev);
+      combined.AddHistogram(cur);
+      float combined_cost = HistogramCost(combined);
+      float cost = combined_cost - slot_costs[j];
+      if (cost < best_cost) {
+        best_cost = cost;
+        best_slot = j;
+      }
+    }
+    if (best_slot == slot_histograms.size()) {
+      // Create new histogram.
+      size_t histogram_index = clusters->histograms.size();
+      clusters->histograms.push_back(cur);
+      clusters->histogram_indexes[i] = histogram_index;
+      if (best_slot < 4) {
+        // We have a free slot, so we put the new histogram there.
+        slot_histograms.push_back(histogram_index);
+        slot_costs.push_back(best_cost);
+      } else {
+        // TODO(szabadka) Find the best histogram to replce.
+        best_slot = (clusters->slot_ids.back() + 1) % 4;
+      }
+      slot_histograms[best_slot] = histogram_index;
+      slot_costs[best_slot] = best_cost;
+      clusters->slot_ids.push_back(best_slot);
+    } else {
+      // Merge this histogram with a previous one.
+      size_t histogram_index = slot_histograms[best_slot];
+      clusters->histograms[histogram_index].AddHistogram(cur);
+      clusters->histogram_indexes[i] = histogram_index;
+      JXL_ASSERT(clusters->slot_ids[histogram_index] == best_slot);
+      slot_costs[best_slot] += best_cost;
+    }
+  }
 }
 
-void BuildJpegHuffmanCode(const uint8_t* depth, jpeg::JPEGHuffmanCode* huff) {
+void BuildJpegHuffmanCode(const Histogram& histo, jpeg::JPEGHuffmanCode* huff) {
+  std::vector<uint32_t> counts(jpeg::kJpegHuffmanAlphabetSize + 1);
+  std::vector<uint8_t> depths(jpeg::kJpegHuffmanAlphabetSize + 1);
+  for (size_t j = 0; j < jpeg::kJpegHuffmanAlphabetSize; ++j) {
+    counts[j] = histo.data_[j];
+  }
+  counts[jpeg::kJpegHuffmanAlphabetSize] = 1;
+  CreateHuffmanTree(counts.data(), counts.size(),
+                    jpeg::kJpegHuffmanMaxBitLength, &depths[0]);
   std::fill(std::begin(huff->counts), std::end(huff->counts), 0);
   std::fill(std::begin(huff->values), std::end(huff->values), 0);
   for (size_t i = 0; i <= jpeg::kJpegHuffmanAlphabetSize; ++i) {
-    if (depth[i] > 0) {
-      ++huff->counts[depth[i]];
+    if (depths[i] > 0) {
+      ++huff->counts[depths[i]];
     }
   }
   int offset[jpeg::kJpegHuffmanMaxBitLength + 1] = {0};
@@ -224,29 +302,33 @@ void BuildJpegHuffmanCode(const uint8_t* depth, jpeg::JPEGHuffmanCode* huff) {
     offset[i] = offset[i - 1] + huff->counts[i - 1];
   }
   for (size_t i = 0; i <= jpeg::kJpegHuffmanAlphabetSize; ++i) {
-    if (depth[i] > 0) {
-      huff->values[offset[depth[i]]++] = i;
+    if (depths[i] > 0) {
+      huff->values[offset[depths[i]]++] = i;
     }
   }
   huff->is_last = false;
 }
 
-void AddJpegHuffmanCodes(std::vector<Histogram>& histograms,
-                         size_t slot_id_offset,
-                         std::vector<jpeg::JPEGHuffmanCode>* huff_codes) {
-  for (size_t i = 0; i < histograms.size(); ++i) {
-    jpeg::JPEGHuffmanCode huff_code;
-    huff_code.slot_id = slot_id_offset + i;
-    std::vector<uint32_t> counts(jpeg::kJpegHuffmanAlphabetSize + 1);
-    std::vector<uint8_t> depths(jpeg::kJpegHuffmanAlphabetSize + 1);
-    for (size_t j = 0; j < jpeg::kJpegHuffmanAlphabetSize; ++j) {
-      counts[j] = histograms[i].data_[j];
-    }
-    counts[jpeg::kJpegHuffmanAlphabetSize] = 1;
-    CreateHuffmanTree(counts.data(), counts.size(),
-                      jpeg::kJpegHuffmanMaxBitLength, &depths[0]);
-    BuildJpegHuffmanCode(&depths[0], &huff_code);
-    huff_codes->emplace_back(std::move(huff_code));
+void AddJpegHuffmanCode(const Histogram& histogram, size_t slot_id,
+                        std::vector<jpeg::JPEGHuffmanCode>* huff_codes) {
+  jpeg::JPEGHuffmanCode huff_code;
+  huff_code.slot_id = slot_id;
+  BuildJpegHuffmanCode(histogram, &huff_code);
+  huff_codes->emplace_back(std::move(huff_code));
+}
+
+void SetJpegHuffmanCode(const JpegClusteredHistograms& clusters,
+                        size_t histogram_id, size_t slot_id_offset,
+                        std::vector<uint32_t>& slot_histograms,
+                        uint32_t* slot_id,
+                        std::vector<jpeg::JPEGHuffmanCode>* huff_codes) {
+  JXL_ASSERT(histogram_id < clusters.histogram_indexes.size());
+  uint32_t histogram_index = clusters.histogram_indexes[histogram_id];
+  *slot_id = clusters.slot_ids[histogram_index];
+  if (slot_histograms[*slot_id] != histogram_index) {
+    AddJpegHuffmanCode(clusters.histograms[histogram_index],
+                       slot_id_offset + *slot_id, huff_codes);
+    slot_histograms[*slot_id] = histogram_index;
   }
 }
 
@@ -291,11 +373,8 @@ void FillJPEGData(const Image3F& opsin, const ImageF& qf, float dc_quant,
   // SOS
   std::vector<ProgressiveScan> progressive_mode = {
       // DC
-      {0, 0, 0, 0, !subsample_blue},
-      // AC 1 - highest bits
-      {1, 63, 0, 1, false},
-      // AC 2 - lowest bit
-      {1, 63, 1, 0, false},
+      {0, 0, 0, 0, !subsample_blue}, {1, 2, 0, 0, false},  {3, 63, 0, 2, false},
+      {3, 63, 2, 1, false},          {3, 63, 1, 0, false},
   };
   AddJpegScanInfos(progressive_mode, &out->scan_info);
   for (size_t i = 0; i < out->scan_info.size(); i++) {
@@ -309,30 +388,58 @@ void FillJPEGData(const Image3F& opsin, const ImageF& qf, float dc_quant,
   jpeg::SerializationState ss;
   JXL_CHECK(jpeg::ProcessJpeg(*out, &ss));
 
-  // Build DC Huffman codes and add them to DHT segment.
-  std::vector<Histogram> dc_histo;
-  std::vector<uint32_t> dc_tbl_indexes;
-  ClusterJpegHistograms(ss.dc_huff_table, 4, &dc_histo, &dc_tbl_indexes);
-  AddJpegHuffmanCodes(dc_histo, 0, &out->huffman_code);
+  // Cluster DC histograms.
+  JpegClusteredHistograms dc_clusters;
+  ClusterJpegHistograms(ss.dc_huff_table, &dc_clusters);
 
-  // Build AC Huffman codes and add them to DHT segment.
-  std::vector<Histogram> ac_histo;
-  std::vector<uint32_t> ac_tbl_indexes;
-  ClusterJpegHistograms(ss.ac_huff_table, 4, &ac_histo, &ac_tbl_indexes);
-  AddJpegHuffmanCodes(ac_histo, 0x10, &out->huffman_code);
+  // Cluster AC histograms.
+  JpegClusteredHistograms ac_clusters;
+  ClusterJpegHistograms(ss.ac_huff_table, &ac_clusters);
+
+  // Rebuild marker_order because we may want to emit Huffman codes in between
+  // scans.
+  out->marker_order.resize(out->marker_order.size() - 2 -
+                           out->scan_info.size());
+
+  // Add the first 4 DC and AC histograms in the first DHT segment.
+  out->marker_order.emplace_back(0xc4);  // DHT
+  std::vector<uint32_t> dc_slot_histograms;
+  std::vector<uint32_t> ac_slot_histograms;
+  for (size_t i = 0; i < dc_clusters.histograms.size(); ++i) {
+    if (i >= 4) break;
+    JXL_ASSERT(dc_clusters.slot_ids[i] == i);
+    AddJpegHuffmanCode(dc_clusters.histograms[i], i, &out->huffman_code);
+    dc_slot_histograms.push_back(i);
+  }
+  for (size_t i = 0; i < ac_clusters.histograms.size(); ++i) {
+    if (i >= 4) break;
+    JXL_ASSERT(ac_clusters.slot_ids[i] == i);
+    AddJpegHuffmanCode(ac_clusters.histograms[i], 0x10 + i, &out->huffman_code);
+    ac_slot_histograms.push_back(i);
+  }
   out->huffman_code.back().is_last = true;
 
-  // Set the Huffman table indexes in the scan_infos.
-  size_t histo_idx = 0;
+  // Set the Huffman table indexes in the scan_infos and emit additional DHT
+  // segments if necessary.
+  size_t histogram_id = 0;
   for (auto& si : out->scan_info) {
+    size_t num_huff_codes = out->huffman_code.size();
     for (size_t c = 0; c < si.num_components; ++c) {
-      JXL_ASSERT(histo_idx < dc_tbl_indexes.size());
-      JXL_ASSERT(histo_idx < ac_tbl_indexes.size());
-      si.components[c].dc_tbl_idx = dc_tbl_indexes[histo_idx];
-      si.components[c].ac_tbl_idx = ac_tbl_indexes[histo_idx];
-      ++histo_idx;
+      SetJpegHuffmanCode(dc_clusters, histogram_id, 0, dc_slot_histograms,
+                         &si.components[c].dc_tbl_idx, &out->huffman_code);
+      SetJpegHuffmanCode(ac_clusters, histogram_id, 0x10, ac_slot_histograms,
+                         &si.components[c].ac_tbl_idx, &out->huffman_code);
+      ++histogram_id;
     }
+    // If we updated a slot histogram in this scan, create an additional DHT
+    // segment.
+    if (out->huffman_code.size() > num_huff_codes) {
+      out->marker_order.emplace_back(0xc4);  // DHT
+      out->huffman_code.back().is_last = true;
+    }
+    out->marker_order.emplace_back(0xda);  // SOS
   }
+  out->marker_order.emplace_back(0xd9);  // EOI
 }
 
 size_t JpegSize(const jpeg::JPEGData& jpeg_data) {


### PR DESCRIPTION
Benchmark before:
```
Encoding            kPixels    Bytes          BPP  E MP/s  D MP/s     Max norm        pnorm       BPP*pnorm   Bugs
------------------------------------------------------------------------------------------------------------------
jpeg:libjxl:d1.0      13270  3197015    1.9272988   5.469  29.993   2.19093180   0.70477101  1.358304300765      0
```

Benchmark after:
```
Encoding            kPixels    Bytes          BPP  E MP/s  D MP/s     Max norm        pnorm       BPP*pnorm   Bugs
------------------------------------------------------------------------------------------------------------------
jpeg:libjxl:d1.0      13270  3163678    1.9072018   4.031  25.939   2.19093180   0.70477101  1.344140529099      0
```