### PR TITLE
Simplex-search optimized xyb-jpeg quantization matrix parameters.

### DIFF
--- a/lib/extras/encode_jpeg.cc
+++ b/lib/extras/encode_jpeg.cc
@@ -125,16 +125,44 @@ void AddJpegQuantMatrices(const ImageF& qf, float dc_quant, float global_scale,
   DequantMatrices dequant;
   std::vector<QuantEncoding> encodings(DequantMatrices::kNum,
                                        QuantEncoding::Library(0));
-  encodings[0] = QuantEncoding::DCT(
-      DctQuantWeightParams({{{{2000.0, -0.5, -0.5, -0.5, -0.5, -0.5}},
-                             {{500.0, -0.1, -0.1, -0.2, -0.2, -0.2}},
-                             {{200.0, -1.0, -0.5, -0.5, -0.5, -0.5}}}},
-                           6));
+  DctQuantWeightParams dct_params =
+      DctQuantWeightParams({{
+                               {{
+                                   2000.0f,         //
+                                   -0.5098828077f,  //
+                                   0.1776620001f,   //
+                                   -0.3956851959f,  //
+                                   -0.3340485990f,  //
+                                   -0.5691086054f,  //
+                               }},
+                               {{
+                                   500.0f,          //
+                                   -0.0927032605f,  //
+                                   -0.3072603941f,  //
+                                   -0.1561524570f,  //
+                                   -0.3872784674f,  //
+                                   0.0549057312f,   //
+                               }},
+                               {{
+                                   200.0f,          //
+                                   0.0085711535f,   //
+                                   -0.5770072937f,  //
+                                   -0.6606003642f,  //
+                                   -0.6159313917f,  //
+                                   -0.4991085827f,  //
+                               }},
+                           }},
+                           6);
+  encodings[0] = QuantEncoding::DCT(dct_params);
   dequant.SetEncodings(encodings);
   JXL_CHECK(dequant.EnsureComputed(1));
   memcpy(qm, dequant.Matrix(0, 0), 3 * kDCTBlockSize * sizeof(qm[0]));
   // Set custom DC quant weights.
-  const float inv_dc_quant[3] = {3200.0f, 512.0f, 320.0f};
+  const float inv_dc_quant[3] = {
+      2140.0,
+      512.0f,
+      320.0f,
+  };
   for (size_t c = 0; c < 3; c++) {
     qm[c * kDCTBlockSize] = 1.0f / (inv_dc_quant[c] * dc_quant);
   }


### PR DESCRIPTION
Benchmark before:
```
Encoding            kPixels    Bytes          BPP  E MP/s  D MP/s     Max norm        pnorm       BPP*pnorm   Bugs
------------------------------------------------------------------------------------------------------------------
jpeg:libjxl:d0.5      13270  4804698    2.8964795   3.723  22.242   1.56636882   0.47385977  1.372525138424      0
jpeg:libjxl:d0.8      13270  3636329    2.1921362   4.089  25.696   1.87652230   0.61543190  1.349110553678      0
jpeg:libjxl:d0.9      13270  3378595    2.0367630   3.790  23.042   2.17102480   0.66006343  1.344392804990      0
jpeg:libjxl:d1.0      13270  3163678    1.9072018   4.064  24.490   2.19093180   0.70477101  1.344140529099      0
jpeg:libjxl:d1.1      13270  2984772    1.7993495   3.966  26.363   2.11484838   0.75048089  1.350377429818      0
jpeg:libjxl:d1.2      13270  2828203    1.7049630   4.278  28.153   2.29096746   0.78898283  1.345186506645      0
jpeg:libjxl:d1.5      13270  2447451    1.4754292   4.083  26.287   3.02021217   0.91575531  1.351132125102      0
jpeg:libjxl:d2.0      13270  2015903    1.2152734   4.220  31.476   3.28036547   1.09683000  1.332948351442      0
Aggregate:            13270  3064488    1.8474056   4.023  25.829   2.25605616   0.73004342  1.348686280677      0
```

Benchmark after:
```
Encoding            kPixels    Bytes          BPP  E MP/s  D MP/s     Max norm        pnorm       BPP*pnorm   Bugs
------------------------------------------------------------------------------------------------------------------
jpeg:libjxl:d0.5      13270  4654354    2.8058457   3.971  20.967   1.54231071   0.46554951  1.306260075416      0
jpeg:libjxl:d0.8      13270  3482816    2.0995920   4.085  24.342   1.70935893   0.61929160  1.300259661216      0
jpeg:libjxl:d0.9      13270  3223473    1.9432488   4.163  22.163   1.84545839   0.67493955  1.311575456149      0
jpeg:libjxl:d1.0      13270  3028977    1.8259982   4.598  25.571   1.90735793   0.71123393  1.298711878895      0
jpeg:libjxl:d1.1      13270  2833331    1.7080543   4.518  26.407   2.19600940   0.76419471  1.305286098499      0
jpeg:libjxl:d1.2      13270  2694178    1.6241669   3.971  25.394   2.27468419   0.79893476  1.297603396949      0
jpeg:libjxl:d1.5      13270  2307256    1.3909136   4.331  26.717   2.60481334   0.94243889  1.310851074545      0
jpeg:libjxl:d2.0      13270  1894603    1.1421485   4.573  33.426   3.18599176   1.12675147  1.286917548072      0
Aggregate:            13270  2919735    1.7601424   4.269  25.400   2.10445561   0.73980436  1.302161048110      0
```