### PR TITLE
Update dec_xyb.cc to fix wasm decode issue

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -31,6 +31,7 @@ Don Olmstead <don.j.olmstead@gmail.com>
 Even Rouault <even.rouault@spatialys.com>
 Fred Brennan <copypaste@kittens.ph>
 Heiko Becker <heirecka@exherbo.org>
+Jim Robinson <jimbo2150@gmail.com>
 Jon Sneyers <jon@cloudinary.com>
 Kai Hollberg <Schweinepriester@users.noreply.github.com>
 Kleis Auke Wolthuizen <github@kleisauke.nl>

--- a/lib/jxl/dec_xyb.cc
+++ b/lib/jxl/dec_xyb.cc
@@ -245,7 +245,7 @@ Status OutputEncodingInfo::MaybeSetColorEncoding(
        color_encoding.tf.IsPQ())) {
     return false;
   }
-  if (!xyb_encoded || !CanOutputToColorEncoding(c_desired)) {
+  if (!xyb_encoded && !CanOutputToColorEncoding(c_desired)) {
     return false;
   }
   return SetColorEncoding(c_desired);


### PR DESCRIPTION
Changed OR to AND. In WASM, images that were not XYB encoded would fail to decode, as `CanOutputToColorEncoding(c_desired)` is never called.