### PR TITLE
Add option to run custom cjpeg command in jpeg benchmark.

### DIFF
--- a/tools/benchmark/benchmark_codec_custom.cc
+++ b/tools/benchmark/benchmark_codec_custom.cc
@@ -49,16 +49,6 @@ Status AddCommandLineOptionsCustomCodec(BenchmarkArgs* args) {
 
 namespace {
 
-std::string GetBaseName(std::string filename) {
-  std::string result = std::move(filename);
-  result = basename(&result[0]);
-  const size_t dot = result.rfind('.');
-  if (dot != std::string::npos) {
-    result.resize(dot);
-  }
-  return result;
-}
-
 // This uses `output_filename` to determine the name of the corresponding
 // `.time` file.
 template <typename F>

--- a/tools/benchmark/benchmark_utils.cc
+++ b/tools/benchmark/benchmark_utils.cc
@@ -50,6 +50,16 @@ Status TemporaryFile::GetFileName(std::string* const output) const {
   return true;
 }
 
+std::string GetBaseName(std::string filename) {
+  std::string result = std::move(filename);
+  result = basename(&result[0]);
+  const size_t dot = result.rfind('.');
+  if (dot != std::string::npos) {
+    result.resize(dot);
+  }
+  return result;
+}
+
 Status RunCommand(const std::string& command,
                   const std::vector<std::string>& arguments, bool quiet) {
   std::vector<char*> args;
@@ -86,6 +96,8 @@ Status TemporaryFile::GetFileName(std::string* const output) const {
   (void)ok_;
   return JXL_FAILURE("Not supported on this build");
 }
+
+std::string GetBaseName(std::string filename) { return filename; }
 
 Status RunCommand(const std::string& command,
                   const std::vector<std::string>& arguments, bool quiet) {

--- a/tools/benchmark/benchmark_utils.h
+++ b/tools/benchmark/benchmark_utils.h
@@ -27,6 +27,8 @@ class TemporaryFile final {
   std::string temp_filename_;
 };
 
+std::string GetBaseName(std::string filename);
+
 Status RunCommand(const std::string& command,
                   const std::vector<std::string>& arguments,
                   bool quiet = false);


### PR DESCRIPTION
With this addition, one can benchmark against a decoder-only libpeg implementation by setting a custom LD_LIBRARY_PATH and using a statically built cjpeg in the benchmark.