### PR TITLE
Read cICP chunks from PNGs

### DIFF
--- a/lib/extras/dec/apng.cc
+++ b/lib/extras/dec/apng.cc
@@ -76,6 +76,9 @@ Status DecodeSRGB(const unsigned char* payload, const size_t payload_size,
   if (payload_size != 1) return JXL_FAILURE("Wrong sRGB size");
   // (PNG uses the same values as ICC.)
   if (payload[0] >= 4) return JXL_FAILURE("Invalid Rendering Intent");
+  color_encoding->white_point = JXL_WHITE_POINT_D65;
+  color_encoding->primaries = JXL_PRIMARIES_SRGB;
+  color_encoding->transfer_function = JXL_TRANSFER_FUNCTION_SRGB;
   color_encoding->rendering_intent =
       static_cast<JxlRenderingIntent>(payload[0]);
   return true;

--- a/lib/extras/dec/apng.cc
+++ b/lib/extras/dec/apng.cc
@@ -81,6 +81,137 @@ Status DecodeSRGB(const unsigned char* payload, const size_t payload_size,
   return true;
 }
 
+// If the cICP profile is not fully supported, return false and leave
+// color_encoding unmodified.
+Status DecodeCICP(const unsigned char* payload, const size_t payload_size,
+                  JxlColorEncoding* color_encoding) {
+  if (payload_size != 4) return JXL_FAILURE("Wrong cICP size");
+  JxlColorEncoding color_enc = *color_encoding;
+
+  // From https://www.itu.int/rec/T-REC-H.273-202107-I/en
+  if (payload[0] == 1) {
+    // IEC 61966-2-1 sRGB
+    color_enc.primaries = JXL_PRIMARIES_SRGB;
+    color_enc.white_point = JXL_WHITE_POINT_D65;
+  } else if (payload[0] == 4) {
+    // Rec. ITU-R BT.470-6 System M
+    color_enc.primaries = JXL_PRIMARIES_CUSTOM;
+    color_enc.primaries_red_xy[0] = 0.67;
+    color_enc.primaries_red_xy[1] = 0.33;
+    color_enc.primaries_green_xy[0] = 0.21;
+    color_enc.primaries_green_xy[1] = 0.71;
+    color_enc.primaries_blue_xy[0] = 0.14;
+    color_enc.primaries_blue_xy[1] = 0.08;
+    color_enc.white_point = JXL_WHITE_POINT_CUSTOM;
+    color_enc.white_point_xy[0] = 0.310;
+    color_enc.white_point_xy[1] = 0.316;
+  } else if (payload[0] == 5) {
+    // Rec. ITU-R BT.1700-0 625 PAL and 625 SECAM
+    color_enc.primaries = JXL_PRIMARIES_CUSTOM;
+    color_enc.primaries_red_xy[0] = 0.64;
+    color_enc.primaries_red_xy[1] = 0.33;
+    color_enc.primaries_green_xy[0] = 0.29;
+    color_enc.primaries_green_xy[1] = 0.60;
+    color_enc.primaries_blue_xy[0] = 0.15;
+    color_enc.primaries_blue_xy[1] = 0.06;
+    color_enc.white_point = JXL_WHITE_POINT_D65;
+  } else if (payload[0] == 6 || payload[0] == 7) {
+    // SMPTE ST 170 (2004) / SMPTE ST 240 (1999)
+    color_enc.primaries = JXL_PRIMARIES_CUSTOM;
+    color_enc.primaries_red_xy[0] = 0.630;
+    color_enc.primaries_red_xy[1] = 0.340;
+    color_enc.primaries_green_xy[0] = 0.310;
+    color_enc.primaries_green_xy[1] = 0.595;
+    color_enc.primaries_blue_xy[0] = 0.155;
+    color_enc.primaries_blue_xy[1] = 0.070;
+    color_enc.white_point = JXL_WHITE_POINT_D65;
+  } else if (payload[0] == 8) {
+    // Generic film (colour filters using Illuminant C)
+    color_enc.primaries = JXL_PRIMARIES_CUSTOM;
+    color_enc.primaries_red_xy[0] = 0.681;
+    color_enc.primaries_red_xy[1] = 0.319;
+    color_enc.primaries_green_xy[0] = 0.243;
+    color_enc.primaries_green_xy[1] = 0.692;
+    color_enc.primaries_blue_xy[0] = 0.145;
+    color_enc.primaries_blue_xy[1] = 0.049;
+    color_enc.white_point = JXL_WHITE_POINT_CUSTOM;
+    color_enc.white_point_xy[0] = 0.310;
+    color_enc.white_point_xy[1] = 0.316;
+  } else if (payload[0] == 9) {
+    // Rec. ITU-R BT.2100-2
+    color_enc.primaries = JXL_PRIMARIES_2100;
+    color_enc.white_point = JXL_WHITE_POINT_D65;
+  } else if (payload[0] == 10) {
+    // CIE 1931 XYZ
+    color_enc.primaries = JXL_PRIMARIES_CUSTOM;
+    color_enc.primaries_red_xy[0] = 1;
+    color_enc.primaries_red_xy[1] = 0;
+    color_enc.primaries_green_xy[0] = 0;
+    color_enc.primaries_green_xy[1] = 1;
+    color_enc.primaries_blue_xy[0] = 0;
+    color_enc.primaries_blue_xy[1] = 0;
+    color_enc.white_point = JXL_WHITE_POINT_E;
+  } else if (payload[0] == 11) {
+    // SMPTE RP 431-2 (2011)
+    color_enc.primaries = JXL_PRIMARIES_P3;
+    color_enc.white_point = JXL_WHITE_POINT_DCI;
+  } else if (payload[0] == 12) {
+    // SMPTE EG 432-1 (2010)
+    color_enc.primaries = JXL_PRIMARIES_P3;
+    color_enc.white_point = JXL_WHITE_POINT_D65;
+  } else if (payload[0] == 22) {
+    color_enc.primaries = JXL_PRIMARIES_CUSTOM;
+    color_enc.primaries_red_xy[0] = 0.630;
+    color_enc.primaries_red_xy[1] = 0.340;
+    color_enc.primaries_green_xy[0] = 0.295;
+    color_enc.primaries_green_xy[1] = 0.605;
+    color_enc.primaries_blue_xy[0] = 0.155;
+    color_enc.primaries_blue_xy[1] = 0.077;
+    color_enc.white_point = JXL_WHITE_POINT_D65;
+  } else {
+    JXL_WARNING("Unsupported primaries specified in cICP chunk: %d",
+                static_cast<int>(payload[0]));
+    return false;
+  }
+
+  if (payload[1] == 1 || payload[1] == 6 || payload[1] == 14 ||
+      payload[1] == 15) {
+    // Rec. ITU-R BT.709-6
+    color_enc.transfer_function = JXL_TRANSFER_FUNCTION_709;
+  } else if (payload[1] == 4) {
+    // Rec. ITU-R BT.1700-0 625 PAL and 625 SECAM
+    color_enc.transfer_function = JXL_TRANSFER_FUNCTION_GAMMA;
+    color_enc.gamma = 1 / 2.2;
+  } else if (payload[1] == 5) {
+    // Rec. ITU-R BT.470-6 System B, G
+    color_enc.transfer_function = JXL_TRANSFER_FUNCTION_GAMMA;
+    color_enc.gamma = 1 / 2.8;
+  } else if (payload[1] == 8 || payload[1] == 13 || payload[1] == 16 ||
+             payload[1] == 17 || payload[1] == 18) {
+    // These codes all match the corresponding JXL enum values
+    color_enc.transfer_function = static_cast<JxlTransferFunction>(payload[1]);
+  } else {
+    JXL_WARNING("Unsupported transfer function specified in cICP chunk: %d",
+                static_cast<int>(payload[1]));
+    return false;
+  }
+
+  if (payload[2] != 0) {
+    JXL_WARNING("Unsupported color space specified in cICP chunk: %d",
+                static_cast<int>(payload[2]));
+    return false;
+  }
+  if (payload[3] != 1) {
+    JXL_WARNING("Unsupported full-range flag specified in cICP chunk: %d",
+                static_cast<int>(payload[3]));
+    return false;
+  }
+  // cICP has no rendering intent, so use the default
+  color_enc.rendering_intent = JXL_RENDERING_INTENT_RELATIVE;
+  *color_encoding = color_enc;
+  return true;
+}
+
 Status DecodeGAMA(const unsigned char* payload, const size_t payload_size,
                   JxlColorEncoding* color_encoding) {
   if (payload_size != 4) return JXL_FAILURE("Wrong gAMA size");
@@ -286,6 +417,7 @@ constexpr uint32_t kId_fcTL = 0x4C546366;
 constexpr uint32_t kId_IDAT = 0x54414449;
 constexpr uint32_t kId_fdAT = 0x54416466;
 constexpr uint32_t kId_IEND = 0x444E4549;
+constexpr uint32_t kId_cICP = 0x50434963;
 constexpr uint32_t kId_iCCP = 0x50434369;
 constexpr uint32_t kId_sRGB = 0x42475273;
 constexpr uint32_t kId_gAMA = 0x414D4167;
@@ -469,7 +601,8 @@ Status DecodeImageAPNG(const Span<const uint8_t> bytes,
 
   ppf->frames.clear();
 
-  bool have_color = false, have_srgb = false;
+  bool have_color = false;
+  bool have_cicp = false, have_iccp = false, have_srgb = false;
   bool errorstate = true;
   if (id == kId_IHDR && chunkIHDR.size() == 25) {
     x0 = 0;
@@ -490,6 +623,7 @@ Status DecodeImageAPNG(const Span<const uint8_t> bytes,
     ppf->color_encoding.white_point = JXL_WHITE_POINT_D65;
     ppf->color_encoding.primaries = JXL_PRIMARIES_SRGB;
     ppf->color_encoding.transfer_function = JXL_TRANSFER_FUNCTION_SRGB;
+    ppf->color_encoding.rendering_intent = JXL_RENDERING_INTENT_RELATIVE;
 
     if (!processing_start(png_ptr, info_ptr, (void*)&frameRaw, hasInfo,
                           chunkIHDR, chunksInfo)) {
@@ -625,7 +759,17 @@ Status DecodeImageAPNG(const Span<const uint8_t> bytes,
                               chunk.size() - 4)) {
             break;
           }
-        } else if (id == kId_iCCP) {
+        } else if (id == kId_cICP) {
+          // Color profile chunks: cICP has the highest priority, followed by
+          // iCCP and sRGB (which shouldn't co-exist, but if they do, we use
+          // iCCP), followed finally by gAMA and cHRM.
+          if (DecodeCICP(chunk.data() + 8, chunk.size() - 12,
+                         &ppf->color_encoding)) {
+            have_cicp = true;
+            have_color = true;
+            ppf->icc.clear();
+          }
+        } else if (!have_cicp && id == kId_iCCP) {
           if (processing_data(png_ptr, info_ptr, chunk.data(), chunk.size())) {
             JXL_WARNING("Corrupt iCCP chunk");
             break;
@@ -642,19 +786,20 @@ Status DecodeImageAPNG(const Span<const uint8_t> bytes,
           if (ok && proflen) {
             ppf->icc.assign(profile, profile + proflen);
             have_color = true;
+            have_iccp = true;
           } else {
             // TODO(eustas): JXL_WARNING?
           }
-        } else if (id == kId_sRGB) {
+        } else if (!have_cicp && !have_iccp && id == kId_sRGB) {
           JXL_RETURN_IF_ERROR(DecodeSRGB(chunk.data() + 8, chunk.size() - 12,
                                          &ppf->color_encoding));
           have_srgb = true;
           have_color = true;
-        } else if (id == kId_gAMA) {
+        } else if (!have_cicp && !have_srgb && !have_iccp && id == kId_gAMA) {
           JXL_RETURN_IF_ERROR(DecodeGAMA(chunk.data() + 8, chunk.size() - 12,
                                          &ppf->color_encoding));
           have_color = true;
-        } else if (id == kId_cHRM) {
+        } else if (!have_cicp && !have_srgb && !have_iccp && id == kId_cHRM) {
           JXL_RETURN_IF_ERROR(DecodeCHRM(chunk.data() + 8, chunk.size() - 12,
                                          &ppf->color_encoding));
           have_color = true;
@@ -677,12 +822,6 @@ Status DecodeImageAPNG(const Span<const uint8_t> bytes,
       }
     }
 
-    if (have_srgb) {
-      ppf->color_encoding.white_point = JXL_WHITE_POINT_D65;
-      ppf->color_encoding.primaries = JXL_PRIMARIES_SRGB;
-      ppf->color_encoding.transfer_function = JXL_TRANSFER_FUNCTION_SRGB;
-      ppf->color_encoding.rendering_intent = JXL_RENDERING_INTENT_PERCEPTUAL;
-    }
     JXL_RETURN_IF_ERROR(ApplyColorHints(
         color_hints, have_color, ppf->info.num_color_channels == 1, ppf));
   }


### PR DESCRIPTION
Since the PNG encoder goes to the trouble of writing them, this allows the PNG decoder to read them.
This means that converting a JXL with an encoded (non-ICC) profile to PNG, and then back to JXL, will in many cases produce a JXL with the original encoded profile instead of a generated ICC, resulting in a smaller file.

- This changes the default rendering intent for PNGs that don't specify one from Perceptual to Relative, to be consistent with the API's default sRGB profile (`JxlColorEncodingSetToSRGB`). Relative was also the default in cjxl classic.

- The existing code was (mistakenly?) overriding the rendering intent from an sRGB chunk to Perceptual after decoding it. It now uses whatever the sRGB chunk specifies.

- cICP doesn't store a rendering intent, so we always use the default (now Relative). Hopefully this isn't too much of a problem.

- I'm not 100% sure whether it's valid to have a cICP chunk in a Grayscale PNG, but the current code supports it by just ignoring the primaries.

cICP example:

```
$ pngreader.py pixel_9,5.png
IHDR [13 B] 1x1 8-bit RGB, no interlace
cICP [4 B] H.273 Primaries[2100 (Rec. ITU-R BT.2100-1)] TransferFunction[Display gamma 2.8] WhitePoint[D65] FullRange[Full range]
iCCP [59607 B] ICC Profile (60960 B; md5=34562abf994ccd066d2c5721d0d68c5d)
IDAT [12 B]
IEND

$ cjxl pixel_9,5.png pixel_9,5.jxl -d 0 -e 1
JPEG XL encoder v0.8.0 afa493d9 [AVX2,SSE4,SSSE3,Unknown]
Read 1x1 image, 59704 bytes, 0.0 MP/s
Encoding [Modular, lossless, effort: 1], 
Compressed to 30 bytes (240.000 bpp).
1 x 1, 0.00 MP/s [0.00, 0.00], 1 reps, 8 threads.

$ jxlinfo pixel_9,5.jxl
JPEG XL image, 1x1, (possibly) lossless, 8-bit RGB
Color space: RGB, D65, Rec.2100 primaries, gamma(0.357143) transfer function, rendering intent: Relative
```

sRGB example, preserving rendering intent:

```
$ pngreader.py pixel_abs.png 
IHDR [13 B] 1x1 8-bit RGB, no interlace
sRGB [1 B] Rendering intent: Absolute colorimetric
IDAT [12 B]
IEND

$ cjxl pixel_abs.png pixel_abs.jxl -d 0 -e 1
JPEG XL encoder v0.8.0 afa493d9 [AVX2,SSE4,SSSE3,Unknown]
Read 1x1 image, 82 bytes, 0.1 MP/s
Encoding [Modular, lossless, effort: 1], 
Compressed to 27 bytes (216.000 bpp).
1 x 1, 0.00 MP/s [0.00, 0.00], 1 reps, 8 threads.

$ jxlinfo pixel_abs.jxl 
JPEG XL image, 1x1, (possibly) lossless, 8-bit RGB
Color space: RGB, D65, sRGB primaries, sRGB transfer function, rendering intent: Absolute
```

cICP with valid but unsupported transfer function - it just uses the default profile:

```
$ pngreader.py pixel_unsupported.png
IHDR [13 B] 1x1 8-bit RGB, no interlace
cICP [4 B] H.273 Primaries[sRGB] TransferFunction[Logarithmic (100:1 range)] WhitePoint[D65] FullRange[Full range]
IDAT [12 B]
IEND

$ cjxl pixel_unsupported.png pixel_unsupported.png.jxl -d 0 -e 1
JPEG XL encoder v0.8.0 afa493d9 [AVX2,SSE4,SSSE3,Unknown]
./lib/extras/dec/apng.cc:196: Unsupported transfer function specified in cICP chunk: 9
./lib/extras/dec/color_hints.cc:54: No color_space/icc_pathname given, assuming sRGB
Read 1x1 image, 85 bytes, 0.1 MP/s
Encoding [Modular, lossless, effort: 1], 
Compressed to 25 bytes (200.000 bpp).
1 x 1, 0.00 MP/s [0.00, 0.00], 1 reps, 8 threads.

$ jxlinfo pixel_unsupported.png.jxl 
JPEG XL image, 1x1, (possibly) lossless, 8-bit RGB
Color space: RGB, D65, sRGB primaries, sRGB transfer function, rendering intent: Relative
```

As above, but with an iCCP to fall back on*:

```
$ pngreader.py pixel_unsupported_plus_icc.png
IHDR [13 B] 1x1 8-bit RGB, no interlace
cICP [4 B] H.273 Primaries[sRGB] TransferFunction[Logarithmic (100:1 range)] WhitePoint[D65] FullRange[Full range]
iCCP [388 B] ICC profile (672 B; md5=1ab524922f1614018495f1aff938a547)
IDAT [12 B]
IEND

$ cjxl pixel_unsupported_plus_icc.png pixel_unsupported_plus_icc.png.jxl -d 0 -e 1
JPEG XL encoder v0.8.0 afa493d9 [AVX2,SSE4,SSSE3,Unknown]
./lib/extras/dec/apng.cc:196: Unsupported transfer function specified in cICP chunk: 9
Read 1x1 image, 485 bytes, 0.0 MP/s
Encoding [Modular, lossless, effort: 1], 
Compressed to 272 bytes (2176.000 bpp).
1 x 1, 0.00 MP/s [0.00, 0.00], 1 reps, 8 threads.

$ jxlinfo pixel_unsupported_plus_icc.png.jxl 
JPEG XL image, 1x1, (possibly) lossless, 8-bit RGB
Color space: 672-byte ICC profile, CMM type: "lcms", color space: "RGB ", rendering intent: 0
```

\* The [W3C PNG spec](https://www.w3.org/TR/png/#cICP-chunk) requires decoders to ignore sRGB and iCCP if a cICP chunk is recognized.
I'm interpreting "recognized" as "recognized and specifying a supported profile", because otherwise it would force us to
ignore the perfectly good ICC profile in the last example.

