### PR TITLE
First version of decoder-only libjpegli library.

### DIFF
--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -68,6 +68,7 @@ jobs:
               -DJPEGXL_ENABLE_TRANSCODE_JPEG=OFF
               -DJPEGXL_ENABLE_PLUGINS=OFF
               -DJPEGXL_ENABLE_VIEWERS=OFF
+              -DJPEGXL_ENABLE_JPEGLI=OFF
           # Build optimized for binary size, all features not needed for
           # reconstructing pixels is disabled.
           - name: release:minimal
@@ -78,6 +79,7 @@ jobs:
               -DJPEGXL_ENABLE_BOXES=OFF
               -DJPEGXL_ENABLE_PLUGINS=OFF
               -DJPEGXL_ENABLE_VIEWERS=OFF
+              -DJPEGXL_ENABLE_JPEGLI=OFF
           # Builds with gcc in release mode
           - name: release:gcc8
             mode: release

--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -123,7 +123,8 @@ jobs:
         ./ci.sh ${{ matrix.build_type || 'release' }} -DJPEGXL_FORCE_SYSTEM_BROTLI=ON \
           -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
           -DCMAKE_C_COMPILER_LAUNCHER=ccache \
-          -DBUILD_TESTING=OFF
+          -DBUILD_TESTING=OFF \
+          -DJPEGXL_ENABLE_JPEGLI=OFF
         # Flatten the artifacts directory structure
         cp tools/conformance/conformance.py build/tools/conformance
         cp tools/conformance/lcms2.py build/tools/conformance

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -100,6 +100,8 @@ set(JPEGXL_ENABLE_DEVTOOLS false CACHE BOOL
     "Build JPEGXL developer tools.")
 set(JPEGXL_ENABLE_TOOLS true CACHE BOOL
     "Build JPEGXL user tools: cjxl and djxl.")
+set(JPEGXL_ENABLE_JPEGLI true CACHE BOOL
+    "Build jpegli shared library.")
 set(JPEGXL_ENABLE_DOXYGEN true CACHE BOOL
     "Generate C API documentation using Doxygen.")
 set(JPEGXL_ENABLE_MANPAGES true CACHE BOOL

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -132,6 +132,15 @@ set(JPEGXL_COVERAGE_FLAGS
 endif()  # JPEGXL_ENABLE_COVERAGE
 endif()  #!MSVC
 
+# strips the -static suffix from all the elements in LIST
+function(strip_static OUTPUT_VAR LIB_LIST)
+  foreach(lib IN LISTS ${LIB_LIST})
+    string(REGEX REPLACE "-static$" "" lib "${lib}")
+    list(APPEND out_list "${lib}")
+  endforeach()
+  set(${OUTPUT_VAR} ${out_list} PARENT_SCOPE)
+endfunction()
+
 # The jxl library definition.
 include(jxl.cmake)
 
@@ -140,6 +149,11 @@ if(JPEGXL_ENABLE_TOOLS)
   include(jxl_extras.cmake)
 endif()
 include(jxl_threads.cmake)
+# We only build JPEGLI on linux for now.
+find_package(JPEG)
+if (JPEG_FOUND AND JPEGXL_ENABLE_JPEGLI AND NOT APPLE AND NOT WIN32 AND NOT JPEGXL_EMSCRIPTEN)
+  include(jpegli.cmake)
+endif()
 
 # Install all the library headers from the source and the generated ones. There
 # is no distinction on which libraries use which header since it is expected

--- a/lib/jpegli.cmake
+++ b/lib/jpegli.cmake
@@ -1,0 +1,132 @@
+# Copyright (c) the JPEG XL Project Authors. All rights reserved.
+#
+# Use of this source code is governed by a BSD-style
+# license that can be found in the LICENSE file.
+
+set(JPEGLI_MAJOR_VERSION 62)
+set(JPEGLI_MINOR_VERSION 3)
+set(JPEGLI_PATCH_VERSION 0)
+set(JPEGLI_LIBRARY_VERSION
+    "${JPEGLI_MAJOR_VERSION}.${JPEGLI_MINOR_VERSION}.${JPEGLI_PATCH_VERSION}"
+)
+
+set(JPEGLI_LIBRARY_SOVERSION "${JPEGLI_MAJOR_VERSION}")
+
+set(JPEGLI_INTERNAL_SOURCES
+  jpegli/color_transform.h
+  jpegli/color_transform.cc
+  jpegli/decode_api.cc
+  jpegli/decode_internal.h
+  jpegli/decode_marker.h
+  jpegli/decode_marker.cc
+  jpegli/decode_scan.h
+  jpegli/decode_scan.cc
+  jpegli/error.h
+  jpegli/error.cc
+  jpegli/huffman.h
+  jpegli/huffman.cc
+  jpegli/idct.h
+  jpegli/idct.cc
+  jpegli/memory_manager.h
+  jpegli/render.h
+  jpegli/render.cc
+  jpegli/source_manager.h
+  jpegli/source_manager.cc
+  jpegli/upsample.h
+  jpegli/upsample.cc
+)
+
+set(JPEGLI_INTERNAL_LIBS
+  hwy
+  Threads::Threads
+  ${ATOMICS_LIBRARIES}
+)
+
+set(OBJ_COMPILE_DEFINITIONS
+  JPEGLI_MAJOR_VERSION=${JPEGLI_MAJOR_VERSION}
+  JPEGLI_MINOR_VERSION=${JPEGLI_MINOR_VERSION}
+  JPEGLI_PATCH_VERSION=${JPEGLI_PATCH_VERSION}
+  # Used to determine if we are building the library when defined or just
+  # including the library when not defined. This is public so libjpeg shared
+  # library gets this define too.
+  JPEGLI_INTERNAL_LIBRARY_BUILD
+)
+
+add_library(jpegli-obj OBJECT ${JPEGLI_INTERNAL_SOURCES})
+target_compile_options(jpegli-obj PRIVATE ${JPEGXL_INTERNAL_FLAGS})
+target_compile_options(jpegli-obj PUBLIC ${JPEGXL_COVERAGE_FLAGS})
+set_property(TARGET jpegli-obj PROPERTY POSITION_INDEPENDENT_CODE ON)
+target_include_directories(jpegli-obj PUBLIC
+  "$<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}>"
+  "$<BUILD_INTERFACE:$<TARGET_PROPERTY:hwy,INTERFACE_INCLUDE_DIRECTORIES>>"
+)
+target_compile_definitions(jpegli-obj PUBLIC
+  ${OBJ_COMPILE_DEFINITIONS}
+)
+
+set(JPEGLI_INTERNAL_OBJECTS $<TARGET_OBJECTS:jpegli-obj>)
+
+add_library(jpeg SHARED ${JPEGLI_INTERNAL_OBJECTS})
+strip_static(JPEGLI_INTERNAL_SHARED_LIBS JPEGLI_INTERNAL_LIBS)
+target_link_libraries(jpeg PUBLIC ${JPEGXL_COVERAGE_FLAGS})
+target_link_libraries(jpeg PRIVATE ${JPEGLI_INTERNAL_SHARED_LIBS})
+set_target_properties(jpeg PROPERTIES
+  VERSION ${JPEGLI_LIBRARY_VERSION}
+  SOVERSION ${JPEGLI_LIBRARY_SOVERSION}
+  LIBRARY_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}"
+  RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}")
+
+# Add a jpeg.version file as a version script to tag symbols with the
+# appropriate version number.
+set_target_properties(jpeg PROPERTIES
+  LINK_DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/jpegli/jpeg.version)
+set_property(TARGET jpeg APPEND_STRING PROPERTY
+  LINK_FLAGS " -Wl,--version-script=${CMAKE_CURRENT_SOURCE_DIR}/jpegli/jpeg.version")
+
+# This hides the default visibility symbols from static libraries bundled into
+# the shared library. In particular this prevents exposing symbols from hwy
+# in the shared library.
+if(LINKER_SUPPORT_EXCLUDE_LIBS)
+  set_property(TARGET jpeg APPEND_STRING PROPERTY
+    LINK_FLAGS " ${LINKER_EXCLUDE_LIBS_FLAG}")
+endif()
+
+if(BUILD_TESTING)
+set(TEST_FILES
+  jpegli/decode_api_test.cc
+)
+
+# Individual test binaries:
+file(MAKE_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/tests)
+foreach (TESTFILE IN LISTS TEST_FILES)
+  # The TESTNAME is the name without the extension or directory.
+  get_filename_component(TESTNAME ${TESTFILE} NAME_WE)
+  add_executable(${TESTNAME} ${TESTFILE})
+  target_compile_options(${TESTNAME} PRIVATE
+    ${JPEGXL_INTERNAL_FLAGS}
+    # Add coverage flags to the test binary so code in the private headers of
+    # the library is also instrumented when running tests that execute it.
+    ${JPEGXL_COVERAGE_FLAGS}
+  )
+  target_compile_definitions(${TESTNAME} PRIVATE
+    -DTEST_DATA_PATH="${JPEGXL_TEST_DATA_PATH}")
+  target_include_directories(${TESTNAME} PRIVATE "${PROJECT_SOURCE_DIR}")
+  target_link_libraries(${TESTNAME}
+    hwy
+    jpeg
+    gmock
+    GTest::GTest
+    GTest::Main
+  )
+  # Output test targets in the test directory.
+  set_target_properties(${TESTNAME} PROPERTIES PREFIX "tests/")
+  if (WIN32 AND CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
+    set_target_properties(${TESTNAME} PROPERTIES COMPILE_FLAGS "-Wno-error")
+  endif ()
+  if(CMAKE_VERSION VERSION_LESS "3.10.3")
+    gtest_discover_tests(${TESTNAME} TIMEOUT 240)
+  else ()
+    gtest_discover_tests(${TESTNAME} DISCOVERY_TIMEOUT 240)
+  endif ()
+endforeach ()
+endif()

--- a/lib/jpegli/README.md
+++ b/lib/jpegli/README.md
@@ -1,0 +1,28 @@
+# Improved JPEG decoder implementation
+
+This subdirectory contains a JPEG decoder implementation that is API and ABI
+compatible with libjpeg62.
+
+*NOTE*: This is still a work in progress, currently only API functions called
+from libjxl's benchmark_xl tool are implemented.
+
+To decompress an ```input.jpg``` file with this new library:
+
+```
+(from the libjxl root directory)
+$ ./ci.sh opt
+$ LD_PRELOAD=./build/libjpeg.so.62 ./build/tools/benchmark_xl --input input.jpg --codec=jpeg --decode_only --save_decompressed --output_dir .
+```
+
+The decompressed file will be saved as ```input.jpg.jpeg.png```.
+
+To benchmark the jpeg encoding-decoding round-trip on an ```input.png``` with
+the new library, first build a statically linked ```cjpeg-static``` binary,
+which is found in ```$PATH```, and then run:
+
+```
+(from the libjxl root directory)
+$ ./ci.sh opt
+$ LD_PRELOAD=./build/libjpeg.so.62 ./build/tools/benchmark_xl --input input.png --codec=jpeg:cjpeg-static:q90
+```
+

--- a/lib/jpegli/color_transform.cc
+++ b/lib/jpegli/color_transform.cc
@@ -1,0 +1,62 @@
+// Copyright (c) the JPEG XL Project Authors. All rights reserved.
+//
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+#include "lib/jpegli/color_transform.h"
+
+#undef HWY_TARGET_INCLUDE
+#define HWY_TARGET_INCLUDE "lib/jpegli/color_transform.cc"
+#include <hwy/foreach_target.h>
+#include <hwy/highway.h>
+
+HWY_BEFORE_NAMESPACE();
+namespace jpegli {
+namespace HWY_NAMESPACE {
+
+// These templates are not found via ADL.
+using hwy::HWY_NAMESPACE::Add;
+using hwy::HWY_NAMESPACE::MulAdd;
+
+void YCbCrToRGB(float* JXL_RESTRICT row0, float* JXL_RESTRICT row1,
+                float* JXL_RESTRICT row2, size_t xsize) {
+  const HWY_FULL(float) df;
+
+  // Full-range BT.601 as defined by JFIF Clause 7:
+  // https://www.itu.int/rec/T-REC-T.871-201105-I/en
+  const auto c128 = Set(df, 128.0f / 255);
+  const auto crcr = Set(df, 1.402f);
+  const auto cgcb = Set(df, -0.114f * 1.772f / 0.587f);
+  const auto cgcr = Set(df, -0.299f * 1.402f / 0.587f);
+  const auto cbcb = Set(df, 1.772f);
+
+  for (size_t x = 0; x < xsize; x += Lanes(df)) {
+    const auto y_vec = Add(Load(df, row0 + x), c128);
+    const auto cb_vec = Load(df, row1 + x);
+    const auto cr_vec = Load(df, row2 + x);
+    const auto r_vec = MulAdd(crcr, cr_vec, y_vec);
+    const auto g_vec = MulAdd(cgcr, cr_vec, MulAdd(cgcb, cb_vec, y_vec));
+    const auto b_vec = MulAdd(cbcb, cb_vec, y_vec);
+    Store(r_vec, df, row0 + x);
+    Store(g_vec, df, row1 + x);
+    Store(b_vec, df, row2 + x);
+  }
+}
+
+// NOLINTNEXTLINE(google-readability-namespace-comments)
+}  // namespace HWY_NAMESPACE
+}  // namespace jpegli
+HWY_AFTER_NAMESPACE();
+
+#if HWY_ONCE
+namespace jpegli {
+
+HWY_EXPORT(YCbCrToRGB);
+
+void YCbCrToRGB(float* JXL_RESTRICT row0, float* JXL_RESTRICT row1,
+                float* JXL_RESTRICT row2, size_t xsize) {
+  return HWY_DYNAMIC_DISPATCH(YCbCrToRGB)(row0, row1, row2, xsize);
+}
+
+}  // namespace jpegli
+#endif  // HWY_ONCE

--- a/lib/jpegli/color_transform.h
+++ b/lib/jpegli/color_transform.h
@@ -1,0 +1,20 @@
+// Copyright (c) the JPEG XL Project Authors. All rights reserved.
+//
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+#ifndef LIB_JPEGLI_COLOR_TRANSFORM_H_
+#define LIB_JPEGLI_COLOR_TRANSFORM_H_
+
+#include <stddef.h>
+
+#include "lib/jxl/base/compiler_specific.h"
+
+namespace jpegli {
+
+void YCbCrToRGB(float* JXL_RESTRICT row0, float* JXL_RESTRICT row1,
+                float* JXL_RESTRICT row2, size_t xsize);
+
+}  // namespace jpegli
+
+#endif  // LIB_JPEGLI_COLOR_TRANSFORM_H_

--- a/lib/jpegli/decode_api.cc
+++ b/lib/jpegli/decode_api.cc
@@ -1,0 +1,211 @@
+// Copyright (c) the JPEG XL Project Authors. All rights reserved.
+//
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+/* clang-format off */
+#include <stdint.h>
+#include <stdio.h>
+#include <jpeglib.h>
+/* clang-format on */
+
+#include <vector>
+
+#include "lib/jpegli/decode_internal.h"
+#include "lib/jpegli/decode_marker.h"
+#include "lib/jpegli/decode_scan.h"
+#include "lib/jpegli/error.h"
+#include "lib/jpegli/memory_manager.h"
+#include "lib/jpegli/render.h"
+#include "lib/jpegli/source_manager.h"
+#include "lib/jxl/base/status.h"
+
+typedef jpeg_decomp_master::State State;
+
+void jpeg_CreateDecompress(j_decompress_ptr cinfo, int version,
+                           size_t structsize) {
+  if (structsize != sizeof(*cinfo)) {
+    JPEGLI_ERROR("jpeg_decompress_struct has wrong size.");
+  }
+  cinfo->master = new jpeg_decomp_master;
+  cinfo->mem =
+      reinterpret_cast<struct jpeg_memory_mgr*>(new jpegli::MemoryManager);
+  cinfo->marker_list = nullptr;
+}
+
+void jpeg_destroy_decompress(j_decompress_ptr cinfo) {
+  auto mem = reinterpret_cast<jpegli::MemoryManager*>(cinfo->mem);
+  for (void* ptr : mem->owned_ptrs) {
+    free(ptr);
+  }
+  delete mem;
+  delete cinfo->master;
+}
+
+void jpeg_abort_decompress(j_decompress_ptr cinfo) {}
+
+void jpeg_save_markers(j_decompress_ptr cinfo, int marker_code,
+                       unsigned int length_limit) {
+  jpeg_decomp_master* m = cinfo->master;
+  m->markers_to_save_.insert(marker_code);
+}
+
+int jpeg_read_header(j_decompress_ptr cinfo, boolean require_image) {
+  jpeg_decomp_master* m = cinfo->master;
+  const uint8_t* data = cinfo->src->next_input_byte;
+  size_t len = cinfo->src->bytes_in_buffer;
+  size_t pos = 0;
+  std::vector<uint8_t> buffer;
+  const uint8_t* last_src_buf_start = data;
+  size_t last_src_buf_len = len;
+
+  while (!m->found_sos_) {
+    bool status = true;
+    if (m->state_ == State::kStart) {
+      // Look for the SOI marker.
+      if (len >= 2) {
+        if (data[0] != 0xff || data[1] != 0xd8) {
+          JPEGLI_ERROR("Did not find SOI marker.");
+        }
+        pos += 2;
+        jpegli::AdvanceInput(cinfo, 2);
+        m->found_soi_ = true;
+        m->state_ = State::kProcessMarkers;
+      } else {
+        status = false;
+      }
+    } else if (m->state_ == State::kProcessMarkers) {
+      status = jpegli::ProcessMarker(cinfo, data, len, &pos);
+    } else {
+      JPEGLI_ERROR("Unexpected state.");
+    }
+    if (!status) {
+      if (buffer.empty()) {
+        buffer.assign(data, data + len);
+      }
+      if ((*cinfo->src->fill_input_buffer)(cinfo)) {
+        buffer.insert(
+            buffer.end(), cinfo->src->next_input_byte,
+            cinfo->src->next_input_byte + cinfo->src->bytes_in_buffer);
+        data = buffer.data();
+        len = buffer.size();
+        last_src_buf_start = cinfo->src->next_input_byte;
+        last_src_buf_len = cinfo->src->bytes_in_buffer;
+        cinfo->src->next_input_byte = data + pos;
+        cinfo->src->bytes_in_buffer = len - pos;
+      } else {
+        return JPEG_SUSPENDED;
+      }
+    }
+  }
+
+  if (!buffer.empty()) {
+    cinfo->src->next_input_byte =
+        (last_src_buf_start + last_src_buf_len - buffer.size() + pos);
+    cinfo->src->bytes_in_buffer = buffer.size() - pos;
+  }
+  return JPEG_HEADER_OK;
+}
+
+boolean jpeg_start_decompress(j_decompress_ptr cinfo) {
+  jpeg_decomp_master* m = cinfo->master;
+  if (m->is_progressive_) {
+    const uint8_t* data = cinfo->src->next_input_byte;
+    size_t len = cinfo->src->bytes_in_buffer;
+    size_t pos = 0;
+    std::vector<uint8_t> buffer;
+    const uint8_t* last_src_buf_start = data;
+    size_t last_src_buf_len = len;
+    while (!m->found_eoi_) {
+      bool status = true;
+      if (m->state_ == State::kProcessMarkers) {
+        status = jpegli::ProcessMarker(cinfo, data, len, &pos);
+      } else if (m->state_ == State::kScan) {
+        status = jpegli::ProcessScan(cinfo, data, len, &pos);
+      } else {
+        JPEGLI_ERROR("Unexpected state.");
+      }
+      if (!status) {
+        if (buffer.empty()) {
+          buffer.assign(data, data + len);
+        }
+        if ((*cinfo->src->fill_input_buffer)(cinfo)) {
+          buffer.insert(
+              buffer.end(), cinfo->src->next_input_byte,
+              cinfo->src->next_input_byte + cinfo->src->bytes_in_buffer);
+          data = buffer.data();
+          len = buffer.size();
+          last_src_buf_start = cinfo->src->next_input_byte;
+          last_src_buf_len = cinfo->src->bytes_in_buffer;
+          cinfo->src->next_input_byte = data + pos;
+          cinfo->src->bytes_in_buffer = len - pos;
+        } else {
+          return FALSE;
+        }
+      }
+    }
+    if (!buffer.empty()) {
+      cinfo->src->next_input_byte =
+          (last_src_buf_start + last_src_buf_len - buffer.size() + pos);
+      cinfo->src->bytes_in_buffer = buffer.size() - pos;
+    }
+  }
+  jpegli::PrepareForOutput(cinfo);
+  return TRUE;
+}
+
+JDIMENSION jpeg_read_scanlines(j_decompress_ptr cinfo, JSAMPARRAY scanlines,
+                               JDIMENSION max_lines) {
+  jpeg_decomp_master* m = cinfo->master;
+  if (max_lines == 0 || m->state_ == State::kEnd) {
+    return 0;
+  }
+  size_t num_output_rows = 0;
+  const uint8_t* data = cinfo->src->next_input_byte;
+  size_t len = cinfo->src->bytes_in_buffer;
+  size_t pos = 0;
+  std::vector<uint8_t> buffer;
+  const uint8_t* last_src_buf_start = data;
+  size_t last_src_buf_len = len;
+
+  while (num_output_rows < max_lines) {
+    bool status = true;
+    if (m->state_ == State::kProcessMarkers) {
+      status = jpegli::ProcessMarker(cinfo, data, len, &pos);
+    } else if (m->state_ == State::kScan) {
+      status = jpegli::ProcessScan(cinfo, data, len, &pos);
+    } else if (m->state_ == State::kRender) {
+      jpegli::ProcessOutput(cinfo, &num_output_rows, scanlines, max_lines);
+    } else if (m->state_ == State::kEnd) {
+      break;
+    } else {
+      JPEGLI_ERROR("Unexpected state.");
+    }
+    if (!status) {
+      if (buffer.empty()) {
+        buffer.assign(data, data + len);
+      }
+      if ((*cinfo->src->fill_input_buffer)(cinfo)) {
+        buffer.insert(
+            buffer.end(), cinfo->src->next_input_byte,
+            cinfo->src->next_input_byte + cinfo->src->bytes_in_buffer);
+        data = buffer.data();
+        len = buffer.size();
+        last_src_buf_start = cinfo->src->next_input_byte;
+        last_src_buf_len = cinfo->src->bytes_in_buffer;
+        cinfo->src->next_input_byte = data + pos;
+        cinfo->src->bytes_in_buffer = len - pos;
+      } else {
+        return num_output_rows;
+      }
+    }
+  }
+  if (!buffer.empty()) {
+    cinfo->src->next_input_byte =
+        (last_src_buf_start + last_src_buf_len - buffer.size() + pos);
+    cinfo->src->bytes_in_buffer = buffer.size() - pos;
+  }
+  return num_output_rows;
+}
+
+boolean jpeg_finish_decompress(j_decompress_ptr cinfo) { return TRUE; }

--- a/lib/jpegli/decode_api_test.cc
+++ b/lib/jpegli/decode_api_test.cc
@@ -1,0 +1,344 @@
+// Copyright (c) the JPEG XL Project Authors. All rights reserved.
+//
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+/* clang-format off */
+#include <stdio.h>
+#include <jpeglib.h>
+#include <setjmp.h>
+#include <stddef.h>
+/* clang-format on */
+
+#include <cmath>
+#include <vector>
+
+#include "gtest/gtest.h"
+#include "lib/jxl/base/file_io.h"
+
+namespace jpegli {
+namespace {
+
+std::vector<uint8_t> ReadTestData(const std::string& filename) {
+  std::string full_path = std::string(TEST_DATA_PATH "/") + filename;
+  std::vector<uint8_t> data;
+  JXL_CHECK(jxl::ReadFile(full_path, &data));
+  printf("Test data %s is %d bytes long.\n", filename.c_str(),
+         static_cast<int>(data.size()));
+  return data;
+}
+
+class PNMParser {
+ public:
+  explicit PNMParser(const uint8_t* data, const size_t len)
+      : pos_(data), end_(data + len) {}
+
+  // Sets "pos" to the first non-header byte/pixel on success.
+  bool ParseHeader(const uint8_t** pos, size_t* xsize, size_t* ysize,
+                   size_t* num_channels, size_t* bitdepth) {
+    if (pos_[0] != 'P' || (pos_[1] != '5' && pos_[1] != '6')) {
+      fprintf(stderr, "Invalid PNM header.");
+      return false;
+    }
+    *num_channels = (pos_[1] == '5' ? 1 : 3);
+    pos_ += 2;
+
+    size_t maxval;
+    if (!SkipWhitespace() || !ParseUnsigned(xsize) || !SkipWhitespace() ||
+        !ParseUnsigned(ysize) || !SkipWhitespace() || !ParseUnsigned(&maxval) ||
+        !SkipWhitespace()) {
+      return false;
+    }
+    if (maxval == 0 || maxval >= 65536) {
+      fprintf(stderr, "Invalid maxval value.\n");
+      return false;
+    }
+    bool found_bitdepth = false;
+    for (int bits = 1; bits <= 16; ++bits) {
+      if (maxval == (1u << bits) - 1) {
+        *bitdepth = bits;
+        found_bitdepth = true;
+        break;
+      }
+    }
+    if (!found_bitdepth) {
+      fprintf(stderr, "Invalid maxval value.\n");
+      return false;
+    }
+
+    *pos = pos_;
+    return true;
+  }
+
+ private:
+  static bool IsLineBreak(const uint8_t c) { return c == '\r' || c == '\n'; }
+  static bool IsWhitespace(const uint8_t c) {
+    return IsLineBreak(c) || c == '\t' || c == ' ';
+  }
+
+  bool ParseUnsigned(size_t* number) {
+    if (pos_ == end_ || *pos_ < '0' || *pos_ > '9') {
+      fprintf(stderr, "Expected unsigned number.\n");
+      return false;
+    }
+    *number = 0;
+    while (pos_ < end_ && *pos_ >= '0' && *pos_ <= '9') {
+      *number *= 10;
+      *number += *pos_ - '0';
+      ++pos_;
+    }
+
+    return true;
+  }
+
+  bool SkipWhitespace() {
+    if (pos_ == end_ || !IsWhitespace(*pos_)) {
+      fprintf(stderr, "Expected whitespace.\n");
+      return false;
+    }
+    while (pos_ < end_ && IsWhitespace(*pos_)) {
+      ++pos_;
+    }
+    return true;
+  }
+
+  const uint8_t* pos_;
+  const uint8_t* const end_;
+};
+
+bool ReadPNM(const std::vector<uint8_t>& data, size_t* xsize, size_t* ysize,
+             size_t* num_channels, size_t* bitdepth,
+             std::vector<uint8_t>* pixels) {
+  if (data.size() < 2) {
+    fprintf(stderr, "PNM file too small.\n");
+    return false;
+  }
+  PNMParser parser(data.data(), data.size());
+  const uint8_t* pos = nullptr;
+  if (!parser.ParseHeader(&pos, xsize, ysize, num_channels, bitdepth)) {
+    return false;
+  }
+  pixels->resize(data.data() + data.size() - pos);
+  memcpy(&(*pixels)[0], pos, pixels->size());
+  return true;
+}
+
+static constexpr uint8_t kFakeEoiMarker[2] = {0xff, 0xd9};
+
+// Custom source manager that refills the input buffer in chunks, simulating
+// a file reader with a fixed buffer size.
+struct TestJpegSourceManager {
+  jpeg_source_mgr pub;
+  const uint8_t* data;
+  size_t len;
+  size_t pos;
+  size_t chunk_size;
+
+  TestJpegSourceManager(const uint8_t* buf, size_t buf_size,
+                        size_t max_chunk_size) {
+    pub.next_input_byte = nullptr;
+    pub.bytes_in_buffer = 0;
+    pub.init_source = init_source;
+    pub.fill_input_buffer = fill_input_buffer;
+    pub.skip_input_data = skip_input_data;
+    pub.resync_to_restart = resync_to_restart;
+    pub.term_source = term_source;
+    data = buf;
+    len = buf_size;
+    pos = 0;
+    chunk_size = max_chunk_size;
+  }
+
+  static void init_source(j_decompress_ptr cinfo) {}
+
+  static boolean fill_input_buffer(j_decompress_ptr cinfo) {
+    auto src = reinterpret_cast<TestJpegSourceManager*>(cinfo->src);
+    if (src->pos < src->len) {
+      src->pub.next_input_byte = src->data + src->pos;
+      src->pub.bytes_in_buffer = std::min(src->len - src->pos, src->chunk_size);
+      src->pos += src->pub.bytes_in_buffer;
+    } else {
+      src->pub.next_input_byte = kFakeEoiMarker;
+      src->pub.bytes_in_buffer = 2;
+    }
+    return TRUE;
+  }
+
+  static void skip_input_data(j_decompress_ptr cinfo, long num_bytes) {}
+
+  static boolean resync_to_restart(j_decompress_ptr cinfo, int desired) {
+    return FALSE;
+  }
+
+  static void term_source(j_decompress_ptr cinfo) {}
+};
+
+struct TestConfig {
+  std::string fn;
+  std::string fn_desc;
+  std::string origfn;
+  size_t chunk_size;
+  size_t max_output_lines;
+  float max_distance;
+};
+
+class DecodeAPITestParam : public ::testing::TestWithParam<TestConfig> {};
+
+TEST_P(DecodeAPITestParam, TestAPI) {
+  TestConfig config = GetParam();
+  const std::vector<uint8_t> compressed = ReadTestData(config.fn.c_str());
+  const std::vector<uint8_t> origdata = ReadTestData(config.origfn.c_str());
+
+  size_t xsize, ysize, num_channels, bitdepth;
+  std::vector<uint8_t> orig;
+  ASSERT_TRUE(
+      ReadPNM(origdata, &xsize, &ysize, &num_channels, &bitdepth, &orig));
+  ASSERT_EQ(8, bitdepth);
+
+  jpeg_decompress_struct cinfo;
+  jpeg_error_mgr jerr;
+  cinfo.err = jpeg_std_error(&jerr);
+  jmp_buf env;
+  if (setjmp(env)) {
+    FAIL();
+  }
+  cinfo.client_data = static_cast<void*>(&env);
+  cinfo.err->error_exit = [](j_common_ptr cinfo) {
+    (*cinfo->err->output_message)(cinfo);
+    jmp_buf* env = static_cast<jmp_buf*>(cinfo->client_data);
+    longjmp(*env, 1);
+  };
+
+  jpeg_create_decompress(&cinfo);
+
+  size_t chunk_size = config.chunk_size;
+  if (chunk_size == 0) chunk_size = compressed.size();
+  TestJpegSourceManager jsrc(compressed.data(), compressed.size(), chunk_size);
+  cinfo.src = reinterpret_cast<jpeg_source_mgr*>(&jsrc);
+
+  ASSERT_EQ(JPEG_HEADER_OK, jpeg_read_header(&cinfo, /*require_image=*/TRUE));
+
+  EXPECT_EQ(xsize, cinfo.image_width);
+  EXPECT_EQ(ysize, cinfo.image_height);
+  EXPECT_EQ(num_channels, cinfo.num_components);
+
+  ASSERT_TRUE(jpeg_start_decompress(&cinfo));
+
+  size_t stride = cinfo.image_width * cinfo.num_components;
+  std::vector<uint8_t> output(cinfo.image_height * stride);
+  size_t max_output_lines = config.max_output_lines;
+  if (max_output_lines == 0) max_output_lines = cinfo.image_height;
+  size_t total_output_lines = 0;
+  while (total_output_lines < cinfo.image_height) {
+    std::vector<JSAMPROW> scanlines(max_output_lines);
+    for (size_t i = 0; i < max_output_lines; ++i) {
+      scanlines[i] = &output[(total_output_lines + i) * stride];
+    }
+    size_t num_output_lines =
+        jpeg_read_scanlines(&cinfo, &scanlines[0], max_output_lines);
+    total_output_lines += num_output_lines;
+    if (total_output_lines < cinfo.image_height) {
+      EXPECT_EQ(num_output_lines, max_output_lines);
+    }
+  }
+
+  ASSERT_TRUE(jpeg_finish_decompress(&cinfo));
+
+  jpeg_destroy_decompress(&cinfo);
+
+  ASSERT_EQ(output.size(), orig.size());
+  double diff2 = 0.0;
+  for (size_t i = 0; i < output.size(); ++i) {
+    double diff = orig[i] - output[i];
+    diff2 += diff * diff;
+  }
+  double rms = std::sqrt(diff2 / orig.size());
+
+  EXPECT_LE(rms, config.max_distance);
+}
+
+std::vector<TestConfig> GenerateTests() {
+  std::vector<TestConfig> all_tests;
+  {
+    std::vector<std::pair<std::string, std::string>> testfiles({
+        {"jxl/flower/flower.png.im_q85_444.jpg", "Q85YUV444"},
+        {"jxl/flower/flower.png.im_q85_420.jpg", "Q85YUV420"},
+        {"jxl/flower/flower.png.im_q85_420_progr.jpg", "Q85YUV420PROGR"},
+        {"jxl/flower/flower.png.im_q85_420_R13B.jpg", "Q85YUV420R13B"},
+    });
+    for (const auto& it : testfiles) {
+      for (size_t chunk_size : {0, 1, 64, 65536}) {
+        for (size_t max_output_lines : {0, 1, 8, 16}) {
+          TestConfig config;
+          config.fn = it.first;
+          config.fn_desc = it.second;
+          config.chunk_size = chunk_size;
+          config.max_output_lines = max_output_lines;
+          config.origfn = "jxl/flower/flower.pnm";
+          config.max_distance = 3.0;
+          all_tests.push_back(config);
+        }
+      }
+    }
+  }
+  {
+    std::vector<std::pair<std::string, std::string>> testfiles({
+        {"jxl/flower/flower.png.im_q85_422.jpg", "Q85YUV422"},
+        {"jxl/flower/flower.png.im_q85_440.jpg", "Q85YUV440"},
+        {"jxl/flower/flower.png.im_q85_444_1x2.jpg", "Q85YUV444_1x2"},
+        {"jxl/flower/flower.png.im_q85_asymmetric.jpg", "Q85Asymmetric"},
+        {"jxl/flower/flower.png.im_q85_gray.jpg", "Q85Gray"},
+        {"jxl/flower/flower.png.im_q85_luma_subsample.jpg", "Q85LumaSubsample"},
+        {"jxl/flower/flower.png.im_q85_rgb.jpg", "Q85RGB"},
+        {"jxl/flower/flower.png.im_q85_rgb_subsample_blue.jpg",
+         "Q85RGBSubsampleBlue"},
+    });
+    for (const auto& it : testfiles) {
+      for (size_t chunk_size : {0, 64}) {
+        for (size_t max_output_lines : {0, 16}) {
+          TestConfig config;
+          config.fn = it.first;
+          config.fn_desc = it.second;
+          config.chunk_size = chunk_size;
+          config.max_output_lines = max_output_lines;
+          config.origfn = "jxl/flower/flower.pnm";
+          config.max_distance = 3.5;
+          if (config.fn_desc == "Q85Gray") {
+            config.origfn = "jxl/flower/flower.pgm";
+            config.max_distance = 1.5;
+          }
+          all_tests.push_back(config);
+        }
+      }
+    }
+  }
+  return all_tests;
+}
+
+std::ostream& operator<<(std::ostream& os, const TestConfig& c) {
+  os << c.fn_desc;
+  if (c.chunk_size == 0) {
+    os << "CompleteInput";
+  } else {
+    os << "InputChunks" << c.chunk_size;
+  }
+  if (c.max_output_lines == 0) {
+    os << "CompleteOutput";
+  } else {
+    os << "OutputLines" << c.max_output_lines;
+  }
+  return os;
+}
+
+std::string TestDescription(
+    const testing::TestParamInfo<DecodeAPITestParam::ParamType>& info) {
+  std::stringstream name;
+  name << info.param;
+  return name.str();
+}
+
+INSTANTIATE_TEST_SUITE_P(DecodeAPITest, DecodeAPITestParam,
+                         testing::ValuesIn(GenerateTests()), TestDescription);
+
+}  // namespace
+}  // namespace jpegli

--- a/lib/jpegli/decode_internal.h
+++ b/lib/jpegli/decode_internal.h
@@ -1,0 +1,221 @@
+// Copyright (c) the JPEG XL Project Authors. All rights reserved.
+//
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+#ifndef LIB_JPEGLI_DECODE_INTERNAL_H_
+#define LIB_JPEGLI_DECODE_INTERNAL_H_
+
+#include <stdint.h>
+
+#include <array>
+#include <set>
+#include <vector>
+
+#include "hwy/aligned_allocator.h"
+#include "lib/jpegli/huffman.h"
+
+namespace jpegli {
+
+template <typename T1, typename T2>
+constexpr inline T1 DivCeil(T1 a, T2 b) {
+  return (a + b - 1) / b;
+}
+
+constexpr int kMaxComponents = 4;
+constexpr int kJpegDCAlphabetSize = 12;
+
+typedef int16_t coeff_t;
+
+// Represents one component of a jpeg file.
+struct JPEGComponent {
+  JPEGComponent()
+      : id(0),
+        h_samp_factor(1),
+        v_samp_factor(1),
+        quant_idx(0),
+        width_in_blocks(0),
+        height_in_blocks(0) {}
+
+  // One-byte id of the component.
+  uint32_t id;
+  // Horizontal and vertical sampling factors.
+  // In interleaved mode, each minimal coded unit (MCU) has
+  // h_samp_factor x v_samp_factor DCT blocks from this component.
+  int h_samp_factor;
+  int v_samp_factor;
+  // The index of the quantization table used for this component.
+  uint32_t quant_idx;
+  // The dimensions of the component measured in 8x8 blocks.
+  uint32_t width_in_blocks;
+  uint32_t height_in_blocks;
+  // The DCT coefficients of this component, laid out block-by-block, divided
+  // through the quantization matrix values.
+  hwy::AlignedFreeUniquePtr<coeff_t[]> coeffs;
+};
+
+// Quantization values for an 8x8 pixel block.
+struct JPEGQuantTable {
+  std::array<int32_t, DCTSIZE2> values;
+  // The index of this quantization table as it was parsed from the input JPEG.
+  // Each DQT marker segment contains an 'index' field, and we save this index
+  // here. Valid values are 0 to 3.
+  uint32_t index = 0;
+};
+
+// Huffman table indexes and MCU dimensions used for one component of one scan.
+struct JPEGComponentScanInfo {
+  uint32_t comp_idx;
+  uint32_t dc_tbl_idx;
+  uint32_t ac_tbl_idx;
+  uint32_t mcu_ysize_blocks;
+  uint32_t mcu_xsize_blocks;
+};
+
+// Contains information that is used in one scan.
+struct JPEGScanInfo {
+  // Parameters used for progressive scans (named the same way as in the spec):
+  //   Ss : Start of spectral band in zig-zag sequence.
+  //   Se : End of spectral band in zig-zag sequence.
+  //   Ah : Successive approximation bit position, high.
+  //   Al : Successive approximation bit position, low.
+  uint32_t Ss;
+  uint32_t Se;
+  uint32_t Ah;
+  uint32_t Al;
+  uint32_t num_components = 0;
+  std::array<JPEGComponentScanInfo, kMaxComponents> components;
+  size_t MCU_rows;
+  size_t MCU_cols;
+};
+
+// State of the decoder that has to be saved before decoding one MCU in case
+// we run out of the bitstream.
+struct MCUCodingState {
+  coeff_t last_dc_coeff[kMaxComponents];
+  int eobrun;
+  std::vector<coeff_t> coeffs;
+};
+
+/* clang-format off */
+constexpr uint32_t kJPEGNaturalOrder[80] = {
+  0,   1,  8, 16,  9,  2,  3, 10,
+  17, 24, 32, 25, 18, 11,  4,  5,
+  12, 19, 26, 33, 40, 48, 41, 34,
+  27, 20, 13,  6,  7, 14, 21, 28,
+  35, 42, 49, 56, 57, 50, 43, 36,
+  29, 22, 15, 23, 30, 37, 44, 51,
+  58, 59, 52, 45, 38, 31, 39, 46,
+  53, 60, 61, 54, 47, 55, 62, 63,
+  // extra entries for safety in decoder
+  63, 63, 63, 63, 63, 63, 63, 63,
+  63, 63, 63, 63, 63, 63, 63, 63
+};
+
+/* clang-format on */
+
+}  // namespace jpegli
+
+// Use this forward-declared libjpeg struct to hold all our private variables.
+// TODO(szabadka) Remove variables that have a corresponding version in cinfo.
+struct jpeg_decomp_master {
+  enum class State {
+    kStart,
+    kProcessMarkers,
+    kScan,
+    kRender,
+    kEnd,
+  };
+  State state_ = State::kStart;
+
+  //
+  // Input handling state.
+  //
+  // Number of bits after codestream_pos_ that were already processed.
+  size_t codestream_bits_ahead_ = 0;
+
+  //
+  // Marker data processing state.
+  //
+  bool found_soi_ = false;
+  bool found_sos_ = false;
+  bool found_app0_ = false;
+  bool found_dri_ = false;
+  bool found_sof_ = false;
+  bool found_eoi_ = false;
+  bool is_ycbcr_ = true;
+  size_t icc_index_ = 0;
+  size_t icc_total_ = 0;
+  std::vector<uint8_t> icc_profile_;
+  size_t restart_interval_ = 0;
+  std::vector<jpegli::JPEGQuantTable> quant_;
+  std::vector<jpegli::JPEGComponent> components_;
+  std::vector<jpegli::HuffmanTableEntry> dc_huff_lut_;
+  std::vector<jpegli::HuffmanTableEntry> ac_huff_lut_;
+  uint8_t huff_slot_defined_[256] = {};
+  std::set<int> markers_to_save_;
+
+  // Fields defined by SOF marker.
+  bool is_progressive_;
+  int max_h_samp_;
+  int max_v_samp_;
+  size_t iMCU_rows_;
+  size_t iMCU_cols_;
+  size_t iMCU_width_;
+  size_t iMCU_height_;
+
+  // Initialized at strat of frame.
+  uint16_t scan_progression_[jpegli::kMaxComponents][DCTSIZE2];
+
+  //
+  // Per scan state.
+  //
+  jpegli::JPEGScanInfo scan_info_;
+  size_t scan_mcu_row_;
+  size_t scan_mcu_col_;
+  jpegli::coeff_t last_dc_coeff_[jpegli::kMaxComponents];
+  int eobrun_;
+  int restarts_to_go_;
+  int next_restart_marker_;
+
+  jpegli::MCUCodingState mcu_;
+
+  //
+  // Rendering state.
+  //
+  size_t output_bit_depth_ = 8;
+  size_t output_stride_;
+
+  hwy::AlignedFreeUniquePtr<float[]> MCU_row_buf_;
+  size_t MCU_row_stride_;
+  size_t MCU_plane_size_;
+  size_t MCU_buf_current_row_;
+  size_t MCU_buf_ready_rows_;
+
+  size_t output_row_;
+  size_t output_mcu_row_;
+  size_t output_ci_;
+  // Temporary buffers for vertically upsampled chroma components. We keep a
+  // ringbuffer of 3 * kBlockDim rows so that we have access for previous and
+  // next rows.
+  hwy::AlignedFreeUniquePtr<float[]> chroma_;
+  size_t num_chroma_;
+  size_t chroma_plane_size_;
+
+  // In the rendering order, vertically upsampled chroma components come first.
+  std::vector<size_t> component_order_;
+  hwy::AlignedFreeUniquePtr<float[]> idct_scratch_;
+  hwy::AlignedFreeUniquePtr<float[]> upsample_scratch_;
+  hwy::AlignedFreeUniquePtr<uint8_t[]> output_scratch_;
+
+  hwy::AlignedFreeUniquePtr<float[]> dequant_;
+  // Per channel and per frequency statistics about the number of nonzeros and
+  // the sum of coefficient absolute values, used in dequantization bias
+  // computation.
+  hwy::AlignedFreeUniquePtr<int[]> nonzeros_;
+  hwy::AlignedFreeUniquePtr<int[]> sumabs_;
+  std::vector<size_t> num_processed_blocks_;
+  hwy::AlignedFreeUniquePtr<float[]> biases_;
+};
+
+#endif  // LIB_JPEGLI_DECODE_INTERNAL_H_

--- a/lib/jpegli/decode_marker.cc
+++ b/lib/jpegli/decode_marker.cc
@@ -1,0 +1,538 @@
+// Copyright (c) the JPEG XL Project Authors. All rights reserved.
+//
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+#include "lib/jpegli/decode_marker.h"
+
+#include <string.h>
+
+#include "lib/jpegli/decode_internal.h"
+#include "lib/jpegli/error.h"
+#include "lib/jpegli/huffman.h"
+#include "lib/jpegli/memory_manager.h"
+#include "lib/jpegli/source_manager.h"
+#include "lib/jxl/base/printf_macros.h"
+
+typedef jpeg_decomp_master::State State;
+
+namespace jpegli {
+namespace {
+
+constexpr int kMaxSampling = 2;
+constexpr int kMaxHuffmanTables = 4;
+constexpr int kMaxQuantTables = 4;
+constexpr int kMaxDimPixels = 65535;
+constexpr uint8_t kIccProfileTag[12] = "ICC_PROFILE";
+
+// Macros for commonly used error conditions.
+
+#define JPEG_VERIFY_LEN(n)                                     \
+  if (pos + (n) > len) {                                       \
+    return JPEGLI_ERROR("Unexpected end of input: pos=%" PRIuS \
+                        " need=%d len=%" PRIuS,                \
+                        pos, static_cast<int>(n), len);        \
+  }
+
+#define JPEG_VERIFY_INPUT(var, low, high)                               \
+  if ((var) < (low) || (var) > (high)) {                                \
+    return JPEGLI_ERROR("Invalid " #var ": %d", static_cast<int>(var)); \
+  }
+
+#define JPEG_VERIFY_MARKER_END()                                  \
+  if (pos != len) {                                               \
+    return JPEGLI_ERROR("Invalid marker length: declared=%" PRIuS \
+                        " actual=%" PRIuS,                        \
+                        len, pos);                                \
+  }
+
+inline int ReadUint8(const uint8_t* data, size_t* pos) {
+  return data[(*pos)++];
+}
+
+inline int ReadUint16(const uint8_t* data, size_t* pos) {
+  int v = (data[*pos] << 8) + data[*pos + 1];
+  *pos += 2;
+  return v;
+}
+
+void ProcessSOF(j_decompress_ptr cinfo, const uint8_t* data, size_t len) {
+  jpeg_decomp_master* m = cinfo->master;
+  if (!m->found_soi_) {
+    JPEGLI_ERROR("Unexpected SOF marker.");
+  }
+  if (m->found_sof_) {
+    JPEGLI_ERROR("Duplicate SOF marker.");
+  }
+  m->found_sof_ = true;
+  m->is_progressive_ = (data[1] == 0xc2);
+  size_t pos = 4;
+  JPEG_VERIFY_LEN(6);
+  int precision = ReadUint8(data, &pos);
+  cinfo->image_height = ReadUint16(data, &pos);
+  cinfo->image_width = ReadUint16(data, &pos);
+  cinfo->arith_code = 0;
+  cinfo->num_components = ReadUint8(data, &pos);
+  JPEG_VERIFY_INPUT(precision, 8, 8);
+  JPEG_VERIFY_INPUT(cinfo->image_height, 1, kMaxDimPixels);
+  JPEG_VERIFY_INPUT(cinfo->image_width, 1, kMaxDimPixels);
+  JPEG_VERIFY_INPUT(cinfo->num_components, 1, kMaxComponents);
+  JPEG_VERIFY_LEN(3 * cinfo->num_components);
+  m->components_.resize(cinfo->num_components);
+
+  // Read sampling factors and quant table index for each component.
+  std::vector<bool> ids_seen(256, false);
+  m->max_h_samp_ = 1;
+  m->max_v_samp_ = 1;
+  for (size_t i = 0; i < m->components_.size(); ++i) {
+    JPEGComponent* c = &m->components_[i];
+    const int id = ReadUint8(data, &pos);
+    if (ids_seen[id]) {  // (cf. section B.2.2, syntax of Ci)
+      JPEGLI_ERROR("Duplicate ID %d in SOF.", id);
+    }
+    ids_seen[id] = true;
+    c->id = id;
+    int factor = ReadUint8(data, &pos);
+    int h_samp_factor = factor >> 4;
+    int v_samp_factor = factor & 0xf;
+    JPEG_VERIFY_INPUT(h_samp_factor, 1, kMaxSampling);
+    JPEG_VERIFY_INPUT(v_samp_factor, 1, kMaxSampling);
+    c->h_samp_factor = h_samp_factor;
+    c->v_samp_factor = v_samp_factor;
+    m->max_h_samp_ = std::max(m->max_h_samp_, h_samp_factor);
+    m->max_v_samp_ = std::max(m->max_v_samp_, v_samp_factor);
+    uint8_t quant_tbl_idx = ReadUint8(data, &pos);
+    bool found_quant_tbl = false;
+    for (size_t j = 0; j < m->quant_.size(); ++j) {
+      if (m->quant_[j].index == quant_tbl_idx) {
+        c->quant_idx = j;
+        found_quant_tbl = true;
+        break;
+      }
+    }
+    if (!found_quant_tbl) {
+      JPEGLI_ERROR("Quantization table with index %u not found", quant_tbl_idx);
+    }
+  }
+  JPEG_VERIFY_MARKER_END();
+
+  if (cinfo->num_components == 1) {
+    m->is_ycbcr_ = true;
+  }
+  if (!m->found_app0_ && cinfo->num_components == 3 &&
+      m->components_[0].id == 'R' && m->components_[1].id == 'G' &&
+      m->components_[2].id == 'B') {
+    m->is_ycbcr_ = false;
+  }
+
+  // We have checked above that none of the sampling factors are 0, so the max
+  // sampling factors can not be 0.
+  m->iMCU_height_ = m->max_v_samp_ * DCTSIZE;
+  m->iMCU_width_ = m->max_h_samp_ * DCTSIZE;
+  m->iMCU_rows_ = DivCeil(cinfo->image_height, m->iMCU_height_);
+  m->iMCU_cols_ = DivCeil(cinfo->image_width, m->iMCU_width_);
+  // Compute the block dimensions for each component.
+  for (size_t i = 0; i < m->components_.size(); ++i) {
+    JPEGComponent* c = &m->components_[i];
+    if (m->max_h_samp_ % c->h_samp_factor != 0 ||
+        m->max_v_samp_ % c->v_samp_factor != 0) {
+      JPEGLI_ERROR("Non-integral subsampling ratios.");
+    }
+    c->width_in_blocks = m->iMCU_cols_ * c->h_samp_factor;
+    c->height_in_blocks = m->iMCU_rows_ * c->v_samp_factor;
+    const uint64_t num_blocks =
+        static_cast<uint64_t>(c->width_in_blocks) * c->height_in_blocks;
+    c->coeffs = hwy::AllocateAligned<coeff_t>(num_blocks * DCTSIZE2);
+    memset(c->coeffs.get(), 0, num_blocks * DCTSIZE2 * sizeof(coeff_t));
+  }
+  memset(m->scan_progression_, 0, sizeof(m->scan_progression_));
+}
+
+void ProcessSOS(j_decompress_ptr cinfo, const uint8_t* data, size_t len) {
+  jpeg_decomp_master* m = cinfo->master;
+  if (!m->found_sof_) {
+    JPEGLI_ERROR("Unexpected SOS marker.");
+  }
+  m->found_sos_ = true;
+  size_t pos = 4;
+  JPEG_VERIFY_LEN(1);
+  size_t comps_in_scan = ReadUint8(data, &pos);
+  JPEG_VERIFY_INPUT(comps_in_scan, 1, m->components_.size());
+
+  m->scan_info_.num_components = comps_in_scan;
+  JPEG_VERIFY_LEN(2 * comps_in_scan);
+  bool is_interleaved = (m->scan_info_.num_components > 1);
+  std::vector<bool> ids_seen(256, false);
+  for (size_t i = 0; i < m->scan_info_.num_components; ++i) {
+    JPEGComponentScanInfo* si = &m->scan_info_.components[i];
+    uint32_t id = ReadUint8(data, &pos);
+    if (ids_seen[id]) {  // (cf. section B.2.3, regarding CSj)
+      return JPEGLI_ERROR("Duplicate ID %d in SOS.", id);
+    }
+    ids_seen[id] = true;
+    JPEGComponent* comp = nullptr;
+    for (size_t j = 0; j < m->components_.size(); ++j) {
+      if (m->components_[j].id == id) {
+        si->comp_idx = j;
+        comp = &m->components_[j];
+      }
+    }
+    if (!comp) {
+      return JPEGLI_ERROR("SOS marker: Could not find component with id %d",
+                          id);
+    }
+    int c = ReadUint8(data, &pos);
+    si->dc_tbl_idx = c >> 4;
+    si->ac_tbl_idx = c & 0xf;
+    JPEG_VERIFY_INPUT(static_cast<int>(si->dc_tbl_idx), 0, 3);
+    JPEG_VERIFY_INPUT(static_cast<int>(si->ac_tbl_idx), 0, 3);
+    si->mcu_xsize_blocks = is_interleaved ? comp->h_samp_factor : 1;
+    si->mcu_ysize_blocks = is_interleaved ? comp->v_samp_factor : 1;
+  }
+  JPEG_VERIFY_LEN(3);
+  m->scan_info_.Ss = ReadUint8(data, &pos);
+  m->scan_info_.Se = ReadUint8(data, &pos);
+  JPEG_VERIFY_INPUT(static_cast<int>(m->scan_info_.Ss), 0, 63);
+  JPEG_VERIFY_INPUT(m->scan_info_.Se, m->scan_info_.Ss, 63);
+  int c = ReadUint8(data, &pos);
+  m->scan_info_.Ah = c >> 4;
+  m->scan_info_.Al = c & 0xf;
+  JPEG_VERIFY_MARKER_END();
+
+  if (m->scan_info_.Ah != 0 && m->scan_info_.Al != m->scan_info_.Ah - 1) {
+    // section G.1.1.1.2 : Successive approximation control only improves
+    // by one bit at a time.
+    JPEGLI_ERROR("Invalid progressive parameters: Al=%d Ah=%d",
+                 m->scan_info_.Al, m->scan_info_.Ah);
+  }
+  if (!m->is_progressive_) {
+    m->scan_info_.Ss = 0;
+    m->scan_info_.Se = 63;
+    m->scan_info_.Ah = 0;
+    m->scan_info_.Al = 0;
+  }
+  const uint16_t scan_bitmask = m->scan_info_.Ah == 0
+                                    ? (0xffff << m->scan_info_.Al)
+                                    : (1u << m->scan_info_.Al);
+  const uint16_t refinement_bitmask = (1 << m->scan_info_.Al) - 1;
+  for (size_t i = 0; i < m->scan_info_.num_components; ++i) {
+    int comp_idx = m->scan_info_.components[i].comp_idx;
+    for (uint32_t k = m->scan_info_.Ss; k <= m->scan_info_.Se; ++k) {
+      if (m->scan_progression_[comp_idx][k] & scan_bitmask) {
+        return JPEGLI_ERROR(
+            "Overlapping scans: component=%d k=%d prev_mask: %u cur_mask %u",
+            comp_idx, k, m->scan_progression_[i][k], scan_bitmask);
+      }
+      if (m->scan_progression_[comp_idx][k] & refinement_bitmask) {
+        return JPEGLI_ERROR(
+            "Invalid scan order, a more refined scan was already done: "
+            "component=%d k=%d prev_mask=%u cur_mask=%u",
+            comp_idx, k, m->scan_progression_[i][k], scan_bitmask);
+      }
+      m->scan_progression_[comp_idx][k] |= scan_bitmask;
+    }
+  }
+  if (m->scan_info_.Al > 10) {
+    return JPEGLI_ERROR("Scan parameter Al=%d is not supported.",
+                        m->scan_info_.Al);
+  }
+  // Check that all the Huffman tables needed for this scan are defined.
+  for (size_t i = 0; i < comps_in_scan; ++i) {
+    if (m->scan_info_.Ss == 0 &&
+        !m->huff_slot_defined_[m->scan_info_.components[i].dc_tbl_idx]) {
+      return JPEGLI_ERROR(
+          "SOS marker: Could not find DC Huffman table with index %d",
+          m->scan_info_.components[i].dc_tbl_idx);
+    }
+    if (m->scan_info_.Se > 0 &&
+        !m->huff_slot_defined_[m->scan_info_.components[i].ac_tbl_idx + 16]) {
+      return JPEGLI_ERROR(
+          "SOS marker: Could not find AC Huffman table with index %d",
+          m->scan_info_.components[i].ac_tbl_idx);
+    }
+  }
+  m->scan_info_.MCU_rows = m->iMCU_rows_;
+  m->scan_info_.MCU_cols = m->iMCU_cols_;
+  if (!is_interleaved) {
+    const JPEGComponent& c =
+        m->components_[m->scan_info_.components[0].comp_idx];
+    m->scan_info_.MCU_cols =
+        DivCeil(cinfo->image_width * c.h_samp_factor, m->iMCU_width_);
+    m->scan_info_.MCU_rows =
+        DivCeil(cinfo->image_height * c.v_samp_factor, m->iMCU_height_);
+  }
+  memset(m->last_dc_coeff_, 0, sizeof(m->last_dc_coeff_));
+  m->restarts_to_go_ = m->restart_interval_;
+  m->next_restart_marker_ = 0;
+  m->eobrun_ = -1;
+  m->scan_mcu_row_ = 0;
+  m->scan_mcu_col_ = 0;
+  m->codestream_bits_ahead_ = 0;
+  size_t mcu_size = 0;
+  for (size_t i = 0; i < m->scan_info_.num_components; ++i) {
+    JPEGComponentScanInfo* si = &m->scan_info_.components[i];
+    mcu_size += si->mcu_ysize_blocks * si->mcu_xsize_blocks;
+  }
+  m->mcu_.coeffs.resize(mcu_size * DCTSIZE2);
+  m->state_ = State::kScan;
+}
+
+// Reads the Define Huffman Table (DHT) marker segment and builds the Huffman
+// decoding table in either dc_huff_lut_ or ac_huff_lut_, depending on the type
+// and solt_id of Huffman code being read.
+void ProcessDHT(j_decompress_ptr cinfo, const uint8_t* data, size_t len) {
+  jpeg_decomp_master* m = cinfo->master;
+  constexpr int kLutSize = kMaxHuffmanTables * kJpegHuffmanLutSize;
+  m->dc_huff_lut_.resize(kLutSize);
+  m->ac_huff_lut_.resize(kLutSize);
+  size_t pos = 4;
+  if (pos == len) {
+    return JPEGLI_ERROR("DHT marker: no Huffman table found");
+  }
+  while (pos < len) {
+    JPEG_VERIFY_LEN(1 + kJpegHuffmanMaxBitLength);
+    // The index of the Huffman code in the current set of Huffman codes. For AC
+    // component Huffman codes, 0x10 is added to the index.
+    int slot_id = ReadUint8(data, &pos);
+    m->huff_slot_defined_[slot_id] = 1;
+    int huffman_index = slot_id;
+    int is_ac_table = (slot_id & 0x10) != 0;
+    HuffmanTableEntry* huff_lut;
+    if (is_ac_table) {
+      huffman_index -= 0x10;
+      JPEG_VERIFY_INPUT(huffman_index, 0, 3);
+      huff_lut = &m->ac_huff_lut_[huffman_index * kJpegHuffmanLutSize];
+    } else {
+      JPEG_VERIFY_INPUT(huffman_index, 0, 3);
+      huff_lut = &m->dc_huff_lut_[huffman_index * kJpegHuffmanLutSize];
+    }
+    // Bit length histogram->
+    std::array<uint32_t, kJpegHuffmanMaxBitLength + 1> counts = {};
+    counts[0] = 0;
+    int total_count = 0;
+    int space = 1 << kJpegHuffmanMaxBitLength;
+    int max_depth = 1;
+    for (size_t i = 1; i <= kJpegHuffmanMaxBitLength; ++i) {
+      int count = ReadUint8(data, &pos);
+      if (count != 0) {
+        max_depth = i;
+      }
+      counts[i] = count;
+      total_count += count;
+      space -= count * (1 << (kJpegHuffmanMaxBitLength - i));
+    }
+    if (is_ac_table) {
+      JPEG_VERIFY_INPUT(total_count, 0, kJpegHuffmanAlphabetSize);
+    } else {
+      JPEG_VERIFY_INPUT(total_count, 0, kJpegDCAlphabetSize);
+    }
+    JPEG_VERIFY_LEN(total_count);
+    // Symbol values sorted by increasing bit lengths.
+    std::array<uint32_t, kJpegHuffmanAlphabetSize + 1> values = {};
+    std::vector<bool> values_seen(256, false);
+    for (int i = 0; i < total_count; ++i) {
+      int value = ReadUint8(data, &pos);
+      if (!is_ac_table) {
+        JPEG_VERIFY_INPUT(value, 0, kJpegDCAlphabetSize - 1);
+      }
+      if (values_seen[value]) {
+        return JPEGLI_ERROR("Duplicate Huffman code value %d", value);
+      }
+      values_seen[value] = true;
+      values[i] = value;
+    }
+    // Add an invalid symbol that will have the all 1 code.
+    ++counts[max_depth];
+    values[total_count] = kJpegHuffmanAlphabetSize;
+    space -= (1 << (kJpegHuffmanMaxBitLength - max_depth));
+    if (space < 0) {
+      return JPEGLI_ERROR("Invalid Huffman code lengths.");
+    } else if (space > 0 && huff_lut[0].value != 0xffff) {
+      // Re-initialize the values to an invalid symbol so that we can recognize
+      // it when reading the bit stream using a Huffman code with space > 0.
+      for (int i = 0; i < kJpegHuffmanLutSize; ++i) {
+        huff_lut[i].bits = 0;
+        huff_lut[i].value = 0xffff;
+      }
+    }
+    BuildJpegHuffmanTable(&counts[0], &values[0], huff_lut);
+  }
+  JPEG_VERIFY_MARKER_END();
+}
+
+void ProcessDQT(j_decompress_ptr cinfo, const uint8_t* data, size_t len) {
+  jpeg_decomp_master* m = cinfo->master;
+  size_t pos = 4;
+  if (pos == len) {
+    return JPEGLI_ERROR("DQT marker: no quantization table found");
+  }
+  while (pos < len && m->quant_.size() < kMaxQuantTables) {
+    JPEG_VERIFY_LEN(1);
+    int quant_table_index = ReadUint8(data, &pos);
+    int precision = quant_table_index >> 4;
+    JPEG_VERIFY_INPUT(precision, 0, 1);
+    quant_table_index &= 0xf;
+    JPEG_VERIFY_INPUT(quant_table_index, 0, 3);
+    JPEG_VERIFY_LEN((precision + 1) * DCTSIZE2);
+    JPEGQuantTable table;
+    table.index = quant_table_index;
+    for (size_t i = 0; i < DCTSIZE2; ++i) {
+      int quant_val =
+          precision ? ReadUint16(data, &pos) : ReadUint8(data, &pos);
+      JPEG_VERIFY_INPUT(quant_val, 1, 65535);
+      table.values[kJPEGNaturalOrder[i]] = quant_val;
+    }
+    m->quant_.push_back(table);
+  }
+  JPEG_VERIFY_MARKER_END();
+}
+
+void ProcessDRI(j_decompress_ptr cinfo, const uint8_t* data, size_t len) {
+  jpeg_decomp_master* m = cinfo->master;
+  if (m->found_dri_) {
+    return JPEGLI_ERROR("Duplicate DRI marker.");
+  }
+  m->found_dri_ = true;
+  size_t pos = 4;
+  JPEG_VERIFY_LEN(2);
+  m->restart_interval_ = ReadUint16(data, &pos);
+  JPEG_VERIFY_MARKER_END();
+}
+
+void ProcessAPP(j_decompress_ptr cinfo, const uint8_t* data, size_t len) {
+  jpeg_decomp_master* m = cinfo->master;
+  const uint8_t marker = data[1];
+  const uint8_t* payload = data + 4;
+  size_t payload_size = len - 4;
+  if (marker == 0xE0) {
+    m->found_app0_ = true;
+    m->is_ycbcr_ = true;
+  } else if (!m->found_app0_ && marker == 0xEE && payload_size == 12 &&
+             memcmp(payload, "Adobe", 5) == 0 && payload[11] == 0) {
+    m->is_ycbcr_ = false;
+  }
+  if (marker == 0xE2) {
+    if (payload_size >= sizeof(kIccProfileTag) &&
+        memcmp(payload, kIccProfileTag, sizeof(kIccProfileTag)) == 0) {
+      payload += sizeof(kIccProfileTag);
+      payload_size -= sizeof(kIccProfileTag);
+      if (payload_size < 2) {
+        return JPEGLI_ERROR("ICC chunk is too small.");
+      }
+      uint8_t index = payload[0];
+      uint8_t total = payload[1];
+      ++m->icc_index_;
+      if (m->icc_index_ != index) {
+        return JPEGLI_ERROR("Invalid ICC chunk order.");
+      }
+      if (total == 0) {
+        return JPEGLI_ERROR("Invalid ICC chunk total.");
+      }
+      if (m->icc_total_ == 0) {
+        m->icc_total_ = total;
+      } else if (m->icc_total_ != total) {
+        return JPEGLI_ERROR("Invalid ICC chunk total.");
+      }
+      if (m->icc_index_ > m->icc_total_) {
+        return JPEGLI_ERROR("Invalid ICC chunk index.");
+      }
+      m->icc_profile_.insert(m->icc_profile_.end(), payload + 2,
+                             payload + payload_size);
+    }
+  }
+}
+
+void ProcessCOM(j_decompress_ptr cinfo, const uint8_t* data, size_t len) {
+  // Nothing to do.
+}
+
+void SaveMarker(j_decompress_ptr cinfo, const uint8_t* data, size_t len) {
+  const uint8_t marker = data[1];
+  const uint8_t* payload = data + 4;
+  size_t payload_size = len - 4;
+
+  // Insert new saved marker to the head of the list.
+  jpeg_saved_marker_ptr next = cinfo->marker_list;
+  cinfo->marker_list = (jpeg_marker_struct*)malloc(sizeof(jpeg_marker_struct));
+  cinfo->marker_list->next = next;
+  cinfo->marker_list->marker = marker;
+  cinfo->marker_list->original_length = payload_size;
+  cinfo->marker_list->data_length = payload_size;
+  cinfo->marker_list->data = (uint8_t*)malloc(payload_size);
+  memcpy(cinfo->marker_list->data, payload, payload_size);
+
+  // Remember to free the newly allocated pointers.
+  auto mem = reinterpret_cast<jpegli::MemoryManager*>(cinfo->mem);
+  mem->owned_ptrs.push_back(cinfo->marker_list);
+  mem->owned_ptrs.push_back(cinfo->marker_list->data);
+}
+
+}  // namespace
+
+bool ProcessMarker(j_decompress_ptr cinfo, const uint8_t* data, size_t len,
+                   size_t* pos) {
+  jpeg_decomp_master* m = cinfo->master;
+  // kIsValidMarker[i] == 1 means (0xc0 + i) is a valid marker.
+  static const uint8_t kIsValidMarker[] = {
+      1, 1, 1, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 1, 1, 1,
+      1, 1, 0, 1, 1, 1, 0, 1, 0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+      1, 1, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0,
+  };
+  // Skip bytes between markers.
+  size_t num_skipped = 0;
+  while (*pos + 1 < len && (data[*pos] != 0xff || data[*pos + 1] < 0xc0 ||
+                            !kIsValidMarker[data[*pos + 1] - 0xc0])) {
+    ++(*pos);
+    ++num_skipped;
+  }
+  if (*pos + 2 > len) {
+    return false;
+  }
+  if (num_skipped > 0) {
+    AdvanceInput(cinfo, num_skipped);
+  }
+  uint8_t marker = data[*pos + 1];
+  if (marker == 0xd9) {
+    m->found_eoi_ = true;
+    m->state_ = m->is_progressive_ ? State::kRender : State::kEnd;
+    *pos += 2;
+    AdvanceInput(cinfo, 2);
+    return true;
+  }
+  if (*pos + 4 > len) {
+    return false;
+  }
+  const uint8_t* marker_data = &data[*pos];
+  size_t marker_len = (data[*pos + 2] << 8) + data[*pos + 3] + 2;
+  if (marker_len < 4) {
+    JPEGLI_ERROR("Invalid marker length");
+  }
+  if (*pos + marker_len > len) {
+    return false;
+  }
+  if (m->markers_to_save_.find(marker) != m->markers_to_save_.end()) {
+    SaveMarker(cinfo, marker_data, marker_len);
+  }
+  if (marker == 0xc0 || marker == 0xc1 || marker == 0xc2) {
+    ProcessSOF(cinfo, marker_data, marker_len);
+  } else if (marker == 0xc4) {
+    ProcessDHT(cinfo, marker_data, marker_len);
+  } else if (marker == 0xda) {
+    ProcessSOS(cinfo, marker_data, marker_len);
+  } else if (marker == 0xdb) {
+    ProcessDQT(cinfo, marker_data, marker_len);
+  } else if (marker == 0xdd) {
+    ProcessDRI(cinfo, marker_data, marker_len);
+  } else if (marker >= 0xe0 && marker <= 0xef) {
+    ProcessAPP(cinfo, marker_data, marker_len);
+  } else if (marker == 0xfe) {
+    ProcessCOM(cinfo, marker_data, marker_len);
+  } else {
+    JPEGLI_ERROR("Unexpected marker 0x%x", marker);
+  }
+  *pos += marker_len;
+  AdvanceInput(cinfo, marker_len);
+  return true;
+}
+
+}  // namespace jpegli

--- a/lib/jpegli/decode_marker.h
+++ b/lib/jpegli/decode_marker.h
@@ -1,0 +1,25 @@
+// Copyright (c) the JPEG XL Project Authors. All rights reserved.
+//
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+#ifndef LIB_JPEGLI_DECODE_MARKER_H_
+#define LIB_JPEGLI_DECODE_MARKER_H_
+
+/* clang-format off */
+#include <stdint.h>
+#include <stdio.h>
+#include <jpeglib.h>
+/* clang-format on */
+
+namespace jpegli {
+
+// Returns true if [data, data + len) contains a valid marker segment (it does
+// not need to be at the start of data), and sets *pos to the offset of the end
+// of the marker segment and fills in the relevant parts of cinfo.
+bool ProcessMarker(j_decompress_ptr cinfo, const uint8_t* data, size_t len,
+                   size_t* pos);
+
+}  // namespace jpegli
+
+#endif  // LIB_JPEGLI_DECODE_MARKER_H_

--- a/lib/jpegli/decode_scan.cc
+++ b/lib/jpegli/decode_scan.cc
@@ -1,0 +1,504 @@
+// Copyright (c) the JPEG XL Project Authors. All rights reserved.
+//
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+#include "lib/jpegli/decode_scan.h"
+
+#include <string.h>
+
+#include "lib/jpegli/decode_internal.h"
+#include "lib/jpegli/error.h"
+#include "lib/jpegli/source_manager.h"
+#include "lib/jxl/base/status.h"
+
+namespace jpegli {
+namespace {
+
+// Max 14 block per MCU (when 1 channel is subsampled)
+// Max 64 nonzero coefficients per block
+// Max 16 symbol bits plus 11 extra bits per nonzero symbol
+// Max 2 bytes per 8 bits (worst case is all bytes are escaped 0xff)
+constexpr int kMaxMCUByteSize = 6048;
+
+// Helper structure to read bits from the entropy coded data segment.
+struct BitReaderState {
+  BitReaderState(const uint8_t* data, const size_t len, size_t pos)
+      : data_(data), len_(len), start_pos_(pos) {
+    Reset(pos);
+  }
+
+  void Reset(size_t pos) {
+    pos_ = pos;
+    val_ = 0;
+    bits_left_ = 0;
+    next_marker_pos_ = len_;
+    FillBitWindow();
+  }
+
+  // Returns the next byte and skips the 0xff/0x00 escape sequences.
+  uint8_t GetNextByte() {
+    if (pos_ >= next_marker_pos_) {
+      ++pos_;
+      return 0;
+    }
+    uint8_t c = data_[pos_++];
+    if (c == 0xff) {
+      uint8_t escape = pos_ < len_ ? data_[pos_] : 0;
+      if (escape == 0) {
+        ++pos_;
+      } else {
+        // 0xff was followed by a non-zero byte, which means that we found the
+        // start of the next marker segment.
+        next_marker_pos_ = pos_ - 1;
+      }
+    }
+    return c;
+  }
+
+  void FillBitWindow() {
+    if (bits_left_ <= 16) {
+      while (bits_left_ <= 56) {
+        val_ <<= 8;
+        val_ |= (uint64_t)GetNextByte();
+        bits_left_ += 8;
+      }
+    }
+  }
+
+  int ReadBits(int nbits) {
+    FillBitWindow();
+    uint64_t val = (val_ >> (bits_left_ - nbits)) & ((1ULL << nbits) - 1);
+    bits_left_ -= nbits;
+    return val;
+  }
+
+  // Sets *pos to the next stream position, and *bit_pos to the bit position
+  // within the next byte where parsing should continue.
+  // Returns false if the stream ended too early.
+  bool FinishStream(size_t* pos, size_t* bit_pos) {
+    *bit_pos = (8 - (bits_left_ & 7)) & 7;
+    // Give back some bytes that we did not use.
+    int unused_bytes_left = DivCeil(bits_left_, 8);
+    while (unused_bytes_left-- > 0) {
+      --pos_;
+      // If we give back a 0 byte, we need to check if it was a 0xff/0x00 escape
+      // sequence, and if yes, we need to give back one more byte.
+      if (((pos_ == len_) || (pos_ < next_marker_pos_ && data_[pos_] == 0)) &&
+          (data_[pos_ - 1] == 0xff)) {
+        --pos_;
+      }
+    }
+    if (pos_ > next_marker_pos_) {
+      *pos = next_marker_pos_;
+      // Data ran out before the scan was complete.
+      return false;
+    }
+    *pos = pos_;
+    return true;
+  }
+
+  const uint8_t* data_;
+  const size_t len_;
+  size_t pos_;
+  uint64_t val_;
+  int bits_left_;
+  size_t next_marker_pos_;
+  size_t start_pos_;
+};
+
+// Returns the next Huffman-coded symbol.
+int ReadSymbol(const HuffmanTableEntry* table, BitReaderState* br) {
+  int nbits;
+  br->FillBitWindow();
+  int val = (br->val_ >> (br->bits_left_ - 8)) & 0xff;
+  table += val;
+  nbits = table->bits - 8;
+  if (nbits > 0) {
+    br->bits_left_ -= 8;
+    table += table->value;
+    val = (br->val_ >> (br->bits_left_ - nbits)) & ((1 << nbits) - 1);
+    table += val;
+  }
+  br->bits_left_ -= table->bits;
+  return table->value;
+}
+
+/**
+ * Returns the DC diff or AC value for extra bits value x and prefix code s.
+ *
+ * CCITT Rec. T.81 (1992 E)
+ * Table F.1 – Difference magnitude categories for DC coding
+ *  SSSS | DIFF values
+ * ------+--------------------------
+ *     0 | 0
+ *     1 | –1, 1
+ *     2 | –3, –2, 2, 3
+ *     3 | –7..–4, 4..7
+ * ......|..........................
+ *    11 | –2047..–1024, 1024..2047
+ *
+ * CCITT Rec. T.81 (1992 E)
+ * Table F.2 – Categories assigned to coefficient values
+ * [ Same as Table F.1, but does not include SSSS equal to 0 and 11]
+ *
+ *
+ * CCITT Rec. T.81 (1992 E)
+ * F.1.2.1.1 Structure of DC code table
+ * For each category,... additional bits... appended... to uniquely identify
+ * which difference... occurred... When DIFF is positive... SSSS... bits of DIFF
+ * are appended. When DIFF is negative... SSSS... bits of (DIFF – 1) are
+ * appended... Most significant bit... is 0 for negative differences and 1 for
+ * positive differences.
+ *
+ * In other words the upper half of extra bits range represents DIFF as is.
+ * The lower half represents the negative DIFFs with an offset.
+ */
+int HuffExtend(int x, int s) {
+  JXL_DASSERT(s >= 1);
+  int half = 1 << (s - 1);
+  if (x >= half) {
+    JXL_DASSERT(x < (1 << s));
+    return x;
+  } else {
+    return x - (1 << s) + 1;
+  }
+}
+
+// Decodes one 8x8 block of DCT coefficients from the bit stream.
+bool DecodeDCTBlock(const HuffmanTableEntry* dc_huff,
+                    const HuffmanTableEntry* ac_huff, int Ss, int Se, int Al,
+                    int* eobrun, BitReaderState* br, coeff_t* last_dc_coeff,
+                    coeff_t* coeffs) {
+  // Nowadays multiplication is even faster than variable shift.
+  int Am = 1 << Al;
+  bool eobrun_allowed = Ss > 0;
+  if (Ss == 0) {
+    int s = ReadSymbol(dc_huff, br);
+    if (s >= kJpegDCAlphabetSize) {
+      return false;
+    }
+    int diff = 0;
+    if (s > 0) {
+      int bits = br->ReadBits(s);
+      diff = HuffExtend(bits, s);
+    }
+    int coeff = diff + *last_dc_coeff;
+    const int dc_coeff = coeff * Am;
+    coeffs[0] = dc_coeff;
+    // TODO(eustas): is there a more elegant / explicit way to check this?
+    if (dc_coeff != coeffs[0]) {
+      return false;
+    }
+    *last_dc_coeff = coeff;
+    ++Ss;
+  }
+  if (Ss > Se) {
+    return true;
+  }
+  if (*eobrun > 0) {
+    --(*eobrun);
+    return true;
+  }
+  for (int k = Ss; k <= Se; k++) {
+    int sr = ReadSymbol(ac_huff, br);
+    if (sr >= kJpegHuffmanAlphabetSize) {
+      return false;
+    }
+    int r = sr >> 4;
+    int s = sr & 15;
+    if (s > 0) {
+      k += r;
+      if (k > Se) {
+        return false;
+      }
+      if (s + Al >= kJpegDCAlphabetSize) {
+        return false;
+      }
+      int bits = br->ReadBits(s);
+      int coeff = HuffExtend(bits, s);
+      coeffs[kJPEGNaturalOrder[k]] = coeff * Am;
+    } else if (r == 15) {
+      k += 15;
+    } else {
+      *eobrun = 1 << r;
+      if (r > 0) {
+        if (!eobrun_allowed) {
+          return false;
+        }
+        *eobrun += br->ReadBits(r);
+      }
+      break;
+    }
+  }
+  --(*eobrun);
+  return true;
+}
+
+bool RefineDCTBlock(const HuffmanTableEntry* ac_huff, int Ss, int Se, int Al,
+                    int* eobrun, BitReaderState* br, coeff_t* coeffs) {
+  // Nowadays multiplication is even faster than variable shift.
+  int Am = 1 << Al;
+  bool eobrun_allowed = Ss > 0;
+  if (Ss == 0) {
+    int s = br->ReadBits(1);
+    coeff_t dc_coeff = coeffs[0];
+    dc_coeff |= s * Am;
+    coeffs[0] = dc_coeff;
+    ++Ss;
+  }
+  if (Ss > Se) {
+    return true;
+  }
+  int p1 = Am;
+  int m1 = -Am;
+  int k = Ss;
+  int r;
+  int s;
+  bool in_zero_run = false;
+  if (*eobrun <= 0) {
+    for (; k <= Se; k++) {
+      s = ReadSymbol(ac_huff, br);
+      if (s >= kJpegHuffmanAlphabetSize) {
+        return false;
+      }
+      r = s >> 4;
+      s &= 15;
+      if (s) {
+        if (s != 1) {
+          return false;
+        }
+        s = br->ReadBits(1) ? p1 : m1;
+        in_zero_run = false;
+      } else {
+        if (r != 15) {
+          *eobrun = 1 << r;
+          if (r > 0) {
+            if (!eobrun_allowed) {
+              return false;
+            }
+            *eobrun += br->ReadBits(r);
+          }
+          break;
+        }
+        in_zero_run = true;
+      }
+      do {
+        coeff_t thiscoef = coeffs[kJPEGNaturalOrder[k]];
+        if (thiscoef != 0) {
+          if (br->ReadBits(1)) {
+            if ((thiscoef & p1) == 0) {
+              if (thiscoef >= 0) {
+                thiscoef += p1;
+              } else {
+                thiscoef += m1;
+              }
+            }
+          }
+          coeffs[kJPEGNaturalOrder[k]] = thiscoef;
+        } else {
+          if (--r < 0) {
+            break;
+          }
+        }
+        k++;
+      } while (k <= Se);
+      if (s) {
+        if (k > Se) {
+          return false;
+        }
+        coeffs[kJPEGNaturalOrder[k]] = s;
+      }
+    }
+  }
+  if (in_zero_run) {
+    return false;
+  }
+  if (*eobrun > 0) {
+    for (; k <= Se; k++) {
+      coeff_t thiscoef = coeffs[kJPEGNaturalOrder[k]];
+      if (thiscoef != 0) {
+        if (br->ReadBits(1)) {
+          if ((thiscoef & p1) == 0) {
+            if (thiscoef >= 0) {
+              thiscoef += p1;
+            } else {
+              thiscoef += m1;
+            }
+          }
+        }
+        coeffs[kJPEGNaturalOrder[k]] = thiscoef;
+      }
+    }
+  }
+  --(*eobrun);
+  return true;
+}
+
+void SaveMCUCodingState(j_decompress_ptr cinfo) {
+  jpeg_decomp_master* m = cinfo->master;
+  memcpy(m->mcu_.last_dc_coeff, m->last_dc_coeff_, sizeof(m->last_dc_coeff_));
+  m->mcu_.eobrun = m->eobrun_;
+  size_t offset = 0;
+  for (size_t i = 0; i < m->scan_info_.num_components; ++i) {
+    JPEGComponentScanInfo* si = &m->scan_info_.components[i];
+    JPEGComponent* c = &m->components_[si->comp_idx];
+    int block_x = m->scan_mcu_col_ * si->mcu_xsize_blocks;
+    for (uint32_t iy = 0; iy < si->mcu_ysize_blocks; ++iy) {
+      int block_y = m->scan_mcu_row_ * si->mcu_ysize_blocks + iy;
+      size_t ncoeffs = si->mcu_xsize_blocks * DCTSIZE2;
+      int block_idx = (block_y * c->width_in_blocks + block_x) * DCTSIZE2;
+      coeff_t* coeffs = &c->coeffs[block_idx];
+      memcpy(&m->mcu_.coeffs[offset], coeffs, ncoeffs * sizeof(coeffs[0]));
+      offset += ncoeffs;
+    }
+  }
+}
+
+void RestoreMCUCodingState(j_decompress_ptr cinfo) {
+  jpeg_decomp_master* m = cinfo->master;
+  memcpy(m->last_dc_coeff_, m->mcu_.last_dc_coeff, sizeof(m->last_dc_coeff_));
+  m->eobrun_ = m->mcu_.eobrun;
+  size_t offset = 0;
+  for (size_t i = 0; i < m->scan_info_.num_components; ++i) {
+    JPEGComponentScanInfo* si = &m->scan_info_.components[i];
+    JPEGComponent* c = &m->components_[si->comp_idx];
+    int block_x = m->scan_mcu_col_ * si->mcu_xsize_blocks;
+    for (uint32_t iy = 0; iy < si->mcu_ysize_blocks; ++iy) {
+      int block_y = m->scan_mcu_row_ * si->mcu_ysize_blocks + iy;
+      size_t ncoeffs = si->mcu_xsize_blocks * DCTSIZE2;
+      int block_idx = (block_y * c->width_in_blocks + block_x) * DCTSIZE2;
+      coeff_t* coeffs = &c->coeffs[block_idx];
+      memcpy(coeffs, &m->mcu_.coeffs[offset], ncoeffs * sizeof(coeffs[0]));
+      offset += ncoeffs;
+    }
+  }
+}
+
+}  // namespace
+
+// Returns true if [data, data + len) contains a valid entropy coded scan, and
+// sets *pos to the offset of the end of the scan data.
+bool ProcessScan(j_decompress_ptr cinfo, const uint8_t* data, size_t len,
+                 size_t* pos) {
+  jpeg_decomp_master* m = cinfo->master;
+  for (; m->scan_mcu_col_ < m->scan_info_.MCU_cols; ++m->scan_mcu_col_) {
+    // Handle the restart intervals.
+    if (m->restart_interval_ > 0 && m->restarts_to_go_ == 0) {
+      if (m->eobrun_ > 0) {
+        JPEGLI_ERROR("End-of-block run too long.");
+      }
+      if (m->codestream_bits_ahead_ > 0) {
+        ++(*pos);
+        AdvanceInput(cinfo, 1);
+        m->codestream_bits_ahead_ = 0;
+      }
+      if (*pos + 2 > len) {
+        return false;
+      }
+      int expected_marker = 0xd0 + m->next_restart_marker_;
+      int marker = data[*pos + 1];
+      if (marker != expected_marker) {
+        JPEGLI_ERROR("Did not find expected restart marker %d actual %d",
+                     expected_marker, marker);
+      }
+      m->next_restart_marker_ += 1;
+      m->next_restart_marker_ &= 0x7;
+      m->restarts_to_go_ = m->restart_interval_;
+      memset(m->last_dc_coeff_, 0, sizeof(m->last_dc_coeff_));
+      m->eobrun_ = -1;  // fresh start
+      *pos += 2;
+      AdvanceInput(cinfo, 2);
+    }
+
+    size_t start_pos = *pos;
+    BitReaderState br(data, len, start_pos);
+    if (m->codestream_bits_ahead_ > 0) {
+      br.ReadBits(m->codestream_bits_ahead_);
+    }
+    if (start_pos + kMaxMCUByteSize > len) {
+      SaveMCUCodingState(cinfo);
+    }
+
+    // Decode one MCU.
+    bool scan_ok = true;
+    for (size_t i = 0; i < m->scan_info_.num_components; ++i) {
+      JPEGComponentScanInfo* si = &m->scan_info_.components[i];
+      JPEGComponent* c = &m->components_[si->comp_idx];
+      const HuffmanTableEntry* dc_lut =
+          &m->dc_huff_lut_[si->dc_tbl_idx * kJpegHuffmanLutSize];
+      const HuffmanTableEntry* ac_lut =
+          &m->ac_huff_lut_[si->ac_tbl_idx * kJpegHuffmanLutSize];
+      for (uint32_t iy = 0; iy < si->mcu_ysize_blocks; ++iy) {
+        int block_y = m->scan_mcu_row_ * si->mcu_ysize_blocks + iy;
+        for (uint32_t ix = 0; ix < si->mcu_xsize_blocks; ++ix) {
+          int block_x = m->scan_mcu_col_ * si->mcu_xsize_blocks + ix;
+          int block_idx = block_y * c->width_in_blocks + block_x;
+          coeff_t* coeffs = &c->coeffs[block_idx * DCTSIZE2];
+          if (m->scan_info_.Ah == 0) {
+            if (!DecodeDCTBlock(dc_lut, ac_lut, m->scan_info_.Ss,
+                                m->scan_info_.Se, m->scan_info_.Al, &m->eobrun_,
+                                &br, &m->last_dc_coeff_[si->comp_idx],
+                                coeffs)) {
+              scan_ok = false;
+            }
+          } else {
+            if (!RefineDCTBlock(ac_lut, m->scan_info_.Ss, m->scan_info_.Se,
+                                m->scan_info_.Al, &m->eobrun_, &br, coeffs)) {
+              scan_ok = false;
+            }
+          }
+        }
+      }
+    }
+    size_t bit_pos;
+    size_t stream_pos;
+    bool stream_ok = br.FinishStream(&stream_pos, &bit_pos);
+    if (stream_pos + 2 > len) {
+      // If reading stopped within the last two bytes, we have to request more
+      // input even if FinishStream() returned true, since the Huffman code
+      // reader could have peaked ahead some bits past the current input chunk
+      // and thus the last prefix code length could have been wrong. We can do
+      // this because a valid JPEG bit stream has two extra bytes at the end.
+      RestoreMCUCodingState(cinfo);
+      return false;
+    }
+    if (!scan_ok) {
+      JPEGLI_ERROR("Failed to decode DCT block");
+    }
+    if (!stream_ok) {
+      // We hit a marker during parsing.
+      JXL_DASSERT(data[stream_pos] == 0xff);
+      JXL_DASSERT(data[stream_pos + 1] != 0);
+      JPEGLI_ERROR("Unexpected end of scan.");
+    }
+    m->codestream_bits_ahead_ = bit_pos;
+    *pos = stream_pos;
+    AdvanceInput(cinfo, *pos - start_pos);
+    if (m->restarts_to_go_ > 0) {
+      --m->restarts_to_go_;
+    }
+  }
+  ++m->scan_mcu_row_;
+  m->scan_mcu_col_ = 0;
+  if (m->scan_mcu_row_ == m->scan_info_.MCU_rows) {
+    // Current scan is done, skip any remaining bits in the last byte.
+    if (m->codestream_bits_ahead_ > 0) {
+      ++(*pos);
+      AdvanceInput(cinfo, 1);
+      m->codestream_bits_ahead_ = 0;
+    }
+    if (m->eobrun_ > 0) {
+      JPEGLI_ERROR("End-of-block run too long.");
+    }
+    if (m->is_progressive_) {
+      m->state_ = jpeg_decomp_master::State::kProcessMarkers;
+    }
+  }
+  if (!m->is_progressive_) {
+    m->state_ = jpeg_decomp_master::State::kRender;
+  }
+  return true;
+}
+
+}  // namespace jpegli

--- a/lib/jpegli/decode_scan.h
+++ b/lib/jpegli/decode_scan.h
@@ -1,0 +1,24 @@
+// Copyright (c) the JPEG XL Project Authors. All rights reserved.
+//
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+#ifndef LIB_JPEGLI_DECODE_SCAN_H_
+#define LIB_JPEGLI_DECODE_SCAN_H_
+
+/* clang-format off */
+#include <stdint.h>
+#include <stdio.h>
+#include <jpeglib.h>
+/* clang-format on */
+
+namespace jpegli {
+
+// Returns true if [data, data + len) contains a valid entropy coded scan, and
+// sets *pos to the offset of the end of the scan data.
+bool ProcessScan(j_decompress_ptr cinfo, const uint8_t* data, size_t len,
+                 size_t* pos);
+
+}  // namespace jpegli
+
+#endif  // LIB_JPEGLI_DECODE_SCAN_H_

--- a/lib/jpegli/error.cc
+++ b/lib/jpegli/error.cc
@@ -1,0 +1,63 @@
+// Copyright (c) the JPEG XL Project Authors. All rights reserved.
+//
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+#include "lib/jpegli/error.h"
+
+/* clang-format off */
+#include <stdint.h>
+#include <stdio.h>
+#include <jpeglib.h>
+#include <stdlib.h>
+#include <setjmp.h>
+#include <string.h>
+/* clang-format on */
+
+namespace jpegli {
+
+const char* const kErrorMessageTable[] = {
+    "Something went wrong.",
+};
+
+void ExitWithAbort(j_common_ptr cinfo) {
+  (*cinfo->err->output_message)(cinfo);
+  exit(EXIT_FAILURE);
+}
+
+void ExitWithLongJump(j_common_ptr cinfo) {
+  (*cinfo->err->output_message)(cinfo);
+  jmp_buf* env = static_cast<jmp_buf*>(cinfo->client_data);
+  longjmp(*env, 1);
+}
+
+void OutputMessage(j_common_ptr cinfo) {
+  fprintf(stderr, "%s", cinfo->err->msg_parm.s);
+}
+
+void FormatMessage(j_common_ptr cinfo, char* buffer) {
+  memcpy(buffer, cinfo->err->msg_parm.s, JMSG_LENGTH_MAX);
+}
+
+// These are not (yet) used by this library.
+void EmitMessage(j_common_ptr cinfo, int msg_level) {}
+void ResetErrorManager(j_common_ptr cinfo) {}
+
+}  // namespace jpegli
+
+struct jpeg_error_mgr* jpeg_std_error(struct jpeg_error_mgr* err) {
+  err->error_exit = jpegli::ExitWithAbort;
+  err->output_message = jpegli::OutputMessage;
+  err->emit_message = jpegli::EmitMessage;
+  err->format_message = jpegli::FormatMessage;
+  err->reset_error_mgr = jpegli::ResetErrorManager;
+  err->msg_code = 0;
+  err->trace_level = 0;
+  err->num_warnings = 0;
+  err->jpeg_message_table = jpegli::kErrorMessageTable;
+  err->last_jpeg_message = 0;
+  err->addon_message_table = nullptr;
+  err->first_addon_message = 0;
+  err->last_addon_message = 0;
+  return err;
+}

--- a/lib/jpegli/error.h
+++ b/lib/jpegli/error.h
@@ -1,0 +1,33 @@
+// Copyright (c) the JPEG XL Project Authors. All rights reserved.
+//
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+#ifndef LIB_JPEGLI_ERROR_H_
+#define LIB_JPEGLI_ERROR_H_
+
+/* clang-format off */
+#include <stdint.h>
+#include <stdio.h>
+#include <jpeglib.h>
+#include <stdarg.h>
+/* clang-format on */
+
+namespace jpegli {
+
+static bool FormatString(char* buffer, const char* format, ...) {
+  va_list args;
+  va_start(args, format);
+  vsnprintf(buffer, JMSG_LENGTH_MAX, format, args);
+  va_end(args);
+  return false;
+}
+
+}  // namespace jpegli
+
+#define JPEGLI_ERROR(format, ...)                                       \
+  jpegli::FormatString(cinfo->err->msg_parm.s, ("%s:%d: " format "\n"), \
+                       __FILE__, __LINE__, ##__VA_ARGS__),              \
+      (*cinfo->err->error_exit)(reinterpret_cast<j_common_ptr>(cinfo))
+
+#endif  // LIB_JPEGLI_ERROR_H_

--- a/lib/jpegli/huffman.cc
+++ b/lib/jpegli/huffman.cc
@@ -1,0 +1,99 @@
+// Copyright (c) the JPEG XL Project Authors. All rights reserved.
+//
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+#include "lib/jpegli/huffman.h"
+
+namespace jpegli {
+
+// Returns the table width of the next 2nd level table, count is the histogram
+// of bit lengths for the remaining symbols, len is the code length of the next
+// processed symbol.
+static inline int NextTableBitSize(const int* count, int len) {
+  int left = 1 << (len - kJpegHuffmanRootTableBits);
+  while (len < static_cast<int>(kJpegHuffmanMaxBitLength)) {
+    left -= count[len];
+    if (left <= 0) break;
+    ++len;
+    left <<= 1;
+  }
+  return len - kJpegHuffmanRootTableBits;
+}
+
+void BuildJpegHuffmanTable(const uint32_t* count, const uint32_t* symbols,
+                           HuffmanTableEntry* lut) {
+  HuffmanTableEntry code;    // current table entry
+  HuffmanTableEntry* table;  // next available space in table
+  int len;                   // current code length
+  int idx;                   // symbol index
+  int key;                   // prefix code
+  int reps;                  // number of replicate key values in current table
+  int low;                   // low bits for current root entry
+  int table_bits;            // key length of current table
+  int table_size;            // size of current table
+
+  // Make a local copy of the input bit length histogram.
+  int tmp_count[kJpegHuffmanMaxBitLength + 1] = {0};
+  int total_count = 0;
+  for (len = 1; len <= static_cast<int>(kJpegHuffmanMaxBitLength); ++len) {
+    tmp_count[len] = count[len];
+    total_count += tmp_count[len];
+  }
+
+  table = lut;
+  table_bits = kJpegHuffmanRootTableBits;
+  table_size = 1 << table_bits;
+
+  // Special case code with only one value.
+  if (total_count == 1) {
+    code.bits = 0;
+    code.value = symbols[0];
+    for (key = 0; key < table_size; ++key) {
+      table[key] = code;
+    }
+    return;
+  }
+
+  // Fill in root table.
+  key = 0;
+  idx = 0;
+  for (len = 1; len <= kJpegHuffmanRootTableBits; ++len) {
+    for (; tmp_count[len] > 0; --tmp_count[len]) {
+      code.bits = len;
+      code.value = symbols[idx++];
+      reps = 1 << (kJpegHuffmanRootTableBits - len);
+      while (reps--) {
+        table[key++] = code;
+      }
+    }
+  }
+
+  // Fill in 2nd level tables and add pointers to root table.
+  table += table_size;
+  table_size = 0;
+  low = 0;
+  for (len = kJpegHuffmanRootTableBits + 1;
+       len <= static_cast<int>(kJpegHuffmanMaxBitLength); ++len) {
+    for (; tmp_count[len] > 0; --tmp_count[len]) {
+      // Start a new sub-table if the previous one is full.
+      if (low >= table_size) {
+        table += table_size;
+        table_bits = NextTableBitSize(tmp_count, len);
+        table_size = 1 << table_bits;
+        low = 0;
+        lut[key].bits = table_bits + kJpegHuffmanRootTableBits;
+        lut[key].value = (table - lut) - key;
+        ++key;
+      }
+      code.bits = len - kJpegHuffmanRootTableBits;
+      code.value = symbols[idx++];
+      reps = 1 << (table_bits - code.bits);
+      while (reps--) {
+        table[low++] = code;
+      }
+    }
+  }
+}
+
+}  // namespace jpegli

--- a/lib/jpegli/huffman.h
+++ b/lib/jpegli/huffman.h
@@ -1,0 +1,38 @@
+// Copyright (c) the JPEG XL Project Authors. All rights reserved.
+//
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+#ifndef LIB_JPEGLI_HUFFMAN_H_
+#define LIB_JPEGLI_HUFFMAN_H_
+
+#include <stdint.h>
+#include <stdlib.h>
+
+namespace jpegli {
+
+constexpr int kJpegHuffmanAlphabetSize = 256;
+constexpr size_t kJpegHuffmanMaxBitLength = 16;
+
+constexpr int kJpegHuffmanRootTableBits = 8;
+// Maximum huffman lookup table size.
+// According to zlib/examples/enough.c, 758 entries are always enough for
+// an alphabet of 257 symbols (256 + 1 special symbol for the all 1s code) and
+// max bit length 16 if the root table has 8 bits.
+constexpr int kJpegHuffmanLutSize = 758;
+
+struct HuffmanTableEntry {
+  // Initialize the value to an invalid symbol so that we can recognize it
+  // when reading the bit stream using a Huffman code with space > 0.
+  HuffmanTableEntry() : bits(0), value(0xffff) {}
+
+  uint8_t bits;    // number of bits used for this symbol
+  uint16_t value;  // symbol value or table offset
+};
+
+void BuildJpegHuffmanTable(const uint32_t* count, const uint32_t* symbols,
+                           HuffmanTableEntry* lut);
+
+}  // namespace jpegli
+
+#endif  // LIB_JPEGLI_HUFFMAN_H_

--- a/lib/jpegli/idct.cc
+++ b/lib/jpegli/idct.cc
@@ -1,0 +1,300 @@
+// Copyright (c) the JPEG XL Project Authors. All rights reserved.
+//
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+#include "lib/jpegli/idct.h"
+
+#include "lib/jxl/base/status.h"
+
+#undef HWY_TARGET_INCLUDE
+#define HWY_TARGET_INCLUDE "lib/jpegli/idct.cc"
+#include <hwy/foreach_target.h>
+#include <hwy/highway.h>
+
+HWY_BEFORE_NAMESPACE();
+namespace jpegli {
+namespace HWY_NAMESPACE {
+
+// These templates are not found via ADL.
+using hwy::HWY_NAMESPACE::Abs;
+using hwy::HWY_NAMESPACE::Add;
+using hwy::HWY_NAMESPACE::Clamp;
+using hwy::HWY_NAMESPACE::Gt;
+using hwy::HWY_NAMESPACE::IfThenElseZero;
+using hwy::HWY_NAMESPACE::Mul;
+using hwy::HWY_NAMESPACE::MulAdd;
+using hwy::HWY_NAMESPACE::NearestInt;
+using hwy::HWY_NAMESPACE::NegMulAdd;
+using hwy::HWY_NAMESPACE::Rebind;
+using hwy::HWY_NAMESPACE::Sub;
+using hwy::HWY_NAMESPACE::Vec;
+using hwy::HWY_NAMESPACE::Xor;
+
+using D = HWY_FULL(float);
+using DI = HWY_FULL(int32_t);
+constexpr D d;
+constexpr DI di;
+
+using D8 = HWY_CAPPED(float, 8);
+constexpr D8 d8;
+
+void DequantBlock(const int16_t* JXL_RESTRICT qblock,
+                  const float* JXL_RESTRICT dequant,
+                  const float* JXL_RESTRICT biases, float* JXL_RESTRICT block) {
+  for (size_t k = 0; k < 64; k += Lanes(d)) {
+    const auto mul = Load(d, dequant + k);
+    const auto bias = Load(d, biases + k);
+    const Rebind<int16_t, DI> di16;
+    const Vec<DI> quant_i = PromoteTo(di, Load(di16, qblock + k));
+    const Rebind<float, DI> df;
+    const auto quant = ConvertTo(df, quant_i);
+    const auto abs_quant = Abs(quant);
+    const auto not_0 = Gt(abs_quant, Zero(df));
+    const auto sign_quant = Xor(quant, abs_quant);
+    const auto biased_quant = Sub(quant, Xor(bias, sign_quant));
+    const auto dequant = IfThenElseZero(not_0, Mul(biased_quant, mul));
+    Store(dequant, d, block + k);
+  }
+}
+
+#if HWY_CAP_GE256
+JXL_INLINE void Transpose8x8Block(const float* JXL_RESTRICT from,
+                                  float* JXL_RESTRICT to) {
+  const D8 d;
+  auto i0 = Load(d, from);
+  auto i1 = Load(d, from + 1 * 8);
+  auto i2 = Load(d, from + 2 * 8);
+  auto i3 = Load(d, from + 3 * 8);
+  auto i4 = Load(d, from + 4 * 8);
+  auto i5 = Load(d, from + 5 * 8);
+  auto i6 = Load(d, from + 6 * 8);
+  auto i7 = Load(d, from + 7 * 8);
+
+  const auto q0 = InterleaveLower(d, i0, i2);
+  const auto q1 = InterleaveLower(d, i1, i3);
+  const auto q2 = InterleaveUpper(d, i0, i2);
+  const auto q3 = InterleaveUpper(d, i1, i3);
+  const auto q4 = InterleaveLower(d, i4, i6);
+  const auto q5 = InterleaveLower(d, i5, i7);
+  const auto q6 = InterleaveUpper(d, i4, i6);
+  const auto q7 = InterleaveUpper(d, i5, i7);
+
+  const auto r0 = InterleaveLower(d, q0, q1);
+  const auto r1 = InterleaveUpper(d, q0, q1);
+  const auto r2 = InterleaveLower(d, q2, q3);
+  const auto r3 = InterleaveUpper(d, q2, q3);
+  const auto r4 = InterleaveLower(d, q4, q5);
+  const auto r5 = InterleaveUpper(d, q4, q5);
+  const auto r6 = InterleaveLower(d, q6, q7);
+  const auto r7 = InterleaveUpper(d, q6, q7);
+
+  i0 = ConcatLowerLower(d, r4, r0);
+  i1 = ConcatLowerLower(d, r5, r1);
+  i2 = ConcatLowerLower(d, r6, r2);
+  i3 = ConcatLowerLower(d, r7, r3);
+  i4 = ConcatUpperUpper(d, r4, r0);
+  i5 = ConcatUpperUpper(d, r5, r1);
+  i6 = ConcatUpperUpper(d, r6, r2);
+  i7 = ConcatUpperUpper(d, r7, r3);
+
+  Store(i0, d, to);
+  Store(i1, d, to + 1 * 8);
+  Store(i2, d, to + 2 * 8);
+  Store(i3, d, to + 3 * 8);
+  Store(i4, d, to + 4 * 8);
+  Store(i5, d, to + 5 * 8);
+  Store(i6, d, to + 6 * 8);
+  Store(i7, d, to + 7 * 8);
+}
+#elif HWY_TARGET != HWY_SCALAR
+JXL_INLINE void Transpose8x8Block(const float* JXL_RESTRICT from,
+                                  float* JXL_RESTRICT to) {
+  const HWY_CAPPED(float, 4) d;
+  for (size_t n = 0; n < 8; n += 4) {
+    for (size_t m = 0; m < 8; m += 4) {
+      auto p0 = Load(d, from + n * 8 + m);
+      auto p1 = Load(d, from + (n + 1) * 8 + m);
+      auto p2 = Load(d, from + (n + 2) * 8 + m);
+      auto p3 = Load(d, from + (n + 3) * 8 + m);
+      const auto q0 = InterleaveLower(d, p0, p2);
+      const auto q1 = InterleaveLower(d, p1, p3);
+      const auto q2 = InterleaveUpper(d, p0, p2);
+      const auto q3 = InterleaveUpper(d, p1, p3);
+
+      const auto r0 = InterleaveLower(d, q0, q1);
+      const auto r1 = InterleaveUpper(d, q0, q1);
+      const auto r2 = InterleaveLower(d, q2, q3);
+      const auto r3 = InterleaveUpper(d, q2, q3);
+      Store(r0, d, to + m * 8 + n);
+      Store(r1, d, to + (1 + m) * 8 + n);
+      Store(r2, d, to + (2 + m) * 8 + n);
+      Store(r3, d, to + (3 + m) * 8 + n);
+    }
+  }
+}
+#else
+JXL_INLINE void Transpose8x8Block(const float* JXL_RESTRICT from,
+                                  float* JXL_RESTRICT to) {
+  for (size_t n = 0; n < 8; ++n) {
+    for (size_t m = 0; m < 8; ++m) {
+      to[8 * n + m] = from[8 * m + n];
+    }
+  }
+}
+#endif
+
+template <size_t N>
+void ForwardEvenOdd(const float* JXL_RESTRICT ain, size_t ain_stride,
+                    float* JXL_RESTRICT aout) {
+  for (size_t i = 0; i < N / 2; i++) {
+    auto in1 = LoadU(d8, ain + 2 * i * ain_stride);
+    Store(in1, d8, aout + i * 8);
+  }
+  for (size_t i = N / 2; i < N; i++) {
+    auto in1 = LoadU(d8, ain + (2 * (i - N / 2) + 1) * ain_stride);
+    Store(in1, d8, aout + i * 8);
+  }
+}
+
+template <size_t N>
+void BTranspose(float* JXL_RESTRICT coeff) {
+  for (size_t i = N - 1; i > 0; i--) {
+    auto in1 = Load(d8, coeff + i * 8);
+    auto in2 = Load(d8, coeff + (i - 1) * 8);
+    Store(Add(in1, in2), d8, coeff + i * 8);
+  }
+  constexpr float kSqrt2 = 1.41421356237f;
+  auto sqrt2 = Set(d8, kSqrt2);
+  auto in1 = Load(d8, coeff);
+  Store(Mul(in1, sqrt2), d8, coeff);
+}
+
+// Constants for DCT implementation. Generated by the following snippet:
+// for i in range(N // 2):
+//    print(1.0 / (2 * math.cos((i + 0.5) * math.pi / N)), end=", ")
+template <size_t N>
+struct WcMultipliers;
+
+template <>
+struct WcMultipliers<4> {
+  static constexpr float kMultipliers[] = {
+      0.541196100146197,
+      1.3065629648763764,
+  };
+};
+
+template <>
+struct WcMultipliers<8> {
+  static constexpr float kMultipliers[] = {
+      0.5097955791041592,
+      0.6013448869350453,
+      0.8999762231364156,
+      2.5629154477415055,
+  };
+};
+
+constexpr float WcMultipliers<4>::kMultipliers[];
+constexpr float WcMultipliers<8>::kMultipliers[];
+
+template <size_t N>
+void MultiplyAndAdd(const float* JXL_RESTRICT coeff, float* JXL_RESTRICT out,
+                    size_t out_stride) {
+  for (size_t i = 0; i < N / 2; i++) {
+    auto mul = Set(d8, WcMultipliers<N>::kMultipliers[i]);
+    auto in1 = Load(d8, coeff + i * 8);
+    auto in2 = Load(d8, coeff + (N / 2 + i) * 8);
+    auto out1 = MulAdd(mul, in2, in1);
+    auto out2 = NegMulAdd(mul, in2, in1);
+    StoreU(out1, d8, out + i * out_stride);
+    StoreU(out2, d8, out + (N - i - 1) * out_stride);
+  }
+}
+
+template <size_t N>
+struct IDCT1DImpl;
+
+template <>
+struct IDCT1DImpl<1> {
+  JXL_INLINE void operator()(const float* from, size_t from_stride, float* to,
+                             size_t to_stride) {
+    StoreU(LoadU(d8, from), d8, to);
+  }
+};
+
+template <>
+struct IDCT1DImpl<2> {
+  JXL_INLINE void operator()(const float* from, size_t from_stride, float* to,
+                             size_t to_stride) {
+    JXL_DASSERT(from_stride >= 8);
+    JXL_DASSERT(to_stride >= 8);
+    auto in1 = LoadU(d8, from);
+    auto in2 = LoadU(d8, from + from_stride);
+    StoreU(Add(in1, in2), d8, to);
+    StoreU(Sub(in1, in2), d8, to + to_stride);
+  }
+};
+
+template <size_t N>
+struct IDCT1DImpl {
+  void operator()(const float* from, size_t from_stride, float* to,
+                  size_t to_stride) {
+    JXL_DASSERT(from_stride >= 8);
+    JXL_DASSERT(to_stride >= 8);
+    HWY_ALIGN float tmp[64];
+    ForwardEvenOdd<N>(from, from_stride, tmp);
+    IDCT1DImpl<N / 2>()(tmp, 8, tmp, 8);
+    BTranspose<N / 2>(tmp + N * 4);
+    IDCT1DImpl<N / 2>()(tmp + N * 4, 8, tmp + N * 4, 8);
+    MultiplyAndAdd<N>(tmp, to, to_stride);
+  }
+};
+
+template <size_t N>
+void IDCT1D(float* JXL_RESTRICT from, float* JXL_RESTRICT output,
+            size_t output_stride) {
+  for (size_t i = 0; i < 8; i += Lanes(d8)) {
+    IDCT1DImpl<N>()(from + i, 8, output + i, output_stride);
+  }
+}
+
+void ComputeScaledIDCT(float* JXL_RESTRICT block0, float* JXL_RESTRICT block1,
+                       float* JXL_RESTRICT output, size_t output_stride) {
+  Transpose8x8Block(block0, block1);
+  IDCT1D<8>(block1, block0, 8);
+  Transpose8x8Block(block0, block1);
+  IDCT1D<8>(block1, output, output_stride);
+}
+
+void InverseTransformBlock(const int16_t* JXL_RESTRICT qblock,
+                           const float* JXL_RESTRICT dequant,
+                           const float* JXL_RESTRICT biases,
+                           float* JXL_RESTRICT scratch_space,
+                           float* JXL_RESTRICT output, size_t output_stride) {
+  float* JXL_RESTRICT block0 = scratch_space;
+  float* JXL_RESTRICT block1 = scratch_space + 64;
+  DequantBlock(qblock, dequant, biases, block0);
+  ComputeScaledIDCT(block0, block1, output, output_stride);
+}
+
+// NOLINTNEXTLINE(google-readability-namespace-comments)
+}  // namespace HWY_NAMESPACE
+}  // namespace jpegli
+HWY_AFTER_NAMESPACE();
+
+#if HWY_ONCE
+namespace jpegli {
+
+HWY_EXPORT(InverseTransformBlock);
+
+void InverseTransformBlock(const int16_t* JXL_RESTRICT qblock,
+                           const float* JXL_RESTRICT dequant_matrices,
+                           const float* JXL_RESTRICT biases,
+                           float* JXL_RESTRICT scratch_space,
+                           float* JXL_RESTRICT output, size_t output_stride) {
+  return HWY_DYNAMIC_DISPATCH(InverseTransformBlock)(
+      qblock, dequant_matrices, biases, scratch_space, output, output_stride);
+}
+
+}  // namespace jpegli
+#endif  // HWY_ONCE

--- a/lib/jpegli/idct.h
+++ b/lib/jpegli/idct.h
@@ -1,0 +1,25 @@
+// Copyright (c) the JPEG XL Project Authors. All rights reserved.
+//
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+#ifndef LIB_JPEGLI_IDCT_H_
+#define LIB_JPEGLI_IDCT_H_
+
+#include <stddef.h>
+#include <stdint.h>
+
+#include "lib/jxl/base/compiler_specific.h"
+
+namespace jpegli {
+
+// Performs dequantization and inverse DCT.
+void InverseTransformBlock(const int16_t* JXL_RESTRICT qblock,
+                           const float* JXL_RESTRICT dequant_matrices,
+                           const float* JXL_RESTRICT biases,
+                           float* JXL_RESTRICT scratch_space,
+                           float* JXL_RESTRICT output, size_t output_stride);
+
+}  // namespace jpegli
+
+#endif  // LIB_JPEGLI_IDCT_H_

--- a/lib/jpegli/jpeg.version
+++ b/lib/jpegli/jpeg.version
@@ -1,0 +1,10 @@
+LIBJPEG_6.2 {
+  global:
+    jpeg*;
+};
+
+LIBJPEGTURBO_6.2 {
+  global:
+    jpeg_mem_src*;
+    tj*;
+};

--- a/lib/jpegli/memory_manager.h
+++ b/lib/jpegli/memory_manager.h
@@ -1,0 +1,26 @@
+// Copyright (c) the JPEG XL Project Authors. All rights reserved.
+//
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+#ifndef LIB_JPEGLI_MEMORY_MANAGER_H_
+#define LIB_JPEGLI_MEMORY_MANAGER_H_
+
+/* clang-format off */
+#include <stdint.h>
+#include <stdio.h>
+#include <jpeglib.h>
+/* clang-format on */
+
+#include <vector>
+
+namespace jpegli {
+
+struct MemoryManager {
+  struct jpeg_memory_mgr pub;
+  std::vector<void*> owned_ptrs;
+};
+
+}  // namespace jpegli
+
+#endif  // LIB_JPEGLI_MEMORY_MANAGER_H_

--- a/lib/jpegli/render.cc
+++ b/lib/jpegli/render.cc
@@ -1,0 +1,417 @@
+// Copyright (c) the JPEG XL Project Authors. All rights reserved.
+//
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+#include "lib/jpegli/render.h"
+
+#include <string.h>
+
+#include <cmath>
+
+#include "hwy/aligned_allocator.h"
+#include "lib/jpegli/color_transform.h"
+#include "lib/jpegli/decode_internal.h"
+#include "lib/jpegli/idct.h"
+#include "lib/jpegli/upsample.h"
+#include "lib/jxl/base/compiler_specific.h"
+#include "lib/jxl/base/status.h"
+
+#ifdef MEMORY_SANITIZER
+#define JXL_MEMORY_SANITIZER 1
+#elif defined(__has_feature)
+#if __has_feature(memory_sanitizer)
+#define JXL_MEMORY_SANITIZER 1
+#else
+#define JXL_MEMORY_SANITIZER 0
+#endif
+#else
+#define JXL_MEMORY_SANITIZER 0
+#endif
+
+#if JXL_MEMORY_SANITIZER
+#include "sanitizer/msan_interface.h"
+#endif
+
+#undef HWY_TARGET_INCLUDE
+#define HWY_TARGET_INCLUDE "lib/jpegli/render.cc"
+#include <hwy/foreach_target.h>
+#include <hwy/highway.h>
+
+HWY_BEFORE_NAMESPACE();
+namespace jpegli {
+namespace HWY_NAMESPACE {
+
+// These templates are not found via ADL.
+using hwy::HWY_NAMESPACE::Abs;
+using hwy::HWY_NAMESPACE::Add;
+using hwy::HWY_NAMESPACE::Clamp;
+using hwy::HWY_NAMESPACE::Gt;
+using hwy::HWY_NAMESPACE::IfThenElseZero;
+using hwy::HWY_NAMESPACE::Mul;
+using hwy::HWY_NAMESPACE::NearestInt;
+using hwy::HWY_NAMESPACE::Rebind;
+using hwy::HWY_NAMESPACE::Vec;
+
+using D = HWY_FULL(float);
+using DI = HWY_FULL(int32_t);
+constexpr D d;
+constexpr DI di;
+
+void GatherBlockStats(const int16_t* JXL_RESTRICT coeffs,
+                      const size_t coeffs_size, int32_t* JXL_RESTRICT nonzeros,
+                      int32_t* JXL_RESTRICT sumabs) {
+  for (size_t i = 0; i < coeffs_size; i += Lanes(d)) {
+    size_t k = i % DCTSIZE2;
+    const Rebind<int16_t, DI> di16;
+    const Vec<DI> coeff = PromoteTo(di, Load(di16, coeffs + i));
+    const auto abs_coeff = Abs(coeff);
+    const auto not_0 = Gt(abs_coeff, Zero(di));
+    const auto nzero = IfThenElseZero(not_0, Set(di, 1));
+    Store(Add(nzero, Load(di, nonzeros + k)), di, nonzeros + k);
+    Store(Add(abs_coeff, Load(di, sumabs + k)), di, sumabs + k);
+  }
+}
+
+void DecenterRow(float* row, size_t xsize) {
+  const HWY_FULL(float) df;
+  const auto c128 = Set(df, 128.0f / 255);
+  for (size_t x = 0; x < xsize; x += Lanes(df)) {
+    Store(Add(Load(df, row + x), c128), df, row + x);
+  }
+}
+
+template <typename T>
+void StoreUnsignedRow(float* JXL_RESTRICT input[3], size_t x0, size_t len,
+                      size_t num_channels, float multiplier, T* output) {
+  const HWY_FULL(float) d;
+  auto zero = Zero(d);
+  auto one = Set(d, 1.0f);
+  auto mul = Set(d, multiplier);
+  const Rebind<T, decltype(d)> du;
+#if JXL_MEMORY_SANITIZER
+  const size_t padding = hwy::RoundUpTo(len, Lanes(d)) - len;
+  for (size_t c = 0; c < num_channels; ++c) {
+    __msan_unpoison(input[c] + x0 + len, sizeof(input[c][0]) * padding);
+  }
+#endif
+  if (num_channels == 1) {
+    for (size_t i = 0; i < len; i += Lanes(d)) {
+      auto v0 = Mul(Clamp(zero, Load(d, &input[0][x0 + i]), one), mul);
+      Store(DemoteTo(du, NearestInt(v0)), du, &output[i]);
+    }
+  } else if (num_channels == 3) {
+    for (size_t i = 0; i < len; i += Lanes(d)) {
+      auto v0 = Mul(Clamp(zero, Load(d, &input[0][x0 + i]), one), mul);
+      auto v1 = Mul(Clamp(zero, Load(d, &input[1][x0 + i]), one), mul);
+      auto v2 = Mul(Clamp(zero, Load(d, &input[2][x0 + i]), one), mul);
+      StoreInterleaved3(DemoteTo(du, NearestInt(v0)),
+                        DemoteTo(du, NearestInt(v1)),
+                        DemoteTo(du, NearestInt(v2)), du, &output[3 * i]);
+    }
+  }
+#if JXL_MEMORY_SANITIZER
+  __msan_poison(output + num_channels * len,
+                sizeof(output[0]) * num_channels * padding);
+#endif
+}
+
+void WriteToOutput(float* JXL_RESTRICT rows[3], size_t x0, size_t len,
+                   size_t num_channels, size_t bit_depth,
+                   uint8_t* JXL_RESTRICT scratch_space,
+                   uint8_t* JXL_RESTRICT output) {
+  const float mul = (1u << bit_depth) - 1;
+  if (bit_depth <= 8) {
+    size_t offset = x0 * num_channels;
+    StoreUnsignedRow(rows, x0, len, num_channels, mul, scratch_space);
+    memcpy(output + offset, scratch_space, len * num_channels);
+  } else {
+    size_t offset = x0 * num_channels * 2;
+    uint16_t* tmp = reinterpret_cast<uint16_t*>(scratch_space);
+    StoreUnsignedRow(rows, x0, len, num_channels, mul, tmp);
+    // TODO(szabadka) Handle endianness.
+    memcpy(output + offset, tmp, len * num_channels * 2);
+  }
+}
+
+// NOLINTNEXTLINE(google-readability-namespace-comments)
+}  // namespace HWY_NAMESPACE
+}  // namespace jpegli
+HWY_AFTER_NAMESPACE();
+
+#if HWY_ONCE
+
+typedef jpeg_decomp_master::State State;
+
+namespace jpegli {
+
+HWY_EXPORT(GatherBlockStats);
+HWY_EXPORT(WriteToOutput);
+HWY_EXPORT(DecenterRow);
+
+void GatherBlockStats(const int16_t* JXL_RESTRICT coeffs,
+                      const size_t coeffs_size, int32_t* JXL_RESTRICT nonzeros,
+                      int32_t* JXL_RESTRICT sumabs) {
+  return HWY_DYNAMIC_DISPATCH(GatherBlockStats)(coeffs, coeffs_size, nonzeros,
+                                                sumabs);
+}
+
+void WriteToOutput(float* JXL_RESTRICT rows[3], size_t x0, size_t len,
+                   size_t num_channels, size_t bit_depth,
+                   uint8_t* JXL_RESTRICT scratch_space,
+                   uint8_t* JXL_RESTRICT output) {
+  return HWY_DYNAMIC_DISPATCH(WriteToOutput)(rows, x0, len, num_channels,
+                                             bit_depth, scratch_space, output);
+}
+
+void DecenterRow(float* row, size_t xsize) {
+  return HWY_DYNAMIC_DISPATCH(DecenterRow)(row, xsize);
+}
+
+// Padding for horizontal chroma upsampling.
+constexpr size_t kPaddingLeft = 64;
+constexpr size_t kPaddingRight = 64;
+constexpr size_t kTempOutputLen = 1024;
+
+// See the following article for the details:
+// J. R. Price and M. Rabbani, "Dequantization bias for JPEG decompression"
+// Proceedings International Conference on Information Technology: Coding and
+// Computing (Cat. No.PR00540), 2000, pp. 30-35, doi: 10.1109/ITCC.2000.844179.
+void ComputeOptimalLaplacianBiases(const int num_blocks, const int* nonzeros,
+                                   const int* sumabs, float* biases) {
+  for (size_t k = 1; k < DCTSIZE2; ++k) {
+    // Notation adapted from the article
+    size_t N = num_blocks;
+    size_t N1 = nonzeros[k];
+    size_t N0 = num_blocks - N1;
+    size_t S = sumabs[k];
+    // Compute gamma from N0, N1, N, S (eq. 11), with A and B being just
+    // temporary grouping of terms.
+    float A = 4.0 * S + 2.0 * N;
+    float B = 4.0 * S - 2.0 * N1;
+    float gamma = (-1.0 * N0 + std::sqrt(N0 * N0 * 1.0 + A * B)) / A;
+    float gamma2 = gamma * gamma;
+    // The bias is computed from gamma with (eq. 5), where the quantization
+    // multiplier Q can be factored out and thus the bias can be applied
+    // directly on the quantized coefficient.
+    biases[k] =
+        0.5 * (((1.0 + gamma2) / (1.0 - gamma2)) + 1.0 / std::log(gamma));
+  }
+}
+
+void PrepareForOutput(j_decompress_ptr cinfo) {
+  jpeg_decomp_master* m = cinfo->master;
+  cinfo->output_components = cinfo->num_components;
+  m->output_stride_ = (cinfo->image_width * m->components_.size() *
+                       DivCeil(m->output_bit_depth_, 8));
+  m->MCU_row_stride_ =
+      m->iMCU_cols_ * m->iMCU_width_ + kPaddingLeft + kPaddingRight;
+  m->MCU_plane_size_ = m->MCU_row_stride_ * m->iMCU_height_;
+  m->MCU_row_buf_ = hwy::AllocateAligned<float>(3 * m->MCU_plane_size_);
+  const size_t nbcomp = m->components_.size();
+  m->num_chroma_ = 0;
+  m->chroma_plane_size_ = m->MCU_row_stride_ * 3 * DCTSIZE;
+  m->chroma_ = hwy::AllocateAligned<float>(3 * m->chroma_plane_size_);
+  for (size_t c = 0; c < nbcomp; ++c) {
+    const auto& comp = m->components_[c];
+    if (comp.v_samp_factor < m->max_v_samp_) {
+      m->component_order_.emplace_back(c);
+      ++m->num_chroma_;
+    }
+  }
+  for (size_t c = 0; c < nbcomp; ++c) {
+    const auto& comp = m->components_[c];
+    if (comp.v_samp_factor == m->max_v_samp_) {
+      m->component_order_.emplace_back(c);
+    }
+  }
+  m->idct_scratch_ = hwy::AllocateAligned<float>(DCTSIZE2 * 2);
+  m->upsample_scratch_ = hwy::AllocateAligned<float>(m->MCU_row_stride_);
+  size_t bytes_per_channel = DivCeil(m->output_bit_depth_, 8);
+  size_t bytes_per_sample = nbcomp * bytes_per_channel;
+  m->output_scratch_ =
+      hwy::AllocateAligned<uint8_t>(bytes_per_sample * kTempOutputLen);
+  m->nonzeros_ = hwy::AllocateAligned<int>(nbcomp * DCTSIZE2);
+  m->sumabs_ = hwy::AllocateAligned<int>(nbcomp * DCTSIZE2);
+  memset(m->nonzeros_.get(), 0, nbcomp * DCTSIZE2 * sizeof(m->nonzeros_[0]));
+  memset(m->sumabs_.get(), 0, nbcomp * DCTSIZE2 * sizeof(m->sumabs_[0]));
+  m->num_processed_blocks_.resize(nbcomp);
+  m->biases_ = hwy::AllocateAligned<float>(nbcomp * DCTSIZE2);
+  memset(m->biases_.get(), 0, nbcomp * DCTSIZE2 * sizeof(m->biases_[0]));
+  m->output_mcu_row_ = 0;
+  m->output_ci_ = 0;
+  m->output_row_ = 0;
+  m->MCU_buf_ready_rows_ = 0;
+  const float kDequantScale = 1.0f / (8 * 255);
+  m->dequant_ = hwy::AllocateAligned<float>(nbcomp * DCTSIZE2);
+  for (size_t c = 0; c < nbcomp; c++) {
+    const auto& comp = m->components_[c];
+    const int32_t* quant = m->quant_[comp.quant_idx].values.data();
+    for (size_t k = 0; k < DCTSIZE2; ++k) {
+      m->dequant_[c * DCTSIZE2 + k] = quant[k] * kDequantScale;
+    }
+  }
+}
+
+void ProcessOutput(j_decompress_ptr cinfo, size_t* num_output_rows,
+                   JSAMPARRAY scanlines, size_t max_output_rows) {
+  jpeg_decomp_master* m = cinfo->master;
+  const size_t nbcomp = m->components_.size();
+  size_t xsize_blocks = DivCeil(cinfo->image_width, DCTSIZE);
+  size_t mcu_y = m->output_mcu_row_;
+  for (; m->output_ci_ < m->components_.size(); ++m->output_ci_) {
+    size_t c = m->component_order_[m->output_ci_];
+    size_t k0 = c * DCTSIZE2;
+    auto& comp = m->components_[c];
+    bool hups = comp.h_samp_factor < m->max_h_samp_;
+    bool vups = comp.v_samp_factor < m->max_v_samp_;
+    size_t nblocks_y = comp.v_samp_factor;
+    float* output;
+    size_t output_ysize;
+    if (vups) {
+      output = m->chroma_.get() + m->output_ci_ * m->chroma_plane_size_;
+      output_ysize = 3 * DCTSIZE;
+    } else {
+      output = m->MCU_row_buf_.get() + c * m->MCU_plane_size_;
+      output_ysize = m->iMCU_height_;
+    }
+    size_t mcu_y0 = vups ? (mcu_y * DCTSIZE) % output_ysize : 0;
+    if (m->output_ci_ == m->num_chroma_ && mcu_y > 0) {
+      // For the previous MCU row we have everything we need at this point,
+      // including the chroma components for the current MCU row that was used
+      // in upsampling, so we can do the color conversion and the interleaved
+      // output.
+      if (m->MCU_buf_ready_rows_ == 0) {
+        m->MCU_buf_ready_rows_ = m->iMCU_height_;
+        m->MCU_buf_current_row_ = 0;
+      }
+      while (m->MCU_buf_current_row_ < m->MCU_buf_ready_rows_ &&
+             *num_output_rows < max_output_rows &&
+             m->output_row_ < cinfo->image_height) {
+        size_t offsets[3];
+        float* rows[3];
+        for (size_t c = 0; c < m->components_.size(); ++c) {
+          offsets[c] = c * m->MCU_plane_size_ +
+                       m->MCU_buf_current_row_ * m->MCU_row_stride_ +
+                       kPaddingLeft;
+        }
+        for (size_t c = 0; c < m->components_.size(); ++c) {
+          rows[c] = m->MCU_row_buf_.get() + offsets[c];
+        }
+        if (m->is_ycbcr_ && nbcomp == 3) {
+          YCbCrToRGB(rows[0], rows[1], rows[2], xsize_blocks * DCTSIZE);
+        } else {
+          for (size_t c = 0; c < m->components_.size(); ++c) {
+            // Libjpeg encoder converts all unsigned input values to signed
+            // ones, i.e. for 8 bit input from [0..255] to [-128..127]. For
+            // YCbCr jpegs this is undone in the YCbCr -> RGB conversion above
+            // by adding 128 to Y channel, but for grayscale and RGB jpegs we
+            // need to undo it here channel by channel.
+            DecenterRow(rows[c], xsize_blocks * DCTSIZE);
+          }
+        }
+        for (size_t x0 = 0; x0 < cinfo->image_width; x0 += kTempOutputLen) {
+          size_t len = std::min(cinfo->image_width - x0, kTempOutputLen);
+          uint8_t* output = scanlines[*num_output_rows];
+          WriteToOutput(rows, x0, len, m->components_.size(),
+                        m->output_bit_depth_, m->output_scratch_.get(), output);
+        }
+        ++m->output_row_;
+        ++(*num_output_rows);
+        ++m->MCU_buf_current_row_;
+      }
+      if (m->output_row_ == cinfo->image_height) {
+        m->state_ = m->is_progressive_ ? State::kEnd : State::kProcessMarkers;
+        return;
+      }
+      if (*num_output_rows == max_output_rows) {
+        return;
+      }
+      m->MCU_buf_ready_rows_ = 0;
+    }
+    if (mcu_y < m->iMCU_rows_) {
+      if (!hups && !vups) {
+        size_t num_coeffs = comp.width_in_blocks * DCTSIZE2;
+        size_t offset = mcu_y * comp.width_in_blocks * DCTSIZE2;
+        // Update statistics for this MCU row.
+        GatherBlockStats(&comp.coeffs[offset], num_coeffs, &m->nonzeros_[k0],
+                         &m->sumabs_[k0]);
+        m->num_processed_blocks_[c] += comp.width_in_blocks;
+        if (mcu_y % 4 == 3) {
+          // Re-compute optimal biases every few MCU-rows.
+          ComputeOptimalLaplacianBiases(m->num_processed_blocks_[c],
+                                        &m->nonzeros_[k0], &m->sumabs_[k0],
+                                        &m->biases_[k0]);
+        }
+      }
+      for (size_t iy = 0; iy < nblocks_y; ++iy) {
+        size_t by = mcu_y * nblocks_y + iy;
+        size_t y0 = mcu_y0 + iy * DCTSIZE;
+        int16_t* JXL_RESTRICT row_in =
+            &comp.coeffs[by * comp.width_in_blocks * DCTSIZE2];
+        float* JXL_RESTRICT row_out =
+            output + y0 * m->MCU_row_stride_ + kPaddingLeft;
+        for (size_t bx = 0; bx < comp.width_in_blocks; ++bx) {
+          InverseTransformBlock(&row_in[bx * DCTSIZE2], &m->dequant_[k0],
+                                &m->biases_[k0], m->idct_scratch_.get(),
+                                &row_out[bx * DCTSIZE], m->MCU_row_stride_);
+        }
+        if (hups) {
+          for (size_t y = 0; y < DCTSIZE; ++y) {
+            float* JXL_RESTRICT row =
+                output + (y0 + y) * m->MCU_row_stride_ + kPaddingLeft;
+            Upsample2Horizontal(row, m->upsample_scratch_.get(),
+                                xsize_blocks * DCTSIZE);
+            memcpy(row, m->upsample_scratch_.get(),
+                   xsize_blocks * DCTSIZE * sizeof(row[0]));
+          }
+        }
+      }
+    }
+    if (vups) {
+      auto y_idx = [&](size_t mcu_y, ssize_t y) {
+        return (output_ysize + mcu_y * DCTSIZE + y) % output_ysize;
+      };
+      if (mcu_y == 0) {
+        // Copy the first row of the current MCU row to the last row of the
+        // previous one.
+        memcpy(output + y_idx(mcu_y, -1) * m->MCU_row_stride_,
+               output + y_idx(mcu_y, 0) * m->MCU_row_stride_,
+               m->MCU_row_stride_ * sizeof(output[0]));
+      }
+      if (mcu_y == m->iMCU_rows_) {
+        // Copy the last row of the current MCU row to the  first row of the
+        // next  one.
+        memcpy(output + y_idx(mcu_y + 1, 0) * m->MCU_row_stride_,
+               output + y_idx(mcu_y, DCTSIZE - 1) * m->MCU_row_stride_,
+               m->MCU_row_stride_ * sizeof(output[0]));
+      }
+      if (mcu_y > 0) {
+        for (size_t y = 0; y < DCTSIZE; ++y) {
+          size_t y_top = y_idx(mcu_y - 1, y - 1);
+          size_t y_cur = y_idx(mcu_y - 1, y);
+          size_t y_bot = y_idx(mcu_y - 1, y + 1);
+          size_t y_out0 = 2 * y;
+          size_t y_out1 = 2 * y + 1;
+          Upsample2Vertical(output + y_top * m->MCU_row_stride_ + kPaddingLeft,
+                            output + y_cur * m->MCU_row_stride_ + kPaddingLeft,
+                            output + y_bot * m->MCU_row_stride_ + kPaddingLeft,
+                            m->MCU_row_buf_.get() + c * m->MCU_plane_size_ +
+                                y_out0 * m->MCU_row_stride_ + kPaddingLeft,
+                            m->MCU_row_buf_.get() + c * m->MCU_plane_size_ +
+                                y_out1 * m->MCU_row_stride_ + kPaddingLeft,
+                            xsize_blocks * DCTSIZE);
+        }
+      }
+    }
+  }
+  ++m->output_mcu_row_;
+  m->output_ci_ = 0;
+  if (!m->is_progressive_ && m->output_mcu_row_ < m->iMCU_rows_) {
+    m->state_ = State::kScan;
+  }
+  JXL_DASSERT(m->output_mcu_row_ <= m->iMCU_rows_);
+}
+
+}  // namespace jpegli
+#endif  // HWY_ONCE

--- a/lib/jpegli/render.h
+++ b/lib/jpegli/render.h
@@ -1,0 +1,26 @@
+// Copyright (c) the JPEG XL Project Authors. All rights reserved.
+//
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+#ifndef LIB_JPEGLI_RENDER_H_
+#define LIB_JPEGLI_RENDER_H_
+
+/* clang-format off */
+#include <stdint.h>
+#include <stdio.h>
+#include <jpeglib.h>
+/* clang-format on */
+
+#include <vector>
+
+namespace jpegli {
+
+void PrepareForOutput(j_decompress_ptr cinfo);
+
+void ProcessOutput(j_decompress_ptr cinfo, size_t* num_output_rows,
+                   JSAMPARRAY scanlines, size_t max_output_rows);
+
+}  // namespace jpegli
+
+#endif  // LIB_JPEGLI_RENDER_H_

--- a/lib/jpegli/source_manager.cc
+++ b/lib/jpegli/source_manager.cc
@@ -1,0 +1,41 @@
+// Copyright (c) the JPEG XL Project Authors. All rights reserved.
+//
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+#include "lib/jpegli/source_manager.h"
+
+#include "lib/jpegli/memory_manager.h"
+
+namespace jpegli {
+
+void init_source(j_decompress_ptr cinfo) {}
+
+void skip_input_data(j_decompress_ptr cinfo, long num_bytes) {}
+
+boolean resync_to_restart(j_decompress_ptr cinfo, int desired) { return FALSE; }
+
+void term_source(j_decompress_ptr cinfo) {}
+
+boolean EmitFakeEoiMarker(j_decompress_ptr cinfo) {
+  static constexpr uint8_t kFakeEoiMarker[2] = {0xff, 0xd9};
+  cinfo->src->next_input_byte = kFakeEoiMarker;
+  cinfo->src->bytes_in_buffer = 2;
+  return TRUE;
+}
+
+}  // namespace jpegli
+
+void jpeg_mem_src(j_decompress_ptr cinfo, const unsigned char* inbuffer,
+                  unsigned long insize) {
+  cinfo->src = (jpeg_source_mgr*)malloc(sizeof(jpeg_source_mgr));
+  cinfo->src->next_input_byte = inbuffer;
+  cinfo->src->bytes_in_buffer = insize;
+  cinfo->src->init_source = jpegli::init_source;
+  cinfo->src->fill_input_buffer = jpegli::EmitFakeEoiMarker;
+  cinfo->src->skip_input_data = jpegli::skip_input_data;
+  cinfo->src->resync_to_restart = jpegli::resync_to_restart;
+  cinfo->src->term_source = jpegli::term_source;
+  auto mem = reinterpret_cast<jpegli::MemoryManager*>(cinfo->mem);
+  mem->owned_ptrs.push_back(cinfo->src);
+}

--- a/lib/jpegli/source_manager.h
+++ b/lib/jpegli/source_manager.h
@@ -1,0 +1,28 @@
+// Copyright (c) the JPEG XL Project Authors. All rights reserved.
+//
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+#ifndef LIB_JPEGLI_SOURCE_MANAGER_H_
+#define LIB_JPEGLI_SOURCE_MANAGER_H_
+
+/* clang-format off */
+#include <stdint.h>
+#include <stdio.h>
+#include <jpeglib.h>
+/* clang-format on */
+
+#include "lib/jxl/base/compiler_specific.h"
+#include "lib/jxl/base/status.h"
+
+namespace jpegli {
+
+static JXL_INLINE void AdvanceInput(j_decompress_ptr cinfo, size_t size) {
+  JXL_DASSERT(size <= cinfo->src->bytes_in_buffer);
+  cinfo->src->bytes_in_buffer -= size;
+  cinfo->src->next_input_byte += size;
+}
+
+}  // namespace jpegli
+
+#endif  // LIB_JPEGLI_SOURCE_MANAGER_H_

--- a/lib/jpegli/upsample.cc
+++ b/lib/jpegli/upsample.cc
@@ -1,0 +1,134 @@
+// Copyright (c) the JPEG XL Project Authors. All rights reserved.
+//
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+#include "lib/jpegli/upsample.h"
+
+#undef HWY_TARGET_INCLUDE
+#define HWY_TARGET_INCLUDE "lib/jpegli/upsample.cc"
+#include <hwy/foreach_target.h>
+#include <hwy/highway.h>
+
+HWY_BEFORE_NAMESPACE();
+namespace jpegli {
+namespace HWY_NAMESPACE {
+
+// These templates are not found via ADL.
+using hwy::HWY_NAMESPACE::Mul;
+using hwy::HWY_NAMESPACE::MulAdd;
+using hwy::HWY_NAMESPACE::Vec;
+
+#if HWY_CAP_GE512
+using hwy::HWY_NAMESPACE::Half;
+using hwy::HWY_NAMESPACE::Vec;
+template <size_t i, class DF, class V>
+HWY_INLINE Vec<Half<Half<DF>>> Quarter(const DF df, V v) {
+  using HF = Half<DF>;
+  using HHF = Half<HF>;
+  auto half = i >= 2 ? UpperHalf(HF(), v) : LowerHalf(HF(), v);
+  return i & 1 ? UpperHalf(HHF(), half) : LowerHalf(HHF(), half);
+}
+
+template <class DF, class V>
+HWY_INLINE Vec<DF> Concat4(const DF df, V v0, V v1, V v2, V v3) {
+  using HF = Half<DF>;
+  return Combine(DF(), Combine(HF(), v3, v2), Combine(HF(), v1, v0));
+}
+
+#endif
+
+// Stores v0[0], v1[0], v0[1], v1[1], ... to mem, in this order. Mem must be
+// aligned.
+template <class DF, class V, typename T>
+void StoreInterleaved(const DF df, V v0, V v1, T* mem) {
+  static_assert(sizeof(T) == 4, "only use StoreInterleaved for 4-byte types");
+#if HWY_TARGET == HWY_SCALAR
+  Store(v0, df, mem);
+  Store(v1, df, mem + 1);
+#elif !HWY_CAP_GE256
+  Store(InterleaveLower(df, v0, v1), df, mem);
+  Store(InterleaveUpper(df, v0, v1), df, mem + Lanes(df));
+#else
+  if (!HWY_CAP_GE512 || Lanes(df) == 8) {
+    auto t0 = InterleaveLower(df, v0, v1);
+    auto t1 = InterleaveUpper(df, v0, v1);
+    Store(ConcatLowerLower(df, t1, t0), df, mem);
+    Store(ConcatUpperUpper(df, t1, t0), df, mem + Lanes(df));
+  } else {
+#if HWY_CAP_GE512
+    auto t0 = InterleaveLower(df, v0, v1);
+    auto t1 = InterleaveUpper(df, v0, v1);
+    Store(Concat4(df, Quarter<0>(df, t0), Quarter<0>(df, t1),
+                  Quarter<1>(df, t0), Quarter<1>(df, t1)),
+          df, mem);
+    Store(Concat4(df, Quarter<2>(df, t0), Quarter<2>(df, t1),
+                  Quarter<3>(df, t0), Quarter<3>(df, t1)),
+          df, mem + Lanes(df));
+#endif
+  }
+#endif
+}
+
+void Upsample2Horizontal(float* JXL_RESTRICT row_in,
+                         float* JXL_RESTRICT row_out, size_t len_out) {
+  HWY_FULL(float) df;
+  auto threefour = Set(df, 0.75f);
+  auto onefour = Set(df, 0.25f);
+  const size_t len_in = len_out >> 1;
+  row_in[-1] = row_in[0];
+  row_in[len_in] = row_in[len_in - 1];
+  for (size_t x = 0; x < len_in; x += Lanes(df)) {
+    auto current = Mul(Load(df, row_in + x), threefour);
+    auto prev = LoadU(df, row_in + x - 1);
+    auto next = LoadU(df, row_in + x + 1);
+    auto left = MulAdd(onefour, prev, current);
+    auto right = MulAdd(onefour, next, current);
+    StoreInterleaved(df, left, right, row_out + x * 2);
+  }
+}
+
+void Upsample2Vertical(const float* JXL_RESTRICT row_top,
+                       const float* JXL_RESTRICT row_mid,
+                       const float* JXL_RESTRICT row_bot,
+                       float* JXL_RESTRICT row_out0,
+                       float* JXL_RESTRICT row_out1, size_t len) {
+  HWY_FULL(float) df;
+  auto threefour = Set(df, 0.75f);
+  auto onefour = Set(df, 0.25f);
+  for (size_t x = 0; x < len; x += Lanes(df)) {
+    auto it = Load(df, row_top + x);
+    auto im = Load(df, row_mid + x);
+    auto ib = Load(df, row_bot + x);
+    auto im_scaled = Mul(im, threefour);
+    Store(MulAdd(it, onefour, im_scaled), df, row_out0 + x);
+    Store(MulAdd(ib, onefour, im_scaled), df, row_out1 + x);
+  }
+}
+
+// NOLINTNEXTLINE(google-readability-namespace-comments)
+}  // namespace HWY_NAMESPACE
+}  // namespace jpegli
+HWY_AFTER_NAMESPACE();
+
+#if HWY_ONCE
+namespace jpegli {
+
+HWY_EXPORT(Upsample2Horizontal);
+HWY_EXPORT(Upsample2Vertical);
+
+void Upsample2Horizontal(float* JXL_RESTRICT row_in,
+                         float* JXL_RESTRICT row_out, size_t len_out) {
+  return HWY_DYNAMIC_DISPATCH(Upsample2Horizontal)(row_in, row_out, len_out);
+}
+
+void Upsample2Vertical(const float* JXL_RESTRICT row_top,
+                       const float* JXL_RESTRICT row_mid,
+                       const float* JXL_RESTRICT row_bot,
+                       float* JXL_RESTRICT row_out0,
+                       float* JXL_RESTRICT row_out1, size_t len) {
+  return HWY_DYNAMIC_DISPATCH(Upsample2Vertical)(row_top, row_mid, row_bot,
+                                                 row_out0, row_out1, len);
+}
+}  // namespace jpegli
+#endif  // HWY_ONCE

--- a/lib/jpegli/upsample.h
+++ b/lib/jpegli/upsample.h
@@ -1,0 +1,26 @@
+// Copyright (c) the JPEG XL Project Authors. All rights reserved.
+//
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+#ifndef LIB_JPEGLI_UPSAMPLE_H_
+#define LIB_JPEGLI_UPSAMPLE_H_
+
+#include <stddef.h>
+
+#include "lib/jxl/base/compiler_specific.h"
+
+namespace jpegli {
+
+void Upsample2Horizontal(float* JXL_RESTRICT row_in,
+                         float* JXL_RESTRICT row_out, size_t len_out);
+
+void Upsample2Vertical(const float* JXL_RESTRICT row_top,
+                       const float* JXL_RESTRICT row_mid,
+                       const float* JXL_RESTRICT row_bot,
+                       float* JXL_RESTRICT row_out0,
+                       float* JXL_RESTRICT row_out1, size_t len);
+
+}  // namespace jpegli
+
+#endif  // LIB_JPEGLI_UPSAMPLE_H_

--- a/lib/jxl.cmake
+++ b/lib/jxl.cmake
@@ -379,15 +379,6 @@ set(JPEGXL_INTERNAL_LIBS
   brotlienc-static
 )
 
-# strips the -static suffix from all the elements in LIST
-function(strip_static OUTPUT_VAR LIB_LIST)
-  foreach(lib IN LISTS ${LIB_LIST})
-    string(REGEX REPLACE "-static$" "" lib "${lib}")
-    list(APPEND out_list "${lib}")
-  endforeach()
-  set(${OUTPUT_VAR} ${out_list} PARENT_SCOPE)
-endfunction()
-
 if (JPEGXL_ENABLE_SKCMS)
   list(APPEND JPEGXL_INTERNAL_FLAGS -DJPEGXL_ENABLE_SKCMS=1)
   if (JPEGXL_BUNDLE_SKCMS)

--- a/lib/jxl/jxl_test.cc
+++ b/lib/jxl/jxl_test.cc
@@ -1306,7 +1306,7 @@ TEST(JxlTest, JXL_TRANSCODE_JPEG_TEST(RoundtripJpegRecompressionGray)) {
   const PaddedBytes orig =
       ReadTestData("jxl/flower/flower.png.im_q85_gray.jpg");
   // JPEG size is 456,528 bytes.
-  EXPECT_NEAR(RoundtripJpeg(orig, &pool), 383847u, 120);
+  EXPECT_NEAR(RoundtripJpeg(orig, &pool), 387496u, 200);
 }
 
 TEST(JxlTest, JXL_TRANSCODE_JPEG_TEST(RoundtripJpegRecompression420)) {

--- a/tools/build_cleaner.py
+++ b/tools/build_cleaner.py
@@ -83,7 +83,6 @@ def SplitLibFiles(repo_files):
                  not any(patt in fn for patt in testonly) and
                  not any(patt in fn for patt in exclude_extras)]
 
-
   enc_srcs = [fn for fn in lib_srcs
               if os.path.basename(fn).startswith('enc_') or
                  os.path.basename(fn).startswith('butteraugli')]
@@ -298,7 +297,8 @@ def BuildCleaner(args):
   # Update the list of tests. CMake version include test files in other libs,
   # not just in libjxl.
   tests = [fn[len('lib/'):] for fn in repo_files
-           if fn.endswith('_test.cc') and fn.startswith('lib/')]
+           if fn.endswith('_test.cc') and fn.startswith('lib/')
+           and not fn.startswith('lib/jpegli')]
   ok = CleanFile(
       args, 'lib/jxl_tests.cmake',
       [(r'set\(TEST_FILES\n([^\)]+)  ### Files before this line',


### PR DESCRIPTION
The libjpegli library is a drop-in replacement to libjpeg62, with improvements inspired by the JPEG XL codec.

The commit adds a minimal version of the libjpeg decoding API.

After building the jpeg and benchmark_xl targets, the following command can be used to convert an input.jpg file to PNG:

```
LD_PRELOAD=./build/libjpeg.so.62 ./build/tools/benchmark_xl --input input.jpg --codec=jpeg --decode_only --save_decompressed --output_dir .
```