### PR TITLE
remove deprecated or dead code

### DIFF
--- a/lib/include/jxl/decode.h
+++ b/lib/include/jxl/decode.h
@@ -168,16 +168,6 @@ typedef enum {
    */
   JXL_DEC_NEED_PREVIEW_OUT_BUFFER = 3,
 
-  /** The decoder is able to decode a DC image and requests setting a DC output
-   * buffer using @ref JxlDecoderSetDCOutBuffer. This occurs if @ref
-   * JXL_DEC_DC_IMAGE is requested and it is possible to decode a DC image from
-   * the codestream and the DC out buffer was not yet set. This event re-occurs
-   * for new frames if there are multiple animation frames.
-   * @deprecated The DC feature in this form will be removed. For progressive
-   * rendering, @ref JxlDecoderFlushImage should be used.
-   */
-  JXL_DEC_NEED_DC_OUT_BUFFER = 4,
-
   /** The decoder requests an output buffer to store the full resolution image,
    * which can be set with @ref JxlDecoderSetImageOutBuffer or with @ref
    * JxlDecoderSetImageOutCallback. This event re-occurs for new frames if
@@ -261,27 +251,11 @@ typedef enum {
   JXL_DEC_FRAME = 0x400,
 
   /** Informative event by @ref JxlDecoderProcessInput
-   * "JxlDecoderProcessInput": DC image, 8x8 sub-sampled frame, decoded. It is
-   * not guaranteed that the decoder will always return DC separately, but when
-   * it does it will do so before outputting the full frame. @ref
-   * JxlDecoderSetDCOutBuffer must be used after getting the basic image
-   * information to be able to get the DC pixels, if not this return status only
-   * indicates we're past this point in the codestream. This event occurs max
-   * once per frame and always later than @ref JXL_DEC_FRAME and other header
-   * events and earlier than full resolution pixel data.
-   *
-   * @deprecated The DC feature in this form will be removed. For progressive
-   * rendering, @ref JxlDecoderFlushImage should be used.
-   */
-  JXL_DEC_DC_IMAGE = 0x800,
-
-  /** Informative event by @ref JxlDecoderProcessInput
    * "JxlDecoderProcessInput": full frame (or layer, in case coalescing is
    * disabled) is decoded. @ref JxlDecoderSetImageOutBuffer must be used after
    * getting the basic image information to be able to get the image pixels, if
    * not this return status only indicates we're past this point in the
-   * codestream. This event occurs max once per frame and always later than @ref
-   * JXL_DEC_DC_IMAGE.
+   * codestream. This event occurs max once per frame.
    * In this case, @ref JxlDecoderReleaseInput will return all bytes from the
    * end of the frame (or if @ref JXL_DEC_JPEG_RECONSTRUCTION is subscribed to,
    * from the end of the last box that is needed for jpeg reconstruction) as
@@ -599,8 +573,6 @@ JXL_EXPORT JxlDecoderStatus JxlDecoderSetCoalescing(JxlDecoder* dec,
  *     available and this informative event is subscribed to.
  * @return @ref JXL_DEC_PREVIEW_IMAGE when preview pixel information is
  *     available and output in the preview buffer.
- * @return @ref JXL_DEC_DC_IMAGE when DC pixel information (8x8 downscaled
- *     version of the image) is available and output is in the DC buffer.
  * @return @ref JXL_DEC_FULL_IMAGE when all pixel information at highest detail
  *     is available and has been output in the pixel buffer.
  */
@@ -991,44 +963,6 @@ JXL_EXPORT JxlDecoderStatus JxlDecoderGetFrameName(const JxlDecoder* dec,
  */
 JXL_EXPORT JxlDecoderStatus JxlDecoderGetExtraChannelBlendInfo(
     const JxlDecoder* dec, size_t index, JxlBlendInfo* blend_info);
-
-/**
- * Returns the minimum size in bytes of the DC image output buffer
- * for the given format. This is the buffer for @ref JxlDecoderSetDCOutBuffer.
- * Requires the basic image information is available in the decoder.
- *
- * @param dec decoder object
- * @param format format of pixels
- * @param size output value, buffer size in bytes
- * @return @ref JXL_DEC_SUCCESS on success, @ref JXL_DEC_ERROR on error, such as
- *     information not available yet.
- *
- * @deprecated The DC feature in this form will be removed. Use @ref
- *     JxlDecoderFlushImage for progressive rendering.
- */
-JXL_DEPRECATED JXL_EXPORT JxlDecoderStatus JxlDecoderDCOutBufferSize(
-    const JxlDecoder* dec, const JxlPixelFormat* format, size_t* size);
-
-/**
- * Sets the buffer to write the lower resolution (8x8 sub-sampled) DC image
- * to. The size of the buffer must be at least as large as given by @ref
- * JxlDecoderDCOutBufferSize. The buffer follows the format described by
- * JxlPixelFormat. The DC image has dimensions ceil(xsize / 8) * ceil(ysize /
- * 8). The buffer is owned by the caller.
- *
- * @param dec decoder object
- * @param format format of pixels. Object owned by user and its contents are
- *     copied internally.
- * @param buffer buffer type to output the pixel data to
- * @param size size of buffer in bytes
- * @return @ref JXL_DEC_SUCCESS on success, @ref JXL_DEC_ERROR on error, such as
- *     size too small.
- *
- * @deprecated The DC feature in this form will be removed. Use @ref
- *     JxlDecoderFlushImage for progressive rendering.
- */
-JXL_DEPRECATED JXL_EXPORT JxlDecoderStatus JxlDecoderSetDCOutBuffer(
-    JxlDecoder* dec, const JxlPixelFormat* format, void* buffer, size_t size);
 
 /**
  * Returns the minimum size in bytes of the image output pixel buffer for the

--- a/lib/jxl/alpha.cc
+++ b/lib/jxl/alpha.cc
@@ -108,15 +108,4 @@ void UnpremultiplyAlpha(float* JXL_RESTRICT r, float* JXL_RESTRICT g,
   }
 }
 
-void UnpremultiplyAlpha(float* JXL_RESTRICT rgba, size_t num_color,
-                        size_t num_pixels) {
-  size_t num_channels = num_color + 1;
-  for (size_t x = 0, ix = 0; x < num_pixels; ++x, ix += num_channels) {
-    const float multiplier = 1.f / std::max(kSmallAlpha, rgba[ix + num_color]);
-    for (size_t c = 0; c < num_color; ++c) {
-      rgba[ix + c] *= multiplier;
-    }
-  }
-}
-
 }  // namespace jxl

--- a/lib/jxl/alpha.h
+++ b/lib/jxl/alpha.h
@@ -60,8 +60,6 @@ void PremultiplyAlpha(float* JXL_RESTRICT r, float* JXL_RESTRICT g,
 void UnpremultiplyAlpha(float* JXL_RESTRICT r, float* JXL_RESTRICT g,
                         float* JXL_RESTRICT b, const float* JXL_RESTRICT a,
                         size_t num_pixels);
-void UnpremultiplyAlpha(float* JXL_RESTRICT rgba, size_t num_color,
-                        size_t num_pixels);
 
 }  // namespace jxl
 

--- a/lib/jxl/dec_external_image.cc
+++ b/lib/jxl/dec_external_image.cc
@@ -489,17 +489,5 @@ Status ConvertToExternal(const jxl::ImageBundle& ib, size_t bits_per_sample,
       pool, out_image, out_size, out_callback, undo_orientation);
 }
 
-Status ConvertToExternal(const jxl::ImageF& channel, size_t bits_per_sample,
-                         bool float_out, JxlEndianness endianness,
-                         size_t stride, jxl::ThreadPool* pool, void* out_image,
-                         size_t out_size, const PixelCallback& out_callback,
-                         jxl::Orientation undo_orientation) {
-  const ImageF* channels[1];
-  channels[0] = &channel;
-  return ConvertChannelsToExternal(channels, 1, bits_per_sample, float_out,
-                                   endianness, stride, pool, out_image,
-                                   out_size, out_callback, undo_orientation);
-}
-
 }  // namespace jxl
 #endif  // HWY_ONCE

--- a/lib/jxl/dec_external_image.h
+++ b/lib/jxl/dec_external_image.h
@@ -41,16 +41,6 @@ Status ConvertToExternal(const jxl::ImageBundle& ib, size_t bits_per_sample,
                          jxl::Orientation undo_orientation,
                          bool unpremul_alpha = false);
 
-// Converts single-channel image to interleaved void* pixel buffer with the
-// given format, with a single channel.
-// This supports the features needed for the C API to get extra channels.
-// Arguments are similar to the multi-channel function above.
-Status ConvertToExternal(const jxl::ImageF& channel, size_t bits_per_sample,
-                         bool float_out, JxlEndianness endianness,
-                         size_t stride_out, jxl::ThreadPool* thread_pool,
-                         void* out_image, size_t out_size,
-                         const PixelCallback& out_callback,
-                         jxl::Orientation undo_orientation);
 }  // namespace jxl
 
 #endif  // LIB_JXL_DEC_EXTERNAL_IMAGE_H_

--- a/lib/jxl/decode.cc
+++ b/lib/jxl/decode.cc
@@ -175,9 +175,9 @@ enum class DecoderStage : uint32_t {
 };
 
 enum class FrameStage : uint32_t {
-  kHeader,      // Must parse frame header.
-  kTOC,         // Must parse TOC
-  kFull,        // Must parse full pixels
+  kHeader,  // Must parse frame header.
+  kTOC,     // Must parse TOC
+  kFull,    // Must parse full pixels
 };
 
 enum class BoxStage : uint32_t {
@@ -346,9 +346,9 @@ struct JxlDecoderStruct {
   bool last_codestream_seen;
   bool got_codestream_signature;
   bool got_basic_info;
-  bool got_transform_data;            // To skip everything before ICC.
-  bool got_all_headers;               // Codestream metadata headers.
-  bool post_headers;                  // Already decoding pixels.
+  bool got_transform_data;  // To skip everything before ICC.
+  bool got_all_headers;     // Codestream metadata headers.
+  bool post_headers;        // Already decoding pixels.
   jxl::ICCReader icc_reader;
   jxl::JxlDecoderFrameIndexBox frame_index_box;
   // This means either we actually got the preview image, or determined we
@@ -2382,33 +2382,6 @@ JXL_EXPORT JxlDecoderStatus JxlDecoderSetPreviewOutBuffer(
   dec->image_out_size = size;
   dec->image_out_format = *format;
 
-  return JXL_DEC_SUCCESS;
-}
-
-JXL_EXPORT JxlDecoderStatus JxlDecoderDCOutBufferSize(
-    const JxlDecoder* dec, const JxlPixelFormat* format, size_t* size) {
-  size_t bits;
-  JxlDecoderStatus status = PrepareSizeCheck(dec, format, &bits);
-  if (status != JXL_DEC_SUCCESS) return status;
-
-  size_t xsize = jxl::DivCeil(
-      dec->metadata.oriented_xsize(dec->keep_orientation), jxl::kBlockDim);
-  size_t ysize = jxl::DivCeil(
-      dec->metadata.oriented_ysize(dec->keep_orientation), jxl::kBlockDim);
-
-  size_t row_size =
-      jxl::DivCeil(xsize * format->num_channels * bits, jxl::kBitsPerByte);
-  size_t last_row_size = row_size;
-  if (format->align > 1) {
-    row_size = jxl::DivCeil(row_size, format->align) * format->align;
-  }
-  *size = row_size * (ysize - 1) + last_row_size;
-  return JXL_DEC_SUCCESS;
-}
-
-JXL_EXPORT JxlDecoderStatus JxlDecoderSetDCOutBuffer(
-    JxlDecoder* dec, const JxlPixelFormat* format, void* buffer, size_t size) {
-  // No buffer set: this feature is deprecated
   return JXL_DEC_SUCCESS;
 }
 

--- a/lib/jxl/decode_test.cc
+++ b/lib/jxl/decode_test.cc
@@ -2333,8 +2333,8 @@ TEST(DecodeTest, DCNotGettableTest) {
 
   JxlDecoder* dec = JxlDecoderCreate(NULL);
 
-  EXPECT_EQ(JXL_DEC_SUCCESS, JxlDecoderSubscribeEvents(
-                                 dec, JXL_DEC_BASIC_INFO | JXL_DEC_DC_IMAGE));
+  EXPECT_EQ(JXL_DEC_SUCCESS,
+            JxlDecoderSubscribeEvents(dec, JXL_DEC_BASIC_INFO));
   EXPECT_EQ(JXL_DEC_SUCCESS,
             JxlDecoderSetInput(
                 dec, reinterpret_cast<const uint8_t*>(compressed.data()),

--- a/lib/jxl/enc_params.h
+++ b/lib/jxl/enc_params.h
@@ -48,68 +48,6 @@ enum class SpeedTier {
   kLightning = 9
 };
 
-inline bool ParseSpeedTier(const std::string& s, SpeedTier* out) {
-  if (s == "lightning") {
-    *out = SpeedTier::kLightning;
-    return true;
-  } else if (s == "thunder") {
-    *out = SpeedTier::kThunder;
-    return true;
-  } else if (s == "falcon") {
-    *out = SpeedTier::kFalcon;
-    return true;
-  } else if (s == "cheetah") {
-    *out = SpeedTier::kCheetah;
-    return true;
-  } else if (s == "hare") {
-    *out = SpeedTier::kHare;
-    return true;
-  } else if (s == "fast" || s == "wombat") {
-    *out = SpeedTier::kWombat;
-    return true;
-  } else if (s == "squirrel") {
-    *out = SpeedTier::kSquirrel;
-    return true;
-  } else if (s == "kitten") {
-    *out = SpeedTier::kKitten;
-    return true;
-  } else if (s == "guetzli" || s == "tortoise") {
-    *out = SpeedTier::kTortoise;
-    return true;
-  }
-  size_t st = 10 - static_cast<size_t>(strtoull(s.c_str(), nullptr, 0));
-  if (st <= static_cast<size_t>(SpeedTier::kLightning) &&
-      st >= static_cast<size_t>(SpeedTier::kTortoise)) {
-    *out = SpeedTier(st);
-    return true;
-  }
-  return false;
-}
-
-inline const char* SpeedTierName(SpeedTier speed_tier) {
-  switch (speed_tier) {
-    case SpeedTier::kLightning:
-      return "lightning";
-    case SpeedTier::kThunder:
-      return "thunder";
-    case SpeedTier::kFalcon:
-      return "falcon";
-    case SpeedTier::kCheetah:
-      return "cheetah";
-    case SpeedTier::kHare:
-      return "hare";
-    case SpeedTier::kWombat:
-      return "wombat";
-    case SpeedTier::kSquirrel:
-      return "squirrel";
-    case SpeedTier::kKitten:
-      return "kitten";
-    case SpeedTier::kTortoise:
-      return "tortoise";
-  }
-  return "INVALID";
-}
-
 // NOLINTNEXTLINE(clang-analyzer-optin.performance.Padding)
 struct CompressParams {
   float butteraugli_distance = 1.0f;

--- a/lib/jxl/speed_tier_test.cc
+++ b/lib/jxl/speed_tier_test.cc
@@ -35,7 +35,7 @@ struct SpeedTierTestParams {
 std::ostream& operator<<(std::ostream& os, SpeedTierTestParams params) {
   auto previous_flags = os.flags();
   os << std::boolalpha;
-  os << "SpeedTierTestParams{" << SpeedTierName(params.speed_tier)
+  os << "SpeedTierTestParams{" << static_cast<size_t>(params.speed_tier)
      << ", /*shrink8=*/" << params.shrink8 << "}";
   os.flags(previous_flags);
   return os;

--- a/tools/benchmark/benchmark_codec_jxl.cc
+++ b/tools/benchmark/benchmark_codec_jxl.cc
@@ -101,6 +101,44 @@ Status AddCommandLineOptionsJxlCodec(BenchmarkArgs* args) {
 
 Status ValidateArgsJxlCodec(BenchmarkArgs* args) { return true; }
 
+inline bool ParseSpeedTier(const std::string& s, SpeedTier* out) {
+  if (s == "lightning") {
+    *out = SpeedTier::kLightning;
+    return true;
+  } else if (s == "thunder") {
+    *out = SpeedTier::kThunder;
+    return true;
+  } else if (s == "falcon") {
+    *out = SpeedTier::kFalcon;
+    return true;
+  } else if (s == "cheetah") {
+    *out = SpeedTier::kCheetah;
+    return true;
+  } else if (s == "hare") {
+    *out = SpeedTier::kHare;
+    return true;
+  } else if (s == "fast" || s == "wombat") {
+    *out = SpeedTier::kWombat;
+    return true;
+  } else if (s == "squirrel") {
+    *out = SpeedTier::kSquirrel;
+    return true;
+  } else if (s == "kitten") {
+    *out = SpeedTier::kKitten;
+    return true;
+  } else if (s == "guetzli" || s == "tortoise") {
+    *out = SpeedTier::kTortoise;
+    return true;
+  }
+  size_t st = 10 - static_cast<size_t>(strtoull(s.c_str(), nullptr, 0));
+  if (st <= static_cast<size_t>(SpeedTier::kLightning) &&
+      st >= static_cast<size_t>(SpeedTier::kTortoise)) {
+    *out = SpeedTier(st);
+    return true;
+  }
+  return false;
+}
+
 class JxlCodec : public ImageCodec {
  public:
   explicit JxlCodec(const BenchmarkArgs& args) : ImageCodec(args) {}


### PR DESCRIPTION
Remove the deprecated DCOutBuffer stuff from the decode API — this was deprecated a long time ago and didn't work anymore anyway, so no need to keep it in.

Also remove some code that is no longer used. Move the speed tier name parsing to benchmark_xl (which is the only thing that still uses that). The function to convert speed settings to animal name strings was only used to produce pretty names for the tests in `speed_tier_test.cc`, so removing that too. Some overloads of `UnpremultiplyAlpha` and `ConvertToExternal` are not used by anything anymore, so removing them too.