### PR TITLE
fix hshift/vshift of metachannels

### DIFF
--- a/lib/jxl/modular/transform/enc_palette.cc
+++ b/lib/jxl/modular/transform/enc_palette.cc
@@ -196,6 +196,7 @@ Status FwdPaletteIteration(Image &input, uint32_t begin_c, uint32_t end_c,
       JXL_DEBUG_V(6, "Channel %i uses only %i colors.", begin_c, idx);
       Channel pch(idx, 1);
       pch.hshift = -1;
+      pch.vshift = -1;
       nb_colors = idx;
       idx = 0;
       pixel_type *JXL_RESTRICT p_palette = pch.Row(0);
@@ -232,6 +233,7 @@ Status FwdPaletteIteration(Image &input, uint32_t begin_c, uint32_t end_c,
     JXL_DEBUG_V(6, "Channel %i uses only %i colors.", begin_c, idx);
     Channel pch(idx, 1);
     pch.hshift = -1;
+    pch.vshift = -1;
     nb_colors = idx;
     idx = 0;
     pixel_type *JXL_RESTRICT p_palette = pch.Row(0);
@@ -337,6 +339,7 @@ Status FwdPaletteIteration(Image &input, uint32_t begin_c, uint32_t end_c,
 
   Channel pch(nb_colors, nb);
   pch.hshift = -1;
+  pch.vshift = -1;
   pixel_type *JXL_RESTRICT p_palette = pch.Row(0);
   intptr_t onerow = pch.plane.PixelsPerRow();
   intptr_t onerow_image = input.channel[begin_c].plane.PixelsPerRow();

--- a/lib/jxl/modular/transform/palette.h
+++ b/lib/jxl/modular/transform/palette.h
@@ -278,6 +278,7 @@ static Status MetaPalette(Image &input, uint32_t begin_c, uint32_t end_c,
                       input.channel.begin() + end_c + 1);
   Channel pch(nb_colors + nb_deltas, nb);
   pch.hshift = -1;
+  pch.vshift = -1;
   input.channel.insert(input.channel.begin(), std::move(pch));
   return true;
 }

--- a/lib/jxl/modular/transform/squeeze.cc
+++ b/lib/jxl/modular/transform/squeeze.cc
@@ -449,13 +449,14 @@ Status MetaSqueeze(Image &image, std::vector<SqueezeParams> *parameters) {
       }
       size_t w = image.channel[c].w;
       size_t h = image.channel[c].h;
+      if (w == 0 || h == 0) return JXL_FAILURE("Squeezing empty channel");
       if (horizontal) {
         image.channel[c].w = (w + 1) / 2;
-        image.channel[c].hshift++;
+        if (image.channel[c].hshift >= 0) image.channel[c].hshift++;
         w = w - (w + 1) / 2;
       } else {
         image.channel[c].h = (h + 1) / 2;
-        image.channel[c].vshift++;
+        if (image.channel[c].vshift >= 0) image.channel[c].vshift++;
         h = h - (h + 1) / 2;
       }
       image.channel[c].shrink();


### PR DESCRIPTION
Metachannels (i.e. channels representing palettes) have `hshift == -1`, but theoretically Squeeze can be applied on them which would make them have `hshift == 0`. This currently never happens because no jxl encoder does that, but it could cause somewhat weird/unexpected things to happen in very contrived cases.

This change makes Squeeze only increment the values of hshift/vshift if they are not -1.
It also makes Squeeze return error when trying to apply it to an empty channel — this is needed to prevent malicious bitstreams from doing an unbounded number of Squeeze steps (this was prevented before by hshift/vshift eventually getting too large, but now we can no longer count on that).
Also it makes Palette set `vshift = -1` (previously both spec and code didn't really define what the vshift of palette metachannels was).

This is technically a spec change, though it does not affect any existing bitstream and even in non-existing bitstreams it would take a very contrived example to cause it to make any difference: something like an image that has dimensions 1000x3, which uses a 3-channel palette with 2000 colors, where one horizontal Squeeze step gets applied, causing the palette to be encoded as two 1000x3 metachannels, which would (without this change) have `hshift == 0`, which would then mean the channel is not skipped when computing the extra properties of the MA tree since it happens to have the same dimensions and hshift/vshift as the non-meta channel. With this change, the hshift/vshift of the palette channel would remain at -1 and it would be skipped when computing the extra properties of the non-meta channel.
I cannot really imagine any useful examples where it would make an actual difference.