### PR TITLE
jpegli: implement jpeg_consume_input()

### DIFF
--- a/lib/jpegli/decode_internal.h
+++ b/lib/jpegli/decode_internal.h
@@ -73,15 +73,6 @@ constexpr uint32_t kJPEGNaturalOrder[80] = {
 // Use this forward-declared libjpeg struct to hold all our private variables.
 // TODO(szabadka) Remove variables that have a corresponding version in cinfo.
 struct jpeg_decomp_master {
-  enum class State {
-    kStart,
-    kProcessMarkers,
-    kScan,
-    kRender,
-    kEnd,
-  };
-  State state_ = State::kStart;
-
   //
   // Input handling state.
   //
@@ -119,6 +110,7 @@ struct jpeg_decomp_master {
   //
   size_t scan_mcu_row_;
   size_t scan_mcu_col_;
+  size_t mcu_rows_per_iMCU_row_;
   jpegli::coeff_t last_dc_coeff_[jpegli::kMaxComponents];
   int eobrun_;
   int restarts_to_go_;

--- a/lib/jpegli/decode_marker.h
+++ b/lib/jpegli/decode_marker.h
@@ -14,11 +14,17 @@
 
 namespace jpegli {
 
-// Returns true if [data, data + len) contains a valid marker segment (it does
-// not need to be at the start of data), and sets *pos to the offset of the end
-// of the marker segment and fills in the relevant parts of cinfo.
-bool ProcessMarker(j_decompress_ptr cinfo, const uint8_t* data, size_t len,
-                   size_t* pos);
+// Reads the available input in the source manager's input buffer until either
+// the end of the next SOS marker or the end of the input.
+// The corresponding fields of cinfo are updated with the processed input data.
+// Upon return, the input buffer will be at the start or at the end of a marker
+// data segment (inter-marker data is allowed).
+// Return value is one of:
+//   * JPEG_SUSPENDED, if the current input buffer ends before the next SOS or
+//       EOI marker. Input buffer refill is handled by the caller;
+//   * JPEG_REACHED_SOS, if the the next SOS marker is found;
+//   * JPEG_REACHED_EOR, if the end of the input is found.
+int ProcessMarkers(j_decompress_ptr cinfo);
 
 }  // namespace jpegli
 

--- a/lib/jpegli/decode_scan.h
+++ b/lib/jpegli/decode_scan.h
@@ -14,10 +14,16 @@
 
 namespace jpegli {
 
-// Returns true if [data, data + len) contains a valid entropy coded scan, and
-// sets *pos to the offset of the end of the scan data.
-bool ProcessScan(j_decompress_ptr cinfo, const uint8_t* data, size_t len,
-                 size_t* pos);
+// Reads the available input in the source manager's input buffer until the end
+// of the next iMCU row.
+// The corresponding fields of cinfo are updated with the processed input data.
+// Upon return, the input buffer will be at the start of an MCU, or at the end
+// of the scan.
+// Return value is one of:
+//   * JPEG_SUSPENDED, if the input buffer ends before the end of an iMCU row;
+//   * JPEG_ROW_COMPLETED, if the next iMCU row (but not the scan) is reached;
+//   * JPEG_SCAN_COMPLETED, if the end of the scan is reached.
+int ProcessScan(j_decompress_ptr cinfo);
 
 }  // namespace jpegli
 

--- a/lib/jpegli/render.cc
+++ b/lib/jpegli/render.cc
@@ -141,8 +141,6 @@ HWY_AFTER_NAMESPACE();
 
 #if HWY_ONCE
 
-typedef jpeg_decomp_master::State State;
-
 namespace jpegli {
 
 HWY_EXPORT(GatherBlockStats);
@@ -318,11 +316,8 @@ void ProcessOutput(j_decompress_ptr cinfo, size_t* num_output_rows,
         ++(*num_output_rows);
         ++m->MCU_buf_current_row_;
       }
-      if (cinfo->output_scanline == cinfo->output_height) {
-        m->state_ = m->is_multiscan_ ? State::kEnd : State::kProcessMarkers;
-        return;
-      }
-      if (*num_output_rows == max_output_rows) {
+      if (cinfo->output_scanline == cinfo->output_height ||
+          *num_output_rows == max_output_rows) {
         return;
       }
       m->MCU_buf_ready_rows_ = 0;
@@ -405,9 +400,6 @@ void ProcessOutput(j_decompress_ptr cinfo, size_t* num_output_rows,
   }
   ++cinfo->output_iMCU_row;
   m->output_ci_ = 0;
-  if (!m->is_multiscan_ && cinfo->output_iMCU_row < cinfo->total_iMCU_rows) {
-    m->state_ = State::kScan;
-  }
   JXL_DASSERT(cinfo->output_iMCU_row <= cinfo->total_iMCU_rows);
 }
 


### PR DESCRIPTION
Added tests for suspending source manager use-case, and tests for consuming input ahead of the output processing.