### PR TITLE
jpegli: implement decoding to cropped output.

### DIFF
--- a/lib/jpegli/decode_api_test.cc
+++ b/lib/jpegli/decode_api_test.cc
@@ -135,6 +135,7 @@ struct TestConfig {
   SourceManagerType source_mgr = SOURCE_MGR_CHUNKED;
   bool pre_consume_input = false;
   bool buffered_image_mode = false;
+  bool crop = false;
 };
 
 bool LoadNextChunk(const TestConfig& config, j_decompress_ptr cinfo) {
@@ -234,6 +235,27 @@ TEST_P(DecodeAPITestParam, TestAPI) {
   EXPECT_EQ(ysize, cinfo.output_height);
   EXPECT_EQ(num_channels, cinfo.out_color_components);
 
+  JDIMENSION xoffset = 0;
+  JDIMENSION yoffset = 0;
+  JDIMENSION xsize_cropped = xsize;
+  JDIMENSION ysize_cropped = ysize;
+  if (config.crop) {
+    xoffset = xsize_cropped = xsize / 3;
+    yoffset = ysize_cropped = ysize / 3;
+    jpeg_crop_scanline(&cinfo, &xoffset, &xsize_cropped);
+  }
+
+  std::vector<uint8_t> cropped(xsize_cropped * ysize_cropped * num_channels);
+  for (size_t y = 0; y < ysize_cropped; ++y) {
+    for (size_t x = 0; x < xsize_cropped; ++x) {
+      size_t crop_ix = y * xsize_cropped + x;
+      size_t orig_ix = (yoffset + y) * xsize + xoffset + x;
+      for (size_t c = 0; c < num_channels; ++c) {
+        cropped[crop_ix * num_channels + c] = orig[orig_ix * num_channels + c];
+      }
+    }
+  }
+
   size_t bytes_per_sample = config.output_bit_depth <= 8 ? 1 : 2;
   size_t stride = cinfo.output_width * cinfo.num_components * bytes_per_sample;
   size_t max_output_lines = config.max_output_lines;
@@ -255,34 +277,47 @@ TEST_P(DecodeAPITestParam, TestAPI) {
       EXPECT_TRUE(jpeg_start_output(&cinfo, cinfo.input_scan_number));
     }
 
-    std::vector<uint8_t> output(cinfo.output_height * stride);
+    std::vector<uint8_t> output(ysize_cropped * stride);
     size_t total_output_lines = 0;
     for (;;) {
-      std::vector<JSAMPROW> scanlines(max_output_lines);
-      for (size_t i = 0; i < max_output_lines; ++i) {
-        scanlines[i] = &output[(cinfo.output_scanline + i) * stride];
+      size_t num_output_lines;
+      size_t max_lines;
+      if (cinfo.output_scanline < yoffset) {
+        max_lines = yoffset - cinfo.output_scanline;
+        num_output_lines = jpeg_skip_scanlines(&cinfo, max_lines);
+      } else if (cinfo.output_scanline >= yoffset + ysize_cropped) {
+        max_lines = cinfo.output_height - cinfo.output_scanline;
+        num_output_lines = jpeg_skip_scanlines(&cinfo, max_lines);
+      } else {
+        size_t lines_left = yoffset + ysize_cropped - cinfo.output_scanline;
+        max_lines = std::min<size_t>(max_output_lines, lines_left);
+        std::vector<JSAMPROW> scanlines(max_lines);
+        for (size_t i = 0; i < max_lines; ++i) {
+          size_t yidx = cinfo.output_scanline - yoffset + i;
+          scanlines[i] = &output[yidx * stride];
+        }
+        num_output_lines =
+            jpeg_read_scanlines(&cinfo, &scanlines[0], max_lines);
       }
-      size_t num_output_lines =
-          jpeg_read_scanlines(&cinfo, &scanlines[0], max_output_lines);
       total_output_lines += num_output_lines;
       EXPECT_EQ(total_output_lines, cinfo.output_scanline);
       if (cinfo.output_scanline >= cinfo.output_height) {
         break;
       }
       if (config.pre_consume_input) {
-        EXPECT_EQ(num_output_lines, max_output_lines);
-      } else if (num_output_lines < max_output_lines) {
+        EXPECT_EQ(num_output_lines, max_lines);
+      } else if (num_output_lines < max_lines) {
         ASSERT_TRUE(LoadNextChunk(config, &cinfo));
       }
     }
     EXPECT_EQ(cinfo.input_iMCU_row, cinfo.total_iMCU_rows);
 
-    ASSERT_EQ(output.size(), orig.size() * bytes_per_sample);
+    ASSERT_EQ(output.size(), cropped.size() * bytes_per_sample);
     const double mul_orig = 1.0 / 255.0;
     const double mul_output = 1.0 / ((1u << config.output_bit_depth) - 1);
     double diff2 = 0.0;
-    for (size_t i = 0; i < orig.size(); ++i) {
-      double sample_orig = orig[i] * mul_orig;
+    for (size_t i = 0; i < cropped.size(); ++i) {
+      double sample_orig = cropped[i] * mul_orig;
       double sample_output;
       if (bytes_per_sample == 1) {
         sample_output = output[i];
@@ -293,7 +328,7 @@ TEST_P(DecodeAPITestParam, TestAPI) {
       double diff = sample_orig - sample_output;
       diff2 += diff * diff;
     }
-    double rms = std::sqrt(diff2 / orig.size()) / mul_orig;
+    double rms = std::sqrt(diff2 / cropped.size()) / mul_orig;
     double max_dist = config.max_distance;
     if (!cinfo.buffered_image || jpeg_input_complete(&cinfo)) {
       // TODO(szabadka) Have expectations for the progression steps as well.
@@ -371,19 +406,22 @@ std::vector<TestConfig> GenerateTests() {
       for (size_t max_output_lines : {0, 16}) {
         for (bool pre_consume : {false, true}) {
           for (bool buffered : {false, true}) {
-            TestConfig config;
-            config.origfn = "jxl/flower/flower.pnm";
-            config.fn = "jxl/flower/flower.png.im_q85_420_progr.jpg";
-            config.fn_desc = "Q85YUV420PROGR";
-            config.max_distance = 3.5;
-            config.chunk_size = chunk_size;
-            config.max_output_lines = max_output_lines;
-            config.pre_consume_input = pre_consume;
-            config.buffered_image_mode = buffered;
-            all_tests.push_back(config);
-            if (config.chunk_size != 0) {
-              config.source_mgr = SOURCE_MGR_SUSPENDING;
+            for (bool crop : {false, true}) {
+              TestConfig config;
+              config.origfn = "jxl/flower/flower.pnm";
+              config.fn = "jxl/flower/flower.png.im_q85_420_progr.jpg";
+              config.fn_desc = "Q85YUV420PROGR";
+              config.max_distance = 3.5;
+              config.chunk_size = chunk_size;
+              config.max_output_lines = max_output_lines;
+              config.pre_consume_input = pre_consume;
+              config.buffered_image_mode = buffered;
+              config.crop = crop;
               all_tests.push_back(config);
+              if (config.chunk_size != 0) {
+                config.source_mgr = SOURCE_MGR_SUSPENDING;
+                all_tests.push_back(config);
+              }
             }
           }
         }
@@ -478,6 +516,9 @@ std::ostream& operator<<(std::ostream& os, const TestConfig& c) {
   }
   if (c.buffered_image_mode) {
     os << "Buffered";
+  }
+  if (c.crop) {
+    os << "Crop";
   }
   os << "BitDepth" << c.output_bit_depth;
   return os;

--- a/lib/jpegli/decode_internal.h
+++ b/lib/jpegli/decode_internal.h
@@ -122,7 +122,7 @@ struct jpeg_decomp_master {
   // Rendering state.
   //
   size_t output_bit_depth_ = 8;
-  size_t output_stride_;
+  size_t xoffset_ = 0;
 
   JSAMPARRAY scanlines_;
   JDIMENSION max_lines_;


### PR DESCRIPTION
The implementation is not yet optimal, it just calls jpeg_read_scanlines and discards the output that is not needed.