### PR TITLE
Build release package for Ubuntu 22.04

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -97,6 +97,7 @@ jobs:
       fail-fast: false
       matrix:
         os:
+        - ubuntu:22.04
         - ubuntu:20.04
         - ubuntu:18.04
         - debian:buster

--- a/AUTHORS
+++ b/AUTHORS
@@ -24,6 +24,7 @@ Aous Naman <aous@unsw.edu.au>
 Artem Selishchev
 Biswapriyo Nath <nathbappai@gmail.com>
 CanadianBaconBoi <beamconnor@gmail.com>
+Damiano Albani <damiano.albani@gmail.com>
 Daniel Novomeský <dnovomesky@gmail.com>
 David Burnett <vargolsoft@gmail.com>
 Dirk Lemstra <dirk@lemstra.org>


### PR DESCRIPTION
This PR adds Ubuntu 22.04 to the existing list of Ubuntu 18.04 and 20.04 for which a package is generated for releases.