### PR TITLE
jpegli: Add rest of the decoder API functions.

### DIFF
--- a/lib/jpegli.cmake
+++ b/lib/jpegli.cmake
@@ -15,6 +15,7 @@ set(JPEGLI_LIBRARY_SOVERSION "${JPEGLI_MAJOR_VERSION}")
 set(JPEGLI_INTERNAL_SOURCES
   jpegli/color_transform.h
   jpegli/color_transform.cc
+  jpegli/common_api.cc
   jpegli/decode_api.cc
   jpegli/decode_internal.h
   jpegli/decode_marker.h

--- a/lib/jpegli/common_api.cc
+++ b/lib/jpegli/common_api.cc
@@ -1,0 +1,56 @@
+// Copyright (c) the JPEG XL Project Authors. All rights reserved.
+//
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+/* clang-format off */
+#include <stdint.h>
+#include <stdio.h>
+#include <jpeglib.h>
+#include <stdlib.h>
+/* clang-format on */
+
+#include "lib/jpegli/decode_internal.h"
+#include "lib/jpegli/memory_manager.h"
+
+void jpeg_abort(j_common_ptr cinfo) {
+  auto mem = reinterpret_cast<jpegli::MemoryManager*>(cinfo->mem);
+  if (mem == nullptr) {
+    return;
+  }
+  for (void* ptr : mem->owned_ptrs) {
+    free(ptr);
+  }
+  mem->owned_ptrs.clear();
+  if (cinfo->is_decompressor) {
+    cinfo->global_state = jpegli::DecodeState::kStart;
+  }
+}
+
+void jpeg_destroy(j_common_ptr cinfo) {
+  auto mem = reinterpret_cast<jpegli::MemoryManager*>(cinfo->mem);
+  if (mem == nullptr) {
+    return;
+  }
+  for (void* ptr : mem->owned_ptrs) {
+    free(ptr);
+  }
+  delete mem;
+  cinfo->mem = nullptr;
+  if (cinfo->is_decompressor) {
+    cinfo->global_state = jpegli::DecodeState::kNull;
+    delete reinterpret_cast<j_decompress_ptr>(cinfo)->master;
+  }
+}
+
+JQUANT_TBL* jpeg_alloc_quant_table(j_common_ptr cinfo) {
+  JQUANT_TBL* table = jpegli::Allocate<JQUANT_TBL>(cinfo, 1);
+  table->sent_table = FALSE;
+  return table;
+}
+
+JHUFF_TBL* jpeg_alloc_huff_table(j_common_ptr cinfo) {
+  JHUFF_TBL* table = jpegli::Allocate<JHUFF_TBL>(cinfo, 1);
+  table->sent_table = FALSE;
+  return table;
+}

--- a/lib/jpegli/decode_internal.h
+++ b/lib/jpegli/decode_internal.h
@@ -27,6 +27,15 @@ constexpr int kJpegDCAlphabetSize = 12;
 
 typedef int16_t coeff_t;
 
+enum DecodeState {
+  kNull,
+  kStart,
+  kInHeader,
+  kHeaderDone,
+  kProcessMarkers,
+  kProcessScan,
+};
+
 // Represents one component of a jpeg file.
 struct JPEGComponent {
   // The DCT coefficients of this component, laid out block-by-block, divided
@@ -114,6 +123,8 @@ struct jpeg_decomp_master {
   std::vector<jpegli::HuffmanTableEntry> ac_huff_lut_;
   uint8_t huff_slot_defined_[256] = {};
   std::set<int> markers_to_save_;
+  jpeg_marker_parser_method app_marker_parsers[16];
+  jpeg_marker_parser_method com_marker_parser;
   // Whether this jpeg has multiple scans (progressive or non-interleaved
   // sequential).
   bool is_multiscan_;

--- a/lib/jpegli/decode_marker.cc
+++ b/lib/jpegli/decode_marker.cc
@@ -431,6 +431,10 @@ void ProcessAPP(j_decompress_ptr cinfo, const uint8_t* data, size_t len) {
   const uint8_t marker = data[1];
   const uint8_t* payload = data + 4;
   size_t payload_size = len - 4;
+  if (m->app_marker_parsers[marker - 0xe0] != nullptr) {
+    (*m->app_marker_parsers[marker - 0xe0])(cinfo);
+    return;
+  }
   if (marker == 0xE0) {
     if (payload_size >= 14 && memcmp(payload, "JFIF", 4) == 0) {
       cinfo->saw_JFIF_marker = TRUE;
@@ -477,7 +481,10 @@ void ProcessAPP(j_decompress_ptr cinfo, const uint8_t* data, size_t len) {
 }
 
 void ProcessCOM(j_decompress_ptr cinfo, const uint8_t* data, size_t len) {
-  // Nothing to do.
+  jpeg_decomp_master* m = cinfo->master;
+  if (m->com_marker_parser != nullptr) {
+    (*m->com_marker_parser)(cinfo);
+  }
 }
 
 void ProcessSOI(j_decompress_ptr cinfo, const uint8_t* data, size_t len) {

--- a/lib/jpegli/decode_scan.cc
+++ b/lib/jpegli/decode_scan.cc
@@ -405,6 +405,7 @@ int ProcessScan(j_decompress_ptr cinfo) {
       if (marker != expected_marker) {
         JPEGLI_ERROR("Did not find expected restart marker %d actual %d",
                      expected_marker, marker);
+        // TODO(szabadka) Use source manager's resync_to_restart callback here.
       }
       m->next_restart_marker_ += 1;
       m->next_restart_marker_ &= 0x7;

--- a/lib/jpegli/memory_manager.h
+++ b/lib/jpegli/memory_manager.h
@@ -22,11 +22,16 @@ struct MemoryManager {
 };
 
 template <typename T>
-T* Allocate(j_decompress_ptr cinfo, size_t len) {
+T* Allocate(j_common_ptr cinfo, size_t len) {
   T* p = reinterpret_cast<T*>(malloc(len * sizeof(T)));
   auto mem = reinterpret_cast<jpegli::MemoryManager*>(cinfo->mem);
   mem->owned_ptrs.push_back(p);
   return p;
+}
+
+template <typename T>
+T* Allocate(j_decompress_ptr cinfo, size_t len) {
+  return Allocate<T>(reinterpret_cast<j_common_ptr>(cinfo), len);
 }
 
 }  // namespace jpegli

--- a/lib/jpegli/source_manager.cc
+++ b/lib/jpegli/source_manager.cc
@@ -5,6 +5,7 @@
 
 #include "lib/jpegli/source_manager.h"
 
+#include "lib/jpegli/error.h"
 #include "lib/jpegli/memory_manager.h"
 
 namespace jpegli {
@@ -12,8 +13,6 @@ namespace jpegli {
 void init_source(j_decompress_ptr cinfo) {}
 
 void skip_input_data(j_decompress_ptr cinfo, long num_bytes) {}
-
-boolean resync_to_restart(j_decompress_ptr cinfo, int desired) { return FALSE; }
 
 void term_source(j_decompress_ptr cinfo) {}
 
@@ -24,16 +23,56 @@ boolean EmitFakeEoiMarker(j_decompress_ptr cinfo) {
   return TRUE;
 }
 
+constexpr size_t kStdioBufferSize = 64 << 10;
+
+struct StdioSourceManager {
+  jpeg_source_mgr pub;
+  FILE* f;
+  uint8_t* buffer;
+
+  static boolean fill_input_buffer(j_decompress_ptr cinfo) {
+    auto src = reinterpret_cast<StdioSourceManager*>(cinfo->src);
+    size_t num_bytes_read = fread(src->buffer, 1, kStdioBufferSize, src->f);
+    if (num_bytes_read == 0) {
+      return EmitFakeEoiMarker(cinfo);
+    }
+    src->pub.next_input_byte = src->buffer;
+    src->pub.bytes_in_buffer = num_bytes_read;
+    return TRUE;
+  }
+};
+
 }  // namespace jpegli
 
 void jpeg_mem_src(j_decompress_ptr cinfo, const unsigned char* inbuffer,
                   unsigned long insize) {
+  if (cinfo->src != nullptr) {
+    JPEGLI_ERROR("jpeg_mem_src: source manager is already set");
+  }
   cinfo->src = jpegli::Allocate<jpeg_source_mgr>(cinfo, 1);
   cinfo->src->next_input_byte = inbuffer;
   cinfo->src->bytes_in_buffer = insize;
   cinfo->src->init_source = jpegli::init_source;
   cinfo->src->fill_input_buffer = jpegli::EmitFakeEoiMarker;
   cinfo->src->skip_input_data = jpegli::skip_input_data;
-  cinfo->src->resync_to_restart = jpegli::resync_to_restart;
+  cinfo->src->resync_to_restart = jpeg_resync_to_restart;
   cinfo->src->term_source = jpegli::term_source;
+}
+
+void jpeg_stdio_src(j_decompress_ptr cinfo, FILE* infile) {
+  if (cinfo->src != nullptr) {
+    JPEGLI_ERROR("jpeg_stdio_src: source manager is already set");
+  }
+  jpegli::StdioSourceManager* src =
+      jpegli::Allocate<jpegli::StdioSourceManager>(cinfo, 1);
+  src->f = infile;
+  src->buffer = jpegli::Allocate<uint8_t>(cinfo, jpegli::kStdioBufferSize);
+  src->pub.next_input_byte = src->buffer;
+  src->pub.bytes_in_buffer = 0;
+  src->pub.init_source = jpegli::init_source;
+  src->pub.fill_input_buffer = jpegli::StdioSourceManager::fill_input_buffer;
+  src->pub.skip_input_data = jpegli::skip_input_data;
+  src->pub.resync_to_restart = jpeg_resync_to_restart;
+  src->pub.term_source = jpegli::term_source;
+  cinfo->src = reinterpret_cast<jpeg_source_mgr*>(src);
 }


### PR DESCRIPTION
  * implemented jpeg_abort(), jpeg_destroy()
  * implemented jpeg_alloc_quant_table(), jpeg_alloc_huff_table()
  * implemented jpeg_set_marker_processor()
  * implemented jpeg_stdio_src()
  * added jpeg_resync_to_restart() that throws an error
  * added dummy jpeg_new_colormap()
  * added dummy jpeg_read_coefficients()