### PR TITLE
Fix support for reading/writing from/to stdin/stdout in cjxl

### DIFF
--- a/tools/cjxl_main.cc
+++ b/tools/cjxl_main.cc
@@ -37,6 +37,7 @@
 #include "lib/extras/dec/pnm.h"
 #include "lib/extras/enc/jxl.h"
 #include "lib/extras/time.h"
+#include "lib/jxl/base/file_io.h"
 #include "lib/jxl/base/override.h"
 #include "lib/jxl/base/printf_macros.h"
 #include "lib/jxl/base/status.h"
@@ -45,7 +46,6 @@
 #include "tools/args.h"
 #include "tools/cmdline.h"
 #include "tools/codec_config.h"
-#include "tools/file_io.h"
 #include "tools/speed_stats.h"
 
 namespace jpegxl {
@@ -942,7 +942,7 @@ int main(int argc, char** argv) {
   jxl::extras::Codec codec = jxl::extras::Codec::kUnknown;
   double decode_mps = 0;
   size_t pixels = 0;
-  if (!jpegxl::tools::ReadFile(args.file_in, &image_data)) {
+  if (!jxl::ReadFile(args.file_in, &image_data)) {
     std::cerr << "Reading image data failed." << std::endl;
     exit(EXIT_FAILURE);
   }
@@ -1015,7 +1015,7 @@ int main(int argc, char** argv) {
   }
 
   if (args.file_out && !args.disable_output) {
-    if (!jpegxl::tools::WriteFile(args.file_out, compressed)) {
+    if (!jxl::WriteFile(compressed, args.file_out)) {
       std::cerr << "Could not write jxl file." << std::endl;
       return EXIT_FAILURE;
     }


### PR DESCRIPTION
There has been work in the past to support reading/writing from/to stdin/stdout for the various programs in libjxl.  
In particular:
- https://github.com/libjxl/libjxl/pull/554
- https://github.com/libjxl/libjxl/pull/594

It's not clear to me what happened, but if I try with libjxl v0.7.0:
```
$ cat file.jpg | cjxl - - > out.jxl               
JPEG XL encoder v0.7.0 0.7.0 [AVX2,SSE4,SSSE3]
Reading image data failed.
```

Whereas it now behaves as such with this PR:
```
$ cat file.jpg | ../build/tools/cjxl - - > out.jxl
JPEG XL encoder v0.8.0 995d56f5 [AVX2,SSE4,SSSE3]
Note: Implicit-default for JPEG is lossless-transcoding. To silence this message, set --lossless_jpeg=(1|0).
Read JPEG image with 65275 bytes.
Encoding [Container | JPEG, lossless transcode, effort: 7 | JPEG reconstruction data], 
Compressed to 41397 bytes including container
```

I tried applying the same fix for `djxl`  as well, but I didn't know how to solve the issue related to the choice of encoder using the extension:
```
$ cat file.jxl | ../build/tools/djxl - - > file.jpg                       
JPEG XL decoder v0.8.0 995d56f5 [AVX2,SSE4,SSSE3]
Read 41397 compressed bytes.
can't decode to the file extension ''
```

I suppose other programs shipped with libjxl would need the same treatment, as in to rely on `ReadFile` and `WriteFile` from `lib/jxl/base/file_io.h`, instead of the functions in `tools/file_io.{c,h}` (why, by the way??). Or, worse, direct use of `fopen()` in `jxlinfo` for example.

But for now, given that I'm not familiar with the code base, here's my first proposal to at least fix `cjxl` 😄 