### PR TITLE
Add CICP to no-png

### DIFF
--- a/lib/jxl_tests.cmake
+++ b/lib/jxl_tests.cmake
@@ -108,7 +108,7 @@ foreach (TESTFILE IN LISTS TEST_FILES)
     set_target_properties(${TESTNAME} PROPERTIES LINK_FLAGS "\
       -O1 \
       -s USE_LIBPNG=1 \
-      -s INITIAL_MEMORY=1536MB \
+      -s ALLOW_MEMORY_GROWTH=1 \
       -s SINGLE_FILE=1 \
       -s PROXY_TO_PTHREAD \
       -s EXIT_RUNTIME=1 \

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -287,7 +287,13 @@ list(APPEND TOOL_BINARIES ${INTERNAL_TOOL_BINARIES})
 
 foreach(BINARY IN LISTS TOOL_BINARIES)
   if(JPEGXL_EMSCRIPTEN)
-    set_target_properties(${BINARY} PROPERTIES LINK_FLAGS "-s USE_LIBPNG=1")
+    set(JXL_WASM_TOOLS_LINK_FLAGS "\
+      -s USE_LIBPNG=1 \
+      -s ALLOW_MEMORY_GROWTH=1 \
+      -s USE_PTHREADS=1 \
+      -s PTHREAD_POOL_SIZE=16 \
+    ")
+    set_target_properties(${BINARY} PROPERTIES LINK_FLAGS "${JXL_WASM_TOOLS_LINK_FLAGS}")
   endif()
 endforeach()
 

--- a/tools/wasm_demo/index.html
+++ b/tools/wasm_demo/index.html
@@ -318,7 +318,8 @@ document.addEventListener('DOMContentLoaded', onDomContentLoaded);
 </script>
 
 <img src="w.jpg?tmp=1" style="width:100%"/>
-<img src="w.jpg?tmp=2" style="width:100%"/>
+<img src="image00.jpg?tmp=2" style="width:100%"/>
+<img src="image01.png?tmp=3" style="width:100%"/>
 
 <!--script type="text/javascript" src="jxl_decoder.js"></script-->
 </body>

--- a/tools/wasm_demo/jxl_decoder_test.js
+++ b/tools/wasm_demo/jxl_decoder_test.js
@@ -125,8 +125,9 @@ function testDecompress() {
   jxlModule._free(buffer);
 
   let pngSize = jxlModule.HEAP32[output >> 2];
-  assertTrue(pngSize >= 400, 'png size');
-  assertTrue(pngSize <= 600, 'png size');
+  let px = 20 * 20;
+  assertTrue(pngSize >= 6 * px, 'png size');
+  assertTrue(pngSize <= 6 * px + 800, 'png size');
 
   jxlModule._jxlCleanup(output);
 }

--- a/tools/wasm_demo/no_png.h
+++ b/tools/wasm_demo/no_png.h
@@ -16,6 +16,7 @@ extern "C" {
 uint8_t* WrapPixelsToPng(size_t width, size_t height, size_t bit_depth,
                          bool has_alpha, const uint8_t* input,
                          const std::vector<uint8_t>& icc,
+                         const std::vector<uint8_t>& cicp,
                          uint32_t* output_size);
 
 }  // extern "C"


### PR DESCRIPTION
Drive-by:
 * fix WASM test
 * do not preallocate memory (1.5GiB) in tests
 * allow memory growth in WASM-compiled tools