### PR TITLE
Less red-green blurring/ringing

### DIFF
--- a/lib/jxl/enc_ac_strategy.cc
+++ b/lib/jxl/enc_ac_strategy.cc
@@ -355,6 +355,9 @@ float EstimateEntropy(const AcStrategy& acs, size_t x, size_t y,
   HWY_FULL(float) df;
 
   const size_t num_blocks = acs.covered_blocks_x() * acs.covered_blocks_y();
+  // avoid large blocks when there is a lot going on in red-green.
+  float cmul[3] = {
+    std::min<float>(2, std::max<float>(1, num_blocks - 1)), 1.0f, 1.0f };
   float quant_norm8 = 0;
   float masking = 0;
   if (num_blocks == 1) {
@@ -437,7 +440,7 @@ float EstimateEntropy(const AcStrategy& acs, size_t x, size_t y,
     }
     entropy_v = MulAdd(nzeros_v, cost1, entropy_v);
 
-    entropy += GetLane(SumOfLanes(df, entropy_v));
+    entropy += cmul[c] * GetLane(SumOfLanes(df, entropy_v));
     size_t num_nzeros = GetLane(SumOfLanes(df, nzeros_v));
     // Add #bit of num_nonzeros, as an estimate of the cost for encoding the
     // number of non-zeros of the block.

--- a/lib/jxl/enc_ac_strategy.cc
+++ b/lib/jxl/enc_ac_strategy.cc
@@ -356,8 +356,8 @@ float EstimateEntropy(const AcStrategy& acs, size_t x, size_t y,
 
   const size_t num_blocks = acs.covered_blocks_x() * acs.covered_blocks_y();
   // avoid large blocks when there is a lot going on in red-green.
-  float cmul[3] = {
-    std::min<float>(2, std::max<float>(1, num_blocks - 1)), 1.0f, 1.0f };
+  float cmul[3] = {std::min<float>(2, std::max<float>(1, num_blocks - 1)), 1.0f,
+                   1.0f};
   float quant_norm8 = 0;
   float masking = 0;
   if (num_blocks == 1) {

--- a/lib/jxl/jxl_test.cc
+++ b/lib/jxl/jxl_test.cc
@@ -235,7 +235,7 @@ TEST(JxlTest, RoundtripResample4) {
   cparams.AddOption(JXL_ENC_FRAME_SETTING_RESAMPLING, 4);
 
   PackedPixelFile ppf_out;
-  EXPECT_NEAR(Roundtrip(t.ppf(), cparams, {}, pool, &ppf_out), 5569, 20);
+  EXPECT_NEAR(Roundtrip(t.ppf(), cparams, {}, pool, &ppf_out), 5518, 50);
   EXPECT_THAT(ButteraugliDistance(t.ppf(), ppf_out), IsSlightlyBelow(22));
 }
 
@@ -466,7 +466,7 @@ TEST(JxlTest, RoundtripNoGaborishNoAR) {
 
   PackedPixelFile ppf_out;
   // TODO(szabadka) Investigate size difference on SCALAR build.
-  EXPECT_NEAR(Roundtrip(t.ppf(), cparams, {}, pool, &ppf_out), 36541, 100);
+  EXPECT_NEAR(Roundtrip(t.ppf(), cparams, {}, pool, &ppf_out), 36541, 104);
   EXPECT_THAT(ButteraugliDistance(t.ppf(), ppf_out), IsSlightlyBelow(2.0));
 }
 
@@ -1395,7 +1395,7 @@ TEST(JxlTest, RoundtripProgressiveLevel2Slow) {
   cparams.AddOption(JXL_ENC_FRAME_SETTING_RESPONSIVE, 1);
 
   PackedPixelFile ppf_out;
-  EXPECT_NEAR(Roundtrip(t.ppf(), cparams, {}, &pool, &ppf_out), 67956, 50);
+  EXPECT_NEAR(Roundtrip(t.ppf(), cparams, {}, &pool, &ppf_out), 69201, 50);
   EXPECT_THAT(ButteraugliDistance(t.ppf(), ppf_out), IsSlightlyBelow(1.13));
 }
 


### PR DESCRIPTION
DZgas reported this problem on discord

There is no related bug

This is a partial mitigation (fixes about 30 % of the problem)

```
Encoding         kPixels    Bytes          BPP  E MP/s  D MP/s     Max norm        pnorm   PSNR   QABPP  SmallB  DCT4x8     AFV  DCT8x8    8x16    8x32      16   16x32      32   32x64      64       BPP*pnorm   Bugs
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
jxl:d0.5:epf0      18611  5404951    2.3232311   1.056   9.377   1.43458343   0.37487900  44.50   2.355  0.9432 29.2418  1.9765  7.4389 25.5920  0.0000 31.8696  1.1499  2.3933  0.0880  0.0880  0.870930556345      0
jxl:d1:epf0        18611  3460860    1.4875949   1.118  11.652   2.03532028   0.60423787  40.83   2.127  0.8487 20.7400  2.1155  5.5865 19.2174  0.0000 31.8366  7.9089 12.3517  0.0880  0.0880  0.898861176626      0
jxl:d3:epf0        18611  1647795    0.7082781   1.117  13.332   4.54048967   1.26984350  35.28   2.259  0.6066 11.9673  1.9477  3.8142 13.1000  0.0000 15.5593 30.0402 23.5370  0.1210  0.0880  0.899402386718      0
jxl:d5:epf0        18611  1152435    0.4953556   1.140  15.009   8.08750057   1.79117804  32.89   2.334  0.4181  8.4137  1.5814  2.8111 11.1440  0.0000 11.7630 35.6934 28.7253  0.1210  0.1100  0.887270107071      0
jxl:d7:epf0        18611   913124    0.3924916   1.160  15.230   8.45760822   2.22480562  31.50   2.319  0.3054  6.5022  1.3311  2.2730 10.1248  0.0000 10.1895 38.5296 31.2616  0.1541  0.1100  0.873217605735      0
jxl:d15:epf0       18611   495754    0.2130919   1.194  15.270  12.62659836   3.94287193  28.68   2.280  0.0946  2.2644  0.5282  0.6107  6.2838  0.0000  6.0727 41.2255 43.1732  0.4181  0.1100  0.840193953115      0
Aggregate:         18611  1588724    0.6828876   1.130  13.113   4.74753585   1.28582577  35.21   2.278  0.4246  9.8243  1.4437  2.9189 12.8811  0.0000 15.0219 15.7884 17.3179  0.1393  0.0984  0.878074459906      0
```

```
Encoding         kPixels    Bytes          BPP  E MP/s  D MP/s     Max norm        pnorm   PSNR   QABPP  SmallB  DCT4x8     AFV  DCT8x8    8x16    8x32      16   16x32      32   32x64      64       BPP*pnorm   Bugs
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
jxl:d0.5:epf0      18611  5415285    2.3276730   1.126   9.628   1.43458343   0.37453001  44.56   2.369  0.9443 30.3043  1.9827  7.7659 26.9021  0.0000 29.1104  1.1416  2.4538  0.0880  0.0880  0.871783404641      0
jxl:d1:epf0        18611  3465943    1.4897798   1.232  10.256   2.03532028   0.60337656  40.88   2.128  0.8511 21.5749  2.1248  5.8004 19.9890  0.0000 30.0622  7.7962 12.4067  0.0880  0.0880  0.898898181525      0
jxl:d3:epf0        18611  1648317    0.7085025   1.217  13.603   4.54048967   1.26957677  35.29   2.253  0.6083 12.2073  1.9556  3.8836 13.3530  0.0000 15.3365 29.6138 23.6140  0.1210  0.0880  0.899498327256      0
jxl:d5:epf0        18611  1152207    0.4952576   1.220  13.515   8.08750057   1.79120707  32.89   2.338  0.4188  8.4973  1.5897  2.8355 11.2500  0.0000 11.6997 35.4183 28.8408  0.1210  0.1100  0.887108944401      0
jxl:d7:epf0        18611   913135    0.3924964   1.223  14.436   8.45760822   2.22552154  31.50   2.319  0.3050  6.5582  1.3349  2.2829 10.1709  0.0000 10.1537 38.3233 31.3882  0.1541  0.1100  0.873509122297      0
jxl:d15:epf0       18611   496730    0.2135114   1.267  15.424  12.62659836   3.94297499  28.68   2.282  0.0946  2.2647  0.5282  0.6111  6.2859  0.0000  6.0727 41.1788 43.2172  0.4181  0.1100  0.841870060863      0
Aggregate:         18611  1590175    0.6835111   1.213  12.621   4.74753585   1.28535357  35.22   2.280  0.4251 10.0121  1.4484  2.9740 13.1474  0.0000 14.5992 15.6571 17.4388  0.1393  0.0984  0.878553381315      0
```