### PR TITLE
jpegli: use cinfo->quant_tbl_ptrs to store quant tables

### DIFF
--- a/lib/jpegli/decode_api.cc
+++ b/lib/jpegli/decode_api.cc
@@ -34,6 +34,9 @@ void InitializeImage(j_decompress_ptr cinfo) {
   cinfo->Y_density = 1;
   cinfo->saw_Adobe_marker = FALSE;
   cinfo->Adobe_transform = 0;
+  for (int i = 0; i < NUM_QUANT_TBLS; ++i) {
+    cinfo->quant_tbl_ptrs[i] = nullptr;
+  }
 }
 
 int ConsumeInput(j_decompress_ptr cinfo) {
@@ -112,6 +115,9 @@ void jpeg_CreateDecompress(j_decompress_ptr cinfo, int version,
   cinfo->buffered_image = FALSE;
   cinfo->raw_data_out = FALSE;
   cinfo->output_scanline = 0;
+  cinfo->sample_range_limit = nullptr;  // not used
+  cinfo->rec_outbuf_height = 1;         // output works with any buffer height
+
   for (int i = 0; i < 16; ++i) {
     cinfo->master->app_marker_parsers[i] = nullptr;
   }

--- a/lib/jpegli/decode_internal.h
+++ b/lib/jpegli/decode_internal.h
@@ -43,15 +43,6 @@ struct JPEGComponent {
   hwy::AlignedFreeUniquePtr<coeff_t[]> coeffs;
 };
 
-// Quantization values for an 8x8 pixel block.
-struct JPEGQuantTable {
-  std::array<int32_t, DCTSIZE2> values;
-  // The index of this quantization table as it was parsed from the input JPEG.
-  // Each DQT marker segment contains an 'index' field, and we save this index
-  // here. Valid values are 0 to 3.
-  uint32_t index = 0;
-};
-
 // State of the decoder that has to be saved before decoding one MCU in case
 // we run out of the bitstream.
 struct MCUCodingState {
@@ -117,7 +108,6 @@ struct jpeg_decomp_master {
   size_t icc_index_ = 0;
   size_t icc_total_ = 0;
   std::vector<uint8_t> icc_profile_;
-  std::vector<jpegli::JPEGQuantTable> quant_;
   std::vector<jpegli::JPEGComponent> components_;
   std::vector<jpegli::HuffmanTableEntry> dc_huff_lut_;
   std::vector<jpegli::HuffmanTableEntry> ac_huff_lut_;

--- a/lib/jpegli/render.cc
+++ b/lib/jpegli/render.cc
@@ -237,9 +237,9 @@ void PrepareForOutput(j_decompress_ptr cinfo) {
   m->dequant_ = hwy::AllocateAligned<float>(coeffs_per_block);
   for (int c = 0; c < cinfo->num_components; c++) {
     const auto& comp = cinfo->comp_info[c];
-    const int32_t* quant = m->quant_[comp.quant_tbl_no].values.data();
+    JQUANT_TBL* table = comp.quant_table;
     for (size_t k = 0; k < DCTSIZE2; ++k) {
-      m->dequant_[c * DCTSIZE2 + k] = quant[k] * kDequantScale;
+      m->dequant_[c * DCTSIZE2 + k] = table->quantval[k] * kDequantScale;
     }
   }
 }


### PR DESCRIPTION
This makes it unnecessary to use an internal variable for this, and will make applications that somehow rely on this field work.