### PR TITLE
no fast lossless animation yet

### DIFF
--- a/lib/jxl/encode.cc
+++ b/lib/jxl/encode.cc
@@ -488,7 +488,7 @@ JxlEncoderStatus JxlEncoderStruct::RefillOutputByteQueue() {
 
     uint32_t duration;
     uint32_t timecode;
-    if (metadata.m.have_animation) {
+    if (input_frame && metadata.m.have_animation) {
       duration = input_frame->option_values.header.duration;
       timecode = input_frame->option_values.header.timecode;
     } else {
@@ -1645,6 +1645,9 @@ static bool CanDoFastLossless(const JxlEncoderFrameSettings* frame_settings,
     return false;
   }
   if (frame_settings->values.header.layer_info.have_crop) {
+    return false;
+  }
+  if (frame_settings->enc->metadata.m.have_animation) {
     return false;
   }
   if (frame_settings->values.cparams.speed_tier != jxl::SpeedTier::kLightning) {


### PR DESCRIPTION
Trying fast lossless on animations currently results in segfault (unless the animation uses cropped frames or something else that disables the fast path anyway), since it's trying to access durations from a variable that is a nullptr when using the fast path.

For now, this just disables the fast lossless path in case of animation.

To deal with all the multi-frame lossless stuff (cropped frames, duration, blend modes, frame names etc), it's probably best to use the general libjxl frame header writer and only keep the simpler fjxl frame header writer for standalone builds of fjxl. One blocker to do that atm, is that the fast path assumes that frame dimensions are a multiple of kChunkSize (which is 16), and it can do that by just making the frame larger than the image if needed. This trick only works for image-sized frames though: in animations and layered still images, frames can be smaller than the canvas and then this trick would not work. The cleanest solution is to remove the frame dimension assumption — i.e. have a special case for the rightmost chunk of every row to avoid using RLE there and to deal with partial chunks. Once that is done, we could use the libjxl frame header writer and use the fast path also for animations and layered images.