### PR TITLE
less ringing for anime

### DIFF
--- a/lib/jpegli/encode_api_test.cc
+++ b/lib/jpegli/encode_api_test.cc
@@ -127,7 +127,7 @@ std::vector<TestConfig> GenerateTests() {
   for (int quality : {80, 90, 100}) {
     TestConfig config;
     config.quality = quality;
-    config.max_dist = quality == 100 ? 0.5 : quality == 90 ? 1.85 : 2.65;
+    config.max_dist = quality == 100 ? 0.5 : quality == 90 ? 1.95 : 2.75;
     all_tests.push_back(config);
   }
   return all_tests;

--- a/lib/jxl/decode_test.cc
+++ b/lib/jxl/decode_test.cc
@@ -1775,7 +1775,7 @@ TEST_P(DecodeAllEncodingsTest, PreserveOriginalProfileTest) {
   EXPECT_EQ(JXL_DEC_FULL_IMAGE, JxlDecoderProcessInput(dec));
   double dist = ButteraugliDistance(xsize, ysize, pixels, c_in, intensity_in,
                                     out, c_in, intensity_in);
-  EXPECT_LT(dist, 1.2);
+  EXPECT_LT(dist, 1.29);
   EXPECT_EQ(JXL_DEC_SUCCESS, JxlDecoderProcessInput(dec));
   JxlDecoderDestroy(dec);
 }
@@ -1868,7 +1868,7 @@ void SetPreferredColorProfileTest(
     double dist = ButteraugliDistance(xsize, ysize, pixels, c_in, intensity_in,
                                       out, c_out, intensity_out);
     if (c_in.white_point == c_out.white_point) {
-      EXPECT_LT(dist, 1.2);
+      EXPECT_LT(dist, 1.29);
     } else {
       EXPECT_LT(dist, 4.0);
     }

--- a/lib/jxl/enc_ac_strategy.cc
+++ b/lib/jxl/enc_ac_strategy.cc
@@ -808,7 +808,7 @@ void ProcessRectACS(PassesEncoderState* JXL_RESTRICT enc_state,
   // Favor all 8x8 transforms (against 16x8 and larger transforms)) at
   // low butteraugli_target distances.
   static const float k8x8mul1 = -0.55;
-  static const float k8x8mul2 = 1.0735757687292623f;
+  static const float k8x8mul2 = 1.0;
   static const float k8x8base = 1.4;
   const float mul8x8 = k8x8mul2 + k8x8mul1 / (butteraugli_target + k8x8base);
   for (size_t iy = 0; iy < rect.ysize(); iy++) {
@@ -833,27 +833,27 @@ void ProcessRectACS(PassesEncoderState* JXL_RESTRICT enc_state,
     float entropy_mul;
   };
   static const float k8X16mul1 = -0.55;
-  static const float k8X16mul2 = 0.9019587899705066;
+  static const float k8X16mul2 = 0.87;
   static const float k8X16base = 1.6;
   const float entropy_mul16X8 =
       k8X16mul2 + k8X16mul1 / (butteraugli_target + k8X16base);
   //  const float entropy_mul16X8 = mul8X16 * 0.91195782912371126f;
 
   static const float k16X16mul1 = -0.35;
-  static const float k16X16mul2 = 0.82;
+  static const float k16X16mul2 = 0.80;
   static const float k16X16base = 2.0;
   const float entropy_mul16X16 =
       k16X16mul2 + k16X16mul1 / (butteraugli_target + k16X16base);
   //  const float entropy_mul16X16 = mul16X16 * 0.83183417727960129f;
 
   static const float k32X16mul1 = -0.1;
-  static const float k32X16mul2 = 0.84;
+  static const float k32X16mul2 = 0.86;
   static const float k32X16base = 2.5;
   const float entropy_mul16X32 =
       k32X16mul2 + k32X16mul1 / (butteraugli_target + k32X16base);
 
-  const float entropy_mul32X32 = 0.9;
-  const float entropy_mul64X64 = 1.43f;
+  const float entropy_mul32X32 = 0.94;
+  const float entropy_mul64X64 = 1.52f;
   // TODO(jyrki): Consider this feedback in further changes:
   // Also effectively when the multipliers for smaller blocks are
   // below 1, this raises the bar for the bigger blocks even higher
@@ -874,8 +874,8 @@ void ProcessRectACS(PassesEncoderState* JXL_RESTRICT enc_state,
       // subdivisions. {AcStrategy::Type::DCT32X32, 5, 1, 5,
       // 0.9822994906548809f},
       // TODO(jyrki): re-enable 64x32 and 64x64 if/when possible.
-      {AcStrategy::Type::DCT64X32, 6, 1, 3, 1.26f},
-      {AcStrategy::Type::DCT32X64, 6, 1, 3, 1.26f},
+      {AcStrategy::Type::DCT64X32, 6, 1, 3, 1.29f},
+      {AcStrategy::Type::DCT32X64, 6, 1, 3, 1.29f},
       // {AcStrategy::Type::DCT64X64, 8, 1, 3, 2.0846542128012948f},
   };
   /*

--- a/lib/jxl/encode_test.cc
+++ b/lib/jxl/encode_test.cc
@@ -523,7 +523,7 @@ TEST(EncodeTest, LossyEncoderUseOriginalProfileTest) {
     ASSERT_EQ(JXL_ENC_SUCCESS,
               JxlEncoderFrameSettingsSetOption(
                   frame_settings, JXL_ENC_FRAME_SETTING_EFFORT, 8));
-    VerifyFrameEncoding(63, 129, enc.get(), frame_settings, 3720, true);
+    VerifyFrameEncoding(63, 129, enc.get(), frame_settings, 3920, true);
   }
 }
 

--- a/lib/jxl/jxl_test.cc
+++ b/lib/jxl/jxl_test.cc
@@ -104,7 +104,7 @@ TEST(JxlTest, RoundtripTinyFast) {
   cparams.distance = 4.0f;
 
   PackedPixelFile ppf_out;
-  EXPECT_NEAR(Roundtrip(t.ppf(), cparams, {}, pool, &ppf_out), 201, 5);
+  EXPECT_NEAR(Roundtrip(t.ppf(), cparams, {}, pool, &ppf_out), 203, 10);
 }
 
 TEST(JxlTest, RoundtripSmallD1) {
@@ -119,8 +119,8 @@ TEST(JxlTest, RoundtripSmallD1) {
 
   {
     PackedPixelFile ppf_out;
-    EXPECT_NEAR(Roundtrip(t.ppf(), {}, {}, pool, &ppf_out), 776, 10);
-    EXPECT_THAT(ButteraugliDistance(t.ppf(), ppf_out), IsSlightlyBelow(1.0));
+    EXPECT_NEAR(Roundtrip(t.ppf(), {}, {}, pool, &ppf_out), 729, 30);
+    EXPECT_THAT(ButteraugliDistance(t.ppf(), ppf_out), IsSlightlyBelow(1.1));
   }
 
   // With a lower intensity target than the default, the bitrate should be
@@ -129,7 +129,7 @@ TEST(JxlTest, RoundtripSmallD1) {
 
   {
     PackedPixelFile ppf_out;
-    EXPECT_NEAR(Roundtrip(t.ppf(), {}, {}, pool, &ppf_out), 628, 10);
+    EXPECT_NEAR(Roundtrip(t.ppf(), {}, {}, pool, &ppf_out), 593, 20);
     EXPECT_THAT(ButteraugliDistance(t.ppf(), ppf_out), IsSlightlyBelow(1.1));
     EXPECT_EQ(ppf_out.info.intensity_target, t.ppf().info.intensity_target);
   }
@@ -200,8 +200,8 @@ TEST(JxlTest, RoundtripOutOfOrderProcessing) {
   cparams.AddOption(JXL_ENC_FRAME_SETTING_EPF, 3);
 
   PackedPixelFile ppf_out;
-  EXPECT_NEAR(Roundtrip(t.ppf(), cparams, {}, &pool, &ppf_out), 23015, 50);
-  EXPECT_LE(ButteraugliDistance(t.ppf(), ppf_out), 1.3);
+  EXPECT_NEAR(Roundtrip(t.ppf(), cparams, {}, &pool, &ppf_out), 20307, 50);
+  EXPECT_LE(ButteraugliDistance(t.ppf(), ppf_out), 1.35);
 }
 
 TEST(JxlTest, RoundtripOutOfOrderProcessingBorder) {
@@ -220,7 +220,7 @@ TEST(JxlTest, RoundtripOutOfOrderProcessingBorder) {
   cparams.AddOption(JXL_ENC_FRAME_SETTING_RESAMPLING, 2);
 
   PackedPixelFile ppf_out;
-  EXPECT_NEAR(Roundtrip(t.ppf(), cparams, {}, &pool, &ppf_out), 9609, 55);
+  EXPECT_NEAR(Roundtrip(t.ppf(), cparams, {}, &pool, &ppf_out), 9337, 55);
   EXPECT_LE(ButteraugliDistance(t.ppf(), ppf_out), 2.8);
 }
 
@@ -293,9 +293,9 @@ TEST(JxlTest, RoundtripMultiGroup) {
   };
 
   auto run_kitten = std::async(std::launch::async, test, SpeedTier::kKitten,
-                               1.0f, 52860u, 11);
+                               1.0f, 50887u, 11.7);
   auto run_wombat = std::async(std::launch::async, test, SpeedTier::kWombat,
-                               2.0f, 32037u, 18.5);
+                               2.0f, 30476u, 20.0);
 }
 
 TEST(JxlTest, RoundtripRGBToGrayscale) {
@@ -351,8 +351,8 @@ TEST(JxlTest, RoundtripLargeFast) {
 
   PackedPixelFile ppf_out;
   // TODO(szabadka) Investigate size difference on SCALAR build.
-  EXPECT_NEAR(Roundtrip(t.ppf(), cparams, {}, &pool, &ppf_out), 446370, 700);
-  EXPECT_THAT(ComputeDistance2(t.ppf(), ppf_out), IsSlightlyBelow(90));
+  EXPECT_NEAR(Roundtrip(t.ppf(), cparams, {}, &pool, &ppf_out), 410937, 700);
+  EXPECT_THAT(ComputeDistance2(t.ppf(), ppf_out), IsSlightlyBelow(100));
 }
 
 TEST(JxlTest, RoundtripDotsForceEpf) {
@@ -369,7 +369,7 @@ TEST(JxlTest, RoundtripDotsForceEpf) {
 
   PackedPixelFile ppf_out;
   // TODO(szabadka) Investigate size difference on SCALAR build.
-  EXPECT_NEAR(Roundtrip(t.ppf(), cparams, {}, &pool, &ppf_out), 38360, 130);
+  EXPECT_NEAR(Roundtrip(t.ppf(), cparams, {}, &pool, &ppf_out), 39213, 130);
   EXPECT_THAT(ComputeDistance2(t.ppf(), ppf_out), IsSlightlyBelow(18));
 }
 
@@ -449,8 +449,8 @@ TEST(JxlTest, RoundtripSmallNL) {
   t.SetDimensions(xsize, ysize);
 
   PackedPixelFile ppf_out;
-  EXPECT_NEAR(Roundtrip(t.ppf(), {}, {}, pool, &ppf_out), 776, 10);
-  EXPECT_THAT(ButteraugliDistance(t.ppf(), ppf_out), IsSlightlyBelow(1.0));
+  EXPECT_NEAR(Roundtrip(t.ppf(), {}, {}, pool, &ppf_out), 729, 20);
+  EXPECT_THAT(ButteraugliDistance(t.ppf(), ppf_out), IsSlightlyBelow(1.1));
 }
 
 TEST(JxlTest, RoundtripNoGaborishNoAR) {
@@ -466,7 +466,7 @@ TEST(JxlTest, RoundtripNoGaborishNoAR) {
 
   PackedPixelFile ppf_out;
   // TODO(szabadka) Investigate size difference on SCALAR build.
-  EXPECT_NEAR(Roundtrip(t.ppf(), cparams, {}, pool, &ppf_out), 36541, 104);
+  EXPECT_NEAR(Roundtrip(t.ppf(), cparams, {}, pool, &ppf_out), 36188, 120);
   EXPECT_THAT(ButteraugliDistance(t.ppf(), ppf_out), IsSlightlyBelow(2.0));
 }
 
@@ -484,7 +484,7 @@ TEST(JxlTest, RoundtripSmallNoGaborish) {
   cparams.AddOption(JXL_ENC_FRAME_SETTING_GABORISH, 0);
 
   PackedPixelFile ppf_out;
-  EXPECT_EQ(Roundtrip(t.ppf(), cparams, {}, pool, &ppf_out), 812);
+  EXPECT_EQ(Roundtrip(t.ppf(), cparams, {}, pool, &ppf_out), 756);
   EXPECT_THAT(ButteraugliDistance(t.ppf(), ppf_out), IsSlightlyBelow(1.2));
 }
 
@@ -511,7 +511,7 @@ TEST(JxlTest, RoundtripSmallPatchesAlpha) {
 
   PackedPixelFile ppf_out;
   EXPECT_NEAR(Roundtrip(t.ppf(), cparams, {}, pool, &ppf_out), 550, 15);
-  EXPECT_THAT(ButteraugliDistance(t.ppf(), ppf_out), IsSlightlyBelow(0.021f));
+  EXPECT_THAT(ButteraugliDistance(t.ppf(), ppf_out), IsSlightlyBelow(0.025f));
 }
 
 TEST(JxlTest, RoundtripSmallPatches) {
@@ -536,7 +536,7 @@ TEST(JxlTest, RoundtripSmallPatches) {
 
   PackedPixelFile ppf_out;
   EXPECT_NEAR(Roundtrip(t.ppf(), cparams, {}, pool, &ppf_out), 455, 10);
-  EXPECT_THAT(ButteraugliDistance(t.ppf(), ppf_out), IsSlightlyBelow(0.021f));
+  EXPECT_THAT(ButteraugliDistance(t.ppf(), ppf_out), IsSlightlyBelow(0.025f));
 }
 
 // TODO(szabadka) Add encoder and decoder API functions that accept frame
@@ -725,7 +725,7 @@ TEST(JxlTest, RoundtripAlpha) {
       EXPECT_TRUE(test::DecodeFile(dparams, compressed, &io2, pool));
       EXPECT_THAT(ButteraugliDistance(io, io2, cparams.ba_params, GetJxlCms(),
                                       /*distmap=*/nullptr, pool),
-                  IsSlightlyBelow(1.2));
+                  IsSlightlyBelow(1.25));
     }
   }
 }
@@ -812,7 +812,7 @@ TEST(JxlTest, RoundtripAlphaResampling) {
   cparams.AddOption(JXL_ENC_FRAME_SETTING_EXTRA_CHANNEL_RESAMPLING, 2);
 
   PackedPixelFile ppf_out;
-  EXPECT_NEAR(Roundtrip(t.ppf(), cparams, {}, pool, &ppf_out), 12149, 60);
+  EXPECT_NEAR(Roundtrip(t.ppf(), cparams, {}, pool, &ppf_out), 11819, 60);
   EXPECT_THAT(ButteraugliDistance(t.ppf(), ppf_out), IsSlightlyBelow(4.9));
 }
 
@@ -1093,7 +1093,7 @@ TEST(JxlTest, RoundtripNoise) {
   cparams.AddOption(JXL_ENC_FRAME_SETTING_NOISE, 1);
 
   PackedPixelFile ppf_out;
-  EXPECT_NEAR(Roundtrip(t.ppf(), cparams, {}, pool, &ppf_out), 38200, 100);
+  EXPECT_NEAR(Roundtrip(t.ppf(), cparams, {}, pool, &ppf_out), 39170, 100);
   EXPECT_THAT(ButteraugliDistance(t.ppf(), ppf_out), IsSlightlyBelow(1.7));
 }
 
@@ -1378,8 +1378,8 @@ TEST(JxlTest, RoundtripProgressive) {
   cparams.AddOption(JXL_ENC_FRAME_SETTING_RESPONSIVE, 1);
 
   PackedPixelFile ppf_out;
-  EXPECT_NEAR(Roundtrip(t.ppf(), cparams, {}, &pool, &ppf_out), 62373, 50);
-  EXPECT_THAT(ButteraugliDistance(t.ppf(), ppf_out), IsSlightlyBelow(1.26));
+  EXPECT_NEAR(Roundtrip(t.ppf(), cparams, {}, &pool, &ppf_out), 56329, 50);
+  EXPECT_THAT(ButteraugliDistance(t.ppf(), ppf_out), IsSlightlyBelow(1.4));
 }
 
 TEST(JxlTest, RoundtripProgressiveLevel2Slow) {
@@ -1395,8 +1395,8 @@ TEST(JxlTest, RoundtripProgressiveLevel2Slow) {
   cparams.AddOption(JXL_ENC_FRAME_SETTING_RESPONSIVE, 1);
 
   PackedPixelFile ppf_out;
-  EXPECT_NEAR(Roundtrip(t.ppf(), cparams, {}, &pool, &ppf_out), 69201, 50);
-  EXPECT_THAT(ButteraugliDistance(t.ppf(), ppf_out), IsSlightlyBelow(1.13));
+  EXPECT_NEAR(Roundtrip(t.ppf(), cparams, {}, &pool, &ppf_out), 67973, 100);
+  EXPECT_THAT(ButteraugliDistance(t.ppf(), ppf_out), IsSlightlyBelow(1.17));
 }
 
 TEST(JxlTest, RoundtripUnsignedCustomBitdepthLossless) {

--- a/lib/jxl/passes_test.cc
+++ b/lib/jxl/passes_test.cc
@@ -49,7 +49,7 @@ TEST(PassesTest, RoundtripSmallPasses) {
   Roundtrip(&io, cparams, {}, pool, &io2);
   EXPECT_THAT(ButteraugliDistance(io, io2, cparams.ba_params, GetJxlCms(),
                                   /*distmap=*/nullptr, pool),
-              IsSlightlyBelow(1.0));
+              IsSlightlyBelow(1.1));
 }
 
 TEST(PassesTest, RoundtripUnalignedPasses) {
@@ -92,8 +92,8 @@ TEST(PassesTest, RoundtripMultiGroupPasses) {
                 IsSlightlyBelow(target_distance + threshold));
   };
 
-  auto run1 = std::async(std::launch::async, test, 1.0f, 0.3f);
-  auto run2 = std::async(std::launch::async, test, 2.0f, 0.3f);
+  auto run1 = std::async(std::launch::async, test, 1.0f, 0.42f);
+  auto run2 = std::async(std::launch::async, test, 2.0f, 0.42f);
 }
 
 TEST(PassesTest, RoundtripLargeFastPasses) {


### PR DESCRIPTION
```
Before:

Encoding      kPixels    Bytes          BPP  E MP/s  D MP/s     Max norm  SSIMULACRA2        pnorm   PSNR   QABPP  SmallB  DCT4x8     AFV  DCT8x8    8x16    8x32      16   16x32      32   32x64      64       BPP*pnorm   Bugs
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
jxl:d0.1        18611 14241577    6.1215124   1.509   9.323   1.15476871  99.91401321   0.12222551  53.28   6.133  1.6289 55.5325  2.6894 15.0325 15.0910  0.0000  9.4921  0.8693  0.2476  0.1100  0.0880  0.748204948196      0
jxl:d0.5        18611  5479933    2.3554609   1.945  14.862   1.46929085  96.88926767   0.37647436  44.44   2.404  0.9800 30.2407  2.0092  7.8113 26.9791  0.0000 28.9949  1.2462  2.3218  0.1100  0.0880  0.886770637752      0
jxl:d0.8        18611  4078457    1.7530590   2.119  14.861   1.69557619  91.53864103   0.51792821  41.97   2.156  0.9054 24.2430  2.1402  6.4571 23.0714  0.0000 31.2905  3.8541  8.5664  0.1430  0.1100  0.907958721234      0
jxl:d1          18611  3529613    1.5171473   2.199  15.715   2.00774384  88.76644280   0.60229937  40.81   2.165  0.8662 21.5691  2.1378  5.8592 20.2723  0.0000 29.9783  7.8787 12.0216  0.1100  0.0880  0.913776845465      0
jxl:d1.1        18611  3319981    1.4270403   2.166  15.924   2.03485632  87.56953427   0.64211106  40.32   2.200  0.8573 20.6296  2.1265  5.6662 19.1527  0.0000 28.7734 10.2445 13.1330  0.1100  0.0880  0.916318392377      0
jxl:d1.2        18611  3134606    1.3473599   2.261  16.176   2.31637263  86.48485835   0.68191556  39.87   2.225  0.8542 19.7603  2.1399  5.4393 18.2566  0.0000 27.8285 12.3132 13.9913  0.1100  0.0880  0.918785673291      0
jxl:d1.3        18611  3000282    1.2896229   2.240  16.638   2.38447690  85.50045256   0.70991620  39.62   2.230  0.8555 18.9154  2.1124  5.2649 17.4698  0.0000 26.7556 14.1343 15.0751  0.1100  0.0880  0.915524175467      0
jxl:d1.4        18611  2854320    1.2268835   2.270  16.742   2.53410959  84.52015301   0.74766274  39.23   2.218  0.8284 18.2879  2.1323  5.0559 17.0524  0.0000 25.6374 15.7326 15.8344  0.1100  0.1100  0.917295059032      0
jxl:d1.5        18611  2725201    1.1713837   1.967  15.393   2.62599325  83.55015731   0.78332633  38.88   2.254  0.8339 17.7625  2.1244  4.9689 16.5187  0.0000 24.5741 17.1301 16.6707  0.1100  0.0880  0.917575729287      0
jxl:d1.6        18611  2607796    1.1209191   2.265  15.764   2.88803959  82.62402741   0.82027484  38.54   2.234  0.8342 17.1768  2.1052  4.8575 16.2140  0.0000 23.4737 18.7119 17.1548  0.1430  0.1100  0.919461728118      0
jxl:d1.7        18611  2500597    1.0748413   2.261  15.831   3.03542662  81.74103831   0.85628371  38.23   2.249  0.8256 16.6875  2.1082  4.8083 15.8378  0.0000 22.6388 19.9608 17.7160  0.1100  0.0880  0.920369120258      0
jxl:d1.8        18611  2407593    1.0348651   2.248  15.977   3.63891172  80.94408624   0.88933518  37.93   2.328  0.8009 16.2326  2.1076  4.6938 15.4933  0.0000 21.9195 21.0969 18.2387  0.1100  0.0880  0.920341904154      0
jxl:d1.8        18611  2407593    1.0348651   2.284  16.199   3.63891172  80.94408624   0.88933518  37.93   2.328  0.8009 16.2326  2.1076  4.6938 15.4933  0.0000 21.9195 21.0969 18.2387  0.1100  0.0880  0.920341904154      0
jxl:d1.9        18611  2320631    0.9974858   2.306  16.156   3.13962269  80.12865849   0.92153576  37.65   2.315  0.8088 15.8220  2.1027  4.6157 15.3489  0.0000 21.0062 22.2056 18.6734  0.1100  0.0880  0.919218875770      0
jxl:d2.0        18611  2238404    0.9621419   2.345  15.959   3.57458711  79.32861042   0.95374621  37.37   2.322  0.7978 15.3860  2.0931  4.4816 15.1061  0.0000 20.3349 23.3087 19.0750  0.1100  0.0880  0.917639191742      0
jxl:d2.1        18611  2165702    0.9308921   2.270  15.978   3.94716954  78.53184225   0.98582302  37.12   2.311  0.7799 15.0150  2.0821  4.4221 14.8695  0.0000 19.6692 24.1147 19.5647  0.1541  0.1100  0.917694877532      0
jxl:d2.2        18611  2096310    0.9010651   2.036  15.534   3.96744919  77.79599900   1.01750992  36.87   2.332  0.7754 14.5604  2.0660  4.3919 14.7051  0.0000 19.1066 24.7859 20.1809  0.1210  0.0880  0.916842654182      0
jxl:d2.3        18611  2033073    0.8738837   2.352  16.381   3.89047718  77.10928695   1.04849742  36.64   2.317  0.7500 14.2832  2.0821  4.3406 14.5009  0.0000 18.4574 25.5920 20.5660  0.1210  0.0880  0.916264778246      0
jxl:d2.4        18611  1973765    0.8483911   2.241  15.634   4.01603556  76.42212327   1.07902381  36.42   2.343  0.7500 13.9765  2.0498  4.3214 14.2815  0.0000 17.8660 26.3595 20.9126  0.1541  0.1100  0.915434183817      0
jxl:d2.5        18611  1919346    0.8250000   2.321  16.009   5.04763269  75.77050850   1.11190308  36.21   2.372  0.7373 13.6570  2.0522  4.2144 14.1419  0.0000 17.2759 27.1077 21.3638  0.1210  0.1100  0.917319990789      0
jxl:d2.6        18611  1866817    0.8024212   2.328  15.985   5.23504496  75.05273833   1.14203694  36.01   2.356  0.7280 13.3582  2.0405  4.1594 13.9885  0.0000 16.8247 27.8340 21.6389  0.1210  0.0880  0.916394662041      0
jxl:d2.7        18611  1816976    0.7809979   2.385  16.220   4.98347330  74.24895339   1.17161817  35.81   2.342  0.7080 13.0814  2.0347  4.1188 13.9053  0.0000 16.3653 28.3457 22.0130  0.1210  0.0880  0.915031285313      0
jxl:d2.8        18611  1770624    0.7610742   2.321  16.068   5.38064909  73.63447436   1.19818444  35.63   2.311  0.6919 12.7922  2.0168  4.0597 13.7788  0.0000 16.0160 28.6042 22.5907  0.1210  0.1100  0.911907260901      0
jxl:d2.9        18611  1727940    0.7427272   2.378  15.745   5.23979092  72.97875701   1.22629926  35.45   2.342  0.6901 12.4958  2.0206  3.9813 13.5999  0.0000 15.6817 29.0884 23.0143  0.1210  0.0880  0.910805777696      0
jxl:d3          18611  1691138    0.7269084   1.948  15.564   5.04983139  72.42699377   1.24900225  35.29   2.325  0.6086 12.2248  1.9635  3.9541 13.4727  0.0000 15.2416 29.6028 23.5040  0.1210  0.0880  0.907910254937      0
jxl:d5          18611  1183303    0.5086237   2.224   8.879   7.60512877  61.12235484   1.74599672  32.96   2.343  0.4175  8.5176  1.6007  2.8881 11.4136  0.0000 11.7149 35.3770 28.6207  0.1210  0.1100  0.888055366674      0
jxl:d7          18611   939060    0.4036398   2.198   8.691   8.36041451  51.97885966   2.17035922  31.55   2.361  0.3005  6.6260  1.3328  2.3235 10.2837  0.0000 10.2500 38.2160 31.1846  0.1541  0.1100  0.876043389015      0
jxl:d15         18611   514935    0.2213365   2.329   8.435  12.70519733  21.29776168   3.72457273  28.65   2.244  0.0849  2.3239  0.5289  0.6833  6.4386  0.0000  6.2763 40.8652 43.0412  0.4291  0.1100  0.824383943184      0
jxl:d24         18611   347606    0.1494128   0.315  20.197  36.94058228  -2.03046553   5.64851278  26.68   2.563  0.1056  2.5677  0.3607  0.8132  3.7021  0.0000  2.8568  9.9859  5.0947  0.0000  0.0000  0.843960330375      0
jxl:d32         18611   287888    0.1237440   0.317  20.019  29.30999374 -14.00087466   6.32629620  26.20   2.353  0.0616  1.9439  0.2682  0.5983  3.3623  0.0000  2.5818 10.7837  5.8870  0.0000  0.0000  0.782841314679      0
jxl:d64         18611   173435    0.0745482   0.315  20.667  37.84056091 -50.19684853   8.56307608  24.86   1.889  0.0086  0.8604  0.1093  0.2624  2.5907  0.0000  1.9339 11.2046  8.5059  0.0110  0.0000  0.638362255508      0
jxl:d128        18611   104251    0.0448106   0.317  18.806  42.47312164 -95.85009274  11.56964093  23.39   1.514  0.0000  0.3559  0.0536  0.1104  1.7723  0.0000  1.3658 10.1867 11.1578  0.1320  0.3521  0.518442699575      0
Aggregate:      18611  1719389    0.7390519   1.723  15.180   4.71785347  75.65518621   1.17961303  35.82   2.330  0.5334 10.9155  1.4201  3.2362 12.2352  0.0000 14.4337 15.7269 13.8798  0.1162  0.0997  0.871795215250      0

After:

Encoding      kPixels    Bytes          BPP  E MP/s  D MP/s     Max norm  SSIMULACRA2        pnorm   PSNR   QABPP  SmallB  DCT4x8     AFV  DCT8x8    8x16    8x32      16   16x32      32   32x64      64       BPP*pnorm   Bugs
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
jxl:d0.1        18611 14271779    6.1344943   1.477   9.564   1.12860060  99.91379988   0.12440833  53.30   6.144  1.7197 65.1604  2.5718 22.6185  5.7770  0.0000  1.6354  0.8638  0.2366  0.1100  0.0880  0.763182215332      0
jxl:d0.5        18611  5496222    2.3624625   1.982  15.183   1.47659278  97.26210424   0.38644012  44.58   2.390  1.0502 38.8054  2.0353 12.7839 26.1552  0.0000 18.3144  1.0701  0.3686  0.1100  0.0880  0.912950280511      0
jxl:d0.8        18611  4103532    1.7638371   2.154  15.706   1.65987968  91.83766155   0.52815075  42.15   2.153  0.9890 31.3060  2.1818 10.1379 24.3341  0.0000 28.7927  1.4662  1.3204  0.1430  0.1100  0.931571901882      0
jxl:d1          18611  3557072    1.5289501   2.178  15.938   1.92622280  89.06178828   0.60932599  41.00   2.143  0.9542 28.1930  2.1863  8.9629 21.6568  0.0000 32.6247  2.6712  3.3341  0.1100  0.0880  0.931629023780      0
jxl:d1.1        18611  3349844    1.4398765   2.144  16.310   1.98564851  87.89892533   0.64739781  40.52   2.148  0.9446 26.8880  2.2076  8.5815 20.1967  0.0000 33.3689  3.6697  4.7261  0.1100  0.0880  0.932172870902      0
jxl:d1.2        18611  3164053    1.3600172   2.236  16.700   2.32554102  86.74367101   0.68493976  40.07   2.172  0.9573 25.7553  2.2032  8.1400 19.0269  0.0000 33.2685  5.0205  6.2116  0.1100  0.0880  0.931529857508      0
jxl:d1.3        18611  3031665    1.3031124   2.227  16.668   2.29406619  85.82884089   0.71402731  39.84   2.144  0.9326 24.8451  2.2245  7.8433 18.1245  0.0000 32.5477  6.3739  7.6806  0.1210  0.0880  0.930457814203      0
jxl:d1.4        18611  2886038    1.2405169   2.263  17.045   2.23208237  84.85932414   0.74891476  39.45   2.168  0.9219 23.9689  2.2076  7.4898 17.4313  0.0000 31.9453  7.5953  8.9571  0.1541  0.1100  0.929041440281      0
jxl:d1.5        18611  2755415    1.1843707   2.010  15.888   2.57920718  83.87807005   0.78328955  39.11   2.186  0.9126 23.1997  2.2314  7.2143 16.9293  0.0000 30.9247  8.9543 10.2060  0.1210  0.0880  0.927705232808      0
jxl:d1.6        18611  2641806    1.1355377   2.250  15.867   2.73776031  82.99028823   0.81631865  38.77   2.204  0.9047 22.5467  2.2485  6.9551 16.4513  0.0000 29.9921 10.2775 11.1413  0.1541  0.1100  0.926960640664      0
jxl:d1.7        18611  2538308    1.0910508   2.306  15.930   2.70882845  82.18668608   0.84806897  38.47   2.197  0.8996 21.8614  2.2599  6.7848 16.0847  0.0000 29.0375 11.3366 12.3077  0.1210  0.0880  0.925286329613      0
jxl:d1.8        18611  2442904    1.0500429   2.274  15.802   2.68523097  81.41053196   0.87963216  38.17   2.188  0.8910 21.3105  2.2503  6.5988 15.8055  0.0000 28.0334 12.4287 13.2320  0.1210  0.1100  0.923651532936      0
jxl:d1.8        18611  2442904    1.0500429   2.279  15.704   2.68523097  81.41053196   0.87963216  38.17   2.188  0.8910 21.3105  2.2503  6.5988 15.8055  0.0000 28.0334 12.4287 13.2320  0.1210  0.1100  0.923651532936      0
jxl:d1.9        18611  2354081    1.0118638   2.339  15.729   2.80019045  80.61058978   0.91157326  37.90   2.208  0.8696 20.7280  2.2375  6.5366 15.5297  0.0000 27.2301 13.4548 13.9858  0.1210  0.0880  0.922387976954      0
jxl:d2.0        18611  2275077    0.9779052   2.323  15.983   2.97956824  79.84620549   0.94355358  37.64   2.215  0.8820 20.2496  2.2382  6.3072 15.3770  0.0000 26.5314 14.3296 14.6570  0.1210  0.0880  0.922705945773      0
jxl:d2.1        18611  2200280    0.9457549   2.287  15.832   3.14992881  79.04363033   0.97363743  37.39   2.215  0.8507 19.6644  2.2468  6.2096 15.1350  0.0000 25.9386 15.1769 15.2952  0.1541  0.1100  0.920822379730      0
jxl:d2.2        18611  2129926    0.9155144   2.078  16.100   3.56173229  78.29906414   1.00370178  37.15   2.217  0.8291 19.1771  2.2197  6.0641 15.0834  0.0000 25.1614 15.9389 16.0985  0.1210  0.0880  0.918903412687      0
jxl:d2.3        18611  2065654    0.8878881   2.390  16.075   3.58476257  77.65709432   1.03240157  36.93   2.241  0.8242 18.7628  2.2203  5.9510 14.9039  0.0000 24.6346 16.5826 16.6927  0.1210  0.0880  0.916657062397      0
jxl:d2.4        18611  2004962    0.8618006   2.295  15.468   3.49940729  76.88232489   1.06223066  36.72   2.223  0.8191 18.3594  2.2069  5.8612 14.7044  0.0000 24.0528 17.2979 17.2154  0.1541  0.1100  0.915431036462      0
jxl:d2.5        18611  1946637    0.8367306   2.407  16.680   3.43024492  76.20739493   1.09122805  36.51   2.244  0.8026 17.9041  2.2032  5.7316 14.5793  0.0000 23.6113 17.9746 17.7215  0.1430  0.1100  0.913063850474      0
jxl:d2.6        18611  1892780    0.8135810   2.400  16.634   3.63434315  75.49628023   1.12141116  36.31   2.246  0.7885 17.6125  2.1805  5.6267 14.4734  0.0000 23.0418 18.4230 18.4148  0.1320  0.0880  0.912358801861      0
jxl:d2.7        18611  1841654    0.7916053   2.392  16.346   4.06104231  74.79519223   1.15218382  36.11   2.261  0.7737 17.1782  2.1753  5.5631 14.3750  0.0000 22.5054 18.8879 19.1025  0.1320  0.0880  0.912074823008      0
jxl:d2.8        18611  1794800    0.7714659   2.391  16.384   4.77330589  74.17451012   1.18286288  35.93   2.294  0.7689 16.8399  2.1619  5.4541 14.3056  0.0000 21.9704 19.4464 19.5702  0.1541  0.1100  0.912538330916      0
jxl:d2.9        18611  1750134    0.7522669   2.406  15.591   4.68796587  73.58022073   1.20703081  35.76   2.233  0.7465 16.5201  2.1567  5.3633 14.3145  0.0000 21.7035 19.7902 19.9663  0.1320  0.0880  0.908009326392      0
jxl:d3          18611  1709942    0.7349910   1.929  15.750   4.08946228  72.86980189   1.23564678  35.59   2.216  0.7060 16.1353  2.1058  5.2550 14.1412  0.0000 21.1987 20.4642 20.5550  0.1320  0.0880  0.908189285863      0
jxl:d5          18611  1178375    0.5065055   2.239   8.862   5.36492777  61.20821509   1.74017006  33.18   2.263  0.4917 10.6427  1.7018  3.4459 11.4852  0.0000 16.6831 29.2287 26.8271  0.1651  0.1100  0.881405722029      0
jxl:d7          18611   916457    0.3939243   2.282   8.593   7.44722080  51.52146138   2.19040378  31.68   2.283  0.3518  7.6517  1.3548  2.4335  9.6716  0.0000 14.0628 34.6205 30.3373  0.1871  0.1100  0.862853222764      0
jxl:d15         18611   513910    0.2208959   2.308   8.524  11.71339130  21.58086051   3.67976810  28.69   2.143  0.1310  2.6574  0.5512  0.7070  5.7955  0.0000  8.1194 40.3562 41.4621  0.8473  0.1541  0.812845811927      0
jxl:d24         18611   364146    0.1565223   0.300  19.271  31.76013374   0.06039902   5.39509184  26.96   2.541  0.1750  2.9586  0.3889  0.8122  3.2351  0.0000  3.5267  9.5430  4.8472  0.0000  0.0000  0.844452136776      0
jxl:d32         18611   294581    0.1266209   0.298  20.372  31.67304420 -12.98927099   6.16612503  26.37   2.329  0.1066  2.2492  0.3078  0.5846  2.8816  0.0000  3.0797 10.5774  5.6999  0.0000  0.0000  0.780760281403      0
jxl:d64         18611   173995    0.0747889   0.300  19.729  31.78253937 -49.26028415   8.43438520  24.91   1.842  0.0203  0.9900  0.1372  0.2252  2.1382  0.0000  2.2516 11.4439  8.2473  0.0330  0.0000  0.630798792202      0
jxl:d128        18611   103651    0.0445527   0.300  19.552  46.27991104 -95.51683237  11.44333612  23.42   1.490  0.0048  0.3301  0.0533  0.0808  1.3610  0.0000  1.4429 10.4783 10.7782  0.3411  0.6162  0.509831663672      0
Aggregate:      18611  1737532    0.7468500   1.724  15.293   4.16149002  59.43491435   1.17162667  36.04   2.258  0.5374 13.7984  1.5048  4.2436 11.7975  0.0000 16.7922 10.1663  9.3448  0.1376  0.1045  0.875029434255      0
```