### PR TITLE
x86 SIMD for fast-lossless

### DIFF
--- a/experimental/fast_lossless/cross_compile_aarch64.sh
+++ b/experimental/fast_lossless/cross_compile_aarch64.sh
@@ -17,7 +17,7 @@ fi
 
 [ -f lodepng.cpp ] || curl -o lodepng.cpp --url 'https://raw.githubusercontent.com/lvandeve/lodepng/8c6a9e30576f07bf470ad6f09458a2dcd7a6a84a/lodepng.cpp'
 [ -f lodepng.h ] || curl -o lodepng.h --url 'https://raw.githubusercontent.com/lvandeve/lodepng/8c6a9e30576f07bf470ad6f09458a2dcd7a6a84a/lodepng.h'
-[ -f lodepng.o ] || "$CXX" lodepng.cpp -O3 -mavx2 -o lodepng.o -c
+[ -f lodepng.o ] || "$CXX" lodepng.cpp -O3 -o lodepng.o -c
 
 "$CXX" -O3 -static \
   -I. lodepng.o \

--- a/lib/jxl/jxl_test.cc
+++ b/lib/jxl/jxl_test.cc
@@ -940,11 +940,12 @@ TEST(JxlTest, JXL_SLOW_TEST(RoundtripLossless8LightningGradient)) {
   t.DecodeFromBytes(orig).ClearMetadata();
 
   JXLCompressParams cparams = CompressParamsForLossless();
-  cparams.AddOption(JXL_ENC_FRAME_SETTING_EFFORT, 1);             // kLightning
-  cparams.AddOption(JXL_ENC_FRAME_SETTING_MODULAR_PREDICTOR, 5);  // Gradient
+  cparams.AddOption(JXL_ENC_FRAME_SETTING_EFFORT, 1);  // kLightning
 
   PackedPixelFile ppf_out;
-  EXPECT_EQ(Roundtrip(t.ppf(), cparams, {}, &pool, &ppf_out), 286648);
+  // Lax comparison because different SIMD will cause different compression.
+  EXPECT_THAT(Roundtrip(t.ppf(), cparams, {}, &pool, &ppf_out),
+              IsSlightlyBelow(286648u));
   EXPECT_EQ(ComputeDistance2(t.ppf(), ppf_out), 0.0);
 }
 


### PR DESCRIPTION
Multiple changes:
- Unified SIMD implementation between NEON and x86
- AVX2 support for >8bit
- AVX512 support (by default not compiled, given the loss in compression density for nonphoto, the increase in compilation time and the marginal speed improvement)

Summary of results (all single core):
- Slight speedup for NEON (~5%)
- 1.5x-2x speedup for AVX2 for >8bit cases
- AVX512 seems ~10% faster for <=8bit, ~10% slower for 15+ bit, and ~same speed in between compared to AVX2.
Results may change on different CPUs.


```
Before, NEON:
    40.340 MP/s
    11.895 bits/pixel

After, NEON:
    42.940 MP/s
    11.895 bits/pixel


Before:


build/fast_lossless /tmp/noise-4.ppm
   215.101 MP/s
    14.997 bits/pixel
0 (0)
build/fast_lossless /tmp/noise-6.ppm
   192.920 MP/s
    21.155 bits/pixel
0 (0)
build/fast_lossless /tmp/noise-8.ppm
   221.169 MP/s
    27.230 bits/pixel
0 (0)
build/fast_lossless /tmp/noise-10.ppm
    59.794 MP/s
    33.229 bits/pixel
0 (0)
build/fast_lossless /tmp/noise-11.ppm
    62.512 MP/s
    36.249 bits/pixel
0 (0)
build/fast_lossless /tmp/noise-12.ppm
    58.901 MP/s
    39.271 bits/pixel
0 (0)
build/fast_lossless /tmp/noise-13.ppm
    57.231 MP/s
    42.294 bits/pixel
0 (0)
build/fast_lossless /tmp/noise-14.ppm
    61.864 MP/s
    48.826 bits/pixel
0 (0)
build/fast_lossless /tmp/noise-15.ppm
    70.043 MP/s
    62.045 bits/pixel
0 (0)
build/fast_lossless /tmp/noise-16.ppm
    73.306 MP/s
    66.092 bits/pixel
0 (0)
build/fast_lossless /data/jpeg_xl_data/imagecompression.info.rgb8/artificial.ppm
   399.720 MP/s
     2.755 bits/pixel
0 (0)
build/fast_lossless /data/jpeg_xl_data/imagecompression.info.rgb16/artificial.ppm
    91.411 MP/s
    10.411 bits/pixel
0 (0)


/data/jpeg_xl_data/imagecompression.info.rgb8/artificial.ppm
Compressed to 2166489 bytes (2.755 bpp).
3072 x 2048, geomean: 392.22 MP/s [273.70, 399.82], 10 reps, 1 threads.

/data/jpeg_xl_data/imagecompression.info.rgb8/big_building.ppm
Compressed to 58067912 bytes (11.895 bpp).
7216 x 5412, geomean: 225.03 MP/s [200.13, 228.94], 10 reps, 1 threads.

/data/jpeg_xl_data/imagecompression.info.rgb8/big_tree.ppm
Compressed to 49273739 bytes (14.230 bpp).
6088 x 4550, geomean: 223.86 MP/s [192.17, 227.71], 10 reps, 1 threads.

/data/jpeg_xl_data/imagecompression.info.rgb8/cathedral.ppm
Compressed to 9082250 bytes (12.077 bpp).
2000 x 3008, geomean: 200.25 MP/s [165.18, 207.82], 10 reps, 1 threads.

/data/jpeg_xl_data/imagecompression.info.rgb8/fireworks.ppm
Compressed to 6052099 bytes (6.564 bpp).
3136 x 2352, geomean: 271.65 MP/s [230.18, 277.66], 10 reps, 1 threads.

/data/jpeg_xl_data/imagecompression.info.rgb8/flower_foveon.ppm
Compressed to 3131828 bytes (7.306 bpp).
2268 x 1512, geomean: 255.73 MP/s [200.03, 269.60], 10 reps, 1 threads.

/data/jpeg_xl_data/imagecompression.info.rgb8/hdr.ppm
Compressed to 6966527 bytes (8.858 bpp).
3072 x 2048, geomean: 245.64 MP/s [191.62, 256.78], 10 reps, 1 threads.

/data/jpeg_xl_data/imagecompression.info.rgb8/leaves_iso_1600.ppm
Compressed to 10708454 bytes (14.240 bpp).
3008 x 2000, geomean: 208.22 MP/s [167.56, 214.71], 10 reps, 1 threads.

/data/jpeg_xl_data/imagecompression.info.rgb8/leaves_iso_200.ppm
Compressed to 9161154 bytes (12.182 bpp).
3008 x 2000, geomean: 184.93 MP/s [147.83, 199.68], 10 reps, 1 threads.

/data/jpeg_xl_data/imagecompression.info.rgb8/nightshot_iso_100.ppm
Compressed to 7850009 bytes (8.514 bpp).
3136 x 2352, geomean: 242.54 MP/s [200.28, 255.84], 10 reps, 1 threads.

/data/jpeg_xl_data/imagecompression.info.rgb8/nightshot_iso_1600.ppm
Compressed to 13001185 bytes (14.101 bpp).
3136 x 2352, geomean: 213.97 MP/s [165.94, 218.16], 10 reps, 1 threads.

/data/jpeg_xl_data/imagecompression.info.rgb8/spider_web.ppm
Compressed to 9819647 bytes (6.481 bpp).
4256 x 2848, geomean: 289.22 MP/s [224.10, 297.04], 10 reps, 1 threads.

/data/jpeg_xl_data/imagecompression.info.rgb16/artificial.ppm
Compressed to 8187355 bytes (10.411 bpp).
3072 x 2048, geomean: 93.76 MP/s [87.83, 95.04], 10 reps, 1 threads.

/data/jpeg_xl_data/imagecompression.info.rgb16/big_building.ppm
Compressed to 175682700 bytes (35.989 bpp).
7216 x 5412, geomean: 77.44 MP/s [69.74, 78.86], 10 reps, 1 threads.

/data/jpeg_xl_data/imagecompression.info.rgb16/big_tree.ppm
Compressed to 137190393 bytes (39.621 bpp).
6088 x 4550, geomean: 71.83 MP/s [66.06, 75.51], 10 reps, 1 threads.

/data/jpeg_xl_data/imagecompression.info.rgb16/bridge.ppm
Compressed to 55554997 bytes (39.929 bpp).
2749 x 4049, geomean: 70.91 MP/s [65.62, 73.58], 10 reps, 1 threads.

/data/jpeg_xl_data/imagecompression.info.rgb16/cathedral.ppm
Compressed to 27088764 bytes (36.022 bpp).
2000 x 3008, geomean: 71.13 MP/s [66.07, 76.28], 10 reps, 1 threads.

/data/jpeg_xl_data/imagecompression.info.rgb16/deer.ppm
Compressed to 63305276 bytes (47.431 bpp).
4043 x 2641, geomean: 72.80 MP/s [66.22, 73.73], 10 reps, 1 threads.

/data/jpeg_xl_data/imagecompression.info.rgb16/fireworks.ppm
Compressed to 24648759 bytes (26.734 bpp).
3136 x 2352, geomean: 74.13 MP/s [67.33, 75.86], 10 reps, 1 threads.

/data/jpeg_xl_data/imagecompression.info.rgb16/flower_foveon.ppm
Compressed to 12662641 bytes (29.541 bpp).
2268 x 1512, geomean: 76.28 MP/s [65.87, 78.88], 10 reps, 1 threads.

/data/jpeg_xl_data/imagecompression.info.rgb16/hdr.ppm
Compressed to 25304787 bytes (32.177 bpp).
3072 x 2048, geomean: 76.64 MP/s [67.67, 78.49], 10 reps, 1 threads.

/data/jpeg_xl_data/imagecompression.info.rgb16/leaves_iso_1600.ppm
Compressed to 29710362 bytes (39.508 bpp).
3008 x 2000, geomean: 74.76 MP/s [64.14, 76.31], 10 reps, 1 threads.

/data/jpeg_xl_data/imagecompression.info.rgb16/leaves_iso_200.ppm
Compressed to 27198872 bytes (36.169 bpp).
3008 x 2000, geomean: 75.55 MP/s [68.31, 77.13], 10 reps, 1 threads.

/data/jpeg_xl_data/imagecompression.info.rgb16/nightshot_iso_100.ppm
Compressed to 28848951 bytes (31.290 bpp).
3136 x 2352, geomean: 70.75 MP/s [57.42, 77.69], 10 reps, 1 threads.

/data/jpeg_xl_data/imagecompression.info.rgb16/nightshot_iso_1600.ppm
Compressed to 36430067 bytes (39.513 bpp).
3136 x 2352, geomean: 72.04 MP/s [63.60, 75.28], 10 reps, 1 threads.

/data/jpeg_xl_data/imagecompression.info.rgb16/spider_web.ppm
Compressed to 42326738 bytes (27.936 bpp).
4256 x 2848, geomean: 79.42 MP/s [57.53, 82.09], 10 reps, 1 threads.




After, AVX2:

build/fast_lossless /tmp/noise-4.ppm
   206.437 MP/s
    14.997 bits/pixel
0 (0)
build/fast_lossless /tmp/noise-6.ppm
   188.015 MP/s
    21.155 bits/pixel
0 (0)
build/fast_lossless /tmp/noise-8.ppm
   207.219 MP/s
    27.230 bits/pixel
0 (0)
build/fast_lossless /tmp/noise-10.ppm
   134.858 MP/s
    33.229 bits/pixel
0 (0)
build/fast_lossless /tmp/noise-11.ppm
   129.525 MP/s
    36.249 bits/pixel
0 (0)
build/fast_lossless /tmp/noise-12.ppm
   129.043 MP/s
    39.271 bits/pixel
0 (0)
build/fast_lossless /tmp/noise-13.ppm
   126.658 MP/s
    42.294 bits/pixel
0 (0)
build/fast_lossless /tmp/noise-14.ppm
   119.956 MP/s
    48.826 bits/pixel
0 (0)
build/fast_lossless /tmp/noise-15.ppm
   107.498 MP/s
    62.045 bits/pixel
0 (0)
build/fast_lossless /tmp/noise-16.ppm
   108.421 MP/s
    66.092 bits/pixel
0 (0)
build/fast_lossless /data/jpeg_xl_data/imagecompression.info.rgb8/artificial.ppm
   383.308 MP/s
     2.755 bits/pixel
0 (0)
build/fast_lossless /data/jpeg_xl_data/imagecompression.info.rgb16/artificial.ppm
   182.200 MP/s
    10.411 bits/pixel
0 (0)


/data/jpeg_xl_data/imagecompression.info.rgb8/artificial.ppm
Compressed to 2166489 bytes (2.755 bpp).
3072 x 2048, geomean: 359.26 MP/s [339.18, 378.29], 10 reps, 1 threads.

/data/jpeg_xl_data/imagecompression.info.rgb8/big_building.ppm
Compressed to 58067912 bytes (11.895 bpp).
7216 x 5412, geomean: 208.65 MP/s [189.40, 211.67], 10 reps, 1 threads.

/data/jpeg_xl_data/imagecompression.info.rgb8/big_tree.ppm
Compressed to 49273739 bytes (14.230 bpp).
6088 x 4550, geomean: 206.08 MP/s [178.44, 210.18], 10 reps, 1 threads.

/data/jpeg_xl_data/imagecompression.info.rgb8/cathedral.ppm
Compressed to 9082250 bytes (12.077 bpp).
2000 x 3008, geomean: 187.21 MP/s [145.97, 196.30], 10 reps, 1 threads.

/data/jpeg_xl_data/imagecompression.info.rgb8/fireworks.ppm
Compressed to 6052099 bytes (6.564 bpp).
3136 x 2352, geomean: 251.48 MP/s [207.01, 264.24], 10 reps, 1 threads.

/data/jpeg_xl_data/imagecompression.info.rgb8/flower_foveon.ppm
Compressed to 3131828 bytes (7.306 bpp).
2268 x 1512, geomean: 227.17 MP/s [197.57, 239.94], 10 reps, 1 threads.

/data/jpeg_xl_data/imagecompression.info.rgb8/hdr.ppm
Compressed to 6966527 bytes (8.858 bpp).
3072 x 2048, geomean: 223.31 MP/s [190.99, 239.23], 10 reps, 1 threads.

/data/jpeg_xl_data/imagecompression.info.rgb8/leaves_iso_1600.ppm
Compressed to 10708454 bytes (14.240 bpp).
3008 x 2000, geomean: 192.50 MP/s [162.38, 202.06], 10 reps, 1 threads.

/data/jpeg_xl_data/imagecompression.info.rgb8/leaves_iso_200.ppm
Compressed to 9161154 bytes (12.182 bpp).
3008 x 2000, geomean: 184.09 MP/s [159.99, 200.23], 10 reps, 1 threads.

/data/jpeg_xl_data/imagecompression.info.rgb8/nightshot_iso_100.ppm
Compressed to 7850009 bytes (8.514 bpp).
3136 x 2352, geomean: 230.53 MP/s [196.08, 242.45], 10 reps, 1 threads.

/data/jpeg_xl_data/imagecompression.info.rgb8/nightshot_iso_1600.ppm
Compressed to 13001185 bytes (14.101 bpp).
3136 x 2352, geomean: 197.00 MP/s [163.73, 203.63], 10 reps, 1 threads.

/data/jpeg_xl_data/imagecompression.info.rgb8/spider_web.ppm
Compressed to 9819647 bytes (6.481 bpp).
4256 x 2848, geomean: 269.64 MP/s [229.53, 276.44], 10 reps, 1 threads.

/data/jpeg_xl_data/imagecompression.info.rgb16/artificial.ppm
Compressed to 8187355 bytes (10.411 bpp).
3072 x 2048, geomean: 180.42 MP/s [133.48, 186.89], 10 reps, 1 threads.

/data/jpeg_xl_data/imagecompression.info.rgb16/big_building.ppm
Compressed to 175682700 bytes (35.989 bpp).
7216 x 5412, geomean: 119.55 MP/s [99.20, 121.49], 10 reps, 1 threads.

/data/jpeg_xl_data/imagecompression.info.rgb16/big_tree.ppm
Compressed to 137190393 bytes (39.621 bpp).
6088 x 4550, geomean: 101.32 MP/s [85.11, 102.97], 10 reps, 1 threads.

/data/jpeg_xl_data/imagecompression.info.rgb16/bridge.ppm
Compressed to 55554997 bytes (39.929 bpp).
2749 x 4049, geomean: 101.89 MP/s [89.33, 105.28], 10 reps, 1 threads.

/data/jpeg_xl_data/imagecompression.info.rgb16/cathedral.ppm
Compressed to 27088764 bytes (36.022 bpp).
2000 x 3008, geomean: 112.96 MP/s [93.05, 118.06], 10 reps, 1 threads.

/data/jpeg_xl_data/imagecompression.info.rgb16/deer.ppm
Compressed to 63305276 bytes (47.431 bpp).
4043 x 2641, geomean: 98.60 MP/s [87.61, 100.77], 10 reps, 1 threads.

/data/jpeg_xl_data/imagecompression.info.rgb16/fireworks.ppm
Compressed to 24648759 bytes (26.734 bpp).
3136 x 2352, geomean: 115.01 MP/s [99.75, 118.74], 10 reps, 1 threads.

/data/jpeg_xl_data/imagecompression.info.rgb16/flower_foveon.ppm
Compressed to 12662641 bytes (29.541 bpp).
2268 x 1512, geomean: 111.45 MP/s [94.18, 121.26], 10 reps, 1 threads.

/data/jpeg_xl_data/imagecompression.info.rgb16/hdr.ppm
Compressed to 25304787 bytes (32.177 bpp).
3072 x 2048, geomean: 111.45 MP/s [93.53, 116.96], 10 reps, 1 threads.

/data/jpeg_xl_data/imagecompression.info.rgb16/leaves_iso_1600.ppm
Compressed to 29710362 bytes (39.508 bpp).
3008 x 2000, geomean: 101.72 MP/s [86.57, 105.28], 10 reps, 1 threads.

/data/jpeg_xl_data/imagecompression.info.rgb16/leaves_iso_200.ppm
Compressed to 27198872 bytes (36.169 bpp).
3008 x 2000, geomean: 106.91 MP/s [92.83, 115.09], 10 reps, 1 threads.

/data/jpeg_xl_data/imagecompression.info.rgb16/nightshot_iso_100.ppm
Compressed to 28848951 bytes (31.290 bpp).
3136 x 2352, geomean: 112.61 MP/s [90.56, 116.69], 10 reps, 1 threads.

/data/jpeg_xl_data/imagecompression.info.rgb16/nightshot_iso_1600.ppm
Compressed to 36430067 bytes (39.513 bpp).
3136 x 2352, geomean: 101.81 MP/s [80.79, 106.91], 10 reps, 1 threads.

/data/jpeg_xl_data/imagecompression.info.rgb16/spider_web.ppm
Compressed to 42326738 bytes (27.936 bpp).
4256 x 2848, geomean: 131.50 MP/s [103.76, 135.93], 10 reps, 1 threads.





After, AVX512:
build/fast_lossless /tmp/noise-4.ppm
   239.459 MP/s
    14.997 bits/pixel
0 (0)
build/fast_lossless /tmp/noise-6.ppm
   228.953 MP/s
    21.155 bits/pixel
0 (0)
build/fast_lossless /tmp/noise-8.ppm
   234.066 MP/s
    27.230 bits/pixel
0 (0)
build/fast_lossless /tmp/noise-10.ppm
   148.661 MP/s
    33.229 bits/pixel
0 (0)
build/fast_lossless /tmp/noise-11.ppm
   144.609 MP/s
    36.249 bits/pixel
0 (0)
build/fast_lossless /tmp/noise-12.ppm
   139.048 MP/s
    39.271 bits/pixel
0 (0)
build/fast_lossless /tmp/noise-13.ppm
   135.609 MP/s
    42.294 bits/pixel
0 (0)
build/fast_lossless /tmp/noise-14.ppm
   120.476 MP/s
    48.826 bits/pixel
0 (0)
build/fast_lossless /tmp/noise-15.ppm
    98.413 MP/s
    62.045 bits/pixel
0 (0)
build/fast_lossless /tmp/noise-16.ppm
    99.166 MP/s
    66.092 bits/pixel
0 (0)
build/fast_lossless /data/jpeg_xl_data/imagecompression.info.rgb8/artificial.ppm
   431.488 MP/s
     3.010 bits/pixel
0 (0)
build/fast_lossless /data/jpeg_xl_data/imagecompression.info.rgb16/artificial.ppm
   136.104 MP/s
    10.495 bits/pixel
0 (0)



/data/jpeg_xl_data/imagecompression.info.rgb8/artificial.ppm
Compressed to 2366813 bytes (3.010 bpp).
3072 x 2048, geomean: 414.07 MP/s [341.68, 447.41], 10 reps, 1 threads.

/data/jpeg_xl_data/imagecompression.info.rgb8/big_building.ppm
Compressed to 58171002 bytes (11.916 bpp).
7216 x 5412, geomean: 245.60 MP/s [224.61, 251.40], 10 reps, 1 threads.

/data/jpeg_xl_data/imagecompression.info.rgb8/big_tree.ppm
Compressed to 49374521 bytes (14.260 bpp).
6088 x 4550, geomean: 232.93 MP/s [203.91, 238.95], 10 reps, 1 threads.

/data/jpeg_xl_data/imagecompression.info.rgb8/cathedral.ppm
Compressed to 9144682 bytes (12.160 bpp).
2000 x 3008, geomean: 234.12 MP/s [176.61, 251.87], 10 reps, 1 threads.

/data/jpeg_xl_data/imagecompression.info.rgb8/fireworks.ppm
Compressed to 6126592 bytes (6.645 bpp).
3136 x 2352, geomean: 281.91 MP/s [205.31, 297.20], 10 reps, 1 threads.

/data/jpeg_xl_data/imagecompression.info.rgb8/flower_foveon.ppm
Compressed to 3132056 bytes (7.307 bpp).
2268 x 1512, geomean: 236.03 MP/s [186.82, 263.80], 10 reps, 1 threads.

/data/jpeg_xl_data/imagecompression.info.rgb8/hdr.ppm
Compressed to 6966539 bytes (8.858 bpp).
3072 x 2048, geomean: 253.61 MP/s [217.24, 271.52], 10 reps, 1 threads.

/data/jpeg_xl_data/imagecompression.info.rgb8/leaves_iso_1600.ppm
Compressed to 10725843 bytes (14.263 bpp).
3008 x 2000, geomean: 222.70 MP/s [172.35, 233.14], 10 reps, 1 threads.

/data/jpeg_xl_data/imagecompression.info.rgb8/leaves_iso_200.ppm
Compressed to 9176954 bytes (12.203 bpp).
3008 x 2000, geomean: 220.06 MP/s [157.62, 234.27], 10 reps, 1 threads.

/data/jpeg_xl_data/imagecompression.info.rgb8/nightshot_iso_100.ppm
Compressed to 7855253 bytes (8.520 bpp).
3136 x 2352, geomean: 250.22 MP/s [202.75, 270.34], 10 reps, 1 threads.

/data/jpeg_xl_data/imagecompression.info.rgb8/nightshot_iso_1600.ppm
Compressed to 13007030 bytes (14.108 bpp).
3136 x 2352, geomean: 233.58 MP/s [177.52, 249.46], 10 reps, 1 threads.

/data/jpeg_xl_data/imagecompression.info.rgb8/spider_web.ppm
Compressed to 9828451 bytes (6.487 bpp).
4256 x 2848, geomean: 275.02 MP/s [216.92, 288.01], 10 reps, 1 threads.

/data/jpeg_xl_data/imagecompression.info.rgb16/artificial.ppm
Compressed to 8253577 bytes (10.495 bpp).
3072 x 2048, geomean: 141.03 MP/s [126.75, 148.24], 10 reps, 1 threads.

/data/jpeg_xl_data/imagecompression.info.rgb16/big_building.ppm
Compressed to 175913151 bytes (36.036 bpp).
7216 x 5412, geomean: 104.74 MP/s [88.56, 106.79], 10 reps, 1 threads.

/data/jpeg_xl_data/imagecompression.info.rgb16/big_tree.ppm
Compressed to 137427734 bytes (39.690 bpp).
6088 x 4550, geomean: 90.11 MP/s [77.22, 91.49], 10 reps, 1 threads.

/data/jpeg_xl_data/imagecompression.info.rgb16/bridge.ppm
Compressed to 55562970 bytes (39.935 bpp).
2749 x 4049, geomean: 89.53 MP/s [79.90, 93.19], 10 reps, 1 threads.

/data/jpeg_xl_data/imagecompression.info.rgb16/cathedral.ppm
Compressed to 27213220 bytes (36.188 bpp).
2000 x 3008, geomean: 91.97 MP/s [79.09, 98.35], 10 reps, 1 threads.

/data/jpeg_xl_data/imagecompression.info.rgb16/deer.ppm
Compressed to 63453629 bytes (47.542 bpp).
4043 x 2641, geomean: 88.91 MP/s [77.25, 91.77], 10 reps, 1 threads.

/data/jpeg_xl_data/imagecompression.info.rgb16/fireworks.ppm
Compressed to 24778973 bytes (26.876 bpp).
3136 x 2352, geomean: 102.36 MP/s [90.46, 107.86], 10 reps, 1 threads.

/data/jpeg_xl_data/imagecompression.info.rgb16/flower_foveon.ppm
Compressed to 12662639 bytes (29.541 bpp).
2268 x 1512, geomean: 102.18 MP/s [83.37, 107.92], 10 reps, 1 threads.

/data/jpeg_xl_data/imagecompression.info.rgb16/hdr.ppm
Compressed to 25304785 bytes (32.177 bpp).
3072 x 2048, geomean: 105.43 MP/s [92.58, 109.94], 10 reps, 1 threads.

/data/jpeg_xl_data/imagecompression.info.rgb16/leaves_iso_1600.ppm
Compressed to 29741118 bytes (39.549 bpp).
3008 x 2000, geomean: 91.64 MP/s [78.37, 94.68], 10 reps, 1 threads.

/data/jpeg_xl_data/imagecompression.info.rgb16/leaves_iso_200.ppm
Compressed to 27233212 bytes (36.214 bpp).
3008 x 2000, geomean: 98.49 MP/s [80.93, 100.96], 10 reps, 1 threads.

/data/jpeg_xl_data/imagecompression.info.rgb16/nightshot_iso_100.ppm
Compressed to 28867110 bytes (31.310 bpp).
3136 x 2352, geomean: 103.88 MP/s [90.37, 106.74], 10 reps, 1 threads.

/data/jpeg_xl_data/imagecompression.info.rgb16/nightshot_iso_1600.ppm
Compressed to 36449770 bytes (39.534 bpp).
3136 x 2352, geomean: 85.05 MP/s [73.59, 91.67], 10 reps, 1 threads.

/data/jpeg_xl_data/imagecompression.info.rgb16/spider_web.ppm
Compressed to 42394513 bytes (27.981 bpp).
4256 x 2848, geomean: 113.37 MP/s [95.80, 116.17], 10 reps, 1 threads.
```