### PR TITLE
improvements for red/green in AC strategy

### DIFF
--- a/lib/jxl/decode_test.cc
+++ b/lib/jxl/decode_test.cc
@@ -1983,7 +1983,7 @@ TEST(DecodeTest, PixelTestOpaqueSrgbLossyNoise) {
     jxl::ButteraugliParams ba;
     EXPECT_THAT(ButteraugliDistance(io0, io1, ba, jxl::GetJxlCms(),
                                     /*distmap=*/nullptr, nullptr),
-                IsSlightlyBelow(2.6f));
+                IsSlightlyBelow(2.0f));
 
     JxlDecoderDestroy(dec);
   }

--- a/lib/jxl/enc_ac_strategy.cc
+++ b/lib/jxl/enc_ac_strategy.cc
@@ -339,6 +339,36 @@ bool MultiBlockTransformCrossesVerticalBoundary(
   return false;
 }
 
+static const float kChromaErrorWeight[AcStrategy::kNumValidStrategies] = {
+    0.5f,  // DCT = 0,
+    1.0f,  // IDENTITY = 1,
+    1.0f,  // DCT2X2 = 2,
+    1.0f,  // DCT4X4 = 3,
+    2.0f,  // DCT16X16 = 4,
+    2.0f,  // DCT32X32 = 5,
+    1.1f,  // DCT16X8 = 6,
+    1.1f,  // DCT8X16 = 7,
+    2.0f,  // DCT32X8 = 8,
+    2.0f,  // DCT8X32 = 9,
+    2.0f,  // DCT32X16 = 10,
+    2.0f,  // DCT16X32 = 11,
+    2.0f,  // DCT4X8 = 12,
+    2.0f,  // DCT8X4 = 13,
+    1.7f,  // AFV0 = 14,
+    1.7f,  // AFV1 = 15,
+    1.7f,  // AFV2 = 16,
+    1.7f,  // AFV3 = 17,
+    2.0f,  // DCT64X64 = 18,
+    2.0f,  // DCT64X32 = 19,
+    2.0f,  // DCT32X64 = 20,
+    2.0f,  // DCT128X128 = 21,
+    2.0f,  // DCT128X64 = 22,
+    2.0f,  // DCT64X128 = 23,
+    2.0f,  // DCT256X256 = 24,
+    2.0f,  // DCT256X128 = 25,
+    2.0f,  // DCT128X256 = 26,
+};
+
 float EstimateEntropy(const AcStrategy& acs, size_t x, size_t y,
                       const ACSConfig& config,
                       const float* JXL_RESTRICT cmap_factors, float* block,
@@ -356,8 +386,7 @@ float EstimateEntropy(const AcStrategy& acs, size_t x, size_t y,
 
   const size_t num_blocks = acs.covered_blocks_x() * acs.covered_blocks_y();
   // avoid large blocks when there is a lot going on in red-green.
-  float cmul[3] = {std::min<float>(2, std::max<float>(1, num_blocks - 1)), 1.0f,
-                   1.0f};
+  float cmul[3] = {kChromaErrorWeight[acs.RawStrategy()], 1.0f, 1.0f};
   float quant_norm8 = 0;
   float masking = 0;
   if (num_blocks == 1) {
@@ -481,7 +510,7 @@ uint8_t FindBest8x8Transform(size_t x, size_t y, int encoding_speed_tier,
           AcStrategy::Type::DCT4X4,
           5,
           4.0f,
-          1.0179946967008329f,
+          0.7f,
       },
       {
           AcStrategy::Type::DCT2X2,

--- a/lib/jxl/enc_adaptive_quantization.cc
+++ b/lib/jxl/enc_adaptive_quantization.cc
@@ -717,7 +717,7 @@ ImageF TileDistMap(const ImageF& distmap, int tile_size, int margin,
 
 constexpr float kDcQuantPow = 0.66f;
 static const float kDcQuant = 1.1f;
-static const float kAcQuant = 0.838f;
+static const float kAcQuant = 0.84f;
 
 void FindBestQuantization(const ImageBundle& linear, const Image3F& opsin,
                           PassesEncoderState* enc_state,

--- a/lib/jxl/encode_test.cc
+++ b/lib/jxl/encode_test.cc
@@ -392,7 +392,7 @@ TEST(EncodeTest, frame_settingsTest) {
     EXPECT_EQ(JXL_ENC_SUCCESS,
               JxlEncoderFrameSettingsSetOption(
                   frame_settings, JXL_ENC_FRAME_SETTING_PROGRESSIVE_DC, 2));
-    VerifyFrameEncoding(63, 129, enc.get(), frame_settings, 2750,
+    VerifyFrameEncoding(63, 129, enc.get(), frame_settings, 2770,
                         /*lossy_use_original_profile=*/false);
     EXPECT_EQ(false, enc->last_used_cparams.responsive);
     EXPECT_EQ(true, enc->last_used_cparams.progressive_mode);

--- a/lib/jxl/encode_test.cc
+++ b/lib/jxl/encode_test.cc
@@ -331,7 +331,7 @@ TEST(EncodeTest, frame_settingsTest) {
     JxlEncoderFrameSettings* frame_settings =
         JxlEncoderFrameSettingsCreate(enc.get(), NULL);
     EXPECT_EQ(JXL_ENC_SUCCESS, JxlEncoderSetFrameDistance(frame_settings, 0.5));
-    VerifyFrameEncoding(63, 129, enc.get(), frame_settings, 3000, false);
+    VerifyFrameEncoding(63, 129, enc.get(), frame_settings, 3030, false);
     EXPECT_EQ(0.5, enc->last_used_cparams.butteraugli_distance);
   }
 
@@ -392,7 +392,7 @@ TEST(EncodeTest, frame_settingsTest) {
     EXPECT_EQ(JXL_ENC_SUCCESS,
               JxlEncoderFrameSettingsSetOption(
                   frame_settings, JXL_ENC_FRAME_SETTING_PROGRESSIVE_DC, 2));
-    VerifyFrameEncoding(63, 129, enc.get(), frame_settings, 2770,
+    VerifyFrameEncoding(63, 129, enc.get(), frame_settings, 2777,
                         /*lossy_use_original_profile=*/false);
     EXPECT_EQ(false, enc->last_used_cparams.responsive);
     EXPECT_EQ(true, enc->last_used_cparams.progressive_mode);

--- a/lib/jxl/jxl_test.cc
+++ b/lib/jxl/jxl_test.cc
@@ -369,7 +369,7 @@ TEST(JxlTest, RoundtripDotsForceEpf) {
 
   PackedPixelFile ppf_out;
   // TODO(szabadka) Investigate size difference on SCALAR build.
-  EXPECT_NEAR(Roundtrip(t.ppf(), cparams, {}, &pool, &ppf_out), 39313, 250);
+  EXPECT_NEAR(Roundtrip(t.ppf(), cparams, {}, &pool, &ppf_out), 39413, 400);
   EXPECT_THAT(ComputeDistance2(t.ppf(), ppf_out), IsSlightlyBelow(18));
 }
 
@@ -1379,7 +1379,7 @@ TEST(JxlTest, RoundtripProgressive) {
   cparams.AddOption(JXL_ENC_FRAME_SETTING_RESPONSIVE, 1);
 
   PackedPixelFile ppf_out;
-  EXPECT_NEAR(Roundtrip(t.ppf(), cparams, {}, &pool, &ppf_out), 56329, 50);
+  EXPECT_NEAR(Roundtrip(t.ppf(), cparams, {}, &pool, &ppf_out), 56429, 550);
   EXPECT_THAT(ButteraugliDistance(t.ppf(), ppf_out), IsSlightlyBelow(1.4));
 }
 
@@ -1396,7 +1396,7 @@ TEST(JxlTest, RoundtripProgressiveLevel2Slow) {
   cparams.AddOption(JXL_ENC_FRAME_SETTING_RESPONSIVE, 1);
 
   PackedPixelFile ppf_out;
-  EXPECT_NEAR(Roundtrip(t.ppf(), cparams, {}, &pool, &ppf_out), 69037, 100);
+  EXPECT_NEAR(Roundtrip(t.ppf(), cparams, {}, &pool, &ppf_out), 68700, 400);
   EXPECT_THAT(ButteraugliDistance(t.ppf(), ppf_out), IsSlightlyBelow(1.17));
 }
 

--- a/lib/jxl/jxl_test.cc
+++ b/lib/jxl/jxl_test.cc
@@ -200,7 +200,7 @@ TEST(JxlTest, RoundtripOutOfOrderProcessing) {
   cparams.AddOption(JXL_ENC_FRAME_SETTING_EPF, 3);
 
   PackedPixelFile ppf_out;
-  EXPECT_NEAR(Roundtrip(t.ppf(), cparams, {}, &pool, &ppf_out), 20300, 50);
+  EXPECT_NEAR(Roundtrip(t.ppf(), cparams, {}, &pool, &ppf_out), 20354, 100);
   EXPECT_LE(ButteraugliDistance(t.ppf(), ppf_out), 1.35);
 }
 
@@ -295,7 +295,7 @@ TEST(JxlTest, RoundtripMultiGroup) {
   auto run_kitten = std::async(std::launch::async, test, SpeedTier::kKitten,
                                1.0f, 50887u, 11.7);
   auto run_wombat = std::async(std::launch::async, test, SpeedTier::kWombat,
-                               2.0f, 30476u, 20.0);
+                               2.0f, 30645u, 20.0);
 }
 
 TEST(JxlTest, RoundtripRGBToGrayscale) {
@@ -484,7 +484,7 @@ TEST(JxlTest, RoundtripSmallNoGaborish) {
   cparams.AddOption(JXL_ENC_FRAME_SETTING_GABORISH, 0);
 
   PackedPixelFile ppf_out;
-  EXPECT_NEAR(Roundtrip(t.ppf(), cparams, {}, pool, &ppf_out), 756, 10);
+  EXPECT_NEAR(Roundtrip(t.ppf(), cparams, {}, pool, &ppf_out), 770, 20);
   EXPECT_THAT(ButteraugliDistance(t.ppf(), ppf_out), IsSlightlyBelow(1.2));
 }
 
@@ -1074,7 +1074,7 @@ TEST(JxlTest, RoundtripDots) {
   cparams.distance = 0.04;
 
   PackedPixelFile ppf_out;
-  EXPECT_NEAR(Roundtrip(t.ppf(), cparams, {}, pool, &ppf_out), 251328, 800);
+  EXPECT_NEAR(Roundtrip(t.ppf(), cparams, {}, pool, &ppf_out), 243906, 800);
   EXPECT_THAT(ButteraugliDistance(t.ppf(), ppf_out), IsSlightlyBelow(0.3));
 }
 
@@ -1396,7 +1396,7 @@ TEST(JxlTest, RoundtripProgressiveLevel2Slow) {
   cparams.AddOption(JXL_ENC_FRAME_SETTING_RESPONSIVE, 1);
 
   PackedPixelFile ppf_out;
-  EXPECT_NEAR(Roundtrip(t.ppf(), cparams, {}, &pool, &ppf_out), 67973, 100);
+  EXPECT_NEAR(Roundtrip(t.ppf(), cparams, {}, &pool, &ppf_out), 69037, 100);
   EXPECT_THAT(ButteraugliDistance(t.ppf(), ppf_out), IsSlightlyBelow(1.17));
 }
 

--- a/lib/jxl/passes_test.cc
+++ b/lib/jxl/passes_test.cc
@@ -92,8 +92,8 @@ TEST(PassesTest, RoundtripMultiGroupPasses) {
                 IsSlightlyBelow(target_distance + threshold));
   };
 
-  auto run1 = std::async(std::launch::async, test, 1.0f, 0.42f);
-  auto run2 = std::async(std::launch::async, test, 2.0f, 0.42f);
+  auto run1 = std::async(std::launch::async, test, 1.0f, 0.5f);
+  auto run2 = std::async(std::launch::async, test, 2.0f, 0.5f);
 }
 
 TEST(PassesTest, RoundtripLargeFastPasses) {


### PR DESCRIPTION
inspired by a test image provided by DZgas, this PR seems to make a substantial improvement on that image, with some lesser degradation on synthetic.png in 'jyrki31' corpus -- broadly the results seem slightly better

0.26 % improvement on BPP * pnorm

```
Before:

Encoding      kPixels    Bytes          BPP  E MP/s  D MP/s     Max norm  SSIMULACRA2        pnorm   PSNR   QABPP  SmallB  DCT4x8     AFV  DCT8x8    8x16    8x32      16   16x32      32   32x64      64       BPP*pnorm   Bugs
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
jxl:d0.1        18611 14271779    6.1344943   1.475   9.685   1.12860060  99.91379988   0.12440833  53.30   6.144  1.7197 65.1604  2.5718 22.6185  5.7770  0.0000  1.6354  0.8638  0.2366  0.1100  0.0880  0.763182215332      0
jxl:d0.5        18611  5496222    2.3624625   1.928  14.945   1.47659278  97.26210424   0.38644012  44.58   2.390  1.0502 38.8054  2.0353 12.7839 26.1552  0.0000 18.3144  1.0701  0.3686  0.1100  0.0880  0.912950280511      0
jxl:d0.8        18611  4103532    1.7638371   2.091  15.022   1.65987968  91.83766155   0.52815075  42.15   2.153  0.9890 31.3060  2.1818 10.1379 24.3341  0.0000 28.7927  1.4662  1.3204  0.1430  0.1100  0.931571901882      0
jxl:d1          18611  3557072    1.5289501   2.116  15.884   1.92622280  89.06178828   0.60932599  41.00   2.143  0.9542 28.1930  2.1863  8.9629 21.6568  0.0000 32.6247  2.6712  3.3341  0.1100  0.0880  0.931629023780      0
jxl:d1.1        18611  3349844    1.4398765   2.137  16.122   1.98564851  87.89892533   0.64739781  40.52   2.148  0.9446 26.8880  2.2076  8.5815 20.1967  0.0000 33.3689  3.6697  4.7261  0.1100  0.0880  0.932172870902      0
jxl:d1.2        18611  3164053    1.3600172   2.214  16.544   2.32554102  86.74367101   0.68493976  40.07   2.172  0.9573 25.7553  2.2032  8.1400 19.0269  0.0000 33.2685  5.0205  6.2116  0.1100  0.0880  0.931529857508      0
jxl:d1.3        18611  3031665    1.3031124   2.213  16.649   2.29406619  85.82884089   0.71402731  39.84   2.144  0.9326 24.8451  2.2245  7.8433 18.1245  0.0000 32.5477  6.3739  7.6806  0.1210  0.0880  0.930457814203      0
jxl:d1.4        18611  2886038    1.2405169   2.242  16.568   2.23208237  84.85932414   0.74891476  39.45   2.168  0.9219 23.9689  2.2076  7.4898 17.4313  0.0000 31.9453  7.5953  8.9571  0.1541  0.1100  0.929041440281      0
jxl:d1.5        18611  2755415    1.1843707   1.963  15.621   2.57920718  83.87807005   0.78328955  39.11   2.186  0.9126 23.1997  2.2314  7.2143 16.9293  0.0000 30.9247  8.9543 10.2060  0.1210  0.0880  0.927705232808      0
jxl:d1.6        18611  2641806    1.1355377   2.268  15.654   2.73776031  82.99028823   0.81631865  38.77   2.204  0.9047 22.5467  2.2485  6.9551 16.4513  0.0000 29.9921 10.2775 11.1413  0.1541  0.1100  0.926960640664      0
jxl:d1.7        18611  2538308    1.0910508   2.238  15.980   2.70882845  82.18668608   0.84806897  38.47   2.197  0.8996 21.8614  2.2599  6.7848 16.0847  0.0000 29.0375 11.3366 12.3077  0.1210  0.0880  0.925286329613      0
jxl:d1.8        18611  2442904    1.0500429   2.187  16.265   2.68523097  81.41053196   0.87963216  38.17   2.188  0.8910 21.3105  2.2503  6.5988 15.8055  0.0000 28.0334 12.4287 13.2320  0.1210  0.1100  0.923651532936      0
jxl:d1.8        18611  2442904    1.0500429   2.307  15.630   2.68523097  81.41053196   0.87963216  38.17   2.188  0.8910 21.3105  2.2503  6.5988 15.8055  0.0000 28.0334 12.4287 13.2320  0.1210  0.1100  0.923651532936      0
jxl:d1.9        18611  2354081    1.0118638   2.283  16.127   2.80019045  80.61058978   0.91157326  37.90   2.208  0.8696 20.7280  2.2375  6.5366 15.5297  0.0000 27.2301 13.4548 13.9858  0.1210  0.0880  0.922387976954      0
jxl:d2.0        18611  2275077    0.9779052   2.295  16.081   2.97956824  79.84620549   0.94355358  37.64   2.215  0.8820 20.2496  2.2382  6.3072 15.3770  0.0000 26.5314 14.3296 14.6570  0.1210  0.0880  0.922705945773      0
jxl:d2.1        18611  2200280    0.9457549   2.318  16.075   3.14992881  79.04363033   0.97363743  37.39   2.215  0.8507 19.6644  2.2468  6.2096 15.1350  0.0000 25.9386 15.1769 15.2952  0.1541  0.1100  0.920822379730      0
jxl:d2.2        18611  2129926    0.9155144   2.059  15.376   3.56173229  78.29906414   1.00370178  37.15   2.217  0.8291 19.1771  2.2197  6.0641 15.0834  0.0000 25.1614 15.9389 16.0985  0.1210  0.0880  0.918903412687      0
jxl:d2.3        18611  2065654    0.8878881   2.343  15.614   3.58476257  77.65709432   1.03240157  36.93   2.241  0.8242 18.7628  2.2203  5.9510 14.9039  0.0000 24.6346 16.5826 16.6927  0.1210  0.0880  0.916657062397      0
jxl:d2.4        18611  2004962    0.8618006   2.240  14.929   3.49940729  76.88232489   1.06223066  36.72   2.223  0.8191 18.3594  2.2069  5.8612 14.7044  0.0000 24.0528 17.2979 17.2154  0.1541  0.1100  0.915431036462      0
jxl:d2.5        18611  1946637    0.8367306   2.286  16.246   3.43024492  76.20739493   1.09122805  36.51   2.244  0.8026 17.9041  2.2032  5.7316 14.5793  0.0000 23.6113 17.9746 17.7215  0.1430  0.1100  0.913063850474      0
jxl:d2.6        18611  1892780    0.8135810   2.345  16.351   3.63434315  75.49628023   1.12141116  36.31   2.246  0.7885 17.6125  2.1805  5.6267 14.4734  0.0000 23.0418 18.4230 18.4148  0.1320  0.0880  0.912358801861      0
jxl:d2.7        18611  1841654    0.7916053   2.396  15.454   4.06104231  74.79519223   1.15218382  36.11   2.261  0.7737 17.1782  2.1753  5.5631 14.3750  0.0000 22.5054 18.8879 19.1025  0.1320  0.0880  0.912074823008      0
jxl:d2.8        18611  1794800    0.7714659   2.358  16.323   4.77330589  74.17451012   1.18286288  35.93   2.294  0.7689 16.8399  2.1619  5.4541 14.3056  0.0000 21.9704 19.4464 19.5702  0.1541  0.1100  0.912538330916      0
jxl:d2.9        18611  1750134    0.7522669   2.366  15.680   4.68796587  73.58022073   1.20703081  35.76   2.233  0.7465 16.5201  2.1567  5.3633 14.3145  0.0000 21.7035 19.7902 19.9663  0.1320  0.0880  0.908009326392      0
jxl:d3          18611  1709942    0.7349910   1.950  15.462   4.08946228  72.86980189   1.23564678  35.59   2.216  0.7060 16.1353  2.1058  5.2550 14.1412  0.0000 21.1987 20.4642 20.5550  0.1320  0.0880  0.908189285863      0
jxl:d5          18611  1178375    0.5065055   2.222   8.739   5.36492777  61.20821509   1.74017006  33.18   2.263  0.4917 10.6427  1.7018  3.4459 11.4852  0.0000 16.6831 29.2287 26.8271  0.1651  0.1100  0.881405722029      0
jxl:d7          18611   916457    0.3939243   2.234   8.772   7.44722080  51.52146138   2.19040378  31.68   2.283  0.3518  7.6517  1.3548  2.4335  9.6716  0.0000 14.0628 34.6205 30.3373  0.1871  0.1100  0.862853222764      0
jxl:d15         18611   513910    0.2208959   2.282   8.205  11.71339130  21.58086051   3.67976810  28.69   2.143  0.1310  2.6574  0.5512  0.7070  5.7955  0.0000  8.1194 40.3562 41.4621  0.8473  0.1541  0.812845811927      0
jxl:d24         18611   364146    0.1565223   0.300  20.099  31.76013374   0.06039902   5.39509184  26.96   2.541  0.1750  2.9586  0.3889  0.8122  3.2351  0.0000  3.5267  9.5430  4.8472  0.0000  0.0000  0.844452136776      0
jxl:d32         18611   294581    0.1266209   0.299  19.873  31.67304420 -12.98927099   6.16612503  26.37   2.329  0.1066  2.2492  0.3078  0.5846  2.8816  0.0000  3.0797 10.5774  5.6999  0.0000  0.0000  0.780760281403      0
jxl:d64         18611   173995    0.0747889   0.298  20.339  31.78253937 -49.26028415   8.43438520  24.91   1.842  0.0203  0.9900  0.1372  0.2252  2.1382  0.0000  2.2516 11.4439  8.2473  0.0330  0.0000  0.630798792202      0
jxl:d128        18611   103651    0.0445527   0.301  20.382  46.27991104 -95.51683237  11.44333612  23.42   1.490  0.0048  0.3301  0.0533  0.0808  1.3610  0.0000  1.4429 10.4783 10.7782  0.3411  0.6162  0.509831663672      0
Aggregate:      18611  1737532    0.7468500   1.703  15.185   4.16149002  59.43491435   1.17162667  36.04   2.258  0.5374 13.7984  1.5048  4.2436 11.7975  0.0000 16.7922 10.1663  9.3448  0.1376  0.1045  0.875029434255      0

After:

Encoding      kPixels    Bytes          BPP  E MP/s  D MP/s     Max norm  SSIMULACRA2        pnorm   PSNR   QABPP  SmallB  DCT4x8     AFV  DCT8x8    8x16    8x32      16   16x32      32   32x64      64       BPP*pnorm   Bugs
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
jxl:d0.1        18611 13984696    6.0110963   1.490  10.097   1.12925887  99.91734422   0.12271291  53.30   6.021  2.3400 26.1339  1.9721 62.4497  4.9709  0.0000  1.6134  0.8665  0.2366  0.1100  0.0880  0.737639127093      0
jxl:d0.5        18611  5464756    2.3489373   1.966  15.106   1.47690403  96.93890510   0.38308157  44.70   2.390  1.2520 30.8779  1.8225 21.0739 25.6264  0.0000 18.4890  1.0674  0.3741  0.1100  0.0880  0.899834602846      0
jxl:d0.8        18611  4092114    1.7589293   2.103  15.494   1.68805385  91.70151396   0.52466113  42.23   2.116  1.1495 26.9496  2.0154 14.5985 24.1037  0.0000 28.9357  1.4662  1.3094  0.1430  0.1100  0.922841827168      0
jxl:d1          18611  3551484    1.5265482   2.124  15.588   1.91239440  89.00280968   0.60628689  41.06   2.126  1.0901 24.9665  2.0501 12.1897 21.5041  0.0000 32.7637  2.6904  3.3286  0.1100  0.0880  0.925526150238      0
jxl:d1.1        18611  3346288    1.4383480   2.138  15.968   1.98521745  87.85395388   0.64489061  40.58   2.158  1.0612 24.0992  2.0828 11.3799 20.0935  0.0000 33.5147  3.6587  4.6931  0.1100  0.0880  0.927577113014      0
jxl:d1.2        18611  3162355    1.3592873   2.198  16.837   2.10823202  86.72498158   0.68200484  40.13   2.151  1.0725 23.2609  2.0917 10.5853 18.9264  0.0000 33.5270  4.9407  6.1786  0.1100  0.0880  0.927040557095      0
jxl:d1.3        18611  3031081    1.3028613   2.198  16.842   2.42569995  85.80417783   0.71192556  39.87   2.172  1.0399 22.5776  2.0948 10.0120 18.0351  0.0000 32.7939  6.3657  7.6531  0.1210  0.0880  0.927540279074      0
jxl:d1.4        18611  2886683    1.2407942   2.237  16.591   2.17066073  84.79182324   0.74687348  39.49   2.162  1.0282 21.9528  2.1165  9.4419 17.3206  0.0000 32.1296  7.5651  8.9626  0.1541  0.1100  0.926716269556      0
jxl:d1.5        18611  2755902    1.1845801   1.976  14.874   2.57920718  83.86492923   0.78208369  39.14   2.206  1.0113 21.3775  2.1254  8.9529 16.8454  0.0000 31.1296  8.9240 10.2060  0.1210  0.0880  0.926440758171      0
jxl:d1.6        18611  2642032    1.1356349   2.287  15.918   2.73776031  82.95614779   0.81456104  38.80   2.196  0.9986 20.8638  2.1612  8.5042 16.3529  0.0000 30.2452 10.2775 11.1138  0.1541  0.1100  0.925043933095      0
jxl:d1.7        18611  2538834    1.0912769   2.295  15.482   2.70966983  82.16757291   0.84681411  38.49   2.205  0.9883 20.3542  2.1567  8.1937 15.9994  0.0000 29.2631 11.3091 12.3077  0.1210  0.0880  0.924108666239      0
jxl:d1.8        18611  2443257    1.0501947   2.233  15.593   2.64282537  81.42121856   0.87868016  38.20   2.180  0.9663 19.9182  2.1774  7.8718 15.7065  0.0000 28.2796 12.4260 13.2045  0.1210  0.1100  0.922785208763      0
jxl:d1.8        18611  2443257    1.0501947   2.268  15.751   2.64282537  81.42121856   0.87868016  38.20   2.180  0.9663 19.9182  2.1774  7.8718 15.7065  0.0000 28.2796 12.4260 13.2045  0.1210  0.1100  0.922785208763      0
jxl:d1.9        18611  2355721    1.0125687   2.300  16.415   2.82750273  80.60032878   0.91017193  37.92   2.207  0.9453 19.4553  2.1732  7.6679 15.4286  0.0000 27.5052 13.4493 13.9473  0.1210  0.0880  0.921611625399      0
jxl:d2.0        18611  2274938    0.9778454   2.310  16.419   2.97395396  79.77996628   0.94217616  37.66   2.235  0.9474 19.0200  2.1842  7.3784 15.3000  0.0000 26.7859 14.3324 14.6240  0.1210  0.0880  0.921302665222      0
jxl:d2.1        18611  2200856    0.9460025   2.311  15.769   3.07843947  79.00491970   0.97281090  37.41   2.202  0.9167 18.5365  2.1956  7.1583 15.1247  0.0000 26.1050 15.1742 15.3062  0.1541  0.1100  0.920281536332      0
jxl:d2.2        18611  2131230    0.9160749   2.092  16.024   3.57915306  78.28841159   1.00237690  37.17   2.205  0.8985 18.1328  2.1653  7.0046 15.0002  0.0000 25.3554 15.9774 16.0380  0.1210  0.0880  0.918252295363      0
jxl:d2.3        18611  2066637    0.8883106   2.306  15.793   3.28470659  77.62696218   1.03092688  36.95   2.231  0.8882 17.7198  2.1677  6.7928 14.8379  0.0000 24.8300 16.6487 16.6872  0.1210  0.0880  0.915783297529      0
jxl:d2.4        18611  2006327    0.8623873   2.213  15.354   3.58500767  76.88383200   1.06076617  36.73   2.249  0.8820 17.4282  2.1543  6.6267 14.6797  0.0000 24.3100 17.2264 17.2099  0.1541  0.1100  0.914791316945      0
jxl:d2.5        18611  1948327    0.8374570   2.343  15.798   3.40545273  76.21033741   1.09004411  36.52   2.249  0.8617 17.0507  2.1578  6.4681 14.5215  0.0000 23.7722 18.0076 17.6885  0.1430  0.1100  0.912865041473      0
jxl:d2.6        18611  1894874    0.8144811   2.368  16.117   3.73614788  75.48032075   1.12011770  36.33   2.258  0.8418 16.8161  2.1351  6.3127 14.4122  0.0000 23.2303 18.3928 18.4203  0.1320  0.0880  0.912314656268      0
jxl:d2.7        18611  1843618    0.7924495   2.356  16.123   4.13348722  74.80449641   1.14954370  36.13   2.245  0.8256 16.3897  2.1285  6.2054 14.3289  0.0000 22.6595 18.9540 19.0695  0.1320  0.0880  0.910955327124      0
jxl:d2.8        18611  1796355    0.7721343   2.317  16.410   5.16240835  74.16015706   1.18266962  35.95   2.308  0.8181 16.1263  2.1131  6.0689 14.2265  0.0000 22.1175 19.4931 19.5537  0.1541  0.1100  0.913179727266      0
jxl:d2.9        18611  1751869    0.7530127   2.327  16.161   4.03294182  73.56246302   1.20523472  35.77   2.218  0.7912 15.8595  2.1186  5.9300 14.2492  0.0000 21.7737 19.8618 19.9773  0.1320  0.0880  0.907557011210      0
jxl:d3          18611  1712260    0.7359874   1.910  15.919   4.81858110  72.91431984   1.23457802  35.60   2.240  0.7434 15.5270  2.0663  5.7863 14.0841  0.0000 21.3321 20.4725 20.5495  0.1320  0.0880  0.908633835530      0
jxl:d5          18611  1180013    0.5072096   2.224   8.750   5.44644165  61.30137355   1.73632473  33.19   2.265  0.5134 10.4487  1.6832  3.6037 11.4714  0.0000 16.7766 29.1819 26.8271  0.1651  0.1100  0.880680530097      0
jxl:d7          18611   917985    0.3945811   2.229   8.554   7.48487997  51.59063671   2.18943302  31.69   2.300  0.3710  7.5554  1.3435  2.4910  9.6599  0.0000 14.1192 34.6178 30.3263  0.1871  0.1100  0.863908805973      0
jxl:d15         18611   516343    0.2219417   2.322   8.347  11.91517258  21.69909173   3.67718425  28.70   2.172  0.1372  2.6567  0.5512  0.7049  5.8127  0.0000  8.0988 40.4058 41.4126  0.8473  0.1541  0.816120595818      0
jxl:d24         18611   364733    0.1567746   0.300  20.111  31.41073227   0.20895381   5.38611808  26.97   2.556  0.1781  2.9273  0.3896  0.8370  3.2296  0.0000  3.5432  9.5237  4.8582  0.0000  0.0000  0.844406528588      0
jxl:d32         18611   295087    0.1268384   0.300  20.237  32.53424454 -12.88709110   6.14968417  26.37   2.322  0.1073  2.2341  0.3057  0.5990  2.8823  0.0000  3.0810 10.6104  5.6669  0.0000  0.0000  0.780016056826      0
jxl:d64         18611   173965    0.0747761   0.300  20.177  31.78253937 -49.26394390   8.43235608  24.91   1.842  0.0210  0.9862  0.1375  0.2252  2.1478  0.0000  2.2530 11.4797  8.2033  0.0330  0.0000  0.630538300833      0
jxl:d128        18611   104273    0.0448201   0.300  20.162  45.40377808 -95.15126077  11.42447866  23.43   1.500  0.0055  0.3318  0.0523  0.0836  1.3555  0.0000  1.4470 10.4921 10.7617  0.3411  0.6162  0.512045923166      0
Aggregate:      18611  1737239    0.7467241   1.705  15.253   4.16133366  62.03107374   1.16870541  36.06   2.258  0.5872 12.6279  1.4473  5.0910 11.6919  0.0000 16.8851 10.1645  9.3326  0.1376  0.1045  0.872700457648      0
```