### PR TITLE
Explicitly SIMDfy prediction.

### DIFF
--- a/experimental/fast_lossless/build.sh
+++ b/experimental/fast_lossless/build.sh
@@ -18,10 +18,10 @@ fi
 
 [ -f lodepng.cpp ] || curl -o lodepng.cpp --url 'https://raw.githubusercontent.com/lvandeve/lodepng/8c6a9e30576f07bf470ad6f09458a2dcd7a6a84a/lodepng.cpp'
 [ -f lodepng.h ] || curl -o lodepng.h --url 'https://raw.githubusercontent.com/lvandeve/lodepng/8c6a9e30576f07bf470ad6f09458a2dcd7a6a84a/lodepng.h'
-[ -f lodepng.o ] || "$CXX" lodepng.cpp -O3 -mavx2 -o lodepng.o -c
+[ -f lodepng.o ] || "$CXX" lodepng.cpp -O3 -o lodepng.o -c
 
 "$CXX" -O3 \
-  -I. lodepng.o \
+  -I. -g lodepng.o \
   -I"$DIR"/../../ \
   "$DIR"/../../lib/jxl/enc_fast_lossless.cc "$DIR"/fast_lossless_main.cc \
   -o fast_lossless


### PR DESCRIPTION
About 10% speedup across the board.

```
Before, NEON:
    42.940 MP/s
    11.895 bits/pixel

After, NEON:
    48.943 MP/s
    11.895 bits/pixel


Before, AVX2:
build/fast_lossless /tmp/noise-4.ppm
   206.035 MP/s
    14.999 bits/pixel
build/fast_lossless /tmp/noise-6.ppm
   204.538 MP/s
    21.155 bits/pixel
build/fast_lossless /tmp/noise-8.ppm
   219.908 MP/s
    27.231 bits/pixel
build/fast_lossless /tmp/noise-10.ppm
   144.475 MP/s
    33.225 bits/pixel
build/fast_lossless /tmp/noise-11.ppm
   132.273 MP/s
    36.248 bits/pixel
build/fast_lossless /tmp/noise-12.ppm
   128.479 MP/s
    39.271 bits/pixel
build/fast_lossless /tmp/noise-13.ppm
   132.436 MP/s
    42.286 bits/pixel
build/fast_lossless /tmp/noise-14.ppm
   106.496 MP/s
    48.830 bits/pixel
build/fast_lossless /tmp/noise-15.ppm
   104.697 MP/s
    62.045 bits/pixel
build/fast_lossless /tmp/noise-16.ppm
   107.240 MP/s
    66.093 bits/pixel
build/fast_lossless /data/jpeg_xl_data/imagecompression.info.rgb8/artificial.ppm
   373.996 MP/s
     2.755 bits/pixel
build/fast_lossless /data/jpeg_xl_data/imagecompression.info.rgb16/artificial.ppm
   188.207 MP/s
    10.411 bits/pixel



Before, AVX512:
build/fast_lossless /tmp/noise-4.ppm
   239.256 MP/s
    14.998 bits/pixel
build/fast_lossless /tmp/noise-6.ppm
   249.227 MP/s
    21.155 bits/pixel
build/fast_lossless /tmp/noise-8.ppm
   243.368 MP/s
    27.231 bits/pixel
build/fast_lossless /tmp/noise-10.ppm
   160.378 MP/s
    33.225 bits/pixel
build/fast_lossless /tmp/noise-11.ppm
   150.700 MP/s
    36.248 bits/pixel
build/fast_lossless /tmp/noise-12.ppm
   148.483 MP/s
    39.271 bits/pixel
build/fast_lossless /tmp/noise-13.ppm
   146.876 MP/s
    42.286 bits/pixel
build/fast_lossless /tmp/noise-14.ppm
   129.960 MP/s
    48.830 bits/pixel
build/fast_lossless /tmp/noise-15.ppm
   104.056 MP/s
    62.045 bits/pixel
build/fast_lossless /tmp/noise-16.ppm
    91.009 MP/s
    66.093 bits/pixel
build/fast_lossless /data/jpeg_xl_data/imagecompression.info.rgb8/artificial.ppm
   428.671 MP/s
     3.010 bits/pixel
build/fast_lossless /data/jpeg_xl_data/imagecompression.info.rgb16/artificial.ppm
   145.438 MP/s
    10.495 bits/pixel



After, AVX2:
build/fast_lossless /tmp/noise-4.ppm
   236.802 MP/s
    14.999 bits/pixel
build/fast_lossless /tmp/noise-6.ppm
   234.735 MP/s
    21.155 bits/pixel
build/fast_lossless /tmp/noise-8.ppm
   258.271 MP/s
    27.231 bits/pixel
build/fast_lossless /tmp/noise-10.ppm
   168.137 MP/s
    33.225 bits/pixel
build/fast_lossless /tmp/noise-11.ppm
   153.102 MP/s
    36.248 bits/pixel
build/fast_lossless /tmp/noise-12.ppm
   150.945 MP/s
    39.271 bits/pixel
build/fast_lossless /tmp/noise-13.ppm
   156.747 MP/s
    42.286 bits/pixel
build/fast_lossless /tmp/noise-14.ppm
   135.037 MP/s
    48.830 bits/pixel
build/fast_lossless /tmp/noise-15.ppm
   112.948 MP/s
    62.045 bits/pixel
build/fast_lossless /tmp/noise-16.ppm
   112.243 MP/s
    66.093 bits/pixel
build/fast_lossless /data/jpeg_xl_data/imagecompression.info.rgb8/artificial.ppm
   429.215 MP/s
     2.755 bits/pixel
build/fast_lossless /data/jpeg_xl_data/imagecompression.info.rgb16/artificial.ppm
   182.140 MP/s
    10.411 bits/pixel



After, AVX512:
build/fast_lossless /tmp/noise-4.ppm
   270.572 MP/s
    14.998 bits/pixel
build/fast_lossless /tmp/noise-6.ppm
   261.115 MP/s
    21.155 bits/pixel
build/fast_lossless /tmp/noise-8.ppm
   267.377 MP/s
    27.231 bits/pixel
build/fast_lossless /tmp/noise-10.ppm
   162.901 MP/s
    33.225 bits/pixel
build/fast_lossless /tmp/noise-11.ppm
   156.421 MP/s
    36.248 bits/pixel
build/fast_lossless /tmp/noise-12.ppm
   157.233 MP/s
    39.271 bits/pixel
build/fast_lossless /tmp/noise-13.ppm
   157.635 MP/s
    42.286 bits/pixel
build/fast_lossless /tmp/noise-14.ppm
   137.901 MP/s
    48.830 bits/pixel
build/fast_lossless /tmp/noise-15.ppm
   104.969 MP/s
    62.045 bits/pixel
build/fast_lossless /tmp/noise-16.ppm
   105.189 MP/s
    66.093 bits/pixel
build/fast_lossless /data/jpeg_xl_data/imagecompression.info.rgb8/artificial.ppm
   526.179 MP/s
     3.010 bits/pixel
build/fast_lossless /data/jpeg_xl_data/imagecompression.info.rgb16/artificial.ppm
   145.219 MP/s
    10.495 bits/pixel
```