### PR TITLE
DZgas' red-green test image correction

### DIFF
--- a/lib/jxl/decode_test.cc
+++ b/lib/jxl/decode_test.cc
@@ -1983,7 +1983,7 @@ TEST(DecodeTest, PixelTestOpaqueSrgbLossyNoise) {
     jxl::ButteraugliParams ba;
     EXPECT_THAT(ButteraugliDistance(io0, io1, ba, jxl::GetJxlCms(),
                                     /*distmap=*/nullptr, nullptr),
-                IsSlightlyBelow(2.2f));
+                IsSlightlyBelow(2.4f));
 
     JxlDecoderDestroy(dec);
   }

--- a/lib/jxl/encode_test.cc
+++ b/lib/jxl/encode_test.cc
@@ -503,7 +503,7 @@ TEST(EncodeTest, LossyEncoderUseOriginalProfileTest) {
     ASSERT_NE(nullptr, enc.get());
     JxlEncoderFrameSettings* frame_settings =
         JxlEncoderFrameSettingsCreate(enc.get(), NULL);
-    VerifyFrameEncoding(63, 129, enc.get(), frame_settings, 4100, true);
+    VerifyFrameEncoding(63, 129, enc.get(), frame_settings, 5143, true);
   }
   {
     JxlEncoderPtr enc = JxlEncoderMake(nullptr);
@@ -513,7 +513,7 @@ TEST(EncodeTest, LossyEncoderUseOriginalProfileTest) {
     EXPECT_EQ(JXL_ENC_SUCCESS,
               JxlEncoderFrameSettingsSetOption(
                   frame_settings, JXL_ENC_FRAME_SETTING_PROGRESSIVE_DC, 2));
-    VerifyFrameEncoding(63, 129, enc.get(), frame_settings, 4500, true);
+    VerifyFrameEncoding(63, 129, enc.get(), frame_settings, 5541, true);
   }
   {
     JxlEncoderPtr enc = JxlEncoderMake(nullptr);
@@ -523,7 +523,7 @@ TEST(EncodeTest, LossyEncoderUseOriginalProfileTest) {
     ASSERT_EQ(JXL_ENC_SUCCESS,
               JxlEncoderFrameSettingsSetOption(
                   frame_settings, JXL_ENC_FRAME_SETTING_EFFORT, 8));
-    VerifyFrameEncoding(63, 129, enc.get(), frame_settings, 3920, true);
+    VerifyFrameEncoding(63, 129, enc.get(), frame_settings, 4644, true);
   }
 }
 

--- a/lib/jxl/jxl_test.cc
+++ b/lib/jxl/jxl_test.cc
@@ -287,7 +287,7 @@ TEST(JxlTest, RoundtripMultiGroup) {
 
     PackedPixelFile ppf_out;
     EXPECT_NEAR(Roundtrip(t.ppf(), cparams, {}, &pool, &ppf_out), expected_size,
-                80);
+                500);
     EXPECT_THAT(ComputeDistance2(t.ppf(), ppf_out),
                 IsSlightlyBelow(expected_distance));
   };
@@ -351,7 +351,7 @@ TEST(JxlTest, RoundtripLargeFast) {
 
   PackedPixelFile ppf_out;
   // TODO(szabadka) Investigate size difference on SCALAR build.
-  EXPECT_NEAR(Roundtrip(t.ppf(), cparams, {}, &pool, &ppf_out), 407453, 700);
+  EXPECT_NEAR(Roundtrip(t.ppf(), cparams, {}, &pool, &ppf_out), 404298, 700);
   EXPECT_THAT(ComputeDistance2(t.ppf(), ppf_out), IsSlightlyBelow(100));
 }
 
@@ -466,7 +466,7 @@ TEST(JxlTest, RoundtripNoGaborishNoAR) {
 
   PackedPixelFile ppf_out;
   // TODO(szabadka) Investigate size difference on SCALAR build.
-  EXPECT_NEAR(Roundtrip(t.ppf(), cparams, {}, pool, &ppf_out), 37093, 120);
+  EXPECT_NEAR(Roundtrip(t.ppf(), cparams, {}, pool, &ppf_out), 37093, 150);
   EXPECT_THAT(ButteraugliDistance(t.ppf(), ppf_out), IsSlightlyBelow(1.8));
 }
 


### PR DESCRIPTION
This seems to reduce other red-green border artefacts, too.

Butteraugli and ssimulacra2 don't agree that this is an improvement, but the red-green image becomes bearable after this PR and other main artefacts are reduced.

Butteraugli thinks this is a 0.3 % degradation
SSIMULACRA2 thinks something like 0.1 %

DZgas' test image at d1 gets ~7 % more bytes as adaptive quantization allocates more bits in red/green saturated areas. The additional bytes sharpen the blurry text and fix some other remaining artefacts.

```
Before:

Encoding      kPixels    Bytes          BPP  E MP/s  D MP/s     Max norm  SSIMULACRA2        pnorm   PSNR   QABPP  SmallB  DCT4x8     AFV  DCT8x8    8x16    8x32      16   16x32      32   32x64      64       BPP*pnorm   Bugs
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
jxl:d0.1        18611 15044326    6.4665612   1.513   9.230   1.12962782  99.92010191   0.11925665  53.89   6.477 40.4601 21.5116  0.6252 29.8594  5.3100  0.0000  1.7166  0.8638  0.2366  0.1100  0.0880  0.771180443964      0
jxl:d0.5        18611  5657878    2.4319477   1.772  14.019   1.47863185  97.36129278   0.37665935  45.00   2.473 14.7154 25.1931  0.7166 13.4177 27.1559  0.0000 17.9402  1.0756  0.3686  0.1100  0.0880  0.916015848219      0
jxl:d0.8        18611  4208381    1.8089048   1.986  14.663   1.69022286  91.87824544   0.51771618  42.47   2.102 11.3576 21.8920  0.8077 10.0629 25.5356  0.0000 28.1215  1.4305  1.3204  0.1430  0.1100  0.936499269827      0
jxl:d1          18611  3642003    1.5654563   2.034  15.915   1.86755776  89.14575226   0.59946063  41.29   2.153 10.0698 20.2803  0.8435  8.7555 22.6161  0.0000 32.0484  2.6024  3.3671  0.1100  0.0880  0.938429422430      0
jxl:d1.1        18611  3428955    1.4738811   2.052  15.685   1.91853881  87.98104375   0.63784097  40.78   2.168  9.5543 19.6145  0.8659  8.3340 21.1238  0.0000 32.7664  3.5542  4.7701  0.1100  0.0880  0.940101722060      0
jxl:d1.2        18611  3238109    1.3918490   2.057  15.893   2.33638668  86.82709996   0.67455548  40.33   2.166  9.0980 19.0114  0.8934  7.8852 19.7765  0.0000 32.8132  4.8334  6.2721  0.1100  0.0880  0.938879356530      0
jxl:d1.3        18611  3100997    1.3329136   2.123  15.325   2.39044285  85.93008247   0.70501245  40.08   2.185  8.6765 18.5317  0.8961  7.5231 18.8804  0.0000 32.1530  6.2309  7.6806  0.1210  0.0880  0.939720684401      0
jxl:d1.4        18611  2950017    1.2680173   2.087  15.660   2.24278617  84.88540266   0.74036454  39.68   2.183  8.3223 18.0107  0.9116  7.2088 18.0145  0.0000 31.4941  7.5706  8.9846  0.1541  0.1100  0.938795027845      0
jxl:d1.5        18611  2813683    1.2094163   2.109  14.396   2.54174995  83.95820922   0.77491274  39.32   2.204  8.0056 17.5537  0.9288  6.9557 17.4341  0.0000 30.5368  8.9130 10.2445  0.1210  0.0880  0.937192107734      0
jxl:d1.6        18611  2695924    1.1587995   2.206  15.354   2.76223683  83.10598124   0.80744657  38.97   2.203  7.7126 17.1566  0.9467  6.7271 16.9279  0.0000 29.6496 10.2170 11.1798  0.1541  0.1100  0.935668677620      0
jxl:d1.7        18611  2588606    1.1126706   2.101  14.885   2.70151877  82.25856853   0.84071902  38.65   2.227  7.4224 16.8024  0.9773  6.5087 16.5854  0.0000 28.6125 11.3008 12.3627  0.1210  0.0880  0.935443319925      0
jxl:d1.8        18611  2490588    1.0705391   2.139  14.892   2.78579783  81.45777419   0.87099349  38.35   2.212  7.1892 16.4482  1.0086  6.3873 16.2271  0.0000 27.7061 12.3242 13.2595  0.1210  0.1100  0.932432608657      0
jxl:d1.8        18611  2490588    1.0705391   2.119  15.858   2.78579783  81.45777419   0.87099349  38.35   2.212  7.1892 16.4482  1.0086  6.3873 16.2271  0.0000 27.7061 12.3242 13.2595  0.1210  0.1100  0.932432608657      0
jxl:d1.9        18611  2399595    1.0314273   2.139  16.066   2.77918530  80.68341290   0.90297829  38.07   2.218  6.9375 16.1315  1.0230  6.2481 15.9011  0.0000 26.9097 13.4136 14.0078  0.1210  0.0880  0.931356413556      0
jxl:d2.0        18611  2316197    0.9955800   2.162  15.141   2.82473421  79.92668746   0.93270135  37.80   2.193  6.7257 15.7993  1.0340  6.0699 15.7099  0.0000 26.2990 14.2058 14.7285  0.1210  0.0880  0.928578774606      0
jxl:d2.1        18611  2238787    0.9623065   2.251  14.780   3.35349011  79.14093490   0.96610258  37.54   2.252  6.4826 15.4156  1.0598  5.9558 15.4733  0.0000 25.5810 15.1549 15.3942  0.1541  0.1100  0.929686818679      0
jxl:d2.2        18611  2165884    0.9309703   2.233  15.422   3.32903099  78.41750323   0.99628453  37.29   2.217  6.2838 15.1164  1.0739  5.8234 15.4403  0.0000 24.8355 15.8564 16.1425  0.1210  0.0880  0.927511349728      0
jxl:d2.3        18611  2100579    0.9029000   2.230  15.595   3.46015573  77.67635306   1.02569449  37.06   2.263  6.1580 14.8358  1.0753  5.7312 15.1700  0.0000 24.2468 16.5579 16.7972  0.1210  0.0880  0.926099592860      0
jxl:d2.4        18611  2036756    0.8754668   2.215  15.605   3.56859946  76.95752256   1.05523639  36.84   2.239  5.9957 14.5494  1.0808  5.5810 15.0566  0.0000 23.8011 17.1713 17.2814  0.1541  0.1100  0.923824372878      0
jxl:d2.5        18611  1977828    0.8501375   2.170  15.265   3.33239198  76.22269563   1.08469355  36.62   2.273  5.8138 14.2681  1.0952  5.4871 14.8537  0.0000 23.3389 17.9224 17.7490  0.1430  0.1100  0.922138662823      0
jxl:d2.6        18611  1922714    0.8264476   2.198  15.320   3.61969137  75.56669614   1.11460687  36.42   2.255  5.6838 14.0367  1.1155  5.3729 14.7175  0.0000 22.8245 18.3240 18.4863  0.1320  0.0880  0.921164211453      0
jxl:d2.7        18611  1870479    0.8039953   2.256  15.751   3.87303877  74.93499104   1.14316471  36.22   2.239  5.5194 13.7478  1.1334  5.3303 14.6632  0.0000 22.2344 18.7696 19.1630  0.1320  0.0880  0.919099013639      0
jxl:d2.8        18611  1820484    0.7825057   2.235  15.015   5.03217363  74.27263995   1.17305075  36.03   2.265  5.3609 13.5174  1.1413  5.2037 14.5985  0.0000 21.6953 19.3528 19.6472  0.1541  0.1100  0.917918916654      0
jxl:d2.9        18611  1776099    0.7634275   2.177  14.263   4.41133070  73.61098963   1.20010391  35.86   2.250  5.2780 13.3180  1.1578  5.1202 14.5628  0.0000 21.3596 19.7105 20.0543  0.1320  0.0880  0.916192373796      0
jxl:d3          18611  1734147    0.7453951   2.062  14.538   4.88195276  72.96157715   1.23093087  35.68   2.257  5.0710 13.0903  1.1299  5.0469 14.4218  0.0000 20.7930 20.4147 20.5935  0.1320  0.0880  0.917529900435      0
jxl:d5          18611  1188111    0.5106904   2.061   8.606   5.28249359  61.23316770   1.73666844  33.21   2.279  3.5047  8.6696  1.0319  3.2568 11.6867  0.0000 16.4602 28.9976 26.8987  0.1651  0.1100  0.886899849057      0
jxl:d7          18611   922883    0.3966864   2.084   8.431   7.21535873  51.52022851   2.19141630  31.70   2.313  2.7117  6.1604  0.8535  2.2788  9.8552  0.0000 13.8592 34.3785 30.3868  0.1871  0.1100  0.869305020776      0
jxl:d15         18611   517951    0.2226329   2.158   8.159  11.85975456  21.79491977   3.68955130  28.69   2.202  1.3046  1.8820  0.3377  0.6571  5.8561  0.0000  8.0286 40.1857 41.5061  0.8693  0.1541  0.821415478139      0
jxl:d24         18611   367938    0.1581522   0.293  18.859  30.86896896  -0.08960468   5.37868678  26.97   2.569  1.0777  2.3964  0.1881  0.7648  3.2599  0.0000  3.5006  9.4687  4.8306  0.0000  0.0000  0.850651263259      0
jxl:d32         18611   296596    0.1274870   0.299  19.035  32.47261429 -13.13899416   6.16561480  26.37   2.364  0.7964  1.8070  0.1547  0.5485  2.9318  0.0000  3.0645 10.5498  5.6339  0.0000  0.0000  0.786035808525      0
Aggregate:      18611  2099388    0.9023881   1.842  14.305   3.59352210  76.10914711   1.00672092  37.17   2.325  5.9778 12.7561  0.8334  5.1895 13.7189  0.0000 19.2658 10.0305  9.3650  0.1403  0.0980  0.908452963178      0

After:

Encoding      kPixels    Bytes          BPP  E MP/s  D MP/s     Max norm  SSIMULACRA2        pnorm   PSNR   QABPP  SmallB  DCT4x8     AFV  DCT8x8    8x16    8x32      16   16x32      32   32x64      64       BPP*pnorm   Bugs
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
jxl:d0.1        18611 15065296    6.4755748   1.510   9.113   1.12765002  99.91226860   0.11994889  53.95   6.486 40.4192 21.4838  0.6248 30.0282  5.2144  0.0000  1.7097  0.8665  0.2366  0.1100  0.0880  0.776737998200      0
jxl:d0.5        18611  5671732    2.4379026   1.822  14.132   1.48691559  97.29544464   0.37851556  45.04   2.474 14.8031 25.1807  0.7221 13.4944 27.0341  0.0000 17.9045  1.0756  0.3686  0.1100  0.0880  0.922784066069      0
jxl:d0.8        18611  4220248    1.8140056   2.005  13.594   1.64892650  91.90863672   0.51935594  42.50   2.119 11.4071 21.9669  0.8053 10.1272 25.4138  0.0000 28.0155  1.4277  1.3645  0.1430  0.1100  0.942114591146      0
jxl:d1          18611  3651625    1.5695922   2.016  15.560   1.86793721  89.17545202   0.60153761  41.30   2.183 10.1107 20.4322  0.8411  8.8161 22.4243  0.0000 32.0938  2.5584  3.3066  0.1100  0.0880  0.944168721120      0
jxl:d1.1        18611  3436153    1.4769750   2.131  15.930   1.93274319  87.92091018   0.64024408  40.80   2.194  9.6004 19.7686  0.8635  8.3824 20.9986  0.0000 32.8214  3.4772  4.6711  0.1100  0.0880  0.945624497590      0
jxl:d1.2        18611  3242711    1.3938271   2.073  15.288   2.33638668  86.81735330   0.67709071  40.34   2.181  9.1121 19.1441  0.8913  7.9289 19.7201  0.0000 32.8572  4.7234  6.2061  0.1100  0.0880  0.943747365225      0
jxl:d1.3        18611  3105471    1.3348367   2.187  16.255   2.67803311  85.88030467   0.70723639  40.08   2.184  8.6906 18.6906  0.8982  7.5592 18.8590  0.0000 32.2080  6.0796  7.5871  0.1210  0.0880  0.944045071566      0
jxl:d1.4        18611  2954371    1.2698888   2.103  16.586   2.23413968  84.88138474   0.74283372  39.68   2.189  8.3419 18.1579  0.9095  7.2449 17.9347  0.0000 31.5106  7.4825  8.9350  0.1541  0.1100  0.943316200931      0
jxl:d1.5        18611  2816855    1.2107797   2.119  14.310   2.54174995  83.97688757   0.77706510  39.32   2.229  8.0217 17.6724  0.9302  6.9612 17.3873  0.0000 30.5271  8.8993 10.1730  0.1210  0.0880  0.940854678570      0
jxl:d1.6        18611  2699043    1.1601401   2.243  15.518   2.72953343  83.08328928   0.81043138  38.97   2.234  7.7250 17.2515  0.9508  6.7553 16.9038  0.0000 29.6689 10.1537 11.1083  0.1541  0.1100  0.940213986331      0
jxl:d1.7        18611  2591053    1.1137224   2.162  15.223   2.72247791  82.24744623   0.84190886  38.65   2.229  7.4399 16.9148  0.9742  6.5400 16.5703  0.0000 28.5987 11.2046 12.3297  0.1210  0.0880  0.937652745202      0
jxl:d1.8        18611  2492439    1.0713347   2.207  15.670   2.68261623  81.47514506   0.87285111  38.35   2.208  7.1865 16.5404  1.0103  6.4172 16.2092  0.0000 27.8037 12.2444 13.1385  0.1210  0.1100  0.935115728357      0
jxl:d1.8        18611  2492439    1.0713347   2.214  15.532   2.68261623  81.47514506   0.87285111  38.35   2.208  7.1865 16.5404  1.0103  6.4172 16.2092  0.0000 27.8037 12.2444 13.1385  0.1210  0.1100  0.935115728357      0
jxl:d1.9        18611  2401180    1.0321085   2.156  16.060   2.83999348  80.65052726   0.90492680  38.06   2.245  6.9341 16.1992  1.0254  6.2556 15.9052  0.0000 26.9496 13.3613 13.9417  0.1210  0.0880  0.933982672870      0
jxl:d2.0        18611  2318512    0.9965750   2.200  15.669   2.83064461  79.89344825   0.93580956  37.79   2.192  6.7247 15.9090  1.0313  6.0706 15.7244  0.0000 26.2384 14.2388 14.6350  0.1210  0.0880  0.932604436488      0
jxl:d2.1        18611  2240615    0.9630923   2.216  15.714   3.16792607  79.14517575   0.96800518  37.54   2.244  6.4908 15.5160  1.0619  5.9572 15.4919  0.0000 25.5191 15.1852 15.2952  0.1541  0.1100  0.932278295631      0
jxl:d2.2        18611  2167190    0.9315317   2.220  15.552   3.26319051  78.39036845   0.99772656  37.29   2.223  6.2770 15.1962  1.0784  5.8361 15.3997  0.0000 24.8327 15.8647 16.0875  0.1210  0.0880  0.929413925062      0
jxl:d2.3        18611  2101426    0.9032641   2.240  15.903   3.53807282  77.67983242   1.02731748  37.07   2.255  6.1583 14.8753  1.0801  5.7271 15.1446  0.0000 24.3637 16.5744 16.6487  0.1210  0.0880  0.927939008677      0
jxl:d2.4        18611  2037950    0.8759800   2.285  15.885   3.57654333  76.95929162   1.05751105  36.84   2.257  5.9977 14.5824  1.0808  5.5851 15.0187  0.0000 23.9098 17.1273 17.2154  0.1541  0.1100  0.926358503892      0
jxl:d2.5        18611  1978135    0.8502695   2.183  16.099   3.28589249  76.28845396   1.08677029  36.63   2.282  5.8083 14.3069  1.0928  5.4981 14.8571  0.0000 23.3348 17.9471 17.6830  0.1430  0.1100  0.924047589674      0
jxl:d2.6        18611  1922650    0.8264201   2.234  15.853   3.68295431  75.57381663   1.11676471  36.42   2.270  5.6690 14.0679  1.1189  5.3709 14.7313  0.0000 22.7874 18.3845 18.4313  0.1320  0.0880  0.922916829235      0
jxl:d2.7        18611  1870668    0.8040765   2.257  15.855   3.85926461  74.94072141   1.14518800  36.23   2.251  5.5160 13.8059  1.1365  5.3186 14.6446  0.0000 22.2124 18.9072 19.0200  0.1320  0.0880  0.920818757147      0
jxl:d2.8        18611  1820845    0.7826609   2.305  14.469   5.28625488  74.23488572   1.17614949  36.03   2.268  5.3726 13.5453  1.1485  5.2037 14.5779  0.0000 21.7049 19.4106 19.5537  0.1541  0.1100  0.920526205963      0
jxl:d2.9        18611  1776474    0.7635887   2.304  14.816   4.34010172  73.65222060   1.20159603  35.86   2.258  5.2784 13.3393  1.1602  5.1188 14.5291  0.0000 21.3624 19.7407 20.0323  0.1320  0.0880  0.917525184531      0
jxl:d3          18611  1733931    0.7453023   2.144  15.411   4.86109877  72.98725028   1.23144983  35.68   2.240  5.0634 13.1010  1.1337  5.0394 14.3895  0.0000 20.8370 20.4257 20.5715  0.1320  0.0880  0.917802398196      0
jxl:d5          18611  1188111    0.5106904   2.071   8.829   5.28249359  61.23316770   1.73666844  33.21   2.279  3.5047  8.6696  1.0319  3.2568 11.6867  0.0000 16.4602 28.9976 26.8987  0.1651  0.1100  0.886899849057      0
jxl:d7          18611   922883    0.3966864   2.077   8.054   7.21535873  51.52022851   2.19141630  31.70   2.313  2.7117  6.1604  0.8535  2.2788  9.8552  0.0000 13.8592 34.3785 30.3868  0.1871  0.1100  0.869305020776      0
jxl:d15         18611   517951    0.2226329   2.238   8.313  11.85975456  21.79491977   3.68955130  28.69   2.202  1.3046  1.8820  0.3377  0.6571  5.8561  0.0000  8.0286 40.1857 41.5061  0.8693  0.1541  0.821415478139      0
jxl:d24         18611   367938    0.1581522   0.298  19.087  30.86896896  -0.08960468   5.37868678  26.97   2.569  1.0777  2.3964  0.1881  0.7648  3.2599  0.0000  3.5006  9.4687  4.8306  0.0000  0.0000  0.850651263259      0
jxl:d32         18611   296596    0.1274870   0.297  19.559  32.47261429 -13.13899416   6.16561480  26.37   2.364  0.7964  1.8070  0.1547  0.5485  2.9318  0.0000  3.0645 10.5498  5.6339  0.0000  0.0000  0.786035808525      0
Aggregate:      18611  2101139    0.9031409   1.871  14.487   3.59549789  76.10674076   1.00893822  37.17   2.332  5.9829 12.8038  0.8342  5.2010 13.6878  0.0000 19.2720  9.9938  9.3264  0.1403  0.0980  0.911213333380      0
```