### PR TITLE
cjxl: add --use_original_profile option

### DIFF
--- a/lib/extras/enc/jxl.cc
+++ b/lib/extras/enc/jxl.cc
@@ -91,7 +91,7 @@ bool EncodeImageJXL(const JXLCompressParams& params, const PackedPixelFile& ppf,
         std::max<uint32_t>(num_alpha_channels, ppf.info.num_extra_channels);
     basic_info.num_color_channels = ppf.info.num_color_channels;
     const bool lossless = params.distance == 0;
-    basic_info.uses_original_profile = lossless;
+    basic_info.uses_original_profile = lossless || params.uses_original_profile;
     if (params.override_bitdepth != 0) {
       basic_info.bits_per_sample = params.override_bitdepth;
       basic_info.exponent_bits_per_sample =

--- a/lib/extras/enc/jxl.h
+++ b/lib/extras/enc/jxl.h
@@ -47,6 +47,8 @@ struct JXLCompressParams {
   // Upper bound on the intensity level present in the image in nits (zero means
   // that the library chooses a default).
   float intensity_target = 0;
+  // Override uses_original_profile
+  bool uses_original_profile = false;
   // Overrides for bitdepth, codestream level and alpha premultiply.
   size_t override_bitdepth = 0;
   int32_t codestream_level = -1;

--- a/tools/cjxl_main.cc
+++ b/tools/cjxl_main.cc
@@ -312,6 +312,12 @@ struct CompressArgs {
         "icc_pathname refers to a binary file containing an ICC profile.",
         &color_hints, &ParseAndAppendKeyValue, 1);
 
+    cmdline->AddOptionFlag(
+        '\0', "use_original_profile",
+        "Force using the original color profile when lossily encoding, "
+        "instead of the XYB transform.",
+        &uses_original_profile, &SetBooleanTrue, 1);
+
     cmdline->AddOptionValue(
         '\0', "override_bitdepth", "0=use from image, 1-32=override",
         "If nonzero, store the given bit depth in the JPEG XL file metadata"
@@ -429,6 +435,9 @@ struct CompressArgs {
 
   // Decoding source image flags
   jxl::extras::ColorHints color_hints;
+
+  // force cjxl to avoid the XYB transform
+  bool uses_original_profile = false;
 
   // JXL flags
   size_t override_bitdepth = 0;
@@ -895,6 +904,7 @@ void ProcessFlags(const jxl::extras::Codec codec,
   params->override_bitdepth = args->override_bitdepth;
   params->codestream_level = args->codestream_level;
   params->premultiply = args->premultiply;
+  params->uses_original_profile = args->uses_original_profile;
   params->compress_boxes = args->compress_boxes != jxl::Override::kOff;
   if (codec == jxl::extras::Codec::kPNM) {
     params->input_bitdepth.type = JXL_BIT_DEPTH_FROM_CODESTREAM;


### PR DESCRIPTION
Enable --use_original_profile on the command-line tool cjxl, which makes libjxl avoid the XYB transform and encode the image in the same color space as the original image. This is potentially useful if the original ICC profile needs to be preserved.