### PR TITLE
[fast-lossless] Speedup and enable (if supported) AVX512 by default 

### DIFF
--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -46,7 +46,7 @@ jobs:
           # Build scalar-only hwy instructions.
           - name: scalar
             mode: release
-            cxxflags: -DHWY_COMPILE_ONLY_SCALAR
+            cxxflags: -DHWY_COMPILE_ONLY_SCALAR -DFJXL_ENABLE_AVX2=0 -DFJXL_ENABLE_AVX512=0
           # Disabling optional features to speed up msan build a little bit.
           - name: msan
             skip_install: true


### PR DESCRIPTION
With the RLE improvements and the changes here, AVX512 is about 50% faster than AVX2 on a i7-11850H.


```
Before, AVX2:
build/fast_lossless /tmp/noise-4.ppm
   245.864 MP/s
    14.668 bits/pixel
build/fast_lossless /tmp/noise-6.ppm
   236.304 MP/s
    20.813 bits/pixel
build/fast_lossless /tmp/noise-8.ppm
   241.526 MP/s
    26.878 bits/pixel
build/fast_lossless /tmp/noise-10.ppm
   164.410 MP/s
    32.878 bits/pixel
build/fast_lossless /tmp/noise-11.ppm
   161.683 MP/s
    35.897 bits/pixel
build/fast_lossless /tmp/noise-12.ppm
   159.196 MP/s
    38.912 bits/pixel
build/fast_lossless /tmp/noise-13.ppm
   159.249 MP/s
    41.925 bits/pixel
build/fast_lossless /tmp/noise-14.ppm
   141.446 MP/s
    48.705 bits/pixel
build/fast_lossless /tmp/noise-15.ppm
   117.555 MP/s
    62.039 bits/pixel
build/fast_lossless /tmp/noise-16.ppm
   119.843 MP/s
    66.092 bits/pixel
build/fast_lossless /data/jpeg_xl_data/imagecompression.info.rgb8/artificial.ppm
   401.069 MP/s
     2.677 bits/pixel
build/fast_lossless /data/jpeg_xl_data/imagecompression.info.rgb16/artificial.ppm
   185.927 MP/s
    10.235 bits/pixel



Before, AVX512:
build/fast_lossless /tmp/noise-4.ppm
   288.877 MP/s
    14.668 bits/pixel
build/fast_lossless /tmp/noise-6.ppm
   274.973 MP/s
    20.813 bits/pixel
build/fast_lossless /tmp/noise-8.ppm
   268.379 MP/s
    26.878 bits/pixel
build/fast_lossless /tmp/noise-10.ppm
   176.508 MP/s
    32.878 bits/pixel
build/fast_lossless /tmp/noise-11.ppm
   173.567 MP/s
    35.897 bits/pixel
build/fast_lossless /tmp/noise-12.ppm
   167.652 MP/s
    38.912 bits/pixel
build/fast_lossless /tmp/noise-13.ppm
   164.720 MP/s
    41.925 bits/pixel
build/fast_lossless /tmp/noise-14.ppm
   147.509 MP/s
    48.705 bits/pixel
build/fast_lossless /tmp/noise-15.ppm
   131.819 MP/s
    62.039 bits/pixel
build/fast_lossless /tmp/noise-16.ppm
   133.364 MP/s
    66.092 bits/pixel
build/fast_lossless /data/jpeg_xl_data/imagecompression.info.rgb8/artificial.ppm
   492.252 MP/s
     2.828 bits/pixel
build/fast_lossless /data/jpeg_xl_data/imagecompression.info.rgb16/artificial.ppm
   215.241 MP/s
    10.298 bits/pixel




After, AVX512:
build/fast_lossless /tmp/noise-4.ppm
   401.756 MP/s
    14.668 bits/pixel
build/fast_lossless /tmp/noise-6.ppm
   380.501 MP/s
    20.813 bits/pixel
build/fast_lossless /tmp/noise-8.ppm
   359.672 MP/s
    26.878 bits/pixel
build/fast_lossless /tmp/noise-10.ppm
   232.566 MP/s
    32.878 bits/pixel
build/fast_lossless /tmp/noise-11.ppm
   228.881 MP/s
    35.897 bits/pixel
build/fast_lossless /tmp/noise-12.ppm
   221.053 MP/s
    38.912 bits/pixel
build/fast_lossless /tmp/noise-13.ppm
   224.517 MP/s
    41.925 bits/pixel
build/fast_lossless /tmp/noise-14.ppm
   216.443 MP/s
    48.705 bits/pixel
build/fast_lossless /tmp/noise-15.ppm
   196.745 MP/s
    62.039 bits/pixel
build/fast_lossless /tmp/noise-16.ppm
   198.877 MP/s
    66.092 bits/pixel
build/fast_lossless /data/jpeg_xl_data/imagecompression.info.rgb8/artificial.ppm
   598.934 MP/s
     2.828 bits/pixel
build/fast_lossless /data/jpeg_xl_data/imagecompression.info.rgb16/artificial.ppm
   305.824 MP/s
    10.298 bits/pixel
```