### PR TITLE
Fix big-endian test for float16

### DIFF
--- a/lib/jxl/modular_test.cc
+++ b/lib/jxl/modular_test.cc
@@ -475,7 +475,7 @@ TEST(ModularTest, PredictorIntegerOverflow) {
   PaddedBytes compressed = std::move(writer).TakeBytes();
   extras::PackedPixelFile ppf;
   extras::JXLDecompressParams params;
-  params.accepted_formats.push_back({1, JXL_TYPE_FLOAT, JXL_LITTLE_ENDIAN, 0});
+  params.accepted_formats.push_back({1, JXL_TYPE_FLOAT, JXL_NATIVE_ENDIAN, 0});
   EXPECT_TRUE(DecodeImageJXL(compressed.data(), compressed.size(), params,
                              nullptr, &ppf));
   ASSERT_EQ(1, ppf.frames.size());
@@ -523,7 +523,7 @@ TEST(ModularTest, UnsqueezeIntegerOverflow) {
   PaddedBytes compressed = std::move(writer).TakeBytes();
   extras::PackedPixelFile ppf;
   extras::JXLDecompressParams params;
-  params.accepted_formats.push_back({1, JXL_TYPE_FLOAT, JXL_LITTLE_ENDIAN, 0});
+  params.accepted_formats.push_back({1, JXL_TYPE_FLOAT, JXL_NATIVE_ENDIAN, 0});
   EXPECT_TRUE(DecodeImageJXL(compressed.data(), compressed.size(), params,
                              nullptr, &ppf));
   ASSERT_EQ(1, ppf.frames.size());

--- a/lib/jxl/test_utils.h
+++ b/lib/jxl/test_utils.h
@@ -410,6 +410,11 @@ std::vector<double> ConvertToRGBA32(const uint8_t* pixels, size_t xsize,
   size_t num_channels = format.num_channels;
   bool gray = num_channels == 1 || num_channels == 2;
   bool alpha = num_channels == 2 || num_channels == 4;
+  JxlEndianness endianness = format.endianness;
+  // Compute actual type:
+  if (endianness == JXL_NATIVE_ENDIAN) {
+    endianness = IsLittleEndian() ? JXL_LITTLE_ENDIAN : JXL_BIG_ENDIAN;
+  }
 
   size_t stride =
       xsize * jxl::DivCeil(GetDataBits(format.data_type) * num_channels,
@@ -434,6 +439,7 @@ std::vector<double> ConvertToRGBA32(const uint8_t* pixels, size_t xsize,
       }
     }
   } else if (format.data_type == JXL_TYPE_UINT16) {
+    JXL_ASSERT(endianness != JXL_NATIVE_ENDIAN);
     // Multiplier to bring to 0-1.0 range
     double mul = factor > 0.0 ? factor : 1.0 / 65535.0;
     for (size_t y = 0; y < ysize; ++y) {
@@ -441,7 +447,7 @@ std::vector<double> ConvertToRGBA32(const uint8_t* pixels, size_t xsize,
         size_t j = (y * xsize + x) * 4;
         size_t i = y * stride + x * num_channels * 2;
         double r, g, b, a;
-        if (format.endianness == JXL_BIG_ENDIAN) {
+        if (endianness == JXL_BIG_ENDIAN) {
           r = (pixels[i + 0] << 8) + pixels[i + 1];
           g = gray ? r : (pixels[i + 2] << 8) + pixels[i + 3];
           b = gray ? r : (pixels[i + 4] << 8) + pixels[i + 5];
@@ -463,12 +469,13 @@ std::vector<double> ConvertToRGBA32(const uint8_t* pixels, size_t xsize,
       }
     }
   } else if (format.data_type == JXL_TYPE_FLOAT) {
+    JXL_ASSERT(endianness != JXL_NATIVE_ENDIAN);
     for (size_t y = 0; y < ysize; ++y) {
       for (size_t x = 0; x < xsize; ++x) {
         size_t j = (y * xsize + x) * 4;
         size_t i = y * stride + x * num_channels * 4;
         double r, g, b, a;
-        if (format.endianness == JXL_BIG_ENDIAN) {
+        if (endianness == JXL_BIG_ENDIAN) {
           r = LoadBEFloat(pixels + i);
           g = gray ? r : LoadBEFloat(pixels + i + 4);
           b = gray ? r : LoadBEFloat(pixels + i + 8);
@@ -486,12 +493,13 @@ std::vector<double> ConvertToRGBA32(const uint8_t* pixels, size_t xsize,
       }
     }
   } else if (format.data_type == JXL_TYPE_FLOAT16) {
+    JXL_ASSERT(endianness != JXL_NATIVE_ENDIAN);
     for (size_t y = 0; y < ysize; ++y) {
       for (size_t x = 0; x < xsize; ++x) {
         size_t j = (y * xsize + x) * 4;
         size_t i = y * stride + x * num_channels * 2;
         double r, g, b, a;
-        if (format.endianness == JXL_BIG_ENDIAN) {
+        if (endianness == JXL_BIG_ENDIAN) {
           r = LoadBEFloat16(pixels + i);
           g = gray ? r : LoadBEFloat16(pixels + i + 2);
           b = gray ? r : LoadBEFloat16(pixels + i + 4);


### PR DESCRIPTION
The following commit allow the
`DecodeTest/DecodeTestParam.PixelTest/301x33*f16*` test family to pass on big-endian architectures.