### PR TITLE
[fix recent build regression] Disable AVX512 with gcc < 11

### DIFF
--- a/lib/jxl/enc_fast_lossless.cc
+++ b/lib/jxl/enc_fast_lossless.cc
@@ -38,9 +38,9 @@
 #endif
 
 #ifndef FJXL_ENABLE_AVX512
-// On clang-7 or earlier, and gcc-8 or earlier, AVX512 seems broken.
+// On clang-7 or earlier, and gcc-10 or earlier, AVX512 seems broken.
 #if (defined(__clang__) && __clang_major__ > 7) || \
-    (defined(__GNUC__) && __GNUC__ > 8)
+    (defined(__GNUC__) && __GNUC__ > 10)
 #define FJXL_ENABLE_AVX512 1
 #endif
 #endif


### PR DESCRIPTION
Commit b612e26914a524b3b9d5a93c4fe3033fd2e63259 breaks build with gcc 9.4 of Ubuntu 20.04 with
```
In file included from /home/even/libjxl/lib/jxl/enc_fast_lossless.cc:3770:
/home/even/libjxl/lib/jxl/enc_fast_lossless.cc: In static member function ‘static std::array<AVX512::{anonymous}::SIMDVec16, 3> AVX512::{anonymous}::SIMDVec16::LoadRGB8(const unsigned char*)’:
/home/even/libjxl/lib/jxl/enc_fast_lossless.cc:960:9: error: ‘_mm512_zextsi256_si512’ was not declared in this scope; did you mean ‘_mm512_castsi256_si512’?
  960 |         _mm512_zextsi256_si512(_mm256_loadu_si256((__m256i*)(data + 64)));
      |         ^~~~~~~~~~~~~~~~~~~~~~
      |         _mm512_castsi256_si512
/home/even/libjxl/lib/jxl/enc_fast_lossless.cc: In function ‘void AVX512::{anonymous}::StoreToWriterAVX512(const AVX512::{anonymous}::Bits32&, {anonymous}::BitWriter&)’:
/home/even/libjxl/lib/jxl/enc_fast_lossless.cc:2207:7: error: ‘_mm512_cvtsi512_si32’ was not declared in this scope; did you mean ‘_mm512_castsi512_si128’?
 2207 |       _mm512_cvtsi512_si32(_mm512_alignr_epi32(bits, bits, 15));
      |       ^~~~~~~~~~~~~~~~~~~~
      |       _mm512_castsi512_si128
```

CC @veluca93

Goldbolt with gcc 11.1: working: https://godbolt.org/z/4qPT4sYGW
Goldbolt with gcc 10.4: broken: https://godbolt.org/z/fvacvscrx