### PR TITLE
Build a separate jpegli-static library that libjpeg.so depends on.

### DIFF
--- a/lib/jpegli.cmake
+++ b/lib/jpegli.cmake
@@ -3,29 +3,23 @@
 # Use of this source code is governed by a BSD-style
 # license that can be found in the LICENSE file.
 
-set(JPEGLI_MAJOR_VERSION 62)
-set(JPEGLI_MINOR_VERSION 3)
-set(JPEGLI_PATCH_VERSION 0)
-set(JPEGLI_LIBRARY_VERSION
-    "${JPEGLI_MAJOR_VERSION}.${JPEGLI_MINOR_VERSION}.${JPEGLI_PATCH_VERSION}"
-)
-
-set(JPEGLI_LIBRARY_SOVERSION "${JPEGLI_MAJOR_VERSION}")
-
 set(JPEGLI_INTERNAL_SOURCES
   jpegli/color_transform.h
   jpegli/color_transform.cc
-  jpegli/common_api.cc
+  jpegli/common.h
+  jpegli/common.cc
   jpegli/dct.h
   jpegli/dct.cc
-  jpegli/decode_api.cc
+  jpegli/decode.h
+  jpegli/decode.cc
   jpegli/decode_internal.h
   jpegli/decode_marker.h
   jpegli/decode_marker.cc
   jpegli/decode_scan.h
   jpegli/decode_scan.cc
   jpegli/destination_manager.cc
-  jpegli/encode_api.cc
+  jpegli/encode.h
+  jpegli/encode.cc
   jpegli/encode_internal.h
   jpegli/entropy_coding.h
   jpegli/entropy_coding.cc
@@ -53,56 +47,21 @@ set(JPEGLI_INTERNAL_LIBS
   ${ATOMICS_LIBRARIES}
 )
 
-set(OBJ_COMPILE_DEFINITIONS
-  JPEGLI_MAJOR_VERSION=${JPEGLI_MAJOR_VERSION}
-  JPEGLI_MINOR_VERSION=${JPEGLI_MINOR_VERSION}
-  JPEGLI_PATCH_VERSION=${JPEGLI_PATCH_VERSION}
-  # Used to determine if we are building the library when defined or just
-  # including the library when not defined. This is public so libjpeg shared
-  # library gets this define too.
-  JPEGLI_INTERNAL_LIBRARY_BUILD
-)
-
-add_library(jpegli-obj OBJECT ${JPEGLI_INTERNAL_SOURCES})
-target_compile_options(jpegli-obj PRIVATE ${JPEGXL_INTERNAL_FLAGS})
-target_compile_options(jpegli-obj PUBLIC ${JPEGXL_COVERAGE_FLAGS})
-set_property(TARGET jpegli-obj PROPERTY POSITION_INDEPENDENT_CODE ON)
-target_include_directories(jpegli-obj PUBLIC
+add_library(jpegli-static STATIC EXCLUDE_FROM_ALL "${JPEGLI_INTERNAL_SOURCES}")
+target_compile_options(jpegli-static PRIVATE "${JPEGXL_INTERNAL_FLAGS}")
+target_compile_options(jpegli-static PUBLIC ${JPEGXL_COVERAGE_FLAGS})
+set_property(TARGET jpegli-static PROPERTY POSITION_INDEPENDENT_CODE ON)
+target_include_directories(jpegli-static PUBLIC
   "$<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}>"
   "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
   "$<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/include>"
   "$<BUILD_INTERFACE:$<TARGET_PROPERTY:hwy,INTERFACE_INCLUDE_DIRECTORIES>>"
 )
-target_compile_definitions(jpegli-obj PUBLIC
-  ${OBJ_COMPILE_DEFINITIONS}
-)
+target_link_libraries(jpegli-static PUBLIC ${JPEGLI_INTERNAL_LIBS})
 
-set(JPEGLI_INTERNAL_OBJECTS $<TARGET_OBJECTS:jpegli-obj>)
-
-file(MAKE_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/jpegli)
-add_library(jpeg SHARED ${JPEGLI_INTERNAL_OBJECTS})
-target_link_libraries(jpeg PUBLIC ${JPEGXL_COVERAGE_FLAGS})
-target_link_libraries(jpeg PRIVATE ${JPEGLI_INTERNAL_LIBS})
-set_target_properties(jpeg PROPERTIES
-  VERSION ${JPEGLI_LIBRARY_VERSION}
-  SOVERSION ${JPEGLI_LIBRARY_SOVERSION}
-  LIBRARY_OUTPUT_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/jpegli"
-  RUNTIME_OUTPUT_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/jpegli")
-
-# Add a jpeg.version file as a version script to tag symbols with the
-# appropriate version number.
-set_target_properties(jpeg PROPERTIES
-  LINK_DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/jpegli/jpeg.version)
-set_property(TARGET jpeg APPEND_STRING PROPERTY
-  LINK_FLAGS " -Wl,--version-script=${CMAKE_CURRENT_SOURCE_DIR}/jpegli/jpeg.version")
-
-# This hides the default visibility symbols from static libraries bundled into
-# the shared library. In particular this prevents exposing symbols from hwy
-# in the shared library.
-if(LINKER_SUPPORT_EXCLUDE_LIBS)
-  set_property(TARGET jpeg APPEND_STRING PROPERTY
-    LINK_FLAGS " ${LINKER_EXCLUDE_LIBS_FLAG}")
-endif()
+#
+# Tests for jpegli-static
+#
 
 if(BUILD_TESTING)
 set(TEST_FILES
@@ -127,7 +86,7 @@ foreach (TESTFILE IN LISTS TEST_FILES)
   target_include_directories(${TESTNAME} PRIVATE "${PROJECT_SOURCE_DIR}")
   target_link_libraries(${TESTNAME}
     hwy
-    jpeg
+    jpegli-static
     gmock
     GTest::GTest
     GTest::Main
@@ -143,4 +102,58 @@ foreach (TESTFILE IN LISTS TEST_FILES)
     gtest_discover_tests(${TESTNAME} DISCOVERY_TIMEOUT 240)
   endif ()
 endforeach ()
+endif()
+
+#
+# Build libjpeg.so that links to libjpeg-static
+#
+
+set(JPEGLI_LIBJPEG_MAJOR_VERSION 62)
+set(JPEGLI_LIBJPEG_MINOR_VERSION 3)
+set(JPEGLI_LIBJPEG_PATCH_VERSION 0)
+set(JPEGLI_LIBJPEG_LIBRARY_VERSION
+    "${JPEGLI_LIBJPEG_MAJOR_VERSION}.${JPEGLI_LIBJPEG_MINOR_VERSION}.${JPEGLI_LIBJPEG_PATCH_VERSION}"
+)
+
+set(JPEGLI_LIBJPEG_LIBRARY_SOVERSION "${JPEGLI_LIBJPEG_MAJOR_VERSION}")
+
+set(JPEGLI_LIBJPEG_OBJ_COMPILE_DEFINITIONS
+  JPEGLI_LIBJPEG_MAJOR_VERSION=${JPEGLI_LIBJPEG_MAJOR_VERSION}
+  JPEGLI_LIBJPEG_MINOR_VERSION=${JPEGLI_LIBJPEG_MINOR_VERSION}
+  JPEGLI_LIBJPEG_PATCH_VERSION=${JPEGLI_LIBJPEG_PATCH_VERSION}
+)
+
+add_library(jpegli-libjpeg-obj OBJECT jpegli/libjpeg_wrapper.cc)
+target_compile_options(jpegli-libjpeg-obj PRIVATE ${JPEGXL_INTERNAL_FLAGS})
+target_compile_options(jpegli-libjpeg-obj PUBLIC ${JPEGXL_COVERAGE_FLAGS})
+set_property(TARGET jpegli-libjpeg-obj PROPERTY POSITION_INDEPENDENT_CODE ON)
+target_include_directories(jpegli-libjpeg-obj PUBLIC "${PROJECT_SOURCE_DIR}")
+target_compile_definitions(jpegli-libjpeg-obj PUBLIC
+  ${JPEGLI_LIBJPEG_OBJ_COMPILE_DEFINITIONS}
+)
+set(JPEGLI_LIBJPEG_INTERNAL_OBJECTS $<TARGET_OBJECTS:jpegli-libjpeg-obj>)
+
+file(MAKE_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/jpegli)
+add_library(jpeg SHARED ${JPEGLI_LIBJPEG_INTERNAL_OBJECTS})
+target_link_libraries(jpeg PUBLIC ${JPEGXL_COVERAGE_FLAGS})
+target_link_libraries(jpeg PRIVATE jpegli-static)
+set_target_properties(jpeg PROPERTIES
+  VERSION ${JPEGLI_LIBJPEG_LIBRARY_VERSION}
+  SOVERSION ${JPEGLI_LIBJPEG_LIBRARY_SOVERSION}
+  LIBRARY_OUTPUT_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/jpegli"
+  RUNTIME_OUTPUT_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/jpegli")
+
+# Add a jpeg.version file as a version script to tag symbols with the
+# appropriate version number.
+set_target_properties(jpeg PROPERTIES
+  LINK_DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/jpegli/jpeg.version)
+set_property(TARGET jpeg APPEND_STRING PROPERTY
+  LINK_FLAGS " -Wl,--version-script=${CMAKE_CURRENT_SOURCE_DIR}/jpegli/jpeg.version")
+
+# This hides the default visibility symbols from static libraries bundled into
+# the shared library. In particular this prevents exposing symbols from hwy
+# in the shared library.
+if(LINKER_SUPPORT_EXCLUDE_LIBS)
+  set_property(TARGET jpeg APPEND_STRING PROPERTY
+    LINK_FLAGS " ${LINKER_EXCLUDE_LIBS_FLAG}")
 endif()

--- a/lib/jpegli/common.cc
+++ b/lib/jpegli/common.cc
@@ -3,18 +3,13 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-/* clang-format off */
-#include <stdint.h>
-#include <stdio.h>
-#include <jpeglib.h>
-#include <stdlib.h>
-/* clang-format on */
+#include "lib/jpegli/common.h"
 
 #include "lib/jpegli/decode_internal.h"
 #include "lib/jpegli/encode_internal.h"
 #include "lib/jpegli/memory_manager.h"
 
-void jpeg_abort(j_common_ptr cinfo) {
+void jpegli_abort(j_common_ptr cinfo) {
   auto mem = reinterpret_cast<jpegli::MemoryManager*>(cinfo->mem);
   if (mem == nullptr) {
     return;
@@ -28,7 +23,7 @@ void jpeg_abort(j_common_ptr cinfo) {
   }
 }
 
-void jpeg_destroy(j_common_ptr cinfo) {
+void jpegli_destroy(j_common_ptr cinfo) {
   auto mem = reinterpret_cast<jpegli::MemoryManager*>(cinfo->mem);
   if (mem == nullptr) {
     return;
@@ -46,13 +41,13 @@ void jpeg_destroy(j_common_ptr cinfo) {
   }
 }
 
-JQUANT_TBL* jpeg_alloc_quant_table(j_common_ptr cinfo) {
+JQUANT_TBL* jpegli_alloc_quant_table(j_common_ptr cinfo) {
   JQUANT_TBL* table = jpegli::Allocate<JQUANT_TBL>(cinfo, 1);
   table->sent_table = FALSE;
   return table;
 }
 
-JHUFF_TBL* jpeg_alloc_huff_table(j_common_ptr cinfo) {
+JHUFF_TBL* jpegli_alloc_huff_table(j_common_ptr cinfo) {
   JHUFF_TBL* table = jpegli::Allocate<JHUFF_TBL>(cinfo, 1);
   table->sent_table = FALSE;
   return table;

--- a/lib/jpegli/common.h
+++ b/lib/jpegli/common.h
@@ -1,0 +1,46 @@
+// Copyright (c) the JPEG XL Project Authors. All rights reserved.
+//
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+//
+// This file conatins the C API of the common encoder/decoder part of libjpegli
+// library, which is based on the C API of libjpeg, with the function names
+// changed from jpeg_* to jpegli_*, while compressor and dempressor object
+// definitions are included directly from jpeglib.h
+//
+// Applications can use the libjpegli library in one of the following ways:
+//
+//  (1) Include jpegli/encode.h and/or jpegli/decode.h, update the function
+//      names of the API and link against libjpegli.
+//
+//  (2) Leave the application code unchanged, but replace the libjpeg.so library
+//      with the one built by this project that is API- and ABI-compatible with
+//      libjpeg-turbo's version of libjpeg.so.
+
+#ifndef LIB_JPEGLI_COMMON_H_
+#define LIB_JPEGLI_COMMON_H_
+
+/* clang-format off */
+#include <stdio.h>
+#include <jpeglib.h>
+/* clang-format on */
+
+#if defined(__cplusplus) || defined(c_plusplus)
+extern "C" {
+#endif
+
+struct jpeg_error_mgr* jpegli_std_error(struct jpeg_error_mgr* err);
+
+void jpegli_abort(j_common_ptr cinfo);
+
+void jpegli_destroy(j_common_ptr cinfo);
+
+JQUANT_TBL* jpegli_alloc_quant_table(j_common_ptr cinfo);
+
+JHUFF_TBL* jpegli_alloc_huff_table(j_common_ptr cinfo);
+
+#if defined(__cplusplus) || defined(c_plusplus)
+}  // extern "C"
+#endif
+
+#endif  // LIB_JPEGLI_COMMON_H_

--- a/lib/jpegli/decode.h
+++ b/lib/jpegli/decode.h
@@ -1,0 +1,94 @@
+// Copyright (c) the JPEG XL Project Authors. All rights reserved.
+//
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+//
+// This file conatins the C API of the decoder part of the libjpegli library,
+// which is based on the C API of libjpeg, with the function names changed from
+// jpeg_* to jpegli_*, while dempressor object definitions are included directly
+// from jpeglib.h
+//
+// Applications can use the libjpegli library in one of the following ways:
+//
+//  (1) Include jpegli/encode.h and/or jpegli/decode.h, update the function
+//      names of the API and link against libjpegli.
+//
+//  (2) Leave the application code unchanged, but replace the libjpeg.so library
+//      with the one built by this project that is API- and ABI-compatible with
+//      libjpeg-turbo's version of libjpeg.so.
+
+#ifndef LIB_JPEGLI_DECODE_H_
+#define LIB_JPEGLI_DECODE_H_
+
+/* clang-format off */
+#include <stdio.h>
+#include <jpeglib.h>
+/* clang-format on */
+
+#include "lib/jpegli/common.h"
+
+#if defined(__cplusplus) || defined(c_plusplus)
+extern "C" {
+#endif
+
+#define jpegli_create_decompress(cinfo)              \
+  jpegli_CreateDecompress((cinfo), JPEG_LIB_VERSION, \
+                          (size_t)sizeof(struct jpeg_decompress_struct))
+
+void jpegli_CreateDecompress(j_decompress_ptr cinfo, int version,
+                             size_t structsize);
+
+void jpegli_stdio_src(j_decompress_ptr cinfo, FILE *infile);
+
+void jpegli_mem_src(j_decompress_ptr cinfo, const unsigned char *inbuffer,
+                    unsigned long insize);
+
+int jpegli_read_header(j_decompress_ptr cinfo, boolean require_image);
+
+boolean jpegli_start_decompress(j_decompress_ptr cinfo);
+
+JDIMENSION jpegli_read_scanlines(j_decompress_ptr cinfo, JSAMPARRAY scanlines,
+                                 JDIMENSION max_lines);
+
+JDIMENSION jpegli_skip_scanlines(j_decompress_ptr cinfo, JDIMENSION num_lines);
+
+void jpegli_crop_scanline(j_decompress_ptr cinfo, JDIMENSION *xoffset,
+                          JDIMENSION *width);
+
+boolean jpegli_finish_decompress(j_decompress_ptr cinfo);
+
+JDIMENSION jpegli_read_raw_data(j_decompress_ptr cinfo, JSAMPIMAGE data,
+                                JDIMENSION max_lines);
+
+boolean jpegli_has_multiple_scans(j_decompress_ptr cinfo);
+
+boolean jpegli_start_output(j_decompress_ptr cinfo, int scan_number);
+
+boolean jpegli_finish_output(j_decompress_ptr cinfo);
+
+boolean jpegli_input_complete(j_decompress_ptr cinfo);
+
+int jpegli_consume_input(j_decompress_ptr cinfo);
+
+void jpegli_calc_output_dimensions(j_decompress_ptr cinfo);
+
+void jpegli_save_markers(j_decompress_ptr cinfo, int marker_code,
+                         unsigned int length_limit);
+
+void jpegli_set_marker_processor(j_decompress_ptr cinfo, int marker_code,
+                                 jpeg_marker_parser_method routine);
+
+boolean jpegli_resync_to_restart(j_decompress_ptr cinfo, int desired);
+
+boolean jpegli_read_icc_profile(j_decompress_ptr cinfo, JOCTET **icc_data_ptr,
+                                unsigned int *icc_data_len);
+
+void jpegli_abort_decompress(j_decompress_ptr cinfo);
+
+void jpegli_destroy_decompress(j_decompress_ptr cinfo);
+
+#if defined(__cplusplus) || defined(c_plusplus)
+}  // extern "C"
+#endif
+
+#endif  // LIB_JPEGLI_DECODE_H_

--- a/lib/jpegli/decode_marker.cc
+++ b/lib/jpegli/decode_marker.cc
@@ -7,6 +7,7 @@
 
 #include <string.h>
 
+#include "lib/jpegli/common.h"
 #include "lib/jpegli/decode_internal.h"
 #include "lib/jpegli/error.h"
 #include "lib/jpegli/huffman.h"
@@ -331,7 +332,7 @@ void ProcessDHT(j_decompress_ptr cinfo, const uint8_t* data, size_t len) {
       table = &cinfo->dc_huff_tbl_ptrs[huffman_index];
     }
     if (*table == nullptr) {
-      *table = jpeg_alloc_huff_table(reinterpret_cast<j_common_ptr>(cinfo));
+      *table = jpegli_alloc_huff_table(reinterpret_cast<j_common_ptr>(cinfo));
     }
     // Bit length histogram
     std::array<uint32_t, kJpegHuffmanMaxBitLength + 1> counts = {};
@@ -412,7 +413,7 @@ void ProcessDQT(j_decompress_ptr cinfo, const uint8_t* data, size_t len) {
 
     if (cinfo->quant_tbl_ptrs[quant_table_index] == nullptr) {
       cinfo->quant_tbl_ptrs[quant_table_index] =
-          jpeg_alloc_quant_table(reinterpret_cast<j_common_ptr>(cinfo));
+          jpegli_alloc_quant_table(reinterpret_cast<j_common_ptr>(cinfo));
     }
     JQUANT_TBL* quant_table = cinfo->quant_tbl_ptrs[quant_table_index];
 

--- a/lib/jpegli/destination_manager.cc
+++ b/lib/jpegli/destination_manager.cc
@@ -3,13 +3,9 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-/* clang-format off */
-#include <stdint.h>
-#include <stdio.h>
-#include <jpeglib.h>
 #include <string.h>
-/* clang-format on */
 
+#include "lib/jpegli/encode.h"
 #include "lib/jpegli/error.h"
 #include "lib/jpegli/memory_manager.h"
 
@@ -85,7 +81,7 @@ struct MemoryDestinationManager {
 
 }  // namespace jpegli
 
-void jpeg_stdio_dest(j_compress_ptr cinfo, FILE* outfile) {
+void jpegli_stdio_dest(j_compress_ptr cinfo, FILE* outfile) {
   if (cinfo->dest != nullptr) {
     JPEGLI_ERROR("jpeg_stdio_dest: destination manager is already set");
   }
@@ -103,10 +99,10 @@ void jpeg_stdio_dest(j_compress_ptr cinfo, FILE* outfile) {
   cinfo->dest = reinterpret_cast<jpeg_destination_mgr*>(dest);
 }
 
-void jpeg_mem_dest(j_compress_ptr cinfo, unsigned char** outbuffer,
-                   unsigned long* outsize) {
+void jpegli_mem_dest(j_compress_ptr cinfo, unsigned char** outbuffer,
+                     unsigned long* outsize) {
   if (cinfo->dest != nullptr) {
-    JPEGLI_ERROR("jpeg_mem_dest: destination manager is already set");
+    JPEGLI_ERROR("jpegli_mem_dest: destination manager is already set");
   }
   jpegli::MemoryDestinationManager* dest =
       jpegli::Allocate<jpegli::MemoryDestinationManager>(cinfo, 1);

--- a/lib/jpegli/encode.h
+++ b/lib/jpegli/encode.h
@@ -1,0 +1,88 @@
+// Copyright (c) the JPEG XL Project Authors. All rights reserved.
+//
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+//
+// This file conatins the C API of the encoder part of the libjpegli library,
+// which is based on the C API of libjpeg, with the function names changed from
+// jpeg_* to jpegli_*, while compressor object definitions are included directly
+// from jpeglib.h
+//
+// Applications can use the libjpegli library in one of the following ways:
+//
+//  (1) Include jpegli/encode.h and/or jpegli/decode.h, update the function
+//      names of the API and link against libjpegli.
+//
+//  (2) Leave the application code unchanged, but replace the libjpeg.so library
+//      with the one built by this project that is API- and ABI-compatible with
+//      libjpeg-turbo's version of libjpeg.so.
+
+#ifndef LIB_JPEGLI_ENCODE_H_
+#define LIB_JPEGLI_ENCODE_H_
+
+/* clang-format off */
+#include <stdio.h>
+#include <jpeglib.h>
+/* clang-format on */
+
+#include "lib/jpegli/common.h"
+
+#if defined(__cplusplus) || defined(c_plusplus)
+extern "C" {
+#endif
+
+#define jpegli_create_compress(cinfo)              \
+  jpegli_CreateCompress((cinfo), JPEG_LIB_VERSION, \
+                        (size_t)sizeof(struct jpeg_compress_struct))
+void jpegli_CreateCompress(j_compress_ptr cinfo, int version,
+                           size_t structsize);
+
+void jpegli_stdio_dest(j_compress_ptr cinfo, FILE* outfile);
+
+void jpegli_mem_dest(j_compress_ptr cinfo, unsigned char** outbuffer,
+                     unsigned long* outsize);
+
+void jpegli_set_defaults(j_compress_ptr cinfo);
+
+void jpegli_default_colorspace(j_compress_ptr cinfo);
+
+void jpegli_set_colorspace(j_compress_ptr cinfo, J_COLOR_SPACE colorspace);
+
+void jpegli_set_quality(j_compress_ptr cinfo, int quality,
+                        boolean force_baseline);
+
+void jpegli_set_linear_quality(j_compress_ptr cinfo, int scale_factor,
+                               boolean force_baseline);
+
+int jpegli_quality_scaling(int quality);
+
+void jpegli_add_quant_table(j_compress_ptr cinfo, int which_tbl,
+                            const unsigned int* basic_table, int scale_factor,
+                            boolean force_baseline);
+
+void jpegli_simple_progression(j_compress_ptr cinfo);
+
+void jpegli_suppress_tables(j_compress_ptr cinfo, boolean suppress);
+
+void jpegli_write_m_header(j_compress_ptr cinfo, int marker,
+                           unsigned int datalen);
+
+void jpegli_write_m_byte(j_compress_ptr cinfo, int val);
+
+void jpegli_write_icc_profile(j_compress_ptr cinfo, const JOCTET* icc_data_ptr,
+                              unsigned int icc_data_len);
+
+void jpegli_start_compress(j_compress_ptr cinfo, boolean write_all_tables);
+
+JDIMENSION jpegli_write_scanlines(j_compress_ptr cinfo, JSAMPARRAY scanlines,
+                                  JDIMENSION num_lines);
+
+void jpegli_finish_compress(j_compress_ptr cinfo);
+
+void jpegli_destroy_compress(j_compress_ptr cinfo);
+
+#if defined(__cplusplus) || defined(c_plusplus)
+}  // extern "C"
+#endif
+
+#endif  // LIB_JPEGLI_ENCODE_H_

--- a/lib/jpegli/error.cc
+++ b/lib/jpegli/error.cc
@@ -5,14 +5,11 @@
 
 #include "lib/jpegli/error.h"
 
-/* clang-format off */
-#include <stdint.h>
-#include <stdio.h>
-#include <jpeglib.h>
-#include <stdlib.h>
 #include <setjmp.h>
+#include <stdlib.h>
 #include <string.h>
-/* clang-format on */
+
+#include "lib/jpegli/common.h"
 
 namespace jpegli {
 
@@ -45,7 +42,7 @@ void ResetErrorManager(j_common_ptr cinfo) {}
 
 }  // namespace jpegli
 
-struct jpeg_error_mgr* jpeg_std_error(struct jpeg_error_mgr* err) {
+struct jpeg_error_mgr* jpegli_std_error(struct jpeg_error_mgr* err) {
   err->error_exit = jpegli::ExitWithAbort;
   err->output_message = jpegli::OutputMessage;
   err->emit_message = jpegli::EmitMessage;

--- a/lib/jpegli/libjpeg_wrapper.cc
+++ b/lib/jpegli/libjpeg_wrapper.cc
@@ -1,0 +1,213 @@
+// Copyright (c) the JPEG XL Project Authors. All rights reserved.
+//
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+//
+// This file contains wrapper-functions that are used to build the libjpeg.so
+// shared library that is API- and ABI-compatible with libjpeg-turbo's version
+// of libjpeg.so.
+
+/* clang-format off */
+#include <stdio.h>
+#include <jpeglib.h>
+/* clang-format on */
+
+#include "lib/jpegli/common.h"
+#include "lib/jpegli/decode.h"
+#include "lib/jpegli/encode.h"
+#include "lib/jpegli/error.h"
+
+struct jpeg_error_mgr *jpeg_std_error(struct jpeg_error_mgr *err) {
+  return jpegli_std_error(err);
+}
+
+void jpeg_abort(j_common_ptr cinfo) { jpegli_abort(cinfo); }
+
+void jpeg_destroy(j_common_ptr cinfo) { jpegli_destroy(cinfo); }
+
+JQUANT_TBL *jpeg_alloc_quant_table(j_common_ptr cinfo) {
+  return jpegli_alloc_quant_table(cinfo);
+}
+
+JHUFF_TBL *jpeg_alloc_huff_table(j_common_ptr cinfo) {
+  return jpegli_alloc_huff_table(cinfo);
+}
+
+void jpeg_CreateDecompress(j_decompress_ptr cinfo, int version,
+                           size_t structsize) {
+  jpegli_CreateDecompress(cinfo, version, structsize);
+}
+
+void jpeg_stdio_src(j_decompress_ptr cinfo, FILE *infile) {
+  jpegli_stdio_src(cinfo, infile);
+}
+
+void jpeg_mem_src(j_decompress_ptr cinfo, const unsigned char *inbuffer,
+                  unsigned long insize) {
+  jpegli_mem_src(cinfo, inbuffer, insize);
+}
+
+int jpeg_read_header(j_decompress_ptr cinfo, boolean require_image) {
+  return jpegli_read_header(cinfo, require_image);
+}
+
+boolean jpeg_start_decompress(j_decompress_ptr cinfo) {
+  return jpegli_start_decompress(cinfo);
+}
+
+JDIMENSION jpeg_read_scanlines(j_decompress_ptr cinfo, JSAMPARRAY scanlines,
+                               JDIMENSION max_lines) {
+  return jpegli_read_scanlines(cinfo, scanlines, max_lines);
+}
+
+JDIMENSION jpeg_skip_scanlines(j_decompress_ptr cinfo, JDIMENSION num_lines) {
+  return jpegli_skip_scanlines(cinfo, num_lines);
+}
+
+void jpeg_crop_scanline(j_decompress_ptr cinfo, JDIMENSION *xoffset,
+                        JDIMENSION *width) {
+  jpegli_crop_scanline(cinfo, xoffset, width);
+}
+
+boolean jpeg_finish_decompress(j_decompress_ptr cinfo) {
+  return jpegli_finish_decompress(cinfo);
+}
+
+JDIMENSION jpeg_read_raw_data(j_decompress_ptr cinfo, JSAMPIMAGE data,
+                              JDIMENSION max_lines) {
+  return jpegli_read_raw_data(cinfo, data, max_lines);
+}
+
+boolean jpeg_has_multiple_scans(j_decompress_ptr cinfo) {
+  return jpegli_has_multiple_scans(cinfo);
+}
+
+boolean jpeg_start_output(j_decompress_ptr cinfo, int scan_number) {
+  return jpegli_start_output(cinfo, scan_number);
+}
+
+boolean jpeg_finish_output(j_decompress_ptr cinfo) {
+  return jpegli_finish_output(cinfo);
+}
+
+boolean jpeg_input_complete(j_decompress_ptr cinfo) {
+  return jpegli_input_complete(cinfo);
+}
+
+int jpeg_consume_input(j_decompress_ptr cinfo) {
+  return jpegli_consume_input(cinfo);
+}
+
+void jpeg_calc_output_dimensions(j_decompress_ptr cinfo) {
+  jpegli_calc_output_dimensions(cinfo);
+}
+
+void jpeg_save_markers(j_decompress_ptr cinfo, int marker_code,
+                       unsigned int length_limit) {
+  jpegli_save_markers(cinfo, marker_code, length_limit);
+}
+
+void jpeg_set_marker_processor(j_decompress_ptr cinfo, int marker_code,
+                               jpeg_marker_parser_method routine) {
+  jpegli_set_marker_processor(cinfo, marker_code, routine);
+}
+
+boolean jpeg_read_icc_profile(j_decompress_ptr cinfo, JOCTET **icc_data_ptr,
+                              unsigned int *icc_data_len) {
+  return jpegli_read_icc_profile(cinfo, icc_data_ptr, icc_data_len);
+}
+
+void jpeg_abort_decompress(j_decompress_ptr cinfo) {
+  return jpegli_abort_decompress(cinfo);
+}
+
+void jpeg_destroy_decompress(j_decompress_ptr cinfo) {
+  return jpegli_destroy_decompress(cinfo);
+}
+
+void jpeg_CreateCompress(j_compress_ptr cinfo, int version, size_t structsize) {
+  jpegli_CreateCompress(cinfo, version, structsize);
+}
+
+void jpeg_stdio_dest(j_compress_ptr cinfo, FILE *outfile) {
+  jpegli_stdio_dest(cinfo, outfile);
+}
+
+void jpeg_mem_dest(j_compress_ptr cinfo, unsigned char **outbuffer,
+                   unsigned long *outsize) {
+  jpegli_mem_dest(cinfo, outbuffer, outsize);
+}
+
+void jpeg_set_defaults(j_compress_ptr cinfo) { jpegli_set_defaults(cinfo); }
+
+void jpeg_default_colorspace(j_compress_ptr cinfo) {
+  jpegli_default_colorspace(cinfo);
+}
+
+void jpeg_set_colorspace(j_compress_ptr cinfo, J_COLOR_SPACE colorspace) {
+  jpegli_set_colorspace(cinfo, colorspace);
+}
+
+void jpeg_set_quality(j_compress_ptr cinfo, int quality,
+                      boolean force_baseline) {
+  jpegli_set_quality(cinfo, quality, force_baseline);
+}
+
+void jpeg_set_linear_quality(j_compress_ptr cinfo, int scale_factor,
+                             boolean force_baseline) {
+  jpegli_set_linear_quality(cinfo, scale_factor, force_baseline);
+}
+
+int jpeg_quality_scaling(int quality) {
+  return jpegli_quality_scaling(quality);
+}
+
+void jpeg_add_quant_table(j_compress_ptr cinfo, int which_tbl,
+                          const unsigned int *basic_table, int scale_factor,
+                          boolean force_baseline) {
+  jpegli_add_quant_table(cinfo, which_tbl, basic_table, scale_factor,
+                         force_baseline);
+}
+
+void jpeg_simple_progression(j_compress_ptr cinfo) {
+  jpegli_simple_progression(cinfo);
+}
+
+void jpeg_suppress_tables(j_compress_ptr cinfo, boolean suppress) {
+  jpegli_suppress_tables(cinfo, suppress);
+}
+
+void jpeg_write_m_header(j_compress_ptr cinfo, int marker,
+                         unsigned int datalen) {
+  jpegli_write_m_header(cinfo, marker, datalen);
+}
+
+void jpeg_write_m_byte(j_compress_ptr cinfo, int val) {
+  jpegli_write_m_byte(cinfo, val);
+}
+
+void jpeg_write_icc_profile(j_compress_ptr cinfo, const JOCTET *icc_data_ptr,
+                            unsigned int icc_data_len) {
+  jpegli_write_icc_profile(cinfo, icc_data_ptr, icc_data_len);
+}
+
+void jpeg_start_compress(j_compress_ptr cinfo, boolean write_all_tables) {
+  jpegli_start_compress(cinfo, write_all_tables);
+}
+
+JDIMENSION jpeg_write_scanlines(j_compress_ptr cinfo, JSAMPARRAY scanlines,
+                                JDIMENSION num_lines) {
+  return jpegli_write_scanlines(cinfo, scanlines, num_lines);
+}
+
+void jpeg_finish_compress(j_compress_ptr cinfo) {
+  jpegli_finish_compress(cinfo);
+}
+
+void jpeg_destroy_compress(j_compress_ptr cinfo) {
+  jpegli_destroy_compress(cinfo);
+}
+
+boolean jpeg_resync_to_restart(j_decompress_ptr cinfo, int desired) {
+  return jpegli_resync_to_restart(cinfo, desired);
+}

--- a/lib/jpegli/source_manager.cc
+++ b/lib/jpegli/source_manager.cc
@@ -5,6 +5,7 @@
 
 #include "lib/jpegli/source_manager.h"
 
+#include "lib/jpegli/decode.h"
 #include "lib/jpegli/error.h"
 #include "lib/jpegli/memory_manager.h"
 
@@ -44,8 +45,8 @@ struct StdioSourceManager {
 
 }  // namespace jpegli
 
-void jpeg_mem_src(j_decompress_ptr cinfo, const unsigned char* inbuffer,
-                  unsigned long insize) {
+void jpegli_mem_src(j_decompress_ptr cinfo, const unsigned char* inbuffer,
+                    unsigned long insize) {
   if (cinfo->src != nullptr) {
     JPEGLI_ERROR("jpeg_mem_src: source manager is already set");
   }
@@ -55,11 +56,11 @@ void jpeg_mem_src(j_decompress_ptr cinfo, const unsigned char* inbuffer,
   cinfo->src->init_source = jpegli::init_source;
   cinfo->src->fill_input_buffer = jpegli::EmitFakeEoiMarker;
   cinfo->src->skip_input_data = jpegli::skip_input_data;
-  cinfo->src->resync_to_restart = jpeg_resync_to_restart;
+  cinfo->src->resync_to_restart = jpegli_resync_to_restart;
   cinfo->src->term_source = jpegli::term_source;
 }
 
-void jpeg_stdio_src(j_decompress_ptr cinfo, FILE* infile) {
+void jpegli_stdio_src(j_decompress_ptr cinfo, FILE* infile) {
   if (cinfo->src != nullptr) {
     JPEGLI_ERROR("jpeg_stdio_src: source manager is already set");
   }
@@ -72,7 +73,7 @@ void jpeg_stdio_src(j_decompress_ptr cinfo, FILE* infile) {
   src->pub.init_source = jpegli::init_source;
   src->pub.fill_input_buffer = jpegli::StdioSourceManager::fill_input_buffer;
   src->pub.skip_input_data = jpegli::skip_input_data;
-  src->pub.resync_to_restart = jpeg_resync_to_restart;
+  src->pub.resync_to_restart = jpegli_resync_to_restart;
   src->pub.term_source = jpegli::term_source;
   cinfo->src = reinterpret_cast<jpeg_source_mgr*>(src);
 }


### PR DESCRIPTION
This way the jpegli-static library can be independently tested and it can be linked to applications that want to use 16-bit input/output.

The libjpeg.so library is built with a single additional libjpeg_wrapper.cc and it links to libjpeg-static.