### PR TITLE
minor masking adjustment

### DIFF
--- a/lib/jxl/enc_adaptive_quantization.cc
+++ b/lib/jxl/enc_adaptive_quantization.cc
@@ -345,7 +345,7 @@ void PerBlockModulations(const float butteraugli_target, const ImageF& xyb_x,
 
 template <typename D, typename V>
 V MaskingSqrt(const D d, V v) {
-  static const float kLogOffset = 26.481471032459346f;
+  static const float kLogOffset = 28;
   static const float kMul = 211.50759899638012f;
   const auto mul_v = Set(d, kMul * 1e8);
   const auto offset_v = Set(d, kLogOffset);
@@ -716,7 +716,7 @@ ImageF TileDistMap(const ImageF& distmap, int tile_size, int margin,
 
 constexpr float kDcQuantPow = 0.66f;
 static const float kDcQuant = 1.1f;
-static const float kAcQuant = 0.833f;
+static const float kAcQuant = 0.841f;
 
 void FindBestQuantization(const ImageBundle& linear, const Image3F& opsin,
                           PassesEncoderState* enc_state,

--- a/lib/jxl/encode_test.cc
+++ b/lib/jxl/encode_test.cc
@@ -503,7 +503,7 @@ TEST(EncodeTest, LossyEncoderUseOriginalProfileTest) {
     ASSERT_NE(nullptr, enc.get());
     JxlEncoderFrameSettings* frame_settings =
         JxlEncoderFrameSettingsCreate(enc.get(), NULL);
-    VerifyFrameEncoding(63, 129, enc.get(), frame_settings, 5143, true);
+    VerifyFrameEncoding(63, 129, enc.get(), frame_settings, 5181, true);
   }
   {
     JxlEncoderPtr enc = JxlEncoderMake(nullptr);
@@ -513,7 +513,7 @@ TEST(EncodeTest, LossyEncoderUseOriginalProfileTest) {
     EXPECT_EQ(JXL_ENC_SUCCESS,
               JxlEncoderFrameSettingsSetOption(
                   frame_settings, JXL_ENC_FRAME_SETTING_PROGRESSIVE_DC, 2));
-    VerifyFrameEncoding(63, 129, enc.get(), frame_settings, 5541, true);
+    VerifyFrameEncoding(63, 129, enc.get(), frame_settings, 5580, true);
   }
   {
     JxlEncoderPtr enc = JxlEncoderMake(nullptr);
@@ -523,7 +523,7 @@ TEST(EncodeTest, LossyEncoderUseOriginalProfileTest) {
     ASSERT_EQ(JXL_ENC_SUCCESS,
               JxlEncoderFrameSettingsSetOption(
                   frame_settings, JXL_ENC_FRAME_SETTING_EFFORT, 8));
-    VerifyFrameEncoding(63, 129, enc.get(), frame_settings, 4644, true);
+    VerifyFrameEncoding(63, 129, enc.get(), frame_settings, 4647, true);
   }
 }
 

--- a/lib/jxl/jxl_test.cc
+++ b/lib/jxl/jxl_test.cc
@@ -200,7 +200,7 @@ TEST(JxlTest, RoundtripOutOfOrderProcessing) {
   cparams.AddOption(JXL_ENC_FRAME_SETTING_EPF, 3);
 
   PackedPixelFile ppf_out;
-  EXPECT_NEAR(Roundtrip(t.ppf(), cparams, {}, &pool, &ppf_out), 20131, 100);
+  EXPECT_NEAR(Roundtrip(t.ppf(), cparams, {}, &pool, &ppf_out), 19861, 100);
   EXPECT_LE(ButteraugliDistance(t.ppf(), ppf_out), 1.35);
 }
 
@@ -220,8 +220,8 @@ TEST(JxlTest, RoundtripOutOfOrderProcessingBorder) {
   cparams.AddOption(JXL_ENC_FRAME_SETTING_RESAMPLING, 2);
 
   PackedPixelFile ppf_out;
-  EXPECT_NEAR(Roundtrip(t.ppf(), cparams, {}, &pool, &ppf_out), 9213, 55);
-  EXPECT_LE(ButteraugliDistance(t.ppf(), ppf_out), 2.8);
+  EXPECT_NEAR(Roundtrip(t.ppf(), cparams, {}, &pool, &ppf_out), 9102, 55);
+  EXPECT_LE(ButteraugliDistance(t.ppf(), ppf_out), 2.9);
 }
 
 TEST(JxlTest, RoundtripResample4) {
@@ -350,7 +350,7 @@ TEST(JxlTest, RoundtripLargeFast) {
   cparams.AddOption(JXL_ENC_FRAME_SETTING_EFFORT, 7);  // kSquirrel
 
   PackedPixelFile ppf_out;
-  EXPECT_NEAR(Roundtrip(t.ppf(), cparams, {}, &pool, &ppf_out), 404298, 100);
+  EXPECT_NEAR(Roundtrip(t.ppf(), cparams, {}, &pool, &ppf_out), 401616, 100);
   EXPECT_THAT(ComputeDistance2(t.ppf(), ppf_out), IsSlightlyBelow(100));
 }
 
@@ -464,7 +464,7 @@ TEST(JxlTest, RoundtripNoGaborishNoAR) {
   cparams.AddOption(JXL_ENC_FRAME_SETTING_GABORISH, 0);
 
   PackedPixelFile ppf_out;
-  EXPECT_NEAR(Roundtrip(t.ppf(), cparams, {}, pool, &ppf_out), 37093, 10);
+  EXPECT_NEAR(Roundtrip(t.ppf(), cparams, {}, pool, &ppf_out), 36986, 100);
   EXPECT_THAT(ButteraugliDistance(t.ppf(), ppf_out), IsSlightlyBelow(1.8));
 }
 
@@ -1377,7 +1377,7 @@ TEST(JxlTest, RoundtripProgressive) {
   cparams.AddOption(JXL_ENC_FRAME_SETTING_RESPONSIVE, 1);
 
   PackedPixelFile ppf_out;
-  EXPECT_NEAR(Roundtrip(t.ppf(), cparams, {}, &pool, &ppf_out), 56429, 750);
+  EXPECT_NEAR(Roundtrip(t.ppf(), cparams, {}, &pool, &ppf_out), 55254, 750);
   EXPECT_THAT(ButteraugliDistance(t.ppf(), ppf_out), IsSlightlyBelow(1.4));
 }
 


### PR DESCRIPTION
flattens masking dynamics a bit, uses resulting bytes for usual ac quantization

reduces max-butteraugli by about 1 % while everything else is more or less unchanged

improved DZgas' image slightly (red pixelized symbols become more 'readable')

```
Before:

Encoding      kPixels    Bytes          BPP  E MP/s  D MP/s     Max norm  SSIMULACRA2        pnorm   PSNR   QABPP  SmallB  DCT4x8     AFV  DCT8x8    8x16    8x32      16   16x32      32   32x64      64       BPP*pnorm   Bugs
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
jxl:d0.1        18611 15065296    6.4755748   1.518   9.140   1.12765002  99.91226860   0.11994889  53.95   6.486 40.4192 21.4838  0.6248 30.0282  5.2144  0.0000  1.7097  0.8665  0.2366  0.1100  0.0880  0.776737998200      0
jxl:d0.5        18611  5671732    2.4379026   1.800  14.317   1.48691559  97.29544464   0.37851556  45.04   2.474 14.8031 25.1807  0.7221 13.4944 27.0341  0.0000 17.9045  1.0756  0.3686  0.1100  0.0880  0.922784066069      0
jxl:d0.8        18611  4220248    1.8140056   2.011  14.279   1.64892650  91.90863672   0.51935594  42.50   2.119 11.4071 21.9669  0.8053 10.1272 25.4138  0.0000 28.0155  1.4277  1.3645  0.1430  0.1100  0.942114591146      0
jxl:d1          18611  3651625    1.5695922   2.061  15.891   1.86793721  89.17545202   0.60153761  41.30   2.183 10.1107 20.4322  0.8411  8.8161 22.4243  0.0000 32.0938  2.5584  3.3066  0.1100  0.0880  0.944168721120      0
jxl:d1.1        18611  3436153    1.4769750   2.104  15.677   1.93274319  87.92091018   0.64024408  40.80   2.194  9.6004 19.7686  0.8635  8.3824 20.9986  0.0000 32.8214  3.4772  4.6711  0.1100  0.0880  0.945624497590      0
jxl:d1.2        18611  3242711    1.3938271   2.104  16.148   2.33638668  86.81735330   0.67709071  40.34   2.181  9.1121 19.1441  0.8913  7.9289 19.7201  0.0000 32.8572  4.7234  6.2061  0.1100  0.0880  0.943747365225      0
jxl:d1.3        18611  3105471    1.3348367   2.135  16.887   2.67803311  85.88030467   0.70723639  40.08   2.184  8.6906 18.6906  0.8982  7.5592 18.8590  0.0000 32.2080  6.0796  7.5871  0.1210  0.0880  0.944045071566      0
jxl:d1.4        18611  2954371    1.2698888   2.120  16.216   2.23413968  84.88138474   0.74283372  39.68   2.189  8.3419 18.1579  0.9095  7.2449 17.9347  0.0000 31.5106  7.4825  8.9350  0.1541  0.1100  0.943316200931      0
jxl:d1.5        18611  2816855    1.2107797   2.161  15.422   2.54174995  83.97688757   0.77706510  39.32   2.229  8.0217 17.6724  0.9302  6.9612 17.3873  0.0000 30.5271  8.8993 10.1730  0.1210  0.0880  0.940854678570      0
jxl:d1.6        18611  2699043    1.1601401   2.256  15.559   2.72953343  83.08328928   0.81043138  38.97   2.234  7.7250 17.2515  0.9508  6.7553 16.9038  0.0000 29.6689 10.1537 11.1083  0.1541  0.1100  0.940213986331      0
jxl:d1.7        18611  2591053    1.1137224   2.175  15.645   2.72247791  82.24744623   0.84190886  38.65   2.229  7.4399 16.9148  0.9742  6.5400 16.5703  0.0000 28.5987 11.2046 12.3297  0.1210  0.0880  0.937652745202      0
jxl:d1.8        18611  2492439    1.0713347   2.314  16.093   2.68261623  81.47514506   0.87285111  38.35   2.208  7.1865 16.5404  1.0103  6.4172 16.2092  0.0000 27.8037 12.2444 13.1385  0.1210  0.1100  0.935115728357      0
jxl:d1.8        18611  2492439    1.0713347   2.251  16.228   2.68261623  81.47514506   0.87285111  38.35   2.208  7.1865 16.5404  1.0103  6.4172 16.2092  0.0000 27.8037 12.2444 13.1385  0.1210  0.1100  0.935115728357      0
jxl:d1.9        18611  2401180    1.0321085   2.160  15.775   2.83999348  80.65052726   0.90492680  38.06   2.245  6.9341 16.1992  1.0254  6.2556 15.9052  0.0000 26.9496 13.3613 13.9417  0.1210  0.0880  0.933982672870      0
jxl:d2.0        18611  2318512    0.9965750   2.246  15.646   2.83064461  79.89344825   0.93580956  37.79   2.192  6.7247 15.9090  1.0313  6.0706 15.7244  0.0000 26.2384 14.2388 14.6350  0.1210  0.0880  0.932604436488      0
jxl:d2.1        18611  2240615    0.9630923   2.267  15.254   3.16792607  79.14517575   0.96800518  37.54   2.244  6.4908 15.5160  1.0619  5.9572 15.4919  0.0000 25.5191 15.1852 15.2952  0.1541  0.1100  0.932278295631      0
jxl:d2.2        18611  2167190    0.9315317   2.306  16.276   3.26319051  78.39036845   0.99772656  37.29   2.223  6.2770 15.1962  1.0784  5.8361 15.3997  0.0000 24.8327 15.8647 16.0875  0.1210  0.0880  0.929413925062      0
jxl:d2.3        18611  2101426    0.9032641   2.268  15.626   3.53807282  77.67983242   1.02731748  37.07   2.255  6.1583 14.8753  1.0801  5.7271 15.1446  0.0000 24.3637 16.5744 16.6487  0.1210  0.0880  0.927939008677      0
jxl:d2.4        18611  2037950    0.8759800   2.300  16.081   3.57654333  76.95929162   1.05751105  36.84   2.257  5.9977 14.5824  1.0808  5.5851 15.0187  0.0000 23.9098 17.1273 17.2154  0.1541  0.1100  0.926358503892      0
jxl:d2.5        18611  1978135    0.8502695   2.211  16.344   3.28589249  76.28845396   1.08677029  36.63   2.282  5.8083 14.3069  1.0928  5.4981 14.8571  0.0000 23.3348 17.9471 17.6830  0.1430  0.1100  0.924047589674      0
jxl:d2.6        18611  1922650    0.8264201   2.250  15.802   3.68295431  75.57381663   1.11676471  36.42   2.270  5.6690 14.0679  1.1189  5.3709 14.7313  0.0000 22.7874 18.3845 18.4313  0.1320  0.0880  0.922916829235      0
jxl:d2.7        18611  1870668    0.8040765   2.311  16.183   3.85926461  74.94072141   1.14518800  36.23   2.251  5.5160 13.8059  1.1365  5.3186 14.6446  0.0000 22.2124 18.9072 19.0200  0.1320  0.0880  0.920818757147      0
jxl:d2.8        18611  1820845    0.7826609   2.340  14.683   5.28625488  74.23488572   1.17614949  36.03   2.268  5.3726 13.5453  1.1485  5.2037 14.5779  0.0000 21.7049 19.4106 19.5537  0.1541  0.1100  0.920526205963      0
jxl:d2.9        18611  1776474    0.7635887   2.302  15.599   4.34010172  73.65222060   1.20159603  35.86   2.258  5.2784 13.3393  1.1602  5.1188 14.5291  0.0000 21.3624 19.7407 20.0323  0.1320  0.0880  0.917525184531      0
jxl:d3          18611  1733931    0.7453023   2.137  15.632   4.86109877  72.98725028   1.23144983  35.68   2.240  5.0634 13.1010  1.1337  5.0394 14.3895  0.0000 20.8370 20.4257 20.5715  0.1320  0.0880  0.917802398196      0
jxl:d5          18611  1188111    0.5106904   2.039   8.549   5.28249359  61.23316770   1.73666844  33.21   2.279  3.5047  8.6696  1.0319  3.2568 11.6867  0.0000 16.4602 28.9976 26.8987  0.1651  0.1100  0.886899849057      0
jxl:d7          18611   922883    0.3966864   2.074   8.476   7.21535873  51.52022851   2.19141630  31.70   2.313  2.7117  6.1604  0.8535  2.2788  9.8552  0.0000 13.8592 34.3785 30.3868  0.1871  0.1100  0.869305020776      0
jxl:d15         18611   517951    0.2226329   2.248   8.162  11.85975456  21.79491977   3.68955130  28.69   2.202  1.3046  1.8820  0.3377  0.6571  5.8561  0.0000  8.0286 40.1857 41.5061  0.8693  0.1541  0.821415478139      0
jxl:d24         18611   367938    0.1581522   0.296  19.653  30.86896896  -0.08960468   5.37868678  26.97   2.569  1.0777  2.3964  0.1881  0.7648  3.2599  0.0000  3.5006  9.4687  4.8306  0.0000  0.0000  0.850651263259      0
jxl:d32         18611   296596    0.1274870   0.298  20.288  32.47261429 -13.13899416   6.16561480  26.37   2.364  0.7964  1.8070  0.1547  0.5485  2.9318  0.0000  3.0645 10.5498  5.6339  0.0000  0.0000  0.786035808525      0
Aggregate:      18611  2101139    0.9031409   1.886  14.723   3.59549789  76.10674076   1.00893822  37.17   2.332  5.9829 12.8038  0.8342  5.2010 13.6878  0.0000 19.2720  9.9938  9.3264  0.1403  0.0980  0.911213333380      0

After:

Encoding      kPixels    Bytes          BPP  E MP/s  D MP/s     Max norm  SSIMULACRA2        pnorm   PSNR   QABPP  SmallB  DCT4x8     AFV  DCT8x8    8x16    8x32      16   16x32      32   32x64      64       BPP*pnorm   Bugs
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
jxl:d0.1        18611 15034555    6.4623612   1.501   9.112   1.13074732  99.91638570   0.12035060  53.96   6.473 40.1124 21.1492  0.6111 30.3002  5.5136  0.0000  1.7964  0.8638  0.2366  0.1100  0.0880  0.777749049704      0
jxl:d0.5        18611  5667198    2.4359538   1.835  14.715   1.47652292  97.35129858   0.37961090  45.05   2.467 14.7423 24.8207  0.7166 13.3616 27.3608  0.0000 18.1287  1.0729  0.3796  0.1100  0.0880  0.924714597626      0
jxl:d0.8        18611  4219542    1.8137021   1.966  14.857   1.68801403  91.91395912   0.52019412  42.52   2.118 11.3641 21.7156  0.8067 10.0447 25.4028  0.0000 28.2287  1.4855  1.4800  0.1430  0.1100  0.943477200011      0
jxl:d1          18611  3651896    1.5697087   2.074  15.907   1.81864929  89.10936372   0.60217103  41.32   2.195 10.1173 20.1805  0.8273  8.7428 22.2874  0.0000 32.2272  2.7069  3.4937  0.1100  0.0880  0.945233077051      0
jxl:d1.1        18611  3435631    1.4767506   2.043  15.646   1.93440890  87.95626414   0.64063098  40.82   2.170  9.5702 19.5227  0.8590  8.2717 20.8796  0.0000 32.7678  3.7220  4.9902  0.1100  0.0880  0.946052205943      0
jxl:d1.2        18611  3244223    1.3944770   2.124  15.484   2.17911577  86.85215495   0.67765054  40.36   2.199  9.0953 18.9065  0.8958  7.8336 19.5468  0.0000 32.7458  5.0232  6.5252  0.1210  0.0880  0.944968078824      0
jxl:d1.3        18611  3107328    1.3356349   2.111  16.509   2.36276221  85.96970433   0.70765053  40.10   2.213  8.6775 18.4581  0.9013  7.4709 18.6961  0.0000 32.0003  6.4344  7.9337  0.1210  0.0880  0.945162728789      0
jxl:d1.4        18611  2955627    1.2704286   2.229  15.980   2.23414660  84.89480458   0.74322674  39.70   2.180  8.3157 17.9368  0.9147  7.1748 17.8591  0.0000 31.1695  7.8044  9.3422  0.1541  0.1100  0.944216536953      0
jxl:d1.5        18611  2818766    1.2116012   2.136  15.426   2.65054059  83.96948992   0.77666827  39.34   2.216  8.0049 17.4537  0.9233  6.8564 17.3123  0.0000 30.3195  9.2211 10.4811  0.1210  0.0880  0.941012167995      0
jxl:d1.6        18611  2700901    1.1609388   2.169  14.972   2.75511765  83.10987404   0.81047892  39.00   2.254  7.7153 17.0613  0.9477  6.6604 16.8853  0.0000 29.3497 10.4536 11.4439  0.1541  0.1100  0.940916406529      0
jxl:d1.7        18611  2592975    1.1145485   2.198  14.546   2.73688054  82.26860975   0.84187438  38.67   2.237  7.4365 16.6862  0.9663  6.5042 16.4582  0.0000 28.3952 11.4274 12.6983  0.1210  0.0880  0.938309855535      0
jxl:d1.8        18611  2494100    1.0720487   2.249  15.268   2.69764805  81.49217866   0.87287838  38.38   2.224  7.1703 16.3571  0.9989  6.3199 16.1528  0.0000 27.5217 12.6048 13.4246  0.1210  0.1100  0.935768136263      0
jxl:d1.8        18611  2494100    1.0720487   2.159  15.486   2.69764805  81.49217866   0.87287838  38.38   2.224  7.1703 16.3571  0.9989  6.3199 16.1528  0.0000 27.5217 12.6048 13.4246  0.1210  0.1100  0.935768136263      0
jxl:d1.9        18611  2403546    1.0331255   2.264  14.826   2.80588341  80.69834542   0.90432380  38.09   2.228  6.9141 16.0479  1.0203  6.1707 15.8667  0.0000 26.7515 13.5456 14.2554  0.1210  0.0880  0.934280004635      0
jxl:d2.0        18611  2319631    0.9970560   2.145  16.290   3.04840040  79.89597055   0.93526145  37.82   2.191  6.6999 15.7550  1.0278  5.9888 15.6625  0.0000 26.0335 14.4562 14.9486  0.1210  0.0880  0.932508055885      0
jxl:d2.1        18611  2242418    0.9638672   2.234  15.562   3.47837114  79.15864955   0.96648149  37.56   2.224  6.4664 15.3375  1.0491  5.8619 15.4864  0.0000 25.3980 15.2429 15.6748  0.1541  0.1100  0.931559859030      0
jxl:d2.2        18611  2170248    0.9328461   2.257  15.616   3.28063869  78.42883971   0.99726926  37.32   2.227  6.2529 15.0342  1.0742  5.7436 15.3633  0.0000 24.7694 16.0490 16.2855  0.1210  0.0880  0.930298774392      0
jxl:d2.3        18611  2103849    0.9043056   2.290  16.351   3.49997211  77.70117273   1.02596859  37.09   2.260  6.1600 14.7096  1.0684  5.6305 15.1020  0.0000 24.1917 16.6542 17.0558  0.1210  0.0880  0.927789137559      0
jxl:d2.4        18611  2039711    0.8767369   2.248  15.376   3.67507172  76.93152118   1.05652125  36.87   2.268  5.9768 14.4073  1.0835  5.5301 14.9603  0.0000 23.7048 17.2924 17.5510  0.1651  0.1100  0.926291181977      0
jxl:d2.5        18611  1980230    0.8511700   2.211  16.245   3.28936338  76.27848642   1.08502223  36.65   2.260  5.7955 14.1054  1.0907  5.4159 14.8214  0.0000 23.2069 17.9086 18.1837  0.1430  0.1100  0.923538332688      0
jxl:d2.6        18611  1925277    0.8275493   2.210  16.451   3.48080873  75.65163539   1.11406713  36.45   2.259  5.6494 13.9046  1.1110  5.2907 14.7271  0.0000 22.6361 18.3708 18.8714  0.1320  0.0880  0.921945475855      0
jxl:d2.7        18611  1873141    0.8051395   2.197  15.201   3.47504854  74.92698144   1.14364283  36.25   2.244  5.4929 13.6491  1.1265  5.2230 14.6329  0.0000 22.0694 18.9677 19.3996  0.1320  0.0880  0.920791990477      0
jxl:d2.8        18611  1824439    0.7842057   2.340  16.156   5.20213556  74.30392233   1.17376001  36.06   2.276  5.3530 13.4507  1.1406  5.1394 14.4603  0.0000 21.6210 19.4739 19.8673  0.1651  0.1100  0.920469299368      0
jxl:d2.9        18611  1777895    0.7641995   2.279  16.444   3.79188395  73.71704978   1.19943455  35.88   2.256  5.2460 13.1818  1.1523  5.0174 14.5009  0.0000 21.1946 19.8398 20.4285  0.1320  0.0880  0.916607307030      0
jxl:d3          18611  1735802    0.7461065   2.052  15.361   4.27177811  72.98922483   1.22669958  35.71   2.230  5.0325 12.9903  1.1193  4.9403 14.3558  0.0000 20.7159 20.4615 20.9456  0.1320  0.0880  0.915248556441      0
jxl:d5          18611  1190044    0.5115212   2.147   8.646   5.15181065  61.29817909   1.73391970  33.24   2.288  3.4792  8.5324  1.0072  3.1663 11.5725  0.0000 16.3461 29.2562 27.1462  0.1651  0.1100  0.886936756767      0
jxl:d7          18611   924674    0.3974562   2.078   8.552   7.22708035  51.65347871   2.18348798  31.72   2.286  2.6739  6.0318  0.8397  2.1928  9.7638  0.0000 13.7134 34.7278 30.5409  0.1871  0.1100  0.867840883816      0
jxl:d15         18611   516544    0.2220281   2.206   8.101  12.37827301  21.76250399   3.67494899  28.71   2.179  1.2840  1.8201  0.3301  0.6255  5.7632  0.0000  7.8773 40.3425 41.6052  0.9353  0.1981  0.815942001273      0
jxl:d24         18611   369912    0.1590007   0.296  19.864  31.85334778   0.29698954   5.35934415  26.98   2.567  1.0691  2.3589  0.1843  0.7410  3.2358  0.0000  3.4579  9.5265  4.9132  0.0000  0.0000  0.852139543377      0
jxl:d32         18611   298044    0.1281094   0.296  20.183  32.34523392 -12.75690509   6.14347792  26.39   2.347  0.7895  1.7860  0.1541  0.5392  2.8995  0.0000  3.0081 10.6269  5.6834  0.0000  0.0000  0.787037341589      0
Aggregate:      18611  2102975    0.9039299   1.871  14.650   3.55373329  62.87762204   1.00813223  37.20   2.330  5.9570 12.6383  0.8275  5.1182 13.6556  0.0000 19.1850 10.1842  9.5765  0.1418  0.0989  0.911280909671      0
```