### PR TITLE
Fix a bunch of ubsan/signed integer overflow errors

### DIFF
--- a/lib/jxl/enc_modular.cc
+++ b/lib/jxl/enc_modular.cc
@@ -684,7 +684,7 @@ Status ModularFrameEncoder::ComputeEncodingData(
     for (size_t i = 0; i < nb_channels; i++) {
       int32_t min, max;
       compute_minmax(gi.channel[gi.nb_meta_channels + i], &min, &max);
-      int64_t colors = max - min + 1;
+      int64_t colors = (int64_t)max - min + 1;
       JXL_DEBUG_V(10, "Channel %" PRIuS ": range=%i..%i", i, min, max);
       Transform maybe_palette_1(TransformId::kPalette);
       maybe_palette_1.begin_c = i + gi.nb_meta_channels;
@@ -1371,7 +1371,7 @@ Status ModularFrameEncoder::PrepareStreamParams(const Rect& rect,
       for (size_t i = 0; i < nb_channels; i++) {
         int32_t min, max;
         compute_minmax(gi.channel[gi.nb_meta_channels + i], &min, &max);
-        int colors = max - min + 1;
+        int64_t colors = (int64_t)max - min + 1;
         JXL_DEBUG_V(10, "Channel %" PRIuS ": range=%i..%i", i, min, max);
         Transform maybe_palette_1(TransformId::kPalette);
         maybe_palette_1.begin_c = i + gi.nb_meta_channels;

--- a/lib/jxl/modular/encoding/enc_ma.cc
+++ b/lib/jxl/modular/encoding/enc_ma.cc
@@ -977,7 +977,7 @@ void CollectPixelSamples(const Image &image, const ModularOptions &options,
     const pixel_type *row = image.channel[channel_ids[i]].Row(y);
     pixel_samples.push_back(row[x]);
     size_t xp = x == 0 ? 1 : x - 1;
-    diff_samples.push_back(row[x] - row[xp]);
+    diff_samples.push_back((int64_t)row[x] - row[xp]);
   }
 }
 


### PR DESCRIPTION
Namely:

libjxl/lib/jxl/enc_modular.cc:685:28: runtime error: signed integer overflow: 1058273171 - -1373346182 cannot be represented in type 'int' libjxl/lib/jxl/enc_modular.cc:1372:26: runtime error: signed integer overflow: 1057915026 - -1419157404 cannot be represented in type 'int' libjxl/lib/jxl/modular/encoding/enc_ma.cc:980:35: runtime error: signed integer overflow: -1321495375 - 880855586 cannot be represented in type 'int'

Steps:

% tools/cjxl -d 0.0 /usr/share/libjxl-testdata/jxl/splines.pfm /tmp/test.jxl