### PR TITLE
Add an explicit flag to allow effort 10.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
    of the input buffer.
  - decoder API: new function `JxlDecoderSetImageBitDepth` to set the bit depth
    of the output buffer.
- - encoder API: add an effort 10 option for lossless compression.
+ - encoder API: add an effort 10 option for lossless compression; using this
+   setting requires calling `JxlEncoderAllowExpertOptions`.
 
 ## [0.7] - 2022-07-21
 

--- a/lib/extras/enc/jxl.cc
+++ b/lib/extras/enc/jxl.cc
@@ -40,6 +40,10 @@ bool EncodeImageJXL(const JXLCompressParams& params, const PackedPixelFile& ppf,
   auto encoder = JxlEncoderMake(/*memory_manager=*/nullptr);
   JxlEncoder* enc = encoder.get();
 
+  if (params.allow_expert_options) {
+    JxlEncoderAllowExpertOptions(enc);
+  }
+
   if (params.runner_opaque != nullptr &&
       JXL_ENC_SUCCESS != JxlEncoderSetParallelRunner(enc, params.runner,
                                                      params.runner_opaque)) {

--- a/lib/extras/enc/jxl.h
+++ b/lib/extras/enc/jxl.h
@@ -57,6 +57,8 @@ struct JXLCompressParams {
   JxlParallelRunner runner = JxlThreadParallelRunner;
   void* runner_opaque = nullptr;
 
+  bool allow_expert_options = false;
+
   void AddOption(JxlEncoderFrameSettingId id, int64_t val) {
     options.emplace_back(JXLOption(id, val, 0));
   }

--- a/lib/include/jxl/encode.h
+++ b/lib/include/jxl/encode.h
@@ -1178,6 +1178,16 @@ JXL_EXPORT void JxlColorEncodingSetToSRGB(JxlColorEncoding* color_encoding,
 JXL_EXPORT void JxlColorEncodingSetToLinearSRGB(
     JxlColorEncoding* color_encoding, JXL_BOOL is_gray);
 
+/**
+ * Enables usage of expert options.
+ *
+ * At the moment, the only expert option is setting an effort value of 10,
+ * which gives the best compression for pixel-lossless modes but is very slow.
+ *
+ * @param enc encoder object.
+ */
+JXL_EXPORT void JxlEncoderAllowExpertOptions(JxlEncoder* enc);
+
 #if defined(__cplusplus) || defined(c_plusplus)
 }
 #endif

--- a/lib/jxl/encode.cc
+++ b/lib/jxl/encode.cc
@@ -1071,9 +1071,16 @@ JxlEncoderStatus JxlEncoderFrameSettingsSetOption(
 
   switch (option) {
     case JXL_ENC_FRAME_SETTING_EFFORT:
-      if (value < 1 || value > 10) {
-        return JXL_API_ERROR(frame_settings->enc, JXL_ENC_ERR_NOT_SUPPORTED,
-                             "Encode effort has to be in [1..10]");
+      if (frame_settings->enc->allow_expert_options) {
+        if (value < 1 || value > 10) {
+          return JXL_API_ERROR(frame_settings->enc, JXL_ENC_ERR_NOT_SUPPORTED,
+                               "Encode effort has to be in [1..10]");
+        }
+      } else {
+        if (value < 1 || value > 9) {
+          return JXL_API_ERROR(frame_settings->enc, JXL_ENC_ERR_NOT_SUPPORTED,
+                               "Encode effort has to be in [1..9]");
+        }
       }
       frame_settings->values.cparams.speed_tier =
           static_cast<jxl::SpeedTier>(10 - value);
@@ -2070,4 +2077,8 @@ void JxlColorEncodingSetToLinearSRGB(JxlColorEncoding* color_encoding,
                                      JXL_BOOL is_gray) {
   ConvertInternalToExternalColorEncoding(
       jxl::ColorEncoding::LinearSRGB(is_gray), color_encoding);
+}
+
+void JxlEncoderAllowExpertOptions(JxlEncoder* enc) {
+  enc->allow_expert_options = true;
 }

--- a/lib/jxl/encode_internal.h
+++ b/lib/jxl/encode_internal.h
@@ -248,6 +248,7 @@ struct JxlEncoderStruct {
   bool basic_info_set;
   bool color_encoding_set;
   bool intensity_target_set;
+  bool allow_expert_options = false;
   int brotli_effort = -1;
 
   // Takes the first frame in the input_queue, encodes it, and appends


### PR DESCRIPTION
```
tools/cjxl 211207159-817bc091-3110-48a1-ab60-63c8424e36e1.png -d 0 -e 10 x.jxl
JPEG XL encoder v0.8.0 31e38dae [AVX3,AVX2,SSE4,SSSE3,Unknown]
Invalid flag value for --effort: Valid range is {1, 2, ..., 9}.

tools/cjxl 211207159-817bc091-3110-48a1-ab60-63c8424e36e1.png -d 0 -e 10 x.jxl --allow_expert_options
JPEG XL encoder v0.8.0 31e38dae [AVX3,AVX2,SSE4,SSSE3,Unknown]
./lib/extras/dec/color_hints.cc:54: No color_space/icc_pathname given, assuming sRGB
Read 451x384 image, 1137 bytes, 145.2 MP/s
Encoding [Modular, lossless, effort: 10],
Compressed to 251 bytes (0.012 bpp).
451 x 384, 0.02 MP/s [0.02, 0.02], 1 reps, 72 threads.

tools/cjxl 211207159-817bc091-3110-48a1-ab60-63c8424e36e1.png -d 0 -e 11 x.jxl --allow_expert_options
JPEG XL encoder v0.8.0 31e38dae [AVX3,AVX2,SSE4,SSSE3,Unknown]
Invalid flag value for --effort: Valid range is {1, 2, ..., 10}.

```