### PR TITLE
Avoid EnumValid as much as possible

### DIFF
--- a/lib/jxl/enc_color_management.cc
+++ b/lib/jxl/enc_color_management.cc
@@ -849,9 +849,9 @@ bool ApplyCICP(const uint8_t color_primaries,
 
   const auto primaries = static_cast<Primaries>(color_primaries);
   const auto tf = static_cast<TransferFunction>(transfer_characteristics);
-  if (!EnumValid(tf) || tf == TransferFunction::kUnknown) return false;
-  if (!(EnumValid(primaries) || color_primaries == 12) ||
-      primaries == Primaries::kCustom) {
+  if (tf == TransferFunction::kUnknown || !EnumValid(tf)) return false;
+  if (primaries == Primaries::kCustom ||
+      !(color_primaries == 12 || EnumValid(primaries))) {
     return false;
   }
   c->SetColorSpace(ColorSpace::kRGB);


### PR DESCRIPTION
We change the order of evaluations in some if statements in order to avoid calling EnumValid when it is in fact not valid, e.g. when color_primaries==12.