### PR TITLE
Support jpegli encoding and/or decoding in benchmark_xl.

### DIFF
--- a/lib/jpegli/encode.cc
+++ b/lib/jpegli/encode.cc
@@ -27,18 +27,11 @@ constexpr unsigned char kICCSignature[12] = {
 constexpr int kICCMarker = JPEG_APP0 + 2;
 constexpr size_t kMaxBytesInMarker = 65533;
 
-float QualityToDistance(int quality) {
-  return (quality >= 100  ? 0.01f
-          : quality >= 30 ? 0.1f + (100 - quality) * 0.09f
-                          : 53.0f / 3000.0f * quality * quality -
-                                23.0f / 20.0f * quality + 25.0f);
-}
-
 float LinearQualityToDistance(int scale_factor) {
   scale_factor = std::min(5000, std::max(0, scale_factor));
   int quality =
       scale_factor < 100 ? 100 - scale_factor / 2 : 5000 / scale_factor;
-  return QualityToDistance(quality);
+  return jpegli_quality_to_distance(quality);
 }
 
 struct ProgressiveScan {
@@ -165,9 +158,16 @@ void jpegli_set_distance(j_compress_ptr cinfo, float distance) {
   cinfo->master->distance = distance;
 }
 
+float jpegli_quality_to_distance(int quality) {
+  return (quality >= 100  ? 0.01f
+          : quality >= 30 ? 0.1f + (100 - quality) * 0.09f
+                          : 53.0f / 3000.0f * quality * quality -
+                                23.0f / 20.0f * quality + 25.0f);
+}
+
 void jpegli_set_quality(j_compress_ptr cinfo, int quality,
                         boolean force_baseline) {
-  cinfo->master->distance = jpegli::QualityToDistance(quality);
+  cinfo->master->distance = jpegli_quality_to_distance(quality);
   cinfo->master->force_baseline = force_baseline;
 }
 

--- a/lib/jpegli/encode.h
+++ b/lib/jpegli/encode.h
@@ -91,6 +91,9 @@ void jpegli_destroy_compress(j_compress_ptr cinfo);
 // Sets the butteraugli target distance for the compressor.
 void jpegli_set_distance(j_compress_ptr cinfo, float distance);
 
+// Returns the butteraugli target distance for the given quality parameter.
+float jpegli_quality_to_distance(int quality);
+
 // Writes an ICC profile for the XYB color space and internally converts the
 // input image to XYB.
 void jpegli_set_xyb_mode(j_compress_ptr cinfo);

--- a/tools/benchmark/benchmark_args.cc
+++ b/tools/benchmark/benchmark_args.cc
@@ -193,11 +193,6 @@ Status BenchmarkArgs::AddCommandLineOptions() {
   AddDouble(&error_pnorm, "error_pnorm",
             "smallest p norm for pooling butteraugli values", 3.0);
 
-  AddFloat(&ba_params.hf_asymmetry, "hf_asymmetry",
-           "Multiplier for weighting HF artefacts more than features "
-           "being smoothed out. 1.0 means no HF asymmetry. 0.3 is "
-           "a good value to start exploring for asymmetry.",
-           0.8f);
   AddFlag(&profiler, "profiler", "If true, print profiler results.", false);
 
   AddFlag(&show_progress, "show_progress",

--- a/tools/benchmark/benchmark_args.h
+++ b/tools/benchmark/benchmark_args.h
@@ -146,7 +146,6 @@ struct BenchmarkArgs {
 
   int num_samples;
   int sample_dimensions;
-  ButteraugliParams ba_params;
 
   bool profiler;
   double error_pnorm;

--- a/tools/benchmark/benchmark_codec.cc
+++ b/tools/benchmark/benchmark_codec.cc
@@ -75,26 +75,8 @@ Status ImageCodec::ParseParam(const std::string& param) {
       return false;
     }
     butteraugli_target_ = butteraugli_target;
-
-    // full hf asymmetry at high distance
-    static const double kHighDistance = 2.5;
-
-    // no hf asymmetry at low distance
-    static const double kLowDistance = 0.6;
-
-    if (butteraugli_target_ >= kHighDistance) {
-      ba_params_.hf_asymmetry = args_.ba_params.hf_asymmetry;
-    } else if (butteraugli_target_ >= kLowDistance) {
-      float w =
-          (butteraugli_target_ - kLowDistance) / (kHighDistance - kLowDistance);
-      ba_params_.hf_asymmetry =
-          args_.ba_params.hf_asymmetry * w + 1.0f * (1.0f - w);
-    } else {
-      ba_params_.hf_asymmetry = 1.0f;
-    }
     return true;
   } else if (param[0] == 'r') {
-    ba_params_.hf_asymmetry = args_.ba_params.hf_asymmetry;
     bitrate_target_ = strtof(param.substr(1).c_str(), nullptr);
     return true;
   }

--- a/tools/benchmark/benchmark_codec.h
+++ b/tools/benchmark/benchmark_codec.h
@@ -43,8 +43,6 @@ class ImageCodec {
   void set_description(const std::string& desc) { description_ = desc; }
   const std::string& description() const { return description_; }
 
-  const ButteraugliParams& BaParams() const { return ba_params_; }
-
   virtual void ParseParameters(const std::string& parameters);
 
   virtual Status ParseParam(const std::string& param);
@@ -87,7 +85,6 @@ class ImageCodec {
   float butteraugli_target_;
   float q_target_;
   float bitrate_target_;
-  ButteraugliParams ba_params_;
   std::string error_message_;
 };
 

--- a/tools/benchmark/benchmark_codec_custom.cc
+++ b/tools/benchmark/benchmark_codec_custom.cc
@@ -101,10 +101,6 @@ class CustomCodec : public ImageCodec {
         break;
       default:
         compress_args_.push_back(param);
-        if (param.size() > 2 && param[0] == '-' && param[1] == 'd') {
-          // For setting ba_params_.hf_asymmetry
-          JXL_RETURN_IF_ERROR(ImageCodec::ParseParam(param.substr(1)));
-        }
         description_ += std::string(":");
         if (param.size() > 2 && param[0] == '-' && param[1] == '-') {
           description_ += param.substr(2);

--- a/tools/benchmark/benchmark_xl.cc
+++ b/tools/benchmark/benchmark_xl.cc
@@ -215,7 +215,7 @@ void DoCompress(const std::string& filename, const CodecInOut& io,
       PROFILER_ZONE("Benchmark stats");
       float distance;
       if (SameSize(ib1, ib2)) {
-        ButteraugliParams params = codec->BaParams();
+        ButteraugliParams params;
         if (ib1.metadata()->IntensityTarget() !=
             ib2.metadata()->IntensityTarget()) {
           fprintf(stderr,
@@ -242,7 +242,7 @@ void DoCompress(const std::string& filename, const CodecInOut& io,
       }
       // Update stats
       s->distance_p_norm +=
-          ComputeDistanceP(distmap, Args()->ba_params, Args()->error_pnorm) *
+          ComputeDistanceP(distmap, ButteraugliParams(), Args()->error_pnorm) *
           input_pixels;
       s->ssimulacra2 += ComputeSSIMULACRA2(ib1, ib2).Score() * input_pixels;
       s->max_distance = std::max(s->max_distance, distance);


### PR DESCRIPTION
With this change it is possible to set jpegli encoding and decoding independently from each other and thus benchmark all combinations.

The distance-dependent hf_asymmetry setting is removed from the benchmark because we would get different butteraugli scores if we set a quality or the corresponding distance.

Example benchmark output:
```
Encoding                                   kPixels    Bytes          BPP  E MP/s  D MP/s     Max norm  SSIMULACRA2        pnorm       BPP*pnorm   Bugs
------------------------------------------------------------------------------------------------------------------------------------------------------
jpeg:q90                                     13270  4838710    2.9169834  34.812  91.189   2.40070152  91.22219875   0.68663652  2.002907346332      0
jpeg:q90:dec-jpegli                          13270  4838710    2.9169834  33.531  48.241   2.17603207  91.91514122   0.62092407  1.811225220820      0
jpeg:q90:dec-jpegli:bd16                     13270  4838710    2.9169834  34.090  48.448   2.16807747  92.09963416   0.61567342  1.795909185459      0
jpeg:enc-jpegli:q90                          13270  3953955    2.3836149   4.803  32.236   1.91680062  87.25370857   0.65623731  1.564217042271      0
jpeg:enc-jpegli:q90:dec-jpegli               13270  3953955    2.3836149   5.086  21.595   1.81215000  87.94607988   0.62230139  1.483326878403      0
jpeg:enc-jpegli:q90:dec-jpegli:bd16          13270  3953955    2.3836149   4.869  21.566   1.82237017  88.14496047   0.61435296  1.464380876154      0
jpeg:enc-jpegli:xyb:q90                      13270  2943200    1.7742881   5.849  43.061   2.09280968  82.67326926   0.75413047  1.338044730787      0
jpeg:enc-jpegli:xyb:q90:dec-jpegli           13270  2943200    1.7742881   5.857  28.072   2.14005589  82.48235289   0.74338715  1.318982986140      0
jpeg:enc-jpegli:xyb:q90:dec-jpegli:bd16      13270  2943200    1.7742881   5.792  23.014   2.14104915  83.03747962   0.72821837  1.292069207287      0
Aggregate:                                   13270  3832896    2.3106353   9.930  35.477   2.06657864  87.34055844   0.66911701  1.546085363235      0
```