### PR TITLE
Add jpegli_set_output_format() API function to jpegli decoder.

### DIFF
--- a/lib/extras/dec/decode.cc
+++ b/lib/extras/dec/decode.cc
@@ -107,8 +107,7 @@ Status DecodeBytes(const Span<const uint8_t> bytes,
   }
 #endif
 #if JPEGXL_ENABLE_JPEG
-  else if (DecodeImageJPG(bytes, color_hints, constraints,
-                          /*output_bit_depth=*/8, ppf)) {
+  else if (DecodeImageJPG(bytes, color_hints, constraints, ppf)) {
     codec = Codec::kJPG;
   }
 #endif

--- a/lib/extras/dec/jpegli.cc
+++ b/lib/extras/dec/jpegli.cc
@@ -69,6 +69,19 @@ void ReadExif(jpeg_decompress_struct* const cinfo,
   }
 }
 
+JpegliDataType ConvertDataType(JxlDataType type) {
+  switch (type) {
+    case JXL_TYPE_UINT8:
+      return JPEGLI_TYPE_UINT8;
+    case JXL_TYPE_UINT16:
+      return JPEGLI_TYPE_UINT16;
+    case JXL_TYPE_FLOAT:
+      return JPEGLI_TYPE_FLOAT;
+    default:
+      return JPEGLI_TYPE_UINT8;
+  }
+}
+
 void MyErrorExit(j_common_ptr cinfo) {
   jmp_buf* env = static_cast<jmp_buf*>(cinfo->client_data);
   (*cinfo->err->output_message)(cinfo);
@@ -169,9 +182,8 @@ Status DecodeJpeg(const std::vector<uint8_t>& compressed,
     ppf->info.num_color_channels = nbcomp;
     ppf->info.orientation = JXL_ORIENT_IDENTITY;
 
-    // Set output bit depth.
-    cinfo.quantize_colors = FALSE;
-    cinfo.desired_number_of_colors = 1 << ppf->info.bits_per_sample;
+    jpegli_set_output_format(&cinfo, ConvertDataType(output_data_type),
+                             JPEGLI_NATIVE_ENDIAN);
     jpegli_start_decompress(&cinfo);
     JXL_ASSERT(cinfo.output_components == nbcomp);
 

--- a/lib/extras/dec/jpg.cc
+++ b/lib/extras/dec/jpg.cc
@@ -165,7 +165,7 @@ void MyOutputMessage(j_common_ptr cinfo) {
 Status DecodeImageJPG(const Span<const uint8_t> bytes,
                       const ColorHints& color_hints,
                       const SizeConstraints& constraints,
-                      size_t output_bit_depth, PackedPixelFile* ppf) {
+                      PackedPixelFile* ppf) {
   // Don't do anything for non-JPEG files (no need to report an error)
   if (!IsJPG(bytes)) return false;
 
@@ -174,10 +174,6 @@ Status DecodeImageJPG(const Span<const uint8_t> bytes,
   // We need to declare all the non-trivial destructor local variables before
   // the call to setjmp().
   std::unique_ptr<JSAMPLE[]> row;
-
-  if (output_bit_depth == 0 || output_bit_depth > 16) {
-    return JXL_FAILURE("Invalid output bitdepth");
-  }
 
   const auto try_catch_block = [&]() -> bool {
     jpeg_decompress_struct cinfo;
@@ -256,18 +252,8 @@ Status DecodeImageJPG(const Span<const uint8_t> bytes,
     ppf->info.num_color_channels = nbcomp;
     ppf->info.orientation = JXL_ORIENT_IDENTITY;
 
-    // Try setting output bit depth. In libjpeg-turbo, this combination of
-    // parameters will be ignored, but in libjpegli it will override output bit
-    // depth.
-    cinfo.quantize_colors = FALSE;
-    cinfo.desired_number_of_colors = 1 << output_bit_depth;
     jpeg_start_decompress(&cinfo);
     JXL_ASSERT(cinfo.output_components == nbcomp);
-    if (cinfo.desired_number_of_colors == 0) {
-      // We know that the output bit depth was set because
-      // desired_number_of_colors was reset to zero by libjpegli.
-      ppf->info.bits_per_sample = output_bit_depth;
-    }
     JxlDataType data_type =
         ppf->info.bits_per_sample <= 8 ? JXL_TYPE_UINT8 : JXL_TYPE_UINT16;
 

--- a/lib/extras/dec/jpg.h
+++ b/lib/extras/dec/jpg.h
@@ -25,8 +25,7 @@ namespace extras {
 // `elapsed_deinterleave`, if non-null, will be set to the time (in seconds)
 // that it took to deinterleave the raw JSAMPLEs to planar floats.
 Status DecodeImageJPG(Span<const uint8_t> bytes, const ColorHints& color_hints,
-                      const SizeConstraints& constraints,
-                      size_t output_bit_depth, PackedPixelFile* ppf);
+                      const SizeConstraints& constraints, PackedPixelFile* ppf);
 
 }  // namespace extras
 }  // namespace jxl

--- a/lib/jpegli/common.cc
+++ b/lib/jpegli/common.cc
@@ -52,3 +52,16 @@ JHUFF_TBL* jpegli_alloc_huff_table(j_common_ptr cinfo) {
   table->sent_table = FALSE;
   return table;
 }
+
+int jpegli_bytes_per_sample(JpegliDataType data_type) {
+  switch (data_type) {
+    case JPEGLI_TYPE_UINT8:
+      return 1;
+    case JPEGLI_TYPE_UINT16:
+      return 2;
+    case JPEGLI_TYPE_FLOAT:
+      return 4;
+    default:
+      return 0;
+  }
+}

--- a/lib/jpegli/common.h
+++ b/lib/jpegli/common.h
@@ -39,6 +39,27 @@ JQUANT_TBL* jpegli_alloc_quant_table(j_common_ptr cinfo);
 
 JHUFF_TBL* jpegli_alloc_huff_table(j_common_ptr cinfo);
 
+//
+// New API structs and functions that are not available in libjpeg
+//
+// NOTE: This part of the API is still experimental and will probably change in
+// the future.
+//
+
+typedef enum {
+  JPEGLI_TYPE_FLOAT = 0,
+  JPEGLI_TYPE_UINT8 = 2,
+  JPEGLI_TYPE_UINT16 = 3,
+} JpegliDataType;
+
+typedef enum {
+  JPEGLI_NATIVE_ENDIAN = 0,
+  JPEGLI_LITTLE_ENDIAN = 1,
+  JPEGLI_BIG_ENDIAN = 2,
+} JpegliEndianness;
+
+int jpegli_bytes_per_sample(JpegliDataType data_type);
+
 #if defined(__cplusplus) || defined(c_plusplus)
 }  // extern "C"
 #endif

--- a/lib/jpegli/decode.h
+++ b/lib/jpegli/decode.h
@@ -87,6 +87,16 @@ void jpegli_abort_decompress(j_decompress_ptr cinfo);
 
 void jpegli_destroy_decompress(j_decompress_ptr cinfo);
 
+//
+// New API functions that are not available in libjpeg
+//
+// NOTE: This part of the API is still experimental and will probably change in
+// the future.
+//
+
+void jpegli_set_output_format(j_decompress_ptr cinfo, JpegliDataType data_type,
+                              JpegliEndianness endianness);
+
 #if defined(__cplusplus) || defined(c_plusplus)
 }  // extern "C"
 #endif

--- a/lib/jpegli/decode_api_test.cc
+++ b/lib/jpegli/decode_api_test.cc
@@ -12,6 +12,7 @@
 #include "gtest/gtest.h"
 #include "lib/jpegli/decode.h"
 #include "lib/jpegli/test_utils.h"
+#include "lib/jxl/base/byte_order.h"
 #include "lib/jxl/base/file_io.h"
 #include "lib/jxl/base/status.h"
 
@@ -122,15 +123,16 @@ struct TestConfig {
   std::string fn;
   std::string fn_desc;
   std::string origfn;
-  size_t chunk_size;
-  size_t max_output_lines;
+  size_t chunk_size = 0;
+  size_t max_output_lines = 0;
   float max_distance;
-  size_t output_bit_depth = 8;
   SourceManagerType source_mgr = SOURCE_MGR_CHUNKED;
   bool pre_consume_input = false;
   bool buffered_image_mode = false;
   bool crop = false;
   bool raw_output = false;
+  JpegliDataType data_type = JPEGLI_TYPE_UINT8;
+  JpegliEndianness endianness = JPEGLI_NATIVE_ENDIAN;
 };
 
 bool LoadNextChunk(const TestConfig& config, j_decompress_ptr cinfo) {
@@ -139,6 +141,28 @@ bool LoadNextChunk(const TestConfig& config, j_decompress_ptr cinfo) {
     return src->LoadNextChunk();
   }
   return false;
+}
+
+std::string DataTypeString(JpegliDataType type) {
+  switch (type) {
+    case JPEGLI_TYPE_UINT8:
+      return "UINT8";
+    case JPEGLI_TYPE_UINT16:
+      return "UINT16";
+    case JPEGLI_TYPE_FLOAT:
+      return "FLOAT";
+    default:
+      return "UNKNOWN";
+  }
+}
+
+std::string EndiannessString(JpegliEndianness endianness) {
+  if (endianness == JPEGLI_BIG_ENDIAN) {
+    return "BE";
+  } else if (endianness == JPEGLI_LITTLE_ENDIAN) {
+    return "LE";
+  }
+  return "";
 }
 
 class DecodeAPITestParam : public ::testing::TestWithParam<TestConfig> {};
@@ -215,8 +239,7 @@ TEST_P(DecodeAPITestParam, TestAPI) {
   EXPECT_EQ(ysize, cinfo.image_height);
   EXPECT_EQ(num_channels, cinfo.num_components);
 
-  cinfo.quantize_colors = FALSE;
-  cinfo.desired_number_of_colors = 1 << config.output_bit_depth;
+  jpegli_set_output_format(&cinfo, config.data_type, config.endianness);
 
   if (jpegli_has_multiple_scans(&cinfo) && config.buffered_image_mode) {
     cinfo.buffered_image = TRUE;
@@ -261,7 +284,7 @@ TEST_P(DecodeAPITestParam, TestAPI) {
     }
   }
 
-  size_t bytes_per_sample = config.output_bit_depth <= 8 ? 1 : 2;
+  size_t bytes_per_sample = jpegli_bytes_per_sample(config.data_type);
   size_t stride = cinfo.output_width * cinfo.num_components * bytes_per_sample;
   size_t max_output_lines = config.max_output_lines;
   if (max_output_lines == 0) max_output_lines = cinfo.output_height;
@@ -357,22 +380,29 @@ TEST_P(DecodeAPITestParam, TestAPI) {
         }
       }
       ASSERT_EQ(output.size(), cropped.size() * bytes_per_sample);
-      const double mul_orig = 1.0 / 255.0;
-      const double mul_output = 1.0 / ((1u << config.output_bit_depth) - 1);
+      bool is_little_endian =
+          (config.endianness == JPEGLI_LITTLE_ENDIAN ||
+           (config.endianness == JPEGLI_NATIVE_ENDIAN && IsLittleEndian()));
+      const double kMul8 = 1.0 / 255.0;
+      const double kMul16 = 1.0 / 65535.0;
       double diff2 = 0.0;
       for (size_t i = 0; i < cropped.size(); ++i) {
-        double sample_orig = cropped[i] * mul_orig;
-        double sample_output;
-        if (bytes_per_sample == 1) {
-          sample_output = output[i];
-        } else {
-          sample_output = output[2 * i] + (output[2 * i + 1] << 8);
+        double sample_orig = cropped[i] * kMul8;
+        double sample_output = 0.0;
+        if (config.data_type == JPEGLI_TYPE_UINT8) {
+          sample_output = output[i] * kMul8;
+        } else if (config.data_type == JPEGLI_TYPE_UINT16) {
+          sample_output = is_little_endian ? LoadLE16(&output[2 * i])
+                                           : LoadBE16(&output[2 * i]);
+          sample_output *= kMul16;
+        } else if (config.data_type == JPEGLI_TYPE_FLOAT) {
+          sample_output = is_little_endian ? LoadLEFloat(&output[4 * i])
+                                           : LoadBEFloat(&output[4 * i]);
         }
-        sample_output *= mul_output;
         double diff = sample_orig - sample_output;
         diff2 += diff * diff;
       }
-      double rms = std::sqrt(diff2 / cropped.size()) / mul_orig;
+      double rms = std::sqrt(diff2 / cropped.size()) / kMul8;
       double max_dist = config.max_distance;
       if (!cinfo.buffered_image || jpegli_input_complete(&cinfo)) {
         EXPECT_LE(rms, max_dist);
@@ -426,26 +456,20 @@ std::vector<TestConfig> GenerateTests() {
     for (const auto& it : testfiles) {
       for (size_t chunk_size : {0, 1, 64, 65536}) {
         for (size_t max_output_lines : {0, 1, 8, 16}) {
-          for (size_t output_bit_depth : {8, 16}) {
-            TestConfig config;
-            config.fn = it.first;
-            config.fn_desc = it.second;
-            config.chunk_size = chunk_size;
-            config.output_bit_depth = output_bit_depth;
-            config.max_output_lines = max_output_lines;
-            config.origfn = "jxl/flower/flower.pnm";
-            config.max_distance = 2.2;
-            if (config.output_bit_depth == 16) {
-              config.max_distance = 2.1;
-            }
+          TestConfig config;
+          config.fn = it.first;
+          config.fn_desc = it.second;
+          config.chunk_size = chunk_size;
+          config.max_output_lines = max_output_lines;
+          config.origfn = "jxl/flower/flower.pnm";
+          config.max_distance = 2.2;
+          all_tests.push_back(config);
+          if (config.chunk_size != 0) {
+            config.source_mgr = SOURCE_MGR_SUSPENDING;
             all_tests.push_back(config);
-            if (config.chunk_size != 0) {
-              config.source_mgr = SOURCE_MGR_SUSPENDING;
-              all_tests.push_back(config);
-            } else {
-              config.source_mgr = SOURCE_MGR_STDIO;
-              all_tests.push_back(config);
-            }
+          } else {
+            config.source_mgr = SOURCE_MGR_STDIO;
+            all_tests.push_back(config);
           }
         }
       }
@@ -548,6 +572,21 @@ std::vector<TestConfig> GenerateTests() {
       }
     }
   }
+  {
+    for (JpegliDataType type : {JPEGLI_TYPE_UINT16, JPEGLI_TYPE_FLOAT}) {
+      for (JpegliEndianness endianness :
+           {JPEGLI_NATIVE_ENDIAN, JPEGLI_LITTLE_ENDIAN, JPEGLI_BIG_ENDIAN}) {
+        TestConfig config;
+        config.fn = "jxl/flower/flower.png.im_q85_444.jpg";
+        config.fn_desc = "Q85YUV444";
+        config.origfn = "jxl/flower/flower.pnm";
+        config.data_type = type;
+        config.endianness = endianness;
+        config.max_distance = 1.8;
+        all_tests.push_back(config);
+      }
+    }
+  }
   return all_tests;
 }
 
@@ -579,7 +618,10 @@ std::ostream& operator<<(std::ostream& os, const TestConfig& c) {
   } else if (c.raw_output) {
     os << "Raw";
   }
-  os << "BitDepth" << c.output_bit_depth;
+  os << DataTypeString(c.data_type);
+  if (c.data_type != JPEGLI_TYPE_UINT8) {
+    os << EndiannessString(c.endianness);
+  }
   return os;
 }
 

--- a/lib/jpegli/decode_internal.h
+++ b/lib/jpegli/decode_internal.h
@@ -14,6 +14,7 @@
 #include <set>
 #include <vector>
 
+#include "lib/jpegli/common.h"
 #include "lib/jpegli/huffman.h"
 #include "lib/jxl/base/compiler_specific.h"  // for ssize_t
 
@@ -143,7 +144,8 @@ struct jpeg_decomp_master {
   //
   // Rendering state.
   //
-  size_t output_bit_depth_ = 8;
+  JpegliDataType output_data_type_ = JPEGLI_TYPE_UINT8;
+  bool swap_endianness_ = false;
   size_t xoffset_ = 0;
 
   JSAMPARRAY scanlines_;

--- a/lib/jpegli/encode.h
+++ b/lib/jpegli/encode.h
@@ -98,18 +98,6 @@ float jpegli_quality_to_distance(int quality);
 // input image to XYB.
 void jpegli_set_xyb_mode(j_compress_ptr cinfo);
 
-typedef enum {
-  JPEGLI_TYPE_FLOAT = 0,
-  JPEGLI_TYPE_UINT8 = 2,
-  JPEGLI_TYPE_UINT16 = 3,
-} JpegliDataType;
-
-typedef enum {
-  JPEGLI_NATIVE_ENDIAN = 0,
-  JPEGLI_LITTLE_ENDIAN = 1,
-  JPEGLI_BIG_ENDIAN = 2,
-} JpegliEndianness;
-
 void jpegli_set_input_format(j_compress_ptr cinfo, JpegliDataType data_type,
                              JpegliEndianness endianness);
 

--- a/lib/jpegli/encode_api_test.cc
+++ b/lib/jpegli/encode_api_test.cc
@@ -90,10 +90,12 @@ void TestDecodedImage(const std::vector<uint8_t>& compressed,
       ASSERT_LE(cinfo.input_scan_number, script.num_scans);
       const jpeg_scan_info& scan = script.scans[cinfo.input_scan_number - 1];
       ASSERT_EQ(cinfo.comps_in_scan, scan.comps_in_scan);
+#if !JXL_MEMORY_SANITIZER
       for (int i = 0; i < cinfo.comps_in_scan; ++i) {
         EXPECT_EQ(cinfo.cur_comp_info[i]->component_index,
                   scan.component_index[i]);
       }
+#endif
       EXPECT_EQ(cinfo.Ss, scan.Ss);
       EXPECT_EQ(cinfo.Se, scan.Se);
       EXPECT_EQ(cinfo.Ah, scan.Ah);

--- a/tools/benchmark/benchmark_codec_jpeg.cc
+++ b/tools/benchmark/benchmark_codec_jpeg.cc
@@ -181,7 +181,7 @@ class JPEGCodec : public ImageCodec {
     } else {
       const double start = Now();
       JXL_RETURN_IF_ERROR(DecodeImageJPG(compressed, extras::ColorHints(),
-                                         SizeConstraints(), bitdepth_, &ppf));
+                                         SizeConstraints(), &ppf));
       const double end = Now();
       speed_stats->NotifyElapsed(end - start);
     }

--- a/tools/cjxl_main.cc
+++ b/tools/cjxl_main.cc
@@ -593,7 +593,7 @@ jxl::Status GetPixeldata(const std::vector<uint8_t>& image_data,
 #endif
 #if JPEGXL_ENABLE_JPEG
     if (jxl::extras::DecodeImageJPG(encoded, color_hints, size_constraints,
-                                    /*output_bit_depth=*/16, &ppf)) {
+                                    &ppf)) {
       return jxl::extras::Codec::kJPG;
     }
 #endif


### PR DESCRIPTION
This new API function replaces the previous and somewhat hacky way of setting the output bit depth through the libjpeg API.