### PR TITLE
update README.md and add description of encode effort settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,15 +21,17 @@ This repository contains a reference implementation of JPEG XL (encoder and
 decoder), called `libjxl`. This software library is
 [used by many applications that support JPEG XL](doc/software_support.md).
 
-JPEG XL is in the final stages of standardization and its codestream and file format
-are frozen.
+JPEG XL was standardized in 2022 as [ISO/IEC 18181](https://jpeg.org/jpegxl/workplan.html).
+The [core codestream](doc/format_overview.md#codestream-features) is specified in 18181-1,
+the [file format](doc/format_overview.md#file-format-features) in 18181-2.
+[Decoder conformance](https://github.com/libjxl/conformance) is defined in 18181-3,
+and 18181-4 is the [reference software](https://github.com/libjxl/libjxl).
 
 The library API, command line options, and tools in this repository are subject
-to change, however files encoded with `cjxl` conform to the JPEG XL format
-specification and can be decoded with current and future `djxl` decoders or
-`libjxl` decoding library.
+to change, however files encoded with `cjxl` conform to the JPEG XL specification
+and can be decoded with current and future `djxl` decoders or `libjxl` decoding library.
 
-## Quick start guide
+## Compilation
 
 For more details and other workflows see the "Advanced guide" below.
 
@@ -105,13 +107,18 @@ The encoder/decoder tools will be available in the `build/tools` directory.
 sudo cmake --install .
 ```
 
-### Basic encoder/decoder
+## Usage
 
 To encode a source image to JPEG XL with default settings:
 
 ```bash
 build/tools/cjxl input.png output.jxl
 ```
+
+The desired visual fidelity can be selected using the `--distance` parameter
+(in units of just-noticeable difference, where 0 is lossless and the most useful lossy range is 0.5 .. 3.0),
+or using `--quality` (on a scale from 0 to 100, roughly matching libjpeg).
+The [encode effort](doc/encode_effort.md) can be selected using the `--effort` parameter.
 
 For more settings run `build/tools/cjxl --help` or for a full list of options
 run `build/tools/cjxl -v -v --help`.
@@ -124,6 +131,9 @@ build/tools/djxl input.jxl output.png
 
 When possible `cjxl`/`djxl` are able to read/write the following
 image formats: .exr, .gif, .jpeg/.jpg, .pfm, .pgm/.ppm, .pgx, .png.
+Specifically for JPEG files, the default `cjxl` behavior is to apply lossless
+recompression and the default `djxl` behavior is to reconstruct the original
+JPEG file.
 
 ### Benchmarking
 
@@ -134,6 +144,12 @@ benchmarking purposes.
 
 For more comprehensive benchmarking options, see the
 [benchmarking guide](doc/benchmarking.md).
+
+### Library API
+
+Besides the `libjxl` library [API documentation](https://libjxl.readthedocs.io/en/latest/),
+there are [example applications](examples/) and [plugins](plugins/) that can be used as a reference or
+starting point for developers who wish to integrate `libjxl` in their project.
 
 ## Advanced guide
 

--- a/doc/encode_effort.md
+++ b/doc/encode_effort.md
@@ -1,0 +1,30 @@
+# Encode effort settings
+
+Various trade-offs between encode speed and compression performance can be selected in libjxl. In `cjxl`, this is done via the `--effort` (`-e`) option.
+Higher effort means slower encoding; generally the higher the effort, the more coding tools are used, computationally more expensive heuristics are used,
+and more exhaustive search is performed.
+
+For lossy compression, higher effort results in better visual quality at a given filesize, and also better
+encoder consistency, i.e. less image-dependent variation in the actual visual quality that is achieved. This means that for lossy compression,
+higher effort does not necessarily mean smaller filesizes for every image — some images may be somewhat lower quality than desired when using
+lower effort heuristics, and to improve consistency, higher effort heuristics may decide to use more bytes for them.
+
+For lossless compression, higher effort should result in smaller filesizes, although this is not guaranteed;
+in particular, e2 can be better than e3 for non-photographic images, and e3 can be better than e4 for photographic images.
+
+The following table describes what the various effort settings do:
+
+|Effort | Modular (lossless) | VarDCT (lossy) |
+|-------|--------------------|----------------|
+| e1 | fast-lossless, fixed YCoCg RCT, fixed ClampedGradient predictor, simple palette detection, no MA tree (one context for everything), Huffman, simple rle-only lz77 | |
+| e2 | global channel palette, fixed MA tree (context based on Gradient-error), ANS, otherwise same as e1 | |
+| e3 | same as e2 but fixed Weighted predictor and fixed MA tree with context based on WP-error | only 8x8, basically XYB jpeg with ANS |
+| e4 | try both ClampedGradient and Weighted predictor, learned MA tree, global palette | simple variable blocks heuristics, adaptive quantization, coefficient reordering |
+| e5 | e4 + patches, local palette / local channel palette, different local RCTs | e4 + gabor-like transform, chroma from luma |
+| e6 | e5 + more RCTs and MA tree properties | e5 + error diffusion, full variable blocks heuristics |
+| e7 | e6 + more RCTs and MA tree properties | e6 + patches (including dots) |
+| e8 | e7 + more RCTs, MA tree properties and Weighted predictor parameters | e7 + Butteraugli iterations for adaptive quantization |
+| e9 | e8 + more RCTs, MA tree properties and Weighted predictor parameters, try all predictors | e8 + more Butteraugli iterations |
+| e10 | e9 + previous-channel MA tree properties, different group dimensions, exhaustively try various e9 options | |
+
+For the entropy coding (context clustering, lz77 search, hybriduint configuration): slower/more exhaustive search as effort goes up.


### PR DESCRIPTION
Some updates/additions to the main README, and a new documentation file explaining what encode effort actually means (which is not just "higher effort implies smaller files" as some people would expect), and what exactly the various effort settings are doing.