### PR TITLE
Remove the AQ-based drop of the LSB in jpegli quantization.

### DIFF
--- a/lib/jpegli/dct.cc
+++ b/lib/jpegli/dct.cc
@@ -59,11 +59,6 @@ void ComputeDCTCoefficients(const jxl::Image3F& opsin, const bool xyb,
             // quantization multiplier.
             float zero_bias = 0.5f * qfmax / qf.Row(by * factor)[bx * factor];
             int cc = std::abs(coeff) < zero_bias ? 0 : std::round(coeff);
-            // If the relative value of the adaptive quantization field is less
-            // than 0.5, we drop the least significant bit.
-            if (zero_bias > 1) {
-              cc = cc / 2 * 2;
-            }
             block[ix * 8 + iy] = cc;
           }
         }

--- a/lib/jpegli/encode_api_test.cc
+++ b/lib/jpegli/encode_api_test.cc
@@ -231,8 +231,8 @@ std::vector<TestConfig> GenerateTests() {
   {
     TestConfig config;
     config.quality = 100;
-    config.max_bpp = 4.2;
-    config.max_dist = 0.9;
+    config.max_bpp = 4.65;
+    config.max_dist = 0.75;
     all_tests.push_back(config);
   }
   {


### PR DESCRIPTION
This does not seem to help any more with the current quantization matrix and entropy coding.

Benchmark before (jpegli encoding libjpeg decoding):
```
Encoding                   kPixels    Bytes          BPP  E MP/s  D MP/s     Max norm  SSIMULACRA2        pnorm       BPP*pnorm   Bugs
--------------------------------------------------------------------------------------------------------------------------------------
jpeg:enc-jpegli:q95          13270  5794758    3.4933305   5.119  27.937   1.38596916  93.46103343   0.46287938  1.616990638243      0
jpeg:enc-jpegli:q90          13270  3936787    2.3732653   5.477  34.725   1.91680062  87.25703326   0.65623733  1.557425270742      0
jpeg:enc-jpegli:q85          13270  3057394    1.8431292   5.516  37.937   2.62046552  82.52436872   0.83109887  1.531822590242      0
jpeg:enc-jpegli:xyb:q95      13270  4264549    2.5708544   5.991  37.784   1.47950292  89.05115715   0.51803909  1.331803067049      0
jpeg:enc-jpegli:xyb:q90      13270  2943196    1.7742857   6.353  43.853   2.09280968  82.67561284   0.75413084  1.338043565214      0
jpeg:enc-jpegli:xyb:q85      13270  2305855    1.3900690   6.612  49.866   2.63821650  77.67960487   0.96307037  1.338734288390      0
Aggregate:                   13270  3555021    2.1431202   5.821  38.063   1.96099954  85.28831579   0.67547319  1.447620220302      0
```

Benchmakr after (jpegli encoding libjpeg decoding):
```
Encoding                   kPixels    Bytes          BPP  E MP/s  D MP/s     Max norm  SSIMULACRA2        pnorm       BPP*pnorm   Bugs
--------------------------------------------------------------------------------------------------------------------------------------
jpeg:enc-jpegli:q94          13270  5409435    3.2610411   5.208  29.327   1.50571752  93.24202136   0.47938494  1.563293990820      0
jpeg:enc-jpegli:q89          13270  3811326    2.2976320   5.479  33.254   2.14484310  87.70502481   0.65293161  1.500196542500      0
jpeg:enc-jpegli:q84          13270  3002498    1.8100355   5.514  37.814   2.48485231  83.16517895   0.82168611  1.487281033907      0
jpeg:enc-jpegli:xyb:q94      13270  3989884    2.4052745   6.134  38.151   1.39153469  88.59425842   0.54025277  1.299456193655      0
jpeg:enc-jpegli:xyb:q89      13270  2855332    1.7213175   6.438  44.082   2.09992790  82.77259267   0.76094816  1.309833374060      0
jpeg:enc-jpegli:xyb:q84      13270  2264070    1.3648792   6.524  47.225   2.94640446  77.69575729   0.96434098  1.316208962167      0
Aggregate:                   13270  3418768    2.0609808   5.861  37.825   2.02568416  85.38426684   0.68350252  1.408685571138      0
```

Benchmark before (jpegli encoding jpegli decoding):

```
Encoding                              kPixels    Bytes          BPP  E MP/s  D MP/s     Max norm  SSIMULACRA2        pnorm       BPP*pnorm   Bugs
-------------------------------------------------------------------------------------------------------------------------------------------------
jpeg:enc-jpegli:q95:dec-jpegli          13270  5794758    3.4933305   5.046  20.201   1.24526358  95.03066646   0.41532140  1.450854889909      0
jpeg:enc-jpegli:q90:dec-jpegli          13270  3936787    2.3732653   5.512  22.419   1.81215000  87.93787291   0.62230079  1.476884856990      0
jpeg:enc-jpegli:q85:dec-jpegli          13270  3057394    1.8431292   5.353  21.448   2.50435567  83.03343872   0.80082370  1.476021551550      0
jpeg:enc-jpegli:xyb:q95:dec-jpegli      13270  4264549    2.5708544   6.145  26.849   1.32461619  89.00039385   0.51124516  1.314336864199      0
jpeg:enc-jpegli:xyb:q90:dec-jpegli      13270  2943196    1.7742857   6.430  29.837   2.14005589  82.48641755   0.74338743  1.318981688573      0
jpeg:enc-jpegli:xyb:q85:dec-jpegli      13270  2305855    1.3900690   6.658  33.554   2.69269133  77.30046412   0.95115147  1.322166193554      0
Aggregate:                              13270  3555021    2.1431202   5.827  25.282   1.87273157  85.61335924   0.64913638  1.391177258447      0
```

Benchmark after (jpegli encoding jpegli decoding):
```
Encoding                              kPixels    Bytes          BPP  E MP/s  D MP/s     Max norm  SSIMULACRA2        pnorm       BPP*pnorm   Bugs
-------------------------------------------------------------------------------------------------------------------------------------------------
jpeg:enc-jpegli:q94:dec-jpegli          13270  5409435    3.2610411   5.186  20.662   1.30362570  94.69989767   0.42922370  1.399716125939      0
jpeg:enc-jpegli:q89:dec-jpegli          13270  3811326    2.2976320   5.484  22.432   2.18101788  88.32525503   0.61808046  1.420121426517      0
jpeg:enc-jpegli:q84:dec-jpegli          13270  3002498    1.8100355   5.667  23.856   2.35035825  83.67509663   0.78834191  1.426926849730      0
jpeg:enc-jpegli:xyb:q94:dec-jpegli      13270  3989884    2.4052745   6.263  27.660   1.30877268  88.49259087   0.53104633  1.277312161208      0
jpeg:enc-jpegli:xyb:q89:dec-jpegli      13270  2855332    1.7213175   6.538  30.471   2.00122976  82.54197918   0.74777798  1.287163318419      0
jpeg:enc-jpegli:xyb:q84:dec-jpegli      13270  2264070    1.3648792   6.846  32.245   2.64077306  77.40505828   0.94648725  1.291840777135      0
Aggregate:                              13270  3418768    2.0609808   5.968  25.880   1.89440607  85.68345309   0.65450132  1.348914659590      0
```