### PR TITLE
Tweak jpegli adaptive zeroing parameters.

### DIFF
--- a/lib/extras/jpegli_test.cc
+++ b/lib/extras/jpegli_test.cc
@@ -140,8 +140,8 @@ TEST(JpegliTest, JpegliYUVEncodeTest) {
 
   PackedPixelFile ppf_out;
   ASSERT_TRUE(DecodeWithLibjpeg(compressed, &ppf_out));
-  EXPECT_THAT(BitsPerPixel(ppf_in, compressed), IsSlightlyBelow(1.7f));
-  EXPECT_THAT(ButteraugliDistance(ppf_in, ppf_out), IsSlightlyBelow(1.26f));
+  EXPECT_THAT(BitsPerPixel(ppf_in, compressed), IsSlightlyBelow(1.65f));
+  EXPECT_THAT(ButteraugliDistance(ppf_in, ppf_out), IsSlightlyBelow(1.4f));
 }
 
 TEST(JpegliTest, JpegliYUVEncodeTestNoAq) {
@@ -159,8 +159,8 @@ TEST(JpegliTest, JpegliYUVEncodeTestNoAq) {
 
   PackedPixelFile ppf_out;
   ASSERT_TRUE(DecodeWithLibjpeg(compressed, &ppf_out));
-  EXPECT_THAT(BitsPerPixel(ppf_in, compressed), IsSlightlyBelow(1.62f));
-  EXPECT_THAT(ButteraugliDistance(ppf_in, ppf_out), IsSlightlyBelow(1.29f));
+  EXPECT_THAT(BitsPerPixel(ppf_in, compressed), IsSlightlyBelow(1.7f));
+  EXPECT_THAT(ButteraugliDistance(ppf_in, ppf_out), IsSlightlyBelow(1.35f));
 }
 
 TEST(JpegliTest, JpegliHDRRoundtripTest) {
@@ -177,7 +177,7 @@ TEST(JpegliTest, JpegliHDRRoundtripTest) {
 
   PackedPixelFile ppf_out;
   ASSERT_TRUE(DecodeJpeg(compressed, JXL_TYPE_UINT16, nullptr, &ppf_out));
-  EXPECT_THAT(BitsPerPixel(ppf_in, compressed), IsSlightlyBelow(2.75f));
+  EXPECT_THAT(BitsPerPixel(ppf_in, compressed), IsSlightlyBelow(2.8f));
   EXPECT_THAT(ButteraugliDistance(ppf_in, ppf_out), IsSlightlyBelow(1.25f));
 }
 

--- a/lib/jpegli/dct.h
+++ b/lib/jpegli/dct.h
@@ -14,8 +14,8 @@
 
 namespace jpegli {
 
-void ComputeDCTCoefficients(const jxl::Image3F& opsin, const bool xyb,
-                            const jxl::ImageF& qf,
+void ComputeDCTCoefficients(const jxl::Image3F& opsin, float distance,
+                            const bool xyb, const jxl::ImageF& qf,
                             const float* qm,
                             std::vector<jxl::jpeg::JPEGComponent>* components);
 

--- a/lib/jpegli/encode.cc
+++ b/lib/jpegli/encode.cc
@@ -427,7 +427,9 @@ void jpegli_finish_compress(j_compress_ptr cinfo) {
 
   // Global scale is chosen in a way that butteraugli 3-norm matches libjpeg
   // with the same quality setting. Fitted for quality 90 on jyrki31 corpus.
-  float global_scale = use_xyb ? 0.9216f : 1.184f;
+  constexpr float kGlobalScaleXYB = 0.92159151f;
+  constexpr float kGlobalScaleYCbCr = 1.10048560f;
+  float global_scale = use_xyb ? kGlobalScaleXYB : kGlobalScaleYCbCr;
   if (!use_xyb) {
     if (color_encoding.tf.IsPQ()) {
       global_scale *= .4f;
@@ -479,7 +481,7 @@ void jpegli_finish_compress(j_compress_ptr cinfo) {
         frame_dim.ysize_blocks / factor;
     m->jpeg_data.components[c].quant_idx = c;
   }
-  jpegli::ComputeDCTCoefficients(opsin, use_xyb, qf, qm,
+  jpegli::ComputeDCTCoefficients(opsin, distance, use_xyb, qf, qm,
                                  &m->jpeg_data.components);
 
   // DHT (the actual Huffman codes will be added later).

--- a/lib/jpegli/encode_api_test.cc
+++ b/lib/jpegli/encode_api_test.cc
@@ -126,6 +126,7 @@ void TestDecodedImage(const std::vector<uint8_t>& compressed,
     diff2 += diff * diff;
   }
   double rms = std::sqrt(diff2 / orig.size()) / mul;
+  printf("rms: %f\n", rms);
   EXPECT_LE(rms, max_dist);
 }
 
@@ -215,6 +216,7 @@ TEST_P(EncodeAPITestParam, TestAPI) {
   std::copy_n(buffer, size, compressed.data());
   std::free(buffer);
   double bpp = compressed.size() * 8.0 / (xsize * ysize);
+  printf("bpp: %f\n", bpp);
   EXPECT_LT(bpp, config.max_bpp);
   TestDecodedImage(compressed, orig, xsize, ysize, num_channels,
                    config.progressive_id, config.max_dist);
@@ -224,37 +226,37 @@ std::vector<TestConfig> GenerateTests() {
   std::vector<TestConfig> all_tests;
   {
     TestConfig config;
-    config.max_bpp = 1.45;
-    config.max_dist = 2.15;
+    config.max_bpp = 1.4;
+    config.max_dist = 2.3;
     all_tests.push_back(config);
   }
   {
     TestConfig config;
     config.quality = 100;
-    config.max_bpp = 4.65;
-    config.max_dist = 0.75;
+    config.max_bpp = 4.1;
+    config.max_dist = 0.85;
     all_tests.push_back(config);
   }
   {
     TestConfig config;
     config.quality = 80;
-    config.max_bpp = 0.9;
-    config.max_dist = 2.95;
+    config.max_bpp = 0.95;
+    config.max_dist = 2.8;
     all_tests.push_back(config);
   }
   {
     TestConfig config;
     config.sampling = SAMPLING_420;
     config.max_bpp = 1.25;
-    config.max_dist = 2.65;
+    config.max_dist = 2.9;
     all_tests.push_back(config);
   }
   {
     for (size_t p = 0; p < kNumTestScripts; ++p) {
       TestConfig config;
       config.progressive_id = p + 1;
-      config.max_bpp = 1.5;
-      config.max_dist = 2.15;
+      config.max_bpp = 1.45;
+      config.max_dist = 2.3;
       all_tests.push_back(config);
     }
   }

--- a/tools/optimizer/update_jpegli_global_scale.py
+++ b/tools/optimizer/update_jpegli_global_scale.py
@@ -1,0 +1,103 @@
+#!/usr/bin/python
+# Copyright (c) the JPEG XL Project Authors. All rights reserved.
+#
+# Use of this source code is governed by a BSD-style
+# license that can be found in the LICENSE file.
+
+"""Script to update jpegli global scale after a change affecting quality.
+
+start as ./update_jpegli_global_scale.py build <corpus-dir>
+"""
+
+import os
+import re
+import subprocess
+import sys
+
+def SourceFileName():
+  return "lib/jpegli/encode.cc"
+
+def ScalePattern(scale_type):
+  return "  constexpr float kGlobalScale" + scale_type + " = ";
+
+def CodecName(scale_type):
+  if scale_type == "YCbCr":
+    return "jpeg:enc-jpegli:q90"
+  elif scale_type == "XYB":
+    return "jpeg:enc-jpegli:xyb:q90"
+  else:
+    raise Exception("Unknown scale type %s" % scale_type)
+  
+def ReadGlobalScale(scale_type):
+  pattern = ScalePattern(scale_type)
+  with open(SourceFileName()) as f:
+    for line in f.read().splitlines():
+      if line.startswith(pattern):
+        return float(line[len(pattern):-2])
+  raise Exception("Global scale %s not found." % scale_type)
+  
+    
+def UpdateGlobalScale(scale_type, new_val):
+  pattern = ScalePattern(scale_type)
+  found_pattern = False
+  fdata = ""
+  with open(SourceFileName()) as f:
+    for line in f.read().splitlines():
+      if line.startswith(pattern):
+        fdata += pattern + "%.8ff;\n" % new_val
+        found_pattern = True
+      else:
+        fdata += line + "\n"
+  if not found_pattern:
+    raise Exception("Global scale %s not found." % scale_type)
+  with open(SourceFileName(), "w") as f:
+    f.write(fdata)
+    f.close()
+
+def EvalPnorm(build_dir, corpus_dir, codec):
+  compile_args = ["ninja", "-C", build_dir, "tools/benchmark_xl"]
+  try:
+    subprocess.check_output(compile_args)
+  except:
+    subprocess.check_call(compile_args)
+  process = subprocess.Popen(
+    (os.path.join(build_dir, "tools/benchmark_xl"),
+     "--input", os.path.join(corpus_dir, "*.png"),
+     "--codec", codec),
+    stdout=subprocess.PIPE,
+    stderr=subprocess.PIPE)
+  (out, err) = process.communicate(input=None)
+  for line in out.splitlines():
+    if line.startswith(codec):
+      return float(line.split()[8])
+  raise Exception("Unexpected benchmark output:\n%sstderr:\n%s" % (out, err))
+
+
+if len(sys.argv) != 3:
+  print("usage: ", sys.argv[0], "build-dir corpus-dir")
+  exit(1)
+
+build_dir = sys.argv[1]
+corpus_dir = sys.argv[2]
+    
+jpeg_pnorm = EvalPnorm(build_dir, corpus_dir, "jpeg:q90")
+
+print("Libjpeg pnorm: %.8f" % jpeg_pnorm)
+
+for scale_type in ["YCbCr", "XYB"]:
+  scale = ReadGlobalScale(scale_type)
+  best_scale = scale
+  best_rel_error = 100.0
+  for i in range(10):
+    jpegli_pnorm = EvalPnorm(build_dir, corpus_dir, CodecName(scale_type))
+    rel_error = abs(jpegli_pnorm / jpeg_pnorm - 1)
+    print("[%-5s] scale: %.8f  pnorm: %.8f  error: %.8f" %
+          (scale_type, scale, jpegli_pnorm, rel_error))
+    if rel_error < best_rel_error:
+      best_rel_error = rel_error
+      best_scale = scale
+    if rel_error < 0.0001:
+      break
+    scale = scale * jpeg_pnorm / jpegli_pnorm
+    UpdateGlobalScale(scale_type, scale)
+  UpdateGlobalScale(scale_type, best_scale)


### PR DESCRIPTION
Add python script to update global scale to match libjpeg quality 90 pnorm.

Benchmark before:
```
Encoding                   kPixels    Bytes          BPP  E MP/s  D MP/s     Max norm  SSIMULACRA2        pnorm       BPP*pnorm   Bugs
--------------------------------------------------------------------------------------------------------------------------------------
jpeg:enc-jpegli:q95          13270  5370748    3.2377189   4.330  27.512   1.50571752  93.15828805   0.48245202  1.562044043045      0
jpeg:enc-jpegli:q90          13270  3625700    2.1857286   5.520  33.601   2.15366292  86.57551788   0.68660493  1.500732036613      0
jpeg:enc-jpegli:q85          13270  2804097    1.6904308   5.355  35.518   2.48398638  82.22072505   0.87241299  1.474753809926      0
jpeg:enc-jpegli:xyb:q95      13270  4603424    2.7751429   5.678  33.608   1.69426656  90.67321501   0.47020969  1.304899072494      0
jpeg:enc-jpegli:xyb:q90      13270  3170600    1.9113747   6.077  40.088   1.90134680  84.71690135   0.68657995  1.312311513450      0
jpeg:enc-jpegli:xyb:q85      13270  2479683    1.4948600   6.318  46.832   2.34824491  80.02210926   0.87567042  1.309004728630      0
Aggregate:                   13270  3542472    2.1355549   5.508  35.705   1.98370072  86.10786644   0.65872037  1.406733528649      0
```

Benchmark after:
```
Encoding                   kPixels    Bytes          BPP  E MP/s  D MP/s     Max norm  SSIMULACRA2        pnorm       BPP*pnorm   Bugs
--------------------------------------------------------------------------------------------------------------------------------------
jpeg:enc-jpegli:q95          13270  5323408    3.2091803   4.909  27.402   1.60794115  92.60851670   0.48322977  1.550771491677      0
jpeg:enc-jpegli:q90          13270  3594661    2.1670170   5.448  35.792   2.19617844  86.24572089   0.68664849  1.487978923693      0
jpeg:enc-jpegli:q85          13270  2937341    1.7707561   5.430  35.004   2.36338425  83.24249534   0.83037363  1.470389140036      0
jpeg:enc-jpegli:xyb:q95      13270  4605780    2.7765632   5.593  32.377   1.69426656  90.69110483   0.47000310  1.304993303823      0
jpeg:enc-jpegli:xyb:q90      13270  3170952    1.9115869   5.971  43.896   1.90134680  84.71284882   0.68652196  1.312346361599      0
jpeg:enc-jpegli:xyb:q85      13270  2479697    1.4948685   6.399  46.650   2.34824491  80.02248763   0.87566177  1.308999177814      0
Aggregate:                   13270  3559991    2.1461165   5.606  36.269   1.99546032  86.14761672   0.65344475  1.402368561848      0
```