### PR TITLE
Add jpegli_use_standard_quant_tables() API function.

### DIFF
--- a/lib/extras/enc/jpegli.cc
+++ b/lib/extras/enc/jpegli.cc
@@ -132,6 +132,8 @@ Status EncodeJpeg(const PackedPixelFile& ppf, const JpegSettings& jpeg_settings,
         cinfo.input_components == 1 ? JCS_GRAYSCALE : JCS_RGB;
     if (jpeg_settings.xyb) {
       jpegli_set_xyb_mode(&cinfo);
+    } else if (jpeg_settings.use_std_quant_tables) {
+      jpegli_use_standard_quant_tables(&cinfo);
     }
     jpegli_set_progressive_level(&cinfo, jpeg_settings.progressive_level);
     jpegli_set_defaults(&cinfo);

--- a/lib/extras/enc/jpegli.h
+++ b/lib/extras/enc/jpegli.h
@@ -24,6 +24,7 @@ struct JpegSettings {
   size_t target_size = 0;
   float distance = 1.f;
   bool use_adaptive_quantization = true;
+  bool use_std_quant_tables = false;
   int progressive_level = 2;
 };
 

--- a/lib/jpegli/dct.cc
+++ b/lib/jpegli/dct.cc
@@ -67,9 +67,9 @@ void ComputeDCTCoefficients(const jxl::Image3F& opsin, float distance,
         zero_bias = std::min(1.5f, zero_bias);
         for (size_t iy = 0, i = 0; iy < 8; iy++) {
           for (size_t ix = 0; ix < 8; ix++, i++) {
-            float coeff = 2040 * dct[i] * qmc[i];
+            float coeff = 2040 * dct[ix * 8 + iy] * qmc[i];
             int cc = std::abs(coeff) < zero_bias ? 0 : std::round(coeff);
-            block[ix * 8 + iy] = cc;
+            block[i] = cc;
           }
         }
         if (xyb) {

--- a/lib/jpegli/encode.h
+++ b/lib/jpegli/encode.h
@@ -110,6 +110,13 @@ void jpegli_enable_adaptive_quantization(j_compress_ptr cinfo, boolean value);
 // greater level value means more progression steps. Default is 2.
 void jpegli_set_progressive_level(j_compress_ptr cinfo, int level);
 
+// If this function is called before starting compression, the quality and
+// linear quality parameters will be used to scale the standard quantization
+// tables from Annex K of the JPEG standard. By default jpegli uses a different
+// set of quantization tables and used different scaling parameters for DC and
+// AC coefficients.
+void jpegli_use_standard_quant_tables(j_compress_ptr cinfo);
+
 #if defined(__cplusplus) || defined(c_plusplus)
 }  // extern "C"
 #endif

--- a/lib/jpegli/encode_api_test.cc
+++ b/lib/jpegli/encode_api_test.cc
@@ -147,6 +147,7 @@ struct TestConfig {
   int progressive_id = 0;
   int progressive_level = -1;
   bool xyb_mode = false;
+  bool libjpeg_mode = false;
   double max_bpp;
   double max_dist;
 };
@@ -205,6 +206,10 @@ TEST_P(EncodeAPITestParam, TestAPI) {
   jpegli_set_quality(&cinfo, config.quality, TRUE);
   if (config.xyb_mode) {
     jpegli_set_xyb_mode(&cinfo);
+  } else if (config.libjpeg_mode) {
+    jpegli_enable_adaptive_quantization(&cinfo, FALSE);
+    jpegli_use_standard_quant_tables(&cinfo);
+    jpegli_set_progressive_level(&cinfo, 0);
   }
   jpegli_start_compress(&cinfo, TRUE);
   size_t stride = xsize * cinfo.input_components;
@@ -281,6 +286,13 @@ std::vector<TestConfig> GenerateTests() {
   }
   {
     TestConfig config;
+    config.libjpeg_mode = true;
+    config.max_bpp = 2.1;
+    config.max_dist = 1.7;
+    all_tests.push_back(config);
+  }
+  {
+    TestConfig config;
     config.color = COLOR_GRAY;
     config.max_bpp = 1.05;
     config.max_dist = 1.4;
@@ -309,6 +321,8 @@ std::ostream& operator<<(std::ostream& os, const TestConfig& c) {
   }
   if (c.xyb_mode) {
     os << "XYB";
+  } else if (c.libjpeg_mode) {
+    os << "Libjpeg";
   }
   return os;
 }

--- a/lib/jpegli/encode_internal.h
+++ b/lib/jpegli/encode_internal.h
@@ -20,6 +20,7 @@ struct jpeg_comp_master {
   jxl::Image3F input;
   float distance;
   bool xyb_mode;
+  bool use_std_tables;
   bool use_adaptive_quantization;
   int progressive_level;
   bool force_baseline;

--- a/lib/jpegli/quant.cc
+++ b/lib/jpegli/quant.cc
@@ -406,14 +406,47 @@ static const float kBaseQuantMatrixYCbCr[] = {
     113.0502548218f,
 };
 
+static const float kBaseQuantMatrixStd[] = {
+    // c = 0
+    16.0f, 11.0f, 10.0f, 16.0f, 24.0f, 40.0f, 51.0f, 61.0f,      //
+    12.0f, 12.0f, 14.0f, 19.0f, 26.0f, 58.0f, 60.0f, 55.0f,      //
+    14.0f, 13.0f, 16.0f, 24.0f, 40.0f, 57.0f, 69.0f, 56.0f,      //
+    14.0f, 17.0f, 22.0f, 29.0f, 51.0f, 87.0f, 80.0f, 62.0f,      //
+    18.0f, 22.0f, 37.0f, 56.0f, 68.0f, 109.0f, 103.0f, 77.0f,    //
+    24.0f, 35.0f, 55.0f, 64.0f, 81.0f, 104.0f, 113.0f, 92.0f,    //
+    49.0f, 64.0f, 78.0f, 87.0f, 103.0f, 121.0f, 120.0f, 101.0f,  //
+    72.0f, 92.0f, 95.0f, 98.0f, 112.0f, 100.0f, 103.0f, 99.0f,   //
+    // c = 1
+    17.0f, 18.0f, 24.0f, 47.0f, 99.0f, 99.0f, 99.0f, 99.0f,  //
+    18.0f, 21.0f, 26.0f, 66.0f, 99.0f, 99.0f, 99.0f, 99.0f,  //
+    24.0f, 26.0f, 56.0f, 99.0f, 99.0f, 99.0f, 99.0f, 99.0f,  //
+    47.0f, 66.0f, 99.0f, 99.0f, 99.0f, 99.0f, 99.0f, 99.0f,  //
+    99.0f, 99.0f, 99.0f, 99.0f, 99.0f, 99.0f, 99.0f, 99.0f,  //
+    99.0f, 99.0f, 99.0f, 99.0f, 99.0f, 99.0f, 99.0f, 99.0f,  //
+    99.0f, 99.0f, 99.0f, 99.0f, 99.0f, 99.0f, 99.0f, 99.0f,  //
+    99.0f, 99.0f, 99.0f, 99.0f, 99.0f, 99.0f, 99.0f, 99.0f,  //
+    // c = 2
+    17.0f, 18.0f, 24.0f, 47.0f, 99.0f, 99.0f, 99.0f, 99.0f,  //
+    18.0f, 21.0f, 26.0f, 66.0f, 99.0f, 99.0f, 99.0f, 99.0f,  //
+    24.0f, 26.0f, 56.0f, 99.0f, 99.0f, 99.0f, 99.0f, 99.0f,  //
+    47.0f, 66.0f, 99.0f, 99.0f, 99.0f, 99.0f, 99.0f, 99.0f,  //
+    99.0f, 99.0f, 99.0f, 99.0f, 99.0f, 99.0f, 99.0f, 99.0f,  //
+    99.0f, 99.0f, 99.0f, 99.0f, 99.0f, 99.0f, 99.0f, 99.0f,  //
+    99.0f, 99.0f, 99.0f, 99.0f, 99.0f, 99.0f, 99.0f, 99.0f,  //
+    99.0f, 99.0f, 99.0f, 99.0f, 99.0f, 99.0f, 99.0f, 99.0f,  //
+};
+
+constexpr const float* kBaseQuantMatrices[NUM_QUANT_MODES] = {
+    kBaseQuantMatrixXYB, kBaseQuantMatrixYCbCr, kBaseQuantMatrixStd};
+
 }  // namespace
 
-void AddJpegQuantMatrices(bool xyb, int num_components, float dc_scale,
+void AddJpegQuantMatrices(QuantMode mode, int num_components, float dc_scale,
                           float ac_scale,
                           std::vector<jxl::jpeg::JPEGQuantTable>* quant_tables,
                           float* qm) {
-  const float* const base_quant_matrix =
-      xyb ? kBaseQuantMatrixXYB : kBaseQuantMatrixYCbCr;
+  JXL_DASSERT(mode < NUM_QUANT_MODES);
+  const float* const base_quant_matrix = kBaseQuantMatrices[mode];
   for (int c = 0, ix = 0; c < num_components; c++) {
     qm[ix] = dc_scale * base_quant_matrix[ix];
     ix++;

--- a/lib/jpegli/quant.h
+++ b/lib/jpegli/quant.h
@@ -14,7 +14,14 @@
 
 namespace jpegli {
 
-void AddJpegQuantMatrices(bool xyb, int num_components, float dc_scale,
+enum QuantMode {
+  QUANT_XYB,
+  QUANT_YUV,
+  QUANT_STD,
+  NUM_QUANT_MODES,
+};
+
+void AddJpegQuantMatrices(QuantMode mode, int num_components, float dc_scale,
                           float ac_scale,
                           std::vector<jxl::jpeg::JPEGQuantTable>* quant_tables,
                           float* qm);

--- a/tools/benchmark/benchmark_codec_jpeg.cc
+++ b/tools/benchmark/benchmark_codec_jpeg.cc
@@ -64,6 +64,10 @@ class JPEGCodec : public ImageCodec {
       xyb_mode_ = true;
       return true;
     }
+    if (param == "std") {
+      use_std_tables_ = true;
+      return true;
+    }
     if (param == "dec-jpegli") {
       jpeg_decoder_ = "jpegli";
       return true;
@@ -134,6 +138,9 @@ class JPEGCodec : public ImageCodec {
           *io, format, io->metadata.m.color_encoding, pool, &ppf));
       extras::JpegSettings settings;
       settings.xyb = xyb_mode_;
+      if (!xyb_mode_) {
+        settings.use_std_quant_tables = use_std_tables_;
+      }
       if (enc_quality_set_) {
         settings.distance = jpegli_quality_to_distance(q_target_);
       } else {
@@ -204,6 +211,7 @@ class JPEGCodec : public ImageCodec {
   int progressive_id_ = -1;
   bool enc_quality_set_ = false;
   bool xyb_mode_ = false;
+  bool use_std_tables_ = false;
   // JPEG decoder and its parameters
   std::string jpeg_decoder_ = "libjpeg";
   size_t bitdepth_ = 8;


### PR DESCRIPTION
Benchmark results:

```
Encoding                           kPixels    Bytes          BPP  E MP/s  D MP/s     Max norm  SSIMULACRA2        pnorm       BPP*pnorm   Bugs
----------------------------------------------------------------------------------------------------------------------------------------------
jpeg:enc-jpegli:q90                  13270  3594661    2.1670170   4.955  33.316   2.19617844  86.24572089   0.68664849  1.487978923693      0
jpeg:enc-jpegli:q90:p0               13270  3679628    2.2182387  12.169  94.790   2.19617844  86.24572089   0.68664849  1.523150280661      0
jpeg:enc-jpegli:q90:p0:noaq          13270  3980121    2.3993889  16.038  84.961   2.46895504  88.28771516   0.68333374  1.639583394752      0
jpeg:enc-jpegli:q90:p0:noaq:std      13270  4794182    2.8901400  15.534  91.504   2.36946797  91.30823740   0.68007899  1.965523522557      0
jpeg:q90                             13270  4838710    2.9169834  32.890  92.842   2.40070152  91.22219875   0.68663652  2.002907346332      0
Aggregate:                           13270  4143434    2.4978412  13.764  74.398   2.32363274  88.63335264   0.68466419  1.710182390246      0
```