### PR TITLE
CMake: clean-up after Brotli update

### DIFF
--- a/cmake/FindBrotli.cmake
+++ b/cmake/FindBrotli.cmake
@@ -31,11 +31,6 @@ foreach(brlib IN ITEMS ${brlibs})
       set_property(TARGET ${brlib} PROPERTY INTERFACE_INCLUDE_DIRECTORIES ${BROTLI_INCLUDE_DIR})
       target_link_libraries(${brlib} INTERFACE ${${BRPREFIX}_LIBRARY})
       set_property(TARGET ${brlib} PROPERTY INTERFACE_COMPILE_OPTIONS ${PC_${BRPREFIX}_CFLAGS_OTHER})
-
-      add_library(${brlib}-static INTERFACE IMPORTED GLOBAL)
-      set_property(TARGET ${brlib}-static PROPERTY INTERFACE_INCLUDE_DIRECTORIES ${BROTLI_INCLUDE_DIR})
-      target_link_libraries(${brlib}-static INTERFACE ${${BRPREFIX}_LIBRARY})
-      set_property(TARGET ${brlib}-static PROPERTY INTERFACE_COMPILE_OPTIONS ${PC_${BRPREFIX}_CFLAGS_OTHER})
     else()
     add_library(${brlib} INTERFACE IMPORTED GLOBAL)
       target_include_directories(${brlib}
@@ -46,11 +41,6 @@ foreach(brlib IN ITEMS ${brlibs})
         INTERFACE ${PC_${BRPREFIX}_LDFLAGS_OTHER})
       target_compile_options(${brlib}
         INTERFACE ${PC_${BRPREFIX}_CFLAGS_OTHER})
-
-      # TODO(deymo): Remove the -static library versions, this target is
-      # currently needed by brunsli.cmake. When importing it this way, the
-      # brotli*-static target is just an alias.
-      add_library(${brlib}-static ALIAS ${brlib})
     endif()
   endif()
 endforeach()

--- a/third_party/CMakeLists.txt
+++ b/third_party/CMakeLists.txt
@@ -61,11 +61,7 @@ if (NOT EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/brotli/c/include/brotli/decode.h" OR
 else()
   # Compile brotli from sources.
   set(BROTLI_DISABLE_TESTS ON CACHE STRING "Disable Brotli tests")
-  # Override default "no-install" policy.
-  if((NOT SANITIZER STREQUAL "asan") AND (NOT SANITIZER STREQUAL "msan"))
-    set(BROTLI_BUNDLED_MODE OFF CACHE INTERNAL "")
-  endif()
-  add_subdirectory(brotli)
+  add_subdirectory(brotli EXCLUDE_FROM_ALL)
   configure_file("${CMAKE_CURRENT_SOURCE_DIR}/brotli/LICENSE"
                  ${PROJECT_BINARY_DIR}/LICENSE.brotli COPYONLY)
   if(APPLE)


### PR DESCRIPTION
Commit google/brotli@641bec0 ensures that Brotli honors the `BUILD_SHARED_LIBS` option in CMake, making commit 43323c0 and 6f20853 redundant.

Resolves #1694.