### PR TITLE
jpegli encoder: remove dependence on lib/jxl/jpeg

### DIFF
--- a/lib/jpegli.cmake
+++ b/lib/jpegli.cmake
@@ -4,8 +4,11 @@
 # license that can be found in the LICENSE file.
 
 set(JPEGLI_INTERNAL_SOURCES
+  jpegli/bitstream.h
+  jpegli/bitstream.cc
   jpegli/color_transform.h
   jpegli/color_transform.cc
+  jpegli/common_internal.h
   jpegli/common.h
   jpegli/common.cc
   jpegli/dct.h

--- a/lib/jpegli/bitstream.cc
+++ b/lib/jpegli/bitstream.cc
@@ -1,0 +1,704 @@
+// Copyright (c) the JPEG XL Project Authors. All rights reserved.
+//
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+#include "lib/jpegli/bitstream.h"
+
+#include "lib/jpegli/error.h"
+#include "lib/jxl/base/bits.h"
+
+namespace jpegli {
+namespace {
+
+const int kJpegPrecision = 8;
+// JpegBitWriter: buffer size
+const size_t kJpegBitWriterChunkSize = 16384;
+
+// Handles the packing of bits into output bytes.
+struct JpegBitWriter {
+  j_compress_ptr cinfo;
+  std::vector<uint8_t> buffer;
+  uint8_t* data;
+  size_t pos;
+  uint64_t put_buffer;
+  int put_bits;
+  bool healthy;
+};
+
+// Holds data that is buffered between 8x8 blocks in progressive mode.
+struct DCTCodingState {
+  // The run length of end-of-band symbols in a progressive scan.
+  int eob_run_;
+  // The huffman table to be used when flushing the state.
+  HuffmanCodeTable* cur_ac_huff_;
+  // The sequence of currently buffered refinement bits for a successive
+  // approximation scan (one where Ah > 0).
+  std::vector<int> refinement_bits_;
+};
+
+// Returns non-zero if and only if x has a zero byte, i.e. one of
+// x & 0xff, x & 0xff00, ..., x & 0xff00000000000000 is zero.
+static JXL_INLINE uint64_t HasZeroByte(uint64_t x) {
+  return (x - 0x0101010101010101ULL) & ~x & 0x8080808080808080ULL;
+}
+
+void JpegBitWriterInit(JpegBitWriter* bw, j_compress_ptr cinfo) {
+  bw->cinfo = cinfo;
+  bw->buffer.resize(kJpegBitWriterChunkSize);
+  bw->data = bw->buffer.data();
+  bw->pos = 0;
+  bw->put_buffer = 0;
+  bw->put_bits = 64;
+  bw->healthy = true;
+}
+
+static JXL_INLINE void Reserve(JpegBitWriter* bw, size_t n_bytes) {
+  if (JXL_UNLIKELY((bw->pos + n_bytes) > kJpegBitWriterChunkSize)) {
+    WriteOutput(bw->cinfo, bw->data, bw->pos);
+    bw->data = bw->buffer.data();
+    bw->pos = 0;
+  }
+}
+
+/**
+ * Writes the given byte to the output, writes an extra zero if byte is 0xFF.
+ *
+ * This method is "careless" - caller must make sure that there is enough
+ * space in the output buffer. Emits up to 2 bytes to buffer.
+ */
+static JXL_INLINE void EmitByte(JpegBitWriter* bw, int byte) {
+  bw->data[bw->pos++] = byte;
+  if (byte == 0xFF) bw->data[bw->pos++] = 0;
+}
+
+static JXL_INLINE void DischargeBitBuffer(JpegBitWriter* bw) {
+  // At this point we are ready to emit the most significant 6 bytes of
+  // put_buffer_ to the output.
+  // The JPEG format requires that after every 0xff byte in the entropy
+  // coded section, there is a zero byte, therefore we first check if any of
+  // the 6 most significant bytes of put_buffer_ is 0xFF.
+  Reserve(bw, 12);
+  if (HasZeroByte(~bw->put_buffer | 0xFFFF)) {
+    // We have a 0xFF byte somewhere, examine each byte and append a zero
+    // byte if necessary.
+    EmitByte(bw, (bw->put_buffer >> 56) & 0xFF);
+    EmitByte(bw, (bw->put_buffer >> 48) & 0xFF);
+    EmitByte(bw, (bw->put_buffer >> 40) & 0xFF);
+    EmitByte(bw, (bw->put_buffer >> 32) & 0xFF);
+    EmitByte(bw, (bw->put_buffer >> 24) & 0xFF);
+    EmitByte(bw, (bw->put_buffer >> 16) & 0xFF);
+  } else {
+    // We don't have any 0xFF bytes, output all 6 bytes without checking.
+    bw->data[bw->pos] = (bw->put_buffer >> 56) & 0xFF;
+    bw->data[bw->pos + 1] = (bw->put_buffer >> 48) & 0xFF;
+    bw->data[bw->pos + 2] = (bw->put_buffer >> 40) & 0xFF;
+    bw->data[bw->pos + 3] = (bw->put_buffer >> 32) & 0xFF;
+    bw->data[bw->pos + 4] = (bw->put_buffer >> 24) & 0xFF;
+    bw->data[bw->pos + 5] = (bw->put_buffer >> 16) & 0xFF;
+    bw->pos += 6;
+  }
+  bw->put_buffer <<= 48;
+  bw->put_bits += 48;
+}
+
+static JXL_INLINE void WriteBits(JpegBitWriter* bw, int nbits, uint64_t bits) {
+  // This is an optimization; if everything goes well,
+  // then |nbits| is positive; if non-existing Huffman symbol is going to be
+  // encoded, its length should be zero; later encoder could check the
+  // "health" of JpegBitWriter.
+  if (nbits == 0) {
+    bw->healthy = false;
+    return;
+  }
+  bw->put_bits -= nbits;
+  bw->put_buffer |= (bits << bw->put_bits);
+  if (bw->put_bits <= 16) DischargeBitBuffer(bw);
+}
+
+void EmitMarker(JpegBitWriter* bw, int marker) {
+  Reserve(bw, 2);
+  JXL_DASSERT(marker != 0xFF);
+  bw->data[bw->pos++] = 0xFF;
+  bw->data[bw->pos++] = marker;
+}
+
+void JumpToByteBoundary(JpegBitWriter* bw) {
+  size_t n_bits = bw->put_bits & 7u;
+  uint8_t pad_pattern = (1u << n_bits) - 1;
+
+  Reserve(bw, 16);
+
+  while (bw->put_bits <= 56) {
+    int c = (bw->put_buffer >> 56) & 0xFF;
+    EmitByte(bw, c);
+    bw->put_buffer <<= 8;
+    bw->put_bits += 8;
+  }
+  if (bw->put_bits < 64) {
+    int pad_mask = 0xFFu >> (64 - bw->put_bits);
+    int c = ((bw->put_buffer >> 56) & ~pad_mask) | pad_pattern;
+    EmitByte(bw, c);
+  }
+  bw->put_buffer = 0;
+  bw->put_bits = 64;
+}
+
+void JpegBitWriterFinish(JpegBitWriter* bw) {
+  if (bw->pos == 0) return;
+  WriteOutput(bw->cinfo, bw->data, bw->pos);
+  bw->data = nullptr;
+  bw->pos = 0;
+}
+
+void DCTCodingStateInit(DCTCodingState* s) {
+  s->eob_run_ = 0;
+  s->cur_ac_huff_ = nullptr;
+  s->refinement_bits_.clear();
+  s->refinement_bits_.reserve(kJPEGMaxCorrectionBits);
+}
+
+static JXL_INLINE void WriteSymbol(int symbol, HuffmanCodeTable* table,
+                                   JpegBitWriter* bw) {
+  WriteBits(bw, table->depth[symbol], table->code[symbol]);
+}
+
+// Emit all buffered data to the bit stream using the given Huffman code and
+// bit writer.
+static JXL_INLINE void Flush(DCTCodingState* s, JpegBitWriter* bw) {
+  if (s->eob_run_ > 0) {
+    int nbits = jxl::FloorLog2Nonzero<uint32_t>(s->eob_run_);
+    int symbol = nbits << 4u;
+    WriteSymbol(symbol, s->cur_ac_huff_, bw);
+    if (nbits > 0) {
+      WriteBits(bw, nbits, s->eob_run_ & ((1 << nbits) - 1));
+    }
+    s->eob_run_ = 0;
+  }
+  for (size_t i = 0; i < s->refinement_bits_.size(); ++i) {
+    WriteBits(bw, 1, s->refinement_bits_[i]);
+  }
+  s->refinement_bits_.clear();
+}
+
+// Buffer some more data at the end-of-band (the last non-zero or newly
+// non-zero coefficient within the [Ss, Se] spectral band).
+static JXL_INLINE void BufferEndOfBand(DCTCodingState* s,
+                                       HuffmanCodeTable* ac_huff,
+                                       const std::vector<int>* new_bits,
+                                       JpegBitWriter* bw) {
+  if (s->eob_run_ == 0) {
+    s->cur_ac_huff_ = ac_huff;
+  }
+  ++s->eob_run_;
+  if (new_bits) {
+    s->refinement_bits_.insert(s->refinement_bits_.end(), new_bits->begin(),
+                               new_bits->end());
+  }
+  if (s->eob_run_ == 0x7FFF ||
+      s->refinement_bits_.size() > kJPEGMaxCorrectionBits - kDCTBlockSize + 1) {
+    Flush(s, bw);
+  }
+}
+
+bool BuildHuffmanCodeTable(const JPEGHuffmanCode& huff,
+                           HuffmanCodeTable* table) {
+  int huff_code[kJpegHuffmanAlphabetSize];
+  // +1 for a sentinel element.
+  uint32_t huff_size[kJpegHuffmanAlphabetSize + 1];
+  int p = 0;
+  for (size_t l = 1; l <= kJpegHuffmanMaxBitLength; ++l) {
+    int i = huff.counts[l];
+    if (p + i > kJpegHuffmanAlphabetSize + 1) {
+      return false;
+    }
+    while (i--) huff_size[p++] = l;
+  }
+
+  if (p == 0) {
+    return true;
+  }
+
+  // Reuse sentinel element.
+  int last_p = p - 1;
+  huff_size[last_p] = 0;
+
+  int code = 0;
+  uint32_t si = huff_size[0];
+  p = 0;
+  while (huff_size[p]) {
+    while ((huff_size[p]) == si) {
+      huff_code[p++] = code;
+      code++;
+    }
+    code <<= 1;
+    si++;
+  }
+  for (p = 0; p < last_p; p++) {
+    int i = huff.values[p];
+    table->depth[i] = huff_size[p];
+    table->code[i] = huff_code[p];
+  }
+  return true;
+}
+
+bool EncodeDCTBlockSequential(const coeff_t* coeffs, HuffmanCodeTable* dc_huff,
+                              HuffmanCodeTable* ac_huff, int num_zero_runs,
+                              coeff_t* last_dc_coeff, JpegBitWriter* bw) {
+  coeff_t temp2;
+  coeff_t temp;
+  temp2 = coeffs[0];
+  temp = temp2 - *last_dc_coeff;
+  *last_dc_coeff = temp2;
+  temp2 = temp;
+  if (temp < 0) {
+    temp = -temp;
+    if (temp < 0) return false;
+    temp2--;
+  }
+  int dc_nbits = (temp == 0) ? 0 : (jxl::FloorLog2Nonzero<uint32_t>(temp) + 1);
+  WriteSymbol(dc_nbits, dc_huff, bw);
+  if (dc_nbits >= 12) return false;
+  if (dc_nbits > 0) {
+    WriteBits(bw, dc_nbits, temp2 & ((1u << dc_nbits) - 1));
+  }
+  int r = 0;
+  for (int k = 1; k < 64; ++k) {
+    if ((temp = coeffs[kJPEGNaturalOrder[k]]) == 0) {
+      r++;
+      continue;
+    }
+    if (temp < 0) {
+      temp = -temp;
+      if (temp < 0) return false;
+      temp2 = ~temp;
+    } else {
+      temp2 = temp;
+    }
+    while (r > 15) {
+      WriteSymbol(0xf0, ac_huff, bw);
+      r -= 16;
+    }
+    int ac_nbits = jxl::FloorLog2Nonzero<uint32_t>(temp) + 1;
+    if (ac_nbits >= 16) return false;
+    int symbol = (r << 4u) + ac_nbits;
+    WriteSymbol(symbol, ac_huff, bw);
+    WriteBits(bw, ac_nbits, temp2 & ((1 << ac_nbits) - 1));
+    r = 0;
+  }
+  for (int i = 0; i < num_zero_runs; ++i) {
+    WriteSymbol(0xf0, ac_huff, bw);
+    r -= 16;
+  }
+  if (r > 0) {
+    WriteSymbol(0, ac_huff, bw);
+  }
+  return true;
+}
+
+bool EncodeDCTBlockProgressive(const coeff_t* coeffs, HuffmanCodeTable* dc_huff,
+                               HuffmanCodeTable* ac_huff, int Ss, int Se,
+                               int Al, int num_zero_runs,
+                               DCTCodingState* coding_state,
+                               coeff_t* last_dc_coeff, JpegBitWriter* bw) {
+  bool eob_run_allowed = Ss > 0;
+  coeff_t temp2;
+  coeff_t temp;
+  if (Ss == 0) {
+    temp2 = coeffs[0] >> Al;
+    temp = temp2 - *last_dc_coeff;
+    *last_dc_coeff = temp2;
+    temp2 = temp;
+    if (temp < 0) {
+      temp = -temp;
+      if (temp < 0) return false;
+      temp2--;
+    }
+    int nbits = (temp == 0) ? 0 : (jxl::FloorLog2Nonzero<uint32_t>(temp) + 1);
+    WriteSymbol(nbits, dc_huff, bw);
+    if (nbits > 0) {
+      WriteBits(bw, nbits, temp2 & ((1 << nbits) - 1));
+    }
+    ++Ss;
+  }
+  if (Ss > Se) {
+    return true;
+  }
+  int r = 0;
+  for (int k = Ss; k <= Se; ++k) {
+    if ((temp = coeffs[kJPEGNaturalOrder[k]]) == 0) {
+      r++;
+      continue;
+    }
+    if (temp < 0) {
+      temp = -temp;
+      if (temp < 0) return false;
+      temp >>= Al;
+      temp2 = ~temp;
+    } else {
+      temp >>= Al;
+      temp2 = temp;
+    }
+    if (temp == 0) {
+      r++;
+      continue;
+    }
+    Flush(coding_state, bw);
+    while (r > 15) {
+      WriteSymbol(0xf0, ac_huff, bw);
+      r -= 16;
+    }
+    int nbits = jxl::FloorLog2Nonzero<uint32_t>(temp) + 1;
+    int symbol = (r << 4u) + nbits;
+    WriteSymbol(symbol, ac_huff, bw);
+    WriteBits(bw, nbits, temp2 & ((1 << nbits) - 1));
+    r = 0;
+  }
+  if (num_zero_runs > 0) {
+    Flush(coding_state, bw);
+    for (int i = 0; i < num_zero_runs; ++i) {
+      WriteSymbol(0xf0, ac_huff, bw);
+      r -= 16;
+    }
+  }
+  if (r > 0) {
+    BufferEndOfBand(coding_state, ac_huff, nullptr, bw);
+    if (!eob_run_allowed) {
+      Flush(coding_state, bw);
+    }
+  }
+  return true;
+}
+
+bool EncodeRefinementBits(const coeff_t* coeffs, HuffmanCodeTable* ac_huff,
+                          int Ss, int Se, int Al, DCTCodingState* coding_state,
+                          JpegBitWriter* bw) {
+  bool eob_run_allowed = Ss > 0;
+  if (Ss == 0) {
+    // Emit next bit of DC component.
+    WriteBits(bw, 1, (coeffs[0] >> Al) & 1);
+    ++Ss;
+  }
+  if (Ss > Se) {
+    return true;
+  }
+  int abs_values[kDCTBlockSize];
+  int eob = 0;
+  for (int k = Ss; k <= Se; k++) {
+    const coeff_t abs_val = std::abs(coeffs[kJPEGNaturalOrder[k]]);
+    abs_values[k] = abs_val >> Al;
+    if (abs_values[k] == 1) {
+      eob = k;
+    }
+  }
+  int r = 0;
+  std::vector<int> refinement_bits;
+  refinement_bits.reserve(kDCTBlockSize);
+  for (int k = Ss; k <= Se; k++) {
+    if (abs_values[k] == 0) {
+      r++;
+      continue;
+    }
+    while (r > 15 && k <= eob) {
+      Flush(coding_state, bw);
+      WriteSymbol(0xf0, ac_huff, bw);
+      r -= 16;
+      for (int bit : refinement_bits) {
+        WriteBits(bw, 1, bit);
+      }
+      refinement_bits.clear();
+    }
+    if (abs_values[k] > 1) {
+      refinement_bits.push_back(abs_values[k] & 1u);
+      continue;
+    }
+    Flush(coding_state, bw);
+    int symbol = (r << 4u) + 1;
+    int new_non_zero_bit = (coeffs[kJPEGNaturalOrder[k]] < 0) ? 0 : 1;
+    WriteSymbol(symbol, ac_huff, bw);
+    WriteBits(bw, 1, new_non_zero_bit);
+    for (int bit : refinement_bits) {
+      WriteBits(bw, 1, bit);
+    }
+    refinement_bits.clear();
+    r = 0;
+  }
+  if (r > 0 || !refinement_bits.empty()) {
+    BufferEndOfBand(coding_state, ac_huff, &refinement_bits, bw);
+    if (!eob_run_allowed) {
+      Flush(coding_state, bw);
+    }
+  }
+  return true;
+}
+
+}  // namespace
+
+void WriteOutput(j_compress_ptr cinfo, const uint8_t* buf, size_t bufsize) {
+  size_t pos = 0;
+  while (pos < bufsize) {
+    if (cinfo->dest->free_in_buffer == 0 &&
+        !(*cinfo->dest->empty_output_buffer)(cinfo)) {
+      JPEGLI_ERROR("Destination suspension is not supported.");
+    }
+    size_t len = std::min<size_t>(cinfo->dest->free_in_buffer, bufsize - pos);
+    memcpy(cinfo->dest->next_output_byte, buf + pos, len);
+    pos += len;
+    cinfo->dest->free_in_buffer -= len;
+    cinfo->dest->next_output_byte += len;
+  }
+}
+
+void WriteOutput(j_compress_ptr cinfo, const std::vector<uint8_t>& bytes) {
+  WriteOutput(cinfo, bytes.data(), bytes.size());
+}
+
+void WriteOutput(j_compress_ptr cinfo, std::initializer_list<uint8_t> bytes) {
+  WriteOutput(cinfo, bytes.begin(), bytes.size());
+}
+
+void EncodeSOF(j_compress_ptr cinfo) {
+  const uint8_t marker = cinfo->progressive_mode ? 0xc2 : 0xc0;
+  const size_t n_comps = cinfo->num_components;
+  const size_t marker_len = 8 + 3 * n_comps;
+  std::vector<uint8_t> data(marker_len + 2);
+  size_t pos = 0;
+  data[pos++] = 0xFF;
+  data[pos++] = marker;
+  data[pos++] = marker_len >> 8u;
+  data[pos++] = marker_len & 0xFFu;
+  data[pos++] = kJpegPrecision;
+  data[pos++] = cinfo->image_height >> 8u;
+  data[pos++] = cinfo->image_height & 0xFFu;
+  data[pos++] = cinfo->image_width >> 8u;
+  data[pos++] = cinfo->image_width & 0xFFu;
+  data[pos++] = n_comps;
+  for (size_t i = 0; i < n_comps; ++i) {
+    jpeg_component_info* comp = &cinfo->comp_info[i];
+    data[pos++] = comp->component_id;
+    data[pos++] = ((comp->h_samp_factor << 4u) | (comp->v_samp_factor));
+    const uint32_t quant_idx = comp->quant_tbl_no;
+    if (cinfo->quant_tbl_ptrs[quant_idx] == nullptr) {
+      JPEGLI_ERROR("Invalid component quant table index %u.", quant_idx);
+    }
+    data[pos++] = quant_idx;
+  }
+  WriteOutput(cinfo, data);
+}
+
+void EncodeSOS(j_compress_ptr cinfo, int scan_index) {
+  const jpeg_scan_info* scan_info = &cinfo->scan_info[scan_index];
+  const ScanCodingInfo& sci = cinfo->master->scan_coding_info[scan_index];
+  const size_t marker_len = 6 + 2 * scan_info->comps_in_scan;
+  std::vector<uint8_t> data(marker_len + 2);
+  size_t pos = 0;
+  data[pos++] = 0xFF;
+  data[pos++] = 0xDA;
+  data[pos++] = marker_len >> 8u;
+  data[pos++] = marker_len & 0xFFu;
+  data[pos++] = scan_info->comps_in_scan;
+  for (int i = 0; i < scan_info->comps_in_scan; ++i) {
+    int comp_idx = scan_info->component_index[i];
+    if (comp_idx >= cinfo->num_components) {
+      JPEGLI_ERROR("Invalid scan component index %u.", comp_idx);
+    }
+    data[pos++] = cinfo->comp_info[comp_idx].component_id;
+    data[pos++] = (sci.dc_tbl_idx[i] << 4u) + sci.ac_tbl_idx[i];
+  }
+  data[pos++] = scan_info->Ss;
+  data[pos++] = scan_info->Se;
+  data[pos++] = ((scan_info->Ah << 4u) | (scan_info->Al));
+  WriteOutput(cinfo, data);
+}
+
+void EncodeDHT(j_compress_ptr cinfo,
+               const std::vector<JPEGHuffmanCode>& huffman_code,
+               size_t* next_huffman_code, size_t num_huffman_codes) {
+  if (num_huffman_codes == 0) {
+    return;
+  }
+
+  size_t marker_len = 2;
+  for (size_t i = 0; i < num_huffman_codes; ++i) {
+    const JPEGHuffmanCode& huff = huffman_code[*next_huffman_code + i];
+    marker_len += kJpegHuffmanMaxBitLength;
+    for (size_t j = 0; j < huff.counts.size(); ++j) {
+      marker_len += huff.counts[j];
+    }
+  }
+  std::vector<uint8_t> data(marker_len + 2);
+  size_t pos = 0;
+  data[pos++] = 0xFF;
+  data[pos++] = 0xC4;
+  data[pos++] = marker_len >> 8u;
+  data[pos++] = marker_len & 0xFFu;
+  for (size_t i = 0; i < num_huffman_codes; ++i) {
+    const size_t huffman_code_index = *next_huffman_code + i;
+    const JPEGHuffmanCode& huff = huffman_code[huffman_code_index];
+    size_t index = huff.slot_id;
+    HuffmanCodeTable* huff_table;
+    if (index & 0x10) {
+      index -= 0x10;
+      huff_table = &cinfo->master->ac_huff_table[index];
+    } else {
+      huff_table = &cinfo->master->dc_huff_table[index];
+    }
+    // TODO(eustas): cache
+    // TODO(eustas): set up non-existing symbols
+    if (!BuildHuffmanCodeTable(huff, huff_table)) {
+      JPEGLI_ERROR("Failed to build Huffman code table.");
+    }
+    size_t total_count = 0;
+    size_t max_length = 0;
+    for (size_t i = 0; i < huff.counts.size(); ++i) {
+      if (huff.counts[i] != 0) {
+        max_length = i;
+      }
+      total_count += huff.counts[i];
+    }
+    --total_count;
+    data[pos++] = huff.slot_id;
+    for (size_t i = 1; i <= kJpegHuffmanMaxBitLength; ++i) {
+      data[pos++] = (i == max_length ? huff.counts[i] - 1 : huff.counts[i]);
+    }
+    for (size_t i = 0; i < total_count; ++i) {
+      data[pos++] = huff.values[i];
+    }
+    if (i + 1 == num_huffman_codes) {
+      JXL_ASSERT(huff.is_last);
+    }
+  }
+  *next_huffman_code += num_huffman_codes;
+  WriteOutput(cinfo, data);
+}
+
+void EncodeDQT(j_compress_ptr cinfo) {
+  // TODO(szabadka) Support 16-bit values (if force_baseline was not set).
+  int marker_len = 2;
+  for (int i = 0; i < NUM_QUANT_TBLS; ++i) {
+    JQUANT_TBL* quant_table = cinfo->quant_tbl_ptrs[i];
+    if (quant_table == nullptr || quant_table->sent_table) continue;
+    marker_len += 1 + kDCTBlockSize;
+  }
+  std::vector<uint8_t> data(marker_len + 2);
+  size_t pos = 0;
+  data[pos++] = 0xFF;
+  data[pos++] = 0xDB;
+  data[pos++] = marker_len >> 8u;
+  data[pos++] = marker_len & 0xFFu;
+  for (int i = 0; i < NUM_QUANT_TBLS; ++i) {
+    JQUANT_TBL* quant_table = cinfo->quant_tbl_ptrs[i];
+    if (quant_table == nullptr || quant_table->sent_table) continue;
+    data[pos++] = i;
+    for (size_t j = 0; j < DCTSIZE2; ++j) {
+      int val_idx = kJPEGNaturalOrder[j];
+      int val = quant_table->quantval[val_idx];
+      data[pos++] = val & 0xFFu;
+    }
+    quant_table->sent_table = TRUE;
+  }
+  WriteOutput(cinfo, data);
+}
+
+bool EncodeDRI(j_compress_ptr cinfo) {
+  WriteOutput(cinfo, {0xFF, 0xDD, 0, 4,
+                      static_cast<uint8_t>(cinfo->restart_interval >> 8),
+                      static_cast<uint8_t>(cinfo->restart_interval & 0xFF)});
+  return true;
+}
+
+bool EncodeScan(j_compress_ptr cinfo,
+                const std::vector<std::vector<coeff_t>>& coeffs,
+                int scan_index) {
+  jpeg_comp_master* m = cinfo->master;
+  const int restart_interval = cinfo->restart_interval;
+  int restarts_to_go = restart_interval;
+  int next_restart_marker = 0;
+
+  JpegBitWriter bw;
+  JpegBitWriterInit(&bw, cinfo);
+
+  coeff_t last_dc_coeff[kMaxComponents] = {0};
+  DCTCodingState coding_state;
+  DCTCodingStateInit(&coding_state);
+
+  const jpeg_scan_info* scan_info = &cinfo->scan_info[scan_index];
+  const ScanCodingInfo& sci = m->scan_coding_info[scan_index];
+  // "Non-interleaved" means color data comes in separate scans, in other words
+  // each scan can contain only one color component.
+  const bool is_interleaved = (scan_info->comps_in_scan > 1);
+  jpeg_component_info* base_comp =
+      &cinfo->comp_info[scan_info->component_index[0]];
+  // h_group / v_group act as numerators for converting number of blocks to
+  // number of MCU. In interleaved mode it is 1, so MCU is represented with
+  // max_*_samp_factor blocks. In non-interleaved mode we choose numerator to
+  // be the samping factor, consequently MCU is always represented with single
+  // block.
+  const int h_group = is_interleaved ? 1 : base_comp->h_samp_factor;
+  const int v_group = is_interleaved ? 1 : base_comp->v_samp_factor;
+  int MCUs_per_row =
+      DivCeil(cinfo->image_width * h_group, 8 * cinfo->max_h_samp_factor);
+  int MCU_rows =
+      DivCeil(cinfo->image_height * v_group, 8 * cinfo->max_v_samp_factor);
+  const bool is_progressive = cinfo->progressive_mode;
+  const int Al = scan_info->Al;
+  const int Ah = scan_info->Ah;
+  const int Ss = scan_info->Ss;
+  const int Se = scan_info->Se;
+
+  for (int mcu_y = 0; mcu_y < MCU_rows; ++mcu_y) {
+    for (int mcu_x = 0; mcu_x < MCUs_per_row; ++mcu_x) {
+      // Possibly emit a restart marker.
+      if (restart_interval > 0 && restarts_to_go == 0) {
+        Flush(&coding_state, &bw);
+        JumpToByteBoundary(&bw);
+        EmitMarker(&bw, 0xD0 + next_restart_marker);
+        next_restart_marker += 1;
+        next_restart_marker &= 0x7;
+        restarts_to_go = restart_interval;
+        memset(last_dc_coeff, 0, sizeof(last_dc_coeff));
+      }
+      // Encode one MCU
+      for (int i = 0; i < scan_info->comps_in_scan; ++i) {
+        int comp_idx = scan_info->component_index[i];
+        jpeg_component_info* comp = &cinfo->comp_info[comp_idx];
+        HuffmanCodeTable* dc_huff = &m->dc_huff_table[sci.dc_tbl_idx[i]];
+        HuffmanCodeTable* ac_huff = &m->ac_huff_table[sci.ac_tbl_idx[i]];
+        int n_blocks_y = is_interleaved ? comp->v_samp_factor : 1;
+        int n_blocks_x = is_interleaved ? comp->h_samp_factor : 1;
+        for (int iy = 0; iy < n_blocks_y; ++iy) {
+          for (int ix = 0; ix < n_blocks_x; ++ix) {
+            int block_y = mcu_y * n_blocks_y + iy;
+            int block_x = mcu_x * n_blocks_x + ix;
+            int block_idx = block_y * comp->width_in_blocks + block_x;
+            int num_zero_runs = 0;
+            const coeff_t* block = &coeffs[comp_idx][block_idx << 6];
+            bool ok;
+            if (!is_progressive) {
+              ok = EncodeDCTBlockSequential(block, dc_huff, ac_huff,
+                                            num_zero_runs,
+                                            last_dc_coeff + comp_idx, &bw);
+            } else if (Ah == 0) {
+              ok = EncodeDCTBlockProgressive(block, dc_huff, ac_huff, Ss, Se,
+                                             Al, num_zero_runs, &coding_state,
+                                             last_dc_coeff + comp_idx, &bw);
+            } else {
+              ok = EncodeRefinementBits(block, ac_huff, Ss, Se, Al,
+                                        &coding_state, &bw);
+            }
+            if (!ok) return false;
+          }
+        }
+      }
+      --restarts_to_go;
+    }
+  }
+  Flush(&coding_state, &bw);
+  JumpToByteBoundary(&bw);
+  JpegBitWriterFinish(&bw);
+  if (!bw.healthy) return false;
+
+  return true;
+}
+
+}  // namespace jpegli

--- a/lib/jpegli/bitstream.h
+++ b/lib/jpegli/bitstream.h
@@ -1,0 +1,34 @@
+// Copyright (c) the JPEG XL Project Authors. All rights reserved.
+//
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+#ifndef LIB_JPEGLI_BITSTREAM_H_
+#define LIB_JPEGLI_BITSTREAM_H_
+
+#include <initializer_list>
+#include <vector>
+
+#include "lib/jpegli/encode_internal.h"
+
+namespace jpegli {
+
+void WriteOutput(j_compress_ptr cinfo, const uint8_t* buf, size_t bufsize);
+void WriteOutput(j_compress_ptr cinfo, const std::vector<uint8_t>& bytes);
+void WriteOutput(j_compress_ptr cinfo, std::initializer_list<uint8_t> bytes);
+
+void EncodeSOF(j_compress_ptr cinfo);
+void EncodeSOS(j_compress_ptr cinfo, int scan_index);
+void EncodeDHT(j_compress_ptr cinfo,
+               const std::vector<JPEGHuffmanCode>& huffman_code,
+               size_t* next_huffman_code, size_t num_huffman_codes);
+void EncodeDQT(j_compress_ptr cinfo);
+bool EncodeDRI(j_compress_ptr cinfo);
+
+bool EncodeScan(j_compress_ptr cinfo,
+                const std::vector<std::vector<jpegli::coeff_t>>& coeffs,
+                int scan_index);
+
+}  // namespace jpegli
+
+#endif  // LIB_JPEGLI_BITSTREAM_H_

--- a/lib/jpegli/common_internal.h
+++ b/lib/jpegli/common_internal.h
@@ -1,0 +1,60 @@
+// Copyright (c) the JPEG XL Project Authors. All rights reserved.
+//
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+#ifndef LIB_JPEGLI_COMMON_INTERNAL_H_
+#define LIB_JPEGLI_COMMON_INTERNAL_H_
+
+namespace jpegli {
+
+template <typename T1, typename T2>
+constexpr inline T1 DivCeil(T1 a, T2 b) {
+  return (a + b - 1) / b;
+}
+
+constexpr size_t kDCTBlockSize = 64;
+constexpr int kMaxComponents = 4;
+constexpr int kMaxQuantTables = 4;
+constexpr int kMaxHuffmanTables = 4;
+constexpr size_t kJpegHuffmanMaxBitLength = 16;
+constexpr int kJpegHuffmanAlphabetSize = 256;
+constexpr int kJpegDCAlphabetSize = 12;
+constexpr int kMaxDHTMarkers = 512;
+constexpr int kMaxDimPixels = 65535;
+constexpr uint8_t kApp1 = 0xE1;
+constexpr uint8_t kApp2 = 0xE2;
+const uint8_t kIccProfileTag[12] = "ICC_PROFILE";
+const uint8_t kExifTag[6] = "Exif\0";
+const uint8_t kXMPTag[29] = "http://ns.adobe.com/xap/1.0/";
+
+/* clang-format off */
+constexpr uint32_t kJPEGNaturalOrder[80] = {
+  0,   1,  8, 16,  9,  2,  3, 10,
+  17, 24, 32, 25, 18, 11,  4,  5,
+  12, 19, 26, 33, 40, 48, 41, 34,
+  27, 20, 13,  6,  7, 14, 21, 28,
+  35, 42, 49, 56, 57, 50, 43, 36,
+  29, 22, 15, 23, 30, 37, 44, 51,
+  58, 59, 52, 45, 38, 31, 39, 46,
+  53, 60, 61, 54, 47, 55, 62, 63,
+  // extra entries for safety in decoder
+  63, 63, 63, 63, 63, 63, 63, 63,
+  63, 63, 63, 63, 63, 63, 63, 63
+};
+
+constexpr uint32_t kJPEGZigZagOrder[64] = {
+  0,   1,  5,  6, 14, 15, 27, 28,
+  2,   4,  7, 13, 16, 26, 29, 42,
+  3,   8, 12, 17, 25, 30, 41, 43,
+  9,  11, 18, 24, 31, 40, 44, 53,
+  10, 19, 23, 32, 39, 45, 52, 54,
+  20, 22, 33, 38, 46, 51, 55, 60,
+  21, 34, 37, 47, 50, 56, 59, 61,
+  35, 36, 48, 49, 57, 58, 62, 63
+};
+/* clang-format on */
+
+}  // namespace jpegli
+
+#endif  // LIB_JPEGLI_COMMON_INTERNAL_H_

--- a/lib/jpegli/dct.cc
+++ b/lib/jpegli/dct.cc
@@ -5,12 +5,13 @@
 
 #include "lib/jpegli/dct.h"
 
+#include <cmath>
+
 #undef HWY_TARGET_INCLUDE
 #define HWY_TARGET_INCLUDE "lib/jpegli/dct.cc"
 #include <hwy/foreach_target.h>
 #include <hwy/highway.h>
 
-#include "lib/jxl/common.h"
 #include "lib/jxl/enc_transforms.h"
 #include "lib/jxl/image.h"
 HWY_BEFORE_NAMESPACE();
@@ -20,15 +21,11 @@ namespace HWY_NAMESPACE {
 constexpr float kZeroBiasMulXYB[] = {0.5f, 0.5f, 0.5f};
 constexpr float kZeroBiasMulYCbCr[] = {0.7f, 1.0f, 0.8f};
 
-void ComputeDCTCoefficients(const jxl::Image3F& opsin, float distance,
-                            const bool xyb, const jxl::ImageF& qf,
-                            const float* qm,
-                            std::vector<jxl::jpeg::JPEGComponent>* components) {
-  int max_samp_factor = 1;
-  for (const auto& c : *components) {
-    JXL_DASSERT(c.h_samp_factor == c.v_samp_factor);
-    max_samp_factor = std::max(c.h_samp_factor, max_samp_factor);
-  }
+void ComputeDCTCoefficients(
+    j_compress_ptr cinfo, const jxl::Image3F& opsin, float distance,
+    const bool xyb, const jxl::ImageF& qf, const float* qm,
+    std::vector<std::vector<jpegli::coeff_t> >* all_coeffs) {
+  int max_samp_factor = cinfo->max_h_samp_factor;
   float qfmin, qfmax;
   ImageMinMax(qf, &qfmin, &qfmax);
   float zero_bias_mul[3] = {0.5f, 0.5f, 0.5f};
@@ -36,27 +33,26 @@ void ComputeDCTCoefficients(const jxl::Image3F& opsin, float distance,
     memcpy(zero_bias_mul, xyb ? kZeroBiasMulXYB : kZeroBiasMulYCbCr,
            sizeof(zero_bias_mul));
   }
-  HWY_ALIGN float scratch_space[2 * jxl::kDCTBlockSize];
+  HWY_ALIGN float scratch_space[2 * kDCTBlockSize];
   jxl::ImageF tmp;
-  for (size_t c = 0; c < components->size(); c++) {
-    auto& comp = (*components)[c];
-    const size_t xsize_blocks = comp.width_in_blocks;
-    const size_t ysize_blocks = comp.height_in_blocks;
-    JXL_DASSERT(max_samp_factor % comp.h_samp_factor == 0);
-    const int factor = max_samp_factor / comp.h_samp_factor;
+  for (int c = 0; c < cinfo->num_components; c++) {
+    jpeg_component_info* comp = &cinfo->comp_info[c];
+    const size_t xsize_blocks = comp->width_in_blocks;
+    const size_t ysize_blocks = comp->height_in_blocks;
+    JXL_DASSERT(max_samp_factor % comp->h_samp_factor == 0);
+    const int factor = max_samp_factor / comp->h_samp_factor;
     const jxl::ImageF* plane = &opsin.Plane(c);
     if (factor > 1) {
       tmp = CopyImage(*plane);
       DownsampleImage(&tmp, factor);
       plane = &tmp;
     }
-    std::vector<jxl::jpeg::coeff_t>& coeffs = comp.coeffs;
-    coeffs.resize(xsize_blocks * ysize_blocks * jxl::kDCTBlockSize);
-    const float* qmc = &qm[c * jxl::kDCTBlockSize];
+    std::vector<coeff_t> coeffs(xsize_blocks * ysize_blocks * kDCTBlockSize);
+    const float* qmc = &qm[c * kDCTBlockSize];
     for (size_t by = 0, bix = 0; by < ysize_blocks; by++) {
       for (size_t bx = 0; bx < xsize_blocks; bx++, bix++) {
-        jxl::jpeg::coeff_t* block = &coeffs[bix * jxl::kDCTBlockSize];
-        HWY_ALIGN float dct[jxl::kDCTBlockSize];
+        coeff_t* block = &coeffs[bix * kDCTBlockSize];
+        HWY_ALIGN float dct[kDCTBlockSize];
         TransformFromPixels(jxl::AcStrategy::Type::DCT,
                             plane->Row(8 * by) + 8 * bx, plane->PixelsPerRow(),
                             dct, scratch_space);
@@ -81,6 +77,7 @@ void ComputeDCTCoefficients(const jxl::Image3F& opsin, float distance,
         }
       }
     }
+    all_coeffs->emplace_back(std::move(coeffs));
   }
 }
 
@@ -94,12 +91,12 @@ namespace jpegli {
 
 HWY_EXPORT(ComputeDCTCoefficients);
 
-void ComputeDCTCoefficients(const jxl::Image3F& opsin, float distance,
-                            const bool xyb, const jxl::ImageF& qf,
-                            const float* qm,
-                            std::vector<jxl::jpeg::JPEGComponent>* components) {
+void ComputeDCTCoefficients(
+    j_compress_ptr cinfo, const jxl::Image3F& opsin, float distance,
+    const bool xyb, const jxl::ImageF& qf, const float* qm,
+    std::vector<std::vector<jpegli::coeff_t> >* coeffs) {
   HWY_DYNAMIC_DISPATCH(ComputeDCTCoefficients)
-  (opsin, distance, xyb, qf, qm, components);
+  (cinfo, opsin, distance, xyb, qf, qm, coeffs);
 }
 
 }  // namespace jpegli

--- a/lib/jpegli/dct.h
+++ b/lib/jpegli/dct.h
@@ -6,18 +6,22 @@
 #ifndef LIB_JPEGLI_DCT_H_
 #define LIB_JPEGLI_DCT_H_
 
+/* clang-format off */
+#include <stdio.h>
+#include <jpeglib.h>
+/* clang-format on */
+
 #include <vector>
 
-#include "lib/jxl/common.h"
+#include "lib/jpegli/encode_internal.h"
 #include "lib/jxl/image.h"
-#include "lib/jxl/jpeg/jpeg_data.h"
 
 namespace jpegli {
 
-void ComputeDCTCoefficients(const jxl::Image3F& opsin, float distance,
-                            const bool xyb, const jxl::ImageF& qf,
-                            const float* qm,
-                            std::vector<jxl::jpeg::JPEGComponent>* components);
+void ComputeDCTCoefficients(j_compress_ptr cinfo, const jxl::Image3F& opsin,
+                            float distance, const bool xyb,
+                            const jxl::ImageF& qf, const float* qm,
+                            std::vector<std::vector<jpegli::coeff_t> >* coeffs);
 
 }  // namespace jpegli
 

--- a/lib/jpegli/decode_internal.h
+++ b/lib/jpegli/decode_internal.h
@@ -15,18 +15,11 @@
 #include <vector>
 
 #include "lib/jpegli/common.h"
+#include "lib/jpegli/common_internal.h"
 #include "lib/jpegli/huffman.h"
 #include "lib/jxl/base/compiler_specific.h"  // for ssize_t
 
 namespace jpegli {
-
-template <typename T1, typename T2>
-constexpr inline T1 DivCeil(T1 a, T2 b) {
-  return (a + b - 1) / b;
-}
-
-constexpr int kMaxComponents = 4;
-constexpr int kJpegDCAlphabetSize = 12;
 
 typedef int16_t coeff_t;
 
@@ -40,7 +33,7 @@ enum DecodeState {
 };
 
 // Represents one component of a jpeg file.
-struct JPEGComponent {
+struct DecJPEGComponent {
   // The DCT coefficients of this component, laid out block-by-block, divided
   // through the quantization matrix values.
   hwy::AlignedFreeUniquePtr<coeff_t[]> coeffs;
@@ -73,23 +66,6 @@ class RowBuffer {
   hwy::AlignedFreeUniquePtr<float[]> data_;
 };
 
-/* clang-format off */
-constexpr uint32_t kJPEGNaturalOrder[80] = {
-  0,   1,  8, 16,  9,  2,  3, 10,
-  17, 24, 32, 25, 18, 11,  4,  5,
-  12, 19, 26, 33, 40, 48, 41, 34,
-  27, 20, 13,  6,  7, 14, 21, 28,
-  35, 42, 49, 56, 57, 50, 43, 36,
-  29, 22, 15, 23, 30, 37, 44, 51,
-  58, 59, 52, 45, 38, 31, 39, 46,
-  53, 60, 61, 54, 47, 55, 62, 63,
-  // extra entries for safety in decoder
-  63, 63, 63, 63, 63, 63, 63, 63,
-  63, 63, 63, 63, 63, 63, 63, 63
-};
-
-/* clang-format on */
-
 }  // namespace jpegli
 
 // Use this forward-declared libjpeg struct to hold all our private variables.
@@ -111,7 +87,7 @@ struct jpeg_decomp_master {
   size_t icc_index_ = 0;
   size_t icc_total_ = 0;
   std::vector<uint8_t> icc_profile_;
-  std::vector<jpegli::JPEGComponent> components_;
+  std::vector<jpegli::DecJPEGComponent> components_;
   std::vector<jpegli::HuffmanTableEntry> dc_huff_lut_;
   std::vector<jpegli::HuffmanTableEntry> ac_huff_lut_;
   uint8_t huff_slot_defined_[256] = {};

--- a/lib/jpegli/decode_marker.cc
+++ b/lib/jpegli/decode_marker.cc
@@ -150,7 +150,7 @@ void ProcessSOF(j_decompress_ptr cinfo, const uint8_t* data, size_t len) {
       DivCeil(cinfo->image_width, cinfo->max_h_samp_factor * DCTSIZE);
   // Compute the block dimensions for each component.
   for (int i = 0; i < cinfo->num_components; ++i) {
-    JPEGComponent* c = &m->components_[i];
+    DecJPEGComponent* c = &m->components_[i];
     jpeg_component_info* comp = &cinfo->comp_info[i];
     if (cinfo->max_h_samp_factor % comp->h_samp_factor != 0 ||
         cinfo->max_v_samp_factor % comp->v_samp_factor != 0) {

--- a/lib/jpegli/decode_scan.cc
+++ b/lib/jpegli/decode_scan.cc
@@ -343,7 +343,7 @@ void SaveMCUCodingState(j_decompress_ptr cinfo) {
   size_t offset = 0;
   for (int i = 0; i < cinfo->comps_in_scan; ++i) {
     const jpeg_component_info* comp = cinfo->cur_comp_info[i];
-    JPEGComponent* c = &m->components_[comp->component_index];
+    DecJPEGComponent* c = &m->components_[comp->component_index];
     int block_x = m->scan_mcu_col_ * comp->MCU_width;
     for (int iy = 0; iy < comp->MCU_height; ++iy) {
       int block_y = m->scan_mcu_row_ * comp->MCU_height + iy;
@@ -363,7 +363,7 @@ void RestoreMCUCodingState(j_decompress_ptr cinfo) {
   size_t offset = 0;
   for (int i = 0; i < cinfo->comps_in_scan; ++i) {
     const jpeg_component_info* comp = cinfo->cur_comp_info[i];
-    JPEGComponent* c = &m->components_[comp->component_index];
+    DecJPEGComponent* c = &m->components_[comp->component_index];
     int block_x = m->scan_mcu_col_ * comp->MCU_width;
     for (int iy = 0; iy < comp->MCU_height; ++iy) {
       int block_y = m->scan_mcu_row_ * comp->MCU_height + iy;
@@ -429,7 +429,7 @@ int ProcessScan(j_decompress_ptr cinfo) {
     bool scan_ok = true;
     for (int i = 0; i < cinfo->comps_in_scan; ++i) {
       const jpeg_component_info* comp = cinfo->cur_comp_info[i];
-      JPEGComponent* c = &m->components_[comp->component_index];
+      DecJPEGComponent* c = &m->components_[comp->component_index];
       const HuffmanTableEntry* dc_lut =
           &m->dc_huff_lut_[comp->dc_tbl_no * kJpegHuffmanLutSize];
       const HuffmanTableEntry* ac_lut =

--- a/lib/jpegli/encode.h
+++ b/lib/jpegli/encode.h
@@ -95,7 +95,8 @@ void jpegli_set_distance(j_compress_ptr cinfo, float distance);
 float jpegli_quality_to_distance(int quality);
 
 // Writes an ICC profile for the XYB color space and internally converts the
-// input image to XYB.
+// input image to XYB. Must be called before jpegli_set_defaults() because some
+// default setting depend on the XYB mode.
 void jpegli_set_xyb_mode(j_compress_ptr cinfo);
 
 void jpegli_set_input_format(j_compress_ptr cinfo, JpegliDataType data_type,

--- a/lib/jpegli/encode_internal.h
+++ b/lib/jpegli/encode_internal.h
@@ -12,9 +12,44 @@
 #include <jpeglib.h>
 /* clang-format on */
 
+#include <array>
+
+#include "lib/jpegli/common_internal.h"
 #include "lib/jpegli/encode.h"
 #include "lib/jxl/image.h"
-#include "lib/jxl/jpeg/jpeg_data.h"
+
+namespace jpegli {
+
+struct JPEGHuffmanCode {
+  // Bit length histogram.
+  std::array<uint32_t, kJpegHuffmanMaxBitLength + 1> counts = {};
+  // Symbol values sorted by increasing bit lengths.
+  std::array<uint32_t, kJpegHuffmanAlphabetSize + 1> values = {};
+  // The index of the Huffman code in the current set of Huffman codes. For AC
+  // component Huffman codes, 0x10 is added to the index.
+  int slot_id = 0;
+  // Set to true if this Huffman code is the last one within its marker segment
+  bool is_last = true;
+};
+
+// DCTCodingState: maximum number of correction bits to buffer
+const int kJPEGMaxCorrectionBits = 1u << 16;
+
+struct HuffmanCodeTable {
+  int depth[256];
+  int code[256];
+};
+
+struct ScanCodingInfo {
+  uint32_t dc_tbl_idx[MAX_COMPS_IN_SCAN];
+  uint32_t ac_tbl_idx[MAX_COMPS_IN_SCAN];
+  // Number of Huffman codes defined in the DHT segment preceding this scan.
+  size_t num_huffman_codes = 0;
+};
+
+typedef int16_t coeff_t;
+
+}  // namespace jpegli
 
 struct jpeg_comp_master {
   jxl::Image3F input;
@@ -25,10 +60,13 @@ struct jpeg_comp_master {
   int progressive_level;
   bool force_baseline;
   J_COLOR_SPACE jpeg_colorspace;
-  jxl::jpeg::JPEGData jpeg_data;
+  std::vector<jpegli::ScanCodingInfo> scan_coding_info;
+  std::vector<std::vector<uint8_t>> special_markers;
   std::vector<uint8_t>* cur_marker_data;
   JpegliDataType data_type;
   JpegliEndianness endianness;
+  std::array<jpegli::HuffmanCodeTable, jpegli::kMaxHuffmanTables> dc_huff_table;
+  std::array<jpegli::HuffmanCodeTable, jpegli::kMaxHuffmanTables> ac_huff_table;
 };
 
 #endif  // LIB_JPEGLI_ENCODE_INTERNAL_H_

--- a/lib/jpegli/entropy_coding.cc
+++ b/lib/jpegli/entropy_coding.cc
@@ -5,25 +5,26 @@
 
 #include "lib/jpegli/entropy_coding.h"
 
+#include "lib/jpegli/encode_internal.h"
+#include "lib/jpegli/error.h"
 #include "lib/jxl/enc_cluster.h"
 #include "lib/jxl/huffman_tree.h"
-#include "lib/jxl/jpeg/dec_jpeg_data_writer.h"
 
 namespace jpegli {
 namespace {
 
 float HistogramCost(const jxl::Histogram& histo) {
-  std::vector<uint32_t> counts(jxl::jpeg::kJpegHuffmanAlphabetSize + 1);
-  std::vector<uint8_t> depths(jxl::jpeg::kJpegHuffmanAlphabetSize + 1);
-  for (size_t i = 0; i < jxl::jpeg::kJpegHuffmanAlphabetSize; ++i) {
+  std::vector<uint32_t> counts(kJpegHuffmanAlphabetSize + 1);
+  std::vector<uint8_t> depths(kJpegHuffmanAlphabetSize + 1);
+  for (size_t i = 0; i < kJpegHuffmanAlphabetSize; ++i) {
     counts[i] = histo.data_[i];
   }
-  counts[jxl::jpeg::kJpegHuffmanAlphabetSize] = 1;
-  jxl::CreateHuffmanTree(counts.data(), counts.size(),
-                         jxl::jpeg::kJpegHuffmanMaxBitLength, &depths[0]);
-  size_t header_bits = (1 + jxl::jpeg::kJpegHuffmanMaxBitLength) * 8;
+  counts[kJpegHuffmanAlphabetSize] = 1;
+  jxl::CreateHuffmanTree(counts.data(), counts.size(), kJpegHuffmanMaxBitLength,
+                         &depths[0]);
+  size_t header_bits = (1 + kJpegHuffmanMaxBitLength) * 8;
   size_t data_bits = 0;
-  for (size_t i = 0; i < jxl::jpeg::kJpegHuffmanAlphabetSize; ++i) {
+  for (size_t i = 0; i < kJpegHuffmanAlphabetSize; ++i) {
     if (depths[i] > 0) {
       header_bits += 8;
       data_bits += counts[i] * depths[i];
@@ -32,21 +33,25 @@ float HistogramCost(const jxl::Histogram& histo) {
   return header_bits + data_bits;
 }
 
+struct Histogram {
+  int count[kJpegHuffmanAlphabetSize];
+  Histogram() { memset(count, 0, sizeof(count)); }
+};
+
 struct JpegClusteredHistograms {
   std::vector<jxl::Histogram> histograms;
   std::vector<uint32_t> histogram_indexes;
   std::vector<uint32_t> slot_ids;
 };
 
-void ClusterJpegHistograms(
-    const std::vector<jxl::jpeg::HuffmanCodeTable>& jpeg_in,
-    JpegClusteredHistograms* clusters) {
+void ClusterJpegHistograms(const std::vector<Histogram>& jpeg_in,
+                           JpegClusteredHistograms* clusters) {
   std::vector<jxl::Histogram> histograms;
-  for (const auto& t : jpeg_in) {
+  for (const auto& h : jpeg_in) {
     jxl::Histogram histo;
-    histo.data_.resize(jxl::jpeg::kJpegHuffmanAlphabetSize);
+    histo.data_.resize(kJpegHuffmanAlphabetSize);
     for (size_t i = 0; i < histo.data_.size(); ++i) {
-      histo.data_[i] = t.depth[i];
+      histo.data_[i] = h.count[i];
       histo.total_count_ += histo.data_[i];
     }
     histograms.push_back(histo);
@@ -101,28 +106,27 @@ void ClusterJpegHistograms(
   }
 }
 
-void BuildJpegHuffmanCode(const jxl::Histogram& histo,
-                          jxl::jpeg::JPEGHuffmanCode* huff) {
-  std::vector<uint32_t> counts(jxl::jpeg::kJpegHuffmanAlphabetSize + 1);
-  std::vector<uint8_t> depths(jxl::jpeg::kJpegHuffmanAlphabetSize + 1);
-  for (size_t j = 0; j < jxl::jpeg::kJpegHuffmanAlphabetSize; ++j) {
+void BuildJpegHuffmanCode(const jxl::Histogram& histo, JPEGHuffmanCode* huff) {
+  std::vector<uint32_t> counts(kJpegHuffmanAlphabetSize + 1);
+  std::vector<uint8_t> depths(kJpegHuffmanAlphabetSize + 1);
+  for (size_t j = 0; j < kJpegHuffmanAlphabetSize; ++j) {
     counts[j] = histo.data_[j];
   }
-  counts[jxl::jpeg::kJpegHuffmanAlphabetSize] = 1;
-  jxl::CreateHuffmanTree(counts.data(), counts.size(),
-                         jxl::jpeg::kJpegHuffmanMaxBitLength, &depths[0]);
+  counts[kJpegHuffmanAlphabetSize] = 1;
+  jxl::CreateHuffmanTree(counts.data(), counts.size(), kJpegHuffmanMaxBitLength,
+                         &depths[0]);
   std::fill(std::begin(huff->counts), std::end(huff->counts), 0);
   std::fill(std::begin(huff->values), std::end(huff->values), 0);
-  for (size_t i = 0; i <= jxl::jpeg::kJpegHuffmanAlphabetSize; ++i) {
+  for (size_t i = 0; i <= kJpegHuffmanAlphabetSize; ++i) {
     if (depths[i] > 0) {
       ++huff->counts[depths[i]];
     }
   }
-  int offset[jxl::jpeg::kJpegHuffmanMaxBitLength + 1] = {0};
-  for (size_t i = 1; i <= jxl::jpeg::kJpegHuffmanMaxBitLength; ++i) {
+  int offset[kJpegHuffmanMaxBitLength + 1] = {0};
+  for (size_t i = 1; i <= kJpegHuffmanMaxBitLength; ++i) {
     offset[i] = offset[i - 1] + huff->counts[i - 1];
   }
-  for (size_t i = 0; i <= jxl::jpeg::kJpegHuffmanAlphabetSize; ++i) {
+  for (size_t i = 0; i <= kJpegHuffmanAlphabetSize; ++i) {
     if (depths[i] > 0) {
       huff->values[offset[depths[i]]++] = i;
     }
@@ -131,8 +135,8 @@ void BuildJpegHuffmanCode(const jxl::Histogram& histo,
 }
 
 void AddJpegHuffmanCode(const jxl::Histogram& histogram, size_t slot_id,
-                        std::vector<jxl::jpeg::JPEGHuffmanCode>* huff_codes) {
-  jxl::jpeg::JPEGHuffmanCode huff_code;
+                        std::vector<JPEGHuffmanCode>* huff_codes) {
+  JPEGHuffmanCode huff_code;
   huff_code.slot_id = slot_id;
   BuildJpegHuffmanCode(histogram, &huff_code);
   huff_codes->emplace_back(std::move(huff_code));
@@ -142,7 +146,7 @@ void SetJpegHuffmanCode(const JpegClusteredHistograms& clusters,
                         size_t histogram_id, size_t slot_id_offset,
                         std::vector<uint32_t>& slot_histograms,
                         uint32_t* slot_id,
-                        std::vector<jxl::jpeg::JPEGHuffmanCode>* huff_codes) {
+                        std::vector<JPEGHuffmanCode>* huff_codes) {
   JXL_ASSERT(histogram_id < clusters.histogram_indexes.size());
   uint32_t histogram_index = clusters.histogram_indexes[histogram_id];
   *slot_id = clusters.slot_ids[histogram_index];
@@ -153,65 +157,354 @@ void SetJpegHuffmanCode(const JpegClusteredHistograms& clusters,
   }
 }
 
+struct DCTState {
+  int eob_run = 0;
+  size_t num_refinement_bits = 0;
+  Histogram* ac_histo = nullptr;
+};
+
+static JXL_INLINE void ProcessFlush(DCTState* s) {
+  if (s->eob_run > 0) {
+    int nbits = jxl::FloorLog2Nonzero<uint32_t>(s->eob_run);
+    int symbol = nbits << 4u;
+    ++s->ac_histo->count[symbol];
+    s->eob_run = 0;
+  }
+  s->num_refinement_bits = 0;
+}
+
+static JXL_INLINE void ProcessEndOfBand(DCTState* s, size_t new_refinement_bits,
+                                        Histogram* new_ac_histo) {
+  if (s->eob_run == 0) {
+    s->ac_histo = new_ac_histo;
+  }
+  ++s->eob_run;
+  s->num_refinement_bits += new_refinement_bits;
+  if (s->eob_run == 0x7FFF ||
+      s->num_refinement_bits > kJPEGMaxCorrectionBits - kDCTBlockSize + 1) {
+    ProcessFlush(s);
+  }
+}
+
+bool ProcessDCTBlockSequential(const coeff_t* coeffs, Histogram* dc_histo,
+                               Histogram* ac_histo, int num_zero_runs,
+                               coeff_t* last_dc_coeff) {
+  coeff_t temp2;
+  coeff_t temp;
+  temp2 = coeffs[0];
+  temp = temp2 - *last_dc_coeff;
+  *last_dc_coeff = temp2;
+  temp2 = temp;
+  if (temp < 0) {
+    temp = -temp;
+    if (temp < 0) return false;
+    temp2--;
+  }
+  int dc_nbits = (temp == 0) ? 0 : (jxl::FloorLog2Nonzero<uint32_t>(temp) + 1);
+  ++dc_histo->count[dc_nbits];
+  if (dc_nbits >= 12) return false;
+  int r = 0;
+  for (int k = 1; k < 64; ++k) {
+    if ((temp = coeffs[kJPEGNaturalOrder[k]]) == 0) {
+      r++;
+      continue;
+    }
+    if (temp < 0) {
+      temp = -temp;
+      if (temp < 0) return false;
+      temp2 = ~temp;
+    } else {
+      temp2 = temp;
+    }
+    while (r > 15) {
+      ++ac_histo->count[0xf0];
+      r -= 16;
+    }
+    int ac_nbits = jxl::FloorLog2Nonzero<uint32_t>(temp) + 1;
+    if (ac_nbits >= 16) return false;
+    int symbol = (r << 4u) + ac_nbits;
+    ++ac_histo->count[symbol];
+    r = 0;
+  }
+  for (int i = 0; i < num_zero_runs; ++i) {
+    ++ac_histo->count[0xf0];
+    r -= 16;
+  }
+  if (r > 0) {
+    ++ac_histo->count[0];
+  }
+  return true;
+}
+
+bool ProcessDCTBlockProgressive(const coeff_t* coeffs, Histogram* dc_histo,
+                                Histogram* ac_histo, int Ss, int Se, int Al,
+                                int num_zero_runs, DCTState* s,
+                                coeff_t* last_dc_coeff) {
+  bool eob_run_allowed = Ss > 0;
+  coeff_t temp2;
+  coeff_t temp;
+  if (Ss == 0) {
+    temp2 = coeffs[0] >> Al;
+    temp = temp2 - *last_dc_coeff;
+    *last_dc_coeff = temp2;
+    temp2 = temp;
+    if (temp < 0) {
+      temp = -temp;
+      if (temp < 0) return false;
+      temp2--;
+    }
+    int nbits = (temp == 0) ? 0 : (jxl::FloorLog2Nonzero<uint32_t>(temp) + 1);
+    ++dc_histo->count[nbits];
+    ++Ss;
+  }
+  if (Ss > Se) {
+    return true;
+  }
+  int r = 0;
+  for (int k = Ss; k <= Se; ++k) {
+    if ((temp = coeffs[kJPEGNaturalOrder[k]]) == 0) {
+      r++;
+      continue;
+    }
+    if (temp < 0) {
+      temp = -temp;
+      if (temp < 0) return false;
+      temp >>= Al;
+      temp2 = ~temp;
+    } else {
+      temp >>= Al;
+      temp2 = temp;
+    }
+    if (temp == 0) {
+      r++;
+      continue;
+    }
+    ProcessFlush(s);
+    while (r > 15) {
+      ++ac_histo->count[0xf0];
+      r -= 16;
+    }
+    int nbits = jxl::FloorLog2Nonzero<uint32_t>(temp) + 1;
+    int symbol = (r << 4u) + nbits;
+    ++ac_histo->count[symbol];
+    r = 0;
+  }
+  if (num_zero_runs > 0) {
+    ProcessFlush(s);
+    for (int i = 0; i < num_zero_runs; ++i) {
+      ++ac_histo->count[0xf0];
+      r -= 16;
+    }
+  }
+  if (r > 0) {
+    ProcessEndOfBand(s, 0, ac_histo);
+    if (!eob_run_allowed) {
+      ProcessFlush(s);
+    }
+  }
+  return true;
+}
+
+bool ProcessRefinementBits(const coeff_t* coeffs, Histogram* ac_histo, int Ss,
+                           int Se, int Al, DCTState* s) {
+  bool eob_run_allowed = Ss > 0;
+  if (Ss == 0) {
+    ++Ss;
+  }
+  if (Ss > Se) {
+    return true;
+  }
+  int abs_values[kDCTBlockSize];
+  int eob = 0;
+  for (int k = Ss; k <= Se; k++) {
+    const coeff_t abs_val = std::abs(coeffs[kJPEGNaturalOrder[k]]);
+    abs_values[k] = abs_val >> Al;
+    if (abs_values[k] == 1) {
+      eob = k;
+    }
+  }
+  int r = 0;
+  size_t num_refinement_bits = 0;
+  for (int k = Ss; k <= Se; k++) {
+    if (abs_values[k] == 0) {
+      r++;
+      continue;
+    }
+    while (r > 15 && k <= eob) {
+      ProcessFlush(s);
+      ++ac_histo->count[0xf0];
+      r -= 16;
+      num_refinement_bits = 0;
+    }
+    if (abs_values[k] > 1) {
+      ++num_refinement_bits;
+      continue;
+    }
+    ProcessFlush(s);
+    int symbol = (r << 4u) + 1;
+    ++ac_histo->count[symbol];
+    num_refinement_bits = 0;
+    r = 0;
+  }
+  if (r > 0 || num_refinement_bits > 0) {
+    ProcessEndOfBand(s, num_refinement_bits, ac_histo);
+    if (!eob_run_allowed) {
+      ProcessFlush(s);
+    }
+  }
+  return true;
+}
+
+bool ProcessScan(j_compress_ptr cinfo,
+                 const std::vector<std::vector<jpegli::coeff_t> >& coeffs,
+                 const jpeg_scan_info* scan_info, int* histo_index,
+                 Histogram* dc_histograms, Histogram* ac_histograms) {
+  int restarts_to_go = cinfo->restart_interval;
+  coeff_t last_dc_coeff[kMaxComponents] = {0};
+  DCTState s;
+
+  // "Non-interleaved" means color data comes in separate scans, in other words
+  // each scan can contain only one color component.
+  const bool is_interleaved = (scan_info->comps_in_scan > 1);
+  jpeg_component_info* base_comp =
+      &cinfo->comp_info[scan_info->component_index[0]];
+  // h_group / v_group act as numerators for converting number of blocks to
+  // number of MCU. In interleaved mode it is 1, so MCU is represented with
+  // max_*_samp_factor blocks. In non-interleaved mode we choose numerator to
+  // be the samping factor, consequently MCU is always represented with single
+  // block.
+  const int h_group = is_interleaved ? 1 : base_comp->h_samp_factor;
+  const int v_group = is_interleaved ? 1 : base_comp->v_samp_factor;
+  int MCUs_per_row =
+      DivCeil(cinfo->image_width * h_group, 8 * cinfo->max_h_samp_factor);
+  int MCU_rows =
+      DivCeil(cinfo->image_height * v_group, 8 * cinfo->max_v_samp_factor);
+  const bool is_progressive = cinfo->progressive_mode;
+  const int Al = scan_info->Al;
+  const int Ah = scan_info->Ah;
+  const int Ss = scan_info->Ss;
+  const int Se = scan_info->Se;
+
+  for (int mcu_y = 0; mcu_y < MCU_rows; ++mcu_y) {
+    for (int mcu_x = 0; mcu_x < MCUs_per_row; ++mcu_x) {
+      // Possibly emit a restart marker.
+      if (cinfo->restart_interval > 0 && restarts_to_go == 0) {
+        ProcessFlush(&s);
+        restarts_to_go = cinfo->restart_interval;
+        memset(last_dc_coeff, 0, sizeof(last_dc_coeff));
+      }
+      // Encode one MCU
+      for (int i = 0; i < scan_info->comps_in_scan; ++i) {
+        int comp_idx = scan_info->component_index[i];
+        jpeg_component_info* comp = &cinfo->comp_info[comp_idx];
+        int histo_idx = *histo_index + i;
+        Histogram* dc_histo = &dc_histograms[histo_idx];
+        Histogram* ac_histo = &ac_histograms[histo_idx];
+        int n_blocks_y = is_interleaved ? comp->v_samp_factor : 1;
+        int n_blocks_x = is_interleaved ? comp->h_samp_factor : 1;
+        for (int iy = 0; iy < n_blocks_y; ++iy) {
+          for (int ix = 0; ix < n_blocks_x; ++ix) {
+            int block_y = mcu_y * n_blocks_y + iy;
+            int block_x = mcu_x * n_blocks_x + ix;
+            int block_idx = block_y * comp->width_in_blocks + block_x;
+            int num_zero_runs = 0;
+            const coeff_t* block = &coeffs[comp_idx][block_idx << 6];
+            bool ok;
+            if (!is_progressive) {
+              ok = ProcessDCTBlockSequential(block, dc_histo, ac_histo,
+                                             num_zero_runs,
+                                             last_dc_coeff + comp_idx);
+            } else if (Ah == 0) {
+              ok = ProcessDCTBlockProgressive(block, dc_histo, ac_histo, Ss, Se,
+                                              Al, num_zero_runs, &s,
+                                              last_dc_coeff + comp_idx);
+            } else {
+              ok = ProcessRefinementBits(block, ac_histo, Ss, Se, Al, &s);
+            }
+            if (!ok) return false;
+          }
+        }
+      }
+      --restarts_to_go;
+    }
+  }
+  ProcessFlush(&s);
+  *histo_index += scan_info->comps_in_scan;
+  return true;
+}
+
+void ProcessJpeg(j_compress_ptr cinfo,
+                 const std::vector<std::vector<jpegli::coeff_t> >& coeffs,
+                 std::vector<Histogram>* dc_histograms,
+                 std::vector<Histogram>* ac_histograms) {
+  int histo_index = 0;
+  for (int i = 0; i < cinfo->num_scans; ++i) {
+    const jpeg_scan_info* si = &cinfo->scan_info[i];
+    if (!ProcessScan(cinfo, coeffs, si, &histo_index, &(*dc_histograms)[0],
+                     &(*ac_histograms)[0])) {
+      JPEGLI_ERROR("Invalid scan.");
+    }
+  }
+}
+
 }  // namespace
 
-void OptimizeHuffmanCodes(jxl::jpeg::JPEGData* out) {
+void OptimizeHuffmanCodes(
+    j_compress_ptr cinfo,
+    const std::vector<std::vector<jpegli::coeff_t> >& coeffs,
+    std::vector<JPEGHuffmanCode>* huffman_codes) {
   // Gather histograms.
-  jxl::jpeg::SerializationState ss;
-  JXL_CHECK(jxl::jpeg::ProcessJpeg(*out, &ss));
+  size_t num_histo = 0;
+  for (int i = 0; i < cinfo->num_scans; ++i) {
+    num_histo += cinfo->scan_info[i].comps_in_scan;
+  }
+  std::vector<Histogram> dc_histograms(num_histo);
+  std::vector<Histogram> ac_histograms(num_histo);
+  ProcessJpeg(cinfo, coeffs, &dc_histograms, &ac_histograms);
 
   // Cluster DC histograms.
   JpegClusteredHistograms dc_clusters;
-  ClusterJpegHistograms(ss.dc_huff_table, &dc_clusters);
+  ClusterJpegHistograms(dc_histograms, &dc_clusters);
 
   // Cluster AC histograms.
   JpegClusteredHistograms ac_clusters;
-  ClusterJpegHistograms(ss.ac_huff_table, &ac_clusters);
-
-  // Rebuild marker_order because we may want to emit Huffman codes in between
-  // scans.
-  out->marker_order.resize(out->marker_order.size() - 2 -
-                           out->scan_info.size());
+  ClusterJpegHistograms(ac_histograms, &ac_clusters);
 
   // Add the first 4 DC and AC histograms in the first DHT segment.
-  out->marker_order.emplace_back(0xc4);  // DHT
   std::vector<uint32_t> dc_slot_histograms;
   std::vector<uint32_t> ac_slot_histograms;
   for (size_t i = 0; i < dc_clusters.histograms.size(); ++i) {
     if (i >= 4) break;
     JXL_ASSERT(dc_clusters.slot_ids[i] == i);
-    AddJpegHuffmanCode(dc_clusters.histograms[i], i, &out->huffman_code);
+    AddJpegHuffmanCode(dc_clusters.histograms[i], i, huffman_codes);
     dc_slot_histograms.push_back(i);
   }
   for (size_t i = 0; i < ac_clusters.histograms.size(); ++i) {
     if (i >= 4) break;
     JXL_ASSERT(ac_clusters.slot_ids[i] == i);
-    AddJpegHuffmanCode(ac_clusters.histograms[i], 0x10 + i, &out->huffman_code);
+    AddJpegHuffmanCode(ac_clusters.histograms[i], 0x10 + i, huffman_codes);
     ac_slot_histograms.push_back(i);
   }
-  out->huffman_code.back().is_last = true;
+  huffman_codes->back().is_last = true;
 
   // Set the Huffman table indexes in the scan_infos and emit additional DHT
   // segments if necessary.
   size_t histogram_id = 0;
-  for (auto& si : out->scan_info) {
-    size_t num_huff_codes = out->huffman_code.size();
-    for (size_t c = 0; c < si.num_components; ++c) {
+  size_t num_huffman_codes_sent = 0;
+  for (int i = 0; i < cinfo->num_scans; ++i) {
+    ScanCodingInfo sci;
+    for (int c = 0; c < cinfo->scan_info[i].comps_in_scan; ++c) {
       SetJpegHuffmanCode(dc_clusters, histogram_id, 0, dc_slot_histograms,
-                         &si.components[c].dc_tbl_idx, &out->huffman_code);
+                         &sci.dc_tbl_idx[c], huffman_codes);
       SetJpegHuffmanCode(ac_clusters, histogram_id, 0x10, ac_slot_histograms,
-                         &si.components[c].ac_tbl_idx, &out->huffman_code);
+                         &sci.ac_tbl_idx[c], huffman_codes);
       ++histogram_id;
     }
-    // If we updated a slot histogram in this scan, create an additional DHT
-    // segment.
-    if (out->huffman_code.size() > num_huff_codes) {
-      out->marker_order.emplace_back(0xc4);  // DHT
-      out->huffman_code.back().is_last = true;
-    }
-    out->marker_order.emplace_back(0xda);  // SOS
+    sci.num_huffman_codes = huffman_codes->size() - num_huffman_codes_sent;
+    huffman_codes->back().is_last = true;
+    num_huffman_codes_sent = huffman_codes->size();
+    cinfo->master->scan_coding_info.emplace_back(std::move(sci));
   }
-  out->marker_order.emplace_back(0xd9);  // EOI
 }
 
 }  // namespace jpegli

--- a/lib/jpegli/entropy_coding.h
+++ b/lib/jpegli/entropy_coding.h
@@ -6,11 +6,21 @@
 #ifndef LIB_JPEGLI_ENTROPY_CODING_H_
 #define LIB_JPEGLI_ENTROPY_CODING_H_
 
-#include "lib/jxl/jpeg/jpeg_data.h"
+/* clang-format off */
+#include <stdio.h>
+#include <jpeglib.h>
+/* clang-format on */
+
+#include <vector>
+
+#include "lib/jpegli/encode_internal.h"
 
 namespace jpegli {
 
-void OptimizeHuffmanCodes(jxl::jpeg::JPEGData* out);
+void OptimizeHuffmanCodes(
+    j_compress_ptr cinfo,
+    const std::vector<std::vector<jpegli::coeff_t> >& coeffs,
+    std::vector<JPEGHuffmanCode>* huffman_codes);
 
 }  // namespace jpegli
 

--- a/lib/jpegli/huffman.h
+++ b/lib/jpegli/huffman.h
@@ -9,10 +9,9 @@
 #include <stdint.h>
 #include <stdlib.h>
 
-namespace jpegli {
+#include "lib/jpegli/common_internal.h"
 
-constexpr int kJpegHuffmanAlphabetSize = 256;
-constexpr size_t kJpegHuffmanMaxBitLength = 16;
+namespace jpegli {
 
 constexpr int kJpegHuffmanRootTableBits = 8;
 // Maximum huffman lookup table size.

--- a/lib/jpegli/quant.h
+++ b/lib/jpegli/quant.h
@@ -6,11 +6,10 @@
 #ifndef LIB_JPEGLI_QUANT_H_
 #define LIB_JPEGLI_QUANT_H_
 
-#include <vector>
-
-#include "lib/jxl/common.h"
-#include "lib/jxl/image.h"
-#include "lib/jxl/jpeg/jpeg_data.h"
+/* clang-format off */
+#include <stdio.h>
+#include <jpeglib.h>
+/* clang-format on */
 
 namespace jpegli {
 
@@ -21,10 +20,8 @@ enum QuantMode {
   NUM_QUANT_MODES,
 };
 
-void AddJpegQuantMatrices(QuantMode mode, int num_components, float dc_scale,
-                          float ac_scale,
-                          std::vector<jxl::jpeg::JPEGQuantTable>* quant_tables,
-                          float* qm);
+void AddJpegQuantMatrices(j_compress_ptr cinfo, QuantMode mode, float dc_scale,
+                          float ac_scale, float* qm);
 
 }  // namespace jpegli
 


### PR DESCRIPTION
This also simplifies the code a bit since we don't need bit-exact reconstruction and we can store most things we need in cinfo instead of jpeg_data.