### PR TITLE
remove all_color_aware optimization in benchmark_xl

### DIFF
--- a/tools/benchmark/benchmark_codec.h
+++ b/tools/benchmark/benchmark_codec.h
@@ -47,11 +47,6 @@ class ImageCodec {
 
   virtual Status ParseParam(const std::string& param);
 
-  // Returns true iff the codec instance (including parameters) can tolerate
-  // ImageBundle c_current() != metadata()->color_encoding, and the possibility
-  // of negative (out of gamut) pixel values.
-  virtual bool IsColorAware() const { return false; }
-
   // Returns true iff the codec instance (including parameters) will operate
   // only with quantized DCT (JPEG) coefficients in input.
   virtual bool IsJpegTranscoder() const { return false; }

--- a/tools/benchmark/benchmark_codec_jxl.cc
+++ b/tools/benchmark/benchmark_codec_jxl.cc
@@ -256,14 +256,6 @@ class JxlCodec : public ImageCodec {
     return true;
   }
 
-  bool IsColorAware() const override {
-    // Can't deal with negative values from color space conversion.
-    if (cparams_.modular_mode) return false;
-    if (normalize_bitrate_) return false;
-    // Otherwise, input may be in any color space.
-    return true;
-  }
-
   bool IsJpegTranscoder() const override {
     // TODO(veluca): figure out when to turn this on.
     return false;


### PR DESCRIPTION
`benchmark_xl` has this specific optimization to convert the input image to linear RGB at load time when all tested codecs don't care about the input colorspace (i.e. are going to do jxl in xyb space), so some time can be saved on color conversions (since it only needs to be converted once per image, instead of once per encode and then again to compute the metrics).

This optimization currently causes some trouble on images with alpha: the ssimulacra2 scores are completely wrong in this case:

Before:
```
./OwlAlpha.png
Encoding      kPixels    Bytes          BPP  E MP/s  D MP/s     Max norm  SSIMULACRA2        pnorm       BPP*pnorm   Bugs
-------------------------------------------------------------------------------------------------------------------------
jxl              1228   107314    0.6986589   1.588  14.699   1.46021366 -90.76316506   0.59830447  0.418010718661      0
jxl:d2           1228    63927    0.4161914   1.626  16.039   2.13230228 -90.91277985   0.89691055  0.373286464125      0
jxl:d4           1228    41296    0.2688542   1.581   9.075   3.05823135 -91.32514713   1.28498285  0.345472992571      0
Aggregate:       1228    65677    0.4275875   1.598  12.885   2.11955735   0.00000000   0.88346545  0.377758797613      0
```

The easiest way to fix this is to just remove this optimization, and always keep input images in the original colorspace. In a way this is also fairer/more consistent for timing purposes: currently the conversion to linear RGB is not counted as part of the encode when only lossy jxl is benchmarked, while it is counted as part of the encode when also lossless jxl or other codecs are benchmarked. This makes `benchmark_xl` slightly slower in some cases but I don't think that matters much.


After:
```
./OwlAlpha.png
Encoding      kPixels    Bytes          BPP  E MP/s  D MP/s     Max norm  SSIMULACRA2        pnorm       BPP*pnorm   Bugs
-------------------------------------------------------------------------------------------------------------------------
jxl              1228   107314    0.6986589   1.592  15.056   1.46021366  88.96036679   0.59830447  0.418010718661      0
jxl:d2           1228    63927    0.4161914   1.610  16.010   2.13230228  83.52329797   0.89691055  0.373286464125      0
jxl:d4           1228    41296    0.2688542   1.569   9.149   3.05823135  75.08115956   1.28498285  0.345472992571      0
Aggregate:       1228    65677    0.4275875   1.591  13.016   2.11955735  82.32120587   0.88346545  0.377758797613      0
```
