### PR TITLE
Alpha distance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Unreleased
 
 ### Added
+ - encoder API: add `JxlEncoderSetExtraChannelDistance` to adjust the quality
+   of extra channels (like alpha) separately.
 
 ### Removed
 

--- a/lib/extras/enc/jxl.cc
+++ b/lib/extras/enc/jxl.cc
@@ -115,6 +115,12 @@ bool EncodeImageJXL(const JXLCompressParams& params, const PackedPixelFile& ppf,
       fprintf(stderr, "JxlEncoderSetFrameBitDepth() failed.\n");
       return false;
     }
+    if (num_alpha_channels != 0 &&
+        JXL_ENC_SUCCESS != JxlEncoderSetExtraChannelDistance(
+                               settings, 0, params.alpha_distance)) {
+      fprintf(stderr, "Setting alpha distance failed.\n");
+      return false;
+    }
     if (lossless &&
         JXL_ENC_SUCCESS != JxlEncoderSetFrameLossless(settings, JXL_TRUE)) {
       fprintf(stderr, "JxlEncoderSetFrameLossless() failed.\n");

--- a/lib/extras/enc/jxl.h
+++ b/lib/extras/enc/jxl.h
@@ -38,6 +38,7 @@ struct JXLCompressParams {
   std::vector<JXLOption> options;
   // Target butteraugli distance, 0.0 means lossless.
   float distance = 1.0f;
+  float alpha_distance = 1.0f;
   // If set to true, forces container mode.
   bool use_container = false;
   // Whether to enable/disable byte-exact jpeg reconstruction for jpeg inputs.

--- a/lib/include/jxl/encode.h
+++ b/lib/include/jxl/encode.h
@@ -1138,6 +1138,22 @@ JXL_DEPRECATED JXL_EXPORT JxlEncoderStatus
 JxlEncoderOptionsSetDistance(JxlEncoderFrameSettings*, float);
 
 /**
+ * Sets the distance level for lossy compression of extra channels.
+ * The distance is as in JxlEncoderSetFrameDistance (lower = higher quality).
+ * If not set, or if set to the special value -1, the distance that was set with
+ * JxlEncoderSetFrameDistance will be used.
+ *
+ * @param frame_settings set of options and metadata for this frame. Also
+ * includes reference to the encoder object.
+ * @param index index of the extra channel to set a distance value for.
+ * @param distance the distance value to set.
+ * @return JXL_ENC_SUCCESS if the operation was successful, JXL_ENC_ERROR
+ * otherwise.
+ */
+JXL_EXPORT JxlEncoderStatus JxlEncoderSetExtraChannelDistance(
+    JxlEncoderFrameSettings* frame_settings, size_t index, float distance);
+
+/**
  * Create a new set of encoder options, with all values initially copied from
  * the @p source options, or set to default if @p source is NULL.
  *

--- a/lib/jxl/enc_modular.cc
+++ b/lib/jxl/enc_modular.cc
@@ -306,7 +306,7 @@ ModularFrameEncoder::ModularFrameEncoder(const FrameHeader& frame_header,
     : frame_dim_(frame_header.ToFrameDimensions()), cparams_(cparams_orig) {
   size_t num_streams =
       ModularStreamId::Num(frame_dim_, frame_header.passes.num_passes);
-  if (cparams_.IsLossless()) {
+  if (cparams_.ModularPartIsLossless()) {
     switch (cparams_.decoding_speed_tier) {
       case 0:
         break;
@@ -331,7 +331,7 @@ ModularFrameEncoder::ModularFrameEncoder(const FrameHeader& frame_header,
     }
   }
   if (cparams_.decoding_speed_tier >= 1 && cparams_.responsive &&
-      cparams_.IsLossless()) {
+      cparams_.ModularPartIsLossless()) {
     cparams_.options.tree_kind =
         ModularOptions::TreeKind::kTrivialTreeNoPredictor;
     cparams_.options.nb_repeats = 0;
@@ -341,7 +341,7 @@ ModularFrameEncoder::ModularFrameEncoder(const FrameHeader& frame_header,
   // use a sensible default if nothing explicit is specified:
   // Squeeze for lossy, no squeeze for lossless
   if (cparams_.responsive < 0) {
-    if (cparams_.IsLossless()) {
+    if (cparams_.ModularPartIsLossless()) {
       cparams_.responsive = 0;
     } else {
       cparams_.responsive = 1;
@@ -428,7 +428,7 @@ ModularFrameEncoder::ModularFrameEncoder(const FrameHeader& frame_header,
     delta_pred_ = cparams_.options.predictor;
     if (cparams_.lossy_palette) cparams_.options.predictor = Predictor::Zero;
   }
-  if (!cparams_.IsLossless()) {
+  if (!cparams_.ModularPartIsLossless()) {
     if (cparams_.options.predictor == Predictor::Weighted ||
         cparams_.options.predictor == Predictor::Variable ||
         cparams_.options.predictor == Predictor::Best)
@@ -637,8 +637,7 @@ Status ModularFrameEncoder::ComputeEncodingData(
         cparams_.level, max_bitdepth, level_max_bitdepth);
 
   // Set options and apply transformations
-
-  if (cparams_.butteraugli_distance > 0) {
+  if (!cparams_.ModularPartIsLossless()) {
     if (cparams_.palette_colors != 0) {
       JXL_DEBUG_V(3, "Lossy encode, not doing palette transforms");
     }
@@ -752,8 +751,8 @@ Status ModularFrameEncoder::ComputeEncodingData(
   if (cparams_.color_transform == ColorTransform::kNone && do_color &&
       gi.channel.size() - gi.nb_meta_channels >= 3 &&
       max_bitdepth + 1 < level_max_bitdepth) {
-    if (cparams_.colorspace < 0 &&
-        (!cparams_.IsLossless() || cparams_.speed_tier > SpeedTier::kHare)) {
+    if (cparams_.colorspace < 0 && (!cparams_.ModularPartIsLossless() ||
+                                    cparams_.speed_tier > SpeedTier::kHare)) {
       Transform ycocg{TransformId::kRCT};
       ycocg.rct_type = 6;
       ycocg.begin_c = gi.nb_meta_channels;
@@ -785,20 +784,32 @@ Status ModularFrameEncoder::ComputeEncodingData(
 
   std::vector<uint32_t> quants;
 
-  if (cparams_.butteraugli_distance > 0) {
+  if (!cparams_.ModularPartIsLossless()) {
     quants.resize(gi.channel.size(), 1);
-    float quality = 0.25f * cparams_.butteraugli_distance;
-    JXL_DEBUG_V(2,
-                "Adding quantization constants corresponding to distance %.3f ",
-                quality);
+    float quantizer = 0.25f;
     if (!cparams_.responsive) {
       JXL_DEBUG_V(1,
                   "Warning: lossy compression without Squeeze "
                   "transform is just color quantization.");
-      quality *= 0.1f;
+      quantizer *= 0.1f;
     }
+    float bitdepth_correction = 1.f;
     if (cparams_.color_transform != ColorTransform::kXYB) {
-      quality *= maxval / 255.f;
+      bitdepth_correction = maxval / 255.f;
+    }
+    std::vector<float> quantizers;
+    float dist = cparams_.butteraugli_distance;
+    for (size_t i = 0; i < 3; i++) {
+      quantizers.push_back(quantizer * dist * bitdepth_correction);
+    }
+    for (size_t i = 0; i < extra_channels.size(); i++) {
+      int ec_bitdepth =
+          metadata.extra_channel_info[i].bit_depth.bits_per_sample;
+      pixel_type ec_maxval = ec_bitdepth < 32 ? (1u << ec_bitdepth) - 1 : 0;
+      bitdepth_correction = ec_maxval / 255.f;
+      if (i < cparams_.ec_distance.size()) dist = cparams_.ec_distance[i];
+      if (dist < 0) dist = cparams_.butteraugli_distance;
+      quantizers.push_back(quantizer * dist * bitdepth_correction);
     }
     if (cparams_.options.nb_repeats == 0) {
       return JXL_FAILURE("nb_repeats = 0 not supported with modular lossy!");
@@ -817,14 +828,15 @@ Status ModularFrameEncoder::ComputeEncodingData(
         component = 1;
       }
       if (cparams_.color_transform == ColorTransform::kXYB && component < 3) {
-        q = quality * squeeze_quality_factor_xyb *
+        q = quantizers[component] * squeeze_quality_factor_xyb *
             squeeze_xyb_qtable[component][shift];
       } else {
         if (cparams_.colorspace != 0 && component > 0 && component < 3) {
-          q = quality * squeeze_quality_factor * squeeze_chroma_qtable[shift];
+          q = quantizers[component] * squeeze_quality_factor *
+              squeeze_chroma_qtable[shift];
         } else {
-          q = quality * squeeze_quality_factor * squeeze_luma_factor *
-              squeeze_luma_qtable[shift];
+          q = quantizers[component] * squeeze_quality_factor *
+              squeeze_luma_factor * squeeze_luma_qtable[shift];
         }
       }
       if (q < 1) q = 1;

--- a/lib/jxl/enc_params.h
+++ b/lib/jxl/enc_params.h
@@ -54,6 +54,10 @@ enum class SpeedTier {
 // NOLINTNEXTLINE(clang-analyzer-optin.performance.Padding)
 struct CompressParams {
   float butteraugli_distance = 1.0f;
+
+  // explicit distances for extra channels (defaults to butteraugli_distance
+  // when not set; value of -1 can be used to represent 'default')
+  std::vector<float> ec_distance;
   size_t target_size = 0;
   float target_bitrate = 0.0f;
 
@@ -73,7 +77,6 @@ struct CompressParams {
   // 0 = default.
   // 1 = slightly worse quality.
   // 4 = fastest speed, lowest quality
-  // TODO(veluca): hook this up to the C API.
   size_t decoding_speed_tier = 0;
 
   int max_butteraugli_iters = 4;
@@ -150,17 +153,32 @@ struct CompressParams {
   bool lossy_palette = false;
 
   // Returns whether these params are lossless as defined by SetLossless();
-  bool IsLossless() const {
-    // YCbCr is also considered lossless here since it's intended for
-    // source material that is already YCbCr (we don't do the fwd transform)
-    return modular_mode && butteraugli_distance == 0.0f &&
-           color_transform != jxl::ColorTransform::kXYB;
+  bool IsLossless() const { return modular_mode && ModularPartIsLossless(); }
+
+  bool ModularPartIsLossless() const {
+    if (modular_mode) {
+      // YCbCr is also considered lossless here since it's intended for
+      // source material that is already YCbCr (we don't do the fwd transform)
+      if (butteraugli_distance != 0 ||
+          color_transform == jxl::ColorTransform::kXYB)
+        return false;
+    }
+    for (float f : ec_distance) {
+      if (f > 0) return false;
+      if (f < 0 && butteraugli_distance != 0) return false;
+    }
+    // if no explicit ec_distance given, and using vardct, then the modular part
+    // is empty or not lossless
+    if (!modular_mode && !ec_distance.size()) return false;
+    // all modular channels are encoded at distance 0
+    return true;
   }
 
   // Sets the parameters required to make the codec lossless.
   void SetLossless() {
     modular_mode = true;
     butteraugli_distance = 0.0f;
+    for (float &f : ec_distance) f = 0.0f;
     color_transform = jxl::ColorTransform::kNone;
   }
 

--- a/lib/jxl/jxl_test.cc
+++ b/lib/jxl/jxl_test.cc
@@ -882,7 +882,7 @@ TEST(JxlTest, RoundtripAlpha16) {
 
   PackedPixelFile ppf_out;
   // TODO(szabadka) Investigate big size difference on i686
-  EXPECT_NEAR(Roundtrip(t.ppf(), cparams, {}, &pool, &ppf_out), 4107, 200);
+  EXPECT_NEAR(Roundtrip(t.ppf(), cparams, {}, &pool, &ppf_out), 3620, 50);
   EXPECT_THAT(ButteraugliDistance(t.ppf(), ppf_out), IsSlightlyBelow(0.7));
 }
 
@@ -1177,7 +1177,7 @@ TEST(JxlTest, RoundtripAnimationPatches) {
   PackedPixelFile ppf_out;
   // 40k with no patches, 27k with patch frames encoded multiple times.
   EXPECT_THAT(Roundtrip(t.ppf(), cparams, dparams, pool, &ppf_out),
-              IsSlightlyBelow(14400));
+              IsSlightlyBelow(16000));
   EXPECT_EQ(ppf_out.frames.size(), t.ppf().frames.size());
   // >10 with broken patches
   EXPECT_THAT(ButteraugliDistance(t.ppf(), ppf_out), IsSlightlyBelow(1.2));

--- a/tools/benchmark/benchmark_codec_jxl.cc
+++ b/tools/benchmark/benchmark_codec_jxl.cc
@@ -177,6 +177,9 @@ class JxlCodec : public ImageCodec {
         return JXL_FAILURE("failed to parse uniform quant parameter %s",
                            param.c_str());
       }
+    } else if (param[0] == 'D') {
+      cparams_.ec_distance.clear();
+      cparams_.ec_distance.push_back(strtof(param.substr(1).c_str(), nullptr));
     } else if (param.substr(0, kMaxPassesPrefix.size()) == kMaxPassesPrefix) {
       std::istringstream parser(param.substr(kMaxPassesPrefix.size()));
       parser >> dparams_.max_passes;

--- a/tools/cjxl_main.cc
+++ b/tools/cjxl_main.cc
@@ -127,6 +127,15 @@ struct CompressArgs {
         "    Mutually exclusive with --quality.",
         &distance, &ParseFloat);
 
+    opt_alpha_distance_id = cmdline->AddOptionValue(
+        'a', "alpha_distance", "maxError",
+        "Max. butteraugli distance for the alpha channel, lower = higher "
+        "quality.\n"
+        "    0.0 = mathematically lossless. 1.0 = visually lossless.\n"
+        "    Default is to use the same value as for the color image.\n"
+        "    Recommended range: 0.5 .. 3.0. Allowed range: 0.0 ... 25.0.",
+        &alpha_distance, &ParseFloat);
+
     // High-level options
     opt_quality_id = cmdline->AddOptionValue(
         'q', "quality", "QUALITY",
@@ -488,6 +497,7 @@ struct CompressArgs {
   int64_t codestream_level = -1;
   int64_t responsive = -1;
   float distance = 1.0;
+  float alpha_distance = 1.0;
   size_t effort = 7;
   size_t brotli_effort = 9;
   std::string frame_indexing;
@@ -501,6 +511,7 @@ struct CompressArgs {
   CommandLineParser::OptionId opt_lossless_jpeg_id = -1;
   CommandLineParser::OptionId opt_responsive_id = -1;
   CommandLineParser::OptionId opt_distance_id = -1;
+  CommandLineParser::OptionId opt_alpha_distance_id = -1;
   CommandLineParser::OptionId opt_quality_id = -1;
   CommandLineParser::OptionId opt_modular_group_size_id = -1;
 };
@@ -647,6 +658,8 @@ void SetDistanceFromFlags(CommandLineParser* cmdline, CompressArgs* args,
                           jxl::extras::JXLCompressParams* params,
                           const jxl::extras::Codec& codec) {
   bool distance_set = cmdline->GetOption(args->opt_distance_id)->matched();
+  bool alpha_distance_set =
+      cmdline->GetOption(args->opt_alpha_distance_id)->matched();
   bool quality_set = cmdline->GetOption(args->opt_quality_id)->matched();
   if (((distance_set && (args->distance != 0.0)) ||
        (quality_set && (args->quality != 100))) &&
@@ -677,6 +690,8 @@ void SetDistanceFromFlags(CommandLineParser* cmdline, CompressArgs* args,
     args->lossless_jpeg = 0;
   }
   params->distance = args->distance;
+  params->alpha_distance =
+      alpha_distance_set ? args->alpha_distance : params->distance;
 }
 
 void ProcessFlags(const jxl::extras::Codec codec,


### PR DESCRIPTION
Adds an option to the API to set the distance for extra channels separately, addressing #2111 .

This e.g. allows doing lossless alpha while the color is lossy, or in general to set the alpha quality independently of the color quality. We might want to experiment with this and set more sensible defaults. (Note: we can't really rely on the metrics though, since they don't really look at alpha, they just use it to blend the image to a solid background.)

Adds a parameter `D` to benchmark_xl and `--alpha_distance` to cjxl.

Flyby fix: correct the modular quantization adjustment to compensate for the actual bitdepth of extra channels (instead of assuming that all channels have the same bitdepth).

```
Encoding       kPixels    Bytes          BPP  E MP/s  D MP/s     Max norm  SSIMULACRA2        pnorm       BPP*pnorm   Bugs
--------------------------------------------------------------------------------------------------------------------------
jxl:d0.5          4312  1326476    2.4608889   1.247   9.371   1.46619773  93.29027781   0.32387099  0.797010517600      0
jxl:d0.5:D0       4312  1535745    2.8491264   1.296   9.113   1.52147913  93.17293088   0.29785035  0.848613285350      0
jxl:d1            4312   923797    1.7138356   1.526   9.811   2.18971467  88.25578150   0.54898038  0.940862091175      0
jxl:d1:D0         4312  1262339    2.3419014   1.246   8.648   2.03960395  88.48580332   0.50947993  1.193151755443      0
jxl:d1:D2         4312   824846    1.5302609   1.487  10.698   2.32580400  88.42132275   0.64015614  0.979605903443      0
jxl:d2            4312   630823    1.1703079   1.507   9.813   3.26052332  82.49513662   0.88900277  1.040406932615      0
jxl:d2:D4         4312   558300    1.0357626   1.391   9.768   3.80601859  82.32916682   1.01417959  1.050449298471      0
jxl:d3            4312   491437    0.9117178   1.425   7.479   4.17905045  78.08833075   1.16395135  1.061195208251      0
jxl:d3:D6         4312   434096    0.8053384   1.468   8.684   4.96663904  77.92568643   1.30559641  1.051446871010      0
Aggregate:        4312   808263    1.4994954   1.395   9.222   2.62748584  85.65005370   0.65969720  0.989212882981      0
```

For some images, doing alpha losslessly results in smaller files than doing it lossy, e.g.:

```
Encoding       kPixels    Bytes          BPP  E MP/s  D MP/s     Max norm  SSIMULACRA2        pnorm       BPP*pnorm   Bugs
--------------------------------------------------------------------------------------------------------------------------
jxl:d0.5           409    47889    0.9353320   0.999  10.693   0.76884204  97.97876012   0.29019442  0.271428139716      0
jxl:d0.5:D0        409    46700    0.9121094   1.014  12.442   0.76884204  98.26795927   0.29005663  0.264563367873      0
jxl:d1             409    31685    0.6188477   1.017  10.603   1.19141257  91.69366061   0.47456421  0.293682948235      0
jxl:d1:D0          409    31095    0.6073242   1.045  11.505   1.19293487  91.82356930   0.47412265  0.287946168915      0
jxl:d2             409    20969    0.4095508   1.021  10.966   2.02522826  86.19662382   0.75935998  0.310996471061      0
jxl:d2:D0          409    20971    0.4095898   1.039  11.696   2.02522278  86.03497192   0.75843025  0.310645329176      0
jxl:d3             409    16549    0.3232227   1.004   9.977   2.59280419  82.55876856   0.97508168  0.315168489608      0
jxl:d3:D0          409    16891    0.3299023   0.985   8.871   2.64150572  82.59064968   0.97371519  0.321230921912      0
Aggregate:         409    26859    0.5245902   1.015  10.794   1.48461947  89.45138936   0.56480591  0.296291627848      0
```

So maybe we should reconsider the default behavior, and do alpha losslessly when doing high quality lossy, and only make alpha lossy when the quality is low enough. To be investigated later...

