### PR TITLE
more dc values to fix DZgas' latest findings

### DIFF
--- a/lib/jxl/enc_adaptive_quantization.cc
+++ b/lib/jxl/enc_adaptive_quantization.cc
@@ -714,8 +714,8 @@ ImageF TileDistMap(const ImageF& distmap, int tile_size, int margin,
   return tile_distmap;
 }
 
-constexpr float kDcQuantPow = 0.66f;
-static const float kDcQuant = 1.1f;
+constexpr float kDcQuantPow = 0.87f;
+static const float kDcQuant = 1.29f;
 static const float kAcQuant = 0.841f;
 
 void FindBestQuantization(const ImageBundle& linear, const Image3F& opsin,
@@ -1018,7 +1018,7 @@ void AdjustQuantField(const AcStrategyImage& ac_strategy, const Rect& rect,
 }
 
 float InitialQuantDC(float butteraugli_target) {
-  const float kDcMul = 1.5;  // Butteraugli target where non-linearity kicks in.
+  const float kDcMul = 0.3;  // Butteraugli target where non-linearity kicks in.
   const float butteraugli_target_dc = std::max<float>(
       0.5f * butteraugli_target,
       std::min<float>(butteraugli_target,

--- a/lib/jxl/encode_test.cc
+++ b/lib/jxl/encode_test.cc
@@ -392,7 +392,7 @@ TEST(EncodeTest, frame_settingsTest) {
     EXPECT_EQ(JXL_ENC_SUCCESS,
               JxlEncoderFrameSettingsSetOption(
                   frame_settings, JXL_ENC_FRAME_SETTING_PROGRESSIVE_DC, 2));
-    VerifyFrameEncoding(63, 129, enc.get(), frame_settings, 2803,
+    VerifyFrameEncoding(63, 129, enc.get(), frame_settings, 2830,
                         /*lossy_use_original_profile=*/false);
     EXPECT_EQ(false, enc->last_used_cparams.responsive);
     EXPECT_EQ(true, enc->last_used_cparams.progressive_mode);

--- a/lib/jxl/encode_test.cc
+++ b/lib/jxl/encode_test.cc
@@ -503,7 +503,7 @@ TEST(EncodeTest, LossyEncoderUseOriginalProfileTest) {
     ASSERT_NE(nullptr, enc.get());
     JxlEncoderFrameSettings* frame_settings =
         JxlEncoderFrameSettingsCreate(enc.get(), NULL);
-    VerifyFrameEncoding(63, 129, enc.get(), frame_settings, 5181, true);
+    VerifyFrameEncoding(63, 129, enc.get(), frame_settings, 5190, true);
   }
   {
     JxlEncoderPtr enc = JxlEncoderMake(nullptr);
@@ -513,7 +513,7 @@ TEST(EncodeTest, LossyEncoderUseOriginalProfileTest) {
     EXPECT_EQ(JXL_ENC_SUCCESS,
               JxlEncoderFrameSettingsSetOption(
                   frame_settings, JXL_ENC_FRAME_SETTING_PROGRESSIVE_DC, 2));
-    VerifyFrameEncoding(63, 129, enc.get(), frame_settings, 5580, true);
+    VerifyFrameEncoding(63, 129, enc.get(), frame_settings, 5620, true);
   }
   {
     JxlEncoderPtr enc = JxlEncoderMake(nullptr);
@@ -523,7 +523,7 @@ TEST(EncodeTest, LossyEncoderUseOriginalProfileTest) {
     ASSERT_EQ(JXL_ENC_SUCCESS,
               JxlEncoderFrameSettingsSetOption(
                   frame_settings, JXL_ENC_FRAME_SETTING_EFFORT, 8));
-    VerifyFrameEncoding(63, 129, enc.get(), frame_settings, 4647, true);
+    VerifyFrameEncoding(63, 129, enc.get(), frame_settings, 4676, true);
   }
 }
 

--- a/lib/jxl/jxl_test.cc
+++ b/lib/jxl/jxl_test.cc
@@ -532,7 +532,7 @@ TEST(JxlTest, RoundtripSmallPatches) {
   cparams.distance = 0.1f;
 
   PackedPixelFile ppf_out;
-  EXPECT_NEAR(Roundtrip(t.ppf(), cparams, {}, pool, &ppf_out), 430, 50);
+  EXPECT_NEAR(Roundtrip(t.ppf(), cparams, {}, pool, &ppf_out), 500, 100);
   EXPECT_THAT(ButteraugliDistance(t.ppf(), ppf_out), IsSlightlyBelow(0.025f));
 }
 

--- a/lib/jxl/jxl_test.cc
+++ b/lib/jxl/jxl_test.cc
@@ -146,7 +146,7 @@ TEST(JxlTest, RoundtripResample2) {
   cparams.AddOption(JXL_ENC_FRAME_SETTING_EFFORT, 3);  // kFalcon
 
   PackedPixelFile ppf_out;
-  EXPECT_EQ(Roundtrip(t.ppf(), cparams, {}, pool, &ppf_out), 16439);
+  EXPECT_NEAR(Roundtrip(t.ppf(), cparams, {}, pool, &ppf_out), 16439, 50);
   EXPECT_THAT(ComputeDistance2(t.ppf(), ppf_out), IsSlightlyBelow(90));
 }
 
@@ -200,7 +200,7 @@ TEST(JxlTest, RoundtripOutOfOrderProcessing) {
   cparams.AddOption(JXL_ENC_FRAME_SETTING_EPF, 3);
 
   PackedPixelFile ppf_out;
-  EXPECT_NEAR(Roundtrip(t.ppf(), cparams, {}, &pool, &ppf_out), 19861, 100);
+  EXPECT_NEAR(Roundtrip(t.ppf(), cparams, {}, &pool, &ppf_out), 20100, 400);
   EXPECT_LE(ButteraugliDistance(t.ppf(), ppf_out), 1.35);
 }
 
@@ -220,7 +220,7 @@ TEST(JxlTest, RoundtripOutOfOrderProcessingBorder) {
   cparams.AddOption(JXL_ENC_FRAME_SETTING_RESAMPLING, 2);
 
   PackedPixelFile ppf_out;
-  EXPECT_NEAR(Roundtrip(t.ppf(), cparams, {}, &pool, &ppf_out), 9102, 55);
+  EXPECT_NEAR(Roundtrip(t.ppf(), cparams, {}, &pool, &ppf_out), 9202, 100);
   EXPECT_LE(ButteraugliDistance(t.ppf(), ppf_out), 2.9);
 }
 
@@ -287,15 +287,15 @@ TEST(JxlTest, RoundtripMultiGroup) {
 
     PackedPixelFile ppf_out;
     EXPECT_NEAR(Roundtrip(t.ppf(), cparams, {}, &pool, &ppf_out), expected_size,
-                500);
+                700);
     EXPECT_THAT(ComputeDistance2(t.ppf(), ppf_out),
                 IsSlightlyBelow(expected_distance));
   };
 
   auto run_kitten = std::async(std::launch::async, test, SpeedTier::kKitten,
-                               1.0f, 50601u, 11.7);
+                               1.0f, 50800u, 11.7);
   auto run_wombat = std::async(std::launch::async, test, SpeedTier::kWombat,
-                               2.0f, 30365u, 20.0);
+                               2.0f, 31000u, 20.0);
 }
 
 TEST(JxlTest, RoundtripRGBToGrayscale) {
@@ -367,7 +367,7 @@ TEST(JxlTest, RoundtripDotsForceEpf) {
   cparams.AddOption(JXL_ENC_FRAME_SETTING_DOTS, 1);
 
   PackedPixelFile ppf_out;
-  EXPECT_NEAR(Roundtrip(t.ppf(), cparams, {}, &pool, &ppf_out), 40230, 50);
+  EXPECT_NEAR(Roundtrip(t.ppf(), cparams, {}, &pool, &ppf_out), 40450, 300);
   EXPECT_THAT(ComputeDistance2(t.ppf(), ppf_out), IsSlightlyBelow(18));
 }
 

--- a/lib/jxl/jxl_test.cc
+++ b/lib/jxl/jxl_test.cc
@@ -876,7 +876,7 @@ TEST(JxlTest, RoundtripAlpha16) {
 
   PackedPixelFile ppf_out;
   // TODO(szabadka) Investigate big size difference on i686
-  EXPECT_NEAR(Roundtrip(t.ppf(), cparams, {}, &pool, &ppf_out), 4007, 150);
+  EXPECT_NEAR(Roundtrip(t.ppf(), cparams, {}, &pool, &ppf_out), 4107, 200);
   EXPECT_THAT(ButteraugliDistance(t.ppf(), ppf_out), IsSlightlyBelow(0.7));
 }
 

--- a/lib/jxl/jxl_test.cc
+++ b/lib/jxl/jxl_test.cc
@@ -1171,7 +1171,7 @@ TEST(JxlTest, RoundtripAnimationPatches) {
   PackedPixelFile ppf_out;
   // 40k with no patches, 27k with patch frames encoded multiple times.
   EXPECT_THAT(Roundtrip(t.ppf(), cparams, dparams, pool, &ppf_out),
-              IsSlightlyBelow(14000));
+              IsSlightlyBelow(14400));
   EXPECT_EQ(ppf_out.frames.size(), t.ppf().frames.size());
   // >10 with broken patches
   EXPECT_THAT(ButteraugliDistance(t.ppf(), ppf_out), IsSlightlyBelow(1.2));

--- a/lib/jxl/jxl_test.cc
+++ b/lib/jxl/jxl_test.cc
@@ -179,7 +179,7 @@ TEST(JxlTest, RoundtripResample2MT) {
   cparams.AddOption(JXL_ENC_FRAME_SETTING_EFFORT, 3);  // kFalcon
 
   PackedPixelFile ppf_out;
-  EXPECT_NEAR(Roundtrip(t.ppf(), cparams, {}, &pool, &ppf_out), 190111, 10);
+  EXPECT_NEAR(Roundtrip(t.ppf(), cparams, {}, &pool, &ppf_out), 190000, 600);
   EXPECT_THAT(ComputeDistance2(t.ppf(), ppf_out), IsSlightlyBelow(340));
 }
 
@@ -350,7 +350,7 @@ TEST(JxlTest, RoundtripLargeFast) {
   cparams.AddOption(JXL_ENC_FRAME_SETTING_EFFORT, 7);  // kSquirrel
 
   PackedPixelFile ppf_out;
-  EXPECT_NEAR(Roundtrip(t.ppf(), cparams, {}, &pool, &ppf_out), 401616, 100);
+  EXPECT_NEAR(Roundtrip(t.ppf(), cparams, {}, &pool, &ppf_out), 405616, 5000);
   EXPECT_THAT(ComputeDistance2(t.ppf(), ppf_out), IsSlightlyBelow(100));
 }
 
@@ -507,7 +507,7 @@ TEST(JxlTest, RoundtripSmallPatchesAlpha) {
   cparams.distance = 0.1f;
 
   PackedPixelFile ppf_out;
-  EXPECT_NEAR(Roundtrip(t.ppf(), cparams, {}, pool, &ppf_out), 550, 15);
+  EXPECT_NEAR(Roundtrip(t.ppf(), cparams, {}, pool, &ppf_out), 620, 70);
   EXPECT_THAT(ButteraugliDistance(t.ppf(), ppf_out), IsSlightlyBelow(0.025f));
 }
 
@@ -532,7 +532,7 @@ TEST(JxlTest, RoundtripSmallPatches) {
   cparams.distance = 0.1f;
 
   PackedPixelFile ppf_out;
-  EXPECT_NEAR(Roundtrip(t.ppf(), cparams, {}, pool, &ppf_out), 450, 12);
+  EXPECT_NEAR(Roundtrip(t.ppf(), cparams, {}, pool, &ppf_out), 430, 50);
   EXPECT_THAT(ButteraugliDistance(t.ppf(), ppf_out), IsSlightlyBelow(0.025f));
 }
 
@@ -809,7 +809,7 @@ TEST(JxlTest, RoundtripAlphaResampling) {
   cparams.AddOption(JXL_ENC_FRAME_SETTING_EXTRA_CHANNEL_RESAMPLING, 2);
 
   PackedPixelFile ppf_out;
-  EXPECT_NEAR(Roundtrip(t.ppf(), cparams, {}, pool, &ppf_out), 11819, 60);
+  EXPECT_NEAR(Roundtrip(t.ppf(), cparams, {}, pool, &ppf_out), 11819, 100);
   EXPECT_THAT(ButteraugliDistance(t.ppf(), ppf_out), IsSlightlyBelow(4.9));
 }
 
@@ -827,7 +827,7 @@ TEST(JxlTest, RoundtripAlphaResamplingOnlyAlpha) {
   cparams.AddOption(JXL_ENC_FRAME_SETTING_EXTRA_CHANNEL_RESAMPLING, 2);
 
   PackedPixelFile ppf_out;
-  EXPECT_NEAR(Roundtrip(t.ppf(), cparams, {}, pool, &ppf_out), 29949, 40);
+  EXPECT_NEAR(Roundtrip(t.ppf(), cparams, {}, pool, &ppf_out), 30100, 300);
   EXPECT_THAT(ButteraugliDistance(t.ppf(), ppf_out), IsSlightlyBelow(1.85));
 }
 
@@ -1083,7 +1083,7 @@ TEST(JxlTest, RoundtripNoise) {
   cparams.AddOption(JXL_ENC_FRAME_SETTING_NOISE, 1);
 
   PackedPixelFile ppf_out;
-  EXPECT_NEAR(Roundtrip(t.ppf(), cparams, {}, pool, &ppf_out), 39864, 700);
+  EXPECT_NEAR(Roundtrip(t.ppf(), cparams, {}, pool, &ppf_out), 39864, 750);
   EXPECT_THAT(ButteraugliDistance(t.ppf(), ppf_out), IsSlightlyBelow(1.7));
 }
 


### PR DESCRIPTION
This adds dc quality everywhere, but more on high quality images

It looks like we could detect if the image is 'grainy' by character and quantize DC more for images that have no polished slow gradients. That could creates 1-5 % more savings. Before that, let's quantize less, so that great worst case performance is quaranteed.

```
Before:

Encoding      kPixels    Bytes          BPP  E MP/s  D MP/s     Max norm  SSIMULACRA2        pnorm   PSNR   QABPP  SmallB  DCT4x8     AFV  DCT8x8    8x16    8x32      16   16x32      32   32x64      64       BPP*pnorm   Bugs
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
jxl:d0.1        18611 15034555    6.4623612   1.545   9.398   1.13074732  99.91638570   0.12035060  53.95   6.473 40.1124 21.1492  0.6111 30.3002  5.5136  0.0000  1.7964  0.8638  0.2366  0.1100  0.0880  0.777749049704      0
jxl:d0.5        18611  5667198    2.4359538   1.768  14.203   1.47652292  97.35129858   0.37961090  45.05   2.467 14.7423 24.8207  0.7166 13.3616 27.3608  0.0000 18.1287  1.0729  0.3796  0.1100  0.0880  0.924714597626      0
jxl:d0.8        18611  4219542    1.8137021   1.961  15.133   1.68988335  91.91395912   0.52161174  42.52   2.123 11.3641 21.7156  0.8067 10.0447 25.4028  0.0000 28.2287  1.4855  1.4800  0.1430  0.1100  0.946048335100      0
jxl:d1          18611  3651896    1.5697087   1.965  15.644   1.82198429  89.10936372   0.60536924  41.32   2.205 10.1173 20.1805  0.8273  8.7428 22.2874  0.0000 32.2272  2.7069  3.4937  0.1100  0.0880  0.950253331178      0
jxl:d1.1        18611  3435631    1.4767506   2.041  16.185   1.94524312  87.95626414   0.64484687  40.82   2.182  9.5702 19.5227  0.8590  8.2717 20.8796  0.0000 32.7678  3.7220  4.9902  0.1100  0.0880  0.952278026402      0
jxl:d1.2        18611  3244223    1.3944770   1.989  16.377   2.19444942  86.85215495   0.68297093  40.36   2.214  9.0953 18.9065  0.8958  7.8336 19.5468  0.0000 32.7458  5.0232  6.5252  0.1210  0.0880  0.952387248706      0
jxl:d1.3        18611  3107328    1.3356349   2.068  16.037   2.38388181  85.96970433   0.71408114  40.10   2.230  8.6775 18.4581  0.9013  7.4709 18.6961  0.0000 32.0003  6.4344  7.9337  0.1210  0.0880  0.953751679773      0
jxl:d1.4        18611  2955627    1.2704286   1.967  16.115   2.25182581  84.89480458   0.75086771  39.70   2.200  8.3157 17.9368  0.9147  7.1748 17.8591  0.0000 31.1695  7.8044  9.3422  0.1541  0.1100  0.953923843434      0
jxl:d1.5        18611  2818766    1.2116012   2.107  15.090   2.67980075  83.96948992   0.78560941  39.34   2.237  8.0049 17.4537  0.9233  6.8564 17.3123  0.0000 30.3195  9.2211 10.4811  0.1210  0.0880  0.951845266696      0
jxl:d1.6        18611  2700901    1.1609388   2.165  15.844   2.78544474  83.10987404   0.82073692  38.99   2.278  7.7153 17.0613  0.9477  6.6604 16.8853  0.0000 29.3497 10.4536 11.4439  0.1541  0.1100  0.952825319994      0
jxl:d1.7        18611  2592975    1.1145485   2.030  14.904   2.74720287  82.26860975   0.85353781  38.67   2.264  7.4365 16.6862  0.9663  6.5042 16.4582  0.0000 28.3952 11.4274 12.6983  0.1210  0.0880  0.951309310544      0
jxl:d1.8        18611  2494100    1.0720487   2.101  15.892   2.74270988  81.49217866   0.88601788  38.38   2.253  7.1703 16.3571  0.9989  6.3199 16.1528  0.0000 27.5217 12.6048 13.4246  0.1210  0.1100  0.949854321787      0
jxl:d1.8        18611  2494100    1.0720487   2.080  15.104   2.74270988  81.49217866   0.88601788  38.38   2.253  7.1703 16.3571  0.9989  6.3199 16.1528  0.0000 27.5217 12.6048 13.4246  0.1210  0.1100  0.949854321787      0
jxl:d1.9        18611  2403546    1.0331255   2.058  14.876   2.88072228  80.69834542   0.91893410  38.09   2.258  6.9141 16.0479  1.0203  6.1707 15.8667  0.0000 26.7515 13.5456 14.2554  0.1210  0.0880  0.949374273785      0
jxl:d2.0        18611  2319631    0.9970560   2.190  14.938   3.09830141  79.89597055   0.95142333  37.81   2.225  6.6999 15.7550  1.0278  5.9888 15.6625  0.0000 26.0335 14.4562 14.9486  0.1210  0.0880  0.948622356177      0
jxl:d2.1        18611  2242418    0.9638672   2.208  14.885   3.48666477  79.15864955   0.98413480  37.56   2.258  6.4664 15.3375  1.0491  5.8619 15.4864  0.0000 25.3980 15.2429 15.6748  0.1541  0.1100  0.948575301084      0
jxl:d2.2        18611  2170248    0.9328461   2.174  16.012   3.34030008  78.42883971   1.01663853  37.32   2.264  6.2529 15.0342  1.0742  5.7436 15.3633  0.0000 24.7694 16.0490 16.2855  0.1210  0.0880  0.948367323661      0
jxl:d2.3        18611  2103849    0.9043056   2.111  15.141   3.56881571  77.70117273   1.04697642  37.09   2.301  6.1600 14.7096  1.0684  5.6305 15.1020  0.0000 24.1917 16.6542 17.0558  0.1210  0.0880  0.946786636075      0
jxl:d2.4        18611  2039711    0.8767369   2.178  16.466   3.74708223  76.93152118   1.07916652  36.87   2.309  5.9768 14.4073  1.0835  5.5301 14.9603  0.0000 23.7048 17.2924 17.5510  0.1651  0.1100  0.946145118001      0
jxl:d2.5        18611  1980230    0.8511700   2.081  16.479   3.32918930  76.27848642   1.10935251  36.65   2.301  5.7955 14.1054  1.0907  5.4159 14.8214  0.0000 23.2069 17.9086 18.1837  0.1430  0.1100  0.944247536884      0
jxl:d2.6        18611  1925277    0.8275493   2.093  15.699   3.50802135  75.65163539   1.13886324  36.45   2.297  5.6494 13.9046  1.1110  5.2907 14.7271  0.0000 22.6361 18.3708 18.8714  0.1320  0.0880  0.942465477855      0
jxl:d2.7        18611  1873141    0.8051395   2.140  15.392   3.48443127  74.92698144   1.16905707  36.25   2.288  5.4929 13.6491  1.1265  5.2230 14.6329  0.0000 22.0694 18.9677 19.3996  0.1320  0.0880  0.941254006194      0
jxl:d2.8        18611  1824439    0.7842057   2.221  16.327   5.22608757  74.30392233   1.19964963  36.06   2.310  5.3530 13.4507  1.1406  5.1394 14.4603  0.0000 21.6210 19.4739 19.8673  0.1651  0.1100  0.940772088403      0
jxl:d2.9        18611  1777895    0.7641995   2.181  15.815   3.84350491  73.71704978   1.22610269  35.88   2.297  5.2460 13.1818  1.1523  5.0174 14.5009  0.0000 21.1946 19.8398 20.4285  0.1320  0.0880  0.936987090207      0
jxl:d3          18611  1735802    0.7461065   2.061  15.767   4.29606438  72.98922483   1.25379376  35.71   2.265  5.0325 12.9903  1.1193  4.9403 14.3558  0.0000 20.7159 20.4615 20.9456  0.1320  0.0880  0.935463701750      0
jxl:d5          18611  1190044    0.5115212   1.985   8.621   5.23901463  61.29817909   1.77335301  33.24   2.329  3.4792  8.5324  1.0072  3.1663 11.5725  0.0000 16.3461 29.2562 27.1462  0.1651  0.1100  0.907107730342      0
jxl:d7          18611   924674    0.3974562   2.070   8.675   7.25545979  51.65347871   2.23300778  31.72   2.322  2.6739  6.0318  0.8397  2.1928  9.7638  0.0000 13.7134 34.7278 30.5409  0.1871  0.1100  0.887522835993      0
jxl:d15         18611   516544    0.2220281   2.090   8.210  12.66305637  21.76250399   3.76416548  28.71   2.222  1.2840  1.8201  0.3301  0.6255  5.7632  0.0000  7.8773 40.3425 41.6052  0.9353  0.1981  0.835750571609      0
jxl:d24         18611   369912    0.1590007   0.312  19.351  31.90237617   0.29698954   5.43313865  26.98   2.585  1.0691  2.3589  0.1843  0.7410  3.2358  0.0000  3.4579  9.5265  4.9132  0.0000  0.0000  0.863872922378      0
jxl:d32         18611   298044    0.1281094   0.318  20.489  32.38453293 -12.75690509   6.23550222  26.39   2.369  0.7895  1.7860  0.1541  0.5392  2.8995  0.0000  3.0081 10.6269  5.6834  0.0000  0.0000  0.798826521124      0
Aggregate:      18611  2102975    0.9039299   1.812  14.661   3.58771359  62.87762204   1.02338788  37.20   2.359  5.9570 12.6383  0.8275  5.1182 13.6556  0.0000 19.1850 10.1842  9.5765  0.1418  0.0989  0.925070951135      0

After:

Encoding      kPixels    Bytes          BPP  E MP/s  D MP/s     Max norm  SSIMULACRA2        pnorm   PSNR   QABPP  SmallB  DCT4x8     AFV  DCT8x8    8x16    8x32      16   16x32      32   32x64      64       BPP*pnorm   Bugs
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
jxl:d0.1        18611 15061426    6.4739113   1.493   9.178   1.13746321  99.91784397   0.12022734  53.96   6.485 40.1124 21.1492  0.6111 30.3002  5.5136  0.0000  1.7964  0.8638  0.2366  0.1100  0.0880  0.778341118942      0
jxl:d0.5        18611  5700801    2.4503975   1.727  14.733   1.43125176  97.48918300   0.37747569  45.07   2.480 14.7423 24.8207  0.7166 13.3616 27.3608  0.0000 18.1287  1.0729  0.3796  0.1100  0.0880  0.924965476095      0
jxl:d0.8        18611  4259403    1.8308358   1.933  14.921   1.59030497  92.40699379   0.51647528  42.54   2.140 11.3641 21.7156  0.8067 10.0447 25.4028  0.0000 28.2287  1.4855  1.4800  0.1430  0.1100  0.945581405220      0
jxl:d1          18611  3693698    1.5876766   1.924  15.228   1.86013091  89.81625806   0.59844598  41.35   2.217 10.1173 20.1805  0.8273  8.7428 22.2874  0.0000 32.2272  2.7069  3.4937  0.1100  0.0880  0.950138670415      0
jxl:d1.1        18611  3478870    1.4953362   2.045  16.152   1.93605149  88.65069624   0.63666699  40.84   2.203  9.5702 19.5227  0.8590  8.2717 20.8796  0.0000 32.7678  3.7220  4.9902  0.1100  0.0880  0.952031204223      0
jxl:d1.2        18611  3287923    1.4132607   2.026  15.147   2.18912482  87.57184178   0.67470570  40.39   2.226  9.0953 18.9065  0.8958  7.8336 19.5468  0.0000 32.7458  5.0232  6.5252  0.1210  0.0880  0.953535065562      0
jxl:d1.3        18611  3152958    1.3552482   2.081  16.228   2.35440016  86.73522764   0.70462999  40.13   2.252  8.6775 18.4581  0.9013  7.4709 18.6961  0.0000 32.0003  6.4344  7.9337  0.1210  0.0880  0.954948522037      0
jxl:d1.4        18611  3002901    1.2907486   1.970  16.412   2.32869148  85.78703533   0.74015067  39.74   2.238  8.3157 17.9368  0.9147  7.1748 17.8591  0.0000 31.1695  7.8044  9.3422  0.1541  0.1100  0.955348451732      0
jxl:d1.5        18611  2865975    1.2318932   2.042  15.528   2.60058641  84.89407847   0.77420132  39.37   2.255  8.0049 17.4537  0.9233  6.8564 17.3123  0.0000 30.3195  9.2211 10.4811  0.1210  0.0880  0.953733328285      0
jxl:d1.6        18611  2746199    1.1804094   2.117  15.945   2.57296562  84.00227187   0.80897738  39.03   2.294  7.7153 17.0613  0.9477  6.6604 16.8853  0.0000 29.3497 10.4536 11.4439  0.1541  0.1100  0.954924505295      0
jxl:d1.7        18611  2636219    1.1331363   2.049  15.835   2.63234687  83.16085932   0.84282254  38.71   2.291  7.4365 16.6862  0.9663  6.5042 16.4582  0.0000 28.3952 11.4274 12.6983  0.1210  0.0880  0.955032780837      0
jxl:d1.8        18611  2534599    1.0894565   2.100  16.127   2.73855901  82.36720533   0.87525073  38.41   2.274  7.1703 16.3571  0.9989  6.3199 16.1528  0.0000 27.5217 12.6048 13.4246  0.1210  0.1100  0.953547631849      0
jxl:d1.8        18611  2534599    1.0894565   2.071  16.024   2.73855901  82.36720533   0.87525073  38.41   2.274  7.1703 16.3571  0.9989  6.3199 16.1528  0.0000 27.5217 12.6048 13.4246  0.1210  0.1100  0.953547631849      0
jxl:d1.9        18611  2442577    1.0499024   2.045  16.073   2.87506485  81.51102528   0.90923994  38.12   2.280  6.9141 16.0479  1.0203  6.1707 15.8667  0.0000 26.7515 13.5456 14.2554  0.1210  0.0880  0.954613167726      0
jxl:d2.0        18611  2357602    1.0133772   2.110  15.708   3.07803488  80.75535563   0.94128876  37.84   2.260  6.6999 15.7550  1.0278  5.9888 15.6625  0.0000 26.0335 14.4562 14.9486  0.1210  0.0880  0.953880605373      0
jxl:d2.1        18611  2278130    0.9792175   2.111  14.945   3.35361195  80.03035007   0.97323506  37.59   2.278  6.4664 15.3375  1.0491  5.8619 15.4864  0.0000 25.3980 15.2429 15.6748  0.1541  0.1100  0.953008780954      0
jxl:d2.2        18611  2204645    0.9476311   2.135  15.799   3.39749813  79.27216167   1.00503114  37.34   2.295  6.2529 15.0342  1.0742  5.7436 15.3633  0.0000 24.7694 16.0490 16.2855  0.1210  0.0880  0.952398798176      0
jxl:d2.3        18611  2137424    0.9187373   2.148  16.359   3.53904057  78.54235948   1.03592439  37.12   2.336  6.1600 14.7096  1.0684  5.6305 15.1020  0.0000 24.1917 16.6542 17.0558  0.1210  0.0880  0.951742350084      0
jxl:d2.4        18611  2072808    0.8909631   2.157  16.209   3.70150709  77.79912609   1.06776098  36.90   2.340  5.9768 14.4073  1.0835  5.5301 14.9603  0.0000 23.7048 17.2924 17.5510  0.1651  0.1100  0.951335662659      0
jxl:d2.5        18611  2012650    0.8651052   2.113  15.061   3.34734440  77.17154744   1.09804291  36.68   2.343  5.7955 14.1054  1.0907  5.4159 14.8214  0.0000 23.2069 17.9086 18.1837  0.1430  0.1100  0.949922602167      0
jxl:d2.6        18611  1955615    0.8405896   2.104  15.640   3.59429502  76.44353311   1.12833396  36.48   2.328  5.6494 13.9046  1.1110  5.2907 14.7271  0.0000 22.6361 18.3708 18.8714  0.1320  0.0880  0.948465795650      0
jxl:d2.7        18611  1901859    0.8174835   2.150  16.387   3.53335905  75.75767933   1.15815759  36.28   2.309  5.4929 13.6491  1.1265  5.2230 14.6329  0.0000 22.0694 18.9677 19.3996  0.1320  0.0880  0.946774665646      0
jxl:d2.8        18611  1851751    0.7959453   2.177  16.320   5.25712490  75.07650297   1.18947717  36.09   2.345  5.3530 13.4507  1.1406  5.1394 14.4603  0.0000 21.6210 19.4739 19.8673  0.1651  0.1100  0.946758802607      0
jxl:d2.9        18611  1803751    0.7753133   2.167  15.803   3.78403759  74.41335423   1.21583165  35.91   2.326  5.2460 13.1818  1.1523  5.0174 14.5009  0.0000 21.1946 19.8398 20.4285  0.1320  0.0880  0.942650456226      0
jxl:d3          18611  1761644    0.7572143   2.027  16.447   4.42189074  73.75170228   1.24323812  35.73   2.304  5.0325 12.9903  1.1193  4.9403 14.3558  0.0000 20.7159 20.4615 20.9456  0.1320  0.0880  0.941397672602      0
jxl:d5          18611  1202708    0.5169647   1.979   8.716   5.37380791  61.82255530   1.76561976  33.25   2.335  3.4792  8.5324  1.0072  3.1663 11.5725  0.0000 16.3461 29.2562 27.1462  0.1651  0.1100  0.912763011814      0
jxl:d7          18611   929734    0.3996312   2.052   8.059   7.25545979  51.91013251   2.23098838  31.73   2.328  2.6739  6.0318  0.8397  2.1928  9.7638  0.0000 13.7134 34.7278 30.5409  0.1871  0.1100  0.891572520191      0
jxl:d15         18611   516544    0.2220281   2.076   7.958  12.66305637  21.76250399   3.76416548  28.71   2.222  1.2840  1.8201  0.3301  0.6255  5.7632  0.0000  7.8773 40.3425 41.6052  0.9353  0.1981  0.835750571609      0
jxl:d24         18611   371316    0.1596042   0.313  20.531  31.65073013   0.48012567   5.43398798  26.99   2.597  1.0691  2.3589  0.1843  0.7410  3.2358  0.0000  3.4579  9.5265  4.9132  0.0000  0.0000  0.867287306761      0
jxl:d32         18611   297870    0.1280346   0.315  20.204  32.38453293 -12.80065458   6.23586332  26.39   2.365  0.7895  1.7860  0.1541  0.5392  2.8995  0.0000  3.0081 10.6269  5.6834  0.0000  0.0000  0.798406393771      0
Aggregate:      18611  2129287    0.9152396   1.796  14.774   3.56659874  64.47001517   1.01417241  37.22   2.381  5.9570 12.6383  0.8275  5.1182 13.6556  0.0000 19.1850 10.1842  9.5765  0.1418  0.0989  0.928210799273      0
```