### PR TITLE
jpegli encoder: support 4-channel input images

### DIFF
--- a/lib/jpegli/bitstream.cc
+++ b/lib/jpegli/bitstream.cc
@@ -622,7 +622,7 @@ bool EncodeScan(j_compress_ptr cinfo,
   JpegBitWriter bw;
   JpegBitWriterInit(&bw, cinfo);
 
-  coeff_t last_dc_coeff[kMaxComponents] = {0};
+  coeff_t last_dc_coeff[MAX_COMPS_IN_SCAN] = {0};
   DCTCodingState coding_state;
   DCTCodingStateInit(&coding_state);
 
@@ -680,12 +680,12 @@ bool EncodeScan(j_compress_ptr cinfo,
             bool ok;
             if (!is_progressive) {
               ok = EncodeDCTBlockSequential(block, dc_huff, ac_huff,
-                                            num_zero_runs,
-                                            last_dc_coeff + comp_idx, &bw);
+                                            num_zero_runs, last_dc_coeff + i,
+                                            &bw);
             } else if (Ah == 0) {
               ok = EncodeDCTBlockProgressive(block, dc_huff, ac_huff, Ss, Se,
                                              Al, num_zero_runs, &coding_state,
-                                             last_dc_coeff + comp_idx, &bw);
+                                             last_dc_coeff + i, &bw);
             } else {
               ok = EncodeRefinementBits(block, ac_huff, Ss, Se, Al,
                                         &coding_state, &bw);

--- a/lib/jpegli/common_internal.h
+++ b/lib/jpegli/common_internal.h
@@ -8,6 +8,11 @@
 
 #include <stddef.h>
 #include <stdint.h>
+#include <string.h>
+
+#include <hwy/aligned_allocator.h>
+
+#include "lib/jxl/base/compiler_specific.h"  // for ssize_t
 
 namespace jpegli {
 
@@ -31,6 +36,8 @@ constexpr inline T1 DivCeil(T1 a, T2 b) {
 }
 
 constexpr size_t kDCTBlockSize = 64;
+// This is set to the same value as MAX_COMPS_IN_SCAN, because that is the
+// maximum number of channels the libjpeg-turbo decoder can decode.
 constexpr int kMaxComponents = 4;
 constexpr int kMaxQuantTables = 4;
 constexpr int kMaxHuffmanTables = 4;
@@ -71,6 +78,37 @@ constexpr uint32_t kJPEGZigZagOrder[64] = {
   35, 36, 48, 49, 57, 58, 62, 63
 };
 /* clang-format on */
+
+template <typename T>
+class RowBuffer {
+ public:
+  void Allocate(size_t num_rows, size_t stride) {
+    ysize_ = num_rows;
+    stride_ = stride;
+    data_ = hwy::AllocateAligned<T>(ysize_ * stride_);
+  }
+
+  T* Row(ssize_t y) { return &data_[((ysize_ + y) % ysize_) * stride_]; }
+
+  size_t stride() const { return stride_; }
+  size_t memstride() const { return stride_ * sizeof(T); }
+
+  void CopyRow(ssize_t y, const T* src, size_t len) {
+    memcpy(Row(y), src, len * sizeof(T));
+  }
+
+  void FillRow(ssize_t y, T val, size_t len) {
+    T* row = Row(y);
+    for (size_t x = 0; x < len; ++x) {
+      row[x] = val;
+    }
+  }
+
+ private:
+  size_t ysize_ = 0;
+  size_t stride_ = 0;
+  hwy::AlignedFreeUniquePtr<T[]> data_;
+};
 
 }  // namespace jpegli
 

--- a/lib/jpegli/decode_internal.h
+++ b/lib/jpegli/decode_internal.h
@@ -17,7 +17,6 @@
 #include "lib/jpegli/common.h"
 #include "lib/jpegli/common_internal.h"
 #include "lib/jpegli/huffman.h"
-#include "lib/jxl/base/compiler_specific.h"  // for ssize_t
 
 namespace jpegli {
 
@@ -36,25 +35,6 @@ struct MCUCodingState {
   coeff_t last_dc_coeff[kMaxComponents];
   int eobrun;
   std::vector<coeff_t> coeffs;
-};
-
-class RowBuffer {
- public:
-  void Allocate(size_t num_rows, size_t stride) {
-    ysize_ = num_rows;
-    stride_ = stride;
-    data_ = hwy::AllocateAligned<float>(ysize_ * stride_);
-  }
-
-  float* Row(ssize_t y) { return &data_[((ysize_ + y) % ysize_) * stride_]; }
-
-  size_t stride() const { return stride_; }
-  size_t memstride() const { return stride_ * sizeof(data_[0]); }
-
- private:
-  size_t ysize_ = 0;
-  size_t stride_ = 0;
-  hwy::AlignedFreeUniquePtr<float[]> data_;
 };
 
 }  // namespace jpegli
@@ -120,8 +100,8 @@ struct jpeg_decomp_master {
   size_t num_output_rows_;
 
   std::array<size_t, jpegli::kMaxComponents> raw_height_;
-  std::array<jpegli::RowBuffer, jpegli::kMaxComponents> raw_output_;
-  std::array<jpegli::RowBuffer, jpegli::kMaxComponents> render_output_;
+  std::array<jpegli::RowBuffer<float>, jpegli::kMaxComponents> raw_output_;
+  std::array<jpegli::RowBuffer<float>, jpegli::kMaxComponents> render_output_;
 
   hwy::AlignedFreeUniquePtr<float[]> idct_scratch_;
   hwy::AlignedFreeUniquePtr<float[]> upsample_scratch_;

--- a/lib/jpegli/encode_internal.h
+++ b/lib/jpegli/encode_internal.h
@@ -17,7 +17,6 @@
 
 #include "lib/jpegli/common_internal.h"
 #include "lib/jpegli/encode.h"
-#include "lib/jxl/image.h"
 
 namespace jpegli {
 
@@ -57,7 +56,7 @@ typedef int16_t coeff_t;
 }  // namespace jpegli
 
 struct jpeg_comp_master {
-  jxl::Image3F input;
+  std::array<jpegli::RowBuffer<float>, jpegli::kMaxComponents> input_buffer;
   float distance = 1.0;
   bool force_baseline = true;
   bool xyb_mode = false;
@@ -73,7 +72,7 @@ struct jpeg_comp_master {
   JpegliEndianness endianness = JPEGLI_NATIVE_ENDIAN;
   std::array<jpegli::HuffmanCodeTable, jpegli::kMaxHuffmanTables> dc_huff_table;
   std::array<jpegli::HuffmanCodeTable, jpegli::kMaxHuffmanTables> ac_huff_table;
-  jxl::ImageF quant_field;
+  jpegli::RowBuffer<float> quant_field;
   float quant_field_max;
 };
 

--- a/lib/jpegli/entropy_coding.cc
+++ b/lib/jpegli/entropy_coding.cc
@@ -360,7 +360,7 @@ bool ProcessScan(j_compress_ptr cinfo,
                  const jpeg_scan_info* scan_info, int* histo_index,
                  Histogram* dc_histograms, Histogram* ac_histograms) {
   int restarts_to_go = cinfo->restart_interval;
-  coeff_t last_dc_coeff[kMaxComponents] = {0};
+  coeff_t last_dc_coeff[MAX_COMPS_IN_SCAN] = {0};
   DCTState s;
 
   // "Non-interleaved" means color data comes in separate scans, in other words
@@ -412,12 +412,11 @@ bool ProcessScan(j_compress_ptr cinfo,
             bool ok;
             if (!is_progressive) {
               ok = ProcessDCTBlockSequential(block, dc_histo, ac_histo,
-                                             num_zero_runs,
-                                             last_dc_coeff + comp_idx);
+                                             num_zero_runs, last_dc_coeff + i);
             } else if (Ah == 0) {
               ok = ProcessDCTBlockProgressive(block, dc_histo, ac_histo, Ss, Se,
                                               Al, num_zero_runs, &s,
-                                              last_dc_coeff + comp_idx);
+                                              last_dc_coeff + i);
             } else {
               ok = ProcessRefinementBits(block, ac_histo, Ss, Se, Al, &s);
             }

--- a/lib/jpegli/render.cc
+++ b/lib/jpegli/render.cc
@@ -323,7 +323,7 @@ void DecodeCurrentiMCURow(j_decompress_ptr cinfo) {
                                       &m->biases_[k0]);
       }
     }
-    RowBuffer* raw_out = &m->raw_output_[c];
+    RowBuffer<float>* raw_out = &m->raw_output_[c];
     for (int iy = 0; iy < compinfo.v_samp_factor; ++iy) {
       size_t by = block_row + iy;
       size_t bix = by * compinfo.width_in_blocks;
@@ -381,8 +381,8 @@ void ProcessOutput(j_decompress_ptr cinfo, size_t* num_output_rows,
     size_t ye = DivCeil(yend, vfactor) * vfactor;
     for (size_t y = yb; y < ye; y += vfactor) {
       for (int c = 0; c < cinfo->num_components; ++c) {
-        RowBuffer* raw_out = &m->raw_output_[c];
-        RowBuffer* render_out = &m->render_output_[c];
+        RowBuffer<float>* raw_out = &m->raw_output_[c];
+        RowBuffer<float>* render_out = &m->render_output_[c];
         const auto& compinfo = cinfo->comp_info[c];
         size_t yc = (y / vfactor) * compinfo.v_samp_factor;
         if (compinfo.v_samp_factor < vfactor) {
@@ -442,7 +442,7 @@ void ProcessOutput(j_decompress_ptr cinfo, size_t* num_output_rows,
     for (int c = 0; c < cinfo->num_components; ++c) {
       const auto& compinfo = cinfo->comp_info[c];
       if (compinfo.h_samp_factor < cinfo->max_h_samp_factor) {
-        RowBuffer* raw_out = &m->raw_output_[c];
+        RowBuffer<float>* raw_out = &m->raw_output_[c];
         size_t y0 = imcu_row * compinfo.v_samp_factor * DCTSIZE;
         for (int iy = 0; iy < compinfo.v_samp_factor * DCTSIZE; ++iy) {
           float* JXL_RESTRICT row = raw_out->Row(y0 + iy);


### PR DESCRIPTION
Remove internal Image3F storage, replace with an array of RowBuffers.

Add test cases for invalid number of channels and unsupported color transforms.