### PR TITLE
jpegli encoder: sanity check component id/index and data precision

### DIFF
--- a/lib/jpegli/bitstream.cc
+++ b/lib/jpegli/bitstream.cc
@@ -11,7 +11,6 @@
 namespace jpegli {
 namespace {
 
-const int kJpegPrecision = 8;
 // JpegBitWriter: buffer size
 const size_t kJpegBitWriterChunkSize = 16384;
 

--- a/lib/jpegli/common_internal.h
+++ b/lib/jpegli/common_internal.h
@@ -40,6 +40,7 @@ constexpr size_t kDCTBlockSize = 64;
 // maximum number of channels the libjpeg-turbo decoder can decode.
 constexpr int kMaxComponents = 4;
 constexpr int kMaxQuantTables = 4;
+constexpr int kJpegPrecision = 8;
 constexpr int kMaxHuffmanTables = 4;
 constexpr size_t kJpegHuffmanMaxBitLength = 16;
 constexpr int kJpegHuffmanAlphabetSize = 256;

--- a/lib/jpegli/decode_marker.cc
+++ b/lib/jpegli/decode_marker.cc
@@ -70,7 +70,7 @@ void ProcessSOF(j_decompress_ptr cinfo, const uint8_t* data, size_t len) {
   cinfo->image_height = ReadUint16(data, &pos);
   cinfo->image_width = ReadUint16(data, &pos);
   cinfo->num_components = ReadUint8(data, &pos);
-  JPEG_VERIFY_INPUT(cinfo->data_precision, 8, 8);
+  JPEG_VERIFY_INPUT(cinfo->data_precision, kJpegPrecision, kJpegPrecision);
   JPEG_VERIFY_INPUT(cinfo->image_height, 1, kMaxDimPixels);
   JPEG_VERIFY_INPUT(cinfo->image_width, 1, kMaxDimPixels);
   JPEG_VERIFY_INPUT(cinfo->num_components, 1, kMaxComponents);

--- a/lib/jpegli/encode.cc
+++ b/lib/jpegli/encode.cc
@@ -422,6 +422,9 @@ void jpegli_start_compress(j_compress_ptr cinfo, boolean write_all_tables) {
       cinfo->num_components > static_cast<int>(jpegli::kMaxComponents)) {
     JPEGLI_ERROR("Invalid number of components.");
   }
+  if (cinfo->data_precision != jpegli::kJpegPrecision) {
+    JPEGLI_ERROR("Invalid data precision");
+  }
   cinfo->global_state = jpegli::kEncHeader;
   jpeg_comp_master* m = cinfo->master;
   cinfo->next_scanline = 0;
@@ -434,6 +437,14 @@ void jpegli_start_compress(j_compress_ptr cinfo, boolean write_all_tables) {
   cinfo->max_h_samp_factor = cinfo->max_v_samp_factor = 1;
   for (int c = 0; c < cinfo->num_components; ++c) {
     jpeg_component_info* comp = &cinfo->comp_info[c];
+    if (comp->component_index != c) {
+      JPEGLI_ERROR("Invalid component index");
+    }
+    for (int j = 0; j < c; ++j) {
+      if (cinfo->comp_info[j].component_id == comp->component_id) {
+        JPEGLI_ERROR("Duplicate component id %d", comp->component_id);
+      }
+    }
     if (comp->h_samp_factor == 0 || comp->v_samp_factor == 0) {
       JPEGLI_ERROR("Invalid sampling factor 0");
     }


### PR DESCRIPTION
Add tests that custom component ids work