### PR TITLE
Add "encode to same size as libjpeg" option to jpegli benchmark

### DIFF
--- a/lib/extras/enc/jpegli.h
+++ b/lib/extras/enc/jpegli.h
@@ -28,6 +28,8 @@ struct JpegSettings {
   bool use_std_quant_tables = false;
   int progressive_level = 2;
   std::string chroma_subsampling;
+  int libjpeg_quality = 0;
+  std::string libjpeg_chroma_subsampling;
 };
 
 Status EncodeJpeg(const PackedPixelFile& ppf, const JpegSettings& jpeg_settings,

--- a/tools/benchmark/benchmark_codec_jpeg.cc
+++ b/tools/benchmark/benchmark_codec_jpeg.cc
@@ -77,6 +77,15 @@ class JPEGCodec : public ImageCodec {
       use_std_tables_ = true;
       return true;
     }
+    if (param[0] == 'Q') {
+      libjpeg_quality_ = strtol(param.substr(1).c_str(), nullptr, 10);
+      return true;
+    }
+    if (param.compare(0, 3, "YUV") == 0) {
+      if (param.size() != 6) return false;
+      libjpeg_chroma_subsampling_ = param.substr(3);
+      return true;
+    }
     if (param == "dec-jpegli") {
       jpeg_decoder_ = "jpegli";
       return true;
@@ -160,10 +169,10 @@ class JPEGCodec : public ImageCodec {
       if (progressive_id_ >= 0) {
         settings.progressive_level = progressive_id_;
       }
-      if (!chroma_subsampling_.empty()) {
-        settings.chroma_subsampling = chroma_subsampling_;
-      }
+      settings.chroma_subsampling = chroma_subsampling_;
       settings.use_adaptive_quantization = enable_adaptive_quant_;
+      settings.libjpeg_quality = libjpeg_quality_;
+      settings.libjpeg_chroma_subsampling = libjpeg_chroma_subsampling_;
       const double start = Now();
       JXL_RETURN_IF_ERROR(extras::EncodeJpeg(ppf, settings, pool, compressed));
       const double end = Now();
@@ -232,6 +241,8 @@ class JPEGCodec : public ImageCodec {
 #if JPEGXL_ENABLE_JPEGLI
   bool xyb_mode_ = false;
   bool use_std_tables_ = false;
+  int libjpeg_quality_ = 0;
+  std::string libjpeg_chroma_subsampling_;
 #endif
   // JPEG decoder and its parameters
   std::string jpeg_decoder_ = "libjpeg";


### PR DESCRIPTION
Example benchmark output:
```
Encoding                      kPixels    Bytes          BPP  E MP/s  D MP/s     Max norm  SSIMULACRA2        pnorm       BPP*pnorm   Bugs
-----------------------------------------------------------------------------------------------------------------------------------------
jpeg:q80                        13270  3185957    1.9206325  42.855 110.438   3.87432337  83.66896084   0.98216786  1.886383532368      0
jpeg:enc-jpegli:Q80             13270  3186422    1.9209128   0.878  38.530   2.81853485  84.90585484   0.76798638  1.475234906282      0
jpeg:q80:yuv420                 13270  2479762    1.4949077  63.668 166.356   6.31123829  77.72421936   1.23785681  1.850481645598      0
jpeg:enc-jpegli:Q80:YUV420      13270  2477555    1.4935772   0.816  43.066   3.63556981  80.06080922   0.97377009  1.454400802458      0
Aggregate:                      13270  2810245    1.6941369   6.648  74.306   3.97856617  81.53979018   0.97648712  1.654302842317      0
```