### PR TITLE
Quantization mitigation for pixel chessboards

### DIFF
--- a/lib/jxl/encode_test.cc
+++ b/lib/jxl/encode_test.cc
@@ -513,7 +513,7 @@ TEST(EncodeTest, LossyEncoderUseOriginalProfileTest) {
     EXPECT_EQ(JXL_ENC_SUCCESS,
               JxlEncoderFrameSettingsSetOption(
                   frame_settings, JXL_ENC_FRAME_SETTING_PROGRESSIVE_DC, 2));
-    VerifyFrameEncoding(63, 129, enc.get(), frame_settings, 5620, true);
+    VerifyFrameEncoding(63, 129, enc.get(), frame_settings, 5644, true);
   }
   {
     JxlEncoderPtr enc = JxlEncoderMake(nullptr);

--- a/lib/jxl/jxl_test.cc
+++ b/lib/jxl/jxl_test.cc
@@ -1063,7 +1063,7 @@ TEST(JxlTest, RoundtripDots) {
   cparams.distance = 0.04;
 
   PackedPixelFile ppf_out;
-  EXPECT_NEAR(Roundtrip(t.ppf(), cparams, {}, pool, &ppf_out), 271125, 800);
+  EXPECT_NEAR(Roundtrip(t.ppf(), cparams, {}, pool, &ppf_out), 274643, 800);
   EXPECT_THAT(ButteraugliDistance(t.ppf(), ppf_out), IsSlightlyBelow(0.3));
 }
 
@@ -1083,7 +1083,7 @@ TEST(JxlTest, RoundtripNoise) {
   cparams.AddOption(JXL_ENC_FRAME_SETTING_NOISE, 1);
 
   PackedPixelFile ppf_out;
-  EXPECT_NEAR(Roundtrip(t.ppf(), cparams, {}, pool, &ppf_out), 39864, 750);
+  EXPECT_NEAR(Roundtrip(t.ppf(), cparams, {}, pool, &ppf_out), 40616, 750);
   EXPECT_THAT(ButteraugliDistance(t.ppf(), ppf_out), IsSlightlyBelow(1.7));
 }
 
@@ -1387,7 +1387,7 @@ TEST(JxlTest, RoundtripProgressiveLevel2Slow) {
   cparams.AddOption(JXL_ENC_FRAME_SETTING_RESPONSIVE, 1);
 
   PackedPixelFile ppf_out;
-  EXPECT_NEAR(Roundtrip(t.ppf(), cparams, {}, &pool, &ppf_out), 68700, 1000);
+  EXPECT_NEAR(Roundtrip(t.ppf(), cparams, {}, &pool, &ppf_out), 69534, 1000);
   EXPECT_THAT(ButteraugliDistance(t.ppf(), ppf_out), IsSlightlyBelow(1.17));
 }
 


### PR DESCRIPTION
This with jyrki31 test corpus + one 1024x1024 chessboard image (with many 64x64 chessboards of various colors and intensities)

Notably, at d2.0 the maximum error goes down from 30 to 3.5. That is mostly indicative how poorly pixel chessboards worked before.

Afterwards, the pixel chessboards look mostly good, with the exception of chessboards with X or B channel only -- because this heuristic only looks at Y channel.

```
Before:

Encoding      kPixels    Bytes          BPP  E MP/s  D MP/s     Max norm  SSIMULACRA2        pnorm   PSNR   QABPP  SmallB  DCT4x8     AFV  DCT8x8    8x16    8x32      16   16x32      32   32x64      64       BPP*pnorm   Bugs
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
jxl:d0.1        19660 15285513    6.2198123   1.559   9.329   3.18274117  98.90720298   0.17834696  51.32   6.429 38.2944 20.1303  0.5785 28.8039  6.3478  0.0000  2.8243  0.9740  2.5886  0.1146  0.0833  1.109284606258      0
jxl:d0.5        19660  5758911    2.3433525   1.868  15.143   4.58528328  95.98842017   0.43210077  43.62   2.456 13.9619 23.5057  0.6787 12.6510 25.9719  0.0000 17.2334  1.4297  4.7136  0.1354  0.4583  1.012564436398      0
jxl:d0.8        19660  4300410    1.7498754   2.035  15.564   6.12889576  90.58297507   0.58227516  41.24   2.128 10.7590 20.5603  0.7637  9.5096 24.0773  0.0000 26.7414  1.7188  5.9428  0.1667  0.5000  1.018908981484      0
jxl:d1          19660  3727802    1.5168761   2.068  15.675  15.75840759  87.62856034   0.73727427  40.13   2.318  9.5783 19.1065  0.7832  8.2769 21.1163  0.0000 30.5240  2.9063  7.9689  0.2083  0.2708  1.118353697963      0
jxl:d1.1        19660  3511084    1.4286916   2.029  16.466  16.30647087  86.02188135   0.80169400  39.66   2.299  9.0607 18.4831  0.8135  7.8309 19.7836  0.0000 31.0332  3.8438  9.3700  0.2292  0.2917  1.145373452702      0
jxl:d1.2        19660  3318076    1.3501549   2.142  16.484  17.04756165  85.00128419   0.84722145  39.27   2.316  8.6108 17.8994  0.8480  7.4165 18.5186  0.0000 31.0136  5.0782 10.8335  0.2500  0.2708  1.143880172636      0
jxl:d1.3        19660  3181741    1.2946789   2.100  16.936  22.17009544  83.77078235   0.93334219  38.97   2.392  8.2153 17.4746  0.8532  7.0727 17.7074  0.0000 30.3118  6.4272 12.2398  0.2708  0.1667  1.208378482017      0
jxl:d1.4        19660  3030019    1.2329419   2.095  17.064  19.84115982  82.77614525   0.94424744  38.64   2.337  7.8725 16.9805  0.8659  6.7921 16.9111  0.0000 29.5227  7.7423 13.5107  0.3125  0.2292  1.164202242101      0
jxl:d1.5        19660  2891788    1.1766945   2.103  16.157  21.40610504  82.13017953   0.99482577  38.36   2.360  7.5783 16.5231  0.8740  6.4907 16.3922  0.0000 28.7167  9.0965 14.5367  0.2813  0.2500  1.170605978630      0
jxl:d1.6        19660  2771186    1.1276204   2.200  15.791  21.09371567  81.27321085   1.02475352  38.02   2.386  7.3042 16.1517  0.8972  6.3051 15.9879  0.0000 27.7961 10.2189 15.4013  0.3854  0.2917  1.155533007281      0
jxl:d1.7        19660  2660263    1.0824849   2.154  15.875  24.99162483  79.85406255   1.11194295  37.73   2.413  7.0402 15.7965  0.9147  6.1573 15.5823  0.0000 26.8911 11.1122 16.5055  0.3854  0.3542  1.203661423657      0
jxl:d1.8        19660  2557614    1.0407161   2.175  16.137  25.73122787  79.01717836   1.14967682  37.44   2.394  6.7879 15.4847  0.9457  5.9829 15.2913  0.0000 26.0617 12.2581 17.0732  0.4167  0.4375  1.196487146026      0
jxl:d1.8        19660  2557614    1.0407161   2.189  16.491  25.73122787  79.01717836   1.14967682  37.44   2.394  6.7879 15.4847  0.9457  5.9829 15.2913  0.0000 26.0617 12.2581 17.0732  0.4167  0.4375  1.196487146026      0
jxl:d1.9        19660  2465047    1.0030497   2.132  16.663  24.53771973  78.31200138   1.16587874  37.19   2.383  6.5454 15.1920  0.9658  5.8416 15.0205  0.0000 25.3351 13.1513 17.7920  0.4167  0.4792  1.169434359586      0
jxl:d2.0        19660  2379650    0.9683009   2.220  16.549  30.10737419  77.11274358   1.26991006  36.93   2.410  6.3426 14.9147  0.9730  5.6694 14.8271  0.0000 24.6528 14.0263 18.4066  0.4063  0.5208  1.229655083175      0
jxl:d2.1        19660  2299105    0.9355264   2.224  15.948  28.90901566  76.75351768   1.28277021  36.67   2.404  6.1215 14.5195  0.9932  5.5493 14.6604  0.0000 24.0512 14.7503 19.1775  0.4375  0.4792  1.200065449057      0
jxl:d2.2        19660  2225331    0.9055071   2.220  16.127  28.63033485  75.40630586   1.31152868  36.47   2.413  5.9194 14.2324  1.0169  5.4373 14.5439  0.0000 23.4536 15.4951 19.6827  0.4375  0.5208  1.187598586166      0
jxl:d2.3        19660  2157452    0.8778866   2.266  16.816  25.76671982  75.21279032   1.30823075  36.28   2.421  5.8315 13.9251  1.0114  5.3302 14.2965  0.0000 22.9067 16.0576 20.2973  0.5208  0.5625  1.148478202197      0
jxl:d2.4        19660  2092198    0.8513341   2.162  15.992  26.65978050  74.36223158   1.34892045  36.06   2.426  5.6580 13.6389  1.0257  5.2351 14.1624  0.0000 22.4431 16.6696 20.7608  0.5833  0.5625  1.148382018403      0
jxl:d2.5        19660  2031651    0.8266970   2.199  16.777  28.63738060  73.82552894   1.40463757  35.88   2.440  5.4864 13.3531  1.0326  5.1271 14.0309  0.0000 21.9744 17.2243 21.2296  0.6146  0.6667  1.161209679241      0
jxl:d2.6        19660  1974071    0.8032672   2.180  16.100  25.89699173  73.14946242   1.40062668  35.71   2.398  5.3481 13.1630  1.0518  5.0086 13.9417  0.0000 21.4366 17.6540 21.8858  0.6042  0.6458  1.125077464498      0
jxl:d2.7        19660  1920388    0.7814231   2.281  16.804  32.79170227  71.89590145   1.51716235  35.51   2.433  5.2000 12.9212  1.0664  4.9444 13.8525  0.0000 20.8975 18.2321 22.2504  0.6667  0.7083  1.185545704397      0
jxl:d2.8        19660  1870055    0.7609422   2.222  16.489  34.37881851  70.98963239   1.56722055  35.33   2.476  5.0675 12.7333  1.0798  4.8653 13.6891  0.0000 20.4705 18.6879 22.6567  0.7396  0.7500  1.192564174402      0
jxl:d2.9        19660  1821584    0.7412189   2.291  16.888  30.76279831  70.23378107   1.55438167  35.16   2.425  4.9662 12.4788  1.0908  4.7498 13.7275  0.0000 20.0668 19.0499 23.0890  0.7083  0.8125  1.152137018484      0
jxl:d3          19660  1779380    0.7240457   2.084  16.314  32.19166565  69.45170596   1.59732386  35.00   2.413  4.7641 12.2974  1.0596  4.6768 13.5901  0.0000 19.6137 19.6332 23.5942  0.7188  0.7917  1.156535439924      0
jxl:d5          19660  1215913    0.4947659   2.063   8.945  28.43227768  58.88559861   2.05787125  32.76   2.364  3.2937  8.0773  0.9535  2.9975 10.9553  0.0000 15.4769 27.8599 29.1047  0.6875  1.3334  1.018164529156      0
jxl:d7          19660   940989    0.3828969   2.116   8.875  28.10729599  48.80101883   2.49970088  31.37   2.333  2.5313  5.7101  0.7949  2.0759  9.2430  0.0000 12.9820 33.0215 31.9850  0.6875  1.7084  0.957127627451      0
jxl:d15         19660   523837    0.2131540   2.143   8.520  32.54151154  19.64166421   4.01223049  28.58   2.200  1.2155  1.7230  0.3125  0.5921  5.4558  0.0000  7.4572 38.2169 40.9435  1.1979  3.6251  0.855222871587      0
jxl:d24         19660   376660    0.1532663   0.312  21.085  56.09043503  -7.28447933   6.27872138  26.32   2.580  1.0124  2.2338  0.1748  0.7015  3.0658  0.0000  3.2774  9.4273  5.5574  0.0104  0.0000  0.962316595795      0
jxl:d32         19660   302561    0.1231148   0.314  20.553  55.51866150 -19.86526829   7.03200490  25.83   2.345  0.7474  1.6908  0.1458  0.5104  2.7461  0.0000  2.8490 10.4377  6.3335  0.0000  0.0000  0.865743767053      0
Aggregate:      19660  2151114    0.8753075   1.867  15.283  22.48970150  73.61845763   1.27252665  36.32   2.460  5.6412 11.9669  0.7834  4.8460 13.0158  0.0000 18.4801 10.1550 14.6434  0.3565  0.4876  1.113852146072      0

After:

Encoding      kPixels    Bytes          BPP  E MP/s  D MP/s     Max norm  SSIMULACRA2        pnorm   PSNR   QABPP  SmallB  DCT4x8     AFV  DCT8x8    8x16    8x32      16   16x32      32   32x64      64       BPP*pnorm   Bugs
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
jxl:d0.1        19660 15915521    6.4761682   1.511   9.198   3.23348093  98.99428664   0.17878710  51.72   7.029 38.2944 20.1303  0.5785 28.8039  6.3478  0.0000  2.8243  0.9740  2.5886  0.1146  0.0833  1.157855335029      0
jxl:d0.5        19660  5940553    2.4172643   1.810  15.045   3.21276617  96.70010097   0.42161284  44.71   2.619 13.9619 23.5057  0.6787 12.6510 25.9719  0.0000 17.2334  1.4297  4.7136  0.1354  0.4583  1.019149654873      0
jxl:d0.8        19660  4418323    1.7978553   2.008  15.586   3.26057243  91.77612269   0.55444754  42.24   2.217 10.7590 20.5603  0.7637  9.5096 24.0773  0.0000 26.7414  1.7188  5.9428  0.1667  0.5000  0.996816431280      0
jxl:d1          19660  3821557    1.5550258   2.020  15.784   3.19191217  89.17550376   0.63126644  41.07   2.257  9.5783 19.1065  0.7832  8.2769 21.1163  0.0000 30.5240  2.9063  7.9689  0.2083  0.2708  0.981635605490      0
jxl:d1.1        19660  3595373    1.4629895   1.948  16.054   3.02163076  87.97909844   0.66618317  40.51   2.223  9.0607 18.4831  0.8135  7.8309 19.7836  0.0000 31.0332  3.8438  9.3700  0.2292  0.2917  0.974619000831      0
jxl:d1.2        19660  3394296    1.3811695   2.056  16.337   3.08511353  86.90772420   0.70215403  40.08   2.233  8.6108 17.8994  0.8480  7.4165 18.5186  0.0000 31.0136  5.0782 10.8335  0.2500  0.2708  0.969793716745      0
jxl:d1.3        19660  3250490    1.3226535   2.071  16.742   3.07759953  86.06076135   0.73135460  39.79   2.249  8.2153 17.4746  0.8532  7.0727 17.7074  0.0000 30.3118  6.4272 12.2398  0.2708  0.1667  0.967328744173      0
jxl:d1.4        19660  3090600    1.2575929   2.047  16.900   3.40462303  85.05613470   0.76857948  39.40   2.234  7.8725 16.9805  0.8659  6.7921 16.9111  0.0000 29.5227  7.7423 13.5107  0.3125  0.2292  0.966560064143      0
jxl:d1.5        19660  2948569    1.1997992   2.008  15.070   3.39136982  84.14519254   0.79924511  39.02   2.246  7.5783 16.5231  0.8740  6.4907 16.3922  0.0000 28.7167  9.0965 14.5367  0.2813  0.2500  0.958933618557      0
jxl:d1.6        19660  2824054    1.1491329   2.146  16.066   3.44558048  83.34327459   0.83401360  38.69   2.279  7.3042 16.1517  0.8972  6.3051 15.9879  0.0000 27.7961 10.2189 15.4013  0.3854  0.2917  0.958392464199      0
jxl:d1.7        19660  2710253    1.1028263   2.118  16.365   3.40887260  82.45981499   0.86611295  38.37   2.269  7.0402 15.7965  0.9147  6.1573 15.5823  0.0000 26.8911 11.1122 16.5055  0.3854  0.3542  0.955172099442      0
jxl:d1.8        19660  2606242    1.0605032   2.136  15.608   3.65920663  81.62967548   0.90119599  38.06   2.258  6.7879 15.4847  0.9457  5.9829 15.2913  0.0000 26.0617 12.2581 17.0732  0.4167  0.4375  0.955721266341      0
jxl:d1.8        19660  2606242    1.0605032   2.104  16.206   3.65920663  81.62967548   0.90119599  38.06   2.258  6.7879 15.4847  0.9457  5.9829 15.2913  0.0000 26.0617 12.2581 17.0732  0.4167  0.4375  0.955721266341      0
jxl:d1.9        19660  2510343    1.0214811   2.050  16.363   3.44089222  80.88385436   0.93265881  37.78   2.253  6.5454 15.1920  0.9658  5.8416 15.0205  0.0000 25.3351 13.1513 17.7920  0.4167  0.4792  0.952693326213      0
jxl:d2.0        19660  2422289    0.9856511   2.156  16.548   3.52861285  80.05436538   0.96541137  37.51   2.231  6.3426 14.9147  0.9730  5.6694 14.8271  0.0000 24.6528 14.0263 18.4066  0.4063  0.5208  0.951558799842      0
jxl:d2.1        19660  2335046    0.9501512   2.195  16.317   3.65361166  79.34253115   0.99782196  37.23   2.241  6.1215 14.5195  0.9932  5.5493 14.6604  0.0000 24.0512 14.7503 19.1775  0.4375  0.4792  0.948081692336      0
jxl:d2.2        19660  2259378    0.9193612   2.171  16.436   3.80213356  78.64778952   1.02662662  36.98   2.256  5.9194 14.2324  1.0169  5.4373 14.5439  0.0000 23.4536 15.4951 19.6827  0.4375  0.5208  0.943840654685      0
jxl:d2.3        19660  2190258    0.8912356   2.157  16.028   3.74905729  77.84159993   1.05957591  36.76   2.291  5.8315 13.9251  1.0114  5.3302 14.2965  0.0000 22.9067 16.0576 20.2973  0.5208  0.5625  0.944331794368      0
jxl:d2.4        19660  2121605    0.8633001   2.143  15.503   5.56280613  77.05809168   1.10143645  36.53   2.324  5.6580 13.6389  1.0257  5.2351 14.1624  0.0000 22.4431 16.6696 20.7608  0.5833  0.5625  0.950870195288      0
jxl:d2.5        19660  2060571    0.8384648   2.155  16.320   3.93239069  76.47608534   1.12299907  36.33   2.294  5.4864 13.3531  1.0326  5.1271 14.0309  0.0000 21.9744 17.2243 21.2296  0.6146  0.6667  0.941595210880      0
jxl:d2.6        19660  2000782    0.8141361   2.188  16.678   4.80652714  75.63320487   1.15899781  36.11   2.291  5.3481 13.1630  1.0518  5.0086 13.9417  0.0000 21.4366 17.6540 21.8858  0.6042  0.6458  0.943582004230      0
jxl:d2.7        19660  1946039    0.7918607   2.191  16.579   4.91346264  74.91770216   1.18841252  35.91   2.273  5.2000 12.9212  1.0664  4.9444 13.8525  0.0000 20.8975 18.2321 22.2504  0.6667  0.7083  0.941057199998      0
jxl:d2.8        19660  1893871    0.7706331   2.125  15.577   5.93927717  74.25805530   1.23083505  35.72   2.309  5.0675 12.7333  1.0798  4.8653 13.6891  0.0000 20.4705 18.6879 22.6567  0.7396  0.7500  0.948522227414      0
jxl:d2.9        19660  1846518    0.7513647   2.240  16.027   5.95156193  73.57390472   1.26500859  35.56   2.306  4.9662 12.4788  1.0908  4.7498 13.7275  0.0000 20.0668 19.0499 23.0890  0.7083  0.8125  0.950482845287      0
jxl:d3          19660  1802405    0.7334148   1.998  15.813   5.96634293  72.89312102   1.29378636  35.39   2.274  4.7641 12.2974  1.0596  4.6768 13.5901  0.0000 19.6137 19.6332 23.5942  0.7188  0.7917  0.948882011851      0
jxl:d5          19660  1227702    0.4995630   2.000   8.763  12.54645920  60.87488553   1.93602398  32.92   2.337  3.2937  8.0773  0.9535  2.9975 10.9553  0.0000 15.4769 27.8599 29.1047  0.6875  1.3334  0.967165859859      0
jxl:d7          19660   950946    0.3869485   2.063   8.691  12.57927036  50.95635549   2.38693454  31.47   2.310  2.5313  5.7101  0.7949  2.0759  9.2430  0.0000 12.9820 33.0215 31.9850  0.6875  1.7084  0.923620635913      0
jxl:d15         19660   529406    0.2154200   2.095   8.354  17.83192444  21.15758599   3.90608877  28.66   2.197  1.2155  1.7230  0.3125  0.5921  5.4558  0.0000  7.4572 38.2169 40.9435  1.1979  3.6251  0.841449834740      0
jxl:d24         19660   378108    0.1538555   0.315  20.858  56.09043503  -7.20690824   6.27287860  26.32   2.579  1.0124  2.2338  0.1748  0.7015  3.0658  0.0000  3.2774  9.4273  5.5574  0.0104  0.0000  0.965117100041      0
jxl:d32         19660   303632    0.1235506   0.315  20.381  55.51866150 -19.83113159   7.02958462  25.83   2.352  0.7474  1.6908  0.1458  0.5104  2.7461  0.0000  2.8490 10.4377  6.3335  0.0000  0.0000  0.868509284476      0
Aggregate:      19660  2188678    0.8905926   1.820  15.069   5.22059578  76.02229916   1.07470677  36.82   2.377  5.6412 11.9669  0.7834  4.8460 13.0158  0.0000 18.4801 10.1550 14.6434  0.3565  0.4876  0.957125840835      0
```