### PR TITLE
some improvement in chessboard heuristics

### DIFF
--- a/lib/jxl/jxl_test.cc
+++ b/lib/jxl/jxl_test.cc
@@ -1063,7 +1063,7 @@ TEST(JxlTest, RoundtripDots) {
   cparams.distance = 0.04;
 
   PackedPixelFile ppf_out;
-  EXPECT_NEAR(Roundtrip(t.ppf(), cparams, {}, pool, &ppf_out), 274643, 800);
+  EXPECT_NEAR(Roundtrip(t.ppf(), cparams, {}, pool, &ppf_out), 271410, 3000);
   EXPECT_THAT(ButteraugliDistance(t.ppf(), ppf_out), IsSlightlyBelow(0.3));
 }
 


### PR DESCRIPTION
3-4 % better Max Norm, some improvement in BPP*pnorm, pnorm, while size is reduced.

The detrimental impact of previous heuristics greatly reduced at d0.1 and d0.5

```
Before:

Encoding      kPixels    Bytes          BPP  E MP/s  D MP/s     Max norm  SSIMULACRA2        pnorm   PSNR   QABPP  SmallB  DCT4x8     AFV  DCT8x8    8x16    8x32      16   16x32      32   32x64      64       BPP*pnorm   Bugs
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
jxl:d0.1        19660 15915521    6.4761682   1.511   9.198   3.23348093  98.99428664   0.17878710  51.72   7.029 38.2944 20.1303  0.5785 28.8039  6.3478  0.0000  2.8243  0.9740  2.5886  0.1146  0.0833  1.157855335029      0
jxl:d0.5        19660  5940553    2.4172643   1.810  15.045   3.21276617  96.70010097   0.42161284  44.71   2.619 13.9619 23.5057  0.6787 12.6510 25.9719  0.0000 17.2334  1.4297  4.7136  0.1354  0.4583  1.019149654873      0
jxl:d0.8        19660  4418323    1.7978553   2.008  15.586   3.26057243  91.77612269   0.55444754  42.24   2.217 10.7590 20.5603  0.7637  9.5096 24.0773  0.0000 26.7414  1.7188  5.9428  0.1667  0.5000  0.996816431280      0
jxl:d1          19660  3821557    1.5550258   2.020  15.784   3.19191217  89.17550376   0.63126644  41.07   2.257  9.5783 19.1065  0.7832  8.2769 21.1163  0.0000 30.5240  2.9063  7.9689  0.2083  0.2708  0.981635605490      0
jxl:d1.1        19660  3595373    1.4629895   1.948  16.054   3.02163076  87.97909844   0.66618317  40.51   2.223  9.0607 18.4831  0.8135  7.8309 19.7836  0.0000 31.0332  3.8438  9.3700  0.2292  0.2917  0.974619000831      0
jxl:d1.2        19660  3394296    1.3811695   2.056  16.337   3.08511353  86.90772420   0.70215403  40.08   2.233  8.6108 17.8994  0.8480  7.4165 18.5186  0.0000 31.0136  5.0782 10.8335  0.2500  0.2708  0.969793716745      0
jxl:d1.3        19660  3250490    1.3226535   2.071  16.742   3.07759953  86.06076135   0.73135460  39.79   2.249  8.2153 17.4746  0.8532  7.0727 17.7074  0.0000 30.3118  6.4272 12.2398  0.2708  0.1667  0.967328744173      0
jxl:d1.4        19660  3090600    1.2575929   2.047  16.900   3.40462303  85.05613470   0.76857948  39.40   2.234  7.8725 16.9805  0.8659  6.7921 16.9111  0.0000 29.5227  7.7423 13.5107  0.3125  0.2292  0.966560064143      0
jxl:d1.5        19660  2948569    1.1997992   2.008  15.070   3.39136982  84.14519254   0.79924511  39.02   2.246  7.5783 16.5231  0.8740  6.4907 16.3922  0.0000 28.7167  9.0965 14.5367  0.2813  0.2500  0.958933618557      0
jxl:d1.6        19660  2824054    1.1491329   2.146  16.066   3.44558048  83.34327459   0.83401360  38.69   2.279  7.3042 16.1517  0.8972  6.3051 15.9879  0.0000 27.7961 10.2189 15.4013  0.3854  0.2917  0.958392464199      0
jxl:d1.7        19660  2710253    1.1028263   2.118  16.365   3.40887260  82.45981499   0.86611295  38.37   2.269  7.0402 15.7965  0.9147  6.1573 15.5823  0.0000 26.8911 11.1122 16.5055  0.3854  0.3542  0.955172099442      0
jxl:d1.8        19660  2606242    1.0605032   2.136  15.608   3.65920663  81.62967548   0.90119599  38.06   2.258  6.7879 15.4847  0.9457  5.9829 15.2913  0.0000 26.0617 12.2581 17.0732  0.4167  0.4375  0.955721266341      0
jxl:d1.8        19660  2606242    1.0605032   2.104  16.206   3.65920663  81.62967548   0.90119599  38.06   2.258  6.7879 15.4847  0.9457  5.9829 15.2913  0.0000 26.0617 12.2581 17.0732  0.4167  0.4375  0.955721266341      0
jxl:d1.9        19660  2510343    1.0214811   2.050  16.363   3.44089222  80.88385436   0.93265881  37.78   2.253  6.5454 15.1920  0.9658  5.8416 15.0205  0.0000 25.3351 13.1513 17.7920  0.4167  0.4792  0.952693326213      0
jxl:d2.0        19660  2422289    0.9856511   2.156  16.548   3.52861285  80.05436538   0.96541137  37.51   2.231  6.3426 14.9147  0.9730  5.6694 14.8271  0.0000 24.6528 14.0263 18.4066  0.4063  0.5208  0.951558799842      0
jxl:d2.1        19660  2335046    0.9501512   2.195  16.317   3.65361166  79.34253115   0.99782196  37.23   2.241  6.1215 14.5195  0.9932  5.5493 14.6604  0.0000 24.0512 14.7503 19.1775  0.4375  0.4792  0.948081692336      0
jxl:d2.2        19660  2259378    0.9193612   2.171  16.436   3.80213356  78.64778952   1.02662662  36.98   2.256  5.9194 14.2324  1.0169  5.4373 14.5439  0.0000 23.4536 15.4951 19.6827  0.4375  0.5208  0.943840654685      0
jxl:d2.3        19660  2190258    0.8912356   2.157  16.028   3.74905729  77.84159993   1.05957591  36.76   2.291  5.8315 13.9251  1.0114  5.3302 14.2965  0.0000 22.9067 16.0576 20.2973  0.5208  0.5625  0.944331794368      0
jxl:d2.4        19660  2121605    0.8633001   2.143  15.503   5.56280613  77.05809168   1.10143645  36.53   2.324  5.6580 13.6389  1.0257  5.2351 14.1624  0.0000 22.4431 16.6696 20.7608  0.5833  0.5625  0.950870195288      0
jxl:d2.5        19660  2060571    0.8384648   2.155  16.320   3.93239069  76.47608534   1.12299907  36.33   2.294  5.4864 13.3531  1.0326  5.1271 14.0309  0.0000 21.9744 17.2243 21.2296  0.6146  0.6667  0.941595210880      0
jxl:d2.6        19660  2000782    0.8141361   2.188  16.678   4.80652714  75.63320487   1.15899781  36.11   2.291  5.3481 13.1630  1.0518  5.0086 13.9417  0.0000 21.4366 17.6540 21.8858  0.6042  0.6458  0.943582004230      0
jxl:d2.7        19660  1946039    0.7918607   2.191  16.579   4.91346264  74.91770216   1.18841252  35.91   2.273  5.2000 12.9212  1.0664  4.9444 13.8525  0.0000 20.8975 18.2321 22.2504  0.6667  0.7083  0.941057199998      0
jxl:d2.8        19660  1893871    0.7706331   2.125  15.577   5.93927717  74.25805530   1.23083505  35.72   2.309  5.0675 12.7333  1.0798  4.8653 13.6891  0.0000 20.4705 18.6879 22.6567  0.7396  0.7500  0.948522227414      0
jxl:d2.9        19660  1846518    0.7513647   2.240  16.027   5.95156193  73.57390472   1.26500859  35.56   2.306  4.9662 12.4788  1.0908  4.7498 13.7275  0.0000 20.0668 19.0499 23.0890  0.7083  0.8125  0.950482845287      0
jxl:d3          19660  1802405    0.7334148   1.998  15.813   5.96634293  72.89312102   1.29378636  35.39   2.274  4.7641 12.2974  1.0596  4.6768 13.5901  0.0000 19.6137 19.6332 23.5942  0.7188  0.7917  0.948882011851      0
jxl:d5          19660  1227702    0.4995630   2.000   8.763  12.54645920  60.87488553   1.93602398  32.92   2.337  3.2937  8.0773  0.9535  2.9975 10.9553  0.0000 15.4769 27.8599 29.1047  0.6875  1.3334  0.967165859859      0
jxl:d7          19660   950946    0.3869485   2.063   8.691  12.57927036  50.95635549   2.38693454  31.47   2.310  2.5313  5.7101  0.7949  2.0759  9.2430  0.0000 12.9820 33.0215 31.9850  0.6875  1.7084  0.923620635913      0
jxl:d15         19660   529406    0.2154200   2.095   8.354  17.83192444  21.15758599   3.90608877  28.66   2.197  1.2155  1.7230  0.3125  0.5921  5.4558  0.0000  7.4572 38.2169 40.9435  1.1979  3.6251  0.841449834740      0
jxl:d24         19660   378108    0.1538555   0.315  20.858  56.09043503  -7.20690824   6.27287860  26.32   2.579  1.0124  2.2338  0.1748  0.7015  3.0658  0.0000  3.2774  9.4273  5.5574  0.0104  0.0000  0.965117100041      0
jxl:d32         19660   303632    0.1235506   0.315  20.381  55.51866150 -19.83113159   7.02958462  25.83   2.352  0.7474  1.6908  0.1458  0.5104  2.7461  0.0000  2.8490 10.4377  6.3335  0.0000  0.0000  0.868509284476      0
Aggregate:      19660  2188678    0.8905926   1.820  15.069   5.22059578  76.02229916   1.07470677  36.82   2.377  5.6412 11.9669  0.7834  4.8460 13.0158  0.0000 18.4801 10.1550 14.6434  0.3565  0.4876  0.957125840835      0

After:

Encoding      kPixels    Bytes          BPP  E MP/s  D MP/s     Max norm  SSIMULACRA2        pnorm   PSNR   QABPP  SmallB  DCT4x8     AFV  DCT8x8    8x16    8x32      16   16x32      32   32x64      64       BPP*pnorm   Bugs
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
jxl:d0.1        19660 15470356    6.2950266   1.474   9.355   3.24331164  98.98237217   0.17969489  51.65   6.661 38.2944 20.1303  0.5785 28.8039  6.3478  0.0000  2.8243  0.9740  2.5886  0.1146  0.0833  1.131184082069      0
jxl:d0.5        19660  5846626    2.3790446   1.785  15.295   3.24575996  96.62373340   0.42341970  44.57   2.538 13.9619 23.5057  0.6787 12.6510 25.9719  0.0000 17.2334  1.4297  4.7136  0.1354  0.4583  1.007334328584      0
jxl:d0.8        19660  4364921    1.7761255   1.937  15.816   3.23406839  91.73645535   0.55552429  42.12   2.165 10.7590 20.5603  0.7637  9.5096 24.0773  0.0000 26.7414  1.7188  5.9428  0.1667  0.5000  0.986680857555      0
jxl:d1          19660  3781775    1.5388382   2.030  15.739   3.20305562  89.17181209   0.63291772  40.98   2.214  9.5783 19.1065  0.7832  8.2769 21.1163  0.0000 30.5240  2.9063  7.9689  0.2083  0.2708  0.973957936775      0
jxl:d1.1        19660  3560723    1.4488901   1.942  16.508   3.26551270  88.00954199   0.66980377  40.46   2.194  9.0607 18.4831  0.8135  7.8309 19.7836  0.0000 31.0332  3.8438  9.3700  0.2292  0.2917  0.970472066094      0
jxl:d1.2        19660  3364901    1.3692084   2.080  16.582   3.15158653  86.90384359   0.70480442  40.04   2.205  8.6108 17.8994  0.8480  7.4165 18.5186  0.0000 31.0136  5.0782 10.8335  0.2500  0.2708  0.965024130203      0
jxl:d1.3        19660  3225202    1.3123636   2.008  16.974   3.25452399  86.04335845   0.73503892  39.77   2.228  8.2153 17.4746  0.8532  7.0727 17.7074  0.0000 30.3118  6.4272 12.2398  0.2708  0.1667  0.964638333958      0
jxl:d1.4        19660  3069897    1.2491686   2.041  17.250   3.40553498  85.06947465   0.76652042  39.37   2.211  7.8725 16.9805  0.8659  6.7921 16.9111  0.0000 29.5227  7.7423 13.5107  0.3125  0.2292  0.957513259676      0
jxl:d1.5        19660  2930020    1.1922514   2.010  15.588   3.39355731  84.17136756   0.79851649  38.99   2.223  7.5783 16.5231  0.8740  6.4907 16.3922  0.0000 28.7167  9.0965 14.5367  0.2813  0.2500  0.952032415621      0
jxl:d1.6        19660  2805841    1.1417219   2.140  15.845   3.44580889  83.41801627   0.83506146  38.66   2.256  7.3042 16.1517  0.8972  6.3051 15.9879  0.0000 27.7961 10.2189 15.4013  0.3854  0.2917  0.953407932037      0
jxl:d1.7        19660  2692185    1.0954742   2.057  15.787   3.40849876  82.55143591   0.86845242  38.36   2.246  7.0402 15.7965  0.9147  6.1573 15.5823  0.0000 26.8911 11.1122 16.5055  0.3854  0.3542  0.951367243733      0
jxl:d1.8        19660  2589056    1.0535101   2.066  16.071   3.65659642  81.70554243   0.90099712  38.04   2.234  6.7879 15.4847  0.9457  5.9829 15.2913  0.0000 26.0617 12.2581 17.0732  0.4167  0.4375  0.949209567757      0
jxl:d1.8        19660  2589056    1.0535101   2.119  16.376   3.65659642  81.70554243   0.90099712  38.04   2.234  6.7879 15.4847  0.9457  5.9829 15.2913  0.0000 26.0617 12.2581 17.0732  0.4167  0.4375  0.949209567757      0
jxl:d1.9        19660  2494890    1.0151931   2.069  16.268   3.44227457  80.92734557   0.93199520  37.77   2.232  6.5454 15.1920  0.9658  5.8416 15.0205  0.0000 25.3351 13.1513 17.7920  0.4167  0.4792  0.946155110990      0
jxl:d2.0        19660  2408453    0.9800211   2.127  16.424   3.52408361  80.07560312   0.96389798  37.50   2.213  6.3426 14.9147  0.9730  5.6694 14.8271  0.0000 24.6528 14.0263 18.4066  0.4063  0.5208  0.944640380932      0
jxl:d2.1        19660  2325135    0.9461183   2.177  15.533   3.54583693  79.44720327   0.99532190  37.23   2.225  6.1215 14.5195  0.9932  5.5493 14.6604  0.0000 24.0512 14.7503 19.1775  0.4375  0.4792  0.941692246924      0
jxl:d2.2        19660  2250033    0.9155586   2.117  16.143   3.80066013  78.70103406   1.02592800  36.98   2.240  5.9194 14.2324  1.0169  5.4373 14.5439  0.0000 23.4536 15.4951 19.6827  0.4375  0.5208  0.939297208219      0
jxl:d2.3        19660  2181139    0.8875250   2.160  16.206   3.74887323  77.94255971   1.05899398  36.77   2.278  5.8315 13.9251  1.0114  5.3302 14.2965  0.0000 22.9067 16.0576 20.2973  0.5208  0.5625  0.939883650172      0
jxl:d2.4        19660  2115014    0.8606182   2.126  15.559   3.70150709  77.16421901   1.09015708  36.56   2.279  5.6580 13.6389  1.0257  5.2351 14.1624  0.0000 22.4431 16.6696 20.7608  0.5833  0.5625  0.938208988787      0
jxl:d2.5        19660  2053618    0.8356356   2.157  16.602   3.93240738  76.56359378   1.12239630  36.36   2.284  5.4864 13.3531  1.0326  5.1271 14.0309  0.0000 21.9744 17.2243 21.2296  0.6146  0.6667  0.937914289383      0
jxl:d2.6        19660  1994611    0.8116251   2.136  15.397   4.18759918  75.78727570   1.15611981  36.14   2.270  5.3481 13.1630  1.0518  5.0086 13.9417  0.0000 21.4366 17.6540 21.8858  0.6042  0.6458  0.938335859083      0
jxl:d2.7        19660  1940546    0.7896256   2.237  16.211   4.51921225  75.08630625   1.18546997  35.94   2.257  5.2000 12.9212  1.0664  4.9444 13.8525  0.0000 20.8975 18.2321 22.2504  0.6667  0.7083  0.936077404955      0
jxl:d2.8        19660  1889396    0.7688122   2.129  15.593   5.25712490  74.37716831   1.21744077  35.76   2.285  5.0675 12.7333  1.0798  4.8653 13.6891  0.0000 20.4705 18.6879 22.6567  0.7396  0.7500  0.935983290591      0
jxl:d2.9        19660  1840547    0.7489351   2.204  16.615   4.65550852  73.65458728   1.24727457  35.59   2.271  4.9662 12.4788  1.0908  4.7498 13.7275  0.0000 20.0668 19.0499 23.0890  0.7083  0.8125  0.934127681774      0
jxl:d3          19660  1796954    0.7311967   2.026  16.005   4.90647221  72.94747378   1.28202899  35.40   2.252  4.7641 12.2974  1.0596  4.6768 13.5901  0.0000 19.6137 19.6332 23.5942  0.7188  0.7917  0.937415367331      0
jxl:d5          19660  1225581    0.4986999   1.965   8.935  12.42521095  61.15941523   1.91711122  32.98   2.326  3.2937  8.0773  0.9535  2.9975 10.9553  0.0000 15.4769 27.8599 29.1047  0.6875  1.3334  0.956063174393      0
jxl:d7          19660   947949    0.3857289   2.015   8.808  12.57799530  51.44435001   2.37835441  31.51   2.297  2.5313  5.7101  0.7949  2.0759  9.2430  0.0000 12.9820 33.0215 31.9850  0.6875  1.7084  0.917400148059      0
jxl:d15         19660   528097    0.2148874   2.155   8.313  16.49061775  21.48272513   3.89054667  28.67   2.181  1.2155  1.7230  0.3125  0.5921  5.4558  0.0000  7.4572 38.2169 40.9435  1.1979  3.6251  0.836029480920      0
jxl:d24         19660   376964    0.1533900   0.302  20.864  56.09043503  -7.27154706   6.27833127  26.32   2.583  1.0124  2.2338  0.1748  0.7015  3.0658  0.0000  3.2774  9.4273  5.5574  0.0104  0.0000  0.963033437133      0
jxl:d32         19660   302771    0.1232002   0.299  18.898  55.51866150 -19.85813581   7.03186646  25.83   2.348  0.7474  1.6908  0.1458  0.5104  2.7461  0.0000  2.8490 10.4377  6.3335  0.0000  0.0000  0.866327602472      0
Aggregate:      19660  2174766    0.8849319   1.802  15.067   5.02451933  76.14956279   1.07312481  36.81   2.349  5.6412 11.9669  0.7834  4.8460 13.0158  0.0000 18.4801 10.1550 14.6434  0.3565  0.4876  0.949642330360      0
```