### PR TITLE
djxl: fix segmentation fault when JPEG is disabled

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -37,6 +37,7 @@ gi-man
 Heiko Becker <heirecka@exherbo.org>
 Jim Robinson <jimbo2150@gmail.com>
 Jon Sneyers <jon@cloudinary.com>
+Julien Olivain <ju.o@free.fr>
 Kai Hollberg <Schweinepriester@users.noreply.github.com>
 Kleis Auke Wolthuizen <github@kleisauke.nl>
 L. E. Segovia

--- a/tools/cmdline.h
+++ b/tools/cmdline.h
@@ -19,7 +19,7 @@ namespace tools {
 
 class CommandLineParser {
  public:
-  typedef size_t OptionId;
+  typedef ssize_t OptionId;
 
   // An abstract class for defining command line options.
   class CmdOptionInterface {

--- a/tools/djxl_main.cc
+++ b/tools/djxl_main.cc
@@ -370,6 +370,7 @@ int main(int argc, const char* argv[]) {
     args.color_space = force_colorspace;
   }
   if (codec == jxl::extras::Codec::kPNM && extension != ".pfm" &&
+      args.opt_jpeg_quality_id != -1 &&
       !cmdline.GetOption(args.opt_jpeg_quality_id)->matched()) {
     args.bits_per_sample = 0;
   }


### PR DESCRIPTION
When libjxl is compiled without JPEG support, by configuring for example with:

    cmake -DCMAKE_DISABLE_FIND_PACKAGE_JPEG=TRUE ...

djxl crashes with a segmentation fault at:
https://github.com/libjxl/libjxl/blob/v0.8.1/tools/djxl_main.cc#L367

The crash can be reproduced with the sequence:

    gm convert IMAGE:LOGO ref.ppm
    cjxl ref.ppm enc.jxl
    djxl enc.jxl dec.ppm

The crash happen because opt_jpeg_quality_id does not get initialized at:
https://github.com/libjxl/libjxl/blob/v0.8.1/tools/djxl_main.cc#L107

This commit fixes the crash by testing opt_jpeg_quality_id only if libjxl is compiled with JPEG.

Signed-off-by: Julien Olivain <ju.o@free.fr>