### PR TITLE
only 1 verbosity level for djxl

### DIFF
--- a/tools/djxl_main.cc
+++ b/tools/djxl_main.cc
@@ -55,7 +55,7 @@ struct DecompressArgs {
 
     cmdline->AddOptionFlag('\0', "disable_output",
                            "No output file will be written (for benchmarking)",
-                           &disable_output, &SetBooleanTrue, 1);
+                           &disable_output, &SetBooleanTrue);
 
     cmdline->AddOptionValue('\0', "num_threads", "N",
                             "Number of worker threads (-1 == use machine "


### PR DESCRIPTION
Currently having the verbosity 1 set for disable_output makes it impossible to get help for this flag, because we don't have a `-v` fla for djxl. The fix is to don't set a verbosity level for this flag.