### PR TITLE
plugins/gimp/file-jxl-save: dont submit sRGB-tagged linear samples

### DIFF
--- a/plugins/gimp/file-jxl-save.cc
+++ b/plugins/gimp/file-jxl-save.cc
@@ -831,11 +831,7 @@ bool SaveJpegXlImage(const gint32 image_id, const gint32 drawable_id,
     g_clear_object(&buffer);
 
     // use babl to fix gamma mismatch issues
-    if (jxl_save_opts.icc_attached) {
-      jxl_save_opts.SetModel(jxl_save_opts.is_linear);
-    } else {
-      jxl_save_opts.SetModel(!jxl_save_opts.is_linear);
-    }
+    jxl_save_opts.SetModel(jxl_save_opts.is_linear);
     jxl_save_opts.pixel_format.data_type = JXL_TYPE_FLOAT;
     jxl_save_opts.SetBablType("float");
     const Babl* destination_format =


### PR DESCRIPTION
After the last patch, the JPEG XL exporter no longer crashes upon lossless exports but it converts sRGB images to linear before feeding them to libjxl, but it tells libjxl that they are sRGB, resulting in incorrect colors. This patch fixes that issue.