### PR TITLE
make sure jpeglib.h is found when building jpegli/libjpeg_wrapper.cc

### DIFF
--- a/lib/jpegli.cmake
+++ b/lib/jpegli.cmake
@@ -85,6 +85,7 @@ set(JPEGLI_LIBJPEG_OBJ_COMPILE_DEFINITIONS
 )
 
 add_library(jpegli-libjpeg-obj OBJECT "${JPEGXL_INTERNAL_JPEGLI_WRAPPER_SOURCES}")
+target_include_directories(jpegli-libjpeg-obj PUBLIC "${JPEG_INCLUDE_DIRS}")
 target_compile_options(jpegli-libjpeg-obj PRIVATE ${JPEGXL_INTERNAL_FLAGS})
 target_compile_options(jpegli-libjpeg-obj PUBLIC ${JPEGXL_COVERAGE_FLAGS})
 set_property(TARGET jpegli-libjpeg-obj PROPERTY POSITION_INDEPENDENT_CODE ON)


### PR DESCRIPTION
allows to build 0.8.1 on OpenBSD and probably NetBSD/FreeBSD - fixes #2167

note that i haven't checked yet consumers (my interest is for gdal on OpenBSD) so i dunno yet if this has to be "propagated to libjxl's own pkg-config files" as suggested by @guijan in #2167