### PR TITLE
Implement the rest of the transcoding functions in jpegli.

### DIFF
--- a/lib/jpegli/decode.cc
+++ b/lib/jpegli/decode.cc
@@ -391,6 +391,42 @@ JDIMENSION jpegli_read_raw_data(j_decompress_ptr cinfo, JSAMPIMAGE data,
   return 0;
 }
 
+jvirt_barray_ptr* jpegli_read_coefficients(j_decompress_ptr cinfo) {
+  if (cinfo->global_state != jpegli::kDecHeaderDone) {
+    JPEGLI_ERROR("jpegli_read_coefficients: unexpected state %d",
+                 cinfo->global_state);
+  }
+  cinfo->global_state = jpegli::kDecProcessScan;
+  jpeg_decomp_master* m = cinfo->master;
+  while (!m->found_eoi_) {
+    int retcode = jpegli::ConsumeInput(cinfo);
+    if (retcode == JPEG_SUSPENDED) {
+      return nullptr;
+    }
+  }
+  j_common_ptr comptr = reinterpret_cast<j_common_ptr>(cinfo);
+  jvirt_barray_ptr* coef_arrays = jpegli::Allocate<jvirt_barray_ptr>(
+      cinfo, cinfo->num_components, JPOOL_IMAGE);
+  for (int c = 0; c < cinfo->num_components; ++c) {
+    size_t xsize_blocks = cinfo->comp_info[c].width_in_blocks;
+    size_t ysize_blocks = cinfo->comp_info[c].height_in_blocks;
+    coef_arrays[c] = (*cinfo->mem->request_virt_barray)(
+        comptr, JPOOL_IMAGE, FALSE, xsize_blocks, ysize_blocks, 1);
+  }
+  (*cinfo->mem->realize_virt_arrays)(comptr);
+  for (int c = 0; c < cinfo->num_components; ++c) {
+    jpeg_component_info* comp = &cinfo->comp_info[c];
+    for (size_t by = 0; by < comp->height_in_blocks; ++by) {
+      JBLOCKARRAY ba = (*cinfo->mem->access_virt_barray)(comptr, coef_arrays[c],
+                                                         by, 1, true);
+      size_t stride = comp->width_in_blocks * sizeof(JBLOCK);
+      size_t offset = by * comp->width_in_blocks * DCTSIZE2;
+      memcpy(ba[0], &m->components_[c].coeffs[offset], stride);
+    }
+  }
+  return coef_arrays;
+}
+
 boolean jpegli_finish_decompress(j_decompress_ptr cinfo) {
   if (cinfo->global_state != jpegli::kDecProcessScan &&
       cinfo->global_state != jpegli::kDecProcessMarkers) {

--- a/lib/jpegli/decode.h
+++ b/lib/jpegli/decode.h
@@ -60,6 +60,8 @@ boolean jpegli_finish_decompress(j_decompress_ptr cinfo);
 JDIMENSION jpegli_read_raw_data(j_decompress_ptr cinfo, JSAMPIMAGE data,
                                 JDIMENSION max_lines);
 
+jvirt_barray_ptr *jpegli_read_coefficients(j_decompress_ptr cinfo);
+
 boolean jpegli_has_multiple_scans(j_decompress_ptr cinfo);
 
 boolean jpegli_start_output(j_decompress_ptr cinfo, int scan_number);

--- a/lib/jpegli/decode_marker.cc
+++ b/lib/jpegli/decode_marker.cc
@@ -104,6 +104,7 @@ void ProcessSOF(j_decompress_ptr cinfo, const uint8_t* data, size_t len) {
     cinfo->max_v_samp_factor =
         std::max(cinfo->max_v_samp_factor, v_samp_factor);
     uint8_t quant_tbl_idx = ReadUint8(data, &pos);
+    comp->quant_tbl_no = quant_tbl_idx;
     comp->quant_table = cinfo->quant_tbl_ptrs[quant_tbl_idx];
     if (comp->quant_table == nullptr) {
       JPEGLI_ERROR("Quantization table with index %u not found", quant_tbl_idx);

--- a/lib/jpegli/encode.cc
+++ b/lib/jpegli/encode.cc
@@ -705,6 +705,47 @@ void jpegli_set_progressive_level(j_compress_ptr cinfo, int level) {
   cinfo->master->progressive_level = level;
 }
 
+void jpegli_copy_critical_parameters(j_decompress_ptr srcinfo,
+                                     j_compress_ptr cinfo) {
+  CheckState(cinfo, jpegli::kEncStart);
+  // Image parameters.
+  cinfo->image_width = srcinfo->image_width;
+  cinfo->image_height = srcinfo->image_height;
+  cinfo->input_components = srcinfo->num_components;
+  cinfo->in_color_space = srcinfo->jpeg_color_space;
+  cinfo->input_gamma = srcinfo->output_gamma;
+  // Compression parameters.
+  jpegli_set_defaults(cinfo);
+  jpegli_set_colorspace(cinfo, srcinfo->jpeg_color_space);
+  if (cinfo->num_components != srcinfo->num_components) {
+    return JPEGLI_ERROR("Mismatch between src colorspace and components");
+  }
+  cinfo->data_precision = srcinfo->data_precision;
+  cinfo->CCIR601_sampling = srcinfo->CCIR601_sampling;
+  cinfo->JFIF_major_version = srcinfo->JFIF_major_version;
+  cinfo->JFIF_minor_version = srcinfo->JFIF_minor_version;
+  cinfo->density_unit = srcinfo->density_unit;
+  cinfo->X_density = srcinfo->X_density;
+  cinfo->Y_density = srcinfo->Y_density;
+  for (int c = 0; c < cinfo->num_components; ++c) {
+    jpeg_component_info* srccomp = &srcinfo->comp_info[c];
+    jpeg_component_info* dstcomp = &cinfo->comp_info[c];
+    dstcomp->component_id = srccomp->component_id;
+    dstcomp->h_samp_factor = srccomp->h_samp_factor;
+    dstcomp->v_samp_factor = srccomp->v_samp_factor;
+    dstcomp->quant_tbl_no = srccomp->quant_tbl_no;
+  }
+  for (int i = 0; i < NUM_QUANT_TBLS; ++i) {
+    if (!srcinfo->quant_tbl_ptrs[i]) continue;
+    if (cinfo->quant_tbl_ptrs[i] == nullptr) {
+      cinfo->quant_tbl_ptrs[i] = jpegli::Allocate<JQUANT_TBL>(cinfo, 1);
+    }
+    memcpy(cinfo->quant_tbl_ptrs[i], srcinfo->quant_tbl_ptrs[i],
+           sizeof(JQUANT_TBL));
+    cinfo->quant_tbl_ptrs[i]->sent_table = FALSE;
+  }
+}
+
 void jpegli_suppress_tables(j_compress_ptr cinfo, boolean suppress) {
   jpegli::SetSentTableFlag(cinfo->quant_tbl_ptrs, NUM_QUANT_TBLS, suppress);
   jpegli::SetSentTableFlag(cinfo->dc_huff_tbl_ptrs, NUM_HUFF_TBLS, suppress);

--- a/lib/jpegli/encode.h
+++ b/lib/jpegli/encode.h
@@ -64,6 +64,9 @@ void jpegli_simple_progression(j_compress_ptr cinfo);
 
 void jpegli_suppress_tables(j_compress_ptr cinfo, boolean suppress);
 
+void jpegli_copy_critical_parameters(j_decompress_ptr srcinfo,
+                                     j_compress_ptr dstinfo);
+
 void jpegli_write_m_header(j_compress_ptr cinfo, int marker,
                            unsigned int datalen);
 

--- a/lib/jpegli/encode_api_test.cc
+++ b/lib/jpegli/encode_api_test.cc
@@ -13,583 +13,41 @@
 #include <cmath>
 #include <vector>
 
-#include "lib/jpegli/common_internal.h"
 #include "lib/jpegli/encode.h"
 #include "lib/jpegli/test_utils.h"
 #include "lib/jpegli/testing.h"
-#include "lib/jxl/base/file_io.h"
-#include "lib/jxl/base/status.h"
-#include "lib/jxl/sanitizers.h"
-
-#define ARRAY_SIZE(X) (sizeof(X) / sizeof((X)[0]))
-
-#define ERROR_HANDLER_SETUP(action)                                           \
-  jpeg_error_mgr jerr;                                                        \
-  cinfo.err = jpegli_std_error(&jerr);                                        \
-  if (setjmp(data.env)) {                                                     \
-    action;                                                                   \
-  }                                                                           \
-  cinfo.client_data = reinterpret_cast<void*>(&data);                         \
-  cinfo.err->error_exit = [](j_common_ptr cinfo) {                            \
-    (*cinfo->err->output_message)(cinfo);                                     \
-    MyClientData* data = reinterpret_cast<MyClientData*>(cinfo->client_data); \
-    if (data->buffer) free(data->buffer);                                     \
-    jpegli_destroy(cinfo);                                                    \
-    longjmp(data->env, 1);                                                    \
-  };
 
 namespace jpegli {
 namespace {
 
-static constexpr int kSpecialMarker = 0xe5;
-static constexpr uint8_t kMarkerData[] = {0, 1, 255, 0, 17};
-
-static constexpr jpeg_scan_info kScript1[] = {
-    {3, {0, 1, 2}, 0, 0, 0, 0},
-    {1, {0}, 1, 63, 0, 0},
-    {1, {1}, 1, 63, 0, 0},
-    {1, {2}, 1, 63, 0, 0},
-};
-static constexpr jpeg_scan_info kScript2[] = {
-    {1, {0}, 0, 0, 0, 0},  {1, {1}, 0, 0, 0, 0},  {1, {2}, 0, 0, 0, 0},
-    {1, {0}, 1, 63, 0, 0}, {1, {1}, 1, 63, 0, 0}, {1, {2}, 1, 63, 0, 0},
-};
-static constexpr jpeg_scan_info kScript3[] = {
-    {3, {0, 1, 2}, 0, 0, 0, 0}, {1, {0}, 1, 63, 0, 1}, {1, {1}, 1, 63, 0, 1},
-    {1, {2}, 1, 63, 0, 1},      {1, {0}, 1, 63, 1, 0}, {1, {1}, 1, 63, 1, 0},
-    {1, {2}, 1, 63, 1, 0},
-};
-
-struct ScanScript {
-  size_t num_scans;
-  const jpeg_scan_info* scans;
-};
-
-static constexpr ScanScript kTestScript[] = {
-    {ARRAY_SIZE(kScript1), kScript1},
-    {ARRAY_SIZE(kScript2), kScript2},
-    {ARRAY_SIZE(kScript3), kScript3},
-};
-static constexpr size_t kNumTestScripts = ARRAY_SIZE(kTestScript);
-
-struct CustomQuantTable {
-  int slot_idx = 0;
-  uint16_t table_type = 0;
-  int scale_factor = 100;
-  bool add_raw = false;
-  bool force_baseline = true;
-  std::vector<unsigned int> basic_table;
-  std::vector<unsigned int> quantval;
-  void Generate() {
-    basic_table.resize(DCTSIZE2);
-    quantval.resize(DCTSIZE2);
-    switch (table_type) {
-      case 0: {
-        for (int k = 0; k < DCTSIZE2; ++k) {
-          basic_table[k] = k + 1;
-        }
-        break;
-      }
-      default:
-        for (int k = 0; k < DCTSIZE2; ++k) {
-          basic_table[k] = table_type;
-        }
-    }
-    for (int k = 0; k < DCTSIZE2; ++k) {
-      quantval[k] = (basic_table[k] * scale_factor + 50U) / 100U;
-      quantval[k] = std::max(quantval[k], 1U);
-      quantval[k] = std::min(quantval[k], 65535U);
-      if (!add_raw) {
-        quantval[k] = std::min(quantval[k], force_baseline ? 255U : 32767U);
-      }
-    }
-  }
-};
-
 struct TestConfig {
-  size_t xsize = 0;
-  size_t ysize = 0;
-  J_COLOR_SPACE in_color_space = JCS_RGB;
-  size_t input_components = 3;
-  bool set_jpeg_colorspace = false;
-  J_COLOR_SPACE jpeg_color_space = JCS_UNKNOWN;
-  std::vector<uint8_t> pixels;
-  int quality = 90;
-  bool custom_quant_tables = false;
-  std::vector<CustomQuantTable> quant_tables;
-  int quant_indexes[kMaxComponents] = {0, 1, 1};
-  bool custom_sampling = false;
-  int h_sampling[kMaxComponents] = {1, 1, 1};
-  int v_sampling[kMaxComponents] = {1, 1, 1};
-  bool custom_component_ids = false;
-  int comp_id[kMaxComponents];
-  int override_JFIF = -1;
-  int override_Adobe = -1;
-  bool add_marker = false;
-  int progressive_id = 0;
-  int progressive_level = -1;
-  int restart_interval = 0;
-  int restart_in_rows = 0;
-  bool raw_data_in = false;
-  std::vector<std::vector<uint8_t>> raw_data;
-  bool write_coeffs = false;
-  std::vector<std::vector<JCOEF>> coeffs;
-  bool optimize_coding = true;
-  bool use_flat_dc_luma_code = false;
-  bool xyb_mode = false;
-  bool libjpeg_mode = false;
+  TestImage input;
+  CompressParams jparams;
+  JpegIOMode input_mode = PIXELS;
   double max_bpp;
   double max_dist;
-
-  int max_h_sample() const {
-    return std::max(h_sampling[0], std::max(h_sampling[1], h_sampling[2]));
-  }
-  int max_v_sample() const {
-    return std::max(v_sampling[0], std::max(v_sampling[1], v_sampling[2]));
-  }
-  int comp_width(int c) const {
-    return DivCeil(xsize * h_sampling[c], max_h_sample() * DCTSIZE) * DCTSIZE;
-  }
-  int comp_height(int c) const {
-    return DivCeil(ysize * v_sampling[c], max_v_sample() * DCTSIZE) * DCTSIZE;
-  }
 };
-
-void SetNumChannels(J_COLOR_SPACE colorspace, size_t* channels) {
-  if (colorspace == JCS_GRAYSCALE) {
-    *channels = 1;
-  } else if (colorspace == JCS_RGB || colorspace == JCS_YCbCr) {
-    *channels = 3;
-  } else if (colorspace == JCS_CMYK || colorspace == JCS_YCCK) {
-    *channels = 4;
-  } else if (colorspace == JCS_UNKNOWN) {
-    ASSERT_LE(*channels, jpegli::kMaxComponents);
-  } else {
-    FAIL();
-  }
-}
-
-void ConvertPixel(const uint8_t* input_rgb, uint8_t* out,
-                  J_COLOR_SPACE colorspace, size_t num_channels) {
-  const float kMul = 255.0f;
-  const float r = input_rgb[0] / kMul;
-  const float g = input_rgb[1] / kMul;
-  const float b = input_rgb[2] / kMul;
-  if (colorspace == JCS_GRAYSCALE) {
-    const float Y = 0.299f * r + 0.587f * g + 0.114f * b;
-    out[0] = static_cast<uint8_t>(std::round(Y * kMul));
-  } else if (colorspace == JCS_RGB || colorspace == JCS_UNKNOWN) {
-    for (size_t c = 0; c < num_channels; ++c) {
-      out[c] = input_rgb[std::min<size_t>(2, c)];
-    }
-  } else if (colorspace == JCS_YCbCr) {
-    float Y = 0.299f * r + 0.587f * g + 0.114f * b;
-    float Cb = -0.168736f * r - 0.331264f * g + 0.5f * b + 0.5f;
-    float Cr = 0.5f * r - 0.418688f * g - 0.081312f * b + 0.5f;
-    out[0] = static_cast<uint8_t>(std::round(Y * kMul));
-    out[1] = static_cast<uint8_t>(std::round(Cb * kMul));
-    out[2] = static_cast<uint8_t>(std::round(Cr * kMul));
-  } else if (colorspace == JCS_CMYK) {
-    float K = 1.0f - std::max(r, std::max(g, b));
-    float scaleK = 1.0f / (1.0f - K);
-    float C = (1.0f - K - r) * scaleK;
-    float M = (1.0f - K - g) * scaleK;
-    float Y = (1.0f - K - b) * scaleK;
-    out[0] = static_cast<uint8_t>(std::round(C * kMul));
-    out[1] = static_cast<uint8_t>(std::round(M * kMul));
-    out[2] = static_cast<uint8_t>(std::round(Y * kMul));
-    out[3] = static_cast<uint8_t>(std::round(K * kMul));
-  } else {
-    JXL_ABORT("Colorspace %d not supported", colorspace);
-  }
-}
-
-void GeneratePixels(TestConfig* config) {
-  const std::vector<uint8_t> imgdata = ReadTestData("jxl/flower/flower.pnm");
-  size_t xsize, ysize, channels, bitdepth;
-  std::vector<uint8_t> pixels;
-  ASSERT_TRUE(ReadPNM(imgdata, &xsize, &ysize, &channels, &bitdepth, &pixels));
-  if (config->xsize == 0) config->xsize = xsize;
-  if (config->ysize == 0) config->ysize = ysize;
-  ASSERT_LE(config->xsize, xsize);
-  ASSERT_LE(config->ysize, ysize);
-  ASSERT_EQ(3, channels);
-  ASSERT_EQ(8, bitdepth);
-  size_t in_bytes_per_pixel = channels;
-  size_t in_stride = xsize * in_bytes_per_pixel;
-  size_t x0 = (xsize - config->xsize) / 2;
-  size_t y0 = (ysize - config->ysize) / 2;
-  SetNumChannels(config->in_color_space, &config->input_components);
-  size_t out_bytes_per_pixel = config->input_components;
-  size_t out_stride = config->xsize * out_bytes_per_pixel;
-  config->pixels.resize(config->ysize * out_stride);
-  for (size_t iy = 0; iy < config->ysize; ++iy) {
-    size_t y = y0 + iy;
-    for (size_t ix = 0; ix < config->xsize; ++ix) {
-      size_t x = x0 + ix;
-      size_t idx_in = y * in_stride + x * in_bytes_per_pixel;
-      size_t idx_out = iy * out_stride + ix * out_bytes_per_pixel;
-      ConvertPixel(&pixels[idx_in], &config->pixels[idx_out],
-                   config->in_color_space, config->input_components);
-    }
-  }
-}
-
-void GenerateRawData(TestConfig* config) {
-  for (size_t c = 0; c < config->input_components; ++c) {
-    size_t xsize = config->comp_width(c);
-    size_t ysize = config->comp_height(c);
-    size_t factor_y = config->max_v_sample() / config->v_sampling[c];
-    size_t factor_x = config->max_h_sample() / config->h_sampling[c];
-    size_t factor = factor_x * factor_y;
-    std::vector<uint8_t> plane(ysize * xsize);
-    size_t bytes_per_pixel = config->input_components;
-    for (size_t y = 0; y < ysize; ++y) {
-      for (size_t x = 0; x < xsize; ++x) {
-        int result = 0;
-        for (size_t iy = 0; iy < factor_y; ++iy) {
-          size_t yy = std::min(y * factor_y + iy, config->ysize - 1);
-          for (size_t ix = 0; ix < factor_x; ++ix) {
-            size_t xx = std::min(x * factor_x + ix, config->xsize - 1);
-            size_t pixel_ix = (yy * config->xsize + xx) * bytes_per_pixel + c;
-            result += config->pixels[pixel_ix];
-          }
-        }
-        result = static_cast<uint8_t>((result + factor / 2) / factor);
-        plane[y * xsize + x] = result;
-      }
-    }
-    config->raw_data.emplace_back(std::move(plane));
-  }
-}
-
-void GenerateCoeffs(TestConfig* config) {
-  for (size_t c = 0; c < config->input_components; ++c) {
-    size_t xsize_blocks = config->comp_width(c) / DCTSIZE;
-    size_t ysize_blocks = config->comp_height(c) / DCTSIZE;
-    std::vector<JCOEF> plane(ysize_blocks * xsize_blocks * kDCTBlockSize);
-    for (size_t by = 0; by < ysize_blocks; ++by) {
-      for (size_t bx = 0; bx < xsize_blocks; ++bx) {
-        for (size_t k = 0; k < kDCTBlockSize; ++k) {
-          plane[(by * xsize_blocks + bx) * kDCTBlockSize + k] =
-              (bx - by) / (k + 1);
-        }
-      }
-    }
-    config->coeffs.emplace_back(std::move(plane));
-  }
-}
-
-struct MyClientData {
-  jmp_buf env;
-  unsigned char* buffer = nullptr;
-  unsigned long size = 0;
-  unsigned char* table_stream = nullptr;
-  unsigned long table_stream_size = 0;
-};
-
-// Verifies that an image encoded with libjpegli can be decoded with libjpeg.
-void TestDecodedImage(const TestConfig& config,
-                      const std::vector<uint8_t>& compressed) {
-  MyClientData data;
-  jpeg_decompress_struct cinfo = {};
-  ERROR_HANDLER_SETUP(FAIL());
-  jpeg_create_decompress(&cinfo);
-  jpeg_mem_src(&cinfo, compressed.data(), compressed.size());
-  if (config.add_marker) {
-    jpeg_save_markers(&cinfo, kSpecialMarker, 0xffff);
-  }
-  EXPECT_EQ(JPEG_REACHED_SOS, jpeg_read_header(&cinfo, /*require_image=*/TRUE));
-  jxl::msan::UnpoisonMemory(cinfo.comp_info,
-                            cinfo.num_components * sizeof(cinfo.comp_info[0]));
-  EXPECT_EQ(config.xsize, cinfo.image_width);
-  EXPECT_EQ(config.ysize, cinfo.image_height);
-  EXPECT_EQ(config.input_components, cinfo.num_components);
-  cinfo.buffered_image = TRUE;
-  cinfo.out_color_space = config.in_color_space;
-  if (config.override_JFIF >= 0) {
-    EXPECT_EQ(cinfo.saw_JFIF_marker, config.override_JFIF);
-  }
-  if (config.override_Adobe >= 0) {
-    EXPECT_EQ(cinfo.saw_Adobe_marker, config.override_Adobe);
-  }
-  if (config.in_color_space == JCS_UNKNOWN) {
-    cinfo.jpeg_color_space = JCS_UNKNOWN;
-  }
-  if (config.add_marker) {
-    bool marker_found = false;
-    for (jpeg_saved_marker_ptr marker = cinfo.marker_list; marker != nullptr;
-         marker = marker->next) {
-      jxl::msan::UnpoisonMemory(marker, sizeof(*marker));
-      jxl::msan::UnpoisonMemory(marker->data, marker->data_length);
-      if (marker->marker == kSpecialMarker &&
-          marker->data_length == sizeof(kMarkerData) &&
-          memcmp(marker->data, kMarkerData, sizeof(kMarkerData)) == 0) {
-        marker_found = true;
-      }
-    }
-    EXPECT_TRUE(marker_found);
-  }
-  if (config.custom_component_ids) {
-    for (int i = 0; i < cinfo.num_components; ++i) {
-      EXPECT_EQ(cinfo.comp_info[i].component_id, config.comp_id[i]);
-    }
-  }
-  if (config.custom_sampling) {
-    for (int i = 0; i < cinfo.num_components; ++i) {
-      EXPECT_EQ(cinfo.comp_info[i].h_samp_factor, config.h_sampling[i]);
-      EXPECT_EQ(cinfo.comp_info[i].v_samp_factor, config.v_sampling[i]);
-    }
-  }
-  if (config.custom_quant_tables) {
-    for (int i = 0; i < cinfo.num_components; ++i) {
-      EXPECT_EQ(cinfo.comp_info[i].quant_tbl_no, config.quant_indexes[i]);
-    }
-    for (const auto& table : config.quant_tables) {
-      JQUANT_TBL* quant_table = cinfo.quant_tbl_ptrs[table.slot_idx];
-      jxl::msan::UnpoisonMemory(quant_table, sizeof(*quant_table));
-      ASSERT_TRUE(quant_table != nullptr);
-      for (int k = 0; k < DCTSIZE2; ++k) {
-        EXPECT_EQ(quant_table->quantval[k], table.quantval[k]);
-      }
-    }
-  }
-  if (config.write_coeffs) {
-    j_common_ptr comptr = reinterpret_cast<j_common_ptr>(&cinfo);
-    jvirt_barray_ptr* coef_arrays = jpeg_read_coefficients(&cinfo);
-    ASSERT_TRUE(coef_arrays != nullptr);
-    for (int c = 0; c < cinfo.num_components; ++c) {
-      jpeg_component_info* comp = &cinfo.comp_info[c];
-      for (size_t by = 0; by < comp->height_in_blocks; ++by) {
-        JBLOCKARRAY ba = (*cinfo.mem->access_virt_barray)(
-            comptr, coef_arrays[c], by, 1, true);
-        size_t stride = comp->width_in_blocks * sizeof(JBLOCK);
-        size_t offset = by * comp->width_in_blocks * kDCTBlockSize;
-        EXPECT_EQ(0, memcmp(ba[0], &config.coeffs[c][offset], stride));
-      }
-    }
-  } else {
-    EXPECT_TRUE(jpeg_start_decompress(&cinfo));
-    while (!jpeg_input_complete(&cinfo)) {
-      EXPECT_GT(cinfo.input_scan_number, 0);
-      EXPECT_TRUE(jpeg_start_output(&cinfo, cinfo.input_scan_number));
-      if (config.progressive_id > 0) {
-        ASSERT_LE(config.progressive_id, kNumTestScripts);
-        const ScanScript& script = kTestScript[config.progressive_id - 1];
-        ASSERT_LE(cinfo.input_scan_number, script.num_scans);
-        const jpeg_scan_info& scan = script.scans[cinfo.input_scan_number - 1];
-        ASSERT_EQ(cinfo.comps_in_scan, scan.comps_in_scan);
-        for (int i = 0; i < cinfo.comps_in_scan; ++i) {
-          EXPECT_EQ(cinfo.cur_comp_info[i]->component_index,
-                    scan.component_index[i]);
-        }
-        EXPECT_EQ(cinfo.Ss, scan.Ss);
-        EXPECT_EQ(cinfo.Se, scan.Se);
-        EXPECT_EQ(cinfo.Ah, scan.Ah);
-        EXPECT_EQ(cinfo.Al, scan.Al);
-      }
-      EXPECT_TRUE(jpeg_finish_output(&cinfo));
-      if (config.restart_interval > 0) {
-        EXPECT_EQ(cinfo.restart_interval, config.restart_interval);
-      } else if (config.restart_in_rows > 0) {
-        EXPECT_EQ(cinfo.restart_interval,
-                  config.restart_in_rows * cinfo.MCUs_per_row);
-      }
-    }
-    EXPECT_TRUE(jpeg_start_output(&cinfo, cinfo.input_scan_number));
-    size_t stride = cinfo.image_width * cinfo.out_color_components;
-    std::vector<uint8_t> output(cinfo.image_height * stride);
-    for (size_t y = 0; y < cinfo.image_height; ++y) {
-      JSAMPROW rows[] = {reinterpret_cast<JSAMPLE*>(&output[y * stride])};
-      jxl::msan::UnpoisonMemory(
-          rows[0],
-          sizeof(JSAMPLE) * cinfo.output_components * cinfo.image_width);
-      EXPECT_EQ(1, jpeg_read_scanlines(&cinfo, rows, 1));
-    }
-    EXPECT_TRUE(jpeg_finish_output(&cinfo));
-    ASSERT_EQ(output.size(), config.pixels.size());
-    const double mul = 1.0 / 255.0;
-    double diff2 = 0.0;
-    for (size_t i = 0; i < config.pixels.size(); ++i) {
-      double sample_orig = config.pixels[i] * mul;
-      double sample_output = output[i] * mul;
-      double diff = sample_orig - sample_output;
-      diff2 += diff * diff;
-    }
-    double rms = std::sqrt(diff2 / config.pixels.size()) / mul;
-    printf("rms: %f\n", rms);
-    EXPECT_LE(rms, config.max_dist);
-  }
-  EXPECT_TRUE(jpeg_finish_decompress(&cinfo));
-  jpeg_destroy_decompress(&cinfo);
-}
-
-bool EncodeWithJpegli(const TestConfig& config,
-                      std::vector<uint8_t>* compressed) {
-  MyClientData data;
-  jpeg_compress_struct cinfo;
-  ERROR_HANDLER_SETUP(return false);
-  jpegli_create_compress(&cinfo);
-  jpegli_mem_dest(&cinfo, &data.buffer, &data.size);
-  cinfo.image_width = config.xsize;
-  cinfo.image_height = config.ysize;
-  cinfo.input_components = config.input_components;
-  cinfo.in_color_space = config.in_color_space;
-  if (config.xyb_mode) {
-    jpegli_set_xyb_mode(&cinfo);
-  }
-  jpegli_set_defaults(&cinfo);
-  if (config.override_JFIF >= 0) {
-    cinfo.write_JFIF_header = config.override_JFIF;
-  }
-  if (config.override_Adobe >= 0) {
-    cinfo.write_Adobe_marker = config.override_Adobe;
-  }
-  if (config.set_jpeg_colorspace) {
-    jpegli_set_colorspace(&cinfo, config.jpeg_color_space);
-  }
-  if (config.custom_component_ids) {
-    for (int c = 0; c < cinfo.num_components; ++c) {
-      cinfo.comp_info[c].component_id = config.comp_id[c];
-    }
-  }
-  if (config.custom_sampling) {
-    for (int c = 0; c < cinfo.num_components; ++c) {
-      cinfo.comp_info[c].h_samp_factor = config.h_sampling[c];
-      cinfo.comp_info[c].v_samp_factor = config.v_sampling[c];
-    }
-  }
-  if (config.custom_quant_tables) {
-    for (int c = 0; c < cinfo.num_components; ++c) {
-      cinfo.comp_info[c].quant_tbl_no = config.quant_indexes[c];
-    }
-    for (const auto& table : config.quant_tables) {
-      if (table.add_raw) {
-        cinfo.quant_tbl_ptrs[table.slot_idx] =
-            jpegli_alloc_quant_table((j_common_ptr)&cinfo);
-        for (int k = 0; k < DCTSIZE2; ++k) {
-          cinfo.quant_tbl_ptrs[table.slot_idx]->quantval[k] = table.quantval[k];
-        }
-        cinfo.quant_tbl_ptrs[table.slot_idx]->sent_table = FALSE;
-      } else {
-        jpegli_add_quant_table(&cinfo, table.slot_idx, &table.basic_table[0],
-                               table.scale_factor, table.force_baseline);
-      }
-    }
-  }
-  if (config.progressive_id > 0) {
-    const ScanScript& script = kTestScript[config.progressive_id - 1];
-    cinfo.scan_info = script.scans;
-    cinfo.num_scans = script.num_scans;
-  } else if (config.progressive_level >= 0) {
-    jpegli_set_progressive_level(&cinfo, config.progressive_level);
-  }
-  cinfo.restart_interval = config.restart_interval;
-  cinfo.restart_in_rows = config.restart_in_rows;
-  cinfo.optimize_coding = config.optimize_coding;
-  cinfo.raw_data_in = config.raw_data_in;
-  if (!config.optimize_coding && config.use_flat_dc_luma_code) {
-    JHUFF_TBL* tbl = cinfo.dc_huff_tbl_ptrs[0];
-    memset(tbl, 0, sizeof(*tbl));
-    tbl->bits[4] = 15;
-    for (int i = 0; i < 15; ++i) tbl->huffval[i] = i;
-  }
-  jpegli_set_quality(&cinfo, config.quality, TRUE);
-  if (config.libjpeg_mode) {
-    jpegli_enable_adaptive_quantization(&cinfo, FALSE);
-    jpegli_use_standard_quant_tables(&cinfo);
-    jpegli_set_progressive_level(&cinfo, 0);
-  }
-  if (!config.write_coeffs) {
-    jpegli_start_compress(&cinfo, TRUE);
-    if (config.add_marker) {
-      jpegli_write_marker(&cinfo, kSpecialMarker, kMarkerData,
-                          sizeof(kMarkerData));
-    }
-  }
-  if (cinfo.raw_data_in) {
-    // Need to copy because jpeg API requires non-const pointers.
-    std::vector<std::vector<uint8_t>> raw_data = config.raw_data;
-    size_t max_lines = config.max_v_sample() * DCTSIZE;
-    std::vector<std::vector<JSAMPROW>> rowdata(cinfo.num_components);
-    std::vector<JSAMPARRAY> data(cinfo.num_components);
-    for (int c = 0; c < cinfo.num_components; ++c) {
-      rowdata[c].resize(config.v_sampling[c] * DCTSIZE);
-      data[c] = &rowdata[c][0];
-    }
-    while (cinfo.next_scanline < cinfo.image_height) {
-      for (int c = 0; c < cinfo.num_components; ++c) {
-        size_t cwidth = config.comp_width(c);
-        size_t cheight = config.comp_height(c);
-        size_t num_lines = config.v_sampling[c] * DCTSIZE;
-        size_t y0 = (cinfo.next_scanline / max_lines) * num_lines;
-        for (size_t i = 0; i < num_lines; ++i) {
-          rowdata[c][i] =
-              (y0 + i < cheight ? &raw_data[c][(y0 + i) * cwidth] : nullptr);
-        }
-      }
-      size_t num_lines = jpegli_write_raw_data(&cinfo, &data[0], max_lines);
-      EXPECT_EQ(num_lines, max_lines);
-    }
-  } else if (config.write_coeffs) {
-    j_common_ptr comptr = reinterpret_cast<j_common_ptr>(&cinfo);
-    jvirt_barray_ptr* coef_arrays = reinterpret_cast<jvirt_barray_ptr*>((
-        *cinfo.mem->alloc_small)(
-        comptr, JPOOL_IMAGE, cinfo.num_components * sizeof(jvirt_barray_ptr)));
-    for (int c = 0; c < cinfo.num_components; ++c) {
-      size_t xsize_blocks = config.comp_width(c) / DCTSIZE;
-      size_t ysize_blocks = config.comp_height(c) / DCTSIZE;
-      coef_arrays[c] = (*cinfo.mem->request_virt_barray)(
-          comptr, JPOOL_IMAGE, FALSE, xsize_blocks, ysize_blocks, 1);
-    }
-    jpegli_write_coefficients(&cinfo, coef_arrays);
-    if (config.add_marker) {
-      jpegli_write_marker(&cinfo, kSpecialMarker, kMarkerData,
-                          sizeof(kMarkerData));
-    }
-    for (int c = 0; c < cinfo.num_components; ++c) {
-      jpeg_component_info* comp = &cinfo.comp_info[c];
-      for (size_t by = 0; by < comp->height_in_blocks; ++by) {
-        JBLOCKARRAY ba = (*cinfo.mem->access_virt_barray)(
-            comptr, coef_arrays[c], by, 1, true);
-        size_t stride = comp->width_in_blocks * sizeof(JBLOCK);
-        size_t offset = by * comp->width_in_blocks * kDCTBlockSize;
-        memcpy(ba[0], &config.coeffs[c][offset], stride);
-      }
-    }
-  } else {
-    size_t stride = cinfo.image_width * cinfo.input_components;
-    std::vector<uint8_t> row_bytes(stride);
-    for (size_t y = 0; y < cinfo.image_height; ++y) {
-      memcpy(&row_bytes[0], &config.pixels[y * stride], stride);
-      JSAMPROW row[] = {row_bytes.data()};
-      jpegli_write_scanlines(&cinfo, row, 1);
-    }
-  }
-  jpegli_finish_compress(&cinfo);
-  jpegli_destroy_compress(&cinfo);
-  compressed->resize(data.size);
-  std::copy_n(data.buffer, data.size, compressed->data());
-  std::free(data.buffer);
-  return true;
-}
 
 class EncodeAPITestParam : public ::testing::TestWithParam<TestConfig> {};
 
 TEST_P(EncodeAPITestParam, TestAPI) {
   TestConfig config = GetParam();
-  GeneratePixels(&config);
-  if (config.raw_data_in) {
-    GenerateRawData(&config);
-  } else if (config.write_coeffs) {
-    GenerateCoeffs(&config);
+  GeneratePixels(&config.input);
+  if (config.input_mode == RAW_DATA) {
+    GenerateRawData(config.jparams, &config.input);
+  } else if (config.input_mode == COEFFICIENTS) {
+    GenerateCoeffs(config.jparams, &config.input);
   }
   std::vector<uint8_t> compressed;
-  ASSERT_TRUE(EncodeWithJpegli(config, &compressed));
-  double bpp = compressed.size() * 8.0 / (config.xsize * config.ysize);
+  ASSERT_TRUE(EncodeWithJpegli(config.input, config.jparams, &compressed));
+  double bpp =
+      compressed.size() * 8.0 / (config.input.xsize * config.input.ysize);
   printf("bpp: %f\n", bpp);
   EXPECT_LT(bpp, config.max_bpp);
-  TestDecodedImage(config, compressed);
+  TestImage output;
+  output.color_space = config.input.color_space;
+  DecodeWithLibjpeg(config.jparams, compressed, config.input_mode, &output);
+  VerifyOutputImage(config.input, output, config.max_dist);
 }
 
 std::vector<TestConfig> GenerateTests() {
@@ -602,41 +60,38 @@ std::vector<TestConfig> GenerateTests() {
   }
   {
     TestConfig config;
-    config.quality = 100;
+    config.jparams.quality = 100;
     config.max_bpp = 5.9;
     config.max_dist = 0.6;
     all_tests.push_back(config);
   }
   {
     TestConfig config;
-    config.quality = 80;
+    config.jparams.quality = 80;
     config.max_bpp = 0.95;
     config.max_dist = 2.9;
     all_tests.push_back(config);
   }
   {
     TestConfig config;
-    config.custom_sampling = true;
-    config.h_sampling[0] = 2;
-    config.v_sampling[0] = 2;
+    config.jparams.h_sampling = {2, 1, 1};
+    config.jparams.v_sampling = {2, 1, 1};
     config.max_bpp = 1.25;
     config.max_dist = 2.9;
     all_tests.push_back(config);
   }
   {
     TestConfig config;
-    config.custom_sampling = true;
-    config.h_sampling[0] = 1;
-    config.v_sampling[0] = 2;
+    config.jparams.h_sampling = {1, 1, 1};
+    config.jparams.v_sampling = {2, 1, 1};
     config.max_bpp = 1.35;
     config.max_dist = 2.5;
     all_tests.push_back(config);
   }
   {
     TestConfig config;
-    config.custom_sampling = true;
-    config.h_sampling[0] = 2;
-    config.v_sampling[0] = 1;
+    config.jparams.h_sampling = {2, 1, 1};
+    config.jparams.v_sampling = {1, 1, 1};
     config.max_bpp = 1.35;
     config.max_dist = 2.5;
     all_tests.push_back(config);
@@ -646,13 +101,10 @@ std::vector<TestConfig> GenerateTests() {
       for (int h2_samp : {1, 2, 4}) {
         for (int v2_samp : {1, 2, 4}) {
           TestConfig config;
-          config.xsize = 137;
-          config.ysize = 75;
-          config.custom_sampling = true;
-          config.h_sampling[0] = h0_samp;
-          config.v_sampling[0] = v0_samp;
-          config.h_sampling[2] = h2_samp;
-          config.v_sampling[2] = v2_samp;
+          config.input.xsize = 137;
+          config.input.ysize = 75;
+          config.jparams.h_sampling = {h0_samp, 1, h2_samp};
+          config.jparams.v_sampling = {v0_samp, 1, v2_samp};
           config.max_bpp = 2.5;
           config.max_dist = 12.0;
           all_tests.push_back(config);
@@ -665,13 +117,10 @@ std::vector<TestConfig> GenerateTests() {
       for (int h2_samp : {1, 3}) {
         for (int v2_samp : {1, 3}) {
           TestConfig config;
-          config.xsize = 205;
-          config.ysize = 99;
-          config.custom_sampling = true;
-          config.h_sampling[0] = h0_samp;
-          config.v_sampling[0] = v0_samp;
-          config.h_sampling[2] = h2_samp;
-          config.v_sampling[2] = v2_samp;
+          config.input.xsize = 205;
+          config.input.ysize = 99;
+          config.jparams.h_sampling = {h0_samp, 1, h2_samp};
+          config.jparams.v_sampling = {v0_samp, 1, v2_samp};
           config.max_bpp = 2.5;
           config.max_dist = 10.0;
           all_tests.push_back(config);
@@ -682,11 +131,10 @@ std::vector<TestConfig> GenerateTests() {
   for (int h0_samp : {1, 2, 3, 4}) {
     for (int v0_samp : {1, 2, 3, 4}) {
       TestConfig config;
-      config.xsize = 217;
-      config.ysize = 129;
-      config.custom_sampling = true;
-      config.h_sampling[0] = h0_samp;
-      config.v_sampling[0] = v0_samp;
+      config.input.xsize = 217;
+      config.input.ysize = 129;
+      config.jparams.h_sampling = {h0_samp, 1, 1};
+      config.jparams.v_sampling = {v0_samp, 1, 1};
       config.max_bpp = 2.0;
       config.max_dist = 5.5;
       all_tests.push_back(config);
@@ -694,87 +142,87 @@ std::vector<TestConfig> GenerateTests() {
   }
   for (size_t p = 0; p < kNumTestScripts; ++p) {
     TestConfig config;
-    config.progressive_id = p + 1;
+    config.jparams.progressive_id = p + 1;
     config.max_bpp = 1.5;
     config.max_dist = 2.2;
     all_tests.push_back(config);
   }
   for (size_t l = 0; l <= 2; ++l) {
     TestConfig config;
-    config.progressive_level = l;
+    config.jparams.progressive_level = l;
     config.max_bpp = 1.5;
     config.max_dist = 2.2;
     all_tests.push_back(config);
   }
   {
     TestConfig config;
-    config.xyb_mode = true;
+    config.jparams.xyb_mode = true;
     config.max_bpp = 1.5;
     config.max_dist = 3.5;
     all_tests.push_back(config);
   }
   {
     TestConfig config;
-    config.libjpeg_mode = true;
+    config.jparams.libjpeg_mode = true;
     config.max_bpp = 2.1;
     config.max_dist = 1.7;
     all_tests.push_back(config);
   }
   {
     TestConfig config;
-    config.in_color_space = JCS_YCbCr;
+    config.input.color_space = JCS_YCbCr;
     config.max_bpp = 1.45;
     config.max_dist = 1.35;
     all_tests.push_back(config);
   }
   for (bool xyb : {false, true}) {
     TestConfig config;
-    config.in_color_space = JCS_GRAYSCALE;
-    config.xyb_mode = xyb;
+    config.input.color_space = JCS_GRAYSCALE;
+    config.jparams.xyb_mode = xyb;
     config.max_bpp = 1.25;
     config.max_dist = 1.4;
     all_tests.push_back(config);
   }
   {
     TestConfig config;
-    config.in_color_space = JCS_RGB;
-    config.set_jpeg_colorspace = true;
-    config.jpeg_color_space = JCS_RGB;
-    config.xyb_mode = false;
+    config.input.color_space = JCS_RGB;
+    config.jparams.set_jpeg_colorspace = true;
+    config.jparams.jpeg_color_space = JCS_RGB;
+    config.jparams.xyb_mode = false;
     config.max_bpp = 3.75;
     config.max_dist = 1.4;
     all_tests.push_back(config);
   }
   {
     TestConfig config;
-    config.in_color_space = JCS_CMYK;
+    config.input.color_space = JCS_CMYK;
     config.max_bpp = 3.75;
     config.max_dist = 1.4;
     all_tests.push_back(config);
-    config.set_jpeg_colorspace = true;
-    config.jpeg_color_space = JCS_YCCK;
+    config.jparams.set_jpeg_colorspace = true;
+    config.jparams.jpeg_color_space = JCS_YCCK;
     config.max_bpp = 3.2;
     config.max_dist = 1.7;
     all_tests.push_back(config);
   }
-  for (int channels = 1; channels <= jpegli::kMaxComponents; ++channels) {
+  for (int channels = 1; channels <= 4; ++channels) {
     TestConfig config;
-    config.in_color_space = JCS_UNKNOWN;
-    config.input_components = channels;
+    config.input.color_space = JCS_UNKNOWN;
+    config.input.components = channels;
     config.max_bpp = 1.25 * channels;
     config.max_dist = 1.4;
     all_tests.push_back(config);
   }
   for (size_t r : {1, 3, 17, 1024}) {
     TestConfig config;
-    config.restart_interval = r;
+    config.jparams.restart_interval = r;
     config.max_bpp = 1.5 + 5.5 / r;
     config.max_dist = 2.2;
     all_tests.push_back(config);
   }
   for (size_t rr : {1, 3, 8, 100}) {
     TestConfig config;
-    config.restart_in_rows = rr;
+    config.jparams.restart_in_rows = rr;
     config.max_bpp = 1.5;
     config.max_dist = 2.2;
     all_tests.push_back(config);
@@ -785,18 +233,16 @@ std::vector<TestConfig> GenerateTests() {
         for (bool baseline : {true, false}) {
           if (!baseline && (add_raw || type * scale < 25500)) continue;
           TestConfig config;
-          config.xsize = 64;
-          config.ysize = 64;
-          config.custom_quant_tables = true;
-          config.quant_indexes[1] = 0;
-          config.quant_indexes[2] = 0;
+          config.input.xsize = 64;
+          config.input.ysize = 64;
           CustomQuantTable table;
           table.table_type = type;
           table.scale_factor = scale;
           table.force_baseline = baseline;
           table.add_raw = add_raw;
           table.Generate();
-          config.quant_tables.push_back(table);
+          config.jparams.quant_tables.push_back(table);
+          config.jparams.quant_indexes = {0, 0, 0};
           float q = (type == 0 ? 16 : type) * scale * 0.01f;
           if (baseline && !add_raw) q = std::max(1.0f, std::min(255.0f, q));
           config.max_bpp = 1.3f + 25.0f / q;
@@ -809,12 +255,10 @@ std::vector<TestConfig> GenerateTests() {
   for (int qidx = 0; qidx < 8; ++qidx) {
     if (qidx == 3) continue;
     TestConfig config;
-    config.xsize = 256;
-    config.ysize = 256;
-    config.custom_quant_tables = true;
-    config.quant_indexes[0] = (qidx >> 2) & 1;
-    config.quant_indexes[1] = (qidx >> 1) & 1;
-    config.quant_indexes[2] = (qidx >> 0) & 1;
+    config.input.xsize = 256;
+    config.input.ysize = 256;
+    config.jparams.quant_indexes = {(qidx >> 2) & 1, (qidx >> 1) & 1,
+                                    (qidx >> 0) & 1};
     config.max_bpp = 2.6;
     config.max_dist = 2.5;
     all_tests.push_back(config);
@@ -823,16 +267,14 @@ std::vector<TestConfig> GenerateTests() {
     for (int slot_idx = 0; slot_idx < 2; ++slot_idx) {
       if (qidx == 0 && slot_idx == 0) continue;
       TestConfig config;
-      config.xsize = 256;
-      config.ysize = 256;
-      config.custom_quant_tables = true;
-      config.quant_indexes[0] = (qidx >> 2) & 1;
-      config.quant_indexes[1] = (qidx >> 1) & 1;
-      config.quant_indexes[2] = (qidx >> 0) & 1;
+      config.input.xsize = 256;
+      config.input.ysize = 256;
+      config.jparams.quant_indexes = {(qidx >> 2) & 1, (qidx >> 1) & 1,
+                                      (qidx >> 0) & 1};
       CustomQuantTable table;
       table.slot_idx = slot_idx;
       table.Generate();
-      config.quant_tables.push_back(table);
+      config.jparams.quant_tables.push_back(table);
       config.max_bpp = 2.6;
       config.max_dist = 2.75;
       all_tests.push_back(config);
@@ -841,25 +283,23 @@ std::vector<TestConfig> GenerateTests() {
   for (int qidx = 0; qidx < 8; ++qidx) {
     for (bool xyb : {false, true}) {
       TestConfig config;
-      config.xsize = 256;
-      config.ysize = 256;
-      config.xyb_mode = xyb;
-      config.custom_quant_tables = true;
-      config.quant_indexes[0] = (qidx >> 2) & 1;
-      config.quant_indexes[1] = (qidx >> 1) & 1;
-      config.quant_indexes[2] = (qidx >> 0) & 1;
+      config.input.xsize = 256;
+      config.input.ysize = 256;
+      config.jparams.xyb_mode = xyb;
+      config.jparams.quant_indexes = {(qidx >> 2) & 1, (qidx >> 1) & 1,
+                                      (qidx >> 0) & 1};
       {
         CustomQuantTable table;
         table.slot_idx = 0;
         table.Generate();
-        config.quant_tables.push_back(table);
+        config.jparams.quant_tables.push_back(table);
       }
       {
         CustomQuantTable table;
         table.slot_idx = 1;
         table.table_type = 20;
         table.Generate();
-        config.quant_tables.push_back(table);
+        config.jparams.quant_tables.push_back(table);
       }
       config.max_bpp = 1.9;
       config.max_dist = 3.75;
@@ -868,32 +308,29 @@ std::vector<TestConfig> GenerateTests() {
   }
   for (bool xyb : {false, true}) {
     TestConfig config;
-    config.xsize = 256;
-    config.ysize = 256;
-    config.xyb_mode = xyb;
-    config.custom_quant_tables = true;
-    config.quant_indexes[0] = 0;
-    config.quant_indexes[1] = 1;
-    config.quant_indexes[2] = 2;
+    config.input.xsize = 256;
+    config.input.ysize = 256;
+    config.jparams.xyb_mode = xyb;
+    config.jparams.quant_indexes = {0, 1, 2};
     {
       CustomQuantTable table;
       table.slot_idx = 0;
       table.Generate();
-      config.quant_tables.push_back(table);
+      config.jparams.quant_tables.push_back(table);
     }
     {
       CustomQuantTable table;
       table.slot_idx = 1;
       table.table_type = 20;
       table.Generate();
-      config.quant_tables.push_back(table);
+      config.jparams.quant_tables.push_back(table);
     }
     {
       CustomQuantTable table;
       table.slot_idx = 2;
       table.table_type = 30;
       table.Generate();
-      config.quant_tables.push_back(table);
+      config.jparams.quant_tables.push_back(table);
     }
     config.max_bpp = 1.5;
     config.max_dist = 3.75;
@@ -901,10 +338,7 @@ std::vector<TestConfig> GenerateTests() {
   }
   {
     TestConfig config;
-    config.custom_component_ids = true;
-    config.comp_id[0] = 7;
-    config.comp_id[1] = 17;
-    config.comp_id[2] = 177;
+    config.jparams.comp_ids = {7, 17, 177};
     config.max_bpp = 1.45;
     config.max_dist = 2.2;
     all_tests.push_back(config);
@@ -913,32 +347,32 @@ std::vector<TestConfig> GenerateTests() {
     TestConfig config;
     config.max_bpp = 1.45;
     config.max_dist = 2.2;
-    config.override_JFIF = 1;
+    config.jparams.override_JFIF = 1;
     all_tests.push_back(config);
-    config.override_JFIF = 0;
-    config.override_Adobe = 1;
+    config.jparams.override_JFIF = 0;
+    config.jparams.override_Adobe = 1;
     all_tests.push_back(config);
-    config.override_JFIF = 1;
-    config.override_Adobe = 1;
+    config.jparams.override_JFIF = 1;
+    config.jparams.override_Adobe = 1;
     all_tests.push_back(config);
   }
   {
     TestConfig config;
-    config.xsize = config.ysize = 256;
+    config.input.xsize = config.input.ysize = 256;
     config.max_bpp = 1.7;
     config.max_dist = 2.3;
-    config.add_marker = true;
+    config.jparams.add_marker = true;
     all_tests.push_back(config);
   }
   {
     TestConfig config;
-    config.xsize = config.ysize = 256;
-    config.progressive_level = 0;
-    config.optimize_coding = false;
+    config.input.xsize = config.input.ysize = 256;
+    config.jparams.progressive_level = 0;
+    config.jparams.optimize_coding = false;
     config.max_bpp = 1.8;
     config.max_dist = 2.3;
     all_tests.push_back(config);
-    config.use_flat_dc_luma_code = true;
+    config.jparams.use_flat_dc_luma_code = true;
     all_tests.push_back(config);
   }
   for (int xsize : {640, 641, 648, 649}) {
@@ -947,20 +381,18 @@ std::vector<TestConfig> GenerateTests() {
         for (int v_sampling : {1, 2}) {
           if (h_sampling == 1 && v_sampling == 1) continue;
           TestConfig config;
-          config.xsize = xsize;
-          config.ysize = ysize;
-          config.in_color_space = JCS_YCbCr;
-          config.custom_sampling = true;
-          config.h_sampling[0] = h_sampling;
-          config.v_sampling[0] = v_sampling;
-          config.raw_data_in = true;
+          config.input.xsize = xsize;
+          config.input.ysize = ysize;
+          config.input.color_space = JCS_YCbCr;
+          config.jparams.h_sampling = {h_sampling, 1, 1};
+          config.jparams.v_sampling = {v_sampling, 1, 1};
+          config.input_mode = RAW_DATA;
           config.max_bpp = 1.7;
           config.max_dist = 2.0;
           all_tests.push_back(config);
-          config.raw_data_in = false;
-          config.write_coeffs = true;
+          config.input_mode = COEFFICIENTS;
           if (xsize & 1) {
-            config.add_marker = true;
+            config.jparams.add_marker = true;
           }
           config.max_bpp = 24.0;
           all_tests.push_back(config);
@@ -989,34 +421,34 @@ std::string ColorSpaceName(J_COLOR_SPACE colorspace) {
 }
 
 std::ostream& operator<<(std::ostream& os, const TestConfig& c) {
-  os << c.xsize << "x" << c.ysize;
-  os << ColorSpaceName(c.in_color_space);
-  if (c.in_color_space == JCS_UNKNOWN) {
-    os << c.input_components;
+  os << c.input.xsize << "x" << c.input.ysize;
+  os << ColorSpaceName(c.input.color_space);
+  if (c.input.color_space == JCS_UNKNOWN) {
+    os << c.input.components;
   }
-  if (c.set_jpeg_colorspace) {
-    os << "to" << ColorSpaceName(c.jpeg_color_space);
+  if (c.jparams.set_jpeg_colorspace) {
+    os << "to" << ColorSpaceName(c.jparams.jpeg_color_space);
   }
-  os << "Q" << c.quality;
-  if (c.custom_sampling) {
+  os << "Q" << c.jparams.quality;
+  if (!c.jparams.h_sampling.empty()) {
     os << "SAMP";
-    for (size_t i = 0; i < c.input_components; ++i) {
+    for (size_t i = 0; i < c.input.components; ++i) {
       os << "_";
-      os << c.h_sampling[i] << "x" << c.v_sampling[i];
+      os << c.jparams.h_sampling[i] << "x" << c.jparams.v_sampling[i];
     }
   }
-  if (c.custom_component_ids) {
+  if (!c.jparams.comp_ids.empty()) {
     os << "CID";
-    for (size_t i = 0; i < c.input_components; ++i) {
-      os << c.comp_id[i];
+    for (size_t i = 0; i < c.input.components; ++i) {
+      os << c.jparams.comp_ids[i];
     }
   }
-  if (c.custom_quant_tables) {
+  if (!c.jparams.quant_indexes.empty()) {
     os << "QIDX";
-    for (size_t i = 0; i < c.input_components; ++i) {
-      os << c.quant_indexes[i];
+    for (size_t i = 0; i < c.input.components; ++i) {
+      os << c.jparams.quant_indexes[i];
     }
-    for (const auto& table : c.quant_tables) {
+    for (const auto& table : c.jparams.quant_tables) {
       os << "TABLE" << table.slot_idx << "T" << table.table_type << "F"
          << table.scale_factor
          << (table.add_raw          ? "R"
@@ -1024,42 +456,41 @@ std::ostream& operator<<(std::ostream& os, const TestConfig& c) {
                                     : "");
     }
   }
-  if (c.progressive_id > 0) {
-    os << "P" << c.progressive_id;
+  if (c.jparams.progressive_id > 0) {
+    os << "P" << c.jparams.progressive_id;
   }
-  if (c.restart_interval > 0) {
-    os << "R" << c.restart_interval;
+  if (c.jparams.restart_interval > 0) {
+    os << "R" << c.jparams.restart_interval;
   }
-  if (c.restart_in_rows > 0) {
-    os << "RR" << c.restart_in_rows;
+  if (c.jparams.restart_in_rows > 0) {
+    os << "RR" << c.jparams.restart_in_rows;
   }
-  if (c.progressive_level >= 0) {
-    os << "PL" << c.progressive_level;
+  if (c.jparams.progressive_level >= 0) {
+    os << "PL" << c.jparams.progressive_level;
   }
-  if (c.xyb_mode) {
+  if (c.jparams.xyb_mode) {
     os << "XYB";
-  } else if (c.libjpeg_mode) {
+  } else if (c.jparams.libjpeg_mode) {
     os << "Libjpeg";
   }
-  if (c.override_JFIF >= 0) {
-    os << (c.override_JFIF ? "AddJFIF" : "NoJFIF");
+  if (c.jparams.override_JFIF >= 0) {
+    os << (c.jparams.override_JFIF ? "AddJFIF" : "NoJFIF");
   }
-  if (c.override_Adobe >= 0) {
-    os << (c.override_JFIF ? "AddAdobe" : "NoAdobe");
+  if (c.jparams.override_Adobe >= 0) {
+    os << (c.jparams.override_JFIF ? "AddAdobe" : "NoAdobe");
   }
-  if (c.add_marker) {
+  if (c.jparams.add_marker) {
     os << "AddMarker";
   }
-  if (!c.optimize_coding) {
+  if (!c.jparams.optimize_coding) {
     os << "FixedTree";
-    if (c.use_flat_dc_luma_code) {
+    if (c.jparams.use_flat_dc_luma_code) {
       os << "FlatDCLuma";
     }
   }
-  if (c.raw_data_in) {
+  if (c.input_mode == RAW_DATA) {
     os << "RawDataIn";
-  }
-  if (c.write_coeffs) {
+  } else if (c.input_mode == COEFFICIENTS) {
     os << "WriteCoeffs";
   }
   return os;

--- a/lib/jpegli/libjpeg_wrapper.cc
+++ b/lib/jpegli/libjpeg_wrapper.cc
@@ -78,6 +78,10 @@ JDIMENSION jpeg_read_raw_data(j_decompress_ptr cinfo, JSAMPIMAGE data,
   return jpegli_read_raw_data(cinfo, data, max_lines);
 }
 
+jvirt_barray_ptr *jpeg_read_coefficients(j_decompress_ptr cinfo) {
+  return jpegli_read_coefficients(cinfo);
+}
+
 boolean jpeg_has_multiple_scans(j_decompress_ptr cinfo) {
   return jpegli_has_multiple_scans(cinfo);
 }
@@ -175,6 +179,11 @@ void jpeg_simple_progression(j_compress_ptr cinfo) {
 
 void jpeg_suppress_tables(j_compress_ptr cinfo, boolean suppress) {
   jpegli_suppress_tables(cinfo, suppress);
+}
+
+void jpeg_copy_critical_parameters(j_decompress_ptr srcinfo,
+                                   j_compress_ptr dstinfo) {
+  jpegli_copy_critical_parameters(srcinfo, dstinfo);
 }
 
 void jpeg_write_m_header(j_compress_ptr cinfo, int marker,

--- a/lib/jpegli/quant.cc
+++ b/lib/jpegli/quant.cc
@@ -573,7 +573,8 @@ void FinalizeQuantMatrices(j_compress_ptr cinfo) {
   for (int c = 0; c < cinfo->num_components; ++c) {
     int quant_idx = cinfo->comp_info[c].quant_tbl_no;
     if (quant_idx < 0 || quant_idx >= NUM_QUANT_TBLS) {
-      JPEGLI_ERROR("Invalid quant table index %d", quant_idx);
+      JPEGLI_ERROR("Invalid quant table index %d for component %d", quant_idx,
+                   c);
     }
     JQUANT_TBL** qtable = &cinfo->quant_tbl_ptrs[quant_idx];
     if (*qtable != nullptr) {

--- a/lib/jpegli/test_utils.h
+++ b/lib/jpegli/test_utils.h
@@ -6,15 +6,176 @@
 #ifndef LIB_JPEGLI_TEST_UTILS_H_
 #define LIB_JPEGLI_TEST_UTILS_H_
 
+/* clang-format off */
+#include <stdio.h>
+#include <jpeglib.h>
+#include <setjmp.h>
+/* clang-format on */
+
+#include <cmath>
 #include <vector>
 
+#include "lib/jpegli/encode.h"
+#include "lib/jpegli/testing.h"
 #include "lib/jxl/base/file_io.h"
+#include "lib/jxl/base/status.h"
+#include "lib/jxl/sanitizers.h"
 
 #if !defined(TEST_DATA_PATH)
 #include "tools/cpp/runfiles/runfiles.h"
 #endif
 
 namespace jpegli {
+
+template <typename T1, typename T2>
+constexpr inline T1 DivCeil(T1 a, T2 b) {
+  return (a + b - 1) / b;
+}
+
+struct MyClientData {
+  jmp_buf env;
+  unsigned char* buffer = nullptr;
+  unsigned long size = 0;
+  unsigned char* table_stream = nullptr;
+  unsigned long table_stream_size = 0;
+};
+
+#define ERROR_HANDLER_SETUP(action)                                           \
+  jpeg_error_mgr jerr;                                                        \
+  cinfo.err = jpegli_std_error(&jerr);                                        \
+  if (setjmp(data.env)) {                                                     \
+    action;                                                                   \
+  }                                                                           \
+  cinfo.client_data = reinterpret_cast<void*>(&data);                         \
+  cinfo.err->error_exit = [](j_common_ptr cinfo) {                            \
+    (*cinfo->err->output_message)(cinfo);                                     \
+    MyClientData* data = reinterpret_cast<MyClientData*>(cinfo->client_data); \
+    if (data->buffer) free(data->buffer);                                     \
+    jpegli_destroy(cinfo);                                                    \
+    longjmp(data->env, 1);                                                    \
+  };
+
+static constexpr int kSpecialMarker = 0xe5;
+static constexpr uint8_t kMarkerData[] = {0, 1, 255, 0, 17};
+
+#define ARRAY_SIZE(X) (sizeof(X) / sizeof((X)[0]))
+
+static constexpr jpeg_scan_info kScript1[] = {
+    {3, {0, 1, 2}, 0, 0, 0, 0},
+    {1, {0}, 1, 63, 0, 0},
+    {1, {1}, 1, 63, 0, 0},
+    {1, {2}, 1, 63, 0, 0},
+};
+static constexpr jpeg_scan_info kScript2[] = {
+    {1, {0}, 0, 0, 0, 0},  {1, {1}, 0, 0, 0, 0},  {1, {2}, 0, 0, 0, 0},
+    {1, {0}, 1, 63, 0, 0}, {1, {1}, 1, 63, 0, 0}, {1, {2}, 1, 63, 0, 0},
+};
+static constexpr jpeg_scan_info kScript3[] = {
+    {3, {0, 1, 2}, 0, 0, 0, 0}, {1, {0}, 1, 63, 0, 1}, {1, {1}, 1, 63, 0, 1},
+    {1, {2}, 1, 63, 0, 1},      {1, {0}, 1, 63, 1, 0}, {1, {1}, 1, 63, 1, 0},
+    {1, {2}, 1, 63, 1, 0},
+};
+
+struct ScanScript {
+  size_t num_scans;
+  const jpeg_scan_info* scans;
+};
+
+static constexpr ScanScript kTestScript[] = {
+    {ARRAY_SIZE(kScript1), kScript1},
+    {ARRAY_SIZE(kScript2), kScript2},
+    {ARRAY_SIZE(kScript3), kScript3},
+};
+static constexpr size_t kNumTestScripts = ARRAY_SIZE(kTestScript);
+
+enum JpegIOMode {
+  PIXELS,
+  RAW_DATA,
+  COEFFICIENTS,
+};
+
+struct CustomQuantTable {
+  int slot_idx = 0;
+  uint16_t table_type = 0;
+  int scale_factor = 100;
+  bool add_raw = false;
+  bool force_baseline = true;
+  std::vector<unsigned int> basic_table;
+  std::vector<unsigned int> quantval;
+  void Generate() {
+    basic_table.resize(DCTSIZE2);
+    quantval.resize(DCTSIZE2);
+    switch (table_type) {
+      case 0: {
+        for (int k = 0; k < DCTSIZE2; ++k) {
+          basic_table[k] = k + 1;
+        }
+        break;
+      }
+      default:
+        for (int k = 0; k < DCTSIZE2; ++k) {
+          basic_table[k] = table_type;
+        }
+    }
+    for (int k = 0; k < DCTSIZE2; ++k) {
+      quantval[k] = (basic_table[k] * scale_factor + 50U) / 100U;
+      quantval[k] = std::max(quantval[k], 1U);
+      quantval[k] = std::min(quantval[k], 65535U);
+      if (!add_raw) {
+        quantval[k] = std::min(quantval[k], force_baseline ? 255U : 32767U);
+      }
+    }
+  }
+};
+
+struct TestImage {
+  size_t xsize = 0;
+  size_t ysize = 0;
+  J_COLOR_SPACE color_space = JCS_RGB;
+  size_t components = 3;
+  std::vector<uint8_t> pixels;
+  std::vector<std::vector<uint8_t>> raw_data;
+  std::vector<std::vector<JCOEF>> coeffs;
+};
+
+struct CompressParams {
+  int quality = 90;
+  bool set_jpeg_colorspace = false;
+  J_COLOR_SPACE jpeg_color_space = JCS_UNKNOWN;
+  std::vector<int> quant_indexes;
+  std::vector<CustomQuantTable> quant_tables;
+  std::vector<int> h_sampling;
+  std::vector<int> v_sampling;
+  std::vector<int> comp_ids;
+  int override_JFIF = -1;
+  int override_Adobe = -1;
+  bool add_marker = false;
+  int progressive_id = 0;
+  int progressive_level = -1;
+  int restart_interval = 0;
+  int restart_in_rows = 0;
+  bool optimize_coding = true;
+  bool use_flat_dc_luma_code = false;
+  bool xyb_mode = false;
+  bool libjpeg_mode = false;
+
+  int h_samp(int c) const { return h_sampling.empty() ? 1 : h_sampling[c]; }
+  int v_samp(int c) const { return v_sampling.empty() ? 1 : v_sampling[c]; }
+  int max_h_sample() const {
+    auto it = std::max_element(h_sampling.begin(), h_sampling.end());
+    return it == h_sampling.end() ? 1 : *it;
+  }
+  int max_v_sample() const {
+    auto it = std::max_element(v_sampling.begin(), v_sampling.end());
+    return it == v_sampling.end() ? 1 : *it;
+  }
+  int comp_width(const TestImage& input, int c) const {
+    return DivCeil(input.xsize * h_samp(c), max_h_sample() * DCTSIZE) * DCTSIZE;
+  }
+  int comp_height(const TestImage& input, int c) const {
+    return DivCeil(input.ysize * v_samp(c), max_v_sample() * DCTSIZE) * DCTSIZE;
+  }
+};
 
 #if defined(TEST_DATA_PATH)
 template <typename S>
@@ -133,6 +294,454 @@ static inline bool ReadPNM(const std::vector<uint8_t>& data, size_t* xsize,
   pixels->resize(data.data() + data.size() - pos);
   memcpy(&(*pixels)[0], pos, pixels->size());
   return true;
+}
+
+void SetNumChannels(J_COLOR_SPACE colorspace, size_t* channels) {
+  if (colorspace == JCS_GRAYSCALE) {
+    *channels = 1;
+  } else if (colorspace == JCS_RGB || colorspace == JCS_YCbCr) {
+    *channels = 3;
+  } else if (colorspace == JCS_CMYK || colorspace == JCS_YCCK) {
+    *channels = 4;
+  } else if (colorspace == JCS_UNKNOWN) {
+    ASSERT_LE(*channels, 4);
+  } else {
+    FAIL();
+  }
+}
+
+void ConvertPixel(const uint8_t* input_rgb, uint8_t* out,
+                  J_COLOR_SPACE colorspace, size_t num_channels) {
+  const float kMul = 255.0f;
+  const float r = input_rgb[0] / kMul;
+  const float g = input_rgb[1] / kMul;
+  const float b = input_rgb[2] / kMul;
+  if (colorspace == JCS_GRAYSCALE) {
+    const float Y = 0.299f * r + 0.587f * g + 0.114f * b;
+    out[0] = static_cast<uint8_t>(std::round(Y * kMul));
+  } else if (colorspace == JCS_RGB || colorspace == JCS_UNKNOWN) {
+    for (size_t c = 0; c < num_channels; ++c) {
+      out[c] = input_rgb[std::min<size_t>(2, c)];
+    }
+  } else if (colorspace == JCS_YCbCr) {
+    float Y = 0.299f * r + 0.587f * g + 0.114f * b;
+    float Cb = -0.168736f * r - 0.331264f * g + 0.5f * b + 0.5f;
+    float Cr = 0.5f * r - 0.418688f * g - 0.081312f * b + 0.5f;
+    out[0] = static_cast<uint8_t>(std::round(Y * kMul));
+    out[1] = static_cast<uint8_t>(std::round(Cb * kMul));
+    out[2] = static_cast<uint8_t>(std::round(Cr * kMul));
+  } else if (colorspace == JCS_CMYK) {
+    float K = 1.0f - std::max(r, std::max(g, b));
+    float scaleK = 1.0f / (1.0f - K);
+    float C = (1.0f - K - r) * scaleK;
+    float M = (1.0f - K - g) * scaleK;
+    float Y = (1.0f - K - b) * scaleK;
+    out[0] = static_cast<uint8_t>(std::round(C * kMul));
+    out[1] = static_cast<uint8_t>(std::round(M * kMul));
+    out[2] = static_cast<uint8_t>(std::round(Y * kMul));
+    out[3] = static_cast<uint8_t>(std::round(K * kMul));
+  } else {
+    JXL_ABORT("Colorspace %d not supported", colorspace);
+  }
+}
+
+void GeneratePixels(TestImage* img) {
+  const std::vector<uint8_t> imgdata = ReadTestData("jxl/flower/flower.pnm");
+  size_t xsize, ysize, channels, bitdepth;
+  std::vector<uint8_t> pixels;
+  ASSERT_TRUE(ReadPNM(imgdata, &xsize, &ysize, &channels, &bitdepth, &pixels));
+  if (img->xsize == 0) img->xsize = xsize;
+  if (img->ysize == 0) img->ysize = ysize;
+  ASSERT_LE(img->xsize, xsize);
+  ASSERT_LE(img->ysize, ysize);
+  ASSERT_EQ(3, channels);
+  ASSERT_EQ(8, bitdepth);
+  size_t in_bytes_per_pixel = channels;
+  size_t in_stride = xsize * in_bytes_per_pixel;
+  size_t x0 = (xsize - img->xsize) / 2;
+  size_t y0 = (ysize - img->ysize) / 2;
+  SetNumChannels(img->color_space, &img->components);
+  size_t out_bytes_per_pixel = img->components;
+  size_t out_stride = img->xsize * out_bytes_per_pixel;
+  img->pixels.resize(img->ysize * out_stride);
+  for (size_t iy = 0; iy < img->ysize; ++iy) {
+    size_t y = y0 + iy;
+    for (size_t ix = 0; ix < img->xsize; ++ix) {
+      size_t x = x0 + ix;
+      size_t idx_in = y * in_stride + x * in_bytes_per_pixel;
+      size_t idx_out = iy * out_stride + ix * out_bytes_per_pixel;
+      ConvertPixel(&pixels[idx_in], &img->pixels[idx_out], img->color_space,
+                   img->components);
+    }
+  }
+}
+
+void GenerateRawData(const CompressParams& jparams, TestImage* img) {
+  for (size_t c = 0; c < img->components; ++c) {
+    size_t xsize = jparams.comp_width(*img, c);
+    size_t ysize = jparams.comp_height(*img, c);
+    size_t factor_y = jparams.max_v_sample() / jparams.v_samp(c);
+    size_t factor_x = jparams.max_h_sample() / jparams.h_samp(c);
+    size_t factor = factor_x * factor_y;
+    std::vector<uint8_t> plane(ysize * xsize);
+    size_t bytes_per_pixel = img->components;
+    for (size_t y = 0; y < ysize; ++y) {
+      for (size_t x = 0; x < xsize; ++x) {
+        int result = 0;
+        for (size_t iy = 0; iy < factor_y; ++iy) {
+          size_t yy = std::min(y * factor_y + iy, img->ysize - 1);
+          for (size_t ix = 0; ix < factor_x; ++ix) {
+            size_t xx = std::min(x * factor_x + ix, img->xsize - 1);
+            size_t pixel_ix = (yy * img->xsize + xx) * bytes_per_pixel + c;
+            result += img->pixels[pixel_ix];
+          }
+        }
+        result = static_cast<uint8_t>((result + factor / 2) / factor);
+        plane[y * xsize + x] = result;
+      }
+    }
+    img->raw_data.emplace_back(std::move(plane));
+  }
+}
+
+void GenerateCoeffs(const CompressParams& jparams, TestImage* img) {
+  for (size_t c = 0; c < img->components; ++c) {
+    size_t xsize_blocks = jparams.comp_width(*img, c) / DCTSIZE;
+    size_t ysize_blocks = jparams.comp_height(*img, c) / DCTSIZE;
+    std::vector<JCOEF> plane(ysize_blocks * xsize_blocks * DCTSIZE2);
+    for (size_t by = 0; by < ysize_blocks; ++by) {
+      for (size_t bx = 0; bx < xsize_blocks; ++bx) {
+        for (size_t k = 0; k < DCTSIZE2; ++k) {
+          plane[(by * xsize_blocks + bx) * DCTSIZE2 + k] = (bx - by) / (k + 1);
+        }
+      }
+    }
+    img->coeffs.emplace_back(std::move(plane));
+  }
+}
+
+bool EncodeWithJpegli(const TestImage& input, const CompressParams& jparams,
+                      std::vector<uint8_t>* compressed) {
+  MyClientData data;
+  jpeg_compress_struct cinfo;
+  ERROR_HANDLER_SETUP(return false);
+  jpegli_create_compress(&cinfo);
+  jpegli_mem_dest(&cinfo, &data.buffer, &data.size);
+  cinfo.image_width = input.xsize;
+  cinfo.image_height = input.ysize;
+  cinfo.input_components = input.components;
+  cinfo.in_color_space = input.color_space;
+  if (jparams.xyb_mode) {
+    jpegli_set_xyb_mode(&cinfo);
+  }
+  jpegli_set_defaults(&cinfo);
+  if (jparams.override_JFIF >= 0) {
+    cinfo.write_JFIF_header = jparams.override_JFIF;
+  }
+  if (jparams.override_Adobe >= 0) {
+    cinfo.write_Adobe_marker = jparams.override_Adobe;
+  }
+  if (jparams.set_jpeg_colorspace) {
+    jpegli_set_colorspace(&cinfo, jparams.jpeg_color_space);
+  }
+  if (!jparams.comp_ids.empty()) {
+    for (int c = 0; c < cinfo.num_components; ++c) {
+      cinfo.comp_info[c].component_id = jparams.comp_ids[c];
+    }
+  }
+  if (!jparams.h_sampling.empty()) {
+    for (int c = 0; c < cinfo.num_components; ++c) {
+      cinfo.comp_info[c].h_samp_factor = jparams.h_sampling[c];
+      cinfo.comp_info[c].v_samp_factor = jparams.v_sampling[c];
+    }
+  }
+  if (!jparams.quant_indexes.empty()) {
+    for (int c = 0; c < cinfo.num_components; ++c) {
+      cinfo.comp_info[c].quant_tbl_no = jparams.quant_indexes[c];
+    }
+    for (const auto& table : jparams.quant_tables) {
+      if (table.add_raw) {
+        cinfo.quant_tbl_ptrs[table.slot_idx] =
+            jpegli_alloc_quant_table((j_common_ptr)&cinfo);
+        for (int k = 0; k < DCTSIZE2; ++k) {
+          cinfo.quant_tbl_ptrs[table.slot_idx]->quantval[k] = table.quantval[k];
+        }
+        cinfo.quant_tbl_ptrs[table.slot_idx]->sent_table = FALSE;
+      } else {
+        jpegli_add_quant_table(&cinfo, table.slot_idx, &table.basic_table[0],
+                               table.scale_factor, table.force_baseline);
+      }
+    }
+  }
+  if (jparams.progressive_id > 0) {
+    const ScanScript& script = kTestScript[jparams.progressive_id - 1];
+    cinfo.scan_info = script.scans;
+    cinfo.num_scans = script.num_scans;
+  } else if (jparams.progressive_level >= 0) {
+    jpegli_set_progressive_level(&cinfo, jparams.progressive_level);
+  }
+  cinfo.restart_interval = jparams.restart_interval;
+  cinfo.restart_in_rows = jparams.restart_in_rows;
+  cinfo.optimize_coding = jparams.optimize_coding;
+  cinfo.raw_data_in = !input.raw_data.empty();
+  if (!jparams.optimize_coding && jparams.use_flat_dc_luma_code) {
+    JHUFF_TBL* tbl = cinfo.dc_huff_tbl_ptrs[0];
+    memset(tbl, 0, sizeof(*tbl));
+    tbl->bits[4] = 15;
+    for (int i = 0; i < 15; ++i) tbl->huffval[i] = i;
+  }
+  jpegli_set_quality(&cinfo, jparams.quality, TRUE);
+  if (jparams.libjpeg_mode) {
+    jpegli_enable_adaptive_quantization(&cinfo, FALSE);
+    jpegli_use_standard_quant_tables(&cinfo);
+    jpegli_set_progressive_level(&cinfo, 0);
+  }
+  if (input.coeffs.empty()) {
+    jpegli_start_compress(&cinfo, TRUE);
+    if (jparams.add_marker) {
+      jpegli_write_marker(&cinfo, kSpecialMarker, kMarkerData,
+                          sizeof(kMarkerData));
+    }
+  }
+  if (cinfo.raw_data_in) {
+    // Need to copy because jpeg API requires non-const pointers.
+    std::vector<std::vector<uint8_t>> raw_data = input.raw_data;
+    size_t max_lines = jparams.max_v_sample() * DCTSIZE;
+    std::vector<std::vector<JSAMPROW>> rowdata(cinfo.num_components);
+    std::vector<JSAMPARRAY> data(cinfo.num_components);
+    for (int c = 0; c < cinfo.num_components; ++c) {
+      rowdata[c].resize(jparams.v_samp(c) * DCTSIZE);
+      data[c] = &rowdata[c][0];
+    }
+    while (cinfo.next_scanline < cinfo.image_height) {
+      for (int c = 0; c < cinfo.num_components; ++c) {
+        size_t cwidth = cinfo.comp_info[c].width_in_blocks * DCTSIZE;
+        size_t cheight = cinfo.comp_info[c].height_in_blocks * DCTSIZE;
+        size_t num_lines = jparams.v_samp(c) * DCTSIZE;
+        size_t y0 = (cinfo.next_scanline / max_lines) * num_lines;
+        for (size_t i = 0; i < num_lines; ++i) {
+          rowdata[c][i] =
+              (y0 + i < cheight ? &raw_data[c][(y0 + i) * cwidth] : nullptr);
+        }
+      }
+      size_t num_lines = jpegli_write_raw_data(&cinfo, &data[0], max_lines);
+      EXPECT_EQ(num_lines, max_lines);
+    }
+  } else if (!input.coeffs.empty()) {
+    j_common_ptr comptr = reinterpret_cast<j_common_ptr>(&cinfo);
+    jvirt_barray_ptr* coef_arrays = reinterpret_cast<jvirt_barray_ptr*>((
+        *cinfo.mem->alloc_small)(
+        comptr, JPOOL_IMAGE, cinfo.num_components * sizeof(jvirt_barray_ptr)));
+    for (int c = 0; c < cinfo.num_components; ++c) {
+      size_t xsize_blocks = jparams.comp_width(input, c) / DCTSIZE;
+      size_t ysize_blocks = jparams.comp_height(input, c) / DCTSIZE;
+      coef_arrays[c] = (*cinfo.mem->request_virt_barray)(
+          comptr, JPOOL_IMAGE, FALSE, xsize_blocks, ysize_blocks, 1);
+    }
+    jpegli_write_coefficients(&cinfo, coef_arrays);
+    if (jparams.add_marker) {
+      jpegli_write_marker(&cinfo, kSpecialMarker, kMarkerData,
+                          sizeof(kMarkerData));
+    }
+    for (int c = 0; c < cinfo.num_components; ++c) {
+      jpeg_component_info* comp = &cinfo.comp_info[c];
+      for (size_t by = 0; by < comp->height_in_blocks; ++by) {
+        JBLOCKARRAY ba = (*cinfo.mem->access_virt_barray)(
+            comptr, coef_arrays[c], by, 1, true);
+        size_t stride = comp->width_in_blocks * sizeof(JBLOCK);
+        size_t offset = by * comp->width_in_blocks * DCTSIZE2;
+        memcpy(ba[0], &input.coeffs[c][offset], stride);
+      }
+    }
+  } else {
+    size_t stride = cinfo.image_width * cinfo.input_components;
+    std::vector<uint8_t> row_bytes(stride);
+    for (size_t y = 0; y < cinfo.image_height; ++y) {
+      memcpy(&row_bytes[0], &input.pixels[y * stride], stride);
+      JSAMPROW row[] = {row_bytes.data()};
+      jpegli_write_scanlines(&cinfo, row, 1);
+    }
+  }
+  jpegli_finish_compress(&cinfo);
+  jpegli_destroy_compress(&cinfo);
+  compressed->resize(data.size);
+  std::copy_n(data.buffer, data.size, compressed->data());
+  std::free(data.buffer);
+  return true;
+}
+
+// Verifies that an image encoded with libjpegli can be decoded with libjpeg,
+// and checks that the jpeg coding metadata matches jparams.
+void DecodeWithLibjpeg(const CompressParams& jparams,
+                       const std::vector<uint8_t>& compressed,
+                       JpegIOMode output_mode, TestImage* output) {
+  jpeg_decompress_struct cinfo = {};
+  const auto try_catch_block = [&]() {
+    jpeg_error_mgr jerr;
+    jmp_buf env;
+    cinfo.err = jpeg_std_error(&jerr);
+    if (setjmp(env)) {
+      FAIL();
+    }
+    cinfo.client_data = reinterpret_cast<void*>(&env);
+    cinfo.err->error_exit = [](j_common_ptr cinfo) {
+      (*cinfo->err->output_message)(cinfo);
+      jmp_buf* env = reinterpret_cast<jmp_buf*>(cinfo->client_data);
+      longjmp(*env, 1);
+    };
+    jpeg_create_decompress(&cinfo);
+    jpeg_mem_src(&cinfo, compressed.data(), compressed.size());
+    if (jparams.add_marker) {
+      jpeg_save_markers(&cinfo, kSpecialMarker, 0xffff);
+    }
+    EXPECT_EQ(JPEG_REACHED_SOS,
+              jpeg_read_header(&cinfo, /*require_image=*/TRUE));
+    jxl::msan::UnpoisonMemory(
+        cinfo.comp_info, cinfo.num_components * sizeof(cinfo.comp_info[0]));
+    output->xsize = cinfo.image_width;
+    output->ysize = cinfo.image_height;
+    output->components = cinfo.num_components;
+    cinfo.buffered_image = TRUE;
+    cinfo.out_color_space = output->color_space;
+    if (jparams.override_JFIF >= 0) {
+      EXPECT_EQ(cinfo.saw_JFIF_marker, jparams.override_JFIF);
+    }
+    if (jparams.override_Adobe >= 0) {
+      EXPECT_EQ(cinfo.saw_Adobe_marker, jparams.override_Adobe);
+    }
+    if (output->color_space == JCS_UNKNOWN) {
+      cinfo.jpeg_color_space = JCS_UNKNOWN;
+    }
+    if (jparams.add_marker) {
+      bool marker_found = false;
+      for (jpeg_saved_marker_ptr marker = cinfo.marker_list; marker != nullptr;
+           marker = marker->next) {
+        jxl::msan::UnpoisonMemory(marker, sizeof(*marker));
+        jxl::msan::UnpoisonMemory(marker->data, marker->data_length);
+        if (marker->marker == kSpecialMarker &&
+            marker->data_length == sizeof(kMarkerData) &&
+            memcmp(marker->data, kMarkerData, sizeof(kMarkerData)) == 0) {
+          marker_found = true;
+        }
+      }
+      EXPECT_TRUE(marker_found);
+    }
+    if (!jparams.comp_ids.empty()) {
+      for (int i = 0; i < cinfo.num_components; ++i) {
+        EXPECT_EQ(cinfo.comp_info[i].component_id, jparams.comp_ids[i]);
+      }
+    }
+    if (!jparams.h_sampling.empty()) {
+      for (int i = 0; i < cinfo.num_components; ++i) {
+        EXPECT_EQ(cinfo.comp_info[i].h_samp_factor, jparams.h_sampling[i]);
+        EXPECT_EQ(cinfo.comp_info[i].v_samp_factor, jparams.v_sampling[i]);
+      }
+    }
+    if (!jparams.quant_indexes.empty()) {
+      for (int i = 0; i < cinfo.num_components; ++i) {
+        EXPECT_EQ(cinfo.comp_info[i].quant_tbl_no, jparams.quant_indexes[i]);
+      }
+      for (const auto& table : jparams.quant_tables) {
+        JQUANT_TBL* quant_table = cinfo.quant_tbl_ptrs[table.slot_idx];
+        jxl::msan::UnpoisonMemory(quant_table, sizeof(*quant_table));
+        ASSERT_TRUE(quant_table != nullptr);
+        for (int k = 0; k < DCTSIZE2; ++k) {
+          EXPECT_EQ(quant_table->quantval[k], table.quantval[k]);
+        }
+      }
+    }
+    if (output_mode == COEFFICIENTS) {
+      j_common_ptr comptr = reinterpret_cast<j_common_ptr>(&cinfo);
+      jvirt_barray_ptr* coef_arrays = jpeg_read_coefficients(&cinfo);
+      ASSERT_TRUE(coef_arrays != nullptr);
+      for (int c = 0; c < cinfo.num_components; ++c) {
+        jpeg_component_info* comp = &cinfo.comp_info[c];
+        std::vector<JCOEF> coeffs(comp->width_in_blocks *
+                                  comp->height_in_blocks * DCTSIZE2);
+        for (size_t by = 0; by < comp->height_in_blocks; ++by) {
+          JBLOCKARRAY ba = (*cinfo.mem->access_virt_barray)(
+              comptr, coef_arrays[c], by, 1, true);
+          size_t stride = comp->width_in_blocks * sizeof(JBLOCK);
+          size_t offset = by * comp->width_in_blocks * DCTSIZE2;
+          memcpy(&coeffs[offset], ba[0], stride);
+        }
+        output->coeffs.emplace_back(std::move(coeffs));
+      }
+    } else {
+      EXPECT_TRUE(jpeg_start_decompress(&cinfo));
+      while (!jpeg_input_complete(&cinfo)) {
+        EXPECT_GT(cinfo.input_scan_number, 0);
+        EXPECT_TRUE(jpeg_start_output(&cinfo, cinfo.input_scan_number));
+        if (jparams.progressive_id > 0) {
+          ASSERT_LE(jparams.progressive_id, kNumTestScripts);
+          const ScanScript& script = kTestScript[jparams.progressive_id - 1];
+          ASSERT_LE(cinfo.input_scan_number, script.num_scans);
+          const jpeg_scan_info& scan =
+              script.scans[cinfo.input_scan_number - 1];
+          ASSERT_EQ(cinfo.comps_in_scan, scan.comps_in_scan);
+          for (int i = 0; i < cinfo.comps_in_scan; ++i) {
+            EXPECT_EQ(cinfo.cur_comp_info[i]->component_index,
+                      scan.component_index[i]);
+          }
+          EXPECT_EQ(cinfo.Ss, scan.Ss);
+          EXPECT_EQ(cinfo.Se, scan.Se);
+          EXPECT_EQ(cinfo.Ah, scan.Ah);
+          EXPECT_EQ(cinfo.Al, scan.Al);
+        }
+        EXPECT_TRUE(jpeg_finish_output(&cinfo));
+        if (jparams.restart_interval > 0) {
+          EXPECT_EQ(cinfo.restart_interval, jparams.restart_interval);
+        } else if (jparams.restart_in_rows > 0) {
+          EXPECT_EQ(cinfo.restart_interval,
+                    jparams.restart_in_rows * cinfo.MCUs_per_row);
+        }
+      }
+      EXPECT_TRUE(jpeg_start_output(&cinfo, cinfo.input_scan_number));
+      size_t stride = cinfo.image_width * cinfo.out_color_components;
+      output->pixels.resize(cinfo.image_height * stride);
+      for (size_t y = 0; y < cinfo.image_height; ++y) {
+        JSAMPROW rows[] = {
+            reinterpret_cast<JSAMPLE*>(&output->pixels[y * stride])};
+        jxl::msan::UnpoisonMemory(
+            rows[0],
+            sizeof(JSAMPLE) * cinfo.output_components * cinfo.image_width);
+        EXPECT_EQ(1, jpeg_read_scanlines(&cinfo, rows, 1));
+      }
+      EXPECT_TRUE(jpeg_finish_output(&cinfo));
+    }
+    EXPECT_TRUE(jpeg_finish_decompress(&cinfo));
+  };
+  try_catch_block();
+  jpeg_destroy_decompress(&cinfo);
+}
+
+void VerifyOutputImage(const TestImage& input, const TestImage& output,
+                       double max_rms) {
+  EXPECT_EQ(output.xsize, input.xsize);
+  EXPECT_EQ(output.ysize, input.ysize);
+  EXPECT_EQ(output.components, input.components);
+  if (!input.coeffs.empty()) {
+    ASSERT_EQ(input.coeffs.size(), input.components);
+    ASSERT_EQ(output.coeffs.size(), input.components);
+    for (size_t c = 0; c < input.components; ++c) {
+      ASSERT_EQ(output.coeffs[c].size(), input.coeffs[c].size());
+      EXPECT_EQ(0, memcmp(input.coeffs[c].data(), output.coeffs[c].data(),
+                          input.coeffs[c].size()));
+    }
+  } else {
+    ASSERT_EQ(output.pixels.size(), input.pixels.size());
+    const double mul = 1.0 / 255.0;
+    double diff2 = 0.0;
+    for (size_t i = 0; i < input.pixels.size(); ++i) {
+      double sample_orig = input.pixels[i] * mul;
+      double sample_output = output.pixels[i] * mul;
+      double diff = sample_orig - sample_output;
+      diff2 += diff * diff;
+    }
+    double rms = std::sqrt(diff2 / input.pixels.size()) / mul;
+    printf("rms: %f\n", rms);
+    EXPECT_LE(rms, max_rms);
+  }
 }
 
 }  // namespace jpegli

--- a/lib/jpegli/transcode_api_test.cc
+++ b/lib/jpegli/transcode_api_test.cc
@@ -1,0 +1,142 @@
+// Copyright (c) the JPEG XL Project Authors. All rights reserved.
+//
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+/* clang-format off */
+#include <stdio.h>
+#include <jpeglib.h>
+#include <setjmp.h>
+/* clang-format on */
+
+#include <vector>
+
+#include "lib/jpegli/encode.h"
+#include "lib/jpegli/decode.h"
+#include "lib/jpegli/test_utils.h"
+#include "lib/jpegli/testing.h"
+
+namespace jpegli {
+namespace {
+
+void TranscodeWithJpegli(const std::vector<uint8_t>& jpeg_input,
+                         std::vector<uint8_t>* jpeg_output) {
+  jpeg_decompress_struct dinfo = {};
+  jpeg_compress_struct cinfo = {};
+  uint8_t* transcoded_data = nullptr;
+  unsigned long transcoded_size;
+  const auto try_catch_block = [&]() {
+    jpeg_error_mgr jerr;
+    jmp_buf env;
+    dinfo.err = jpegli_std_error(&jerr);
+    if (setjmp(env)) {
+      FAIL();
+    }
+    dinfo.client_data = reinterpret_cast<void*>(&env);
+    dinfo.err->error_exit = [](j_common_ptr cinfo) {
+      (*cinfo->err->output_message)(cinfo);
+      jmp_buf* env = reinterpret_cast<jmp_buf*>(cinfo->client_data);
+      longjmp(*env, 1);
+    };
+    jpegli_create_decompress(&dinfo);
+    jpegli_mem_src(&dinfo, jpeg_input.data(), jpeg_input.size());
+    EXPECT_EQ(JPEG_REACHED_SOS,
+              jpegli_read_header(&dinfo, /*require_image=*/TRUE));
+    jvirt_barray_ptr* coef_arrays = jpegli_read_coefficients(&dinfo);
+    ASSERT_TRUE(coef_arrays != nullptr);
+    cinfo.err = dinfo.err;
+    cinfo.client_data = dinfo.client_data;
+    jpegli_create_compress(&cinfo);
+    jpegli_mem_dest(&cinfo, &transcoded_data, &transcoded_size);
+    jpegli_copy_critical_parameters(&dinfo, &cinfo);
+    jpegli_write_coefficients(&cinfo, coef_arrays);
+    jpegli_finish_compress(&cinfo);
+    jpegli_finish_decompress(&dinfo);
+  };
+  try_catch_block();
+  jpegli_destroy_decompress(&dinfo);
+  jpegli_destroy_compress(&cinfo);
+  if (transcoded_data) {
+    jpeg_output->assign(transcoded_data, transcoded_data + transcoded_size);
+    free(transcoded_data);
+  }
+}
+
+struct TestConfig {
+  TestImage input;
+  CompressParams jparams;
+};
+
+class TranscodeAPITestParam : public ::testing::TestWithParam<TestConfig> {};
+
+TEST_P(TranscodeAPITestParam, TestAPI) {
+  TestConfig config = GetParam();
+  GeneratePixels(&config.input);
+
+  // Start with sequential non-optimized jpeg.
+  config.jparams.progressive_level = 0;
+  config.jparams.optimize_coding = FALSE;
+  std::vector<uint8_t> compressed;
+  ASSERT_TRUE(EncodeWithJpegli(config.input, config.jparams, &compressed));
+
+  // Transcode with default settings, this will create a progressive jpeg with
+  // optimized Huffman codes.
+  std::vector<uint8_t> transcoded;
+  TranscodeWithJpegli(compressed, &transcoded);
+
+  // We expect a size reduction of at least 5%.
+  EXPECT_LT(transcoded.size(), compressed.size() * 0.95f);
+
+  // Verify that transcoding is lossless.
+  TestImage output0, output1;
+  DecodeWithLibjpeg(CompressParams(), compressed, PIXELS, &output0);
+  DecodeWithLibjpeg(CompressParams(), transcoded, PIXELS, &output1);
+  VerifyOutputImage(output0, output1, 0.0);
+}
+
+std::vector<TestConfig> GenerateTests() {
+  std::vector<TestConfig> all_tests;
+  const size_t xsize0 = 1024;
+  const size_t ysize0 = 768;
+  for (int dxsize : {0, 1, 8, 9}) {
+    for (int dysize : {0, 1, 8, 9}) {
+      for (int h_sampling : {1, 2}) {
+        for (int v_sampling : {1, 2}) {
+          TestConfig config;
+          config.input.xsize = xsize0 + dxsize;
+          config.input.ysize = ysize0 + dysize;
+          config.jparams.h_sampling = {h_sampling, 1, 1};
+          config.jparams.v_sampling = {v_sampling, 1, 1};
+          all_tests.push_back(config);
+        }
+      }
+    }
+  }
+  return all_tests;
+}
+
+std::ostream& operator<<(std::ostream& os, const TestConfig& c) {
+  os << c.input.xsize << "x" << c.input.ysize;
+  if (!c.jparams.h_sampling.empty()) {
+    os << "SAMP";
+    for (size_t i = 0; i < c.input.components; ++i) {
+      os << "_";
+      os << c.jparams.h_sampling[i] << "x" << c.jparams.v_sampling[i];
+    }
+  }
+  return os;
+}
+
+std::string TestDescription(
+    const testing::TestParamInfo<TranscodeAPITestParam::ParamType>& info) {
+  std::stringstream name;
+  name << info.param;
+  return name.str();
+}
+
+JPEGLI_INSTANTIATE_TEST_SUITE_P(TranscodeAPITest, TranscodeAPITestParam,
+                                testing::ValuesIn(GenerateTests()),
+                                TestDescription);
+
+}  // namespace
+}  // namespace jpegli

--- a/lib/jxl_lists.bzl
+++ b/lib/jxl_lists.bzl
@@ -497,6 +497,7 @@ libjxl_jpegli_testlib_files = [
 libjxl_jpegli_tests = [
     "jpegli/decode_api_test.cc",
     "jpegli/encode_api_test.cc",
+    "jpegli/transcode_api_test.cc",
 ]
 
 libjxl_jpegli_wrapper_sources = [

--- a/lib/jxl_lists.cmake
+++ b/lib/jxl_lists.cmake
@@ -497,6 +497,7 @@ set(JPEGXL_INTERNAL_JPEGLI_TESTLIB_FILES
 set(JPEGXL_INTERNAL_JPEGLI_TESTS
   jpegli/decode_api_test.cc
   jpegli/encode_api_test.cc
+  jpegli/transcode_api_test.cc
 )
 
 set(JPEGXL_INTERNAL_JPEGLI_WRAPPER_SOURCES


### PR DESCRIPTION
Added jpegli_read_coefficients() and jpegli_copy_critical_parameters()

Refactored the test config into input image and compression params, and added a transcode_api_test.cc which resuses the code for jpeg file generation with jpegli and jpeg file verification with libjpeg.