### PR TITLE
Add missing <atomic> content to fix gcc compilation for RISCV architecture.

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -30,6 +30,7 @@ Daniel Novomeský <dnovomesky@gmail.com>
 David Burnett <vargolsoft@gmail.com>
 Dirk Lemstra <dirk@lemstra.org>
 Don Olmstead <don.j.olmstead@gmail.com>
+Dong Xu <xdong181@gmail.com>
 Even Rouault <even.rouault@spatialys.com>
 Fred Brennan <copypaste@kittens.ph>
 Heiko Becker <heirecka@exherbo.org>

--- a/lib/jxl/enc_xyb.cc
+++ b/lib/jxl/enc_xyb.cc
@@ -6,8 +6,8 @@
 #include "lib/jxl/enc_xyb.h"
 
 #include <algorithm>
-#include <cstdlib>
 #include <atomic>
+#include <cstdlib>
 
 #undef HWY_TARGET_INCLUDE
 #define HWY_TARGET_INCLUDE "lib/jxl/enc_xyb.cc"

--- a/lib/jxl/enc_xyb.cc
+++ b/lib/jxl/enc_xyb.cc
@@ -7,6 +7,7 @@
 
 #include <algorithm>
 #include <cstdlib>
+#include <atomic>
 
 #undef HWY_TARGET_INCLUDE
 #define HWY_TARGET_INCLUDE "lib/jxl/enc_xyb.cc"


### PR DESCRIPTION
compiling v0.8.1 of libjxl for riscv64 is currently broken with:

```
[ 33%] Building CXX object lib/CMakeFiles/jxl_enc-obj.dir/jxl/jpeg/enc_jpeg_data.cc.o
/build/libjxl/src/libjxl/lib/jxl/enc_xyb.cc: In function ‘jxl::Image3F jxl::N_SCALAR::TransformToLinearRGB(const jxl::Image3F&, const jxl::ColorEncoding&, float, const JxlCmsInterface&, jxl::ThreadPool*)’:
/build/libjxl/src/libjxl/lib/jxl/enc_xyb.cc:223:21: error: variable ‘std::atomic<bool> ok’ has initializer but incomplete type
  223 |   std::atomic<bool> ok{true};
      |                     ^~
[ 33%] Building CXX object lib/CMakeFiles/jxl_dec-obj.dir/jxl/gauss_blur.cc.o
[ 33%] Building CXX object lib/CMakeFiles/jxl_dec-obj.dir/jxl/headers.cc.o
make[2]: *** [lib/CMakeFiles/jxl_enc-obj.dir/build.make:566: lib/CMakeFiles/jxl_enc-obj.dir/jxl/enc_xyb.cc.o] Error 1
make[2]: *** Waiting for unfinished jobs....
```

The error looks like https://github.com/libjxl/libjxl/issues/1407 and I tried to fix it as described in the issue. Now it compiles successfully on riscv64.