### PR TITLE
Faster no-adaptive-quantization code-path in jpegli encoder.

### DIFF
--- a/lib/jpegli/adaptive_quantization.cc
+++ b/lib/jpegli/adaptive_quantization.cc
@@ -666,15 +666,20 @@ void ComputeAdaptiveQuantField(j_compress_ptr cinfo) {
     }
     jxl::ImageF qf =
         jpegli::InitialQuantField(m->distance, input, nullptr, m->distance);
-    float qfmin;
-    ImageMinMax(qf, &qfmin, &m->quant_field_max);
+    float qfmin, qfmax;
+    ImageMinMax(qf, &qfmin, &qfmax);
+    m->quant_field_max = qfmax;
     for (size_t y = 0; y < y_comp->height_in_blocks; ++y) {
-      m->quant_field.CopyRow(y, qf.Row(y), y_comp->width_in_blocks);
+      const float* row_in = qf.Row(y);
+      float* row_out = m->quant_field.Row(y);
+      for (size_t x = 0; x < y_comp->width_in_blocks; ++x) {
+        row_out[x] = (qfmax / row_in[x]) - 1.0f;
+      }
     }
   } else {
     m->quant_field_max = kDefaultQuantFieldMax;
     for (size_t y = 0; y < ysize_blocks; ++y) {
-      m->quant_field.FillRow(y, m->quant_field_max, xsize_blocks);
+      m->quant_field.FillRow(y, 0.0f, xsize_blocks);
     }
   }
 }


### PR DESCRIPTION
The adaptive quantization path got a little bit faster as well by precomputing the inverse of the quantization field.

Benchmark before:
```
Encoding                       kPixels    Bytes          BPP  E MP/s  D MP/s     Max norm  SSIMULACRA2        pnorm       BPP*pnorm   Bugs
------------------------------------------------------------------------------------------------------------------------------------------
jpeg:enc-jpegli:q90:p0           13270  3679226    2.2179964  36.226 191.392   2.26414490  86.30366270   0.68598218  1.521506008833      0
jpeg:enc-jpegli:q90:p0:noaq      13270  4054300    2.4441072  43.646 173.163   2.29879761  88.59430808   0.67347722  1.646050522326      0
Aggregate:                       13270  3862213    2.3283086  39.763 182.050   2.28140546  87.44148490   0.67970094  1.582553556933      0
```

Benchmark after:
```
Encoding                       kPixels    Bytes          BPP  E MP/s  D MP/s     Max norm  SSIMULACRA2        pnorm       BPP*pnorm   Bugs
------------------------------------------------------------------------------------------------------------------------------------------
jpeg:enc-jpegli:q90:p0           13270  3679226    2.2179964  38.303 192.340   2.26414490  86.30366270   0.68598218  1.521506008833      0
jpeg:enc-jpegli:q90:p0:noaq      13270  4054300    2.4441072  50.672 174.793   2.29879761  88.59430808   0.67347722  1.646050522326      0
Aggregate:                       13270  3862213    2.3283086  44.055 183.357   2.28140546  87.44148490   0.67970094  1.582553556933      0
```