### PR TITLE
Support aligned allocators in the jpegli memory manager.

### DIFF
--- a/lib/jpegli/bitstream.h
+++ b/lib/jpegli/bitstream.h
@@ -26,12 +26,9 @@ void EncodeDHT(j_compress_ptr cinfo, const JPEGHuffmanCode* huffman_codes,
 void EncodeDQT(j_compress_ptr cinfo);
 bool EncodeDRI(j_compress_ptr cinfo);
 
-bool EncodeScan(j_compress_ptr cinfo,
-                const std::vector<std::vector<coeff_t>>& coeffs,
-                int scan_index);
+bool EncodeScan(j_compress_ptr cinfo, int scan_index);
 
-void EncodeSingleScan(j_compress_ptr cinfo,
-                      const std::vector<std::vector<coeff_t>>& coeffs);
+void EncodeSingleScan(j_compress_ptr cinfo);
 
 }  // namespace jpegli
 

--- a/lib/jpegli/dct.h
+++ b/lib/jpegli/dct.h
@@ -17,8 +17,7 @@
 
 namespace jpegli {
 
-void ComputeDCTCoefficients(j_compress_ptr cinfo,
-                            std::vector<std::vector<jpegli::coeff_t> >* coeffs);
+void ComputeDCTCoefficients(j_compress_ptr cinfo);
 
 }  // namespace jpegli
 

--- a/lib/jpegli/encode_internal.h
+++ b/lib/jpegli/encode_internal.h
@@ -72,6 +72,7 @@ struct jpeg_comp_master {
   uint8_t* next_marker_byte = nullptr;
   JpegliDataType data_type = JPEGLI_TYPE_UINT8;
   JpegliEndianness endianness = JPEGLI_NATIVE_ENDIAN;
+  std::array<jpegli::coeff_t*, jpegli::kMaxComponents> coefficients;
   jpegli::HuffmanCodeTable huff_tables[8];
   std::array<jpegli::HuffmanCodeTable, jpegli::kMaxHuffmanTables> dc_huff_table;
   std::array<jpegli::HuffmanCodeTable, jpegli::kMaxHuffmanTables> ac_huff_table;

--- a/lib/jpegli/entropy_coding.h
+++ b/lib/jpegli/entropy_coding.h
@@ -42,10 +42,8 @@ void ClusterJpegHistograms(const Histogram* histo_data, size_t num,
 void AddJpegHuffmanCode(const jxl::Histogram& histogram, size_t slot_id,
                         std::vector<JPEGHuffmanCode>* huff_codes);
 
-void OptimizeHuffmanCodes(
-    j_compress_ptr cinfo,
-    const std::vector<std::vector<jpegli::coeff_t> >& coeffs,
-    std::vector<JPEGHuffmanCode>* huffman_codes);
+void OptimizeHuffmanCodes(j_compress_ptr cinfo,
+                          std::vector<JPEGHuffmanCode>* huffman_codes);
 
 }  // namespace jpegli
 

--- a/lib/jpegli/memory_manager.cc
+++ b/lib/jpegli/memory_manager.cc
@@ -7,6 +7,7 @@
 
 #include <string.h>
 
+#include <hwy/aligned_allocator.h>
 #include <vector>
 
 #include "lib/jpegli/error.h"
@@ -32,16 +33,17 @@ struct MemoryManager {
   std::vector<std::vector<void*>> owned_ptrs;
 };
 
-void CheckPoolId(j_common_ptr cinfo, int pool_id) {
-  if (pool_id < 0 || pool_id >= JPOOL_NUMPOOLS) {
-    JPEGLI_ERROR("Invalid pool id %d", pool_id);
-  }
-}
-
 void* Alloc(j_common_ptr cinfo, int pool_id, size_t sizeofobject) {
   MemoryManager* mem = reinterpret_cast<MemoryManager*>(cinfo->mem);
-  CheckPoolId(cinfo, pool_id);
-  void* p = malloc(sizeofobject);
+  if (pool_id < 0 || pool_id >= 2 * JPOOL_NUMPOOLS) {
+    JPEGLI_ERROR("Invalid pool id %d", pool_id);
+  }
+  void* p;
+  if (pool_id < JPOOL_NUMPOOLS) {
+    p = malloc(sizeofobject);
+  } else {
+    p = hwy::AllocateAlignedBytes(sizeofobject, nullptr, nullptr);
+  }
   if (p == nullptr) {
     JPEGLI_ERROR("Out of memory");
   }
@@ -101,11 +103,17 @@ T** AccessVirtualArray(j_common_ptr cinfo, Control* ptr, JDIMENSION start_row,
 
 void FreePool(j_common_ptr cinfo, int pool_id) {
   MemoryManager* mem = reinterpret_cast<MemoryManager*>(cinfo->mem);
-  CheckPoolId(cinfo, pool_id);
+  if (pool_id < 0 || pool_id >= JPOOL_NUMPOOLS) {
+    JPEGLI_ERROR("Invalid pool id %d", pool_id);
+  }
   for (void* ptr : mem->owned_ptrs[pool_id]) {
     free(ptr);
   }
   mem->owned_ptrs[pool_id].clear();
+  for (void* ptr : mem->owned_ptrs[JPOOL_NUMPOOLS + pool_id]) {
+    hwy::FreeAlignedBytes(ptr, nullptr, nullptr);
+  }
+  mem->owned_ptrs[JPOOL_NUMPOOLS + pool_id].clear();
 }
 
 void SelfDestruct(j_common_ptr cinfo) {
@@ -136,7 +144,7 @@ void InitMemoryManager(j_common_ptr cinfo) {
       jpegli::AccessVirtualArray<jvirt_barray_control, JBLOCK>;
   mem->pub.free_pool = jpegli::FreePool;
   mem->pub.self_destruct = jpegli::SelfDestruct;
-  mem->owned_ptrs.resize(JPOOL_NUMPOOLS);
+  mem->owned_ptrs.resize(2 * JPOOL_NUMPOOLS);
   cinfo->mem = reinterpret_cast<struct jpeg_memory_mgr*>(mem);
 }
 

--- a/lib/jpegli/memory_manager.h
+++ b/lib/jpegli/memory_manager.h
@@ -12,6 +12,9 @@
 #include <stdlib.h>
 /* clang-format on */
 
+#define JPOOL_PERMANENT_ALIGNED (JPOOL_NUMPOOLS + JPOOL_PERMANENT)
+#define JPOOL_IMAGE_ALIGNED (JPOOL_NUMPOOLS + JPOOL_IMAGE)
+
 namespace jpegli {
 
 void InitMemoryManager(j_common_ptr cinfo);


### PR DESCRIPTION
Use aligned allocators instead of vector for quantized coefficients, this also removes an unnecessary memset in the vector constructor.