### PR TITLE
quantization improvement for chromacity checkboard

### DIFF
--- a/lib/jxl/decode_test.cc
+++ b/lib/jxl/decode_test.cc
@@ -1987,7 +1987,7 @@ TEST(DecodeTest, PixelTestOpaqueSrgbLossyNoise) {
     EXPECT_THAT(
         ButteraugliDistance(io0.frames, io1.frames, ba, jxl::GetJxlCms(),
                             /*distmap=*/nullptr, nullptr),
-        IsSlightlyBelow(2.4f));
+        IsSlightlyBelow(1.2f));
 
     JxlDecoderDestroy(dec);
   }

--- a/lib/jxl/enc_group.cc
+++ b/lib/jxl/enc_group.cc
@@ -64,7 +64,6 @@ void QuantizeBlockAC(const Quantizer& quantizer, const bool error_diffusion,
       thres[i] -= Clamp1(0.003f * xsize * ysize, 0.f, (c > 0 ? 0.08f : 0.12f));
     }
   }
-
   if (!error_diffusion) {
     HWY_CAPPED(float, kBlockDim) df;
     HWY_CAPPED(int32_t, kBlockDim) di;
@@ -101,7 +100,6 @@ void QuantizeBlockAC(const Quantizer& quantizer, const bool error_diffusion,
   }
 
 retry:
-  int sum_of_highest_freq_row_and_column = 0;
   int hfNonZeros[4] = {};
   float hfError[4] = {};
   float hfMaxError[4] = {};
@@ -128,10 +126,6 @@ retry:
       if (v != 0.0f) {
         hfNonZeros[hfix] += std::abs(v);
       }
-      if ((y == ysize * kBlockDim - 1 || x == xsize * kBlockDim - 1) &&
-          (x >= xsize * 4 && y >= ysize * 4)) {
-        sum_of_highest_freq_row_and_column += std::abs(v);
-      }
     }
   }
   if (c != 1) return;
@@ -154,65 +148,7 @@ retry:
     }
   }
   if (goretry) goto retry;
-  // Heuristic for improving accuracy of high-frequency patterns
-  // occurring in an environment with no medium-frequency masking
-  // patterns. This should be improved later to be done in X and B
-  // planes too as 32x32 and larger transforms become rather ugly
-  // when this is not compensated for.
-  if (5 * sum_of_highest_freq_row_and_column > hfNonZeros[0] + 20) {
-    *quant += 6;
-    if (3 * sum_of_highest_freq_row_and_column >= hfNonZeros[0] + 20) {
-      *quant += 5;
-    }
-    if (2 * sum_of_highest_freq_row_and_column >= hfNonZeros[0] + 20) {
-      *quant += 5;
-    }
-    if (sum_of_highest_freq_row_and_column >= (hfNonZeros[0] + 20)) {
-      *quant += 5;
-    }
-    if (*quant >= Quantizer::kQuantMax) {
-      *quant = Quantizer::kQuantMax - 1;
-    }
-    qac = quantizer.Scale() * (*quant);
-    for (size_t y = 0; y < ysize * kBlockDim; y++) {
-      for (size_t x = 0; x < xsize * kBlockDim; x++) {
-        if (x < xsize && y < ysize) {
-          continue;
-        }
-        const size_t pos = y * kBlockDim * xsize + x;
-        const size_t hfix = (static_cast<size_t>(y >= kBlockDim / 2) * 2 +
-                             static_cast<size_t>(x >= kBlockDim / 2));
-        const float val = block_in[pos] * (qm[pos] * qac * qm_multiplier);
-        const float v = (std::abs(val) < thres[hfix]) ? 0 : rintf(val);
-        block_out[pos] = static_cast<int32_t>(v);
-      }
-    }
-  }
-  if (quant_kind == AcStrategy::Type::DCT) {
-    // If this 8x8 block is too flat, increase the adaptive quantization level
-    // a bit to reduce visible block boundaries and requantize the block.
-    if (hfNonZeros[0] + hfNonZeros[1] + hfNonZeros[2] + hfNonZeros[3] < 11) {
-      *quant += 1;
-      if (*quant >= Quantizer::kQuantMax) {
-        *quant = Quantizer::kQuantMax - 1;
-      }
-      qac = quantizer.Scale() * (*quant);
-      for (size_t y = 0; y < kBlockDim; y++) {
-        for (size_t x = 0; x < kBlockDim; x++) {
-          if (x < 1 && y < 1) {
-            continue;
-          }
-          const size_t pos = y * kBlockDim + x;
-          const size_t hfix = (static_cast<size_t>(y >= kBlockDim / 2) * 2 +
-                               static_cast<size_t>(x >= kBlockDim / 2));
-          const float val = block_in[pos] * (qm[pos] * qac * qm_multiplier);
-          const float v = (std::abs(val) < thres[hfix]) ? 0 : rintf(val);
-          block_out[pos] = static_cast<int32_t>(v);
-        }
-      }
-    }
-    return;
-  }
+
   for (int i = 1; i < 4; ++i) {
     if (hfError[i] >= hfErrorLimit && hfNonZeros[i] == 0) {
       const size_t pos = hfMaxErrorIx[i];
@@ -223,15 +159,125 @@ retry:
   }
 }
 
+bool AdjustQuantBlockAC(const Quantizer& quantizer, size_t c,
+                        float qm_multiplier, size_t quant_kind, size_t xsize,
+                        size_t ysize, const float* JXL_RESTRICT block_in,
+                        int32_t* quant) {
+  // No quantization adjusting for these small blocks.
+  // Quantization adjusting attempts to fix some known issues
+  // with larger blocks and on the 8x8 dct's emerging 8x8 blockiness
+  // when there are not many non-zeros.
+  constexpr size_t kPartialBlockKinds =
+      (1 << AcStrategy::Type::IDENTITY) | (1 << AcStrategy::Type::DCT2X2) |
+      (1 << AcStrategy::Type::DCT4X4) | (1 << AcStrategy::Type::DCT4X8) |
+      (1 << AcStrategy::Type::DCT8X4) | (1 << AcStrategy::Type::AFV0) |
+      (1 << AcStrategy::Type::AFV1) | (1 << AcStrategy::Type::AFV2) |
+      (1 << AcStrategy::Type::AFV3);
+  if ((1 << quant_kind) & kPartialBlockKinds) return true;
+
+  const float* JXL_RESTRICT qm = quantizer.InvDequantMatrix(quant_kind, c);
+  float qac = quantizer.Scale() * (*quant);
+  float thres[4] = {0.58f, 0.635f, 0.66f, 0.7f};
+  if (c == 0) {
+    for (int i = 1; i < 4; ++i) {
+      thres[i] += 0.08f;
+    }
+  }
+  if (c == 2) {
+    for (int i = 1; i < 4; ++i) {
+      thres[i] = 0.75f;
+    }
+  }
+  if (xsize > 1 || ysize > 1) {
+    for (int i = 0; i < 4; ++i) {
+      thres[i] -= Clamp1(0.003f * xsize * ysize, 0.f, (c > 0 ? 0.08f : 0.12f));
+    }
+  }
+  float sum_of_highest_freq_row_and_column = 0;
+  float hfNonZeros[4] = {};
+  for (size_t y = 0; y < ysize * kBlockDim; y++) {
+    for (size_t x = 0; x < xsize * kBlockDim; x++) {
+      const size_t pos = y * kBlockDim * xsize + x;
+      if (x < xsize && y < ysize) {
+        continue;
+      }
+      const size_t hfix = (static_cast<size_t>(y >= ysize * kBlockDim / 2) * 2 +
+                           static_cast<size_t>(x >= xsize * kBlockDim / 2));
+      const float val = block_in[pos] * (qm[pos] * qac * qm_multiplier);
+      const float v = (std::abs(val) < thres[hfix]) ? 0 : rintf(val);
+      if (v != 0.0f) {
+        hfNonZeros[hfix] += std::abs(val);
+        if ((y == ysize * kBlockDim - 1 || x == xsize * kBlockDim - 1) &&
+            (x >= xsize * 4 && y >= ysize * 4)) {
+          sum_of_highest_freq_row_and_column += std::abs(val);
+        }
+      }
+    }
+  }
+  // Heuristic for improving accuracy of high-frequency patterns
+  // occurring in an environment with no medium-frequency masking
+  // patterns. This should be improved later to be done in X and B
+  // planes too as 32x32 and larger transforms become rather ugly
+  // when this is not compensated for.
+  if (15 * sum_of_highest_freq_row_and_column >= hfNonZeros[0] + 1) {
+    constexpr int inc = 5;
+    *quant += inc;
+    if (8 * sum_of_highest_freq_row_and_column >= hfNonZeros[0] + 1) {
+      *quant += inc;
+    }
+    if (5 * sum_of_highest_freq_row_and_column >= hfNonZeros[0] + 1) {
+      *quant += inc;
+    }
+    if (3 * sum_of_highest_freq_row_and_column >= hfNonZeros[0] + 1) {
+      *quant += inc;
+    }
+    if (*quant >= Quantizer::kQuantMax) {
+      *quant = Quantizer::kQuantMax - 1;
+    }
+  }
+  if (quant_kind == AcStrategy::Type::DCT) {
+    // If this 8x8 block is too flat, increase the adaptive quantization level
+    // a bit to reduce visible block boundaries and requantize the block.
+    if (hfNonZeros[0] + hfNonZeros[1] + hfNonZeros[2] + hfNonZeros[3] < 11) {
+      *quant += 1;
+      if (*quant >= Quantizer::kQuantMax) {
+        *quant = Quantizer::kQuantMax - 1;
+      }
+    }
+  }
+  return hfNonZeros[0] > 2.0f * xsize * ysize;
+}
+
 // NOTE: caller takes care of extracting quant from rect of RawQuantField.
-void QuantizeRoundtripYBlockAC(const Quantizer& quantizer,
+void QuantizeRoundtripYBlockAC(PassesEncoderState* enc_state, const size_t size,
+                               const Quantizer& quantizer,
                                const bool error_diffusion, size_t quant_kind,
                                size_t xsize, size_t ysize,
                                const float* JXL_RESTRICT biases, int32_t* quant,
                                float* JXL_RESTRICT inout,
                                int32_t* JXL_RESTRICT quantized) {
+  {
+    int32_t max_quant = 0;
+    int quant_orig = *quant;
+    float val[3] = {enc_state->x_qm_multiplier, 1.0f,
+                    enc_state->b_qm_multiplier};
+    int clut[3] = {1, 0, 2};
+    for (int ii = 0; ii < 3; ++ii) {
+      int c = clut[ii];
+      *quant = quant_orig;
+      bool stop_adjusting =
+          AdjustQuantBlockAC(quantizer, c, val[c], quant_kind, xsize, ysize,
+                             inout + c * size, quant);
+      max_quant = std::max(*quant, max_quant);
+      if (stop_adjusting) {
+        break;
+      }
+    }
+    *quant = max_quant;
+  }
+
   QuantizeBlockAC(quantizer, error_diffusion, 1, 1.0f, quant_kind, xsize, ysize,
-                  inout, quant, quantized);
+                  inout + size, quant, quantized + size);
 
   PROFILER_ZONE("enc quant adjust bias");
   const float* JXL_RESTRICT dequant_matrix =
@@ -241,10 +287,10 @@ void QuantizeRoundtripYBlockAC(const Quantizer& quantizer,
   HWY_CAPPED(int32_t, kDCTBlockSize) di;
   const auto inv_qac = Set(df, quantizer.inv_quant_ac(*quant));
   for (size_t k = 0; k < kDCTBlockSize * xsize * ysize; k += Lanes(df)) {
-    const auto quant = Load(di, quantized + k);
+    const auto quant = Load(di, quantized + size + k);
     const auto adj_quant = AdjustQuantBias(di, 1, quant, biases);
     const auto dequantm = Load(df, dequant_matrix + k);
-    Store(Mul(Mul(adj_quant, dequantm), inv_qac), df, inout + k);
+    Store(Mul(Mul(adj_quant, dequantm), inv_qac), df, inout + size + k);
   }
 }
 
@@ -335,21 +381,18 @@ void ComputeCoefficients(size_t group_idx, PassesEncoderState* enc_state,
 
           // DCT Y channel, roundtrip-quantize it and set DC.
           int32_t quant_ac = row_quant_ac[bx];
-          TransformFromPixels(acs.Strategy(), opsin_rows[1] + bx * kBlockDim,
-                              opsin_stride, coeffs_in + size, scratch_space);
-          DCFromLowestFrequencies(acs.Strategy(), coeffs_in + size,
-                                  dc_rows[1] + bx, dc_stride);
-          QuantizeRoundtripYBlockAC(enc_state->shared.quantizer,
-                                    error_diffusion, acs.RawStrategy(), xblocks,
-                                    yblocks, kDefaultQuantBias, &quant_ac,
-                                    coeffs_in + size, quantized + size);
-
-          // DCT X and B channels
-          for (size_t c : {0, 2}) {
+          for (size_t c : {0, 1, 2}) {
             TransformFromPixels(acs.Strategy(), opsin_rows[c] + bx * kBlockDim,
                                 opsin_stride, coeffs_in + c * size,
                                 scratch_space);
           }
+          DCFromLowestFrequencies(acs.Strategy(), coeffs_in + size,
+                                  dc_rows[1] + bx, dc_stride);
+
+          QuantizeRoundtripYBlockAC(
+              enc_state, size, enc_state->shared.quantizer, error_diffusion,
+              acs.RawStrategy(), xblocks, yblocks, kDefaultQuantBias, &quant_ac,
+              coeffs_in, quantized);
 
           // Unapply color correlation
           for (size_t k = 0; k < size; k += Lanes(d)) {

--- a/lib/jxl/jxl_test.cc
+++ b/lib/jxl/jxl_test.cc
@@ -148,7 +148,7 @@ TEST(JxlTest, RoundtripResample2) {
   cparams.AddOption(JXL_ENC_FRAME_SETTING_EFFORT, 3);  // kFalcon
 
   PackedPixelFile ppf_out;
-  EXPECT_NEAR(Roundtrip(t.ppf(), cparams, {}, pool, &ppf_out), 16439, 50);
+  EXPECT_NEAR(Roundtrip(t.ppf(), cparams, {}, pool, &ppf_out), 18449, 50);
   EXPECT_THAT(ComputeDistance2(t.ppf(), ppf_out), IsSlightlyBelow(90));
 }
 
@@ -181,7 +181,7 @@ TEST(JxlTest, RoundtripResample2MT) {
   cparams.AddOption(JXL_ENC_FRAME_SETTING_EFFORT, 3);  // kFalcon
 
   PackedPixelFile ppf_out;
-  EXPECT_NEAR(Roundtrip(t.ppf(), cparams, {}, &pool, &ppf_out), 190000, 600);
+  EXPECT_NEAR(Roundtrip(t.ppf(), cparams, {}, &pool, &ppf_out), 199270, 600);
   EXPECT_THAT(ComputeDistance2(t.ppf(), ppf_out), IsSlightlyBelow(340));
 }
 
@@ -222,7 +222,7 @@ TEST(JxlTest, RoundtripOutOfOrderProcessingBorder) {
   cparams.AddOption(JXL_ENC_FRAME_SETTING_RESAMPLING, 2);
 
   PackedPixelFile ppf_out;
-  EXPECT_NEAR(Roundtrip(t.ppf(), cparams, {}, &pool, &ppf_out), 9202, 100);
+  EXPECT_NEAR(Roundtrip(t.ppf(), cparams, {}, &pool, &ppf_out), 9554, 100);
   EXPECT_LE(ButteraugliDistance(t.ppf(), ppf_out), 2.9);
 }
 
@@ -237,7 +237,7 @@ TEST(JxlTest, RoundtripResample4) {
   cparams.AddOption(JXL_ENC_FRAME_SETTING_RESAMPLING, 4);
 
   PackedPixelFile ppf_out;
-  EXPECT_NEAR(Roundtrip(t.ppf(), cparams, {}, pool, &ppf_out), 5771, 50);
+  EXPECT_NEAR(Roundtrip(t.ppf(), cparams, {}, pool, &ppf_out), 5855, 50);
   EXPECT_THAT(ButteraugliDistance(t.ppf(), ppf_out), IsSlightlyBelow(22));
 }
 
@@ -252,7 +252,7 @@ TEST(JxlTest, RoundtripResample8) {
   cparams.AddOption(JXL_ENC_FRAME_SETTING_RESAMPLING, 8);
 
   PackedPixelFile ppf_out;
-  EXPECT_NEAR(Roundtrip(t.ppf(), cparams, {}, pool, &ppf_out), 2037, 30);
+  EXPECT_NEAR(Roundtrip(t.ppf(), cparams, {}, pool, &ppf_out), 2078, 30);
   EXPECT_THAT(ButteraugliDistance(t.ppf(), ppf_out), IsSlightlyBelow(50));
 }
 
@@ -319,7 +319,7 @@ TEST(JxlTest, RoundtripRGBToGrayscale) {
   size_t compressed_size;
   JXL_EXPECT_OK(
       Roundtrip(&io, cparams, dparams, &io2, _, &compressed_size, &pool));
-  EXPECT_LE(compressed_size, 55000u);
+  EXPECT_LE(compressed_size, 61000u);
   EXPECT_TRUE(io2.Main().IsGray());
 
   // Convert original to grayscale here, because TransformTo refuses to
@@ -373,7 +373,7 @@ TEST(JxlTest, RoundtripDotsForceEpf) {
   cparams.AddOption(JXL_ENC_FRAME_SETTING_DOTS, 1);
 
   PackedPixelFile ppf_out;
-  EXPECT_NEAR(Roundtrip(t.ppf(), cparams, {}, &pool, &ppf_out), 40450, 300);
+  EXPECT_NEAR(Roundtrip(t.ppf(), cparams, {}, &pool, &ppf_out), 41269, 300);
   EXPECT_THAT(ComputeDistance2(t.ppf(), ppf_out), IsSlightlyBelow(18));
 }
 
@@ -817,7 +817,7 @@ TEST(JxlTest, RoundtripAlphaResampling) {
   cparams.AddOption(JXL_ENC_FRAME_SETTING_EXTRA_CHANNEL_RESAMPLING, 2);
 
   PackedPixelFile ppf_out;
-  EXPECT_NEAR(Roundtrip(t.ppf(), cparams, {}, pool, &ppf_out), 11819, 100);
+  EXPECT_NEAR(Roundtrip(t.ppf(), cparams, {}, pool, &ppf_out), 12155, 100);
   EXPECT_THAT(ButteraugliDistance(t.ppf(), ppf_out), IsSlightlyBelow(4.9));
 }
 
@@ -835,7 +835,7 @@ TEST(JxlTest, RoundtripAlphaResamplingOnlyAlpha) {
   cparams.AddOption(JXL_ENC_FRAME_SETTING_EXTRA_CHANNEL_RESAMPLING, 2);
 
   PackedPixelFile ppf_out;
-  EXPECT_NEAR(Roundtrip(t.ppf(), cparams, {}, pool, &ppf_out), 30100, 300);
+  EXPECT_NEAR(Roundtrip(t.ppf(), cparams, {}, pool, &ppf_out), 31951, 300);
   EXPECT_THAT(ButteraugliDistance(t.ppf(), ppf_out), IsSlightlyBelow(1.85));
 }
 


### PR DESCRIPTION
This increases quantization precision for high-frequency patterns without low precision content. This doesn't completely solve the chessboard pattern issues since the 32x32 etc. quantization matrices quantize rather heavily in chromacity high-frequency area, but is more of a small mitigation.

max error is reduced by 11 %, BPP*pnorm aggregate 0.2 %

This test is with the jyrki31 corpus augmented with the chessboard pattern.

This doesn't quite fix the problem fully, but is a substantial improvement.

```
Before:

Encoding      kPixels    Bytes          BPP  E MP/s  D MP/s     Max norm  SSIMULACRA2        pnorm   PSNR   QABPP  SmallB  DCT4x8     AFV  DCT8x8    8x16    8x32      16   16x32      32   32x64      64       BPP*pnorm   Bugs
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
jxl:d0.1        19660 15470356    6.2950266   1.522   9.537   3.24331164  98.98237217   0.17969489  51.65   6.661 38.2944 20.1303  0.5785 28.8039  6.3478  0.0000  2.8243  0.9740  2.5886  0.1146  0.0833  1.131184082069      0
jxl:d0.5        19660  5846614    2.3790397   1.796  15.073   3.24575996  96.62373340   0.42341970  44.57   2.538 13.9619 23.5057  0.6787 12.6510 25.9719  0.0000 17.2334  1.4297  4.7136  0.1354  0.4583  1.007332261065      0
jxl:d0.8        19660  4364915    1.7761231   1.952  15.776   3.23406839  91.73645535   0.55552429  42.12   2.165 10.7590 20.5603  0.7637  9.5096 24.0773  0.0000 26.7414  1.7188  5.9428  0.1667  0.5000  0.986679501268      0
jxl:d1          19660  3781765    1.5388341   1.954  16.233   3.20305562  89.17181209   0.63291772  40.98   2.214  9.5783 19.1065  0.7832  8.2769 21.1163  0.0000 30.5240  2.9063  7.9689  0.2083  0.2708  0.973955361376      0
jxl:d1.1        19660  3560712    1.4488856   1.960  15.188   3.26551270  88.00954199   0.66980377  40.46   2.194  9.0607 18.4831  0.8135  7.8309 19.7836  0.0000 31.0332  3.8438  9.3700  0.2292  0.2917  0.970469068054      0
jxl:d1.2        19660  3364893    1.3692051   2.009  16.772   3.15158653  86.90384359   0.70480442  40.04   2.205  8.6108 17.8994  0.8480  7.4165 18.5186  0.0000 31.0136  5.0782 10.8335  0.2500  0.2708  0.965021835873      0
jxl:d1.3        19660  3225190    1.3123587   2.053  17.042   3.25452399  86.04335845   0.73503892  39.77   2.228  8.2153 17.4746  0.8532  7.0727 17.7074  0.0000 30.3118  6.4272 12.2398  0.2708  0.1667  0.964634744831      0
jxl:d1.4        19660  3069889    1.2491654   2.033  17.040   3.40553498  85.06947465   0.76652042  39.37   2.211  7.8725 16.9805  0.8659  6.7921 16.9111  0.0000 29.5227  7.7423 13.5107  0.3125  0.2292  0.957510764444      0
jxl:d1.5        19660  2930012    1.1922482   2.038  15.289   3.39355731  84.17136756   0.79851649  38.99   2.223  7.5783 16.5231  0.8740  6.4907 16.3922  0.0000 28.7167  9.0965 14.5367  0.2813  0.2500  0.952029816233      0
jxl:d1.6        19660  2805837    1.1417202   2.096  15.414   3.44580889  83.41801627   0.83506146  38.66   2.256  7.3042 16.1517  0.8972  6.3051 15.9879  0.0000 27.7961 10.2189 15.4013  0.3854  0.2917  0.953406572861      0
jxl:d1.7        19660  2692175    1.0954702   2.078  15.967   3.40849876  82.55143591   0.86845242  38.36   2.246  7.0402 15.7965  0.9147  6.1573 15.5823  0.0000 26.8911 11.1122 16.5055  0.3854  0.3542  0.951363709922      0
jxl:d1.8        19660  2589046    1.0535060   2.126  15.609   3.65659642  81.70554243   0.90099712  38.04   2.234  6.7879 15.4847  0.9457  5.9829 15.2913  0.0000 26.0617 12.2581 17.0732  0.4167  0.4375  0.949205901519      0
jxl:d1.8        19660  2589046    1.0535060   2.134  16.022   3.65659642  81.70554243   0.90099712  38.04   2.234  6.7879 15.4847  0.9457  5.9829 15.2913  0.0000 26.0617 12.2581 17.0732  0.4167  0.4375  0.949205901519      0
jxl:d1.9        19660  2494883    1.0151903   2.060  16.545   3.44227457  80.92734557   0.93199520  37.77   2.232  6.5454 15.1920  0.9658  5.8416 15.0205  0.0000 25.3351 13.1513 17.7920  0.4167  0.4792  0.946152456329      0
jxl:d2.0        19660  2408444    0.9800175   2.168  16.410   3.52408361  80.07560312   0.96389798  37.50   2.213  6.3426 14.9147  0.9730  5.6694 14.8271  0.0000 24.6528 14.0263 18.4066  0.4063  0.5208  0.944636850963      0
jxl:d2.1        19660  2325125    0.9461142   2.144  16.174   3.54583693  79.44720327   0.99532190  37.23   2.225  6.1215 14.5195  0.9932  5.5493 14.6604  0.0000 24.0512 14.7503 19.1775  0.4375  0.4792  0.941688196870      0
jxl:d2.2        19660  2250022    0.9155541   2.135  16.505   3.80066013  78.70103406   1.02592800  36.98   2.240  5.9194 14.2324  1.0169  5.4373 14.5439  0.0000 23.4536 15.4951 19.6827  0.4375  0.5208  0.939292616167      0
jxl:d2.3        19660  2181129    0.8875210   2.162  16.552   3.74887323  77.94255971   1.05899398  36.77   2.278  5.8315 13.9251  1.0114  5.3302 14.2965  0.0000 22.9067 16.0576 20.2973  0.5208  0.5625  0.939879341031      0
jxl:d2.4        19660  2115004    0.8606141   2.139  16.315   3.70150709  77.16421901   1.09015708  36.56   2.279  5.6580 13.6389  1.0257  5.2351 14.1624  0.0000 22.4431 16.6696 20.7608  0.5833  0.5625  0.938204552841      0
jxl:d2.5        19660  2053608    0.8356315   2.161  16.623   3.93240738  76.56359378   1.12239630  36.36   2.284  5.4864 13.3531  1.0326  5.1271 14.0309  0.0000 21.9744 17.2243 21.2296  0.6146  0.6667  0.937909722252      0
jxl:d2.6        19660  1994598    0.8116198   2.122  15.635   4.18759918  75.78727570   1.15611981  36.14   2.270  5.3481 13.1630  1.0518  5.0086 13.9417  0.0000 21.4366 17.6540 21.8858  0.6042  0.6458  0.938329743422      0
jxl:d2.7        19660  1940531    0.7896195   2.171  16.435   4.51921225  75.08630625   1.18546997  35.94   2.257  5.2000 12.9212  1.0664  4.9444 13.8525  0.0000 20.8975 18.2321 22.2504  0.6667  0.7083  0.936070169279      0
jxl:d2.8        19660  1889383    0.7688069   2.118  15.722   5.25712490  74.37716831   1.21744077  35.76   2.285  5.0675 12.7333  1.0798  4.8653 13.6891  0.0000 20.4705 18.6879 22.6567  0.7396  0.7500  0.935976850553      0
jxl:d2.9        19660  1840550    0.7489363   2.221  16.731   4.65550852  73.65458728   1.24727457  35.59   2.271  4.9662 12.4788  1.0908  4.7498 13.7275  0.0000 20.0668 19.0499 23.0890  0.7083  0.8125  0.934129204355      0
jxl:d3          19660  1796882    0.7311674   2.055  15.726   4.90647221  72.94747378   1.28202899  35.40   2.252  4.7641 12.2974  1.0596  4.6768 13.5901  0.0000 19.6137 19.6332 23.5942  0.7188  0.7917  0.937377807156      0
jxl:d5          19660  1225422    0.4986352   1.955   8.893  12.42521095  61.15941523   1.91711122  32.98   2.326  3.2937  8.0773  0.9535  2.9975 10.9553  0.0000 15.4769 27.8599 29.1047  0.6875  1.3334  0.955939140123      0
jxl:d7          19660   947621    0.3855955   2.059   8.718  12.57799530  51.44435001   2.37835441  31.51   2.296  2.5313  5.7101  0.7949  2.0759  9.2430  0.0000 12.9820 33.0215 31.9850  0.6875  1.7084  0.917082718272      0
jxl:d15         19660   527918    0.2148146   2.052   8.413  16.49061775  21.48272513   3.89054667  28.67   2.180  1.2155  1.7230  0.3125  0.5921  5.4558  0.0000  7.4572 38.2169 40.9435  1.1979  3.6251  0.835746106318      0
jxl:d24         19660   376940    0.1533803   0.314  20.450  56.09043503  -7.27154706   6.27833127  26.32   2.583  1.0124  2.2338  0.1748  0.7015  3.0658  0.0000  3.2774  9.4273  5.5574  0.0104  0.0000  0.962972124109      0
jxl:d32         19660   302738    0.1231868   0.315  20.204  55.51866150 -19.85813581   7.03186646  25.83   2.348  0.7474  1.6908  0.1458  0.5104  2.7461  0.0000  2.8490 10.4377  6.3335  0.0000  0.0000  0.866233178598      0
Aggregate:      19660  2174686    0.8848991   1.807  15.110   5.02451933  76.14956279   1.07312481  36.81   2.349  5.6412 11.9669  0.7834  4.8460 13.0158  0.0000 18.4801 10.1550 14.6434  0.3565  0.4876  0.949607180564      0

After:

Encoding      kPixels    Bytes          BPP  E MP/s  D MP/s     Max norm  SSIMULACRA2        pnorm   PSNR   QABPP  SmallB  DCT4x8     AFV  DCT8x8    8x16    8x32      16   16x32      32   32x64      64       BPP*pnorm   Bugs
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
jxl:d0.1        19660 15789003    6.4246869   1.523   9.224   3.23673868  98.98098677   0.17819115  51.69   6.801 38.2944 20.1303  0.5785 28.8039  6.3478  0.0000  2.8243  0.9740  2.5886  0.1146  0.0833  1.144822324096      0
jxl:d0.5        19660  5946491    2.4196805   1.818  14.610   3.25658631  96.81112053   0.42159708  44.69   2.595 13.9619 23.5057  0.6787 12.6510 25.9719  0.0000 17.2334  1.4297  4.7136  0.1354  0.4583  1.020130244167      0
jxl:d0.8        19660  4427977    1.8017836   1.967  15.592   3.21241617  91.83833613   0.55318441  42.32   2.203 10.7590 20.5603  0.7637  9.5096 24.0773  0.0000 26.7414  1.7188  5.9428  0.1667  0.5000  0.996718573526      0
jxl:d1          19660  3831363    1.5590160   2.010  15.095   3.20704770  89.27834823   0.63083905  41.16   2.248  9.5783 19.1065  0.7832  8.2769 21.1163  0.0000 30.5240  2.9063  7.9689  0.2083  0.2708  0.983488148974      0
jxl:d1.1        19660  3603407    1.4662586   1.964  15.856   3.18268919  88.19010759   0.66586659  40.64   2.221  9.0607 18.4831  0.8135  7.8309 19.7836  0.0000 31.0332  3.8438  9.3700  0.2292  0.2917  0.976332623886      0
jxl:d1.2        19660  3404157    1.3851820   2.029  16.497   3.17544794  87.14336981   0.70178232  40.20   2.230  8.6108 17.8994  0.8480  7.4165 18.5186  0.0000 31.0136  5.0782 10.8335  0.2500  0.2708  0.972096243372      0
jxl:d1.3        19660  3261976    1.3273273   2.010  16.316   3.18828392  86.36392385   0.73014673  39.98   2.249  8.2153 17.4746  0.8532  7.0727 17.7074  0.0000 30.3118  6.4272 12.2398  0.2708  0.1667  0.969143676737      0
jxl:d1.4        19660  3104538    1.2632644   2.013  16.293   3.20169067  85.36220516   0.76506660  39.59   2.236  7.8725 16.9805  0.8659  6.7921 16.9111  0.0000 29.5227  7.7423 13.5107  0.3125  0.2292  0.966481363205      0
jxl:d1.5        19660  2961887    1.2052184   2.036  15.389   3.02950239  84.58119712   0.79506644  39.24   2.238  7.5783 16.5231  0.8740  6.4907 16.3922  0.0000 28.7167  9.0965 14.5367  0.2813  0.2500  0.958228686442      0
jxl:d1.6        19660  2835951    1.1539739   2.089  15.766   3.41575408  83.65511786   0.83089438  38.88   2.286  7.3042 16.1517  0.8972  6.3051 15.9879  0.0000 27.7961 10.2189 15.4013  0.3854  0.2917  0.958830420831      0
jxl:d1.7        19660  2720919    1.1071663   2.068  15.766   2.99913979  82.86698610   0.85905268  38.58   2.263  7.0402 15.7965  0.9147  6.1573 15.5823  0.0000 26.8911 11.1122 16.5055  0.3854  0.3542  0.951114209389      0
jxl:d1.8        19660  2616685    1.0647526   2.112  15.810   3.20106363  82.06029046   0.89381365  38.30   2.254  6.7879 15.4847  0.9457  5.9829 15.2913  0.0000 26.0617 12.2581 17.0732  0.4167  0.4375  0.951690398316      0
jxl:d1.8        19660  2616685    1.0647526   2.110  16.382   3.20106363  82.06029046   0.89381365  38.30   2.254  6.7879 15.4847  0.9457  5.9829 15.2913  0.0000 26.0617 12.2581 17.0732  0.4167  0.4375  0.951690398316      0
jxl:d1.9        19660  2520383    1.0255664   2.033  15.994   3.20603085  81.24771575   0.92490680  38.01   2.252  6.5454 15.1920  0.9658  5.8416 15.0205  0.0000 25.3351 13.1513 17.7920  0.4167  0.4792  0.948553379467      0
jxl:d2.0        19660  2433198    0.9900901   2.107  16.131   3.23058653  80.51176777   0.95679558  37.75   2.233  6.3426 14.9147  0.9730  5.6694 14.8271  0.0000 24.6528 14.0263 18.4066  0.4063  0.5208  0.947313817247      0
jxl:d2.1        19660  2348654    0.9556884   2.144  15.936   3.35398006  79.80753363   0.98497074  37.50   2.246  6.1215 14.5195  0.9932  5.5493 14.6604  0.0000 24.0512 14.7503 19.1775  0.4375  0.4792  0.941325089313      0
jxl:d2.2        19660  2273016    0.9249106   2.152  16.390   3.44846964  79.02912518   1.01807605  37.26   2.264  5.9194 14.2324  1.0169  5.4373 14.5439  0.0000 23.4536 15.4951 19.6827  0.4375  0.5208  0.941629321990      0
jxl:d2.3        19660  2202781    0.8963313   2.185  16.470   3.53806543  78.31633702   1.04750610  37.04   2.282  5.8315 13.9251  1.0114  5.3302 14.2965  0.0000 22.9067 16.0576 20.2973  0.5208  0.5625  0.938912546907      0
jxl:d2.4        19660  2135854    0.8690981   2.096  16.157   3.70063972  77.59895217   1.07878547  36.83   2.300  5.6580 13.6389  1.0257  5.2351 14.1624  0.0000 22.4431 16.6696 20.7608  0.5833  0.5625  0.937570453371      0
jxl:d2.5        19660  2072748    0.8434198   2.130  16.224   3.34734321  76.93106734   1.10670690  36.63   2.294  5.4864 13.3531  1.0326  5.1271 14.0309  0.0000 21.9744 17.2243 21.2296  0.6146  0.6667  0.933418457603      0
jxl:d2.6        19660  2013295    0.8192278   2.124  16.311   3.21627975  76.28459437   1.13086419  36.43   2.259  5.3481 13.1630  1.0518  5.0086 13.9417  0.0000 21.4366 17.6540 21.8858  0.6042  0.6458  0.926435373247      0
jxl:d2.7        19660  1958699    0.7970122   2.200  16.417   3.99259996  75.57212526   1.16602640  36.22   2.274  5.2000 12.9212  1.0664  4.9444 13.8525  0.0000 20.8975 18.2321 22.2504  0.6667  0.7083  0.929337252379      0
jxl:d2.8        19660  1906626    0.7758232   2.158  16.530   5.25637627  74.91964992   1.19263272  36.04   2.285  5.0675 12.7333  1.0798  4.8653 13.6891  0.0000 20.4705 18.6879 22.6567  0.7396  0.7500  0.925272157200      0
jxl:d2.9        19660  1857482    0.7558261   2.165  16.732   3.78401232  74.25279237   1.21988561  35.87   2.279  4.9662 12.4788  1.0908  4.7498 13.7275  0.0000 20.0668 19.0499 23.0890  0.7083  0.8125  0.922021366055      0
jxl:d3          19660  1813201    0.7378077   1.993  16.228   4.41894913  73.58882301   1.24832635  35.70   2.249  4.7641 12.2974  1.0596  4.6768 13.5901  0.0000 19.6137 19.6332 23.5942  0.7188  0.7917  0.921024854294      0
jxl:d5          19660  1236655    0.5032060   1.955   8.962   5.44389057  61.69178261   1.76654846  33.24   2.281  3.2937  8.0773  0.9535  2.9975 10.9553  0.0000 15.4769 27.8599 29.1047  0.6875  1.3334  0.888937801662      0
jxl:d7          19660   955884    0.3889578   2.043   8.794   7.25439930  51.94589997   2.24028602  31.69   2.277  2.5313  5.7101  0.7949  2.0759  9.2430  0.0000 12.9820 33.0215 31.9850  0.6875  1.7084  0.871376658078      0
jxl:d15         19660   532865    0.2168275   2.029   8.392  12.66306782  22.52471286   3.74903521  28.78   2.169  1.2155  1.7230  0.3125  0.5921  5.4558  0.0000  7.4572 38.2169 40.9435  1.1979  3.6251  0.812894110721      0
jxl:d24         19660   390509    0.1589016   0.318  21.031  56.09043503  -6.73674694   6.24633809  26.36   2.664  1.0124  2.2338  0.1748  0.7015  3.0658  0.0000  3.2774  9.4273  5.5574  0.0104  0.0000  0.992553206128      0
jxl:d32         19660   312053    0.1269772   0.314  20.536  55.51866150 -19.51606870   7.00725103  25.86   2.401  0.7474  1.6908  0.1458  0.5104  2.7461  0.0000  2.8490 10.4377  6.3335  0.0000  0.0000  0.889760866027      0
Aggregate:      19660  2201854    0.8959542   1.802  15.065   4.47263725  76.62000967   1.05752942  37.02   2.368  5.6412 11.9669  0.7834  4.8460 13.0158  0.0000 18.4801 10.1550 14.6434  0.3565  0.4876  0.947497959457      0
```