### PR TITLE
Remove input scaling for 8-bit input in jpegli_write_scanlines()

### DIFF
--- a/lib/jpegli/adaptive_quantization.cc
+++ b/lib/jpegli/adaptive_quantization.cc
@@ -653,6 +653,7 @@ void ComputeAdaptiveQuantField(j_compress_ptr cinfo) {
   int y_channel = cinfo->jpeg_color_space == JCS_RGB ? 1 : 0;
   jpeg_component_info* y_comp = &cinfo->comp_info[y_channel];
   m->quant_field.Allocate(ysize_blocks, xsize_blocks);
+  static constexpr float kScale = 1.0f / 255.0f;
   if (m->use_adaptive_quantization &&
       y_comp->h_samp_factor == cinfo->max_h_samp_factor &&
       y_comp->v_samp_factor == cinfo->max_v_samp_factor) {
@@ -664,6 +665,7 @@ void ComputeAdaptiveQuantField(j_compress_ptr cinfo) {
       memcpy(input.Row(y), m->input_buffer[y_channel].Row(y),
              input.xsize() * sizeof(float));
     }
+    ScaleImage(kScale, &input);
     jxl::ImageF qf =
         jpegli::InitialQuantField(m->distance, input, nullptr, m->distance);
     float qfmin, qfmax;

--- a/lib/jpegli/color_transform.cc
+++ b/lib/jpegli/color_transform.cc
@@ -82,7 +82,7 @@ void RGBToYCbCr(float* JXL_RESTRICT row0, float* JXL_RESTRICT row1,
 
   // Full-range BT.601 as defined by JFIF Clause 7:
   // https://www.itu.int/rec/T-REC-T.871-201105-I/en
-  const auto c128 = Set(df, 128.0f / 255);
+  const auto c128 = Set(df, 128.0f);
   const auto kR = Set(df, 0.299f);  // NTSC luma
   const auto kG = Set(df, 0.587f);
   const auto kB = Set(df, 0.114f);
@@ -115,7 +115,7 @@ void CMYKToYCCK(float* JXL_RESTRICT row0, float* JXL_RESTRICT row1,
                 float* JXL_RESTRICT row2, float* JXL_RESTRICT row3,
                 size_t xsize) {
   const HWY_CAPPED(float, 8) df;
-  const auto unity = Set(df, 1.0f);
+  const auto unity = Set(df, 255.0f);
   for (size_t x = 0; x < xsize; x += Lanes(df)) {
     Store(Sub(unity, Load(df, row0 + x)), df, row0 + x);
     Store(Sub(unity, Load(df, row1 + x)), df, row1 + x);

--- a/lib/jpegli/dct.cc
+++ b/lib/jpegli/dct.cc
@@ -135,7 +135,7 @@ void QuantizeBlockNoAQ(const float* dct, const float* qmc, int32_t* block) {
   }
 }
 
-static constexpr float kDCBias = 128.0f / 255.0f;
+static constexpr float kDCBias = 128.0f;
 
 void ComputeDCTCoefficients(j_compress_ptr cinfo) {
   jpeg_comp_master* m = cinfo->master;
@@ -163,7 +163,7 @@ void ComputeDCTCoefficients(j_compress_ptr cinfo) {
     JQUANT_TBL* quant_table = cinfo->quant_tbl_ptrs[comp->quant_tbl_no];
     std::vector<float> qmc(kDCTBlockSize);
     for (size_t k = 0; k < kDCTBlockSize; k++) {
-      qmc[k] = 2040.0f / quant_table->quantval[k];
+      qmc[k] = 8.0f / quant_table->quantval[k];
     }
     RowBuffer<float>* plane = &m->input_buffer[c];
     for (size_t by = 0, bix = 0; by < ysize_blocks; by++) {

--- a/lib/jpegli/encode.cc
+++ b/lib/jpegli/encode.cc
@@ -220,8 +220,8 @@ void ReadLine(const uint8_t* row_in, size_t xsize, size_t c,
     memset(row_out, 0, xsize * sizeof(row_out[0]));
     return;
   }
-  static constexpr double kMul8 = 1.0 / 255.0;
-  static constexpr double kMul16 = 1.0 / 65535.0;
+  static constexpr double kMul16 = 1.0 / 257.0;
+  static constexpr double kMulFloat = 255.0;
   const int pwidth = num_components * jpegli_bytes_per_sample(data_type);
   bool is_little_endian =
       (endianness == JPEGLI_LITTLE_ENDIAN ||
@@ -229,7 +229,7 @@ void ReadLine(const uint8_t* row_in, size_t xsize, size_t c,
   if (data_type == JPEGLI_TYPE_UINT8) {
     const uint8_t* p = &row_in[c];
     for (size_t x = 0; x < xsize; ++x, p += pwidth) {
-      row_out[x] = p[0] * kMul8;
+      row_out[x] = p[0];
     }
   } else if (data_type == JPEGLI_TYPE_UINT16 && is_little_endian) {
     const uint8_t* p = &row_in[c * 2];
@@ -244,12 +244,12 @@ void ReadLine(const uint8_t* row_in, size_t xsize, size_t c,
   } else if (data_type == JPEGLI_TYPE_FLOAT && is_little_endian) {
     const uint8_t* p = &row_in[c * 4];
     for (size_t x = 0; x < xsize; ++x, p += pwidth) {
-      row_out[x] = LoadLEFloat(p);
+      row_out[x] = LoadLEFloat(p) * kMulFloat;
     }
   } else if (data_type == JPEGLI_TYPE_FLOAT && !is_little_endian) {
     const uint8_t* p = &row_in[c * 4];
     for (size_t x = 0; x < xsize; ++x, p += pwidth) {
-      row_out[x] = LoadBEFloat(p);
+      row_out[x] = LoadBEFloat(p) * kMulFloat;
     }
   }
 }


### PR DESCRIPTION
Instead do the scaling before adaptive quantization and adjust the multipliers in the DCT stage.

Benchmark before:
```
Encoding                       kPixels    Bytes          BPP  E MP/s  D MP/s     Max norm  SSIMULACRA2        pnorm       BPP*pnorm   Bugs
------------------------------------------------------------------------------------------------------------------------------------------
jpeg:enc-jpegli:p0:q90           13270  3679250    2.2180109  44.912 200.397   2.26414490  86.30579721   0.68598112  1.521513573278      0
jpeg:enc-jpegli:p0:noaq:q90      13270  4054221    2.4440596  68.389 182.477   2.29879761  88.59588680   0.67347566  1.646014648716      0
jpeg:q90                         13270  4838710    2.9169834  67.079 169.634   2.40070152  91.22219875   0.68663652  2.002907346332      0
Aggregate:                       13270  4163566    2.5099774  59.062 183.740   2.32049716  88.68524184   0.68200410  1.711814873250      0
```

Benchmark after:
```
Encoding                       kPixels    Bytes          BPP  E MP/s  D MP/s     Max norm  SSIMULACRA2        pnorm       BPP*pnorm   Bugs
------------------------------------------------------------------------------------------------------------------------------------------
jpeg:enc-jpegli:p0:q90           13270  3679204    2.2179831  47.272 203.135   2.26414490  86.30230304   0.68598251  1.521497645179      0
jpeg:enc-jpegli:p0:noaq:q90      13270  4054257    2.4440813  74.382 184.559   2.29879761  88.59713846   0.67347830  1.646035711071      0
jpeg:q90                         13270  4838710    2.9169834  68.046 171.360   2.40070152  91.22219875   0.68663652  2.002907346332      0
Aggregate:                       13270  4163561    2.5099743  62.081 185.899   2.32049716  88.68446262   0.68200546  1.711816201188      0
```