### PR TITLE
Remove the dependence on ImageF from the jpegli encoder.

### DIFF
--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -26,6 +26,7 @@ jobs:
     name: Ubuntu Build ${{ matrix.name }}
     runs-on: ${{ matrix.os || 'ubuntu-latest' }}
     strategy:
+      fail-fast: false
       matrix:
         # We have one job per "name" in the matrix. Attributes are set on the
         # specific job names.

--- a/lib/jpegli/render.cc
+++ b/lib/jpegli/render.cc
@@ -397,7 +397,7 @@ void ProcessOutput(j_decompress_ptr cinfo, size_t* num_output_rows,
           JXL_ASSERT(y == static_cast<size_t>(yc));
           for (int yix = 0; yix < vfactor; ++yix) {
             memcpy(render_out->Row(yix), raw_out->Row(yc + yix),
-                   raw_out->memstride());
+                   raw_out->xsize() * sizeof(float));
           }
         }
       }

--- a/lib/jpegli/simd.cc
+++ b/lib/jpegli/simd.cc
@@ -1,0 +1,38 @@
+// Copyright (c) the JPEG XL Project Authors. All rights reserved.
+//
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+#include "lib/jpegli/simd.h"
+
+#undef HWY_TARGET_INCLUDE
+#define HWY_TARGET_INCLUDE "lib/jpegli/simd.cc"
+#include <hwy/foreach_target.h>
+#include <hwy/highway.h>
+
+HWY_BEFORE_NAMESPACE();
+namespace jpegli {
+namespace HWY_NAMESPACE {
+
+size_t GetVectorSize() { return HWY_LANES(uint8_t); }
+
+// NOLINTNEXTLINE(google-readability-namespace-comments)
+}  // namespace HWY_NAMESPACE
+}  // namespace jpegli
+HWY_AFTER_NAMESPACE();
+
+#if HWY_ONCE
+namespace jpegli {
+namespace {
+
+HWY_EXPORT(GetVectorSize);  // Local function.
+
+}  // namespace
+
+size_t VectorSize() {
+  static size_t bytes = HWY_DYNAMIC_DISPATCH(GetVectorSize)();
+  return bytes;
+}
+
+}  // namespace jpegli
+#endif  // HWY_ONCE

--- a/lib/jpegli/simd.h
+++ b/lib/jpegli/simd.h
@@ -1,0 +1,18 @@
+// Copyright (c) the JPEG XL Project Authors. All rights reserved.
+//
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+#ifndef LIB_JPEGLI_SIMD_H_
+#define LIB_JPEGLI_SIMD_H_
+
+#include <stddef.h>
+
+namespace jpegli {
+
+// Returns SIMD vector size in bytes.
+size_t VectorSize();
+
+}  // namespace jpegli
+
+#endif  // LIB_JPEGLI_SIMD_H_

--- a/lib/jxl_lists.bzl
+++ b/lib/jxl_lists.bzl
@@ -488,6 +488,8 @@ libjxl_jpegli_sources = [
     "jpegli/quant.h",
     "jpegli/render.cc",
     "jpegli/render.h",
+    "jpegli/simd.cc",
+    "jpegli/simd.h",
     "jpegli/source_manager.cc",
     "jpegli/source_manager.h",
     "jpegli/upsample.cc",

--- a/lib/jxl_lists.cmake
+++ b/lib/jxl_lists.cmake
@@ -488,6 +488,8 @@ set(JPEGXL_INTERNAL_JPEGLI_SOURCES
   jpegli/quant.h
   jpegli/render.cc
   jpegli/render.h
+  jpegli/simd.cc
+  jpegli/simd.h
   jpegli/source_manager.cc
   jpegli/source_manager.h
   jpegli/upsample.cc


### PR DESCRIPTION
Adaptive quantization was the last place where we used it, this change removes the need of one image copy and one image scaling. The input scaling factor is rolled into the various constants.

Benchmark before:
```
Encoding                  kPixels    Bytes          BPP  E MP/s  D MP/s     Max norm  SSIMULACRA2        pnorm       BPP*pnorm   Bugs
-------------------------------------------------------------------------------------------------------------------------------------
jpeg:enc-jpegli:p0:q90      13270  3679204    2.2179831  73.002 200.177   2.26414490  86.30231498   0.68598247  1.521497538051      0
jpeg:q90                    13270  4838710    2.9169834  68.118 171.392   2.40070152  91.22219875   0.68663652  2.002907346332      0
Aggregate:                  13270  4219313    2.5435841  70.518 185.226   2.33142362  88.72816311   0.68630941  1.745685709510      0
```

Benchmark after:
```
Encoding                  kPixels    Bytes          BPP  E MP/s  D MP/s     Max norm  SSIMULACRA2        pnorm       BPP*pnorm   Bugs
-------------------------------------------------------------------------------------------------------------------------------------
jpeg:enc-jpegli:p0:q90      13270  3679204    2.2179831  76.038 202.326   2.26414490  86.30231498   0.68598247  1.521497538051      0
jpeg:q90                    13270  4838710    2.9169834  67.426 169.951   2.40070152  91.22219875   0.68663652  2.002907346332      0
Aggregate:                  13270  4219313    2.5435841  71.602 185.433   2.33142362  88.72816311   0.68630941  1.745685709510      0
```