### PR TITLE
CMake: Export jxl and jxl_threads targets.

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -51,6 +51,7 @@ Misaki Kasumi <misakikasumi@outlook.com>
 Nicholas Hayes <0xC0000054@users.noreply.github.com>
 Nigel Tao <nigeltao@golang.org>
 Petr Diblík
+Pierre Wendling <pierre.wendling.4@gmail.com>
 Pieter Wuille
 roland-rollo
 Samuel Leong <wvvwvvvvwvvw@gmail.com>

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -154,6 +154,52 @@ install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/include/jxl
 install(DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/include/jxl
   DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}")
 
+# Destination of CMake files
+if(NOT DEFINED JPEGXL_INSTALL_CMAKEDIR)
+  set(JPEGXL_INSTALL_CMAKEDIR "${CMAKE_INSTALL_LIBDIR}/cmake/JPEGXL")
+endif()
+
+# Find modules also need to be installed for non-vendored libraries
+if(JPEGXL_FORCE_SYSTEM_BROTLI)
+  list(APPEND JPEGXL_FIND_MODULES "${PROJECT_SOURCE_DIR}/cmake/FindBrotli.cmake")
+endif()
+if(JPEGXL_FORCE_SYSTEM_HWY)
+  list(APPEND JPEGXL_FIND_MODULES "${PROJECT_SOURCE_DIR}/cmake/FindHWY.cmake")
+endif()
+if(JPEGXL_FORCE_SYSTEM_LCMS2 AND NOT JPEGXL_ENABLE_SKCMS)
+  list(APPEND JPEGXL_FIND_MODULES "${PROJECT_SOURCE_DIR}/cmake/FindLCMS2.cmake")
+endif()
+
+# Prepare and install the CMake config files
+include(CMakePackageConfigHelpers)
+configure_package_config_file("${CMAKE_CURRENT_SOURCE_DIR}/JPEGXLConfig.cmake.in"
+  "${CMAKE_CURRENT_BINARY_DIR}/JPEGXLConfig.cmake"
+  INSTALL_DESTINATION "${JPEGXL_INSTALL_CMAKEDIR}")
+
+write_basic_package_version_file("${CMAKE_CURRENT_BINARY_DIR}/JPEGXLConfigVersion.cmake"
+  VERSION "${JPEGXL_LIBRARY_VERSION}"
+  COMPATIBILITY SameMinorVersion)
+
+install(FILES
+  "${CMAKE_CURRENT_BINARY_DIR}/JPEGXLConfig.cmake"
+  "${CMAKE_CURRENT_BINARY_DIR}/JPEGXLConfigVersion.cmake"
+  ${JPEGXL_FIND_MODULES}
+  DESTINATION "${JPEGXL_INSTALL_CMAKEDIR}")
+
+# Export the library targets
+install(EXPORT JxlTargets
+  FILE "JPEGXLTargets.cmake"
+  NAMESPACE JPEGXL::
+  DESTINATION "${JPEGXL_INSTALL_CMAKEDIR}")
+
+# If vendored dependencies were used, they also need to be exported
+if(HAS_EXPORTED_VENDORED_DEPS)
+  install(EXPORT JxlDeps 
+    FILE "JPEGXLDeps.cmake"
+    NAMESPACE JPEGXLDeps::
+    DESTINATION "${JPEGXL_INSTALL_CMAKEDIR}")
+endif()
+
 if(BUILD_TESTING)
   cmake_policy(SET CMP0057 NEW)  # https://gitlab.kitware.com/cmake/cmake/issues/18198
   include(GoogleTest)

--- a/lib/JPEGXLConfig.cmake.in
+++ b/lib/JPEGXLConfig.cmake.in
@@ -1,0 +1,54 @@
+@PACKAGE_INIT@
+
+# Save which library was vendored
+set(JPEGXL_USES_SYSTEM_BROTLI @JPEGXL_FORCE_SYSTEM_BROTLI@)
+set(JPEGXL_USES_SYSTEM_LCMS2  @JPEGXL_FORCE_SYSTEM_LCMS2@)
+set(JPEGXL_USES_SKCMS         @JPEGXL_ENABLE_SKCMS@)
+set(JPEGXL_USES_TCMALLOC      @JPEGXL_ENABLE_TCMALLOC@)
+set(JPEGXL_USES_VENDORED_DEPS @HAS_EXPORTED_VENDORED_DEPS@)
+
+# Every non-vendored target linked needs to be available
+include(CMakeFindDependencyMacro)
+
+list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}")
+
+if(NOT TARGET Threads::Threads)
+  find_dependency(Threads)
+endif()
+
+if(NOT HWY_FOUND)
+  find_dependency(HWY 1.0.0)
+endif()
+
+if(JPEGXL_USES_SYSTEM_BROTLI AND NOT Brotli_FOUND)
+  find_dependency(Brotli)
+endif()
+
+if(JPEGXL_USES_SYSTEM_LCMS2 AND NOT LCMS2_FOUND AND NOT JPEGXL_USES_SKCMS)
+  find_dependency(LCMS2 2.13)
+endif()
+
+if(JPEGXL_USES_TCMALLOC AND NOT TARGET PkgConfig::TCMallocMinimal)
+  find_dependency(PkgConfig)
+  pkg_check_modules(TCMallocMinimal REQUIRED IMPORTED_TARGET libtcmalloc_minimal)
+endif()
+
+list(REMOVE_ITEM CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}")
+
+# Vendored dependencies have special targets
+if(JPEGXL_USES_VENDORED_DEPS)
+  include("${CMAKE_CURRENT_LIST_DIR}/JPEGXLDeps.cmake")
+endif()
+
+include("${CMAKE_CURRENT_LIST_DIR}/JPEGXLTargets.cmake")
+
+# In static-only builds, create an alias
+if(TARGET JPEGXL::jxl-static AND NOT TARGET JPEGXL::jxl)
+  add_library(JPEGXL::jxl ALIAS JPEGXL::jxl-static)
+endif()
+  
+if(TARGET JPEGXL::jxl_threads-static AND NOT TARGET JPEGXL::jxl_threads)
+  add_library(JPEGXL::jxl_threads ALIAS JPEGXL::jxl_threads-static)
+endif()
+
+check_required_components(Jxl)

--- a/lib/jxl.cmake
+++ b/lib/jxl.cmake
@@ -93,10 +93,16 @@ foreach(path ${JPEGXL_INTERNAL_PUBLIC_HEADERS})
 endforeach()
 
 add_library(jxl_includes INTERFACE)
-target_include_directories(jxl_includes SYSTEM INTERFACE
+target_include_directories(jxl_includes INTERFACE
   "$<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/include>"
+  "$<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}/include>"
+  "$<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>"
 )
 add_dependencies(jxl_includes jxl_export)
+
+# Export the headers as JPEGXL::headers
+set_target_properties(jxl_includes PROPERTIES EXPORT_NAME "headers")
+install(TARGETS jxl_includes EXPORT JxlTargets)
 
 # Base headers / utilities.
 add_library(jxl_base-obj OBJECT ${JPEGXL_INTERNAL_BASE_SOURCES})
@@ -231,7 +237,7 @@ if (NOT WIN32 OR MINGW)
   set_target_properties(jxl-static PROPERTIES OUTPUT_NAME "jxl")
   set_target_properties(jxl_dec-static PROPERTIES OUTPUT_NAME "jxl_dec")
 endif()
-install(TARGETS jxl-static DESTINATION ${CMAKE_INSTALL_LIBDIR})
+install(TARGETS jxl-static EXPORT JxlTargets DESTINATION ${CMAKE_INSTALL_LIBDIR})
 install(TARGETS jxl_dec-static DESTINATION ${CMAKE_INSTALL_LIBDIR})
 
 if (BUILD_SHARED_LIBS)
@@ -295,6 +301,7 @@ endforeach()
 # contains symbols also in libjxl which would conflict if programs try to use
 # both.
 install(TARGETS jxl
+  EXPORT JxlTargets
   RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
   LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
   ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR})

--- a/lib/jxl_threads.cmake
+++ b/lib/jxl_threads.cmake
@@ -16,14 +16,10 @@ function(_set_jxl_threads _target)
   set_property(TARGET ${_target} PROPERTY POSITION_INDEPENDENT_CODE ON)
 
   target_include_directories(${_target}
-    PRIVATE
-      "${PROJECT_SOURCE_DIR}"
-    PUBLIC
-      "${CMAKE_CURRENT_SOURCE_DIR}/include"
-      "${CMAKE_CURRENT_BINARY_DIR}/include")
+    PRIVATE "${PROJECT_SOURCE_DIR}")
 
   target_link_libraries(${_target}
-    PUBLIC ${JPEGXL_COVERAGE_FLAGS} Threads::Threads
+    PUBLIC ${JPEGXL_COVERAGE_FLAGS} Threads::Threads jxl_includes
   )
 
   set_target_properties(${_target} PROPERTIES
@@ -38,6 +34,7 @@ function(_set_jxl_threads _target)
     set_target_properties(${_target} PROPERTIES OUTPUT_NAME "jxl_threads")
   endif()
   install(TARGETS ${_target}
+    EXPORT JxlTargets
     RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
     LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
     ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR})

--- a/third_party/CMakeLists.txt
+++ b/third_party/CMakeLists.txt
@@ -69,6 +69,7 @@ else()
   add_subdirectory(brotli)
   configure_file("${CMAKE_CURRENT_SOURCE_DIR}/brotli/LICENSE"
                  ${PROJECT_BINARY_DIR}/LICENSE.brotli COPYONLY)
+  list(APPEND VENDORED_DEPENDENCIES brotlienc brotlidec brotlicommon)
   if(APPLE)
     if(NOT DEFINED CMAKE_MACOSX_RPATH)
       # Use @rpath in install_name when CMAKE_MACOSX_RPATH is not set.
@@ -103,6 +104,9 @@ if (JPEGXL_ENABLE_SKCMS OR JPEGXL_ENABLE_PLUGINS)
   include(skcms.cmake)
   configure_file("${CMAKE_CURRENT_SOURCE_DIR}/skcms/LICENSE"
                  ${PROJECT_BINARY_DIR}/LICENSE.skcms COPYONLY)
+  if(NOT JPEGXL_BUNDLE_SKCMS)
+    list(APPEND VENDORED_DEPENDENCIES skcms skcms-obj)
+  endif()
 endif ()
 if (JPEGXL_ENABLE_VIEWERS OR NOT JPEGXL_ENABLE_SKCMS)
   if( NOT EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/lcms/.git" OR JPEGXL_FORCE_SYSTEM_LCMS2 )
@@ -114,6 +118,10 @@ if (JPEGXL_ENABLE_VIEWERS OR NOT JPEGXL_ENABLE_SKCMS)
     include(lcms2.cmake)
     configure_file("${CMAKE_CURRENT_SOURCE_DIR}/lcms/COPYING"
                    ${PROJECT_BINARY_DIR}/LICENSE.lcms COPYONLY)
+    # Only install it when it is a dependency of the library
+    if(NOT JPEGXL_ENABLE_SKCMS)
+      list(APPEND VENDORED_DEPENDENCIES lcms2)
+    endif()
   endif()
 endif()
 
@@ -173,3 +181,15 @@ if (JPEGXL_ENABLE_SJPEG)
   configure_file("${CMAKE_CURRENT_SOURCE_DIR}/sjpeg/COPYING"
                  ${PROJECT_BINARY_DIR}/LICENSE.sjpeg COPYONLY)
 endif ()
+
+# Export vendored dependencies used by the core libraries
+set(HAS_EXPORTED_VENDORED_DEPS FALSE PARENT_SCOPE)
+if(DEFINED VENDORED_DEPENDENCIES)
+  install(TARGETS ${VENDORED_DEPENDENCIES} 
+    EXPORT JxlDeps
+    RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+    LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+    ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+    PUBLIC_HEADER DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
+  set(HAS_EXPORTED_VENDORED_DEPS TRUE PARENT_SCOPE)
+endif()

--- a/third_party/lcms2.cmake
+++ b/third_party/lcms2.cmake
@@ -42,7 +42,7 @@ add_library(lcms2 STATIC EXCLUDE_FROM_ALL
   lcms/src/lcms2_internal.h
 )
 target_include_directories(lcms2
-    PUBLIC "${CMAKE_CURRENT_LIST_DIR}/lcms/include")
+    PUBLIC "$<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}/lcms/include>")
 # This warning triggers with gcc-8.
 if (CMAKE_C_COMPILER_ID MATCHES "GNU")
 target_compile_options(lcms2

--- a/third_party/skcms.cmake
+++ b/third_party/skcms.cmake
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 add_library(skcms-obj OBJECT EXCLUDE_FROM_ALL skcms/skcms.cc)
-target_include_directories(skcms-obj PUBLIC "${CMAKE_CURRENT_LIST_DIR}/skcms/")
+target_include_directories(skcms-obj PUBLIC "$<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}/skcms/>")
 
 # This library is meant to be compiled/used by external libs (such as plugins)
 # that need to use skcms. We use a wrapper for libjxl.


### PR DESCRIPTION
## Description

This enables downstream projects to consume libjxl through CMake's `find_package` without relying on pkg-config or Find modules:

```cmake
find_package(Jxl)
target_link_libraries(main PRIVATE Jxl::jxl Jxl::jxl_threads)
```

The only targets exported in this PR are jxl(-static) and jxl_threads(-static) in order to match what is provided with pc files. The `jxl_includes` target is also exported as `Jxl::headers` to handle the include directories for the other targets.

When doing a static-only build (`BUILD_SHARED_LIBS=OFF`), the `Jxl::jxl` and `Jxl::jxl_threads` targets are aliases of their respective static target. This makes it so all four targets are always available.

When Highway, Brotli, LCMS2, or SKCMS are vendored (but not bundled), they are also installed under the `JxlDeps::` namespace. This is required by CMake, as all dependencies of an exported library which are not imported must be exported as well.

When using system dependencies, the associated Find modules are also installed since they are required for static linking.

## Testing

The tests conducted include:
- Building with and without the shared library (ensures all targets are always always and working)
- Using system dependencies + bundled SKCMS (ensures no extraneous targets are installed when not needed)
- Using vendored dependencies with LCMS2 (ensures the `JxlDeps::` targets work properly)
- Using vendored dependencies and non-bundled SKCMS (same as above)

For every configuration, the package was searched by setting either `CMAKE_PREFIX_PATH` to the installed prefix or `Jxl_DIR` to the directory containing `JxlConfig.cmake` (by default `<prefix>/lib/cmake/Jxl`). Then an example executable was built and linked against the exported targets.