### PR TITLE
SIMDify input deinterleaving.

### DIFF
--- a/lib/extras/enc/jpegli.cc
+++ b/lib/extras/enc/jpegli.cc
@@ -300,6 +300,13 @@ Status EncodeJpeg(const PackedPixelFile& ppf, const JpegSettings& jpeg_settings,
       cinfo.write_JFIF_header = false;
       cinfo.write_Adobe_marker = false;
     }
+    const PackedImage& image = ppf.frames[0].color;
+    if (jpeg_settings.xyb) {
+      jpegli_set_input_format(&cinfo, JPEGLI_TYPE_FLOAT, JPEGLI_NATIVE_ENDIAN);
+    } else {
+      jpegli_set_input_format(&cinfo, ConvertDataType(image.format.data_type),
+                              ConvertEndianness(image.format.endianness));
+    }
     jpegli_start_compress(&cinfo, TRUE);
     if (!jpeg_settings.app_data.empty()) {
       JXL_RETURN_IF_ERROR(WriteAppData(&cinfo, jpeg_settings.app_data));
@@ -309,10 +316,8 @@ Status EncodeJpeg(const PackedPixelFile& ppf, const JpegSettings& jpeg_settings,
       jpegli_write_icc_profile(&cinfo, output_encoding.ICC().data(),
                                output_encoding.ICC().size());
     }
-    const PackedImage& image = ppf.frames[0].color;
     const uint8_t* pixels = reinterpret_cast<const uint8_t*>(image.pixels());
     if (jpeg_settings.xyb) {
-      jpegli_set_input_format(&cinfo, JPEGLI_TYPE_FLOAT, JPEGLI_NATIVE_ENDIAN);
       float* src_buf = c_transform.BufSrc(0);
       float* dst_buf = c_transform.BufDst(0);
       for (size_t y = 0; y < image.ysize; ++y) {
@@ -348,8 +353,6 @@ Status EncodeJpeg(const PackedPixelFile& ppf, const JpegSettings& jpeg_settings,
         jpegli_write_scanlines(&cinfo, row, 1);
       }
     } else {
-      jpegli_set_input_format(&cinfo, ConvertDataType(image.format.data_type),
-                              ConvertEndianness(image.format.endianness));
       row_bytes.resize(image.stride);
       for (size_t y = 0; y < info.ysize; ++y) {
         memcpy(&row_bytes[0], pixels + y * image.stride, image.stride);

--- a/lib/jpegli/dct.cc
+++ b/lib/jpegli/dct.cc
@@ -177,7 +177,7 @@ void ComputeDCTCoefficients(j_compress_ptr cinfo) {
     }
     RowBuffer<float>* plane = &m->input_buffer[c];
     for (size_t by = 0, bix = 0; by < ysize_blocks; by++) {
-      const float* row = plane->Row(8 * by);
+      const float* row = plane->DirectRow(8 * by);
       for (size_t bx = 0; bx < xsize_blocks; bx++, bix++) {
         coeff_t* block = &coeffs[bix * kDCTBlockSize];
         TransformFromPixels(jxl::AcStrategy::Type::DCT, row + 8 * bx,
@@ -186,7 +186,7 @@ void ComputeDCTCoefficients(j_compress_ptr cinfo) {
         if (m->use_adaptive_quantization) {
           // Create more zeros in areas where jpeg xl would have used a lower
           // quantization multiplier.
-          float relq = m->quant_field.Row(by * v_factor)[bx * h_factor];
+          float relq = m->quant_field.DirectRow(by * v_factor)[bx * h_factor];
           float zero_bias = 0.5f + zero_bias_mul[c] * relq;
           zero_bias = std::min(1.5f, zero_bias);
           QuantizeBlock(dct1, &qmc[0], zero_bias, block);

--- a/lib/jpegli/encode_api_test.cc
+++ b/lib/jpegli/encode_api_test.cc
@@ -395,6 +395,24 @@ std::vector<TestConfig> GenerateTests() {
       }
     }
   }
+  for (JpegliDataType data_type : {JPEGLI_TYPE_UINT16, JPEGLI_TYPE_FLOAT}) {
+    for (JpegliEndianness endianness :
+         {JPEGLI_LITTLE_ENDIAN, JPEGLI_BIG_ENDIAN, JPEGLI_NATIVE_ENDIAN}) {
+      J_COLOR_SPACE colorspace[4] = {JCS_GRAYSCALE, JCS_UNKNOWN, JCS_RGB,
+                                     JCS_CMYK};
+      float max_bpp[4] = {1.25, 2.5, 1.45, 3.75};
+      for (int channels = 1; channels <= 4; ++channels) {
+        TestConfig config;
+        config.input.data_type = data_type;
+        config.input.endianness = endianness;
+        config.input.components = channels;
+        config.input.color_space = colorspace[channels - 1];
+        config.max_bpp = max_bpp[channels - 1];
+        config.max_dist = 2.2;
+        all_tests.push_back(config);
+      }
+    }
+  }
   return all_tests;
 };
 
@@ -415,8 +433,26 @@ std::string ColorSpaceName(J_COLOR_SPACE colorspace) {
   }
 }
 
+std::string InputMethod(JpegliDataType data_type, JpegliEndianness endianness) {
+  std::string retval;
+  if (data_type == JPEGLI_TYPE_UINT8) {
+    return "UINT8";
+  } else if (data_type == JPEGLI_TYPE_UINT16) {
+    retval = "UINT16";
+  } else if (data_type == JPEGLI_TYPE_FLOAT) {
+    retval = "FLOAT";
+  }
+  if (endianness == JPEGLI_LITTLE_ENDIAN) {
+    retval += "LE";
+  } else if (endianness == JPEGLI_BIG_ENDIAN) {
+    retval += "BE";
+  }
+  return retval;
+}
+
 std::ostream& operator<<(std::ostream& os, const TestConfig& c) {
   os << c.input.xsize << "x" << c.input.ysize;
+  os << InputMethod(c.input.data_type, c.input.endianness);
   os << ColorSpaceName(c.input.color_space);
   if (c.input.color_space == JCS_UNKNOWN) {
     os << c.input.components;

--- a/lib/jpegli/encode_internal.h
+++ b/lib/jpegli/encode_internal.h
@@ -72,6 +72,8 @@ struct jpeg_comp_master {
   uint8_t* next_marker_byte = nullptr;
   JpegliDataType data_type = JPEGLI_TYPE_UINT8;
   JpegliEndianness endianness = JPEGLI_NATIVE_ENDIAN;
+  void (*input_method)(const uint8_t* row_in, size_t len,
+                       float* row_out[jpegli::kMaxComponents]);
   std::array<jpegli::coeff_t*, jpegli::kMaxComponents> coefficients;
   jpegli::HuffmanCodeTable huff_tables[8];
   std::array<jpegli::HuffmanCodeTable, jpegli::kMaxHuffmanTables> dc_huff_table;

--- a/lib/jpegli/input.cc
+++ b/lib/jpegli/input.cc
@@ -1,0 +1,414 @@
+// Copyright (c) the JPEG XL Project Authors. All rights reserved.
+//
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+#include "lib/jpegli/input.h"
+
+#undef HWY_TARGET_INCLUDE
+#define HWY_TARGET_INCLUDE "lib/jpegli/input.cc"
+#include <hwy/foreach_target.h>
+#include <hwy/highway.h>
+
+#include "lib/jpegli/encode_internal.h"
+#include "lib/jpegli/error.h"
+#include "lib/jxl/base/byte_order.h"
+#include "lib/jxl/base/compiler_specific.h"
+
+HWY_BEFORE_NAMESPACE();
+namespace jpegli {
+namespace HWY_NAMESPACE {
+
+using hwy::HWY_NAMESPACE::Mul;
+using hwy::HWY_NAMESPACE::Rebind;
+using hwy::HWY_NAMESPACE::Vec;
+
+using D = HWY_FULL(float);
+using DU = HWY_FULL(uint32_t);
+using DU8 = Rebind<uint8_t, D>;
+using DU16 = Rebind<uint16_t, D>;
+
+constexpr D d;
+constexpr DU du;
+constexpr DU8 du8;
+constexpr DU16 du16;
+
+static constexpr double kMul16 = 1.0 / 257.0;
+static constexpr double kMulFloat = 255.0;
+
+template <size_t C>
+void ReadUint8Row(const uint8_t* row_in, size_t x0, size_t len,
+                  float* row_out[kMaxComponents]) {
+  for (size_t x = x0; x < len; ++x) {
+    for (size_t c = 0; c < C; ++c) {
+      row_out[c][x] = row_in[C * x + c];
+    }
+  }
+}
+
+template <size_t C, bool swap_endianness = false>
+void ReadUint16Row(const uint8_t* row_in, size_t x0, size_t len,
+                   float* row_out[kMaxComponents]) {
+  const uint16_t* row16 = reinterpret_cast<const uint16_t*>(row_in);
+  for (size_t x = x0; x < len; ++x) {
+    for (size_t c = 0; c < C; ++c) {
+      uint16_t val = row16[C * x + c];
+      if (swap_endianness) val = JXL_BSWAP16(val);
+      row_out[c][x] = val * kMul16;
+    }
+  }
+}
+
+template <size_t C, bool swap_endianness = false>
+void ReadFloatRow(const uint8_t* row_in, size_t x0, size_t len,
+                  float* row_out[kMaxComponents]) {
+  const float* rowf = reinterpret_cast<const float*>(row_in);
+  for (size_t x = x0; x < len; ++x) {
+    for (size_t c = 0; c < C; ++c) {
+      float val = rowf[C * x + c];
+      if (swap_endianness) val = BSwapFloat(val);
+      row_out[c][x] = val * kMulFloat;
+    }
+  }
+}
+
+void ReadUint8RowSingle(const uint8_t* row_in, size_t len,
+                        float* row_out[kMaxComponents]) {
+  const size_t N = Lanes(d);
+  const size_t simd_len = len & (~(N - 1));
+  float* JXL_RESTRICT const row0 = row_out[0];
+  for (size_t x = 0; x < simd_len; x += N) {
+    Store(ConvertTo(d, PromoteTo(du, LoadU(du8, row_in + x))), d, row0 + x);
+  }
+  ReadUint8Row<1>(row_in, simd_len, len, row_out);
+}
+
+void ReadUint8RowInterleaved2(const uint8_t* row_in, size_t len,
+                              float* row_out[kMaxComponents]) {
+  const size_t N = Lanes(d);
+  const size_t simd_len = len & (~(N - 1));
+  float* JXL_RESTRICT const row0 = row_out[0];
+  float* JXL_RESTRICT const row1 = row_out[1];
+  Vec<DU8> out0, out1;
+  for (size_t x = 0; x < simd_len; x += N) {
+    LoadInterleaved2(du8, row_in + 2 * x, out0, out1);
+    Store(ConvertTo(d, PromoteTo(du, out0)), d, row0 + x);
+    Store(ConvertTo(d, PromoteTo(du, out1)), d, row1 + x);
+  }
+  ReadUint8Row<2>(row_in, simd_len, len, row_out);
+}
+
+void ReadUint8RowInterleaved3(const uint8_t* row_in, size_t len,
+                              float* row_out[kMaxComponents]) {
+  const size_t N = Lanes(d);
+  const size_t simd_len = len & (~(N - 1));
+  float* JXL_RESTRICT const row0 = row_out[0];
+  float* JXL_RESTRICT const row1 = row_out[1];
+  float* JXL_RESTRICT const row2 = row_out[2];
+  Vec<DU8> out0, out1, out2;
+  for (size_t x = 0; x < simd_len; x += N) {
+    LoadInterleaved3(du8, row_in + 3 * x, out0, out1, out2);
+    Store(ConvertTo(d, PromoteTo(du, out0)), d, row0 + x);
+    Store(ConvertTo(d, PromoteTo(du, out1)), d, row1 + x);
+    Store(ConvertTo(d, PromoteTo(du, out2)), d, row2 + x);
+  }
+  ReadUint8Row<3>(row_in, simd_len, len, row_out);
+}
+
+void ReadUint8RowInterleaved4(const uint8_t* row_in, size_t len,
+                              float* row_out[kMaxComponents]) {
+  const size_t N = Lanes(d);
+  const size_t simd_len = len & (~(N - 1));
+  float* JXL_RESTRICT const row0 = row_out[0];
+  float* JXL_RESTRICT const row1 = row_out[1];
+  float* JXL_RESTRICT const row2 = row_out[2];
+  float* JXL_RESTRICT const row3 = row_out[3];
+  Vec<DU8> out0, out1, out2, out3;
+  for (size_t x = 0; x < simd_len; x += N) {
+    LoadInterleaved4(du8, row_in + 4 * x, out0, out1, out2, out3);
+    Store(ConvertTo(d, PromoteTo(du, out0)), d, row0 + x);
+    Store(ConvertTo(d, PromoteTo(du, out1)), d, row1 + x);
+    Store(ConvertTo(d, PromoteTo(du, out2)), d, row2 + x);
+    Store(ConvertTo(d, PromoteTo(du, out3)), d, row3 + x);
+  }
+  ReadUint8Row<4>(row_in, simd_len, len, row_out);
+}
+
+void ReadUint16RowSingle(const uint8_t* row_in, size_t len,
+                         float* row_out[kMaxComponents]) {
+  const size_t N = Lanes(d);
+  const size_t simd_len = len & (~(N - 1));
+  const auto mul = Set(d, kMul16);
+  const uint16_t* JXL_RESTRICT const row =
+      reinterpret_cast<const uint16_t*>(row_in);
+  float* JXL_RESTRICT const row0 = row_out[0];
+  for (size_t x = 0; x < simd_len; x += N) {
+    Store(Mul(mul, ConvertTo(d, PromoteTo(du, LoadU(du16, row + x)))), d,
+          row0 + x);
+  }
+  ReadUint16Row<1>(row_in, simd_len, len, row_out);
+}
+
+void ReadUint16RowInterleaved2(const uint8_t* row_in, size_t len,
+                               float* row_out[kMaxComponents]) {
+  const size_t N = Lanes(d);
+  const size_t simd_len = len & (~(N - 1));
+  const auto mul = Set(d, kMul16);
+  const uint16_t* JXL_RESTRICT const row =
+      reinterpret_cast<const uint16_t*>(row_in);
+  float* JXL_RESTRICT const row0 = row_out[0];
+  float* JXL_RESTRICT const row1 = row_out[1];
+  Vec<DU16> out0, out1;
+  for (size_t x = 0; x < simd_len; x += N) {
+    LoadInterleaved2(du16, row + 2 * x, out0, out1);
+    Store(Mul(mul, ConvertTo(d, PromoteTo(du, out0))), d, row0 + x);
+    Store(Mul(mul, ConvertTo(d, PromoteTo(du, out1))), d, row1 + x);
+  }
+  ReadUint16Row<2>(row_in, simd_len, len, row_out);
+}
+
+void ReadUint16RowInterleaved3(const uint8_t* row_in, size_t len,
+                               float* row_out[kMaxComponents]) {
+  const size_t N = Lanes(d);
+  const size_t simd_len = len & (~(N - 1));
+  const auto mul = Set(d, kMul16);
+  const uint16_t* JXL_RESTRICT const row =
+      reinterpret_cast<const uint16_t*>(row_in);
+  float* JXL_RESTRICT const row0 = row_out[0];
+  float* JXL_RESTRICT const row1 = row_out[1];
+  float* JXL_RESTRICT const row2 = row_out[2];
+  Vec<DU16> out0, out1, out2;
+  for (size_t x = 0; x < simd_len; x += N) {
+    LoadInterleaved3(du16, row + 3 * x, out0, out1, out2);
+    Store(Mul(mul, ConvertTo(d, PromoteTo(du, out0))), d, row0 + x);
+    Store(Mul(mul, ConvertTo(d, PromoteTo(du, out1))), d, row1 + x);
+    Store(Mul(mul, ConvertTo(d, PromoteTo(du, out2))), d, row2 + x);
+  }
+  ReadUint16Row<3>(row_in, simd_len, len, row_out);
+}
+
+void ReadUint16RowInterleaved4(const uint8_t* row_in, size_t len,
+                               float* row_out[kMaxComponents]) {
+  const size_t N = Lanes(d);
+  const size_t simd_len = len & (~(N - 1));
+  const auto mul = Set(d, kMul16);
+  const uint16_t* JXL_RESTRICT const row =
+      reinterpret_cast<const uint16_t*>(row_in);
+  float* JXL_RESTRICT const row0 = row_out[0];
+  float* JXL_RESTRICT const row1 = row_out[1];
+  float* JXL_RESTRICT const row2 = row_out[2];
+  float* JXL_RESTRICT const row3 = row_out[3];
+  Vec<DU16> out0, out1, out2, out3;
+  for (size_t x = 0; x < simd_len; x += N) {
+    LoadInterleaved4(du16, row + 4 * x, out0, out1, out2, out3);
+    Store(Mul(mul, ConvertTo(d, PromoteTo(du, out0))), d, row0 + x);
+    Store(Mul(mul, ConvertTo(d, PromoteTo(du, out1))), d, row1 + x);
+    Store(Mul(mul, ConvertTo(d, PromoteTo(du, out2))), d, row2 + x);
+    Store(Mul(mul, ConvertTo(d, PromoteTo(du, out3))), d, row3 + x);
+  }
+  ReadUint16Row<4>(row_in, simd_len, len, row_out);
+}
+
+void ReadUint16RowSingleSwap(const uint8_t* row_in, size_t len,
+                             float* row_out[kMaxComponents]) {
+  ReadUint16Row<1, true>(row_in, 0, len, row_out);
+}
+
+void ReadUint16RowInterleaved2Swap(const uint8_t* row_in, size_t len,
+                                   float* row_out[kMaxComponents]) {
+  ReadUint16Row<2, true>(row_in, 0, len, row_out);
+}
+
+void ReadUint16RowInterleaved3Swap(const uint8_t* row_in, size_t len,
+                                   float* row_out[kMaxComponents]) {
+  ReadUint16Row<3, true>(row_in, 0, len, row_out);
+}
+
+void ReadUint16RowInterleaved4Swap(const uint8_t* row_in, size_t len,
+                                   float* row_out[kMaxComponents]) {
+  ReadUint16Row<4, true>(row_in, 0, len, row_out);
+}
+
+void ReadFloatRowSingle(const uint8_t* row_in, size_t len,
+                        float* row_out[kMaxComponents]) {
+  const size_t N = Lanes(d);
+  const size_t simd_len = len & (~(N - 1));
+  const auto mul = Set(d, kMulFloat);
+  const float* JXL_RESTRICT const row = reinterpret_cast<const float*>(row_in);
+  float* JXL_RESTRICT const row0 = row_out[0];
+  for (size_t x = 0; x < simd_len; x += N) {
+    Store(Mul(mul, Load(d, row + x)), d, row0 + x);
+  }
+  ReadFloatRow<1>(row_in, simd_len, len, row_out);
+}
+
+void ReadFloatRowInterleaved2(const uint8_t* row_in, size_t len,
+                              float* row_out[kMaxComponents]) {
+  const size_t N = Lanes(d);
+  const size_t simd_len = len & (~(N - 1));
+  const auto mul = Set(d, kMulFloat);
+  const float* JXL_RESTRICT const row = reinterpret_cast<const float*>(row_in);
+  float* JXL_RESTRICT const row0 = row_out[0];
+  float* JXL_RESTRICT const row1 = row_out[1];
+  Vec<D> out0, out1;
+  for (size_t x = 0; x < simd_len; x += N) {
+    LoadInterleaved2(d, row + 2 * x, out0, out1);
+    Store(Mul(mul, out0), d, row0 + x);
+    Store(Mul(mul, out1), d, row1 + x);
+  }
+  ReadFloatRow<2>(row_in, simd_len, len, row_out);
+}
+
+void ReadFloatRowInterleaved3(const uint8_t* row_in, size_t len,
+                              float* row_out[kMaxComponents]) {
+  const size_t N = Lanes(d);
+  const size_t simd_len = len & (~(N - 1));
+  const auto mul = Set(d, kMulFloat);
+  const float* JXL_RESTRICT const row = reinterpret_cast<const float*>(row_in);
+  float* JXL_RESTRICT const row0 = row_out[0];
+  float* JXL_RESTRICT const row1 = row_out[1];
+  float* JXL_RESTRICT const row2 = row_out[2];
+  Vec<D> out0, out1, out2;
+  for (size_t x = 0; x < simd_len; x += N) {
+    LoadInterleaved3(d, row + 3 * x, out0, out1, out2);
+    Store(Mul(mul, out0), d, row0 + x);
+    Store(Mul(mul, out1), d, row1 + x);
+    Store(Mul(mul, out2), d, row2 + x);
+  }
+  ReadFloatRow<3>(row_in, simd_len, len, row_out);
+}
+
+void ReadFloatRowInterleaved4(const uint8_t* row_in, size_t len,
+                              float* row_out[kMaxComponents]) {
+  const size_t N = Lanes(d);
+  const size_t simd_len = len & (~(N - 1));
+  const auto mul = Set(d, kMulFloat);
+  const float* JXL_RESTRICT const row = reinterpret_cast<const float*>(row_in);
+  float* JXL_RESTRICT const row0 = row_out[0];
+  float* JXL_RESTRICT const row1 = row_out[1];
+  float* JXL_RESTRICT const row2 = row_out[2];
+  float* JXL_RESTRICT const row3 = row_out[3];
+  Vec<D> out0, out1, out2, out3;
+  for (size_t x = 0; x < simd_len; x += N) {
+    LoadInterleaved4(d, row + 4 * x, out0, out1, out2, out3);
+    Store(Mul(mul, out0), d, row0 + x);
+    Store(Mul(mul, out1), d, row1 + x);
+    Store(Mul(mul, out2), d, row2 + x);
+    Store(Mul(mul, out3), d, row3 + x);
+  }
+  ReadFloatRow<4>(row_in, simd_len, len, row_out);
+}
+
+void ReadFloatRowSingleSwap(const uint8_t* row_in, size_t len,
+                            float* row_out[kMaxComponents]) {
+  ReadFloatRow<1, true>(row_in, 0, len, row_out);
+}
+
+void ReadFloatRowInterleaved2Swap(const uint8_t* row_in, size_t len,
+                                  float* row_out[kMaxComponents]) {
+  ReadFloatRow<2, true>(row_in, 0, len, row_out);
+}
+
+void ReadFloatRowInterleaved3Swap(const uint8_t* row_in, size_t len,
+                                  float* row_out[kMaxComponents]) {
+  ReadFloatRow<3, true>(row_in, 0, len, row_out);
+}
+
+void ReadFloatRowInterleaved4Swap(const uint8_t* row_in, size_t len,
+                                  float* row_out[kMaxComponents]) {
+  ReadFloatRow<4, true>(row_in, 0, len, row_out);
+}
+
+// NOLINTNEXTLINE(google-readability-namespace-comments)
+}  // namespace HWY_NAMESPACE
+}  // namespace jpegli
+HWY_AFTER_NAMESPACE();
+
+#if HWY_ONCE
+namespace jpegli {
+
+HWY_EXPORT(ReadUint8RowSingle);
+HWY_EXPORT(ReadUint8RowInterleaved2);
+HWY_EXPORT(ReadUint8RowInterleaved3);
+HWY_EXPORT(ReadUint8RowInterleaved4);
+HWY_EXPORT(ReadUint16RowSingle);
+HWY_EXPORT(ReadUint16RowInterleaved2);
+HWY_EXPORT(ReadUint16RowInterleaved3);
+HWY_EXPORT(ReadUint16RowInterleaved4);
+HWY_EXPORT(ReadUint16RowSingleSwap);
+HWY_EXPORT(ReadUint16RowInterleaved2Swap);
+HWY_EXPORT(ReadUint16RowInterleaved3Swap);
+HWY_EXPORT(ReadUint16RowInterleaved4Swap);
+HWY_EXPORT(ReadFloatRowSingle);
+HWY_EXPORT(ReadFloatRowInterleaved2);
+HWY_EXPORT(ReadFloatRowInterleaved3);
+HWY_EXPORT(ReadFloatRowInterleaved4);
+HWY_EXPORT(ReadFloatRowSingleSwap);
+HWY_EXPORT(ReadFloatRowInterleaved2Swap);
+HWY_EXPORT(ReadFloatRowInterleaved3Swap);
+HWY_EXPORT(ReadFloatRowInterleaved4Swap);
+
+void ChooseInputMethod(j_compress_ptr cinfo) {
+  jpeg_comp_master* m = cinfo->master;
+  bool swap_endianness =
+      (m->endianness == JPEGLI_LITTLE_ENDIAN && !IsLittleEndian()) ||
+      (m->endianness == JPEGLI_BIG_ENDIAN && IsLittleEndian());
+  m->input_method = nullptr;
+  if (m->data_type == JPEGLI_TYPE_UINT8) {
+    if (cinfo->raw_data_in || cinfo->input_components == 1) {
+      m->input_method = HWY_DYNAMIC_DISPATCH(ReadUint8RowSingle);
+    } else if (cinfo->input_components == 2) {
+      m->input_method = HWY_DYNAMIC_DISPATCH(ReadUint8RowInterleaved2);
+    } else if (cinfo->input_components == 3) {
+      m->input_method = HWY_DYNAMIC_DISPATCH(ReadUint8RowInterleaved3);
+    } else if (cinfo->input_components == 4) {
+      m->input_method = HWY_DYNAMIC_DISPATCH(ReadUint8RowInterleaved4);
+    }
+  } else if (m->data_type == JPEGLI_TYPE_UINT16 && !swap_endianness) {
+    if (cinfo->raw_data_in || cinfo->input_components == 1) {
+      m->input_method = HWY_DYNAMIC_DISPATCH(ReadUint16RowSingle);
+    } else if (cinfo->input_components == 2) {
+      m->input_method = HWY_DYNAMIC_DISPATCH(ReadUint16RowInterleaved2);
+    } else if (cinfo->input_components == 3) {
+      m->input_method = HWY_DYNAMIC_DISPATCH(ReadUint16RowInterleaved3);
+    } else if (cinfo->input_components == 4) {
+      m->input_method = HWY_DYNAMIC_DISPATCH(ReadUint16RowInterleaved4);
+    }
+  } else if (m->data_type == JPEGLI_TYPE_UINT16 && swap_endianness) {
+    if (cinfo->raw_data_in || cinfo->input_components == 1) {
+      m->input_method = HWY_DYNAMIC_DISPATCH(ReadUint16RowSingleSwap);
+    } else if (cinfo->input_components == 2) {
+      m->input_method = HWY_DYNAMIC_DISPATCH(ReadUint16RowInterleaved2Swap);
+    } else if (cinfo->input_components == 3) {
+      m->input_method = HWY_DYNAMIC_DISPATCH(ReadUint16RowInterleaved3Swap);
+    } else if (cinfo->input_components == 4) {
+      m->input_method = HWY_DYNAMIC_DISPATCH(ReadUint16RowInterleaved4Swap);
+    }
+  } else if (m->data_type == JPEGLI_TYPE_FLOAT && !swap_endianness) {
+    if (cinfo->raw_data_in || cinfo->input_components == 1) {
+      m->input_method = HWY_DYNAMIC_DISPATCH(ReadFloatRowSingle);
+    } else if (cinfo->input_components == 2) {
+      m->input_method = HWY_DYNAMIC_DISPATCH(ReadFloatRowInterleaved2);
+    } else if (cinfo->input_components == 3) {
+      m->input_method = HWY_DYNAMIC_DISPATCH(ReadFloatRowInterleaved3);
+    } else if (cinfo->input_components == 4) {
+      m->input_method = HWY_DYNAMIC_DISPATCH(ReadFloatRowInterleaved4);
+    }
+  } else if (m->data_type == JPEGLI_TYPE_FLOAT && swap_endianness) {
+    if (cinfo->raw_data_in || cinfo->input_components == 1) {
+      m->input_method = HWY_DYNAMIC_DISPATCH(ReadFloatRowSingleSwap);
+    } else if (cinfo->input_components == 2) {
+      m->input_method = HWY_DYNAMIC_DISPATCH(ReadFloatRowInterleaved2Swap);
+    } else if (cinfo->input_components == 3) {
+      m->input_method = HWY_DYNAMIC_DISPATCH(ReadFloatRowInterleaved3Swap);
+    } else if (cinfo->input_components == 4) {
+      m->input_method = HWY_DYNAMIC_DISPATCH(ReadFloatRowInterleaved4Swap);
+    }
+  }
+  if (m->input_method == nullptr) {
+    JPEGLI_ERROR("Could not find input method.");
+  }
+}
+
+}  // namespace jpegli
+#endif  // HWY_ONCE

--- a/lib/jpegli/input.h
+++ b/lib/jpegli/input.h
@@ -1,0 +1,20 @@
+// Copyright (c) the JPEG XL Project Authors. All rights reserved.
+//
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+#ifndef LIB_JPEGLI_INPUT_H_
+#define LIB_JPEGLI_INPUT_H_
+
+/* clang-format off */
+#include <stdio.h>
+#include <jpeglib.h>
+/* clang-format on */
+
+namespace jpegli {
+
+void ChooseInputMethod(j_compress_ptr cinfo);
+
+}  // namespace jpegli
+
+#endif  // LIB_JPEGLI_INPUT_H_

--- a/lib/jpegli/test_utils.h
+++ b/lib/jpegli/test_utils.h
@@ -19,9 +19,12 @@
 #include <setjmp.h>
 /* clang-format on */
 
+#include "lib/jpegli/common.h"
+
 namespace jpegli {
 
-// TODO(eustas): use common.h?
+// We define this here as well to make sure that the *_api_test.cc tests only
+// use the public API and therefore we don't include any *_internal.h headers.
 template <typename T1, typename T2>
 constexpr inline T1 DivCeil(T1 a, T2 b) {
   return (a + b - 1) / b;
@@ -105,6 +108,8 @@ struct TestImage {
   size_t ysize = 0;
   J_COLOR_SPACE color_space = JCS_RGB;
   size_t components = 3;
+  JpegliDataType data_type = JPEGLI_TYPE_UINT8;
+  JpegliEndianness endianness = JPEGLI_NATIVE_ENDIAN;
   std::vector<uint8_t> pixels;
   std::vector<std::vector<uint8_t>> raw_data;
   std::vector<std::vector<JCOEF>> coeffs;

--- a/lib/jxl_lists.bzl
+++ b/lib/jxl_lists.bzl
@@ -482,6 +482,8 @@ libjxl_jpegli_sources = [
     "jpegli/huffman.h",
     "jpegli/idct.cc",
     "jpegli/idct.h",
+    "jpegli/input.cc",
+    "jpegli/input.h",
     "jpegli/memory_manager.cc",
     "jpegli/memory_manager.h",
     "jpegli/quant.cc",

--- a/lib/jxl_lists.cmake
+++ b/lib/jxl_lists.cmake
@@ -482,6 +482,8 @@ set(JPEGXL_INTERNAL_JPEGLI_SOURCES
   jpegli/huffman.h
   jpegli/idct.cc
   jpegli/idct.h
+  jpegli/input.cc
+  jpegli/input.h
   jpegli/memory_manager.cc
   jpegli/memory_manager.h
   jpegli/quant.cc


### PR DESCRIPTION
drive-by: use DirectRow() instead of the (cyclical) Row() in dct.cc

Benchmark before:
```
Encoding                  kPixels    Bytes          BPP  E MP/s  D MP/s     Max norm  SSIMULACRA2        pnorm       BPP*pnorm   Bugs
-------------------------------------------------------------------------------------------------------------------------------------
jpeg:enc-jpegli:p0:q90      13270  3679204    2.2179831  78.468 200.201   2.26414490  86.30231498   0.68598247  1.521497538051      0
jpeg:q90                    13270  4838710    2.9169834  67.006 169.425   2.40070152  91.22219875   0.68663652  2.002907346332      0
Aggregate:                  13270  4219313    2.5435841  72.511 184.172   2.33142362  88.72816311   0.68630941  1.745685709510      0
```

Benchmark after:
```
Encoding                  kPixels    Bytes          BPP  E MP/s  D MP/s     Max norm  SSIMULACRA2        pnorm       BPP*pnorm   Bugs
-------------------------------------------------------------------------------------------------------------------------------------
jpeg:enc-jpegli:p0:q90      13270  3679204    2.2179831  84.561 200.566   2.26414490  86.30231498   0.68598247  1.521497538051      0
jpeg:q90                    13270  4838710    2.9169834  67.213 171.114   2.40070152  91.22219875   0.68663652  2.002907346332      0
Aggregate:                  13270  4219313    2.5435841  75.390 185.256   2.33142362  88.72816311   0.68630941  1.745685709510      0
```