### PR TITLE
Preparations for streaming encoder: write DQT and SOF earlier.

### DIFF
--- a/lib/extras/jpegli_test.cc
+++ b/lib/extras/jpegli_test.cc
@@ -188,8 +188,8 @@ TEST(JpegliTest, JpegliYUVEncodeTest) {
 
   PackedPixelFile ppf_out;
   ASSERT_TRUE(DecodeWithLibjpeg(compressed, &ppf_out));
-  EXPECT_THAT(BitsPerPixel(ppf_in, compressed), IsSlightlyBelow(1.68f));
-  EXPECT_THAT(ButteraugliDistance(ppf_in, ppf_out), IsSlightlyBelow(1.28f));
+  EXPECT_THAT(BitsPerPixel(ppf_in, compressed), IsSlightlyBelow(1.67f));
+  EXPECT_THAT(ButteraugliDistance(ppf_in, ppf_out), IsSlightlyBelow(1.32f));
 }
 
 TEST(JpegliTest, JpegliYUVChromaSubsamplingEncodeTest) {
@@ -208,8 +208,8 @@ TEST(JpegliTest, JpegliYUVChromaSubsamplingEncodeTest) {
 
     PackedPixelFile ppf_out;
     ASSERT_TRUE(DecodeWithLibjpeg(compressed, &ppf_out));
-    EXPECT_LE(BitsPerPixel(ppf_in, compressed), 1.6f);
-    EXPECT_LE(ButteraugliDistance(ppf_in, ppf_out), 1.8f);
+    EXPECT_LE(BitsPerPixel(ppf_in, compressed), 1.55f);
+    EXPECT_LE(ButteraugliDistance(ppf_in, ppf_out), 1.82f);
   }
 }
 
@@ -228,8 +228,8 @@ TEST(JpegliTest, JpegliYUVEncodeTestNoAq) {
 
   PackedPixelFile ppf_out;
   ASSERT_TRUE(DecodeWithLibjpeg(compressed, &ppf_out));
-  EXPECT_THAT(BitsPerPixel(ppf_in, compressed), IsSlightlyBelow(1.72f));
-  EXPECT_THAT(ButteraugliDistance(ppf_in, ppf_out), IsSlightlyBelow(1.45f));
+  EXPECT_THAT(BitsPerPixel(ppf_in, compressed), IsSlightlyBelow(1.76f));
+  EXPECT_THAT(ButteraugliDistance(ppf_in, ppf_out), IsSlightlyBelow(1.32f));
 }
 
 TEST(JpegliTest, JpegliHDRRoundtripTest) {

--- a/lib/jpegli/adaptive_quantization.cc
+++ b/lib/jpegli/adaptive_quantization.cc
@@ -555,7 +555,7 @@ HWY_EXPORT(PerBlockModulations);
 namespace {
 
 constexpr float kDcQuantPow = 0.66f;
-static const float kDcQuant = 1.1f;
+static const float kDcQuant = 1.913f;
 static const float kAcQuant = 0.841f;
 
 }  // namespace
@@ -567,11 +567,7 @@ float InitialQuantDC(float butteraugli_target) {
       std::min<float>(butteraugli_target,
                       kDcMul * std::pow((1.0f / kDcMul) * butteraugli_target,
                                         kDcQuantPow)));
-  // We want the maximum DC value to be at most 2**15 * kInvDCQuant / quant_dc.
-  // The maximum DC value might not be in the kXybRange because of inverse
-  // gaborish, so we add some slack to the maximum theoretical quant obtained
-  // this way (64).
-  return std::min(kDcQuant / butteraugli_target_dc, 50.f);
+  return kDcQuant / butteraugli_target_dc;
 }
 
 void AdaptiveQuantizationMap(const float butteraugli_target,
@@ -606,7 +602,6 @@ void ComputeAdaptiveQuantField(j_compress_ptr cinfo) {
         qfmax = std::max(qfmax, row[x]);
       }
     }
-    m->quant_field_max = qfmax;
     for (size_t y = 0; y < ysize_blocks; ++y) {
       float* row = m->quant_field.DirectRow(y);
       for (size_t x = 0; x < xsize_blocks; ++x) {
@@ -614,7 +609,6 @@ void ComputeAdaptiveQuantField(j_compress_ptr cinfo) {
       }
     }
   } else {
-    m->quant_field_max = kDefaultQuantFieldMax;
     for (size_t y = 0; y < ysize_blocks; ++y) {
       m->quant_field.FillRow(y, 0.0f, xsize_blocks);
     }

--- a/lib/jpegli/encode_api_test.cc
+++ b/lib/jpegli/encode_api_test.cc
@@ -359,9 +359,13 @@ std::vector<TestConfig> GenerateTests() {
     config.jparams.add_marker = true;
     all_tests.push_back(config);
   }
-  {
+  for (JpegIOMode input_mode : {PIXELS, RAW_DATA}) {
     TestConfig config;
     config.input.xsize = config.input.ysize = 256;
+    config.input_mode = input_mode;
+    if (input_mode == RAW_DATA) {
+      config.input.color_space = JCS_YCbCr;
+    }
     config.jparams.progressive_level = 0;
     config.jparams.optimize_coding = false;
     config.max_bpp = 1.8;

--- a/lib/jpegli/encode_internal.h
+++ b/lib/jpegli/encode_internal.h
@@ -39,7 +39,6 @@ struct JPEGHuffmanCode {
 const int kJPEGMaxCorrectionBits = 1u << 16;
 
 constexpr int kDefaultProgressiveLevel = 2;
-constexpr float kDefaultQuantFieldMax = 0.575f;
 
 struct HuffmanCodeTable {
   int depth[256];
@@ -79,7 +78,6 @@ struct jpeg_comp_master {
   std::array<jpegli::HuffmanCodeTable, jpegli::kMaxHuffmanTables> dc_huff_table;
   std::array<jpegli::HuffmanCodeTable, jpegli::kMaxHuffmanTables> ac_huff_table;
   jpegli::RowBuffer<float> quant_field;
-  float quant_field_max = jpegli::kDefaultQuantFieldMax;
   jvirt_barray_ptr* coeff_buffers = nullptr;
 };
 

--- a/lib/jpegli/quant.cc
+++ b/lib/jpegli/quant.cc
@@ -532,14 +532,14 @@ void FinalizeQuantMatrices(j_compress_ptr cinfo) {
 
   // Global scale is chosen in a way that butteraugli 3-norm matches libjpeg
   // with the same quality setting. Fitted for quality 90 on jyrki31 corpus.
-  constexpr float kGlobalScaleXYB = 0.86747522f;
-  constexpr float kGlobalScaleYCbCr = 1.03148720f;
+  constexpr float kGlobalScaleXYB = 1.44563150f;
+  constexpr float kGlobalScaleYCbCr = 1.73480749f;
 
   float ac_scale, dc_scale;
   const float* base_quant_matrix;
 
   if (cinfo->jpeg_color_space == JCS_RGB && m->xyb_mode) {
-    ac_scale = kGlobalScaleXYB * m->distance / m->quant_field_max;
+    ac_scale = kGlobalScaleXYB * m->distance;
     dc_scale = kGlobalScaleXYB / InitialQuantDC(m->distance);
     base_quant_matrix = kBaseQuantMatrixXYB;
   } else if (cinfo->jpeg_color_space == JCS_YCbCr && !m->use_std_tables &&
@@ -561,7 +561,7 @@ void FinalizeQuantMatrices(j_compress_ptr cinfo) {
     } else if (cicp_tf == kTransferFunctionHLG) {
       global_scale *= .5f;
     }
-    ac_scale = global_scale * m->distance / m->quant_field_max;
+    ac_scale = global_scale * m->distance;
     dc_scale = global_scale / InitialQuantDC(m->distance);
     base_quant_matrix = kBaseQuantMatrixYCbCr;
   } else {


### PR DESCRIPTION
We write DQT and SOF in the first call to jpegli_write_scanlines() or jpegli_write_raw_data(). To make this work quant_field_max was removed from quant table calculation and the relevant constants were updated. The effect on size/quality seems to be neutral on all metrics.

Benchmark before:
```
Encoding                   kPixels    Bytes          BPP  E MP/s  D MP/s     Max norm  SSIMULACRA2        pnorm       BPP*pnorm   Bugs
--------------------------------------------------------------------------------------------------------------------------------------
jpeg:enc-jpegli:q90          13270  3592229    2.1655508  18.380  68.514   2.26414490  86.30231498   0.68598247  1.485529907995      0
jpeg:enc-jpegli:xyb:q90      13270  3108580    1.8739863  18.852  79.471   2.23073959  84.88789541   0.68692255  1.287283475504      0
jpeg:enc-jpegli:p0:q90       13270  3679204    2.2179831  80.289 190.700   2.26414490  86.30231498   0.68598247  1.521497538051      0
Aggregate:                   13270  3450590    2.0801645  30.301 101.262   2.25295458  85.82824240   0.68629569  1.427607922438      0
```

Benchmark after:
```
Encoding                   kPixels    Bytes          BPP  E MP/s  D MP/s     Max norm  SSIMULACRA2        pnorm       BPP*pnorm   Bugs
--------------------------------------------------------------------------------------------------------------------------------------
jpeg:enc-jpegli:q90          13270  3587770    2.1628628  18.115  70.087   2.25433660  86.32254081   0.68681241  1.485480997421      0
jpeg:enc-jpegli:xyb:q90      13270  3108476    1.8739236  18.608  81.193   2.13027716  84.85884641   0.68753171  1.288381922542      0
jpeg:enc-jpegli:p0:q90       13270  3672874    2.2141671  79.930 192.978   2.25433660  86.32254081   0.68681241  1.520717474342      0
Aggregate:                   13270  3447144    2.0780871  29.979 103.170   2.21220080  85.83185878   0.68705210  1.427754112702      0
```