### PR TITLE
Fix for DZgas chromacity ringing

### DIFF
--- a/lib/jxl/decode_test.cc
+++ b/lib/jxl/decode_test.cc
@@ -1986,7 +1986,7 @@ TEST(DecodeTest, PixelTestOpaqueSrgbLossyNoise) {
     EXPECT_THAT(
         ButteraugliDistance(io0.frames, io1.frames, ba, jxl::GetJxlCms(),
                             /*distmap=*/nullptr, nullptr),
-        IsSlightlyBelow(1.2f));
+        IsSlightlyBelow(1.4f));
 
     JxlDecoderDestroy(dec);
   }

--- a/lib/jxl/enc_adaptive_quantization.cc
+++ b/lib/jxl/enc_adaptive_quantization.cc
@@ -716,7 +716,7 @@ ImageF TileDistMap(const ImageF& distmap, int tile_size, int margin,
 
 constexpr float kDcQuantPow = 0.87f;
 static const float kDcQuant = 1.29f;
-static const float kAcQuant = 0.841f;
+static const float kAcQuant = 0.839f;
 
 void FindBestQuantization(const ImageBundle& linear, const Image3F& opsin,
                           PassesEncoderState* enc_state,

--- a/lib/jxl/enc_chroma_from_luma.h
+++ b/lib/jxl/enc_chroma_from_luma.h
@@ -48,8 +48,8 @@ struct CfLHeuristics {
   void ComputeTile(const Rect& r, const Image3F& opsin,
                    const DequantMatrices& dequant,
                    const AcStrategyImage* ac_strategy,
-                   const Quantizer* quantizer, bool fast, size_t thread,
-                   ColorCorrelationMap* cmap);
+                   const ImageI* raw_quant_field, const Quantizer* quantizer,
+                   bool fast, size_t thread, ColorCorrelationMap* cmap);
 
   void ComputeDC(bool fast, ColorCorrelationMap* cmap);
 

--- a/lib/jxl/enc_heuristics.cc
+++ b/lib/jxl/enc_heuristics.cc
@@ -881,6 +881,7 @@ Status DefaultEncoderHeuristics::LossyFrameHeuristics(
     if (cparams.speed_tier <= SpeedTier::kSquirrel) {
       cfl_heuristics.ComputeTile(r, *opsin, enc_state->shared.matrices,
                                  /*ac_strategy=*/nullptr,
+                                 /*raw_quant_field=*/nullptr,
                                  /*quantizer=*/nullptr, /*fast=*/false, thread,
                                  &enc_state->shared.cmap);
     }
@@ -905,7 +906,7 @@ Status DefaultEncoderHeuristics::LossyFrameHeuristics(
     if (cparams.speed_tier <= SpeedTier::kHare) {
       cfl_heuristics.ComputeTile(
           r, *opsin, enc_state->shared.matrices, &enc_state->shared.ac_strategy,
-          &enc_state->shared.quantizer,
+          &enc_state->shared.raw_quant_field, &enc_state->shared.quantizer,
           /*fast=*/cparams.speed_tier >= SpeedTier::kWombat, thread,
           &enc_state->shared.cmap);
     }

--- a/lib/jxl/jxl_test.cc
+++ b/lib/jxl/jxl_test.cc
@@ -202,7 +202,7 @@ TEST(JxlTest, RoundtripOutOfOrderProcessing) {
   cparams.AddOption(JXL_ENC_FRAME_SETTING_EPF, 3);
 
   PackedPixelFile ppf_out;
-  EXPECT_NEAR(Roundtrip(t.ppf(), cparams, {}, &pool, &ppf_out), 20100, 400);
+  EXPECT_NEAR(Roundtrip(t.ppf(), cparams, {}, &pool, &ppf_out), 20741, 400);
   EXPECT_LE(ButteraugliDistance(t.ppf(), ppf_out), 1.35);
 }
 
@@ -295,7 +295,7 @@ TEST(JxlTest, RoundtripMultiGroup) {
   };
 
   auto run_kitten = std::async(std::launch::async, test, SpeedTier::kKitten,
-                               1.0f, 50800u, 11.7);
+                               1.0f, 51595u, 11.7);
   auto run_wombat = std::async(std::launch::async, test, SpeedTier::kWombat,
                                2.0f, 31000u, 20.0);
 }
@@ -356,7 +356,7 @@ TEST(JxlTest, RoundtripLargeFast) {
   cparams.AddOption(JXL_ENC_FRAME_SETTING_EFFORT, 7);  // kSquirrel
 
   PackedPixelFile ppf_out;
-  EXPECT_NEAR(Roundtrip(t.ppf(), cparams, {}, &pool, &ppf_out), 405616, 5000);
+  EXPECT_NEAR(Roundtrip(t.ppf(), cparams, {}, &pool, &ppf_out), 412757, 5000);
   EXPECT_THAT(ComputeDistance2(t.ppf(), ppf_out), IsSlightlyBelow(100));
 }
 
@@ -469,7 +469,7 @@ TEST(JxlTest, RoundtripNoGaborishNoAR) {
   cparams.AddOption(JXL_ENC_FRAME_SETTING_GABORISH, 0);
 
   PackedPixelFile ppf_out;
-  EXPECT_NEAR(Roundtrip(t.ppf(), cparams, {}, pool, &ppf_out), 36986, 100);
+  EXPECT_NEAR(Roundtrip(t.ppf(), cparams, {}, pool, &ppf_out), 37241, 100);
   EXPECT_THAT(ButteraugliDistance(t.ppf(), ppf_out), IsSlightlyBelow(1.8));
 }
 
@@ -488,7 +488,7 @@ TEST(JxlTest, RoundtripSmallNoGaborish) {
 
   PackedPixelFile ppf_out;
   EXPECT_NEAR(Roundtrip(t.ppf(), cparams, {}, pool, &ppf_out), 749, 20);
-  EXPECT_THAT(ButteraugliDistance(t.ppf(), ppf_out), IsSlightlyBelow(1.2));
+  EXPECT_THAT(ButteraugliDistance(t.ppf(), ppf_out), IsSlightlyBelow(1.4));
 }
 
 TEST(JxlTest, RoundtripSmallPatchesAlpha) {
@@ -514,7 +514,7 @@ TEST(JxlTest, RoundtripSmallPatchesAlpha) {
 
   PackedPixelFile ppf_out;
   EXPECT_NEAR(Roundtrip(t.ppf(), cparams, {}, pool, &ppf_out), 620, 70);
-  EXPECT_THAT(ButteraugliDistance(t.ppf(), ppf_out), IsSlightlyBelow(0.025f));
+  EXPECT_THAT(ButteraugliDistance(t.ppf(), ppf_out), IsSlightlyBelow(0.02f));
 }
 
 TEST(JxlTest, RoundtripSmallPatches) {
@@ -539,7 +539,7 @@ TEST(JxlTest, RoundtripSmallPatches) {
 
   PackedPixelFile ppf_out;
   EXPECT_NEAR(Roundtrip(t.ppf(), cparams, {}, pool, &ppf_out), 500, 100);
-  EXPECT_THAT(ButteraugliDistance(t.ppf(), ppf_out), IsSlightlyBelow(0.025f));
+  EXPECT_THAT(ButteraugliDistance(t.ppf(), ppf_out), IsSlightlyBelow(0.02f));
 }
 
 // TODO(szabadka) Add encoder and decoder API functions that accept frame
@@ -1071,7 +1071,7 @@ TEST(JxlTest, RoundtripDots) {
   cparams.distance = 0.04;
 
   PackedPixelFile ppf_out;
-  EXPECT_NEAR(Roundtrip(t.ppf(), cparams, {}, pool, &ppf_out), 271410, 3000);
+  EXPECT_NEAR(Roundtrip(t.ppf(), cparams, {}, pool, &ppf_out), 276702, 3000);
   EXPECT_THAT(ButteraugliDistance(t.ppf(), ppf_out), IsSlightlyBelow(0.3));
 }
 


### PR DESCRIPTION
This reduces small values of CfL that seem to be able to project HF noise from Y to X in a sporadic manner. This change is more experimental programming than a result of thinking and then making a deliberate change. Some of the related changes improve the CfL in general, and the bringing CfL factors towards zero is the main driver for reducing the sporadic chromacity noise.

0.3 % drop in BPP*pnorm
2 % improvement in max error
DZgas test images at 400 % zoom: day and night difference

```
Before

Encoding      kPixels    Bytes          BPP  E MP/s  D MP/s     Max norm  SSIMULACRA2        pnorm   PSNR   QABPP  SmallB  DCT4x8     AFV  DCT8x8    8x16    8x32      16   16x32      32   32x64      64       BPP*pnorm   Bugs
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
jxl:d0.1        19725 15858752    6.4316292   1.471   9.092   3.23673868  98.98437226   0.17788403  51.69   6.807 38.4127 20.1153  0.5795 28.7362  6.3306  0.0000  2.8149  0.9707  2.5800  0.1142  0.0831  1.144084138758      0
jxl:d0.5        19725  5979529    2.4250404   1.786  15.047   3.25658631  96.80589204   0.42131045  44.67   2.599 14.0650 23.5123  0.6774 12.6462 25.9336  0.0000 17.1878  1.4250  4.6980  0.1350  0.4568  1.021694832243      0
jxl:d0.8        19725  4452548    1.8057624   1.891  15.148   3.21241617  91.82420246   0.55310536  42.30   2.206 10.8284 20.5861  0.7624  9.5176 24.0453  0.0000 26.6941  1.7157  5.9231  0.1661  0.4983  0.998776863365      0
jxl:d1          19725  3852537    1.5624237   1.972  15.857   3.20704770  89.26327515   0.63088249  41.14   2.253  9.6334 19.1433  0.7813  8.2873 21.0994  0.0000 30.4680  2.9044  7.9424  0.2076  0.2699  0.985705744032      0
jxl:d1.1        19725  3623500    1.4695361   1.979  16.365   3.18268919  88.17275982   0.66596584  40.63   2.226  9.1075 18.5187  0.8121  7.8386 19.7737  0.0000 30.9820  3.8466  9.3388  0.2284  0.2907  0.978660849032      0
jxl:d1.2        19725  3422982    1.3882146   1.925  15.762   3.17544794  87.12250517   0.70194746  40.19   2.235  8.6484 17.9464  0.8471  7.4204 18.5109  0.0000 30.9677  5.0795 10.7976  0.2492  0.2699  0.974453717608      0
jxl:d1.3        19725  3280185    1.3303023   1.997  16.505   3.18828392  86.34295453   0.73032451  39.96   2.253  8.2503 17.5184  0.8520  7.0762 17.7089  0.0000 30.2695  6.4266 12.1992  0.2699  0.1661  0.971552346330      0
jxl:d1.4        19725  3121844    1.2660860   2.085  16.870   3.20169067  85.34178296   0.76531423  39.57   2.241  7.9045 17.0204  0.8643  6.7955 16.9185  0.0000 29.4856  7.7426 13.4658  0.3115  0.2284  0.968953598722      0
jxl:d1.5        19725  2978261    1.2078548   2.021  15.954   3.02950239  84.55942363   0.79536673  39.22   2.242  7.6076 16.5694  0.8721  6.4909 16.4007  0.0000 28.6862  9.0923 14.4884  0.2803  0.2492  0.960687561743      0
jxl:d1.6        19725  2851404    1.1564071   2.070  16.045   3.41575408  83.63041434   0.83126943  38.87   2.291  7.3305 16.1892  0.8948  6.3059 15.9952  0.0000 27.7803 10.2110 15.3554  0.3841  0.2907  0.961285868371      0
jxl:d1.7        19725  2735763    1.1095081   2.025  16.241   2.99913979  82.84056587   0.85946343  38.57   2.267  7.0625 15.8414  0.9127  6.1570 15.6026  0.0000 26.8667 11.1012 16.4559  0.3841  0.3530  0.953581611283      0
jxl:d1.8        19725  2630856    1.0669623   2.052  15.051   3.20106363  82.03490026   0.89424482  38.28   2.259  6.8098 15.5263  0.9445  5.9850 15.3125  0.0000 26.0426 12.2485 17.0165  0.4153  0.4361  0.954125498614      0
jxl:d1.8        19725  2630856    1.0669623   2.093  15.707   3.20106363  82.03490026   0.89424482  38.28   2.259  6.8098 15.5263  0.9445  5.9850 15.3125  0.0000 26.0426 12.2485 17.0165  0.4153  0.4361  0.954125498614      0
jxl:d1.9        19725  2533987    1.0276764   2.111  15.885   3.20603085  81.22053403   0.92538329  37.99   2.258  6.5658 15.2301  0.9646  5.8413 15.0355  0.0000 25.3275 13.1362 17.7433  0.4153  0.4776  0.950994548054      0
jxl:d2.0        19725  2446276    0.9921046   2.140  16.042   3.23058653  80.48256972   0.95730999  37.74   2.237  6.3634 14.9543  0.9724  5.6700 14.8479  0.0000 24.6384 14.0109 18.3558  0.4049  0.5191  0.949751605667      0
jxl:d2.1        19725  2361310    0.9576460   2.042  16.424   3.35398006  79.77816457   0.98550623  37.48   2.251  6.1414 14.5637  0.9922  5.5483 14.6838  0.0000 24.0401 14.7298 19.1241  0.4361  0.4776  0.943766097302      0
jxl:d2.2        19725  2285195    0.9267770   2.132  16.188   3.44846964  78.99790240   1.01869961  37.24   2.270  5.9361 14.2740  1.0165  5.4351 14.5709  0.0000 23.4393 15.4825 19.6277  0.4361  0.5191  0.944107392730      0
jxl:d2.3        19725  2214544    0.8981240   2.082  15.702   3.53806543  78.28281189   1.04816675  37.03   2.288  5.8475 13.9684  1.0110  5.3293 14.3171  0.0000 22.8981 16.0406 20.2454  0.5191  0.5606  0.941383723778      0
jxl:d2.4        19725  2147226    0.8708227   2.152  16.003   3.70063972  77.56531721   1.07944545  36.82   2.305  5.6733 13.6780  1.0246  5.2346 14.1776  0.0000 22.4439 16.6557 20.7074  0.5814  0.5606  0.940005617184      0
jxl:d2.5        19725  2083728    0.8450707   2.186  16.833   3.34734321  76.89736595   1.10740351  36.61   2.299  5.4984 13.3996  1.0314  5.1275 14.0511  0.0000 21.9689 17.2086 21.1746  0.6126  0.6645  0.935834205805      0
jxl:d2.6        19725  2023857    0.8207895   2.111  16.255   3.21627975  76.24888017   1.13161167  36.41   2.264  5.3615 13.2007  1.0515  5.0117 13.9635  0.0000 21.4290 17.6395 21.8339  0.6022  0.6437  0.928815026750      0
jxl:d2.7        19725  1968965    0.7985277   2.143  16.406   3.99259996  75.53678408   1.16679041  36.21   2.279  5.2148 12.9548  1.0658  4.9468 13.8772  0.0000 20.8995 18.2105 22.1973  0.6645  0.7060  0.931714469309      0
jxl:d2.8        19725  1916590    0.7772867   2.124  16.209   5.25637627  74.88322098   1.19341408  36.03   2.290  5.0818 12.7634  1.0801  4.8683 13.7156  0.0000 20.4712 18.6699 22.6022  0.7371  0.7475  0.927624835546      0
jxl:d2.9        19725  1867149    0.7572355   2.106  15.869   3.78401232  74.21631412   1.22069115  35.85   2.283  4.9796 12.5090  1.0905  4.7505 13.7591  0.0000 20.0663 19.0333 23.0330  0.7060  0.8098  0.924350679939      0
jxl:d3          19725  1822669    0.7391963   1.936  15.610   4.41894913  73.55099291   1.24915181  35.68   2.252  4.7775 12.3289  1.0587  4.6792 13.6202  0.0000 19.6160 19.6147 23.5366  0.7164  0.7891  0.923368429048      0
jxl:d5          19725  1242978    0.5040985   2.051   8.722   5.44389057  61.64136166   1.76784341  33.22   2.286  3.3016  8.0923  0.9522  3.0001 10.9812  0.0000 15.5007 27.8556 29.0392  0.6852  1.3289  0.891167272442      0
jxl:d7          19725   960655    0.3896004   1.967   8.648   7.25439930  51.88031700   2.24168343  31.68   2.282  2.5355  5.7122  0.7949  2.0768  9.2694  0.0000 13.0038 33.0364 31.9203  0.6852  1.7027  0.873360855399      0
jxl:d15         19725   535462    0.2171604   2.032   8.135  12.66306782  22.41367055   3.75023443  28.77   2.171  1.2160  1.7238  0.3121  0.5928  5.4663  0.0000  7.4882 38.2353 40.8853  1.2043  3.6130  0.814402439341      0
jxl:d24         19725   392488    0.1591763   0.296  19.920  56.09043503  -6.85490932   6.24325012  26.36   2.665  1.0119  2.2328  0.1749  0.7008  3.0634  0.0000  3.2756  9.4453  5.5441  0.0104  0.0000  0.993777386347      0
jxl:d32         19725   313464    0.1271275   0.298  19.909  55.51866150 -19.66737636   7.00500026  25.86   2.402  0.7465  1.6894  0.1454  0.5107  2.7435  0.0000  2.8460 10.4549  6.3228  0.0000  0.0000  0.890528493913      0
Aggregate:      19725  2213507    0.8977033   1.777  14.949   4.47263725  76.57907592   1.05784587  37.01   2.373  5.6589 11.9909  0.7825  4.8470 13.0260  0.0000 18.4701 10.1484 14.6028  0.3555  0.4860  0.949631706475      0

After

Encoding      kPixels    Bytes          BPP  E MP/s  D MP/s     Max norm  SSIMULACRA2        pnorm   PSNR   QABPP  SmallB  DCT4x8     AFV  DCT8x8    8x16    8x32      16   16x32      32   32x64      64       BPP*pnorm   Bugs
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
jxl:d0.1        19725 16002061    6.4897492   1.491   9.414   3.23409367  98.99529775   0.17782588  51.50   6.870 40.3176 19.5589  0.4241 28.1797  5.3047  0.0000  2.8175  0.9318  3.0057  0.1142  0.0831  1.154045341717      0
jxl:d0.5        19725  6023086    2.4427052   1.779  14.805   3.23773599  96.79422603   0.41971834  44.52   2.604 14.3291 24.8058  0.5970 12.1936 21.4854  0.0000 20.5802  1.3834  4.8329  0.1142  0.4153  1.025248178206      0
jxl:d0.8        19725  4481033    1.8173147   1.844  15.133   3.23450589  91.93641612   0.55227235  42.14   2.198 11.0467 21.3492  0.7021  9.2292 19.5011  0.0000 30.4343  1.6430  6.2086  0.1661  0.4568  1.003652654843      0
jxl:d1          19725  3871996    1.5703154   1.932  15.930   3.25637197  89.28194844   0.63132225  40.99   2.265  9.7918 19.6608  0.7443  8.0320 17.9412  0.0000 32.5159  2.6189  8.9339  0.2076  0.2907  0.991375053909      0
jxl:d1.1        19725  3641807    1.4769606   1.976  16.416   3.16788769  88.09047093   0.66698469  40.50   2.234  9.2671 18.9700  0.7874  7.5956 17.3007  0.0000 32.5432  3.2211 10.5328  0.2492  0.2699  0.985110130973      0
jxl:d1.2        19725  3440268    1.3952251   1.959  15.138   3.19898939  87.06669102   0.70315926  40.05   2.223  8.8022 18.3493  0.8124  7.2611 16.6155  0.0000 32.2071  3.9816 12.2095  0.2492  0.2492  0.981065427097      0
jxl:d1.3        19725  3298170    1.3375962   1.951  16.707   3.28041935  86.19844750   0.73295927  39.84   2.259  8.4262 17.7673  0.8374  6.9126 16.2307  0.0000 31.3376  4.9861 13.8032  0.2699  0.1661  0.980403539490      0
jxl:d1.4        19725  3138598    1.2728807   2.034  17.322   3.23519540  85.27952745   0.76590839  39.49   2.248  8.0592 17.3290  0.8513  6.6177 15.7960  0.0000 30.4343  5.8219 15.2879  0.3322  0.2076  0.974909970165      0
jxl:d1.5        19725  2993850    1.2141771   1.953  15.272   3.08881354  84.43599440   0.79669949  39.12   2.265  7.7380 16.8660  0.8659  6.3504 15.4780  0.0000 29.5596  6.7017 16.6168  0.3322  0.2284  0.967334254173      0
jxl:d1.6        19725  2863952    1.1614960   2.016  16.096   3.21953201  83.56481641   0.82800623  38.80   2.280  7.4554 16.4789  0.8705  6.0960 15.2619  0.0000 28.6421  7.5505 17.6654  0.4049  0.3115  0.961725948858      0
jxl:d1.7        19725  2747700    1.1143492   1.958  16.249   3.09254408  82.71217001   0.86240831  38.49   2.290  7.1933 16.0776  0.9059  6.0214 15.0147  0.0000 27.5727  8.4070 18.8386  0.3530  0.3530  0.961024011746      0
jxl:d1.8        19725  2641304    1.0711996   2.016  16.053   2.83224392  81.90449911   0.89044834  38.19   2.260  6.8987 15.7982  0.9331  5.8446 14.7675  0.0000 26.6435  9.3622 19.5965  0.4153  0.4776  0.953847861860      0
jxl:d1.8        19725  2641304    1.0711996   2.056  15.688   2.83224392  81.90449911   0.89044834  38.19   2.260  6.8987 15.7982  0.9331  5.8446 14.7675  0.0000 26.6435  9.3622 19.5965  0.4153  0.4776  0.953847861860      0
jxl:d1.9        19725  2544072    1.0317664   2.055  16.386   2.89167786  81.07180432   0.92309591  37.92   2.264  6.6842 15.4621  0.9532  5.7177 14.5942  0.0000 25.6935 10.2291 20.4686  0.4153  0.5191  0.952419363891      0
jxl:d2.0        19725  2454038    0.9952525   2.080  16.654   2.95859790  80.27055403   0.95475529  37.66   2.265  6.4892 15.1831  0.9578  5.5480 14.5105  0.0000 24.9369 10.8676 21.3200  0.4049  0.5191  0.950222589657      0
jxl:d2.1        19725  2371951    0.9619615   1.963  16.014   3.45534086  79.58803255   0.98429747  37.42   2.281  6.2456 14.7879  0.9785  5.4270 14.2983  0.0000 24.4450 11.5373 22.0623  0.4776  0.4776  0.946856305079      0
jxl:d2.2        19725  2293223    0.9300328   2.062  15.953   3.28763151  78.75895600   1.01716984  37.17   2.275  6.0282 14.5413  1.0012  5.3070 14.2107  0.0000 23.6767 12.3004 22.6852  0.4464  0.5399  0.946001352410      0
jxl:d2.3        19725  2221748    0.9010456   2.022  15.714   3.61206818  78.04858405   1.04784188  36.94   2.307  5.9146 14.1864  1.0068  5.2048 14.0414  0.0000 23.1187 13.1102 23.1473  0.5295  0.4776  0.944153363514      0
jxl:d2.4        19725  2152801    0.8730837   2.101  16.402   3.74226904  77.40653631   1.07740036  36.73   2.295  5.7222 13.8983  1.0259  5.1340 13.9466  0.0000 22.5516 13.7954 23.6145  0.5918  0.4568  0.940660692497      0
jxl:d2.5        19725  2090365    0.8477623   2.096  16.303   3.64757252  76.79113994   1.10634437  36.53   2.310  5.5672 13.6790  1.0184  4.9961 13.8123  0.0000 22.0402 14.4833 23.8532  0.6022  0.6852  0.937917090222      0
jxl:d2.6        19725  2029341    0.8230136   2.059  16.375   3.39854527  76.10758841   1.13556927  36.33   2.274  5.4098 13.4009  1.0457  4.9118 13.7468  0.0000 21.4640 15.1399 24.3620  0.6126  0.6437  0.934588975646      0
jxl:d2.7        19725  1973631    0.8004200   2.081  16.297   3.54417300  75.44779083   1.16160940  36.13   2.273  5.2609 13.1475  1.0522  4.8359 13.6280  0.0000 20.8943 15.8641 24.7046  0.6645  0.6852  0.929775435549      0
jxl:d2.8        19725  1920433    0.7788452   2.079  16.540   5.15458059  74.76292339   1.19630892  35.95   2.288  5.1301 12.9953  1.0690  4.7509 13.4885  0.0000 20.4582 16.4273 24.9538  0.7579  0.7060  0.931739468126      0
jxl:d2.9        19725  1871263    0.7589040   2.073  15.888   3.53680801  74.10658862   1.22085133  35.78   2.268  5.0124 12.7614  1.0648  4.6921 13.4684  0.0000 20.1169 16.9387 25.1874  0.7268  0.7683  0.926508917533      0
jxl:d3          19725  1827058    0.7409763   1.919  16.185   4.51680946  73.45606744   1.24995649  35.60   2.239  4.8190 12.5700  1.0447  4.5838 13.3561  0.0000 19.5900 17.7952 25.5144  0.7371  0.7268  0.926188159358      0
jxl:d5          19725  1244368    0.5046623   1.993   8.895   5.33030987  61.48264618   1.77794620  33.17   2.320  3.3291  8.2302  0.9428  2.9421 10.7612  0.0000 15.5630 27.1055 29.8698  0.6645  1.3289  0.897262343816      0
jxl:d7          19725   961091    0.3897773   1.983   8.459   7.01131439  51.83360776   2.24432581  31.62   2.273  2.5550  5.8238  0.7751  2.0550  9.1293  0.0000 12.9558 32.5588 32.5069  0.7164  1.6612  0.874787173170      0
jxl:d15         19725   538425    0.2183621   1.964   8.391  11.56018829  22.41492452   3.72555949  28.74   2.142  1.2118  1.7543  0.3095  0.5814  5.4072  0.0000  7.5245 37.9394 40.9736  1.2978  3.7376  0.813520896425      0
jxl:d24         19725   392085    0.1590128   0.304  20.179  55.62599945  -7.23217726   6.25463759  26.33   2.659  1.0256  2.2750  0.1707  0.6836  3.0264  0.0000  3.2938  9.2532  5.7206  0.0104  0.0000  0.994567747846      0
jxl:d32         19725   313204    0.1270221   0.306  20.863  55.60064316 -19.87287127   7.01650510  25.83   2.415  0.7472  1.7280  0.1402  0.4967  2.7169  0.0000  2.8551 10.3485  6.4266  0.0000  0.0000  0.891251220895      0
Aggregate:      19725  2221752    0.9010471   1.746  15.057   4.38838237  76.47880486   1.05750378  36.92   2.378  5.7402 12.2129  0.7573  4.7341 12.3220  0.0000 18.9381  8.6324 16.1821  0.3610  0.4754  0.952860689107      0
```