### PR TITLE
Streaming adaptive quantization field computation in jpegli.

### DIFF
--- a/lib/extras/jpegli_test.cc
+++ b/lib/extras/jpegli_test.cc
@@ -188,7 +188,7 @@ TEST(JpegliTest, JpegliYUVEncodeTest) {
 
   PackedPixelFile ppf_out;
   ASSERT_TRUE(DecodeWithLibjpeg(compressed, &ppf_out));
-  EXPECT_THAT(BitsPerPixel(ppf_in, compressed), IsSlightlyBelow(1.67f));
+  EXPECT_THAT(BitsPerPixel(ppf_in, compressed), IsSlightlyBelow(1.7f));
   EXPECT_THAT(ButteraugliDistance(ppf_in, ppf_out), IsSlightlyBelow(1.32f));
 }
 

--- a/lib/jpegli/common_internal.h
+++ b/lib/jpegli/common_internal.h
@@ -114,8 +114,20 @@ class RowBuffer {
   size_t ysize() const { return ysize_; };
   size_t stride() const { return stride_; }
 
-  void CopyRow(ssize_t y, const T* src, size_t len) {
-    memcpy(Row(y), src, len * sizeof(T));
+  void PadRow(size_t y, size_t from, int border) {
+    float* row = DirectRow(y);
+    for (int offset = -border; offset < 0; ++offset) {
+      row[offset] = row[0];
+    }
+    float last_val = row[from - 1];
+    for (size_t x = from; x < xsize_ + border; ++x) {
+      row[x] = last_val;
+    }
+  }
+
+  void CopyRow(ssize_t dst_row, ssize_t src_row, int border) {
+    memcpy(Row(dst_row) - border, Row(src_row) - border,
+           (xsize_ + 2 * border) * sizeof(T));
   }
 
   void FillRow(ssize_t y, T val, size_t len) {

--- a/lib/jpegli/downsample.cc
+++ b/lib/jpegli/downsample.cc
@@ -282,8 +282,9 @@ void DownsampleInputBuffer(j_compress_ptr cinfo) {
     return;
   }
   jpeg_comp_master* m = cinfo->master;
-  const size_t y0 = cinfo->next_scanline - DCTSIZE * cinfo->max_v_samp_factor;
-  const size_t y1 = cinfo->next_scanline;
+  const size_t iMCU_height = DCTSIZE * cinfo->max_v_samp_factor;
+  const size_t y0 = m->next_iMCU_row * iMCU_height;
+  const size_t y1 = y0 + iMCU_height;
   const size_t xsize_padded = m->xsize_blocks * DCTSIZE;
   for (int c = 0; c < cinfo->num_components; c++) {
     jpeg_component_info* comp = &cinfo->comp_info[c];

--- a/lib/jpegli/encode_internal.h
+++ b/lib/jpegli/encode_internal.h
@@ -80,8 +80,10 @@ struct jpeg_comp_master {
   jpegli::HuffmanCodeTable huff_tables[8];
   std::array<jpegli::HuffmanCodeTable, jpegli::kMaxHuffmanTables> dc_huff_table;
   std::array<jpegli::HuffmanCodeTable, jpegli::kMaxHuffmanTables> ac_huff_table;
+  jpegli::RowBuffer<float> pre_erosion;
   jpegli::RowBuffer<float> quant_field;
   jvirt_barray_ptr* coeff_buffers = nullptr;
+  size_t next_iMCU_row;
 };
 
 #endif  // LIB_JPEGLI_ENCODE_INTERNAL_H_


### PR DESCRIPTION
Instead of comparing the quant field values to the quant field maximum, we compare it against a fixed constant. This changes the results slightly, but it looks neutral quality-wise.

Benchmark before:
```
Encoding                   kPixels    Bytes          BPP  E MP/s  D MP/s     Max norm  SSIMULACRA2        pnorm       BPP*pnorm   Bugs
--------------------------------------------------------------------------------------------------------------------------------------
jpeg:enc-jpegli:q90          13270  3587770    2.1628628  19.083  70.559   2.25433660  86.32254081   0.68681241  1.485480997421      0
jpeg:enc-jpegli:xyb:q90      13270  3108476    1.8739236  20.062  81.030   2.13027716  84.85884641   0.68753171  1.288381922542      0
jpeg:enc-jpegli:p0:q90       13270  3672874    2.2141671  82.396 188.680   2.25433660  86.32254081   0.68681241  1.520717474342      0
Aggregate:                   13270  3447144    2.0780871  31.597 102.559   2.21220080  85.83185878   0.68705210  1.427754112702      0
```

Benchmark after:
```
Encoding                   kPixels    Bytes          BPP  E MP/s  D MP/s     Max norm  SSIMULACRA2        pnorm       BPP*pnorm   Bugs
--------------------------------------------------------------------------------------------------------------------------------------
jpeg:enc-jpegli:q90          13270  3587818    2.1628917  18.414  70.067   2.18228006  86.34496873   0.68622828  1.484237448050      0
jpeg:enc-jpegli:xyb:q90      13270  3112648    1.8764387  19.507  80.590   2.11653256  84.89391218   0.68727137  1.289622587765      0
jpeg:enc-jpegli:p0:q90       13270  3673582    2.2145939  82.848 192.789   2.18228006  86.34496873   0.68622828  1.519716990350      0
Aggregate:                   13270  3448922    2.0791592  30.989 102.871   2.16014038  85.85854813   0.68657580  1.427500420938      0
```