### PR TITLE
reoptimized gaborish encoding

### DIFF
--- a/lib/jxl/decode_test.cc
+++ b/lib/jxl/decode_test.cc
@@ -1986,7 +1986,7 @@ TEST(DecodeTest, PixelTestOpaqueSrgbLossyNoise) {
     EXPECT_THAT(
         ButteraugliDistance(io0.frames, io1.frames, ba, jxl::GetJxlCms(),
                             /*distmap=*/nullptr, nullptr),
-        IsSlightlyBelow(1.4f));
+        IsSlightlyBelow(2.4f));
 
     JxlDecoderDestroy(dec);
   }

--- a/lib/jxl/enc_gaborish.cc
+++ b/lib/jxl/enc_gaborish.cc
@@ -20,9 +20,9 @@ void GaborishInverse(Image3F* in_out, float mul, ThreadPool* pool) {
 
   // Only an approximation. One or even two 3x3, and rank-1 (separable) 5x5
   // are insufficient.
-  constexpr float kGaborish[5] = {
-      -0.092359145662814029f,  -0.039253623634014627f, 0.016176494530216929f,
-      0.00083458437774987476f, 0.004512465323949319f,
+  static const float kGaborish[5] = {
+      -0.088188686933903332f, -0.043510240843796254f, 0.016038526595420832f,
+      0.0013932467887255813f, 0.0042737176783204326f,
   };
   /*
     better would be:

--- a/lib/jxl/encode_test.cc
+++ b/lib/jxl/encode_test.cc
@@ -503,7 +503,7 @@ TEST(EncodeTest, LossyEncoderUseOriginalProfileTest) {
     ASSERT_NE(nullptr, enc.get());
     JxlEncoderFrameSettings* frame_settings =
         JxlEncoderFrameSettingsCreate(enc.get(), NULL);
-    VerifyFrameEncoding(63, 129, enc.get(), frame_settings, 5190, true);
+    VerifyFrameEncoding(63, 129, enc.get(), frame_settings, 5358, true);
   }
   {
     JxlEncoderPtr enc = JxlEncoderMake(nullptr);
@@ -513,7 +513,7 @@ TEST(EncodeTest, LossyEncoderUseOriginalProfileTest) {
     EXPECT_EQ(JXL_ENC_SUCCESS,
               JxlEncoderFrameSettingsSetOption(
                   frame_settings, JXL_ENC_FRAME_SETTING_PROGRESSIVE_DC, 2));
-    VerifyFrameEncoding(63, 129, enc.get(), frame_settings, 5644, true);
+    VerifyFrameEncoding(63, 129, enc.get(), frame_settings, 5767, true);
   }
   {
     JxlEncoderPtr enc = JxlEncoderMake(nullptr);
@@ -523,7 +523,7 @@ TEST(EncodeTest, LossyEncoderUseOriginalProfileTest) {
     ASSERT_EQ(JXL_ENC_SUCCESS,
               JxlEncoderFrameSettingsSetOption(
                   frame_settings, JXL_ENC_FRAME_SETTING_EFFORT, 8));
-    VerifyFrameEncoding(63, 129, enc.get(), frame_settings, 4676, true);
+    VerifyFrameEncoding(63, 129, enc.get(), frame_settings, 4765, true);
   }
 }
 

--- a/lib/jxl/jxl_test.cc
+++ b/lib/jxl/jxl_test.cc
@@ -66,14 +66,14 @@ TEST(JxlTest, RoundtripSinglePixel) {
   TestImage t;
   t.SetDimensions(1, 1).AddFrame().ZeroFill();
   PackedPixelFile ppf_out;
-  EXPECT_EQ(Roundtrip(t.ppf(), {}, {}, nullptr, &ppf_out), 54);
+  EXPECT_EQ(Roundtrip(t.ppf(), {}, {}, nullptr, &ppf_out), 55);
 }
 
 TEST(JxlTest, RoundtripSinglePixelWithAlpha) {
   TestImage t;
   t.SetDimensions(1, 1).SetChannels(4).AddFrame().ZeroFill();
   PackedPixelFile ppf_out;
-  EXPECT_EQ(Roundtrip(t.ppf(), {}, {}, nullptr, &ppf_out), 58);
+  EXPECT_EQ(Roundtrip(t.ppf(), {}, {}, nullptr, &ppf_out), 59);
 }
 
 // Changing serialized signature causes Decode to fail.
@@ -270,7 +270,7 @@ TEST(JxlTest, RoundtripUnalignedD2) {
   cparams.distance = 2.0;
 
   PackedPixelFile ppf_out;
-  EXPECT_NEAR(Roundtrip(t.ppf(), cparams, {}, pool, &ppf_out), 482, 10);
+  EXPECT_NEAR(Roundtrip(t.ppf(), cparams, {}, pool, &ppf_out), 493, 10);
   EXPECT_THAT(ButteraugliDistance(t.ppf(), ppf_out), IsSlightlyBelow(1.72));
 }
 
@@ -297,7 +297,7 @@ TEST(JxlTest, RoundtripMultiGroup) {
   auto run_kitten = std::async(std::launch::async, test, SpeedTier::kKitten,
                                1.0f, 51595u, 11.7);
   auto run_wombat = std::async(std::launch::async, test, SpeedTier::kWombat,
-                               2.0f, 31000u, 20.0);
+                               2.0f, 31722u, 20.0);
 }
 
 TEST(JxlTest, RoundtripRGBToGrayscale) {
@@ -469,7 +469,7 @@ TEST(JxlTest, RoundtripNoGaborishNoAR) {
   cparams.AddOption(JXL_ENC_FRAME_SETTING_GABORISH, 0);
 
   PackedPixelFile ppf_out;
-  EXPECT_NEAR(Roundtrip(t.ppf(), cparams, {}, pool, &ppf_out), 37241, 100);
+  EXPECT_NEAR(Roundtrip(t.ppf(), cparams, {}, pool, &ppf_out), 37335, 100);
   EXPECT_THAT(ButteraugliDistance(t.ppf(), ppf_out), IsSlightlyBelow(1.8));
 }
 
@@ -488,7 +488,7 @@ TEST(JxlTest, RoundtripSmallNoGaborish) {
 
   PackedPixelFile ppf_out;
   EXPECT_NEAR(Roundtrip(t.ppf(), cparams, {}, pool, &ppf_out), 749, 20);
-  EXPECT_THAT(ButteraugliDistance(t.ppf(), ppf_out), IsSlightlyBelow(1.4));
+  EXPECT_THAT(ButteraugliDistance(t.ppf(), ppf_out), IsSlightlyBelow(1.05));
 }
 
 TEST(JxlTest, RoundtripSmallPatchesAlpha) {
@@ -513,8 +513,8 @@ TEST(JxlTest, RoundtripSmallPatchesAlpha) {
   cparams.distance = 0.1f;
 
   PackedPixelFile ppf_out;
-  EXPECT_NEAR(Roundtrip(t.ppf(), cparams, {}, pool, &ppf_out), 620, 70);
-  EXPECT_THAT(ButteraugliDistance(t.ppf(), ppf_out), IsSlightlyBelow(0.02f));
+  EXPECT_NEAR(Roundtrip(t.ppf(), cparams, {}, pool, &ppf_out), 708, 70);
+  EXPECT_THAT(ButteraugliDistance(t.ppf(), ppf_out), IsSlightlyBelow(0.016f));
 }
 
 TEST(JxlTest, RoundtripSmallPatches) {
@@ -538,8 +538,8 @@ TEST(JxlTest, RoundtripSmallPatches) {
   cparams.distance = 0.1f;
 
   PackedPixelFile ppf_out;
-  EXPECT_NEAR(Roundtrip(t.ppf(), cparams, {}, pool, &ppf_out), 500, 100);
-  EXPECT_THAT(ButteraugliDistance(t.ppf(), ppf_out), IsSlightlyBelow(0.02f));
+  EXPECT_NEAR(Roundtrip(t.ppf(), cparams, {}, pool, &ppf_out), 605, 100);
+  EXPECT_THAT(ButteraugliDistance(t.ppf(), ppf_out), IsSlightlyBelow(0.016f));
 }
 
 // TODO(szabadka) Add encoder and decoder API functions that accept frame
@@ -730,7 +730,7 @@ TEST(JxlTest, RoundtripAlpha) {
       EXPECT_THAT(ButteraugliDistance(io.frames, io2.frames, cparams.ba_params,
                                       GetJxlCms(),
                                       /*distmap=*/nullptr),
-                  IsSlightlyBelow(1.25));
+                  IsSlightlyBelow(1.5));
     }
   }
 }
@@ -789,7 +789,7 @@ TEST(JxlTest, RoundtripAlphaPremultiplied) {
           EXPECT_THAT(ButteraugliDistance(io.frames, io2.frames,
                                           cparams.ba_params, GetJxlCms(),
                                           /*distmap=*/nullptr),
-                      IsSlightlyBelow(1.25));
+                      IsSlightlyBelow(1.5));
           EXPECT_TRUE(io2.UnpremultiplyAlpha());
           EXPECT_FALSE(io2.Main().AlphaIsPremultiplied());
         }
@@ -884,7 +884,7 @@ TEST(JxlTest, RoundtripAlpha16) {
 
   PackedPixelFile ppf_out;
   // TODO(szabadka) Investigate big size difference on i686
-  EXPECT_NEAR(Roundtrip(t.ppf(), cparams, {}, &pool, &ppf_out), 3620, 50);
+  EXPECT_NEAR(Roundtrip(t.ppf(), cparams, {}, &pool, &ppf_out), 3515, 50);
   EXPECT_THAT(ButteraugliDistance(t.ppf(), ppf_out), IsSlightlyBelow(0.7));
 }
 
@@ -1091,7 +1091,7 @@ TEST(JxlTest, RoundtripNoise) {
   cparams.AddOption(JXL_ENC_FRAME_SETTING_NOISE, 1);
 
   PackedPixelFile ppf_out;
-  EXPECT_NEAR(Roundtrip(t.ppf(), cparams, {}, pool, &ppf_out), 40616, 750);
+  EXPECT_NEAR(Roundtrip(t.ppf(), cparams, {}, pool, &ppf_out), 41456, 750);
   EXPECT_THAT(ButteraugliDistance(t.ppf(), ppf_out), IsSlightlyBelow(1.7));
 }
 
@@ -1386,7 +1386,7 @@ TEST(JxlTest, RoundtripProgressive) {
   cparams.AddOption(JXL_ENC_FRAME_SETTING_RESPONSIVE, 1);
 
   PackedPixelFile ppf_out;
-  EXPECT_NEAR(Roundtrip(t.ppf(), cparams, {}, &pool, &ppf_out), 55254, 750);
+  EXPECT_NEAR(Roundtrip(t.ppf(), cparams, {}, &pool, &ppf_out), 56307, 750);
   EXPECT_THAT(ButteraugliDistance(t.ppf(), ppf_out), IsSlightlyBelow(1.4));
 }
 

--- a/lib/jxl/jxl_test.cc
+++ b/lib/jxl/jxl_test.cc
@@ -1130,7 +1130,7 @@ TEST(JxlTest, RoundtripAnimation) {
 
   PackedPixelFile ppf_out;
   EXPECT_THAT(Roundtrip(t.ppf(), {}, dparams, pool, &ppf_out),
-              IsSlightlyBelow(2400));
+              IsSlightlyBelow(2500));
 
   t.CoalesceGIFAnimationWithAlpha();
   ASSERT_EQ(ppf_out.frames.size(), t.ppf().frames.size());
@@ -1179,7 +1179,7 @@ TEST(JxlTest, RoundtripAnimationPatches) {
   PackedPixelFile ppf_out;
   // 40k with no patches, 27k with patch frames encoded multiple times.
   EXPECT_THAT(Roundtrip(t.ppf(), cparams, dparams, pool, &ppf_out),
-              IsSlightlyBelow(16000));
+              IsSlightlyBelow(16200));
   EXPECT_EQ(ppf_out.frames.size(), t.ppf().frames.size());
   // >10 with broken patches
   EXPECT_THAT(ButteraugliDistance(t.ppf(), ppf_out), IsSlightlyBelow(1.2));

--- a/lib/jxl/jxl_test.cc
+++ b/lib/jxl/jxl_test.cc
@@ -165,7 +165,7 @@ TEST(JxlTest, RoundtripResample2Slow) {
   cparams.distance = 10.0;
 
   PackedPixelFile ppf_out;
-  EXPECT_NEAR(Roundtrip(t.ppf(), cparams, {}, pool, &ppf_out), 3988, 100);
+  EXPECT_NEAR(Roundtrip(t.ppf(), cparams, {}, pool, &ppf_out), 4088, 200);
   EXPECT_THAT(ComputeDistance2(t.ppf(), ppf_out), IsSlightlyBelow(250));
 }
 

--- a/tools/optimizer/simplex_fork.py
+++ b/tools/optimizer/simplex_fork.py
@@ -60,15 +60,15 @@ def EvalCacheForget():
 
 def RandomizedJxlCodecs():
   retval = []
-  minval = 0.5
-  maxval = 3.3
+  minval = 0.15
+  maxval = 0.3
   rangeval = maxval/minval
-  steps = 7
+  steps = 2
   for i in range(steps):
     mul = minval * rangeval**(float(i)/(steps - 1))
     mul *= 0.99 + 0.05 * random.random()
     retval.append("jxl:epf2:d%.3f" % mul)
-  steps = 7
+  steps = 2
   for i in range(steps - 1):
     mul = minval * rangeval**(float(i+0.5)/(steps - 1))
     mul *= 0.99 + 0.05 * random.random()
@@ -101,8 +101,8 @@ def Eval(vec, binary_name, cached=True):
   process = subprocess.Popen(
       (binary_name,
        '--input',
-       '/usr/local/google/home/jyrki/mix_corpus/*.png',
-       '--error_pnorm=3',
+       '/usr/local/google/home/jyrki/newcorpus/split/*.png',
+       '--error_pnorm=8',
        '--more_columns',
        '--codec', g_codecs),
       stdout=subprocess.PIPE,
@@ -122,7 +122,7 @@ def Eval(vec, binary_name, cached=True):
     sys.stdout.flush()
     if line[0:3] == b'jxl':
       bpp = line.split()[3]
-      dist_pnorm = line.split()[7]
+      dist_pnorm = line.split()[8]
       vec[0] *= float(dist_pnorm) * float(bpp) / 16.0
       #vec[0] *= (float(dist_max) * float(bpp) / 16.0) ** 0.2
       n += 1


### PR DESCRIPTION
10+ % improvement on max error
~7 % improvement for BPP * pnorm for high quality images ~3 % aggregate BPP * pnorm improvement
~0.5 improvement in SSIMULACRA2

This may be an improvement now mostly because the chessboard image is part of the test set now.

```
Encoding      kPixels    Bytes          BPP  E MP/s  D MP/s     Max norm  SSIMULACRA2        pnorm   PSNR   QABPP  SmallB  DCT4x8     AFV  DCT8x8    8x16    8x32      16   16x32      32   32x64      64       BPP*pnorm   Bugs
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
jxl:d0.1        19725 16002061    6.4897492   1.491   9.414   3.23409367  98.99529775   0.17782588  51.50   6.870 40.3176 19.5589  0.4241 28.1797  5.3047  0.0000  2.8175  0.9318  3.0057  0.1142  0.0831  1.154045341717      0
jxl:d0.5        19725  6023086    2.4427052   1.779  14.805   3.23773599  96.79422603   0.41971834  44.52   2.604 14.3291 24.8058  0.5970 12.1936 21.4854  0.0000 20.5802  1.3834  4.8329  0.1142  0.4153  1.025248178206      0
jxl:d0.8        19725  4481033    1.8173147   1.844  15.133   3.23450589  91.93641612   0.55227235  42.14   2.198 11.0467 21.3492  0.7021  9.2292 19.5011  0.0000 30.4343  1.6430  6.2086  0.1661  0.4568  1.003652654843      0
jxl:d1          19725  3871996    1.5703154   1.932  15.930   3.25637197  89.28194844   0.63132225  40.99   2.265  9.7918 19.6608  0.7443  8.0320 17.9412  0.0000 32.5159  2.6189  8.9339  0.2076  0.2907  0.991375053909      0
jxl:d1.1        19725  3641807    1.4769606   1.976  16.416   3.16788769  88.09047093   0.66698469  40.50   2.234  9.2671 18.9700  0.7874  7.5956 17.3007  0.0000 32.5432  3.2211 10.5328  0.2492  0.2699  0.985110130973      0
jxl:d1.2        19725  3440268    1.3952251   1.959  15.138   3.19898939  87.06669102   0.70315926  40.05   2.223  8.8022 18.3493  0.8124  7.2611 16.6155  0.0000 32.2071  3.9816 12.2095  0.2492  0.2492  0.981065427097      0
jxl:d1.3        19725  3298170    1.3375962   1.951  16.707   3.28041935  86.19844750   0.73295927  39.84   2.259  8.4262 17.7673  0.8374  6.9126 16.2307  0.0000 31.3376  4.9861 13.8032  0.2699  0.1661  0.980403539490      0
jxl:d1.4        19725  3138598    1.2728807   2.034  17.322   3.23519540  85.27952745   0.76590839  39.49   2.248  8.0592 17.3290  0.8513  6.6177 15.7960  0.0000 30.4343  5.8219 15.2879  0.3322  0.2076  0.974909970165      0
jxl:d1.5        19725  2993850    1.2141771   1.953  15.272   3.08881354  84.43599440   0.79669949  39.12   2.265  7.7380 16.8660  0.8659  6.3504 15.4780  0.0000 29.5596  6.7017 16.6168  0.3322  0.2284  0.967334254173      0
jxl:d1.6        19725  2863952    1.1614960   2.016  16.096   3.21953201  83.56481641   0.82800623  38.80   2.280  7.4554 16.4789  0.8705  6.0960 15.2619  0.0000 28.6421  7.5505 17.6654  0.4049  0.3115  0.961725948858      0
jxl:d1.7        19725  2747700    1.1143492   1.958  16.249   3.09254408  82.71217001   0.86240831  38.49   2.290  7.1933 16.0776  0.9059  6.0214 15.0147  0.0000 27.5727  8.4070 18.8386  0.3530  0.3530  0.961024011746      0
jxl:d1.8        19725  2641304    1.0711996   2.016  16.053   2.83224392  81.90449911   0.89044834  38.19   2.260  6.8987 15.7982  0.9331  5.8446 14.7675  0.0000 26.6435  9.3622 19.5965  0.4153  0.4776  0.953847861860      0
jxl:d1.8        19725  2641304    1.0711996   2.056  15.688   2.83224392  81.90449911   0.89044834  38.19   2.260  6.8987 15.7982  0.9331  5.8446 14.7675  0.0000 26.6435  9.3622 19.5965  0.4153  0.4776  0.953847861860      0
jxl:d1.9        19725  2544072    1.0317664   2.055  16.386   2.89167786  81.07180432   0.92309591  37.92   2.264  6.6842 15.4621  0.9532  5.7177 14.5942  0.0000 25.6935 10.2291 20.4686  0.4153  0.5191  0.952419363891      0
jxl:d2.0        19725  2454038    0.9952525   2.080  16.654   2.95859790  80.27055403   0.95475529  37.66   2.265  6.4892 15.1831  0.9578  5.5480 14.5105  0.0000 24.9369 10.8676 21.3200  0.4049  0.5191  0.950222589657      0
jxl:d2.1        19725  2371951    0.9619615   1.963  16.014   3.45534086  79.58803255   0.98429747  37.42   2.281  6.2456 14.7879  0.9785  5.4270 14.2983  0.0000 24.4450 11.5373 22.0623  0.4776  0.4776  0.946856305079      0
jxl:d2.2        19725  2293223    0.9300328   2.062  15.953   3.28763151  78.75895600   1.01716984  37.17   2.275  6.0282 14.5413  1.0012  5.3070 14.2107  0.0000 23.6767 12.3004 22.6852  0.4464  0.5399  0.946001352410      0
jxl:d2.3        19725  2221748    0.9010456   2.022  15.714   3.61206818  78.04858405   1.04784188  36.94   2.307  5.9146 14.1864  1.0068  5.2048 14.0414  0.0000 23.1187 13.1102 23.1473  0.5295  0.4776  0.944153363514      0
jxl:d2.4        19725  2152801    0.8730837   2.101  16.402   3.74226904  77.40653631   1.07740036  36.73   2.295  5.7222 13.8983  1.0259  5.1340 13.9466  0.0000 22.5516 13.7954 23.6145  0.5918  0.4568  0.940660692497      0
jxl:d2.5        19725  2090365    0.8477623   2.096  16.303   3.64757252  76.79113994   1.10634437  36.53   2.310  5.5672 13.6790  1.0184  4.9961 13.8123  0.0000 22.0402 14.4833 23.8532  0.6022  0.6852  0.937917090222      0
jxl:d2.6        19725  2029341    0.8230136   2.059  16.375   3.39854527  76.10758841   1.13556927  36.33   2.274  5.4098 13.4009  1.0457  4.9118 13.7468  0.0000 21.4640 15.1399 24.3620  0.6126  0.6437  0.934588975646      0
jxl:d2.7        19725  1973631    0.8004200   2.081  16.297   3.54417300  75.44779083   1.16160940  36.13   2.273  5.2609 13.1475  1.0522  4.8359 13.6280  0.0000 20.8943 15.8641 24.7046  0.6645  0.6852  0.929775435549      0
jxl:d2.8        19725  1920433    0.7788452   2.079  16.540   5.15458059  74.76292339   1.19630892  35.95   2.288  5.1301 12.9953  1.0690  4.7509 13.4885  0.0000 20.4582 16.4273 24.9538  0.7579  0.7060  0.931739468126      0
jxl:d2.9        19725  1871263    0.7589040   2.073  15.888   3.53680801  74.10658862   1.22085133  35.78   2.268  5.0124 12.7614  1.0648  4.6921 13.4684  0.0000 20.1169 16.9387 25.1874  0.7268  0.7683  0.926508917533      0
jxl:d3          19725  1827058    0.7409763   1.919  16.185   4.51680946  73.45606744   1.24995649  35.60   2.239  4.8190 12.5700  1.0447  4.5838 13.3561  0.0000 19.5900 17.7952 25.5144  0.7371  0.7268  0.926188159358      0
jxl:d5          19725  1244368    0.5046623   1.993   8.895   5.33030987  61.48264618   1.77794620  33.17   2.320  3.3291  8.2302  0.9428  2.9421 10.7612  0.0000 15.5630 27.1055 29.8698  0.6645  1.3289  0.897262343816      0
jxl:d7          19725   961091    0.3897773   1.983   8.459   7.01131439  51.83360776   2.24432581  31.62   2.273  2.5550  5.8238  0.7751  2.0550  9.1293  0.0000 12.9558 32.5588 32.5069  0.7164  1.6612  0.874787173170      0
jxl:d15         19725   538425    0.2183621   1.964   8.391  11.56018829  22.41492452   3.72555949  28.74   2.142  1.2118  1.7543  0.3095  0.5814  5.4072  0.0000  7.5245 37.9394 40.9736  1.2978  3.7376  0.813520896425      0
jxl:d24         19725   392085    0.1590128   0.304  20.179  55.62599945  -7.23217726   6.25463759  26.33   2.659  1.0256  2.2750  0.1707  0.6836  3.0264  0.0000  3.2938  9.2532  5.7206  0.0104  0.0000  0.994567747846      0
jxl:d32         19725   313204    0.1270221   0.306  20.863  55.60064316 -19.87287127   7.01650510  25.83   2.415  0.7472  1.7280  0.1402  0.4967  2.7169  0.0000  2.8551 10.3485  6.4266  0.0000  0.0000  0.891251220895      0
Aggregate:      19725  2221752    0.9010471   1.746  15.057   4.38838237  76.47880486   1.05750378  36.92   2.378  5.7402 12.2129  0.7573  4.7341 12.3220  0.0000 18.9381  8.6324 16.1821  0.3610  0.4754  0.952860689107      0
```

```
Encoding      kPixels    Bytes          BPP  E MP/s  D MP/s     Max norm  SSIMULACRA2        pnorm   PSNR   QABPP  SmallB  DCT4x8     AFV  DCT8x8    8x16    8x32      16   16x32      32   32x64      64       BPP*pnorm   Bugs
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
jxl:d0.1        19725 15859929    6.4321066   1.113   7.180   1.20213747  99.75197220   0.12778971  53.19   6.464 40.0606 19.6393  0.4266 28.1330  5.3877  0.0000  2.9109  0.9292  3.0628  0.1038  0.0831  0.821957008678      0
jxl:d0.5        19725  5965867    2.4194996   1.264  10.567   1.58008265  97.34719161   0.37444212  44.56   2.473 14.0401 24.8568  0.5999 12.0953 21.7865  0.0000 20.6075  1.3834  4.7966  0.1350  0.4361  0.905962578692      0
jxl:d0.8        19725  4439195    1.8003470   1.367  10.526   1.96780396  92.43935853   0.51481049  42.10   2.125 10.8086 21.3469  0.6914  9.1526 19.6796  0.0000 30.5706  1.6715  6.2345  0.1869  0.3945  0.926837516451      0
jxl:d1          19725  3841407    1.5579098   1.392  11.557   2.42639732  89.70656694   0.59883331  40.96   2.211  9.6308 19.5436  0.7453  7.9684 18.0885  0.0000 32.5795  2.6137  9.0481  0.2076  0.3115  0.932928299772      0
jxl:d1.1        19725  3614876    1.4660386   1.459  11.401   2.42971182  88.51965202   0.63656851  40.45   2.173  9.1156 18.8753  0.7887  7.5537 17.4149  0.0000 32.5964  3.2315 10.6730  0.2388  0.2492  0.933233983318      0
jxl:d1.2        19725  3415306    1.3851015   1.374  11.861   2.47504044  87.46639444   0.67413318  40.02   2.195  8.6731 18.2429  0.8098  7.1956 16.6947  0.0000 32.3927  4.0050 12.2251  0.2907  0.2076  0.933742912875      0
jxl:d1.3        19725  3277165    1.3290775   1.495  12.719   2.54784679  86.62922947   0.70435411  39.84   2.213  8.3022 17.6726  0.8384  6.8838 16.2697  0.0000 31.5738  5.0198 13.7409  0.2699  0.1661  0.936141194572      0
jxl:d1.4        19725  3117938    1.2645018   1.503  11.441   2.78824568  85.68874831   0.73943125  39.45   2.216  7.9392 17.1891  0.8543  6.5541 15.8453  0.0000 30.5654  5.8997 15.3398  0.3426  0.2076  0.935012182817      0
jxl:d1.5        19725  2977725    1.2076375   1.475  11.460   2.40605474  84.81725962   0.77172845  39.12   2.231  7.6076 16.7466  0.8646  6.3380 15.5637  0.0000 29.5972  6.7692 16.6480  0.3530  0.2492  0.931968190341      0
jxl:d1.6        19725  2851373    1.1563945   1.529  11.261   2.58277917  83.92791991   0.80361297  38.79   2.238  7.3591 16.3800  0.8744  6.0791 15.3041  0.0000 28.6499  7.6569 17.6862  0.4153  0.3322  0.929293640336      0
jxl:d1.7        19725  2735666    1.1094687   1.446  11.836   2.78496289  83.11093651   0.83680366  38.48   2.245  7.0895 16.0085  0.9068  5.9909 15.0653  0.0000 27.5662  8.5031 18.7867  0.4049  0.4153  0.928407496216      0
jxl:d1.8        19725  2631481    1.0672158   1.440  11.685   2.75935864  82.31299963   0.87194744  38.19   2.241  6.8468 15.7032  0.9360  5.7810 14.8103  0.0000 26.7149  9.3882 19.6536  0.4464  0.4568  0.930556056177      0
jxl:d1.8        19725  2631481    1.0672158   1.531  11.019   2.75935864  82.31299963   0.87194744  38.19   2.241  6.8468 15.7032  0.9360  5.7810 14.8103  0.0000 26.7149  9.3882 19.6536  0.4464  0.4568  0.930556056177      0
jxl:d1.9        19725  2534453    1.0278654   1.497  12.026   3.06357622  81.46092016   0.90993824  37.91   2.277  6.6138 15.3648  0.9480  5.6797 14.6143  0.0000 25.8376 10.1928 20.5413  0.4257  0.5191  0.935294006424      0
jxl:d2.0        19725  2447704    0.9926837   1.515  10.642   3.03604913  80.62727970   0.93947509  37.66   2.256  6.4114 15.1124  0.9568  5.5587 14.4962  0.0000 24.9862 10.8884 21.3615  0.4880  0.4776  0.932601610620      0
jxl:d2.1        19725  2363805    0.9586579   1.490  11.515   3.46271396  79.86479798   0.96868673  37.40   2.244  6.1849 14.7561  0.9789  5.4147 14.2938  0.0000 24.3983 11.6359 22.0156  0.5191  0.5399  0.928639150504      0
jxl:d2.2        19725  2288651    0.9281786   1.551  11.114   3.75931025  79.14464099   1.01316192  37.18   2.268  5.9844 14.4761  0.9902  5.3011 14.2276  0.0000 23.6196 12.3990 22.6904  0.5087  0.5399  0.940395239454      0
jxl:d2.3        19725  2217463    0.8993078   1.535  12.060   3.48660374  78.43142952   1.03732276  36.96   2.310  5.8352 14.1932  1.0210  5.1905 14.0738  0.0000 23.1148 12.9882 23.2822  0.4776  0.5606  0.932872477406      0
jxl:d2.4        19725  2153528    0.8733785   1.557  12.177   3.53474808  77.78478825   1.06654211  36.75   2.286  5.6888 13.9018  1.0168  5.1003 13.9427  0.0000 22.5788 13.7253 23.5470  0.5918  0.6437  0.931494988804      0
jxl:d2.5        19725  2090676    0.8478885   1.501  12.470   3.48026729  77.10789295   1.09822155  36.53   2.297  5.5217 13.6549  1.0236  4.9903 13.7876  0.0000 22.0571 14.4936 23.9726  0.5710  0.6645  0.931169379853      0
jxl:d2.6        19725  2031232    0.8237805   1.493  10.630   3.37381721  76.46311265   1.12342092  36.34   2.286  5.3942 13.3756  1.0360  4.9254 13.7228  0.0000 21.5666 15.1140 24.3256  0.5918  0.6852  0.925452275923      0
jxl:d2.7        19725  1975469    0.8011654   1.539  11.125   3.46650577  75.73450089   1.15053030  36.15   2.278  5.2482 13.1118  1.0373  4.8355 13.6345  0.0000 21.1019 15.7914 24.6163  0.6126  0.7475  0.921765124468      0
jxl:d2.8        19725  1923804    0.7802123   1.571  12.571   3.49681234  75.13477880   1.18328549  35.96   2.275  5.1077 12.9846  1.0613  4.7294 13.5222  0.0000 20.5413 16.4559 24.8603  0.7475  0.7268  0.923213947638      0
jxl:d2.9        19725  1874370    0.7601640   1.526  12.153   3.80102682  74.51770186   1.21074795  35.78   2.253  5.0023 12.7345  1.0622  4.7103 13.5222  0.0000 20.1001 16.9439 25.2081  0.7268  0.7268  0.920367043336      0
jxl:d3          19725  1831792    0.7428962   1.418  12.665   4.28672409  73.87618739   1.24674099  35.62   2.274  4.8125 12.5859  1.0415  4.6100 13.3224  0.0000 19.7081 17.6680 25.4625  0.7164  0.8098  0.926199172222      0
jxl:d5          19725  1255594    0.5092150   1.408   6.689   5.34499407  62.12965162   1.76517741  33.23   2.316  3.3486  8.2951  0.9542  2.9839 10.8066  0.0000 15.6214 26.9679 29.7140  0.6748  1.3705  0.898854890992      0
jxl:d7          19725   973120    0.3946557   1.444   6.444   6.79172993  52.51071611   2.21669981  31.70   2.260  2.5563  5.9364  0.7991  2.0975  9.1721  0.0000 12.9402 32.5276 32.3511  0.7164  1.6404  0.874833237095      0
jxl:d15         19725   541401    0.2195690   1.406   6.304  11.73615837  22.99802351   3.68077552  28.81   2.149  1.2287  1.7893  0.3254  0.6064  5.5000  0.0000  7.6556 37.9186 40.6985  1.2770  3.7376  0.808184241178      0
jxl:d24         19725   395555    0.1604201   0.249  14.459  55.77207184  -6.46506034   6.22868803  26.36   2.674  1.0330  2.3282  0.1746  0.6995  3.0368  0.0000  3.2808  9.2065  5.6999  0.0000  0.0000  0.999206961016      0
jxl:d32         19725   316833    0.1284939   0.252  14.468  55.58572388 -19.06268289   6.95952830  25.87   2.377  0.7605  1.7569  0.1372  0.5211  2.7169  0.0000  2.8850 10.3226  6.3591  0.0000  0.0000  0.894256710104      0
Aggregate:      19725  2218551    0.8997491   1.294  10.918   3.79257619  76.94885733   1.02182860  36.97   2.350  5.6981 12.2161  0.7588  4.7421 12.3691  0.0000 19.0149  8.6491 16.1919  0.4218  0.4873  0.919389325387      0
```