### PR TITLE
Use the same type of coeff buffer for encoding and transcoding.

### DIFF
--- a/lib/jpegli/encode_internal.h
+++ b/lib/jpegli/encode_internal.h
@@ -78,7 +78,6 @@ struct jpeg_comp_master {
       float* rows_in[MAX_SAMP_FACTOR], size_t len, float* row_out);
   float* quant_mul[jpegli::kMaxComponents];
   float zero_bias_mul[jpegli::kMaxComponents];
-  jpegli::coeff_t* coefficients[jpegli::kMaxComponents];
   int h_factor[jpegli::kMaxComponents];
   int v_factor[jpegli::kMaxComponents];
   jpegli::HuffmanCodeTable huff_tables[8];

--- a/lib/jpegli/memory_manager.cc
+++ b/lib/jpegli/memory_manager.cc
@@ -10,6 +10,7 @@
 #include <hwy/aligned_allocator.h>
 #include <vector>
 
+#include "lib/jpegli/common_internal.h"
 #include "lib/jpegli/error.h"
 
 struct jvirt_sarray_control {
@@ -55,8 +56,14 @@ template <typename T>
 T** Alloc2dArray(j_common_ptr cinfo, int pool_id, JDIMENSION samplesperrow,
                  JDIMENSION numrows) {
   T** array = Allocate<T*>(cinfo, numrows, pool_id);
+  // Always use aligned allocator for large 2d arrays.
+  if (pool_id < JPOOL_NUMPOOLS) {
+    pool_id += JPOOL_NUMPOOLS;
+  }
+  size_t stride = RoundUpTo(samplesperrow, HWY_ALIGNMENT);
+  T* buffer = Allocate<T>(cinfo, numrows * stride, pool_id);
   for (size_t i = 0; i < numrows; ++i) {
-    array[i] = Allocate<T>(cinfo, samplesperrow, pool_id);
+    array[i] = &buffer[i * stride];
   }
   return array;
 }


### PR DESCRIPTION
This removes the need to copy the coefficient buffer when we do transcoding and we need one less data structure in jpeg_comp_master.