### PR TITLE
Don't allocate full input buffer in jpegli encoder.

### DIFF
--- a/lib/jpegli/common_internal.h
+++ b/lib/jpegli/common_internal.h
@@ -110,14 +110,12 @@ class RowBuffer {
     return &data_[((ysize_ + y) % ysize_) * stride_ + offset_];
   }
 
-  T* DirectRow(size_t y) const { return &data_[y * stride_ + offset_]; }
-
   size_t xsize() const { return xsize_; };
   size_t ysize() const { return ysize_; };
   size_t stride() const { return stride_; }
 
   void PadRow(size_t y, size_t from, int border) {
-    float* row = DirectRow(y);
+    float* row = Row(y);
     for (int offset = -border; offset < 0; ++offset) {
       row[offset] = row[0];
     }

--- a/lib/jpegli/dct.cc
+++ b/lib/jpegli/dct.cc
@@ -316,21 +316,21 @@ void ComputeDCTCoefficients(j_compress_ptr cinfo) {
         reinterpret_cast<j_common_ptr>(cinfo), m->coeff_buffers[c], by0,
         max_block_rows, true);
     float* qmc = m->quant_mul[c];
-    RowBuffer<float>* plane = &m->input_buffer[c];
+    RowBuffer<float>* plane = m->raw_data[c];
     const int h_factor = m->h_factor[c];
     const int v_factor = m->v_factor[c];
     for (int iy = 0; iy < comp->v_samp_factor; iy++) {
       size_t by = by0 + iy;
       if (by >= comp->height_in_blocks) continue;
       JBLOCKROW brow = ba[iy];
-      const float* row = plane->DirectRow(8 * by);
+      const float* row = plane->Row(8 * by);
       for (size_t bx = 0; bx < comp->width_in_blocks; bx++) {
         JCOEF* block = &brow[bx][0];
         TransformFromPixels(row + 8 * bx, plane->stride(), dct, scratch_space);
         if (m->use_adaptive_quantization) {
           // Create more zeros in areas where jpeg xl would have used a lower
           // quantization multiplier.
-          float relq = m->quant_field.DirectRow(by * v_factor)[bx * h_factor];
+          float relq = m->quant_field.Row(by * v_factor)[bx * h_factor];
           float zero_bias = 0.5f + m->zero_bias_mul[c] * relq;
           zero_bias = std::min(1.5f, zero_bias);
           QuantizeBlock(dct, qmc, zero_bias, block);

--- a/lib/jpegli/downsample.cc
+++ b/lib/jpegli/downsample.cc
@@ -293,14 +293,15 @@ void DownsampleInputBuffer(j_compress_ptr cinfo) {
     if (h_factor == 1 && v_factor == 1) {
       continue;
     }
-    auto& buffer = m->input_buffer[c];
+    auto& input = m->input_buffer[c];
+    auto& output = m->downsampler_output[c];
     const size_t yout0 = y0 / v_factor;
     float* rows_in[MAX_SAMP_FACTOR];
     for (size_t yin = y0, yout = yout0; yin < y1; yin += v_factor, ++yout) {
       for (int iy = 0; iy < v_factor; ++iy) {
-        rows_in[iy] = buffer.DirectRow(yin + iy);
+        rows_in[iy] = input.Row(yin + iy);
       }
-      float* row_out = buffer.DirectRow(yout);
+      float* row_out = output.Row(yout);
       (*m->downsample_method[c])(rows_in, xsize_padded, row_out);
     }
   }

--- a/lib/jpegli/encode_internal.h
+++ b/lib/jpegli/encode_internal.h
@@ -57,7 +57,9 @@ typedef int16_t coeff_t;
 }  // namespace jpegli
 
 struct jpeg_comp_master {
-  std::array<jpegli::RowBuffer<float>, jpegli::kMaxComponents> input_buffer;
+  jpegli::RowBuffer<float> input_buffer[jpegli::kMaxComponents];
+  jpegli::RowBuffer<float> downsampler_output[jpegli::kMaxComponents];
+  jpegli::RowBuffer<float>* raw_data[jpegli::kMaxComponents];
   float distance = 1.0;
   bool force_baseline = true;
   bool xyb_mode = false;


### PR DESCRIPTION
We now only need a ring-buffer of 3 iMCU rows. Similarly for the adaptive quantization map related structures we only allocate a ring-buffer of block rows.