### PR TITLE
Extend error manager support in jpegli.

### DIFF
--- a/lib/jpegli/encode.cc
+++ b/lib/jpegli/encode.cc
@@ -770,6 +770,7 @@ void jpegli_suppress_tables(j_compress_ptr cinfo, boolean suppress) {
 
 void jpegli_start_compress(j_compress_ptr cinfo, boolean write_all_tables) {
   CheckState(cinfo, jpegli::kEncStart);
+  (*cinfo->err->reset_error_mgr)(reinterpret_cast<j_common_ptr>(cinfo));
   jpegli::ProcessCompressionParams(cinfo);
   jpegli::AllocateBuffers(cinfo);
   jpegli::ChooseInputMethod(cinfo);
@@ -795,6 +796,7 @@ void jpegli_start_compress(j_compress_ptr cinfo, boolean write_all_tables) {
 void jpegli_write_coefficients(j_compress_ptr cinfo,
                                jvirt_barray_ptr* coef_arrays) {
   CheckState(cinfo, jpegli::kEncStart);
+  (*cinfo->err->reset_error_mgr)(reinterpret_cast<j_common_ptr>(cinfo));
   jpegli::ProcessCompressionParams(cinfo);
   (*cinfo->mem->realize_virt_arrays)(reinterpret_cast<j_common_ptr>(cinfo));
   cinfo->master->coeff_buffers = coef_arrays;
@@ -814,6 +816,7 @@ void jpegli_write_tables(j_compress_ptr cinfo) {
   if (cinfo->dest == nullptr) {
     JPEGLI_ERROR("Missing destination.");
   }
+  (*cinfo->err->reset_error_mgr)(reinterpret_cast<j_common_ptr>(cinfo));
   (*cinfo->dest->init_destination)(cinfo);
   jpeg_comp_master* m = cinfo->master;
   jpegli::WriteOutput(cinfo, {0xFF, 0xD8});  // SOI

--- a/lib/jpegli/error.cc
+++ b/lib/jpegli/error.cc
@@ -9,56 +9,90 @@
 #include <stdlib.h>
 #include <string.h>
 
+#include <string>
+
 #include "lib/jpegli/common.h"
 
 namespace jpegli {
 
+const char* const kErrorMessageTable[] = {
+    "Message codes are not supported, error message is in msg_parm.s string",
+};
+
 bool FormatString(char* buffer, const char* format, ...) {
   va_list args;
   va_start(args, format);
-  vsnprintf(buffer, JMSG_LENGTH_MAX, format, args);
+  vsnprintf(buffer, JMSG_STR_PARM_MAX, format, args);
   va_end(args);
   return false;
 }
 
-const char* const kErrorMessageTable[] = {
-    "Something went wrong.",
-};
-
 void ExitWithAbort(j_common_ptr cinfo) {
   (*cinfo->err->output_message)(cinfo);
+  jpegli_destroy(cinfo);
   exit(EXIT_FAILURE);
 }
 
-void ExitWithLongJump(j_common_ptr cinfo) {
-  (*cinfo->err->output_message)(cinfo);
-  jmp_buf* env = static_cast<jmp_buf*>(cinfo->client_data);
-  longjmp(*env, 1);
+void EmitMessage(j_common_ptr cinfo, int msg_level) {
+  if (msg_level < 0) {
+    if (cinfo->err->num_warnings <= 5 || cinfo->err->trace_level >= 3) {
+      (*cinfo->err->output_message)(cinfo);
+    }
+    ++cinfo->err->num_warnings;
+  } else if (cinfo->err->trace_level >= msg_level) {
+    (*cinfo->err->output_message)(cinfo);
+  }
 }
 
 void OutputMessage(j_common_ptr cinfo) {
-  fprintf(stderr, "%s", cinfo->err->msg_parm.s);
+  char buffer[JMSG_LENGTH_MAX];
+  (*cinfo->err->format_message)(cinfo, buffer);
+  fprintf(stderr, "%s\n", buffer);
 }
 
 void FormatMessage(j_common_ptr cinfo, char* buffer) {
-  memcpy(buffer, cinfo->err->msg_parm.s, JMSG_LENGTH_MAX);
+  jpeg_error_mgr* err = cinfo->err;
+  int code = err->msg_code;
+  if (code == 0) {
+    memcpy(buffer, cinfo->err->msg_parm.s, JMSG_STR_PARM_MAX);
+  } else if (err->addon_message_table != nullptr &&
+             code >= err->first_addon_message &&
+             code <= err->last_addon_message) {
+    std::string msg(err->addon_message_table[code - err->first_addon_message]);
+    if (msg.find("%s") != std::string::npos) {
+      snprintf(buffer, JMSG_LENGTH_MAX, msg.data(), err->msg_parm.s);
+    } else {
+      snprintf(buffer, JMSG_LENGTH_MAX, msg.data(), err->msg_parm.i[0],
+               err->msg_parm.i[1], err->msg_parm.i[2], err->msg_parm.i[3],
+               err->msg_parm.i[4], err->msg_parm.i[5], err->msg_parm.i[6],
+               err->msg_parm.i[7]);
+    }
+  } else {
+    snprintf(buffer, JMSG_LENGTH_MAX, "%s", kErrorMessageTable[0]);
+  }
 }
 
-// These are not (yet) used by this library.
-void EmitMessage(j_common_ptr cinfo, int msg_level) {}
-void ResetErrorManager(j_common_ptr cinfo) {}
+void ResetErrorManager(j_common_ptr cinfo) {
+  memset(cinfo->err->msg_parm.s, 0, JMSG_STR_PARM_MAX);
+  cinfo->err->msg_code = 0;
+  cinfo->err->num_warnings = 0;
+}
 
 }  // namespace jpegli
 
 struct jpeg_error_mgr* jpegli_std_error(struct jpeg_error_mgr* err) {
   err->error_exit = jpegli::ExitWithAbort;
-  err->output_message = jpegli::OutputMessage;
   err->emit_message = jpegli::EmitMessage;
+  err->output_message = jpegli::OutputMessage;
   err->format_message = jpegli::FormatMessage;
   err->reset_error_mgr = jpegli::ResetErrorManager;
-  err->msg_code = 0;
+  memset(err->msg_parm.s, 0, JMSG_STR_PARM_MAX);
   err->trace_level = 0;
   err->num_warnings = 0;
+  // We don't support message codes and message table, but we define one here
+  // in case the application has a custom format_message and tries to access
+  // these fields there.
+  err->msg_code = 0;
   err->jpeg_message_table = jpegli::kErrorMessageTable;
   err->last_jpeg_message = 0;
   err->addon_message_table = nullptr;

--- a/lib/jpegli/error.h
+++ b/lib/jpegli/error.h
@@ -19,9 +19,21 @@ bool FormatString(char* buffer, const char* format, ...);
 
 }  // namespace jpegli
 
-#define JPEGLI_ERROR(format, ...)                                       \
-  jpegli::FormatString(cinfo->err->msg_parm.s, ("%s:%d: " format "\n"), \
-                       __FILE__, __LINE__, ##__VA_ARGS__),              \
+#define JPEGLI_ERROR(format, ...)                                            \
+  jpegli::FormatString(cinfo->err->msg_parm.s, ("%s:%d: " format), __FILE__, \
+                       __LINE__, ##__VA_ARGS__),                             \
       (*cinfo->err->error_exit)(reinterpret_cast<j_common_ptr>(cinfo))
+
+#define JPEGLI_WARN(format, ...)                                             \
+  jpegli::FormatString(cinfo->err->msg_parm.s, ("%s:%d: " format), __FILE__, \
+                       __LINE__, ##__VA_ARGS__),                             \
+      (*cinfo->err->emit_message)(reinterpret_cast<j_common_ptr>(cinfo), -1)
+
+#define JPEGLI_TRACE(level, format, ...)                                     \
+  if (cinfo->err->trace_level >= (level))                                    \
+  jpegli::FormatString(cinfo->err->msg_parm.s, ("%s:%d: " format), __FILE__, \
+                       __LINE__, ##__VA_ARGS__),                             \
+      (*cinfo->err->emit_message)(reinterpret_cast<j_common_ptr>(cinfo),     \
+                                  (level))
 
 #endif  // LIB_JPEGLI_ERROR_H_


### PR DESCRIPTION
This change adds support for warning and trace messages, and an addon error message table that is used by eg. cjpeg/djpeg.