### PR TITLE
more optimizations for difficult images

### DIFF
--- a/lib/jxl/enc_adaptive_quantization.cc
+++ b/lib/jxl/enc_adaptive_quantization.cc
@@ -717,7 +717,7 @@ ImageF TileDistMap(const ImageF& distmap, int tile_size, int margin,
 
 constexpr float kDcQuantPow = 0.87f;
 static const float kDcQuant = 1.295f;
-static const float kAcQuant = 0.854f;
+static const float kAcQuant = 0.8526f;
 
 void FindBestQuantization(const ImageBundle& linear, const Image3F& opsin,
                           PassesEncoderState* enc_state,

--- a/lib/jxl/enc_gaborish.cc
+++ b/lib/jxl/enc_gaborish.cc
@@ -19,11 +19,13 @@ void GaborishInverse(Image3F* in_out, float mul, ThreadPool* pool) {
   JXL_ASSERT(mul >= 0.0f);
 
   // Only an approximation. One or even two 3x3, and rank-1 (separable) 5x5
-  // are insufficient.
+  // are insufficient. The numbers here have been obtained by butteraugli
+  // based optimizing the whole system and the errors produced are likely
+  // more favorable for good rate-distortion compromises rather than
+  // just using mathematical optimization to find the inverse.
   static const float kGaborish[5] = {
-      -0.088188686933903332f, -0.043510240843796254f, 0.016038526595420832f,
-      0.0013932467887255813f, 0.0042737176783204326f,
-  };
+      -0.090881924078487886f, -0.043663953593472138f, 0.01392497846646211f,
+      0.0036189602184591141f, 0.0030557936884763499f};
   /*
     better would be:
       1.0 - mul * (4 * (kGaborish[0] + kGaborish[1] +

--- a/lib/jxl/enc_group.cc
+++ b/lib/jxl/enc_group.cc
@@ -49,10 +49,10 @@ void QuantizeBlockAC(const Quantizer& quantizer, const bool error_diffusion,
   const float* JXL_RESTRICT qm = quantizer.InvDequantMatrix(quant_kind, c);
   float qac = quantizer.Scale() * (*quant);
   // Not SIMD-fied for now.
-  float thres[4] = {0.58f, 0.635f, 0.66f, 0.7f};
+  float thres[4] = {0.58f, 0.66f, 0.66f, 0.7f};
   if (c == 0) {
     for (int i = 1; i < 4; ++i) {
-      thres[i] += 0.08f;
+      thres[i] = 0.71f;
     }
   }
   if (c == 2) {
@@ -63,6 +63,9 @@ void QuantizeBlockAC(const Quantizer& quantizer, const bool error_diffusion,
   if (xsize > 1 || ysize > 1) {
     for (int i = 0; i < 4; ++i) {
       thres[i] -= Clamp1(0.003f * xsize * ysize, 0.f, (c > 0 ? 0.08f : 0.12f));
+      if (thres[i] < 0.54) {
+        thres[i] = 0.54;
+      }
     }
   }
   if (!error_diffusion) {
@@ -178,10 +181,10 @@ bool AdjustQuantBlockAC(const Quantizer& quantizer, size_t c,
 
   const float* JXL_RESTRICT qm = quantizer.InvDequantMatrix(quant_kind, c);
   float qac = quantizer.Scale() * (*quant);
-  float thres[4] = {0.58f, 0.635f, 0.66f, 0.7f};
+  float thres[4] = {0.58f, 0.66f, 0.66f, 0.7f};
   if (c == 0) {
     for (int i = 1; i < 4; ++i) {
-      thres[i] += 0.08f;
+      thres[i] = 0.71f;
     }
   }
   if (c == 2) {
@@ -192,6 +195,9 @@ bool AdjustQuantBlockAC(const Quantizer& quantizer, size_t c,
   if (xsize > 1 || ysize > 1) {
     for (int i = 0; i < 4; ++i) {
       thres[i] -= Clamp1(0.003f * xsize * ysize, 0.f, (c > 0 ? 0.08f : 0.12f));
+      if (thres[i] < 0.54) {
+        thres[i] = 0.54;
+      }
     }
   }
   float sum_of_highest_freq_row_and_column = 0;

--- a/lib/jxl/jxl_test.cc
+++ b/lib/jxl/jxl_test.cc
@@ -222,7 +222,7 @@ TEST(JxlTest, RoundtripOutOfOrderProcessingBorder) {
   cparams.AddOption(JXL_ENC_FRAME_SETTING_RESAMPLING, 2);
 
   PackedPixelFile ppf_out;
-  EXPECT_NEAR(Roundtrip(t.ppf(), cparams, {}, &pool, &ppf_out), 9554, 100);
+  EXPECT_NEAR(Roundtrip(t.ppf(), cparams, {}, &pool, &ppf_out), 9656, 100);
   EXPECT_LE(ButteraugliDistance(t.ppf(), ppf_out), 2.9);
 }
 
@@ -373,7 +373,7 @@ TEST(JxlTest, RoundtripDotsForceEpf) {
   cparams.AddOption(JXL_ENC_FRAME_SETTING_DOTS, 1);
 
   PackedPixelFile ppf_out;
-  EXPECT_NEAR(Roundtrip(t.ppf(), cparams, {}, &pool, &ppf_out), 41269, 300);
+  EXPECT_NEAR(Roundtrip(t.ppf(), cparams, {}, &pool, &ppf_out), 41736, 300);
   EXPECT_THAT(ComputeDistance2(t.ppf(), ppf_out), IsSlightlyBelow(18));
 }
 
@@ -817,7 +817,7 @@ TEST(JxlTest, RoundtripAlphaResampling) {
   cparams.AddOption(JXL_ENC_FRAME_SETTING_EXTRA_CHANNEL_RESAMPLING, 2);
 
   PackedPixelFile ppf_out;
-  EXPECT_NEAR(Roundtrip(t.ppf(), cparams, {}, pool, &ppf_out), 12155, 100);
+  EXPECT_NEAR(Roundtrip(t.ppf(), cparams, {}, pool, &ppf_out), 12272, 130);
   EXPECT_THAT(ButteraugliDistance(t.ppf(), ppf_out), IsSlightlyBelow(4.9));
 }
 
@@ -885,7 +885,7 @@ TEST(JxlTest, RoundtripAlpha16) {
   PackedPixelFile ppf_out;
   // TODO(szabadka) Investigate big size difference on i686
   EXPECT_NEAR(Roundtrip(t.ppf(), cparams, {}, &pool, &ppf_out), 3515, 50);
-  EXPECT_THAT(ButteraugliDistance(t.ppf(), ppf_out), IsSlightlyBelow(0.7));
+  EXPECT_THAT(ButteraugliDistance(t.ppf(), ppf_out), IsSlightlyBelow(0.8));
 }
 
 namespace {
@@ -1071,8 +1071,8 @@ TEST(JxlTest, RoundtripDots) {
   cparams.distance = 0.04;
 
   PackedPixelFile ppf_out;
-  EXPECT_NEAR(Roundtrip(t.ppf(), cparams, {}, pool, &ppf_out), 276702, 3000);
-  EXPECT_THAT(ButteraugliDistance(t.ppf(), ppf_out), IsSlightlyBelow(0.3));
+  EXPECT_NEAR(Roundtrip(t.ppf(), cparams, {}, pool, &ppf_out), 279836, 3000);
+  EXPECT_THAT(ButteraugliDistance(t.ppf(), ppf_out), IsSlightlyBelow(0.35));
 }
 
 TEST(JxlTest, RoundtripNoise) {


### PR DESCRIPTION
0.02 db better PSNR
0.24 % improved BPP*pnorm
Max norm reduced by 38 % and BPP*pnorm by 8 % at d0.1 
Max norm reduced by 7 % and BPP*pnorm by 0.37 % at d1

```
Before

Encoding      kPixels    Bytes          BPP  E MP/s  D MP/s     Max norm  SSIMULACRA2        pnorm   PSNR   QABPP  SmallB  DCT4x8     AFV  DCT8x8    8x16    8x32      16   16x32      32   32x64      64       BPP*pnorm   Bugs
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
jxl:d0.1        19791 16033582    6.4810008   1.444   8.938   1.38181531  99.69665288   0.13035467  52.68   6.539 40.0026 19.5743  0.4252 28.2471  5.4191  0.0000  2.9013  0.9261  3.0526  0.1035  0.0828  0.844828741996      0
jxl:d0.5        19791  6068636    2.4530286   1.794  14.926   2.20771909  97.24909008   0.37776380  43.78   2.557 13.9952 24.7744  0.5979 12.0912 21.7183  0.0000 20.7410  1.3789  4.8687  0.1345  0.4346  0.926665403491      0
jxl:d0.8        19791  4523437    1.8284373   1.848  15.284   3.69005775  92.31410162   0.52017631  41.32   2.244 10.7728 21.2762  0.6891  9.1249 19.6144  0.0000 30.7306  1.6660  6.2812  0.1863  0.3932  0.951109750354      0
jxl:d1          19791  3918210    1.5837959   1.927  15.509   4.05260658  89.55863371   0.60452222  40.22   2.330  9.5990 19.4789  0.7428  7.9420 18.0286  0.0000 32.7433  2.6077  9.0751  0.2070  0.3104  0.957439834250      0
jxl:d1.1        19791  3688142    1.4907992   1.905  15.646   4.49570084  88.37251717   0.64282634  39.75   2.299  9.0854 18.8128  0.7861  7.5287 17.3573  0.0000 32.7498  3.2234 10.7049  0.2380  0.2483  0.958324998325      0
jxl:d1.2        19791  3485250    1.4087874   1.953  16.089   4.43750000  87.31274467   0.68059338  39.31   2.313  8.6444 18.1825  0.8071  7.1717 16.6394  0.0000 32.5415  3.9943 12.2571  0.2897  0.2070  0.958811373848      0
jxl:d1.3        19791  3347875    1.3532585   1.985  15.924   4.34814739  86.47241816   0.71007550  39.19   2.330  8.2747 17.6140  0.8356  6.8610 16.2158  0.0000 31.7408  5.0110 13.7472  0.2690  0.1656  0.960915679321      0
jxl:d1.4        19791  3185553    1.2876456   1.906  15.910   4.35611057  85.52432159   0.74559479  38.81   2.327  7.9129 17.1322  0.8514  6.5324 15.7928  0.0000 30.7306  5.8879 15.3459  0.3415  0.2070  0.960061865520      0
jxl:d1.5        19791  3042867    1.2299699   1.956  15.910   5.29898691  84.64219691   0.77880134  38.48   2.363  7.5824 16.6911  0.8618  6.3171 15.5121  0.0000 29.7553  6.7598 16.6549  0.3518  0.2483  0.957902216578      0
jxl:d1.6        19791  2914055    1.1779023   2.025  14.840   5.93965578  83.74368853   0.81218077  38.19   2.382  7.3347 16.3257  0.8715  6.0590 15.2560  0.0000 28.7956  7.6471 17.7001  0.4139  0.3311  0.956669581055      0
jxl:d1.7        19791  2795004    1.1297802   1.949  15.683   5.45076942  82.92900476   0.84460592  37.89   2.368  7.0660 15.9555  0.9038  5.9711 15.0206  0.0000 27.6715  8.5060 18.8228  0.4036  0.4139  0.954219033375      0
jxl:d1.8        19791  2688149    1.0865879   2.026  16.152   6.38916874  82.13496724   0.88086419  37.62   2.380  6.8241 15.6512  0.9329  5.7618 14.7664  0.0000 26.8023  9.3933 19.7024  0.4450  0.4553  0.957136345123      0
jxl:d1.8        19791  2688149    1.0865879   1.965  15.567   6.38916874  82.13496724   0.88086419  37.62   2.380  6.8241 15.6512  0.9329  5.7618 14.7664  0.0000 26.8023  9.3933 19.7024  0.4450  0.4553  0.957136345123      0
jxl:d1.9        19791  2589487    1.0467073   2.028  15.865   6.43212509  81.28000239   0.91914349  37.37   2.413  6.5919 15.3139  0.9449  5.6609 14.5711  0.0000 25.9150 10.2082 20.5871  0.4243  0.5174  0.962074201879      0
jxl:d2.0        19791  2500631    1.0107904   2.066  16.229   6.96550274  80.45583648   0.94906148  37.14   2.398  6.3901 15.0623  0.9536  5.5403 14.4534  0.0000 25.0354 10.9274 21.4098  0.4864  0.4760  0.959302275620      0
jxl:d2.1        19791  2416325    0.9767128   2.039  16.144   6.42044258  79.69559714   0.97787886  36.92   2.373  6.1644 14.7073  0.9756  5.3967 14.2516  0.0000 24.4443 11.6931 22.0462  0.5174  0.5381  0.955106772051      0
jxl:d2.2        19791  2339875    0.9458106   2.010  15.474   6.64706421  78.97869554   1.02219880  36.71   2.398  5.9646 14.4282  0.9869  5.2836 14.1857  0.0000 23.6423 12.4795 22.7188  0.5070  0.5381  0.966806457631      0
jxl:d2.3        19791  2267473    0.9165447   2.043  16.091   6.48388195  78.26961129   1.04656226  36.50   2.433  5.8158 14.1462  1.0176  5.1733 14.0324  0.0000 23.1262 13.0797 23.3086  0.4760  0.5588  0.959221072391      0
jxl:d2.4        19791  2202907    0.8904462   2.092  16.166   6.29933834  77.63528066   1.07483017  36.30   2.404  5.6700 13.8558  1.0134  5.0834 13.9043  0.0000 22.5713 13.8377 23.5673  0.5898  0.6416  0.957078435107      0
jxl:d2.5        19791  2138912    0.8645785   2.045  16.185   5.75084305  76.96615052   1.10620571  36.11   2.401  5.5035 13.6097  1.0202  4.9738 13.7497  0.0000 22.0436 14.6060 23.9967  0.5691  0.6623  0.956401684085      0
jxl:d2.6        19791  2078926    0.8403313   2.132  16.612   6.05204773  76.32558282   1.13088048  35.92   2.395  5.3764 13.3313  1.0325  4.9104 13.6838  0.0000 21.5469 15.2373 24.3434  0.5898  0.6830  0.950314284312      0
jxl:d2.7        19791  2021636    0.8171739   2.099  15.825   5.67558765  75.59478741   1.15804957  35.73   2.376  5.2309 13.0684  1.0338  4.8208 13.5945  0.0000 21.0748 15.9073 24.6487  0.6105  0.7450  0.946327868763      0
jxl:d2.8        19791  1968788    0.7958120   2.085  15.858   5.80623341  74.99873903   1.19057049  35.55   2.373  5.0908 12.9416  1.0577  4.7151 13.4814  0.0000 20.5043 16.5773 24.8970  0.7450  0.7244  0.947470253621      0
jxl:d2.9        19791  1918370    0.7754323   2.105  14.987   6.27850342  74.38979954   1.21850507  35.37   2.357  4.9857 12.6923  1.0587  4.6966 13.4794  0.0000 20.0581 17.0559 25.2592  0.7244  0.7244  0.944868199262      0
jxl:d3          19791  1874505    0.7577015   1.834  15.645   6.50936508  73.74238163   1.25447956  35.22   2.379  4.7966 12.5442  1.0380  4.5961 13.2796  0.0000 19.6636 17.7725 25.5231  0.7140  0.8071  0.950520990693      0
jxl:d5          19791  1290034    0.5214500   1.862   8.511   7.90506411  62.01130035   1.77406135  32.97   2.418  3.3375  8.2676  0.9510  2.9740 10.7709  0.0000 15.5697 27.0752 29.7502  0.6726  1.3659  0.925084294157      0
jxl:d7          19791  1003915    0.4057967   1.911   8.469   7.90485382  52.38952252   2.22462604  31.50   2.351  2.5478  5.9167  0.7965  2.0906  9.1417  0.0000 12.8973 32.6062 32.3889  0.7140  1.6350  0.902745803887      0
jxl:d15         19791   564647    0.2282383   1.997   8.267  11.73615837  22.88715827   3.68807651  28.68   2.225  1.2246  1.7834  0.3243  0.6044  5.4818  0.0000  7.6303 37.8396 40.8483  1.2728  3.7252  0.841760349383      0
jxl:d24         19791   400167    0.1617532   0.310  20.738  55.77207184  -6.79643147   6.28027861  25.87   2.714  1.0296  2.3205  0.1740  0.6972  3.0268  0.0000  3.2699  9.2019  5.7379  0.0000  0.0000  1.015854947254      0
jxl:d32         19791   320149    0.1294088   0.310  20.932  55.58572388 -19.38386134   7.00898884  25.42   2.406  0.7580  1.7511  0.1368  0.5193  2.7079  0.0000  2.8754 10.3039  6.4053  0.0000  0.0000  0.907024537472      0
Aggregate:      19791  2267134    0.9164076   1.733  14.801   6.31057696  76.79799467   1.03050781  36.47   2.462  5.6796 12.1757  0.7563  4.7283 12.3342  0.0000 19.0380  8.6647 16.2322  0.4204  0.4857  0.944365151022      0

After

Encoding      kPixels    Bytes          BPP  E MP/s  D MP/s     Max norm  SSIMULACRA2        pnorm   PSNR   QABPP  SmallB  DCT4x8     AFV  DCT8x8    8x16    8x32      16   16x32      32   32x64      64       BPP*pnorm   Bugs
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
jxl:d0.1        19791 16130930    6.5203502   1.472   8.992   0.84890330  99.92156557   0.11912448  53.40   6.520 40.3580 19.4734  0.4466 27.9745  5.3356  0.0000  2.9763  0.9210  3.0630  0.1035  0.0828  0.776733346041      0
jxl:d0.5        19791  6086456    2.4602317   1.738  14.119   1.71342385  97.51090676   0.37420968  43.89   2.535 14.1533 24.8582  0.5898 12.0572 21.5870  0.0000 20.6725  1.3840  4.8842  0.1345  0.4139  0.920642493372      0
jxl:d0.8        19791  4534134    1.8327611   1.851  15.318   3.49407816  92.33245890   0.51666801  41.39   2.217 10.8666 21.3884  0.6855  9.1152 19.4928  0.0000 30.6465  1.6634  6.2863  0.1966  0.3932  0.946929053757      0
jxl:d1          19791  3925534    1.5867564   1.881  15.009   3.76737738  89.63131370   0.60111225  40.28   2.306  9.6549 19.5630  0.7441  7.9080 17.9471  0.0000 32.6527  2.6258  9.1217  0.2483  0.2690  0.953818710756      0
jxl:d1.1        19791  3695031    1.4935838   1.911  15.680   3.97126365  88.46601174   0.64082411  39.79   2.276  9.1511 18.8962  0.7929  7.4951 17.2544  0.0000 32.6786  3.2285 10.7618  0.2277  0.2483  0.957124533825      0
jxl:d1.2        19791  3490703    1.4109916   1.978  16.127   4.28889942  87.37458032   0.67936772  39.34   2.304  8.7478 18.2081  0.8039  7.1740 16.5605  0.0000 32.4303  4.0253 12.3088  0.2690  0.2070  0.958582121158      0
jxl:d1.3        19791  3351955    1.3549077   1.986  16.877   3.95312285  86.49627685   0.70685816  39.22   2.320  8.3436 17.6674  0.8349  6.8409 16.1246  0.0000 31.6787  4.9592 13.8196  0.3001  0.1656  0.957727540303      0
jxl:d1.4        19791  3189170    1.2891077   1.944  16.504   4.29666567  85.58025750   0.74311544  38.84   2.332  7.9760 17.1985  0.8488  6.5311 15.7424  0.0000 30.5832  5.8931 15.3925  0.3622  0.2070  0.957955801823      0
jxl:d1.5        19791  3044580    1.2306623   1.953  14.700   5.49123621  84.71571785   0.78053850  38.49   2.382  7.6713 16.7765  0.8543  6.2983 15.4326  0.0000 29.6118  6.7623 16.7274  0.3932  0.2070  0.960579324758      0
jxl:d1.6        19791  2915895    1.1786460   2.040  15.466   6.01680660  83.77461036   0.81759663  38.20   2.386  7.3987 16.3597  0.8676  6.0619 15.2366  0.0000 28.6171  7.6548 17.8035  0.4036  0.3311  0.963657019815      0
jxl:d1.7        19791  2795396    1.1299386   1.949  15.577   6.12723637  82.90818689   0.84669323  37.92   2.384  7.1116 16.0101  0.9045  5.9659 15.0219  0.0000 27.4891  8.5655 18.8280  0.4036  0.4346  0.956711395008      0
jxl:d1.8        19791  2687436    1.0862997   2.058  14.779   6.81322289  82.11536444   0.88072314  37.62   2.402  6.8852 15.7226  0.9287  5.7706 14.7108  0.0000 26.6432  9.4036 19.7282  0.4450  0.4967  0.956729256652      0
jxl:d1.8        19791  2687436    1.0862997   1.995  15.655   6.81322289  82.11536444   0.88072314  37.62   2.402  6.8852 15.7226  0.9287  5.7706 14.7108  0.0000 26.6432  9.4036 19.7282  0.4450  0.4967  0.956729256652      0
jxl:d1.9        19791  2589533    1.0467259   2.041  15.435   6.78516674  81.30761783   0.91632874  37.37   2.391  6.6356 15.3721  0.9449  5.6464 14.5368  0.0000 25.7947 10.2237 20.6285  0.4139  0.5381  0.959145015750      0
jxl:d2.0        19791  2498271    1.0098365   1.997  15.791   7.00792789  80.43861934   0.95064371  37.14   2.404  6.4584 15.1170  0.9417  5.5135 14.4211  0.0000 24.9449 10.9041 21.4305  0.5070  0.4967  0.959994722163      0
jxl:d2.1        19791  2414735    0.9760701   2.086  15.431   6.87189102  79.67007127   0.98090177  36.91   2.397  6.1935 14.7700  0.9730  5.3883 14.2070  0.0000 24.3512 11.6517 22.1652  0.5174  0.5174  0.957428860058      0
jxl:d2.2        19791  2338786    0.9453704   2.034  15.718   7.36959553  78.98924086   1.02398385  36.70   2.431  5.9969 14.4971  0.9889  5.2819 14.1423  0.0000 23.6255 12.4278 22.7291  0.5070  0.5381  0.968044032683      0
jxl:d2.3        19791  2266937    0.9163280   2.079  15.431   6.52260447  78.25839449   1.04851117  36.50   2.413  5.8757 14.1559  1.0138  5.1756 14.0447  0.0000 22.9632 13.1108 23.3396  0.4967  0.5588  0.960780165392      0
jxl:d2.4        19791  2199169    0.8889352   1.968  14.597   6.41371012  77.61210145   1.07745753  36.30   2.416  5.7185 13.9014  1.0128  5.0734 13.9153  0.0000 22.4200 13.8429 23.5673  0.6002  0.6830  0.957789967343      0
jxl:d2.5        19791  2136035    0.8634156   2.067  15.736   5.44637823  76.94421585   1.10699744  36.11   2.392  5.5578 13.6489  1.0160  4.9925 13.7426  0.0000 21.8832 14.6293 24.0330  0.5898  0.6416  0.955798835023      0
jxl:d2.6        19791  2077652    0.8398163   2.010  15.545   5.55945873  76.31489321   1.13049012  35.92   2.385  5.4061 13.3879  1.0345  4.8933 13.6851  0.0000 21.4667 15.2140 24.3123  0.6312  0.7037  0.949404081201      0
jxl:d2.7        19791  2021332    0.8170510   2.054  15.428   5.42007971  75.59054769   1.17019180  35.74   2.370  5.2693 13.1311  1.0312  4.8224 13.5874  0.0000 20.9351 15.8814 24.7211  0.6726  0.6830  0.956106386688      0
jxl:d2.8        19791  1967622    0.7953407   2.085  15.688   5.86958170  74.97050701   1.19782110  35.56   2.389  5.1348 13.0086  1.0468  4.7076 13.4458  0.0000 20.4371 16.5618 24.9643  0.7244  0.7037  0.952675827153      0
jxl:d2.9        19791  1916541    0.7746930   2.093  16.033   6.72100353  74.32747672   1.22747636  35.37   2.388  5.0355 12.7389  1.0600  4.6779 13.4652  0.0000 20.0063 16.9705 25.3420  0.7140  0.7244  0.950917343368      0
jxl:d3          19791  1871869    0.7566359   1.875  15.826   6.77040863  73.77033686   1.25245084  35.21   2.372  4.8270 12.6125  1.0393  4.5770 13.2388  0.0000 19.5898 17.7647 25.6162  0.7037  0.7657  0.947649329262      0
jxl:d5          19791  1288368    0.5207766   1.970   8.704   6.84611320  61.90486111   1.77602879  32.96   2.400  3.3524  8.2967  0.9507  2.9724 10.7133  0.0000 15.4791 27.1554 29.7553  0.6933  1.3659  0.924914204685      0
jxl:d7          19791  1002139    0.4050788   1.899   8.442   7.45719814  52.33028766   2.23324928  31.52   2.329  2.5608  5.9410  0.7978  2.0935  9.1663  0.0000 12.8495 32.5467 32.4199  0.7037  1.6557  0.904641868355      0
jxl:d15         19791   560225    0.2264509   1.985   7.834  11.63091469  22.68432201   3.69717707  28.67   2.222  1.2185  1.7899  0.3237  0.6079  5.4889  0.0000  7.5759 37.8732 40.8586  1.1693  3.8287  0.837228981289      0
jxl:d24         19791   401442    0.1622685   0.302  20.054  55.34418488  -6.85293031   6.27572219  25.87   2.705  1.0241  2.3315  0.1720  0.6904  3.0106  0.0000  3.2479  9.2484  5.7327  0.0000  0.0000  1.018352268725      0
jxl:d32         19791   319210    0.1290292   0.305  20.583  55.45763397 -19.62135116   7.03435547  25.41   2.431  0.7606  1.7501  0.1342  0.5164  2.7157  0.0000  2.8612 10.2936  6.4260  0.0000  0.0000  0.907637262047      0
Aggregate:      19791  2267139    0.9164097   1.731  14.569   6.12920140  76.78588631   1.02800024  36.49   2.462  5.7196 12.2172  0.7551  4.7198 12.2988  0.0000 18.9699  8.6666 16.2701  0.4283  0.4827  0.942069436674      0
```