### PR TITLE
Move jxl->jpegxl::tools in tools/

### DIFF
--- a/lib/jxl/inverse_mtf-inl.h
+++ b/lib/jxl/inverse_mtf-inl.h
@@ -58,8 +58,8 @@ inline void InverseMoveToFrontTransform(uint8_t* v, int v_len) {
   }
 #if JXL_MEMORY_SANITIZER
   const HWY_CAPPED(uint8_t, 64) d;
-  for (i = 0; i < Lanes(d); ++i) {
-    mtf[256 + i] = 0;
+  for (size_t j = 0; j < Lanes(d); ++j) {
+    mtf[256 + j] = 0;
   }
 #endif  // JXL_MEMORY_SANITIZER
   for (i = 0; i < v_len; ++i) {

--- a/tools/benchmark/benchmark_args.cc
+++ b/tools/benchmark/benchmark_args.cc
@@ -32,7 +32,8 @@
 #include "tools/benchmark/benchmark_codec_avif.h"
 #endif  // BENCHMARK_AVIF
 
-namespace jxl {
+namespace jpegxl {
+namespace tools {
 
 std::vector<std::string> SplitString(const std::string& s, char c) {
   std::vector<std::string> result;
@@ -236,8 +237,8 @@ Status BenchmarkArgs::ValidateArgs() {
     fprintf(stderr, "Missing --input filename(s).\n");
     return false;
   }
-  if (extras::CodecFromExtension(output_extension, &bits_per_sample) ==
-      extras::Codec::kUnknown) {
+  if (jxl::extras::CodecFromExtension(output_extension, &bits_per_sample) ==
+      jxl::extras::Codec::kUnknown) {
     JXL_WARNING("Unrecognized output_extension %s, try .png",
                 output_extension.c_str());
     return false;  // already warned
@@ -248,7 +249,7 @@ Status BenchmarkArgs::ValidateArgs() {
   if (!output_description.empty()) {
     // Validate, but also create the profile (only needs to happen once).
     JxlColorEncoding output_encoding_external;
-    if (!ParseDescription(output_description, &output_encoding_external)) {
+    if (!jxl::ParseDescription(output_description, &output_encoding_external)) {
       JXL_WARNING("Unrecognized output_description %s, try RGB_D65_SRG_Rel_Lin",
                   output_description.c_str());
       return false;  // already warned
@@ -281,4 +282,5 @@ Status BenchmarkArgs::ValidateArgs() {
   return true;
 }
 
-}  // namespace jxl
+}  // namespace tools
+}  // namespace jpegxl

--- a/tools/benchmark/benchmark_args.h
+++ b/tools/benchmark/benchmark_args.h
@@ -23,7 +23,12 @@
 #include "tools/args.h"
 #include "tools/cmdline.h"
 
-namespace jxl {
+namespace jpegxl {
+namespace tools {
+
+using ::jxl::ColorEncoding;
+using ::jxl::Override;
+using ::jxl::Status;
 
 std::vector<std::string> SplitString(const std::string& s, char c);
 
@@ -171,6 +176,7 @@ struct BenchmarkArgs {
 // Returns singleton
 BenchmarkArgs* Args();
 
-}  // namespace jxl
+}  // namespace tools
+}  // namespace jpegxl
 
 #endif  // TOOLS_BENCHMARK_BENCHMARK_ARGS_H_

--- a/tools/benchmark/benchmark_codec.cc
+++ b/tools/benchmark/benchmark_codec.cc
@@ -42,7 +42,11 @@
 #include "tools/benchmark/benchmark_codec_avif.h"
 #endif  // BENCHMARK_AVIF
 
-namespace jxl {
+namespace jpegxl {
+namespace tools {
+
+using ::jxl::Image3F;
+using ::jxl::ThreadPoolInternal;
 
 void ImageCodec::ParseParameters(const std::string& parameters) {
   params_ = parameters;
@@ -93,7 +97,7 @@ class NoneCodec : public ImageCodec {
                   ThreadPoolInternal* pool, std::vector<uint8_t>* compressed,
                   jpegxl::tools::SpeedStats* speed_stats) override {
     PROFILER_ZONE("NoneCompress");
-    const double start = Now();
+    const double start = jxl::Now();
     // Encode image size so we "decompress" something of the same size, as
     // required by butteraugli.
     const uint32_t xsize = io->xsize();
@@ -101,7 +105,7 @@ class NoneCodec : public ImageCodec {
     compressed->resize(8);
     memcpy(compressed->data(), &xsize, 4);
     memcpy(compressed->data() + 4, &ysize, 4);
-    const double end = Now();
+    const double end = jxl::Now();
     speed_stats->NotifyElapsed(end - start);
     return true;
   }
@@ -111,7 +115,7 @@ class NoneCodec : public ImageCodec {
                     ThreadPoolInternal* pool, CodecInOut* io,
                     jpegxl::tools::SpeedStats* speed_stats) override {
     PROFILER_ZONE("NoneDecompress");
-    const double start = Now();
+    const double start = jxl::Now();
     JXL_ASSERT(compressed.size() == 8);
     uint32_t xsize, ysize;
     memcpy(&xsize, compressed.data(), 4);
@@ -121,7 +125,7 @@ class NoneCodec : public ImageCodec {
     io->metadata.m.SetFloat32Samples();
     io->metadata.m.color_encoding = ColorEncoding::SRGB();
     io->SetFromImage(std::move(image), io->metadata.m.color_encoding);
-    const double end = Now();
+    const double end = jxl::Now();
     speed_stats->NotifyElapsed(end - start);
     return true;
   }
@@ -170,4 +174,5 @@ ImageCodecPtr CreateImageCodec(const std::string& description) {
   return result;
 }
 
-}  // namespace jxl
+}  // namespace tools
+}  // namespace jpegxl

--- a/tools/benchmark/benchmark_codec.h
+++ b/tools/benchmark/benchmark_codec.h
@@ -26,7 +26,12 @@
 #include "tools/cmdline.h"
 #include "tools/speed_stats.h"
 
-namespace jxl {
+namespace jpegxl {
+namespace tools {
+
+using ::jxl::CodecInOut;
+using ::jxl::Span;
+using ::jxl::ThreadPoolInternal;
 
 // Thread-compatible.
 class ImageCodec {
@@ -89,6 +94,7 @@ using ImageCodecPtr = std::unique_ptr<ImageCodec>;
 // then ParseParameters of the codec gets called with the part behind the colon.
 ImageCodecPtr CreateImageCodec(const std::string& description);
 
-}  // namespace jxl
+}  // namespace tools
+}  // namespace jpegxl
 
 #endif  // TOOLS_BENCHMARK_BENCHMARK_CODEC_H_

--- a/tools/benchmark/benchmark_codec_avif.h
+++ b/tools/benchmark/benchmark_codec_avif.h
@@ -10,11 +10,13 @@
 #include "tools/benchmark/benchmark_args.h"
 #include "tools/benchmark/benchmark_codec.h"
 
-namespace jxl {
+namespace jpegxl {
+namespace tools {
 ImageCodec* CreateNewAvifCodec(const BenchmarkArgs& args);
 
 // Registers the avif-specific command line options.
 Status AddCommandLineOptionsAvifCodec(BenchmarkArgs* args);
-}  // namespace jxl
+}  // namespace tools
+}  // namespace jpegxl
 
 #endif  // TOOLS_BENCHMARK_BENCHMARK_CODEC_AVIF_H_

--- a/tools/benchmark/benchmark_codec_custom.cc
+++ b/tools/benchmark/benchmark_codec_custom.cc
@@ -22,7 +22,10 @@
 #include "lib/jxl/image_bundle.h"
 #include "tools/benchmark/benchmark_utils.h"
 
-namespace jxl {
+namespace jpegxl {
+namespace tools {
+
+using ::jxl::ThreadPoolInternal;
 
 struct CustomCodecArgs {
   std::string extension;
@@ -54,9 +57,9 @@ namespace {
 template <typename F>
 Status ReportCodecRunningTime(F&& function, std::string output_filename,
                               jpegxl::tools::SpeedStats* const speed_stats) {
-  const double start = Now();
+  const double start = jxl::Now();
   JXL_RETURN_IF_ERROR(function());
-  const double end = Now();
+  const double end = jxl::Now();
   const std::string time_filename =
       GetBaseName(std::move(output_filename)) + ".time";
   std::ifstream time_stream(time_filename);
@@ -133,9 +136,9 @@ class CustomCodec : public ImageCodec {
     if (!custom_args->colorspace.empty()) {
       JxlColorEncoding colorspace;
       JXL_RETURN_IF_ERROR(
-          ParseDescription(custom_args->colorspace, &colorspace));
+          jxl::ParseDescription(custom_args->colorspace, &colorspace));
       JXL_RETURN_IF_ERROR(
-          ConvertExternalToInternalColorEncoding(colorspace, &c_enc));
+          jxl::ConvertExternalToInternalColorEncoding(colorspace, &c_enc));
     }
     JXL_RETURN_IF_ERROR(EncodeToFile(*io, c_enc, bits, in_filename, pool));
     std::vector<std::string> arguments = compress_args_;
@@ -146,7 +149,7 @@ class CustomCodec : public ImageCodec {
           return RunCommand(compress_command_, arguments, custom_args->quiet);
         },
         encoded_filename, speed_stats));
-    return ReadFile(encoded_filename, compressed);
+    return jxl::ReadFile(encoded_filename, compressed);
   }
 
   Status Decompress(const std::string& filename,
@@ -160,7 +163,7 @@ class CustomCodec : public ImageCodec {
     JXL_RETURN_IF_ERROR(encoded_file.GetFileName(&encoded_filename));
     JXL_RETURN_IF_ERROR(out_file.GetFileName(&out_filename));
 
-    JXL_RETURN_IF_ERROR(WriteFile(compressed, encoded_filename));
+    JXL_RETURN_IF_ERROR(jxl::WriteFile(compressed, encoded_filename));
     JXL_RETURN_IF_ERROR(ReportCodecRunningTime(
         [&, this] {
           return RunCommand(
@@ -169,11 +172,11 @@ class CustomCodec : public ImageCodec {
               custom_args->quiet);
         },
         out_filename, speed_stats));
-    extras::ColorHints hints;
+    jxl::extras::ColorHints hints;
     if (!custom_args->colorspace.empty()) {
       hints.Add("color_space", custom_args->colorspace);
     }
-    JXL_RETURN_IF_ERROR(SetFromFile(out_filename, hints, io, pool));
+    JXL_RETURN_IF_ERROR(jxl::SetFromFile(out_filename, hints, io, pool));
     io->metadata.m.SetIntensityTarget(saved_intensity_target_);
     return true;
   }
@@ -193,15 +196,18 @@ ImageCodec* CreateNewCustomCodec(const BenchmarkArgs& args) {
   return new CustomCodec(args);
 }
 
-}  // namespace jxl
+}  // namespace tools
+}  // namespace jpegxl
 
 #else
 
-namespace jxl {
+namespace jpegxl {
+namespace tools {
 
 ImageCodec* CreateNewCustomCodec(const BenchmarkArgs& args) { return nullptr; }
 Status AddCommandLineOptionsCustomCodec(BenchmarkArgs* args) { return true; }
 
-}  // namespace jxl
+}  // namespace tools
+}  // namespace jpegxl
 
 #endif  // _MSC_VER

--- a/tools/benchmark/benchmark_codec_custom.h
+++ b/tools/benchmark/benchmark_codec_custom.h
@@ -37,11 +37,13 @@
 #include "tools/benchmark/benchmark_args.h"
 #include "tools/benchmark/benchmark_codec.h"
 
-namespace jxl {
+namespace jpegxl {
+namespace tools {
 
 ImageCodec* CreateNewCustomCodec(const BenchmarkArgs& args);
 Status AddCommandLineOptionsCustomCodec(BenchmarkArgs* args);
 
-}  // namespace jxl
+}  // namespace tools
+}  // namespace jpegxl
 
 #endif  // TOOLS_BENCHMARK_BENCHMARK_CODEC_CUSTOM_H_

--- a/tools/benchmark/benchmark_codec_jpeg.h
+++ b/tools/benchmark/benchmark_codec_jpeg.h
@@ -10,11 +10,13 @@
 #include "tools/benchmark/benchmark_args.h"
 #include "tools/benchmark/benchmark_codec.h"
 
-namespace jxl {
+namespace jpegxl {
+namespace tools {
 ImageCodec* CreateNewJPEGCodec(const BenchmarkArgs& args);
 
 // Registers the jpeg-specific command line options.
 Status AddCommandLineOptionsJPEGCodec(BenchmarkArgs* args);
-}  // namespace jxl
+}  // namespace tools
+}  // namespace jpegxl
 
 #endif  // TOOLS_BENCHMARK_BENCHMARK_CODEC_JPEG_H_

--- a/tools/benchmark/benchmark_codec_jxl.h
+++ b/tools/benchmark/benchmark_codec_jxl.h
@@ -12,12 +12,14 @@
 #include "tools/benchmark/benchmark_args.h"
 #include "tools/benchmark/benchmark_codec.h"
 
-namespace jxl {
+namespace jpegxl {
+namespace tools {
 ImageCodec* CreateNewJxlCodec(const BenchmarkArgs& args);
 
 // Registers the jxl-specific command line options.
 Status AddCommandLineOptionsJxlCodec(BenchmarkArgs* args);
 Status ValidateArgsJxlCodec(BenchmarkArgs* args);
-}  // namespace jxl
+}  // namespace tools
+}  // namespace jpegxl
 
 #endif  // TOOLS_BENCHMARK_BENCHMARK_CODEC_JXL_H_

--- a/tools/benchmark/benchmark_codec_png.cc
+++ b/tools/benchmark/benchmark_codec_png.cc
@@ -25,7 +25,10 @@
 #include "lib/jxl/image_bundle.h"
 #include "lib/jxl/image_metadata.h"
 
-namespace jxl {
+namespace jpegxl {
+namespace tools {
+
+using ::jxl::ThreadPoolInternal;
 
 struct PNGArgs {
   // Empty, no PNG-specific args currently.
@@ -46,10 +49,11 @@ class PNGCodec : public ImageCodec {
                   ThreadPoolInternal* pool, std::vector<uint8_t>* compressed,
                   jpegxl::tools::SpeedStats* speed_stats) override {
     const size_t bits = io->metadata.m.bit_depth.bits_per_sample;
-    const double start = Now();
-    JXL_RETURN_IF_ERROR(Encode(*io, extras::Codec::kPNG, io->Main().c_current(),
-                               bits, compressed, pool));
-    const double end = Now();
+    const double start = jxl::Now();
+    JXL_RETURN_IF_ERROR(jxl::Encode(*io, jxl::extras::Codec::kPNG,
+                                    io->Main().c_current(), bits, compressed,
+                                    pool));
+    const double end = jxl::Now();
     speed_stats->NotifyElapsed(end - start);
     return true;
   }
@@ -58,13 +62,14 @@ class PNGCodec : public ImageCodec {
                     const Span<const uint8_t> compressed,
                     ThreadPoolInternal* pool, CodecInOut* io,
                     jpegxl::tools::SpeedStats* speed_stats) override {
-    extras::PackedPixelFile ppf;
-    const double start = Now();
-    JXL_RETURN_IF_ERROR(extras::DecodeImageAPNG(
-        compressed, extras::ColorHints(), SizeConstraints(), &ppf));
-    const double end = Now();
+    jxl::extras::PackedPixelFile ppf;
+    const double start = jxl::Now();
+    JXL_RETURN_IF_ERROR(jxl::extras::DecodeImageAPNG(
+        compressed, jxl::extras::ColorHints(), jxl::SizeConstraints(), &ppf));
+    const double end = jxl::Now();
     speed_stats->NotifyElapsed(end - start);
-    JXL_RETURN_IF_ERROR(ConvertPackedPixelFileToCodecInOut(ppf, pool, io));
+    JXL_RETURN_IF_ERROR(
+        jxl::extras::ConvertPackedPixelFileToCodecInOut(ppf, pool, io));
     return true;
   }
 };
@@ -73,6 +78,7 @@ ImageCodec* CreateNewPNGCodec(const BenchmarkArgs& args) {
   return new PNGCodec(args);
 }
 
-}  // namespace jxl
+}  // namespace tools
+}  // namespace jpegxl
 
 #endif

--- a/tools/benchmark/benchmark_codec_png.h
+++ b/tools/benchmark/benchmark_codec_png.h
@@ -14,12 +14,14 @@
 #include "tools/benchmark/benchmark_args.h"
 #include "tools/benchmark/benchmark_codec.h"
 
-namespace jxl {
+namespace jpegxl {
+namespace tools {
 ImageCodec* CreateNewPNGCodec(const BenchmarkArgs& args);
 
 // Registers the png-specific command line options.
 Status AddCommandLineOptionsPNGCodec(BenchmarkArgs* args);
-}  // namespace jxl
+}  // namespace tools
+}  // namespace jpegxl
 
 #endif
 

--- a/tools/benchmark/benchmark_codec_webp.h
+++ b/tools/benchmark/benchmark_codec_webp.h
@@ -13,11 +13,13 @@
 #include "tools/benchmark/benchmark_args.h"
 #include "tools/benchmark/benchmark_codec.h"
 
-namespace jxl {
+namespace jpegxl {
+namespace tools {
 ImageCodec* CreateNewWebPCodec(const BenchmarkArgs& args);
 
 // Registers the webp-specific command line options.
 Status AddCommandLineOptionsWebPCodec(BenchmarkArgs* args);
-}  // namespace jxl
+}  // namespace tools
+}  // namespace jpegxl
 
 #endif  // TOOLS_BENCHMARK_BENCHMARK_CODEC_WEBP_H_

--- a/tools/benchmark/benchmark_file_io.cc
+++ b/tools/benchmark/benchmark_file_io.cc
@@ -38,7 +38,8 @@
 #define GLOB_TILDE 0
 #endif
 
-namespace jxl {
+namespace jpegxl {
+namespace tools {
 
 const char kPathSeparator = '/';
 
@@ -229,4 +230,5 @@ Status MatchFiles(const std::string& pattern, std::vector<std::string>* list) {
 #endif  // HAS_GLOB
 }
 
-}  // namespace jxl
+}  // namespace tools
+}  // namespace jpegxl

--- a/tools/benchmark/benchmark_file_io.h
+++ b/tools/benchmark/benchmark_file_io.h
@@ -15,7 +15,10 @@
 #include "lib/jxl/base/file_io.h"
 #include "lib/jxl/base/status.h"
 
-namespace jxl {
+namespace jpegxl {
+namespace tools {
+
+using ::jxl::Status;
 
 // Checks if the file exists, either as file or as directory
 bool PathExists(const std::string& fname);
@@ -48,6 +51,7 @@ Status MatchFiles(const std::string& pattern, std::vector<std::string>* list);
 
 std::string JoinPath(const std::string& first, const std::string& second);
 
-}  // namespace jxl
+}  // namespace tools
+}  // namespace jpegxl
 
 #endif  // TOOLS_BENCHMARK_BENCHMARK_FILE_IO_H_

--- a/tools/benchmark/benchmark_stats.cc
+++ b/tools/benchmark/benchmark_stats.cc
@@ -17,7 +17,8 @@
 #include "lib/jxl/base/status.h"
 #include "tools/benchmark/benchmark_args.h"
 
-namespace jxl {
+namespace jpegxl {
+namespace tools {
 namespace {
 
 // Computes longest codec name from Args()->codec, for table alignment.
@@ -169,7 +170,7 @@ void BenchmarkStats::PrintMoreStats() const {
   if (Args()->print_more_stats) {
     jxl_stats.Print();
     size_t total_bits = jxl_stats.aux_out.TotalBits();
-    size_t compressed_bits = total_compressed_size * kBitsPerByte;
+    size_t compressed_bits = total_compressed_size * jxl::kBitsPerByte;
     if (total_bits != compressed_bits) {
       printf("Total layer bits: %" PRIuS " vs total compressed bits: %" PRIuS
              "  (%.2f%% accounted for)\n",
@@ -377,4 +378,5 @@ std::string PrintAggregate(
   return PrintFormattedEntries(num_extra_metrics, result);
 }
 
-}  // namespace jxl
+}  // namespace tools
+}  // namespace jpegxl

--- a/tools/benchmark/benchmark_stats.h
+++ b/tools/benchmark/benchmark_stats.h
@@ -14,7 +14,10 @@
 
 #include "lib/jxl/enc_aux_out.h"
 
-namespace jxl {
+namespace jpegxl {
+namespace tools {
+
+using ::jxl::AuxOut;
 
 std::string StringPrintf(const char* format, ...);
 
@@ -77,6 +80,7 @@ std::string PrintAggregate(
     size_t num_extra_metrics,
     const std::vector<std::vector<ColumnValue>>& aggregate);
 
-}  // namespace jxl
+}  // namespace tools
+}  // namespace jpegxl
 
 #endif  // TOOLS_BENCHMARK_BENCHMARK_STATS_H_

--- a/tools/benchmark/benchmark_utils.cc
+++ b/tools/benchmark/benchmark_utils.cc
@@ -27,7 +27,8 @@
 
 extern char** environ;
 
-namespace jxl {
+namespace jpegxl {
+namespace tools {
 TemporaryFile::TemporaryFile(std::string basename, std::string extension) {
   const auto extension_size = 1 + extension.size();
   temp_filename_ = std::move(basename) + "_XXXXXX." + std::move(extension);
@@ -84,11 +85,13 @@ Status RunCommand(const std::string& command,
   return WIFEXITED(wstatus) && WEXITSTATUS(wstatus) == EXIT_SUCCESS;
 }
 
-}  // namespace jxl
+}  // namespace tools
+}  // namespace jpegxl
 
 #else
 
-namespace jxl {
+namespace jpegxl {
+namespace tools {
 
 TemporaryFile::TemporaryFile(std::string basename, std::string extension) {}
 TemporaryFile::~TemporaryFile() {}
@@ -104,6 +107,7 @@ Status RunCommand(const std::string& command,
   return JXL_FAILURE("Not supported on this build");
 }
 
-}  // namespace jxl
+}  // namespace tools
+}  // namespace jpegxl
 
 #endif  // _MSC_VER

--- a/tools/benchmark/benchmark_utils.h
+++ b/tools/benchmark/benchmark_utils.h
@@ -11,7 +11,10 @@
 
 #include "lib/jxl/base/status.h"
 
-namespace jxl {
+namespace jpegxl {
+namespace tools {
+
+using ::jxl::Status;
 
 class TemporaryFile final {
  public:
@@ -33,6 +36,7 @@ Status RunCommand(const std::string& command,
                   const std::vector<std::string>& arguments,
                   bool quiet = false);
 
-}  // namespace jxl
+}  // namespace tools
+}  // namespace jpegxl
 
 #endif  // TOOLS_BENCHMARK_BENCHMARK_UTILS_H_

--- a/tools/color_encoding_fuzzer.cc
+++ b/tools/color_encoding_fuzzer.cc
@@ -7,18 +7,20 @@
 
 #include "lib/extras/dec/color_description.h"
 
-namespace jxl {
+namespace jpegxl {
+namespace tools {
 
 int TestOneInput(const uint8_t* data, size_t size) {
   std::string description(reinterpret_cast<const char*>(data), size);
   JxlColorEncoding c;
-  (void)ParseDescription(description, &c);
+  (void)jxl::ParseDescription(description, &c);
 
   return 0;
 }
 
-}  // namespace jxl
+}  // namespace tools
+}  // namespace jpegxl
 
 extern "C" int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size) {
-  return jxl::TestOneInput(data, size);
+  return jpegxl::tools::TestOneInput(data, size);
 }

--- a/tools/comparison_viewer/codec_comparison_window.cc
+++ b/tools/comparison_viewer/codec_comparison_window.cc
@@ -31,7 +31,8 @@
 #include "tools/comparison_viewer/split_image_view.h"
 #include "tools/icc_detect/icc_detect.h"
 
-namespace jxl {
+namespace jpegxl {
+namespace tools {
 
 static constexpr char kPngSuffix[] = "png";
 
@@ -313,4 +314,5 @@ void CodecComparisonWindow::browseDirectory(const QDir& directory, int depth) {
   }
 }
 
-}  // namespace jxl
+}  // namespace tools
+}  // namespace jpegxl

--- a/tools/comparison_viewer/codec_comparison_window.h
+++ b/tools/comparison_viewer/codec_comparison_window.h
@@ -16,14 +16,16 @@
 #include "lib/jxl/common.h"
 #include "tools/comparison_viewer/ui_codec_comparison_window.h"
 
-namespace jxl {
+namespace jpegxl {
+namespace tools {
 
 class CodecComparisonWindow : public QMainWindow {
   Q_OBJECT
 
  public:
   explicit CodecComparisonWindow(
-      const QString& directory, float intensityTarget = kDefaultIntensityTarget,
+      const QString& directory,
+      float intensityTarget = jxl::kDefaultIntensityTarget,
       QWidget* parent = nullptr);
   ~CodecComparisonWindow() override = default;
 
@@ -72,6 +74,7 @@ class CodecComparisonWindow : public QMainWindow {
   const QByteArray monitorIccProfile_;
 };
 
-}  // namespace jxl
+}  // namespace tools
+}  // namespace jpegxl
 
 #endif  // TOOLS_COMPARISON_VIEWER_CODEC_COMPARISON_WINDOW_H_

--- a/tools/comparison_viewer/codec_comparison_window.ui
+++ b/tools/comparison_viewer/codec_comparison_window.ui
@@ -152,14 +152,14 @@
      </layout>
     </item>
     <item>
-     <widget class="jxl::SplitImageView" name="splitImageView" native="true"/>
+     <widget class="jpegxl::tools::SplitImageView" name="splitImageView" native="true"/>
     </item>
    </layout>
   </widget>
  </widget>
  <customwidgets>
   <customwidget>
-   <class>jxl::SplitImageView</class>
+   <class>jpegxl::tools::SplitImageView</class>
    <extends>QWidget</extends>
    <header>split_image_view.h</header>
    <container>1</container>

--- a/tools/comparison_viewer/compare_codecs.cc
+++ b/tools/comparison_viewer/compare_codecs.cc
@@ -66,7 +66,7 @@ int main(int argc, char** argv) {
 
   for (const QString& folder : folders) {
     auto* const window =
-        new jxl::CodecComparisonWindow(folder, intensityTarget);
+        new jpegxl::tools::CodecComparisonWindow(folder, intensityTarget);
     window->setAttribute(Qt::WA_DeleteOnClose);
     window->show();
   }

--- a/tools/comparison_viewer/compare_images.cc
+++ b/tools/comparison_viewer/compare_images.cc
@@ -87,13 +87,14 @@ int main(int argc, char** argv) {
     parser.showHelp(EXIT_FAILURE);
   }
 
-  jxl::SplitImageView view;
+  jpegxl::tools::SplitImageView view;
 
-  const QByteArray monitorIccProfile = jxl::GetMonitorIccProfile(&view);
+  const QByteArray monitorIccProfile =
+      jpegxl::tools::GetMonitorIccProfile(&view);
 
   const QString leftImagePath = arguments.takeFirst();
-  QImage leftImage = jxl::loadImage(leftImagePath, monitorIccProfile,
-                                    intensityTarget, colorSpaceHint);
+  QImage leftImage = jpegxl::tools::loadImage(leftImagePath, monitorIccProfile,
+                                              intensityTarget, colorSpaceHint);
   if (leftImage.isNull()) {
     displayLoadingError(leftImagePath);
     return EXIT_FAILURE;
@@ -101,8 +102,8 @@ int main(int argc, char** argv) {
   view.setLeftImage(std::move(leftImage));
 
   const QString rightImagePath = arguments.takeFirst();
-  QImage rightImage = jxl::loadImage(rightImagePath, monitorIccProfile,
-                                     intensityTarget, colorSpaceHint);
+  QImage rightImage = jpegxl::tools::loadImage(
+      rightImagePath, monitorIccProfile, intensityTarget, colorSpaceHint);
   if (rightImage.isNull()) {
     displayLoadingError(rightImagePath);
     return EXIT_FAILURE;
@@ -111,8 +112,8 @@ int main(int argc, char** argv) {
 
   if (!arguments.empty()) {
     const QString middleImagePath = arguments.takeFirst();
-    QImage middleImage = jxl::loadImage(middleImagePath, monitorIccProfile,
-                                        intensityTarget, colorSpaceHint);
+    QImage middleImage = jpegxl::tools::loadImage(
+        middleImagePath, monitorIccProfile, intensityTarget, colorSpaceHint);
     if (middleImage.isNull()) {
       displayLoadingError(middleImagePath);
       return EXIT_FAILURE;

--- a/tools/comparison_viewer/image_loading.h
+++ b/tools/comparison_viewer/image_loading.h
@@ -12,7 +12,8 @@
 
 #include "lib/jxl/common.h"
 
-namespace jxl {
+namespace jpegxl {
+namespace tools {
 
 // `extension` should not include the dot.
 bool canLoadImageWithExtension(QString extension);
@@ -21,9 +22,10 @@ bool canLoadImageWithExtension(QString extension);
 // specified. Thread-hostile.
 QImage loadImage(const QString& filename,
                  const QByteArray& targetIccProfile = QByteArray(),
-                 float intensityTarget = kDefaultIntensityTarget,
+                 float intensityTarget = jxl::kDefaultIntensityTarget,
                  const QString& sourceColorSpaceHint = QString());
 
-}  // namespace jxl
+}  // namespace tools
+}  // namespace jpegxl
 
 #endif  // TOOLS_COMPARISON_VIEWER_IMAGE_LOADING_H_

--- a/tools/comparison_viewer/settings.cc
+++ b/tools/comparison_viewer/settings.cc
@@ -5,7 +5,8 @@
 
 #include "tools/comparison_viewer/settings.h"
 
-namespace jxl {
+namespace jpegxl {
+namespace tools {
 
 SettingsDialog::SettingsDialog(QWidget* const parent)
     : QDialog(parent), settings_("JPEG XL project", "Comparison tool") {
@@ -48,4 +49,5 @@ void SettingsDialog::settingsToUi() {
   ui_.grayTime->setValue(renderingSettings_.grayMSecs);
 }
 
-}  // namespace jxl
+}  // namespace tools
+}  // namespace jpegxl

--- a/tools/comparison_viewer/settings.h
+++ b/tools/comparison_viewer/settings.h
@@ -12,7 +12,8 @@
 #include "tools/comparison_viewer/split_image_renderer.h"
 #include "tools/comparison_viewer/ui_settings.h"
 
-namespace jxl {
+namespace jpegxl {
+namespace tools {
 
 class SettingsDialog : public QDialog {
   Q_OBJECT
@@ -35,6 +36,7 @@ class SettingsDialog : public QDialog {
   SplitImageRenderingSettings renderingSettings_;
 };
 
-}  // namespace jxl
+}  // namespace tools
+}  // namespace jpegxl
 
 #endif  // TOOLS_COMPARISON_VIEWER_SETTINGS_H_

--- a/tools/comparison_viewer/split_image_renderer.cc
+++ b/tools/comparison_viewer/split_image_renderer.cc
@@ -17,7 +17,8 @@
 #include <QPoint>
 #include <QRect>
 
-namespace jxl {
+namespace jpegxl {
+namespace tools {
 
 SplitImageRenderer::SplitImageRenderer(QWidget* const parent)
     : QWidget(parent) {
@@ -236,4 +237,5 @@ void SplitImageRenderer::setRenderingMode(const RenderingMode newMode) {
   emit renderingModeChanged(mode_);
 }
 
-}  // namespace jxl
+}  // namespace tools
+}  // namespace jpegxl

--- a/tools/comparison_viewer/split_image_renderer.h
+++ b/tools/comparison_viewer/split_image_renderer.h
@@ -15,7 +15,8 @@
 #include <QWheelEvent>
 #include <QWidget>
 
-namespace jxl {
+namespace jpegxl {
+namespace tools {
 
 struct SplitImageRenderingSettings {
   int fadingMSecs;
@@ -85,6 +86,7 @@ class SplitImageRenderer : public QWidget {
   double scale_ = 1.;
 };
 
-}  // namespace jxl
+}  // namespace tools
+}  // namespace jpegxl
 
 #endif  // TOOLS_COMPARISON_VIEWER_SPLIT_IMAGE_RENDERER_H_

--- a/tools/comparison_viewer/split_image_view.cc
+++ b/tools/comparison_viewer/split_image_view.cc
@@ -11,7 +11,8 @@
 
 #include "tools/comparison_viewer/split_image_renderer.h"
 
-namespace jxl {
+namespace jpegxl {
+namespace tools {
 
 SplitImageView::SplitImageView(QWidget* const parent) : QWidget(parent) {
   ui_.setupUi(this);
@@ -68,4 +69,5 @@ void SplitImageView::on_settingsButton_clicked() {
   }
 }
 
-}  // namespace jxl
+}  // namespace tools
+}  // namespace jpegxl

--- a/tools/comparison_viewer/split_image_view.h
+++ b/tools/comparison_viewer/split_image_view.h
@@ -11,7 +11,8 @@
 #include "tools/comparison_viewer/settings.h"
 #include "tools/comparison_viewer/ui_split_image_view.h"
 
-namespace jxl {
+namespace jpegxl {
+namespace tools {
 
 class SplitImageView : public QWidget {
   Q_OBJECT
@@ -35,6 +36,7 @@ class SplitImageView : public QWidget {
   SettingsDialog settings_;
 };
 
-}  // namespace jxl
+}  // namespace tools
+}  // namespace jpegxl
 
 #endif  // TOOLS_COMPARISON_VIEWER_SPLIT_IMAGE_VIEW_H_

--- a/tools/comparison_viewer/split_image_view.ui
+++ b/tools/comparison_viewer/split_image_view.ui
@@ -17,7 +17,7 @@
      <property name="widgetResizable">
       <bool>true</bool>
      </property>
-     <widget class="jxl::SplitImageRenderer" name="splitImageRenderer"/>
+     <widget class="jpegxl::tools::SplitImageRenderer" name="splitImageRenderer"/>
     </widget>
    </item>
    <item>
@@ -130,7 +130,7 @@
  </widget>
  <customwidgets>
   <customwidget>
-   <class>jxl::SplitImageRenderer</class>
+   <class>jpegxl::tools::SplitImageRenderer</class>
    <extends>QWidget</extends>
    <header>split_image_renderer.h</header>
    <container>1</container>

--- a/tools/decode_and_encode.cc
+++ b/tools/decode_and_encode.cc
@@ -13,7 +13,6 @@
 #include "lib/jxl/base/thread_pool_internal.h"
 #include "lib/jxl/codec_in_out.h"
 
-namespace jxl {
 namespace {
 
 // Reads an input file (typically PNM) with color_space hint and writes to an
@@ -27,16 +26,16 @@ int Convert(int argc, char** argv) {
   const std::string& desc = argv[2];
   const std::string& pathname_out = argv[3];
 
-  CodecInOut io;
-  extras::ColorHints color_hints;
-  ThreadPoolInternal pool(4);
+  jxl::CodecInOut io;
+  jxl::extras::ColorHints color_hints;
+  jxl::ThreadPoolInternal pool(4);
   color_hints.Add("color_space", desc);
-  if (!SetFromFile(pathname_in, color_hints, &io, &pool)) {
+  if (!jxl::SetFromFile(pathname_in, color_hints, &io, &pool)) {
     fprintf(stderr, "Failed to read %s\n", pathname_in.c_str());
     return 1;
   }
 
-  if (!EncodeToFile(io, pathname_out, &pool)) {
+  if (!jxl::EncodeToFile(io, pathname_out, &pool)) {
     fprintf(stderr, "Failed to write %s\n", pathname_out.c_str());
     return 1;
   }
@@ -45,6 +44,5 @@ int Convert(int argc, char** argv) {
 }
 
 }  // namespace
-}  // namespace jxl
 
-int main(int argc, char** argv) { return jxl::Convert(argc, argv); }
+int main(int argc, char** argv) { return Convert(argc, argv); }

--- a/tools/decode_basic_info_fuzzer.cc
+++ b/tools/decode_basic_info_fuzzer.cc
@@ -6,7 +6,8 @@
 #include <jxl/decode.h>
 #include <stdint.h>
 
-namespace jxl {
+namespace jpegxl {
+namespace tools {
 
 int TestOneInput(const uint8_t* data, size_t size) {
   JxlDecoderStatus status;
@@ -50,8 +51,9 @@ int TestOneInput(const uint8_t* data, size_t size) {
   return 0;
 }
 
-}  // namespace jxl
+}  // namespace tools
+}  // namespace jpegxl
 
 extern "C" int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size) {
-  return jxl::TestOneInput(data, size);
+  return jpegxl::tools::TestOneInput(data, size);
 }

--- a/tools/fields_fuzzer.cc
+++ b/tools/fields_fuzzer.cc
@@ -15,7 +15,15 @@
 #include "lib/jxl/modular/encoding/encoding.h"
 #include "lib/jxl/modular/transform/transform.h"
 
-namespace jxl {
+namespace jpegxl {
+namespace tools {
+
+using ::jxl::BitReader;
+using ::jxl::CodecMetadata;
+using ::jxl::CustomTransformData;
+using ::jxl::ImageMetadata;
+using ::jxl::SizeHeader;
+using ::jxl::Span;
 
 int TestOneInput(const uint8_t* data, size_t size) {
   // Global parameters used by some headers.
@@ -26,20 +34,20 @@ int TestOneInput(const uint8_t* data, size_t size) {
   BitReader reader(Span<const uint8_t>(data + 1, size - 1));
 #define FUZZER_CASE_HEADER(number, classname, ...) \
   case number: {                                   \
-    classname header{__VA_ARGS__};                 \
-    (void)Bundle::Read(&reader, &header);          \
+    ::jxl::classname header{__VA_ARGS__};          \
+    (void)jxl::Bundle::Read(&reader, &header);     \
     break;                                         \
   }
   switch (data[0]) {
     case 0: {
       SizeHeader size_header;
-      (void)ReadSizeHeader(&reader, &size_header);
+      (void)jxl::ReadSizeHeader(&reader, &size_header);
       break;
     }
 
     case 1: {
       ImageMetadata metadata;
-      (void)ReadImageMetadata(&reader, &metadata);
+      (void)jxl::ReadImageMetadata(&reader, &metadata);
       break;
     }
 
@@ -69,7 +77,7 @@ int TestOneInput(const uint8_t* data, size_t size) {
     default: {
       CustomTransformData transform_data;
       transform_data.nonserialized_xyb_encoded = true;
-      (void)Bundle::Read(&reader, &transform_data);
+      (void)jxl::Bundle::Read(&reader, &transform_data);
       break;
     }
   }
@@ -78,8 +86,9 @@ int TestOneInput(const uint8_t* data, size_t size) {
   return 0;
 }
 
-}  // namespace jxl
+}  // namespace tools
+}  // namespace jpegxl
 
 extern "C" int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size) {
-  return jxl::TestOneInput(data, size);
+  return jpegxl::tools::TestOneInput(data, size);
 }

--- a/tools/flicker_test/main.cc
+++ b/tools/flicker_test/main.cc
@@ -11,9 +11,9 @@
 int main(int argc, char** argv) {
   QApplication application(argc, argv);
 
-  jxl::FlickerTestWizard wizard;
+  jpegxl::tools::FlickerTestWizard wizard;
   if (wizard.exec()) {
-    jxl::FlickerTestWindow test_window(wizard.parameters());
+    jpegxl::tools::FlickerTestWindow test_window(wizard.parameters());
     if (test_window.proceedWithTest()) {
       test_window.showMaximized();
       return application.exec();

--- a/tools/flicker_test/parameters.cc
+++ b/tools/flicker_test/parameters.cc
@@ -5,7 +5,8 @@
 
 #include "tools/flicker_test/parameters.h"
 
-namespace jxl {
+namespace jpegxl {
+namespace tools {
 
 namespace {
 
@@ -84,4 +85,5 @@ void FlickerTestParameters::saveTo(QSettings* const settings) const {
   settings->endGroup();
 }
 
-}  // namespace jxl
+}  // namespace tools
+}  // namespace jpegxl

--- a/tools/flicker_test/parameters.h
+++ b/tools/flicker_test/parameters.h
@@ -8,7 +8,8 @@
 
 #include <QSettings>
 
-namespace jxl {
+namespace jpegxl {
+namespace tools {
 
 struct FlickerTestParameters {
   QString originalFolder;
@@ -27,6 +28,7 @@ struct FlickerTestParameters {
   void saveTo(QSettings* settings) const;
 };
 
-}  // namespace jxl
+}  // namespace tools
+}  // namespace jpegxl
 
 #endif  // TOOLS_FLICKER_TEST_PARAMETERS_H_

--- a/tools/flicker_test/setup.cc
+++ b/tools/flicker_test/setup.cc
@@ -11,7 +11,8 @@
 #include <QMessageBox>
 #include <QPushButton>
 
-namespace jxl {
+namespace jpegxl {
+namespace tools {
 
 FlickerTestWizard::FlickerTestWizard(QWidget* const parent)
     : QWizard(parent), settings_("JPEG XL project", "Flickering test") {
@@ -148,4 +149,5 @@ bool FlickerTestWizard::validateCurrentPage() {
   return QWizard::validateCurrentPage();
 }
 
-}  // namespace jxl
+}  // namespace tools
+}  // namespace jpegxl

--- a/tools/flicker_test/setup.h
+++ b/tools/flicker_test/setup.h
@@ -11,7 +11,8 @@
 #include "tools/flicker_test/parameters.h"
 #include "tools/flicker_test/ui_setup.h"
 
-namespace jxl {
+namespace jpegxl {
+namespace tools {
 
 class FlickerTestWizard : public QWizard {
   Q_OBJECT
@@ -39,6 +40,7 @@ class FlickerTestWizard : public QWizard {
   QSettings settings_;
 };
 
-}  // namespace jxl
+}  // namespace tools
+}  // namespace jpegxl
 
 #endif  // TOOLS_FLICKER_TEST_SETUP_H_

--- a/tools/flicker_test/setup.ui
+++ b/tools/flicker_test/setup.ui
@@ -328,7 +328,7 @@
   <widget class="QWizardPage" name="spacingPage">
    <layout class="QVBoxLayout" name="verticalLayout_3" stretch="1,0,0">
     <item>
-     <widget class="jxl::SplitView" name="spacingDemo" native="true"/>
+     <widget class="jpegxl::tools::SplitView" name="spacingDemo" native="true"/>
     </item>
     <item>
      <spacer name="verticalSpacer_2">
@@ -389,7 +389,7 @@
  </widget>
  <customwidgets>
   <customwidget>
-   <class>jxl::SplitView</class>
+   <class>jpegxl::tools::SplitView</class>
    <extends>QWidget</extends>
    <header>tools/flicker_test/split_view.h</header>
    <container>1</container>

--- a/tools/flicker_test/split_view.cc
+++ b/tools/flicker_test/split_view.cc
@@ -8,7 +8,8 @@
 #include <QMouseEvent>
 #include <QPainter>
 
-namespace jxl {
+namespace jpegxl {
+namespace tools {
 
 SplitView::SplitView(QWidget* const parent)
     : QWidget(parent), g_(std::random_device()()) {
@@ -164,4 +165,5 @@ void SplitView::updateMinimumSize() {
   setMinimumHeight(std::max(original_.height(), altered_.height()));
 }
 
-}  // namespace jxl
+}  // namespace tools
+}  // namespace jpegxl

--- a/tools/flicker_test/split_view.h
+++ b/tools/flicker_test/split_view.h
@@ -14,7 +14,8 @@
 #include <QWidget>
 #include <random>
 
-namespace jxl {
+namespace jpegxl {
+namespace tools {
 
 class SplitView : public QWidget {
   Q_OBJECT
@@ -79,6 +80,7 @@ class SplitView : public QWidget {
   QElapsedTimer viewingStartTime_;
 };
 
-}  // namespace jxl
+}  // namespace tools
+}  // namespace jpegxl
 
 #endif  // TOOLS_FLICKER_TEST_SPLIT_VIEW_H_

--- a/tools/flicker_test/test_window.cc
+++ b/tools/flicker_test/test_window.cc
@@ -13,7 +13,8 @@
 
 #include "tools/icc_detect/icc_detect.h"
 
-namespace jxl {
+namespace jpegxl {
+namespace tools {
 
 FlickerTestWindow::FlickerTestWindow(FlickerTestParameters parameters,
                                      QWidget* const parent)
@@ -181,4 +182,5 @@ retry:
       parameters_.grayFadingTimeMSecs, parameters_.grayTimeMSecs);
 }
 
-}  // namespace jxl
+}  // namespace tools
+}  // namespace jpegxl

--- a/tools/flicker_test/test_window.h
+++ b/tools/flicker_test/test_window.h
@@ -16,7 +16,8 @@
 #include "tools/flicker_test/parameters.h"
 #include "tools/flicker_test/ui_test_window.h"
 
-namespace jxl {
+namespace jpegxl {
+namespace tools {
 
 class FlickerTestWindow : public QMainWindow {
   Q_OBJECT
@@ -45,6 +46,7 @@ class FlickerTestWindow : public QMainWindow {
   QStringList remainingImages_;
 };
 
-}  // namespace jxl
+}  // namespace tools
+}  // namespace jpegxl
 
 #endif  // TOOLS_FLICKER_TEST_TEST_WINDOW_H_

--- a/tools/flicker_test/test_window.ui
+++ b/tools/flicker_test/test_window.ui
@@ -64,7 +64,7 @@
         </item>
        </layout>
       </widget>
-      <widget class="jxl::SplitView" name="splitView"/>
+      <widget class="jpegxl::tools::SplitView" name="splitView"/>
       <widget class="QWidget" name="finalPage">
        <layout class="QVBoxLayout" name="verticalLayout_3">
         <item>
@@ -104,7 +104,7 @@
  </widget>
  <customwidgets>
   <customwidget>
-   <class>jxl::SplitView</class>
+   <class>jpegxl::tools::SplitView</class>
    <extends>QWidget</extends>
    <header>tools/flicker_test/split_view.h</header>
    <container>1</container>

--- a/tools/fuzzer_corpus.cc
+++ b/tools/fuzzer_corpus.cc
@@ -458,14 +458,13 @@ int main(int argc, const char** argv) {
     specs.back().override_decoder_spec = 0;
 
     jxl::ThreadPoolInternal pool{num_threads};
-    if (!RunOnPool(
-            &pool, 0, specs.size(), jxl::ThreadPool::NoInit,
-            [&specs, dest_dir, regenerate, quiet](const uint32_t task,
-                                                  size_t /* thread */) {
-              const ImageSpec& spec = specs[task];
-              GenerateFile(dest_dir, spec, regenerate, quiet);
-            },
-            "FuzzerCorpus")) {
+    const auto generate = [&specs, dest_dir, regenerate, quiet](
+                              const uint32_t task, size_t /* thread */) {
+      const ImageSpec& spec = specs[task];
+      GenerateFile(dest_dir, spec, regenerate, quiet);
+    };
+    if (!RunOnPool(&pool, 0, specs.size(), jxl::ThreadPool::NoInit, generate,
+                   "FuzzerCorpus")) {
       std::cerr << "Error generating fuzzer corpus" << std::endl;
       return 1;
     }

--- a/tools/icc_detect/icc_detect.h
+++ b/tools/icc_detect/icc_detect.h
@@ -9,11 +9,13 @@
 #include <QByteArray>
 #include <QWidget>
 
-namespace jxl {
+namespace jpegxl {
+namespace tools {
 
 // Should be cached if possible.
 QByteArray GetMonitorIccProfile(const QWidget* widget);
 
-}  // namespace jxl
+}  // namespace tools
+}  // namespace jpegxl
 
 #endif  // TOOLS_ICC_DETECT_ICC_DETECT_H_

--- a/tools/icc_detect/icc_detect_empty.cc
+++ b/tools/icc_detect/icc_detect_empty.cc
@@ -5,10 +5,12 @@
 
 #include "tools/icc_detect/icc_detect.h"
 
-namespace jxl {
+namespace jpegxl {
+namespace tools {
 
 QByteArray GetMonitorIccProfile(const QWidget* const /*widget*/) {
   return QByteArray();
 }
 
-}  // namespace jxl
+}  // namespace tools
+}  // namespace jpegxl

--- a/tools/icc_detect/icc_detect_win32.cc
+++ b/tools/icc_detect/icc_detect_win32.cc
@@ -10,7 +10,8 @@
 #include <memory>
 #include <type_traits>
 
-namespace jxl {
+namespace jpegxl {
+namespace tools {
 
 namespace {
 
@@ -61,4 +62,5 @@ QByteArray GetMonitorIccProfile(const QWidget* const widget) {
   return profile;
 }
 
-}  // namespace jxl
+}  // namespace tools
+}  // namespace jpegxl

--- a/tools/icc_detect/icc_detect_x11.cc
+++ b/tools/icc_detect/icc_detect_x11.cc
@@ -13,7 +13,8 @@
 #include <algorithm>
 #include <memory>
 
-namespace jxl {
+namespace jpegxl {
+namespace tools {
 
 namespace {
 
@@ -74,4 +75,5 @@ QByteArray GetMonitorIccProfile(const QWidget* const widget) {
       xcb_get_property_value_length(profile.get()));
 }
 
-}  // namespace jxl
+}  // namespace tools
+}  // namespace jpegxl

--- a/tools/image_utils.cc
+++ b/tools/image_utils.cc
@@ -12,14 +12,20 @@
 namespace jpegxl {
 namespace tools {
 
-jxl::Status TransformCodecInOutTo(jxl::CodecInOut& io,
-                                  const jxl::ColorEncoding& c_desired,
+using ::jxl::CodecInOut;
+using ::jxl::ColorEncoding;
+using ::jxl::ImageBundle;
+using ::jxl::Status;
+using ::jxl::ThreadPool;
+
+jxl::Status TransformCodecInOutTo(CodecInOut& io,
+                                  const ColorEncoding& c_desired,
                                   const JxlCmsInterface& cms,
-                                  jxl::ThreadPool* pool) {
+                                  ThreadPool* pool) {
   if (io.metadata.m.have_preview) {
     JXL_RETURN_IF_ERROR(io.preview_frame.TransformTo(c_desired, cms, pool));
   }
-  for (jxl::ImageBundle& ib : io.frames) {
+  for (ImageBundle& ib : io.frames) {
     JXL_RETURN_IF_ERROR(ib.TransformTo(c_desired, cms, pool));
   }
   return true;

--- a/tools/image_utils.h
+++ b/tools/image_utils.h
@@ -10,6 +10,7 @@
 
 #include "lib/jxl/base/status.h"
 
+// Forward declarations.
 namespace jxl {
 class CodecInOut;
 struct ColorEncoding;

--- a/tools/rans_fuzzer.cc
+++ b/tools/rans_fuzzer.cc
@@ -6,7 +6,15 @@
 #include "lib/jxl/dec_ans.h"
 #include "lib/jxl/entropy_coder.h"
 
-namespace jxl {
+namespace jpegxl {
+namespace tools {
+
+using ::jxl::ANSCode;
+using ::jxl::ANSSymbolReader;
+using ::jxl::BitReader;
+using ::jxl::BitReaderScopedCloser;
+using ::jxl::Span;
+using ::jxl::Status;
 
 int TestOneInput(const uint8_t* data, size_t size) {
   if (size < 2) return 0;
@@ -28,7 +36,7 @@ int TestOneInput(const uint8_t* data, size_t size) {
     const size_t maxreads = size * 8;
     size_t numreads = 0;
     int context = 0;
-    while (DivCeil(br.TotalBitsConsumed(), kBitsPerByte) < size &&
+    while (jxl::DivCeil(br.TotalBitsConsumed(), jxl::kBitsPerByte) < size &&
            numreads <= maxreads) {
       int code = ansreader.ReadHybridUint(context, &br, context_map);
       context = code % numContexts;
@@ -39,8 +47,9 @@ int TestOneInput(const uint8_t* data, size_t size) {
   return 0;
 }
 
-}  // namespace jxl
+}  // namespace tools
+}  // namespace jpegxl
 
 extern "C" int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size) {
-  return jxl::TestOneInput(data, size);
+  return jpegxl::tools::TestOneInput(data, size);
 }

--- a/tools/set_from_bytes_fuzzer.cc
+++ b/tools/set_from_bytes_fuzzer.cc
@@ -12,22 +12,22 @@
 #include "lib/jxl/base/thread_pool_internal.h"
 #include "lib/jxl/codec_in_out.h"
 
-namespace jxl {
+namespace {
 
 int TestOneInput(const uint8_t* data, size_t size) {
-  CodecInOut io;
+  jxl::CodecInOut io;
   io.constraints.dec_max_xsize = 1u << 16;
   io.constraints.dec_max_ysize = 1u << 16;
   io.constraints.dec_max_pixels = 1u << 22;
-  ThreadPoolInternal pool(0);
+  jxl::ThreadPoolInternal pool(0);
 
-  (void)SetFromBytes(Span<const uint8_t>(data, size), &io, &pool);
+  (void)jxl::SetFromBytes(jxl::Span<const uint8_t>(data, size), &io, &pool);
 
   return 0;
 }
 
-}  // namespace jxl
+}  // namespace
 
 extern "C" int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size) {
-  return jxl::TestOneInput(data, size);
+  return TestOneInput(data, size);
 }

--- a/tools/viewer/load_jxl.cc
+++ b/tools/viewer/load_jxl.cc
@@ -16,7 +16,8 @@
 
 #include "lcms2.h"
 
-namespace jxl {
+namespace jpegxl {
+namespace tools {
 
 namespace {
 
@@ -171,4 +172,5 @@ QImage loadJxlImage(const QString& filename, const QByteArray& targetIccProfile,
   return result;
 }
 
-}  // namespace jxl
+}  // namespace tools
+}  // namespace jpegxl

--- a/tools/viewer/load_jxl.h
+++ b/tools/viewer/load_jxl.h
@@ -10,11 +10,13 @@
 #include <QImage>
 #include <QString>
 
-namespace jxl {
+namespace jpegxl {
+namespace tools {
 
 QImage loadJxlImage(const QString& filename, const QByteArray& targetIccProfile,
                     qint64* elapsed, bool* usedRequestedProfile = nullptr);
 
-}  // namespace jxl
+}  // namespace tools
+}  // namespace jpegxl
 
 #endif  // TOOLS_VIEWER_LOAD_JXL_H_

--- a/tools/viewer/main.cc
+++ b/tools/viewer/main.cc
@@ -12,7 +12,7 @@ int main(int argc, char** argv) {
   QStringList arguments = application.arguments();
   arguments.removeFirst();
 
-  jxl::ViewerWindow window;
+  jpegxl::tools::ViewerWindow window;
   window.show();
 
   if (!arguments.empty()) {

--- a/tools/viewer/viewer_window.cc
+++ b/tools/viewer/viewer_window.cc
@@ -15,7 +15,8 @@
 #include "tools/icc_detect/icc_detect.h"
 #include "tools/viewer/load_jxl.h"
 
-namespace jxl {
+namespace jpegxl {
+namespace tools {
 
 namespace {
 
@@ -127,4 +128,5 @@ void ViewerWindow::refreshImage() {
   }
 }
 
-}  // namespace jxl
+}  // namespace tools
+}  // namespace jpegxl

--- a/tools/viewer/viewer_window.h
+++ b/tools/viewer/viewer_window.h
@@ -12,7 +12,8 @@
 
 #include "tools/viewer/ui_viewer_window.h"
 
-namespace jxl {
+namespace jpegxl {
+namespace tools {
 
 class ViewerWindow : public QMainWindow {
   Q_OBJECT
@@ -36,6 +37,7 @@ class ViewerWindow : public QMainWindow {
   bool hasWarnedAboutMonitorProfile_ = false;
 };
 
-}  // namespace jxl
+}  // namespace tools
+}  // namespace jpegxl
 
 #endif  // TOOLS_VIEWER_VIEWER_WINDOW_H_

--- a/tools/xyb_range.cc
+++ b/tools/xyb_range.cc
@@ -18,8 +18,15 @@
 #include "lib/jxl/image.h"
 #include "lib/jxl/image_bundle.h"
 
-namespace jxl {
+namespace jpegxl {
+namespace tools {
 namespace {
+
+using ::jxl::CodecInOut;
+using ::jxl::ColorEncoding;
+using ::jxl::Image3F;
+using ::jxl::ImageBundle;
+using ::jxl::ThreadPool;
 
 void PrintXybRange() {
   Image3F linear(1u << 16, 257);
@@ -43,7 +50,7 @@ void PrintXybRange() {
   const ImageBundle& ib = io.Main();
   ThreadPool* null_pool = nullptr;
   Image3F opsin(ib.xsize(), ib.ysize());
-  (void)ToXYB(ib, null_pool, &opsin, GetJxlCms());
+  (void)jxl::ToXYB(ib, null_pool, &opsin, jxl::GetJxlCms());
   for (size_t c = 0; c < 3; ++c) {
     float minval = 1e10f;
     float maxval = -1e10f;
@@ -75,6 +82,7 @@ void PrintXybRange() {
 }
 
 }  // namespace
-}  // namespace jxl
+}  // namespace tools
+}  // namespace jpegxl
 
-int main() { jxl::PrintXybRange(); }
+int main() { jpegxl::tools::PrintXybRange(); }


### PR DESCRIPTION
jxl namespace is meant to be used only by libjxl itself. threads, tools, benchmarks, etc. should reside in jpegxl namespce.