### PR TITLE
Move ThreadPoolInternal out of base/

### DIFF
--- a/lib/BUILD
+++ b/lib/BUILD
@@ -107,6 +107,7 @@ cc_library(
     name = 'includes',
     hdrs = libjxl_public_headers + [JXL_EXPORT_H],
     strip_include_prefix = 'include',
+    deps = [":jpegxl_version"],
 )
 
 cc_library(
@@ -125,7 +126,6 @@ cc_library(
     deps = [
         ':base',
         ':includes',
-        ':jpegxl_version',
     ] + libjxl_deps_brotli + libjxl_deps_hwy + libjxl_deps_skcms
 )
 

--- a/lib/extras/codec_test.cc
+++ b/lib/extras/codec_test.cc
@@ -20,7 +20,6 @@
 #include "lib/extras/enc/encode.h"
 #include "lib/extras/packed_image_convert.h"
 #include "lib/jxl/base/random.h"
-#include "lib/jxl/base/thread_pool_internal.h"
 #include "lib/jxl/color_management.h"
 #include "lib/jxl/enc_butteraugli_comparator.h"
 #include "lib/jxl/enc_color_management.h"
@@ -31,6 +30,9 @@
 #include "lib/jxl/testing.h"
 
 namespace jxl {
+
+using test::ThreadPoolForTests;
+
 namespace extras {
 namespace {
 
@@ -315,7 +317,7 @@ void TestRoundTrip(const TestImageParams& params, ThreadPool* pool) {
 }
 
 TEST(CodecTest, TestRoundTrip) {
-  ThreadPoolInternal pool(12);
+  ThreadPoolForTests pool(12);
 
   TestImageParams params;
   params.xsize = 7;
@@ -345,7 +347,7 @@ TEST(CodecTest, TestRoundTrip) {
 }
 
 TEST(CodecTest, LosslessPNMRoundtrip) {
-  ThreadPoolInternal pool(12);
+  ThreadPoolForTests pool(12);
 
   static const char* kChannels[] = {"", "g", "ga", "rgb", "rgba"};
   static const char* kExtension[] = {"", ".pgm", ".pam", ".ppm", ".pam"};
@@ -422,7 +424,7 @@ void DecodeRoundtrip(const std::string& pathname, ThreadPool* pool,
 
 #if 0
 TEST(CodecTest, TestMetadataSRGB) {
-  ThreadPoolInternal pool(12);
+  ThreadPoolForTests pool(12);
 
   const char* paths[] = {"external/raw.pixls/DJI-FC6310-16bit_srgb8_v4_krita.png",
                          "external/raw.pixls/Google-Pixel2XL-16bit_srgb8_v4_krita.png",
@@ -450,7 +452,7 @@ TEST(CodecTest, TestMetadataSRGB) {
 }
 
 TEST(CodecTest, TestMetadataLinear) {
-  ThreadPoolInternal pool(12);
+  ThreadPoolForTests pool(12);
 
   const char* paths[3] = {
       "external/raw.pixls/Google-Pixel2XL-16bit_acescg_g1_v4_krita.png",
@@ -483,7 +485,7 @@ TEST(CodecTest, TestMetadataLinear) {
 }
 
 TEST(CodecTest, TestMetadataICC) {
-  ThreadPoolInternal pool(12);
+  ThreadPoolForTests pool(12);
 
   const char* paths[] = {
       "external/raw.pixls/DJI-FC6310-16bit_709_v4_krita.png",
@@ -510,7 +512,7 @@ TEST(CodecTest, TestMetadataICC) {
 }
 
 TEST(CodecTest, Testexternal/pngsuite) {
-  ThreadPoolInternal pool(12);
+  ThreadPoolForTests pool(12);
 
   // Ensure we can load PNG with text, japanese UTF-8, compressed text.
   CodecInOut tmp1;
@@ -556,7 +558,7 @@ void VerifyWideGamutMetadata(const std::string& relative_pathname,
 }
 
 TEST(CodecTest, TestWideGamut) {
-  ThreadPoolInternal pool(12);
+  ThreadPoolForTests pool(12);
   // VerifyWideGamutMetadata("external/wide-gamut-tests/P3-sRGB-color-bars.png",
   //                        Primaries::kP3, &pool);
   VerifyWideGamutMetadata("external/wide-gamut-tests/P3-sRGB-color-ring.png",

--- a/lib/jxl/bit_reader_test.cc
+++ b/lib/jxl/bit_reader_test.cc
@@ -12,11 +12,11 @@
 #include "lib/jxl/base/data_parallel.h"
 #include "lib/jxl/base/random.h"
 #include "lib/jxl/base/span.h"
-#include "lib/jxl/base/thread_pool_internal.h"
 #include "lib/jxl/common.h"
 #include "lib/jxl/dec_bit_reader.h"
 #include "lib/jxl/enc_aux_out.h"
 #include "lib/jxl/enc_bit_writer.h"
+#include "lib/jxl/test_utils.h"
 #include "lib/jxl/testing.h"
 
 namespace jxl {
@@ -51,7 +51,7 @@ struct Symbol {
 
 // Reading from output gives the same values.
 TEST(BitReaderTest, TestRoundTrip) {
-  ThreadPoolInternal pool(8);
+  test::ThreadPoolForTests pool(8);
   EXPECT_TRUE(RunOnPool(
       &pool, 0, 1000, ThreadPool::NoInit,
       [](const uint32_t task, size_t /* thread */) {
@@ -85,7 +85,7 @@ TEST(BitReaderTest, TestRoundTrip) {
 
 // SkipBits is the same as reading that many bits.
 TEST(BitReaderTest, TestSkip) {
-  ThreadPoolInternal pool(8);
+  test::ThreadPoolForTests pool(8);
   EXPECT_TRUE(RunOnPool(
       &pool, 0, 96, ThreadPool::NoInit,
       [](const uint32_t task, size_t /* thread */) {

--- a/lib/jxl/color_management_test.cc
+++ b/lib/jxl/color_management_test.cc
@@ -17,7 +17,6 @@
 #include "lib/jxl/base/data_parallel.h"
 #include "lib/jxl/base/file_io.h"
 #include "lib/jxl/base/random.h"
-#include "lib/jxl/base/thread_pool_internal.h"
 #include "lib/jxl/enc_color_management.h"
 #include "lib/jxl/enc_xyb.h"
 #include "lib/jxl/image_test_utils.h"
@@ -43,6 +42,8 @@ using ::testing::FloatNear;
 // Small enough to be fast. If changed, must update Generate*.
 static constexpr size_t kWidth = 16;
 
+static constexpr size_t kNumThreads = 1;  // only have a single row.
+
 struct Globals {
   // TODO(deymo): Make this a const.
   static Globals* GetInstance() {
@@ -51,9 +52,7 @@ struct Globals {
   }
 
  private:
-  static constexpr size_t kNumThreads = 0;  // only have a single row.
-
-  Globals() : pool(kNumThreads) {
+  Globals() {
     in_gray = GenerateGray();
     in_color = GenerateColor();
     out_gray = ImageF(kWidth, 1);
@@ -103,8 +102,6 @@ struct Globals {
   }
 
  public:
-  ThreadPoolInternal pool;
-
   // ImageF so we can use VerifyRelativeError; all are interleaved RGB.
   ImageF in_gray;
   ImageF in_color;
@@ -137,10 +134,10 @@ class ColorManagementTest
     ColorSpaceTransform xform_rev(cms);
     const float intensity_target =
         c.tf.IsHLG() ? 1000 : kDefaultIntensityTarget;
-    ASSERT_TRUE(xform_fwd.Init(c_native, c, intensity_target, kWidth,
-                               g->pool.NumThreads()));
-    ASSERT_TRUE(xform_rev.Init(c, c_native, intensity_target, kWidth,
-                               g->pool.NumThreads()));
+    ASSERT_TRUE(
+        xform_fwd.Init(c_native, c, intensity_target, kWidth, kNumThreads));
+    ASSERT_TRUE(
+        xform_rev.Init(c, c_native, intensity_target, kWidth, kNumThreads));
 
     const size_t thread = 0;
     const ImageF& in = c.IsGray() ? g->in_gray : g->in_color;

--- a/lib/jxl/convolve_test.cc
+++ b/lib/jxl/convolve_test.cc
@@ -19,9 +19,9 @@
 #include "lib/jxl/base/data_parallel.h"
 #include "lib/jxl/base/printf_macros.h"
 #include "lib/jxl/base/random.h"
-#include "lib/jxl/base/thread_pool_internal.h"
 #include "lib/jxl/image_ops.h"
 #include "lib/jxl/image_test_utils.h"
+#include "lib/jxl/test_utils.h"
 #include "lib/jxl/testing.h"
 
 #ifndef JXL_DEBUG_CONVOLVE
@@ -138,7 +138,7 @@ void VerifySeparable7(const size_t xsize, const size_t ysize, ThreadPool* pool,
 void TestConvolve() {
   TestNeighbors();
 
-  ThreadPoolInternal pool(4);
+  test::ThreadPoolForTests pool(4);
   EXPECT_EQ(true,
             RunOnPool(
                 &pool, kConvolveMaxRadius, 40, ThreadPool::NoInit,
@@ -147,7 +147,7 @@ void TestConvolve() {
                   Rng rng(129 + 13 * xsize);
 
                   ThreadPool* null_pool = nullptr;
-                  ThreadPoolInternal pool3(3);
+                  test::ThreadPoolForTests pool3(3);
                   for (size_t ysize = kConvolveMaxRadius; ysize < 16; ++ysize) {
                     JXL_DEBUG(JXL_DEBUG_CONVOLVE,
                               "%" PRIuS " x %" PRIuS " (target %" PRIx64

--- a/lib/jxl/data_parallel_test.cc
+++ b/lib/jxl/data_parallel_test.cc
@@ -5,7 +5,6 @@
 
 #include "lib/jxl/base/data_parallel.h"
 
-#include "lib/jxl/base/thread_pool_internal.h"
 #include "lib/jxl/test_utils.h"
 #include "lib/jxl/testing.h"
 

--- a/lib/jxl/dct_test.cc
+++ b/lib/jxl/dct_test.cc
@@ -14,7 +14,6 @@
 #include <hwy/highway.h>
 #include <hwy/tests/test_util-inl.h>
 
-#include "lib/jxl/base/thread_pool_internal.h"
 #include "lib/jxl/common.h"
 #include "lib/jxl/dct-inl.h"
 #include "lib/jxl/dct_for_test.h"
@@ -157,7 +156,7 @@ void TestIdctAccuracy(float accuracy, size_t start = 0, size_t end = N * N) {
 
 template <size_t N>
 void TestInverseT(float accuracy) {
-  ThreadPoolInternal pool(N < 32 ? 0 : 8);
+  test::ThreadPoolForTests pool(N < 32 ? 0 : 8);
   enum { kBlockSize = N * N };
   EXPECT_TRUE(RunOnPool(
       &pool, 0, kBlockSize, ThreadPool::NoInit,

--- a/lib/jxl/enc_external_image_test.cc
+++ b/lib/jxl/enc_external_image_test.cc
@@ -10,7 +10,6 @@
 
 #include "lib/jxl/base/compiler_specific.h"
 #include "lib/jxl/base/data_parallel.h"
-#include "lib/jxl/base/thread_pool_internal.h"
 #include "lib/jxl/color_encoding_internal.h"
 #include "lib/jxl/image_ops.h"
 #include "lib/jxl/image_test_utils.h"

--- a/lib/jxl/gradient_test.cc
+++ b/lib/jxl/gradient_test.cc
@@ -15,7 +15,6 @@
 #include "lib/jxl/base/data_parallel.h"
 #include "lib/jxl/base/override.h"
 #include "lib/jxl/base/padded_bytes.h"
-#include "lib/jxl/base/thread_pool_internal.h"
 #include "lib/jxl/codec_in_out.h"
 #include "lib/jxl/color_encoding_internal.h"
 #include "lib/jxl/color_management.h"
@@ -193,13 +192,13 @@ void TestGradient(ThreadPool* pool, uint32_t color0, uint32_t color1,
 static constexpr bool fast_mode = true;
 
 TEST(GradientTest, SteepGradient) {
-  ThreadPoolInternal pool(8);
+  test::ThreadPoolForTests pool(8);
   // Relatively steep gradients, colors from the sky of stp.png
   TestGradient(&pool, 0xd99d58, 0x889ab1, 512, 512, 90, fast_mode, 3.0);
 }
 
 TEST(GradientTest, SubtleGradient) {
-  ThreadPoolInternal pool(8);
+  test::ThreadPoolForTests pool(8);
   // Very subtle gradient
   TestGradient(&pool, 0xb89b7b, 0xa89b8d, 512, 512, 90, fast_mode, 4.0);
 }

--- a/lib/jxl/jxl_test.cc
+++ b/lib/jxl/jxl_test.cc
@@ -22,7 +22,6 @@
 #include "lib/jxl/base/data_parallel.h"
 #include "lib/jxl/base/override.h"
 #include "lib/jxl/base/padded_bytes.h"
-#include "lib/jxl/base/thread_pool_internal.h"
 #include "lib/jxl/codec_in_out.h"
 #include "lib/jxl/color_encoding_internal.h"
 #include "lib/jxl/color_management.h"
@@ -59,6 +58,7 @@ using test::ButteraugliDistance;
 using test::ComputeDistance2;
 using test::Roundtrip;
 using test::TestImage;
+using test::ThreadPoolForTests;
 
 #define JXL_TEST_NL 0  // Disabled in code
 
@@ -170,7 +170,7 @@ TEST(JxlTest, RoundtripResample2Slow) {
 }
 
 TEST(JxlTest, RoundtripResample2MT) {
-  ThreadPoolInternal pool(4);
+  ThreadPoolForTests pool(4);
   const PaddedBytes orig = jxl::test::ReadTestData("jxl/flower/flower.png");
   // image has to be large enough to have multiple groups after downsampling
   TestImage t;
@@ -281,7 +281,7 @@ TEST(JxlTest, RoundtripMultiGroup) {
 
   auto test = [&](jxl::SpeedTier speed_tier, float target_distance,
                   size_t expected_size, float expected_distance) {
-    ThreadPoolInternal pool(4);
+    ThreadPoolForTests pool(4);
     JXLCompressParams cparams;
     int64_t effort = 10 - static_cast<int>(speed_tier);
     cparams.AddOption(JXL_ENC_FRAME_SETTING_EFFORT, effort);
@@ -301,7 +301,7 @@ TEST(JxlTest, RoundtripMultiGroup) {
 }
 
 TEST(JxlTest, RoundtripRGBToGrayscale) {
-  ThreadPoolInternal pool(4);
+  ThreadPoolForTests pool(4);
   const PaddedBytes orig = jxl::test::ReadTestData("jxl/flower/flower.png");
   CodecInOut io;
   ASSERT_TRUE(SetFromBytes(Span<const uint8_t>(orig), &io, &pool));
@@ -347,7 +347,7 @@ TEST(JxlTest, RoundtripRGBToGrayscale) {
 }
 
 TEST(JxlTest, RoundtripLargeFast) {
-  ThreadPoolInternal pool(8);
+  ThreadPoolForTests pool(8);
   const PaddedBytes orig = jxl::test::ReadTestData("jxl/flower/flower.png");
   TestImage t;
   t.DecodeFromBytes(orig).ClearMetadata();
@@ -361,7 +361,7 @@ TEST(JxlTest, RoundtripLargeFast) {
 }
 
 TEST(JxlTest, RoundtripDotsForceEpf) {
-  ThreadPoolInternal pool(8);
+  ThreadPoolForTests pool(8);
   const PaddedBytes orig = jxl::test::ReadTestData(
       "external/wesaturate/500px/cvo9xd_keong_macan_srgb8.png");
   TestImage t;
@@ -381,7 +381,7 @@ TEST(JxlTest, RoundtripDotsForceEpf) {
 // which involves additional processing including adaptive reconstruction.
 // Failing this may be a sign of race conditions or invalid memory accesses.
 TEST(JxlTest, RoundtripD2Consistent) {
-  ThreadPoolInternal pool(8);
+  ThreadPoolForTests pool(8);
   const PaddedBytes orig = jxl::test::ReadTestData("jxl/flower/flower.png");
   TestImage t;
   t.DecodeFromBytes(orig).ClearMetadata();
@@ -421,7 +421,7 @@ TEST(JxlTest, RoundtripLargeConsistent) {
   cparams.distance = 2.0;
 
   auto roundtrip_and_compare = [&]() {
-    ThreadPoolInternal pool(8);
+    ThreadPoolForTests pool(8);
     PackedPixelFile ppf2;
     size_t size = Roundtrip(t.ppf(), cparams, {}, &pool, &ppf2);
     double dist = ComputeDistance2(t.ppf(), ppf2);
@@ -855,7 +855,7 @@ TEST(JxlTest, RoundtripAlphaNonMultipleOf8) {
 }
 
 TEST(JxlTest, RoundtripAlpha16) {
-  ThreadPoolInternal pool(4);
+  ThreadPoolForTests pool(4);
   // The image is wider than 512 pixels to ensure multiple groups are tested.
   size_t xsize = 1200, ysize = 160;
   TestImage t;
@@ -900,7 +900,7 @@ JXLCompressParams CompressParamsForLossless() {
 }  // namespace
 
 TEST(JxlTest, JXL_SLOW_TEST(RoundtripLossless8)) {
-  ThreadPoolInternal pool(8);
+  ThreadPoolForTests pool(8);
   const PaddedBytes orig = jxl::test::ReadTestData(
       "external/wesaturate/500px/tmshre_riaphotographs_srgb8.png");
   TestImage t;
@@ -914,7 +914,7 @@ TEST(JxlTest, JXL_SLOW_TEST(RoundtripLossless8)) {
 }
 
 TEST(JxlTest, JXL_SLOW_TEST(RoundtripLossless8ThunderGradient)) {
-  ThreadPoolInternal pool(8);
+  ThreadPoolForTests pool(8);
   const PaddedBytes orig = jxl::test::ReadTestData(
       "external/wesaturate/500px/tmshre_riaphotographs_srgb8.png");
   TestImage t;
@@ -930,7 +930,7 @@ TEST(JxlTest, JXL_SLOW_TEST(RoundtripLossless8ThunderGradient)) {
 }
 
 TEST(JxlTest, JXL_SLOW_TEST(RoundtripLossless8LightningGradient)) {
-  ThreadPoolInternal pool(8);
+  ThreadPoolForTests pool(8);
   const PaddedBytes orig = jxl::test::ReadTestData(
       "external/wesaturate/500px/tmshre_riaphotographs_srgb8.png");
   TestImage t;
@@ -947,7 +947,7 @@ TEST(JxlTest, JXL_SLOW_TEST(RoundtripLossless8LightningGradient)) {
 }
 
 TEST(JxlTest, JXL_SLOW_TEST(RoundtripLossless8Falcon)) {
-  ThreadPoolInternal pool(8);
+  ThreadPoolForTests pool(8);
   const PaddedBytes orig = jxl::test::ReadTestData(
       "external/wesaturate/500px/tmshre_riaphotographs_srgb8.png");
   TestImage t;
@@ -1229,7 +1229,7 @@ void RoundtripJpegToPixels(const PaddedBytes& jpeg_in,
 }
 
 TEST(JxlTest, JXL_TRANSCODE_JPEG_TEST(RoundtripJpegRecompression444)) {
-  ThreadPoolInternal pool(8);
+  ThreadPoolForTests pool(8);
   const PaddedBytes orig =
       jxl::test::ReadTestData("jxl/flower/flower.png.im_q85_444.jpg");
   // JPEG size is 696,659 bytes.
@@ -1239,7 +1239,7 @@ TEST(JxlTest, JXL_TRANSCODE_JPEG_TEST(RoundtripJpegRecompression444)) {
 #if JPEGXL_ENABLE_JPEG
 
 TEST(JxlTest, JXL_TRANSCODE_JPEG_TEST(RoundtripJpegRecompressionToPixels)) {
-  ThreadPoolInternal pool(8);
+  ThreadPoolForTests pool(8);
   const PaddedBytes orig =
       jxl::test::ReadTestData("jxl/flower/flower.png.im_q85_444.jpg");
   TestImage t;
@@ -1251,7 +1251,7 @@ TEST(JxlTest, JXL_TRANSCODE_JPEG_TEST(RoundtripJpegRecompressionToPixels)) {
 }
 
 TEST(JxlTest, JXL_TRANSCODE_JPEG_TEST(RoundtripJpegRecompressionToPixels420)) {
-  ThreadPoolInternal pool(8);
+  ThreadPoolForTests pool(8);
   const PaddedBytes orig =
       jxl::test::ReadTestData("jxl/flower/flower.png.im_q85_420.jpg");
   TestImage t;
@@ -1264,7 +1264,7 @@ TEST(JxlTest, JXL_TRANSCODE_JPEG_TEST(RoundtripJpegRecompressionToPixels420)) {
 
 TEST(JxlTest,
      JXL_TRANSCODE_JPEG_TEST(RoundtripJpegRecompressionToPixels420EarlyFlush)) {
-  ThreadPoolInternal pool(8);
+  ThreadPoolForTests pool(8);
   const PaddedBytes orig =
       jxl::test::ReadTestData("jxl/flower/flower.png.im_q85_420.jpg");
   TestImage t;
@@ -1280,7 +1280,7 @@ TEST(JxlTest,
 
 TEST(JxlTest,
      JXL_TRANSCODE_JPEG_TEST(RoundtripJpegRecompressionToPixels420Mul16)) {
-  ThreadPoolInternal pool(8);
+  ThreadPoolForTests pool(8);
   const PaddedBytes orig =
       jxl::test::ReadTestData("jxl/flower/flower_cropped.jpg");
   TestImage t;
@@ -1293,7 +1293,7 @@ TEST(JxlTest,
 
 TEST(JxlTest,
      JXL_TRANSCODE_JPEG_TEST(RoundtripJpegRecompressionToPixels_asymmetric)) {
-  ThreadPoolInternal pool(8);
+  ThreadPoolForTests pool(8);
   const PaddedBytes orig =
       jxl::test::ReadTestData("jxl/flower/flower.png.im_q85_asymmetric.jpg");
   TestImage t;
@@ -1307,7 +1307,7 @@ TEST(JxlTest,
 #endif
 
 TEST(JxlTest, JXL_TRANSCODE_JPEG_TEST(RoundtripJpegRecompressionGray)) {
-  ThreadPoolInternal pool(8);
+  ThreadPoolForTests pool(8);
   const PaddedBytes orig =
       jxl::test::ReadTestData("jxl/flower/flower.png.im_q85_gray.jpg");
   // JPEG size is 456,528 bytes.
@@ -1315,7 +1315,7 @@ TEST(JxlTest, JXL_TRANSCODE_JPEG_TEST(RoundtripJpegRecompressionGray)) {
 }
 
 TEST(JxlTest, JXL_TRANSCODE_JPEG_TEST(RoundtripJpegRecompression420)) {
-  ThreadPoolInternal pool(8);
+  ThreadPoolForTests pool(8);
   const PaddedBytes orig =
       jxl::test::ReadTestData("jxl/flower/flower.png.im_q85_420.jpg");
   // JPEG size is 546,797 bytes.
@@ -1324,7 +1324,7 @@ TEST(JxlTest, JXL_TRANSCODE_JPEG_TEST(RoundtripJpegRecompression420)) {
 
 TEST(JxlTest,
      JXL_TRANSCODE_JPEG_TEST(RoundtripJpegRecompression_luma_subsample)) {
-  ThreadPoolInternal pool(8);
+  ThreadPoolForTests pool(8);
   const PaddedBytes orig = jxl::test::ReadTestData(
       "jxl/flower/flower.png.im_q85_luma_subsample.jpg");
   // JPEG size is 400,724 bytes.
@@ -1333,7 +1333,7 @@ TEST(JxlTest,
 
 TEST(JxlTest, JXL_TRANSCODE_JPEG_TEST(RoundtripJpegRecompression444_12)) {
   // 444 JPEG that has an interesting sampling-factor (1x2, 1x2, 1x2).
-  ThreadPoolInternal pool(8);
+  ThreadPoolForTests pool(8);
   const PaddedBytes orig =
       jxl::test::ReadTestData("jxl/flower/flower.png.im_q85_444_1x2.jpg");
   // JPEG size is 703,874 bytes.
@@ -1341,7 +1341,7 @@ TEST(JxlTest, JXL_TRANSCODE_JPEG_TEST(RoundtripJpegRecompression444_12)) {
 }
 
 TEST(JxlTest, JXL_TRANSCODE_JPEG_TEST(RoundtripJpegRecompression422)) {
-  ThreadPoolInternal pool(8);
+  ThreadPoolForTests pool(8);
   const PaddedBytes orig =
       jxl::test::ReadTestData("jxl/flower/flower.png.im_q85_422.jpg");
   // JPEG size is 522,057 bytes.
@@ -1349,7 +1349,7 @@ TEST(JxlTest, JXL_TRANSCODE_JPEG_TEST(RoundtripJpegRecompression422)) {
 }
 
 TEST(JxlTest, JXL_TRANSCODE_JPEG_TEST(RoundtripJpegRecompression440)) {
-  ThreadPoolInternal pool(8);
+  ThreadPoolForTests pool(8);
   const PaddedBytes orig =
       jxl::test::ReadTestData("jxl/flower/flower.png.im_q85_440.jpg");
   // JPEG size is 603,623 bytes.
@@ -1359,7 +1359,7 @@ TEST(JxlTest, JXL_TRANSCODE_JPEG_TEST(RoundtripJpegRecompression440)) {
 TEST(JxlTest, JXL_TRANSCODE_JPEG_TEST(RoundtripJpegRecompression_asymmetric)) {
   // 2x vertical downsample of one chroma channel, 2x horizontal downsample of
   // the other.
-  ThreadPoolInternal pool(8);
+  ThreadPoolForTests pool(8);
   const PaddedBytes orig =
       jxl::test::ReadTestData("jxl/flower/flower.png.im_q85_asymmetric.jpg");
   // JPEG size is 604,601 bytes.
@@ -1367,7 +1367,7 @@ TEST(JxlTest, JXL_TRANSCODE_JPEG_TEST(RoundtripJpegRecompression_asymmetric)) {
 }
 
 TEST(JxlTest, JXL_TRANSCODE_JPEG_TEST(RoundtripJpegRecompression420Progr)) {
-  ThreadPoolInternal pool(8);
+  ThreadPoolForTests pool(8);
   const PaddedBytes orig =
       jxl::test::ReadTestData("jxl/flower/flower.png.im_q85_420_progr.jpg");
   // JPEG size is 522,057 bytes.
@@ -1375,7 +1375,7 @@ TEST(JxlTest, JXL_TRANSCODE_JPEG_TEST(RoundtripJpegRecompression420Progr)) {
 }
 
 TEST(JxlTest, RoundtripProgressive) {
-  ThreadPoolInternal pool(4);
+  ThreadPoolForTests pool(4);
   const PaddedBytes orig = jxl::test::ReadTestData("jxl/flower/flower.png");
   TestImage t;
   t.DecodeFromBytes(orig).ClearMetadata().SetDimensions(600, 1024);
@@ -1391,7 +1391,7 @@ TEST(JxlTest, RoundtripProgressive) {
 }
 
 TEST(JxlTest, RoundtripProgressiveLevel2Slow) {
-  ThreadPoolInternal pool(8);
+  ThreadPoolForTests pool(8);
   const PaddedBytes orig = jxl::test::ReadTestData("jxl/flower/flower.png");
   TestImage t;
   t.DecodeFromBytes(orig).ClearMetadata().SetDimensions(600, 1024);

--- a/lib/jxl/lehmer_code_test.cc
+++ b/lib/jxl/lehmer_code_test.cc
@@ -15,7 +15,7 @@
 #include "lib/jxl/base/bits.h"
 #include "lib/jxl/base/data_parallel.h"
 #include "lib/jxl/base/random.h"
-#include "lib/jxl/base/thread_pool_internal.h"
+#include "lib/jxl/test_utils.h"
 #include "lib/jxl/testing.h"
 
 namespace jxl {
@@ -86,7 +86,7 @@ void RoundtripSizeRange(ThreadPool* pool, uint32_t begin, uint32_t end) {
 }
 
 TEST(LehmerCodeTest, TestRoundtrips) {
-  ThreadPoolInternal pool(8);
+  test::ThreadPoolForTests pool(8);
 
   RoundtripSizeRange<uint16_t>(&pool, 1, 1026);
 

--- a/lib/jxl/modular_test.cc
+++ b/lib/jxl/modular_test.cc
@@ -17,7 +17,6 @@
 #include "lib/jxl/base/data_parallel.h"
 #include "lib/jxl/base/override.h"
 #include "lib/jxl/base/padded_bytes.h"
-#include "lib/jxl/base/thread_pool_internal.h"
 #include "lib/jxl/codec_in_out.h"
 #include "lib/jxl/color_encoding_internal.h"
 #include "lib/jxl/color_management.h"

--- a/lib/jxl/passes_test.cc
+++ b/lib/jxl/passes_test.cc
@@ -14,7 +14,6 @@
 #include "lib/jxl/base/data_parallel.h"
 #include "lib/jxl/base/override.h"
 #include "lib/jxl/base/padded_bytes.h"
-#include "lib/jxl/base/thread_pool_internal.h"
 #include "lib/jxl/color_encoding_internal.h"
 #include "lib/jxl/common.h"
 #include "lib/jxl/enc_aux_out.h"
@@ -29,8 +28,11 @@
 #include "lib/jxl/testing.h"
 
 namespace jxl {
-namespace {
+
 using test::Roundtrip;
+using test::ThreadPoolForTests;
+
+namespace {
 
 TEST(PassesTest, RoundtripSmallPasses) {
   const PaddedBytes orig = jxl::test::ReadTestData(
@@ -74,13 +76,13 @@ TEST(PassesTest, RoundtripMultiGroupPasses) {
   const PaddedBytes orig = jxl::test::ReadTestData("jxl/flower/flower.png");
   CodecInOut io;
   {
-    ThreadPoolInternal pool(4);
+    ThreadPoolForTests pool(4);
     ASSERT_TRUE(SetFromBytes(Span<const uint8_t>(orig), &io, &pool));
   }
   io.ShrinkTo(600, 1024);  // partial X, full Y group
 
   auto test = [&](float target_distance, float threshold) {
-    ThreadPoolInternal pool(4);
+    ThreadPoolForTests pool(4);
     CompressParams cparams;
     cparams.butteraugli_distance = target_distance;
     cparams.progressive_mode = true;
@@ -98,7 +100,7 @@ TEST(PassesTest, RoundtripMultiGroupPasses) {
 }
 
 TEST(PassesTest, RoundtripLargeFastPasses) {
-  ThreadPoolInternal pool(8);
+  ThreadPoolForTests pool(8);
   const PaddedBytes orig = jxl::test::ReadTestData("jxl/flower/flower.png");
   CodecInOut io;
   ASSERT_TRUE(SetFromBytes(Span<const uint8_t>(orig), &io, &pool));
@@ -116,7 +118,7 @@ TEST(PassesTest, RoundtripLargeFastPasses) {
 // which involves additional processing including adaptive reconstruction.
 // Failing this may be a sign of race conditions or invalid memory accesses.
 TEST(PassesTest, RoundtripProgressiveConsistent) {
-  ThreadPoolInternal pool(8);
+  ThreadPoolForTests pool(8);
   const PaddedBytes orig = jxl::test::ReadTestData("jxl/flower/flower.png");
   CodecInOut io;
   ASSERT_TRUE(SetFromBytes(Span<const uint8_t>(orig), &io, &pool));
@@ -153,7 +155,7 @@ TEST(PassesTest, RoundtripProgressiveConsistent) {
 }
 
 TEST(PassesTest, AllDownsampleFeasible) {
-  ThreadPoolInternal pool(8);
+  ThreadPoolForTests pool(8);
   const PaddedBytes orig = jxl::test::ReadTestData(
       "external/wesaturate/500px/u76c0g_bliznaca_srgb8.png");
   CodecInOut io;
@@ -202,7 +204,7 @@ TEST(PassesTest, AllDownsampleFeasible) {
 }
 
 TEST(PassesTest, AllDownsampleFeasibleQProgressive) {
-  ThreadPoolInternal pool(8);
+  ThreadPoolForTests pool(8);
   const PaddedBytes orig = jxl::test::ReadTestData(
       "external/wesaturate/500px/u76c0g_bliznaca_srgb8.png");
   CodecInOut io;
@@ -251,7 +253,7 @@ TEST(PassesTest, AllDownsampleFeasibleQProgressive) {
 }
 
 TEST(PassesTest, ProgressiveDownsample2DegradesCorrectlyGrayscale) {
-  ThreadPoolInternal pool(8);
+  ThreadPoolForTests pool(8);
   const PaddedBytes orig = jxl::test::ReadTestData(
       "external/wesaturate/500px/cvo9xd_keong_macan_grayscale.png");
   CodecInOut io_orig;
@@ -301,7 +303,7 @@ TEST(PassesTest, ProgressiveDownsample2DegradesCorrectlyGrayscale) {
 }
 
 TEST(PassesTest, ProgressiveDownsample2DegradesCorrectly) {
-  ThreadPoolInternal pool(8);
+  ThreadPoolForTests pool(8);
   const PaddedBytes orig = jxl::test::ReadTestData("jxl/flower/flower.png");
   CodecInOut io_orig;
   ASSERT_TRUE(SetFromBytes(Span<const uint8_t>(orig), &io_orig, &pool));
@@ -349,7 +351,7 @@ TEST(PassesTest, ProgressiveDownsample2DegradesCorrectly) {
 }
 
 TEST(PassesTest, NonProgressiveDCImage) {
-  ThreadPoolInternal pool(8);
+  ThreadPoolForTests pool(8);
   const PaddedBytes orig = jxl::test::ReadTestData("jxl/flower/flower.png");
   CodecInOut io;
   ASSERT_TRUE(SetFromBytes(Span<const uint8_t>(orig), &io, &pool));

--- a/lib/jxl/speed_tier_test.cc
+++ b/lib/jxl/speed_tier_test.cc
@@ -8,7 +8,6 @@
 #include "lib/extras/codec.h"
 #include "lib/jxl/base/data_parallel.h"
 #include "lib/jxl/base/padded_bytes.h"
-#include "lib/jxl/base/thread_pool_internal.h"
 #include "lib/jxl/codec_in_out.h"
 #include "lib/jxl/enc_butteraugli_comparator.h"
 #include "lib/jxl/enc_cache.h"
@@ -84,7 +83,7 @@ TEST_P(SpeedTierTest, Roundtrip) {
   const PaddedBytes orig = jxl::test::ReadTestData(
       "external/wesaturate/500px/u76c0g_bliznaca_srgb8.png");
   CodecInOut io;
-  ThreadPoolInternal pool(8);
+  test::ThreadPoolForTests pool(8);
   ASSERT_TRUE(SetFromBytes(Span<const uint8_t>(orig), &io, &pool));
 
   const SpeedTierTestParams& params = GetParam();

--- a/lib/jxl/test_utils.h
+++ b/lib/jxl/test_utils.h
@@ -27,6 +27,7 @@
 #include "lib/jxl/codec_in_out.h"
 #include "lib/jxl/color_encoding_internal.h"
 #include "lib/jxl/enc_params.h"
+#include "lib/threads/thread_parallel_runner_internal.h"
 
 namespace jxl {
 
@@ -140,6 +141,19 @@ bool SamePixels(const extras::PackedImage& a, const extras::PackedImage& b);
 
 bool SamePixels(const extras::PackedPixelFile& a,
                 const extras::PackedPixelFile& b);
+
+class ThreadPoolForTests : public ThreadPool {
+ public:
+  explicit ThreadPoolForTests(int num_worker_threads)
+      : ThreadPool(&jpegxl::ThreadParallelRunner::Runner,
+                   static_cast<void*>(&runner_)),
+        runner_(num_worker_threads) {}
+  ThreadPoolForTests(const ThreadPoolForTests&) = delete;
+  ThreadPoolForTests& operator&(const ThreadPoolForTests&) = delete;
+
+ private:
+  jpegxl::ThreadParallelRunner runner_;
+};
 
 }  // namespace test
 

--- a/lib/jxl/xorshift128plus_test.cc
+++ b/lib/jxl/xorshift128plus_test.cc
@@ -16,7 +16,7 @@
 #include <hwy/tests/test_util-inl.h>
 
 #include "lib/jxl/base/data_parallel.h"
-#include "lib/jxl/base/thread_pool_internal.h"
+#include "lib/jxl/test_utils.h"
 #include "lib/jxl/xorshift128plus-inl.h"
 
 HWY_BEFORE_NAMESPACE();
@@ -286,7 +286,7 @@ void TestSeedChanges() {
 }
 
 void TestFloat() {
-  ThreadPoolInternal pool(8);
+  test::ThreadPoolForTests pool(8);
 
 #ifdef JXL_DISABLE_SLOW_TESTS
   const uint32_t kMaxSeed = 256;
@@ -332,7 +332,7 @@ void TestFloat() {
 
 // Not more than one 64-bit zero
 void TestNotZero() {
-  ThreadPoolInternal pool(8);
+  test::ThreadPoolForTests pool(8);
 
 #ifdef JXL_DISABLE_SLOW_TESTS
   const uint32_t kMaxSeed = 500;

--- a/lib/jxl_lists.bzl
+++ b/lib/jxl_lists.bzl
@@ -29,7 +29,6 @@ libjxl_base_sources = [
     "jxl/base/scope_guard.h",
     "jxl/base/span.h",
     "jxl/base/status.h",
-    "jxl/base/thread_pool_internal.h",
 ]
 
 libjxl_codec_apng_sources = [

--- a/lib/jxl_lists.cmake
+++ b/lib/jxl_lists.cmake
@@ -29,7 +29,6 @@ set(JPEGXL_INTERNAL_BASE_SOURCES
   jxl/base/scope_guard.h
   jxl/base/span.h
   jxl/base/status.h
-  jxl/base/thread_pool_internal.h
 )
 
 set(JPEGXL_INTERNAL_CODEC_APNG_SOURCES

--- a/lib/threads/thread_parallel_runner_internal.h
+++ b/lib/threads/thread_parallel_runner_internal.h
@@ -64,11 +64,6 @@ class ThreadParallelRunner {
   // Waits for all threads to exit.
   ~ThreadParallelRunner();
 
-  // Returns number of worker threads created (some may be sleeping and never
-  // wake up in time to participate in Run). Useful for characterizing
-  // performance; 0 means "run on main thread".
-  size_t NumWorkerThreads() const { return num_worker_threads_; }
-
   // Returns maximum number of main/worker threads that may call Func. Useful
   // for allocating per-thread storage.
   size_t NumThreads() const { return num_threads_; }

--- a/lib/threads/thread_parallel_runner_test.cc
+++ b/lib/threads/thread_parallel_runner_test.cc
@@ -6,8 +6,10 @@
 #include <atomic>
 
 #include "lib/jxl/base/data_parallel.h"
-#include "lib/jxl/base/thread_pool_internal.h"
+#include "lib/jxl/test_utils.h"
 #include "lib/jxl/testing.h"
+
+using jxl::test::ThreadPoolForTests;
 
 namespace jpegxl {
 namespace {
@@ -26,7 +28,7 @@ int PopulationCount(uint64_t bits) {
 // (joining with its threads), num_threads=0 works (runs on current thread).
 TEST(ThreadParallelRunnerTest, TestPool) {
   for (int num_threads = 0; num_threads <= 18; ++num_threads) {
-    jxl::ThreadPoolInternal pool(num_threads);
+    ThreadPoolForTests pool(num_threads);
     for (int num_tasks = 0; num_tasks < 32; ++num_tasks) {
       std::vector<int> mementos(num_tasks);
       for (int begin = 0; begin < 32; ++begin) {
@@ -55,7 +57,7 @@ TEST(ThreadParallelRunnerTest, TestSmallAssignments) {
   // WARNING: cumulative total threads must not exceed profiler.h kMaxThreads.
   const int kMaxThreads = 8;
   for (int num_threads = 1; num_threads <= kMaxThreads; ++num_threads) {
-    jxl::ThreadPoolInternal pool(num_threads);
+    ThreadPoolForTests pool(num_threads);
 
     // (Avoid mutex because it may perturb the worker thread scheduling)
     std::atomic<uint64_t> id_bits{0};
@@ -95,7 +97,7 @@ struct Counter {
 
 TEST(ThreadParallelRunnerTest, TestCounter) {
   const int kNumThreads = 12;
-  jxl::ThreadPoolInternal pool(kNumThreads);
+  ThreadPoolForTests pool(kNumThreads);
   alignas(128) Counter counters[kNumThreads];
 
   const int kNumTasks = kNumThreads * 19;

--- a/tools/benchmark/benchmark_codec.cc
+++ b/tools/benchmark/benchmark_codec.cc
@@ -46,7 +46,6 @@ namespace jpegxl {
 namespace tools {
 
 using ::jxl::Image3F;
-using ::jxl::ThreadPoolInternal;
 
 void ImageCodec::ParseParameters(const std::string& parameters) {
   params_ = parameters;

--- a/tools/benchmark/benchmark_codec.h
+++ b/tools/benchmark/benchmark_codec.h
@@ -16,7 +16,6 @@
 #include "lib/jxl/base/padded_bytes.h"
 #include "lib/jxl/base/span.h"
 #include "lib/jxl/base/status.h"
-#include "lib/jxl/base/thread_pool_internal.h"
 #include "lib/jxl/butteraugli/butteraugli.h"
 #include "lib/jxl/codec_in_out.h"
 #include "lib/jxl/image.h"
@@ -25,13 +24,13 @@
 #include "tools/benchmark/benchmark_stats.h"
 #include "tools/cmdline.h"
 #include "tools/speed_stats.h"
+#include "tools/thread_pool_internal.h"
 
 namespace jpegxl {
 namespace tools {
 
 using ::jxl::CodecInOut;
 using ::jxl::Span;
-using ::jxl::ThreadPoolInternal;
 
 // Thread-compatible.
 class ImageCodec {

--- a/tools/benchmark/benchmark_codec_avif.cc
+++ b/tools/benchmark/benchmark_codec_avif.cc
@@ -9,11 +9,11 @@
 #include "lib/extras/time.h"
 #include "lib/jxl/base/padded_bytes.h"
 #include "lib/jxl/base/span.h"
-#include "lib/jxl/base/thread_pool_internal.h"
 #include "lib/jxl/codec_in_out.h"
 #include "lib/jxl/dec_external_image.h"
 #include "lib/jxl/enc_external_image.h"
 #include "tools/cmdline.h"
+#include "tools/thread_pool_internal.h"
 
 #define JXL_RETURN_IF_AVIF_ERROR(result)                                       \
   do {                                                                         \
@@ -32,7 +32,6 @@ using ::jxl::ImageBundle;
 using ::jxl::PaddedBytes;
 using ::jxl::Primaries;
 using ::jxl::Span;
-using ::jxl::ThreadPoolInternal;
 using ::jxl::TransferFunction;
 using ::jxl::WhitePoint;
 

--- a/tools/benchmark/benchmark_codec_custom.cc
+++ b/tools/benchmark/benchmark_codec_custom.cc
@@ -17,15 +17,13 @@
 #include "lib/extras/enc/apng.h"
 #include "lib/extras/time.h"
 #include "lib/jxl/base/file_io.h"
-#include "lib/jxl/base/thread_pool_internal.h"
 #include "lib/jxl/codec_in_out.h"
 #include "lib/jxl/image_bundle.h"
 #include "tools/benchmark/benchmark_utils.h"
+#include "tools/thread_pool_internal.h"
 
 namespace jpegxl {
 namespace tools {
-
-using ::jxl::ThreadPoolInternal;
 
 struct CustomCodecArgs {
   std::string extension;

--- a/tools/benchmark/benchmark_codec_jpeg.cc
+++ b/tools/benchmark/benchmark_codec_jpeg.cc
@@ -30,16 +30,14 @@
 #include "lib/jxl/base/file_io.h"
 #include "lib/jxl/base/padded_bytes.h"
 #include "lib/jxl/base/span.h"
-#include "lib/jxl/base/thread_pool_internal.h"
 #include "lib/jxl/codec_in_out.h"
 #include "lib/jxl/image_bundle.h"
 #include "tools/benchmark/benchmark_utils.h"
 #include "tools/cmdline.h"
+#include "tools/thread_pool_internal.h"
 
 namespace jpegxl {
 namespace tools {
-
-using ::jxl::ThreadPoolInternal;
 
 class JPEGCodec : public ImageCodec {
  public:

--- a/tools/benchmark/benchmark_codec_jxl.cc
+++ b/tools/benchmark/benchmark_codec_jxl.cc
@@ -50,7 +50,6 @@ using ::jxl::PaddedBytes;
 using ::jxl::PassesEncoderState;
 using ::jxl::Predictor;
 using ::jxl::SpeedTier;
-using ::jxl::ThreadPoolInternal;
 using ::jxl::extras::EncodedImage;
 using ::jxl::extras::Encoder;
 using ::jxl::extras::JXLDecompressParams;

--- a/tools/benchmark/benchmark_codec_png.cc
+++ b/tools/benchmark/benchmark_codec_png.cc
@@ -20,15 +20,13 @@
 #include "lib/extras/time.h"
 #include "lib/jxl/base/padded_bytes.h"
 #include "lib/jxl/base/span.h"
-#include "lib/jxl/base/thread_pool_internal.h"
 #include "lib/jxl/codec_in_out.h"
 #include "lib/jxl/image_bundle.h"
 #include "lib/jxl/image_metadata.h"
+#include "tools/thread_pool_internal.h"
 
 namespace jpegxl {
 namespace tools {
-
-using ::jxl::ThreadPoolInternal;
 
 struct PNGArgs {
   // Empty, no PNG-specific args currently.

--- a/tools/benchmark/benchmark_codec_webp.cc
+++ b/tools/benchmark/benchmark_codec_webp.cc
@@ -17,7 +17,6 @@
 #include "lib/jxl/base/data_parallel.h"
 #include "lib/jxl/base/padded_bytes.h"
 #include "lib/jxl/base/span.h"
-#include "lib/jxl/base/thread_pool_internal.h"
 #include "lib/jxl/codec_in_out.h"
 #include "lib/jxl/dec_external_image.h"
 #include "lib/jxl/enc_color_management.h"
@@ -26,6 +25,7 @@
 #include "lib/jxl/image.h"
 #include "lib/jxl/image_bundle.h"
 #include "lib/jxl/sanitizers.h"
+#include "tools/thread_pool_internal.h"
 
 namespace jpegxl {
 namespace tools {
@@ -33,7 +33,6 @@ namespace tools {
 using ::jxl::ImageBundle;
 using ::jxl::ImageMetadata;
 using ::jxl::ThreadPool;
-using ::jxl::ThreadPoolInternal;
 
 // Sets image data from 8-bit sRGB pixel array in bytes.
 // Amount of input bytes per pixel must be:

--- a/tools/benchmark/benchmark_xl.cc
+++ b/tools/benchmark/benchmark_xl.cc
@@ -32,7 +32,6 @@
 #include "lib/jxl/base/random.h"
 #include "lib/jxl/base/span.h"
 #include "lib/jxl/base/status.h"
-#include "lib/jxl/base/thread_pool_internal.h"
 #include "lib/jxl/codec_in_out.h"
 #include "lib/jxl/color_encoding_internal.h"
 #include "lib/jxl/enc_butteraugli_comparator.h"
@@ -50,6 +49,7 @@
 #include "tools/codec_config.h"
 #include "tools/speed_stats.h"
 #include "tools/ssimulacra2.h"
+#include "tools/thread_pool_internal.h"
 
 namespace jpegxl {
 namespace tools {
@@ -65,7 +65,6 @@ using ::jxl::PaddedBytes;
 using ::jxl::Rng;
 using ::jxl::Status;
 using ::jxl::ThreadPool;
-using ::jxl::ThreadPoolInternal;
 
 Status WriteImage(Image3F&& image, ThreadPool* pool,
                   const std::string& filename) {

--- a/tools/butteraugli_main.cc
+++ b/tools/butteraugli_main.cc
@@ -16,7 +16,6 @@
 #include "lib/jxl/base/padded_bytes.h"
 #include "lib/jxl/base/printf_macros.h"
 #include "lib/jxl/base/status.h"
-#include "lib/jxl/base/thread_pool_internal.h"
 #include "lib/jxl/butteraugli/butteraugli.h"
 #include "lib/jxl/codec_in_out.h"
 #include "lib/jxl/color_encoding_internal.h"
@@ -27,16 +26,17 @@
 #include "lib/jxl/image.h"
 #include "lib/jxl/image_bundle.h"
 #include "lib/jxl/image_ops.h"
+#include "tools/thread_pool_internal.h"
 
 namespace {
 
+using jpegxl::tools::ThreadPoolInternal;
 using jxl::ButteraugliParams;
 using jxl::CodecInOut;
 using jxl::ColorEncoding;
 using jxl::Image3F;
 using jxl::ImageF;
 using jxl::Status;
-using jxl::ThreadPoolInternal;
 
 Status WriteImage(Image3F&& image, const std::string& filename) {
   ThreadPoolInternal pool(4);

--- a/tools/comparison_viewer/image_loading.cc
+++ b/tools/comparison_viewer/image_loading.cc
@@ -11,11 +11,11 @@
 #include "lib/extras/codec.h"
 #include "lib/extras/dec/color_hints.h"
 #include "lib/jxl/base/file_io.h"
-#include "lib/jxl/base/thread_pool_internal.h"
 #include "lib/jxl/color_management.h"
 #include "lib/jxl/enc_color_management.h"
 #include "lib/jxl/image_bundle.h"
 #include "lib/jxl/image_metadata.h"
+#include "tools/thread_pool_internal.h"
 #include "tools/viewer/load_jxl.h"
 
 namespace jpegxl {
@@ -30,7 +30,6 @@ using jxl::Rect;
 using jxl::Span;
 using jxl::Status;
 using jxl::ThreadPool;
-using jxl::ThreadPoolInternal;
 using jxl::extras::ColorHints;
 
 namespace {

--- a/tools/decode_and_encode.cc
+++ b/tools/decode_and_encode.cc
@@ -10,8 +10,8 @@
 #include "lib/extras/codec.h"
 #include "lib/jxl/base/data_parallel.h"
 #include "lib/jxl/base/status.h"
-#include "lib/jxl/base/thread_pool_internal.h"
 #include "lib/jxl/codec_in_out.h"
+#include "tools/thread_pool_internal.h"
 
 namespace {
 
@@ -28,7 +28,7 @@ int Convert(int argc, char** argv) {
 
   jxl::CodecInOut io;
   jxl::extras::ColorHints color_hints;
-  jxl::ThreadPoolInternal pool(4);
+  jpegxl::tools::ThreadPoolInternal pool(4);
   color_hints.Add("color_space", desc);
   if (!jxl::SetFromFile(pathname_in, color_hints, &io, &pool)) {
     fprintf(stderr, "Failed to read %s\n", pathname_in.c_str());

--- a/tools/fuzzer_corpus.cc
+++ b/tools/fuzzer_corpus.cc
@@ -29,7 +29,6 @@
 #include "lib/jxl/base/file_io.h"
 #include "lib/jxl/base/override.h"
 #include "lib/jxl/base/span.h"
-#include "lib/jxl/base/thread_pool_internal.h"
 #include "lib/jxl/codec_in_out.h"
 #include "lib/jxl/enc_ans.h"
 #include "lib/jxl/enc_aux_out.h"
@@ -41,6 +40,7 @@
 #include "lib/jxl/encode_internal.h"
 #include "lib/jxl/jpeg/enc_jpeg_data.h"
 #include "lib/jxl/modular/encoding/context_predict.h"
+#include "tools/thread_pool_internal.h"
 
 namespace {
 
@@ -457,7 +457,7 @@ int main(int argc, const char** argv) {
     specs.back().params.noise = true;
     specs.back().override_decoder_spec = 0;
 
-    jxl::ThreadPoolInternal pool{num_threads};
+    jpegxl::tools::ThreadPoolInternal pool{num_threads};
     const auto generate = [&specs, dest_dir, regenerate, quiet](
                               const uint32_t task, size_t /* thread */) {
       const ImageSpec& spec = specs[task];

--- a/tools/hdr/display_to_hlg.cc
+++ b/tools/hdr/display_to_hlg.cc
@@ -9,14 +9,14 @@
 #include "lib/extras/codec.h"
 #include "lib/extras/hlg.h"
 #include "lib/extras/tone_mapping.h"
-#include "lib/jxl/base/thread_pool_internal.h"
 #include "lib/jxl/enc_color_management.h"
 #include "tools/args.h"
 #include "tools/cmdline.h"
 #include "tools/image_utils.h"
+#include "tools/thread_pool_internal.h"
 
 int main(int argc, const char** argv) {
-  jxl::ThreadPoolInternal pool;
+  jpegxl::tools::ThreadPoolInternal pool;
 
   jpegxl::tools::CommandLineParser parser;
   float max_nits = 0;

--- a/tools/hdr/exr_to_pq.cc
+++ b/tools/hdr/exr_to_pq.cc
@@ -10,11 +10,11 @@
 #include "lib/extras/dec/decode.h"
 #include "lib/extras/packed_image_convert.h"
 #include "lib/jxl/base/file_io.h"
-#include "lib/jxl/base/thread_pool_internal.h"
 #include "lib/jxl/enc_color_management.h"
 #include "lib/jxl/image_bundle.h"
 #include "tools/cmdline.h"
 #include "tools/image_utils.h"
+#include "tools/thread_pool_internal.h"
 
 namespace {
 
@@ -42,7 +42,7 @@ bool ParseLuminanceInfo(const char* argument, LuminanceInfo* luminance_info) {
 }  // namespace
 
 int main(int argc, const char** argv) {
-  jxl::ThreadPoolInternal pool;
+  jpegxl::tools::ThreadPoolInternal pool;
 
   jpegxl::tools::CommandLineParser parser;
   LuminanceInfo luminance_info;

--- a/tools/hdr/generate_lut_template.cc
+++ b/tools/hdr/generate_lut_template.cc
@@ -7,13 +7,13 @@
 #include <stdlib.h>
 
 #include "lib/extras/codec.h"
-#include "lib/jxl/base/thread_pool_internal.h"
 #include "lib/jxl/image_metadata.h"
 #include "tools/args.h"
 #include "tools/cmdline.h"
+#include "tools/thread_pool_internal.h"
 
 int main(int argc, const char** argv) {
-  jxl::ThreadPoolInternal pool;
+  jpegxl::tools::ThreadPoolInternal pool;
 
   jpegxl::tools::CommandLineParser parser;
   size_t N = 64;

--- a/tools/hdr/pq_to_hlg.cc
+++ b/tools/hdr/pq_to_hlg.cc
@@ -9,14 +9,14 @@
 #include "lib/extras/codec.h"
 #include "lib/extras/hlg.h"
 #include "lib/extras/tone_mapping.h"
-#include "lib/jxl/base/thread_pool_internal.h"
 #include "lib/jxl/enc_color_management.h"
 #include "tools/args.h"
 #include "tools/cmdline.h"
 #include "tools/image_utils.h"
+#include "tools/thread_pool_internal.h"
 
 int main(int argc, const char** argv) {
-  jxl::ThreadPoolInternal pool;
+  jpegxl::tools::ThreadPoolInternal pool;
 
   jpegxl::tools::CommandLineParser parser;
   float max_nits = 0;

--- a/tools/hdr/render_hlg.cc
+++ b/tools/hdr/render_hlg.cc
@@ -9,14 +9,14 @@
 #include "lib/extras/codec.h"
 #include "lib/extras/hlg.h"
 #include "lib/extras/tone_mapping.h"
-#include "lib/jxl/base/thread_pool_internal.h"
 #include "lib/jxl/enc_color_management.h"
 #include "tools/args.h"
 #include "tools/cmdline.h"
 #include "tools/image_utils.h"
+#include "tools/thread_pool_internal.h"
 
 int main(int argc, const char** argv) {
-  jxl::ThreadPoolInternal pool;
+  jpegxl::tools::ThreadPoolInternal pool;
 
   jpegxl::tools::CommandLineParser parser;
   float target_nits = 0;

--- a/tools/hdr/texture_to_cube.cc
+++ b/tools/hdr/texture_to_cube.cc
@@ -7,13 +7,13 @@
 #include <stdlib.h>
 
 #include "lib/extras/codec.h"
-#include "lib/jxl/base/thread_pool_internal.h"
 #include "lib/jxl/image_bundle.h"
 #include "tools/args.h"
 #include "tools/cmdline.h"
+#include "tools/thread_pool_internal.h"
 
 int main(int argc, const char** argv) {
-  jxl::ThreadPoolInternal pool;
+  jpegxl::tools::ThreadPoolInternal pool;
 
   jpegxl::tools::CommandLineParser parser;
   const char* input_filename = nullptr;

--- a/tools/hdr/tone_map.cc
+++ b/tools/hdr/tone_map.cc
@@ -8,15 +8,15 @@
 
 #include "lib/extras/codec.h"
 #include "lib/extras/tone_mapping.h"
-#include "lib/jxl/base/thread_pool_internal.h"
 #include "lib/jxl/enc_color_management.h"
 #include "lib/jxl/image_bundle.h"
 #include "tools/args.h"
 #include "tools/cmdline.h"
 #include "tools/image_utils.h"
+#include "tools/thread_pool_internal.h"
 
 int main(int argc, const char** argv) {
-  jxl::ThreadPoolInternal pool;
+  jpegxl::tools::ThreadPoolInternal pool;
 
   jpegxl::tools::CommandLineParser parser;
   float max_nits = 0;

--- a/tools/set_from_bytes_fuzzer.cc
+++ b/tools/set_from_bytes_fuzzer.cc
@@ -9,8 +9,8 @@
 #include "lib/extras/codec.h"
 #include "lib/jxl/base/data_parallel.h"
 #include "lib/jxl/base/span.h"
-#include "lib/jxl/base/thread_pool_internal.h"
 #include "lib/jxl/codec_in_out.h"
+#include "tools/thread_pool_internal.h"
 
 namespace {
 
@@ -19,7 +19,7 @@ int TestOneInput(const uint8_t* data, size_t size) {
   io.constraints.dec_max_xsize = 1u << 16;
   io.constraints.dec_max_ysize = 1u << 16;
   io.constraints.dec_max_pixels = 1u << 22;
-  jxl::ThreadPoolInternal pool(0);
+  jpegxl::tools::ThreadPoolInternal pool(0);
 
   (void)jxl::SetFromBytes(jxl::Span<const uint8_t>(data, size), &io, &pool);
 

--- a/tools/thread_pool_internal.h
+++ b/tools/thread_pool_internal.h
@@ -3,8 +3,8 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-#ifndef LIB_JXL_BASE_THREAD_POOL_INTERNAL_H_
-#define LIB_JXL_BASE_THREAD_POOL_INTERNAL_H_
+#ifndef TOOLS_THREAD_POOL_INTERNAL_H_
+#define TOOLS_THREAD_POOL_INTERNAL_H_
 
 #include <jxl/parallel_runner.h>
 #include <stddef.h>
@@ -14,14 +14,11 @@
 #include "lib/jxl/base/data_parallel.h"
 #include "lib/threads/thread_parallel_runner_internal.h"
 
-namespace jxl {
+namespace jpegxl {
+namespace tools {
 
-// Helper class to pass an internal ThreadPool-like object using threads. This
-// is only suitable for tests or tools that access the internal API of JPEG XL.
-// In other cases the caller will provide a JxlParallelRunner() for handling
-// this. This class uses jpegxl::ThreadParallelRunner (from jpegxl_threads
-// library). For interface details check jpegxl::ThreadParallelRunner.
-class ThreadPoolInternal : public ThreadPool {
+// Helper class to pass an internal ThreadPool-like object using threads.
+class ThreadPoolInternal : public jxl::ThreadPool {
  public:
   // Starts the given number of worker threads and blocks until they are ready.
   // "num_worker_threads" defaults to one per hyperthread. If zero, all tasks
@@ -36,17 +33,12 @@ class ThreadPoolInternal : public ThreadPool {
   ThreadPoolInternal& operator&(const ThreadPoolInternal&) = delete;
 
   size_t NumThreads() const { return runner_.NumThreads(); }
-  size_t NumWorkerThreads() const { return runner_.NumWorkerThreads(); }
-
-  template <class Func>
-  void RunOnEachThread(const Func& func) {
-    runner_.RunOnEachThread(func);
-  }
 
  private:
   jpegxl::ThreadParallelRunner runner_;
 };
 
-}  // namespace jxl
+}  // namespace tools
+}  // namespace jpegxl
 
-#endif  // LIB_JXL_BASE_THREAD_POOL_INTERNAL_H_
+#endif  // TOOLS_THREAD_POOL_INTERNAL_H_


### PR DESCRIPTION
 - cut dependency base->threads
 - clarify usage of class:
   - new simpler ThreadPoolForTests is provided by test_utils
   - nearly copy of old one is moved to tools/