### PR TITLE
Add decoder tests for scan header and restart intervals.

### DIFF
--- a/lib/jpegli/decode.cc
+++ b/lib/jpegli/decode.cc
@@ -86,6 +86,9 @@ int ConsumeInput(j_decompress_ptr cinfo) {
     if (!(*cinfo->src->fill_input_buffer)(cinfo)) {
       return status;
     }
+    if (src->bytes_in_buffer == 0) {
+      JPEGLI_ERROR("Empty input.");
+    }
     // Save the end of the current input so that we can restore it after the
     // input processing succeeds.
     last_input_byte = cinfo->src->next_input_byte + src->bytes_in_buffer;

--- a/lib/jpegli/test_utils.h
+++ b/lib/jpegli/test_utils.h
@@ -158,6 +158,11 @@ struct CompressParams {
 
 std::ostream& operator<<(std::ostream& os, const CompressParams& jparams);
 
+void VerifyHeader(const CompressParams& jparams, j_decompress_ptr cinfo);
+void VerifyRestartInterval(const CompressParams& jparams,
+                           j_decompress_ptr cinfo);
+void VerifyScanHeader(const CompressParams& jparams, j_decompress_ptr cinfo);
+
 struct DecompressParams {
   size_t chunk_size = 65536;
   size_t max_output_lines = 16;


### PR DESCRIPTION
This caught two bugs in the main decoding function.