### PR TITLE
Improving difficult images, max error -25 %

### DIFF
--- a/lib/jxl/decode_test.cc
+++ b/lib/jxl/decode_test.cc
@@ -1677,7 +1677,7 @@ TEST(DecodeTest, PixelTestWithICCProfileLossy) {
   jxl::ButteraugliParams ba;
   EXPECT_THAT(ButteraugliDistance(io0.frames, io1.frames, ba, jxl::GetJxlCms(),
                                   /*distmap=*/nullptr, nullptr),
-              IsSlightlyBelow(0.86f));
+              IsSlightlyBelow(0.6f));
 
   JxlDecoderDestroy(dec);
 }
@@ -1986,7 +1986,7 @@ TEST(DecodeTest, PixelTestOpaqueSrgbLossyNoise) {
     EXPECT_THAT(
         ButteraugliDistance(io0.frames, io1.frames, ba, jxl::GetJxlCms(),
                             /*distmap=*/nullptr, nullptr),
-        IsSlightlyBelow(2.4f));
+        IsSlightlyBelow(1.55f));
 
     JxlDecoderDestroy(dec);
   }

--- a/lib/jxl/enc_adaptive_quantization.cc
+++ b/lib/jxl/enc_adaptive_quantization.cc
@@ -717,7 +717,7 @@ ImageF TileDistMap(const ImageF& distmap, int tile_size, int margin,
 
 constexpr float kDcQuantPow = 0.87f;
 static const float kDcQuant = 1.295f;
-static const float kAcQuant = 0.83f;
+static const float kAcQuant = 0.825f;
 
 void FindBestQuantization(const ImageBundle& linear, const Image3F& opsin,
                           PassesEncoderState* enc_state,

--- a/lib/jxl/encode_test.cc
+++ b/lib/jxl/encode_test.cc
@@ -503,7 +503,7 @@ TEST(EncodeTest, LossyEncoderUseOriginalProfileTest) {
     ASSERT_NE(nullptr, enc.get());
     JxlEncoderFrameSettings* frame_settings =
         JxlEncoderFrameSettingsCreate(enc.get(), NULL);
-    VerifyFrameEncoding(63, 129, enc.get(), frame_settings, 5358, true);
+    VerifyFrameEncoding(63, 129, enc.get(), frame_settings, 5694, true);
   }
   {
     JxlEncoderPtr enc = JxlEncoderMake(nullptr);
@@ -513,7 +513,7 @@ TEST(EncodeTest, LossyEncoderUseOriginalProfileTest) {
     EXPECT_EQ(JXL_ENC_SUCCESS,
               JxlEncoderFrameSettingsSetOption(
                   frame_settings, JXL_ENC_FRAME_SETTING_PROGRESSIVE_DC, 2));
-    VerifyFrameEncoding(63, 129, enc.get(), frame_settings, 5767, true);
+    VerifyFrameEncoding(63, 129, enc.get(), frame_settings, 6046, true);
   }
   {
     JxlEncoderPtr enc = JxlEncoderMake(nullptr);
@@ -523,7 +523,7 @@ TEST(EncodeTest, LossyEncoderUseOriginalProfileTest) {
     ASSERT_EQ(JXL_ENC_SUCCESS,
               JxlEncoderFrameSettingsSetOption(
                   frame_settings, JXL_ENC_FRAME_SETTING_EFFORT, 8));
-    VerifyFrameEncoding(63, 129, enc.get(), frame_settings, 4798, true);
+    VerifyFrameEncoding(63, 129, enc.get(), frame_settings, 5165, true);
   }
 }
 

--- a/lib/jxl/jxl_test.cc
+++ b/lib/jxl/jxl_test.cc
@@ -133,7 +133,7 @@ TEST(JxlTest, RoundtripSmallD1) {
   {
     PackedPixelFile ppf_out;
     EXPECT_NEAR(Roundtrip(t.ppf(), {}, {}, pool, &ppf_out), 593, 20);
-    EXPECT_THAT(ButteraugliDistance(t.ppf(), ppf_out), IsSlightlyBelow(1.2));
+    EXPECT_THAT(ButteraugliDistance(t.ppf(), ppf_out), IsSlightlyBelow(1.3));
     EXPECT_EQ(ppf_out.info.intensity_target, t.ppf().info.intensity_target);
   }
 }
@@ -238,7 +238,7 @@ TEST(JxlTest, RoundtripResample4) {
   cparams.AddOption(JXL_ENC_FRAME_SETTING_RESAMPLING, 4);
 
   PackedPixelFile ppf_out;
-  EXPECT_NEAR(Roundtrip(t.ppf(), cparams, {}, pool, &ppf_out), 5855, 50);
+  EXPECT_NEAR(Roundtrip(t.ppf(), cparams, {}, pool, &ppf_out), 5923, 50);
   EXPECT_THAT(ButteraugliDistance(t.ppf(), ppf_out), IsSlightlyBelow(22));
 }
 
@@ -253,7 +253,7 @@ TEST(JxlTest, RoundtripResample8) {
   cparams.AddOption(JXL_ENC_FRAME_SETTING_RESAMPLING, 8);
 
   PackedPixelFile ppf_out;
-  EXPECT_NEAR(Roundtrip(t.ppf(), cparams, {}, pool, &ppf_out), 2115, 30);
+  EXPECT_NEAR(Roundtrip(t.ppf(), cparams, {}, pool, &ppf_out), 2162, 40);
   EXPECT_THAT(ButteraugliDistance(t.ppf(), ppf_out), IsSlightlyBelow(50));
 }
 
@@ -470,7 +470,7 @@ TEST(JxlTest, RoundtripNoGaborishNoAR) {
   cparams.AddOption(JXL_ENC_FRAME_SETTING_GABORISH, 0);
 
   PackedPixelFile ppf_out;
-  EXPECT_NEAR(Roundtrip(t.ppf(), cparams, {}, pool, &ppf_out), 37335, 100);
+  EXPECT_NEAR(Roundtrip(t.ppf(), cparams, {}, pool, &ppf_out), 37764, 100);
   EXPECT_THAT(ButteraugliDistance(t.ppf(), ppf_out), IsSlightlyBelow(1.8));
 }
 
@@ -514,7 +514,7 @@ TEST(JxlTest, RoundtripSmallPatchesAlpha) {
   cparams.distance = 0.1f;
 
   PackedPixelFile ppf_out;
-  EXPECT_NEAR(Roundtrip(t.ppf(), cparams, {}, pool, &ppf_out), 708, 70);
+  EXPECT_NEAR(Roundtrip(t.ppf(), cparams, {}, pool, &ppf_out), 636, 70);
   EXPECT_THAT(ButteraugliDistance(t.ppf(), ppf_out), IsSlightlyBelow(0.02f));
 }
 
@@ -731,7 +731,7 @@ TEST(JxlTest, RoundtripAlpha) {
       EXPECT_THAT(ButteraugliDistance(io.frames, io2.frames, cparams.ba_params,
                                       GetJxlCms(),
                                       /*distmap=*/nullptr),
-                  IsSlightlyBelow(1.5));
+                  IsSlightlyBelow(1.15));
     }
   }
 }
@@ -845,14 +845,14 @@ TEST(JxlTest, RoundtripAlphaPremultiplied) {
           EXPECT_THAT(ButteraugliDistance(io.frames, io2.frames,
                                           cparams.ba_params, GetJxlCms(),
                                           /*distmap=*/nullptr),
-                      IsSlightlyBelow(1.5));
+                      IsSlightlyBelow(1.15));
           EXPECT_TRUE(UnpremultiplyAlpha(io2));
           EXPECT_FALSE(io2.Main().AlphaIsPremultiplied());
         }
         EXPECT_THAT(ButteraugliDistance(io_nopremul.frames, io2.frames,
                                         cparams.ba_params, GetJxlCms(),
                                         /*distmap=*/nullptr),
-                    IsSlightlyBelow(1.5));
+                    IsSlightlyBelow(1.4));
       }
     }
   }
@@ -1238,7 +1238,7 @@ TEST(JxlTest, RoundtripAnimationPatches) {
               IsSlightlyBelow(16200));
   EXPECT_EQ(ppf_out.frames.size(), t.ppf().frames.size());
   // >10 with broken patches
-  EXPECT_THAT(ButteraugliDistance(t.ppf(), ppf_out), IsSlightlyBelow(1.2));
+  EXPECT_THAT(ButteraugliDistance(t.ppf(), ppf_out), IsSlightlyBelow(0.9));
 }
 
 #endif  // JPEGXL_ENABLE_GIF
@@ -1442,7 +1442,7 @@ TEST(JxlTest, RoundtripProgressive) {
   cparams.AddOption(JXL_ENC_FRAME_SETTING_RESPONSIVE, 1);
 
   PackedPixelFile ppf_out;
-  EXPECT_NEAR(Roundtrip(t.ppf(), cparams, {}, &pool, &ppf_out), 56307, 750);
+  EXPECT_NEAR(Roundtrip(t.ppf(), cparams, {}, &pool, &ppf_out), 55352, 750);
   EXPECT_THAT(ButteraugliDistance(t.ppf(), ppf_out), IsSlightlyBelow(1.4));
 }
 


### PR DESCRIPTION
Heuristics for deciding chromacity quantization multipliers based on individual pixels in the image (the worst colorful pixel).

Average BPP * pnorm improvement of ~0.4 %

```
Before:

Encoding      kPixels    Bytes          BPP  E MP/s  D MP/s     Max norm  SSIMULACRA2        pnorm   PSNR   QABPP  SmallB  DCT4x8     AFV  DCT8x8    8x16    8x32      16   16x32      32   32x64      64       BPP*pnorm   Bugs
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
jxl:d0.1        19988 16523292    6.6132527   1.468   9.103   0.82352817  99.92358975   0.11904343  53.30   6.613 40.2246 19.6242  0.4403 27.7621  5.5246  0.0000  3.0149  0.9298  3.0226  0.1025  0.0820  0.787264266380      0
jxl:d0.5        19988  6212290    2.4863958   1.807  14.687   1.60779905  97.53258276   0.37259065  43.91   2.539 14.2882 24.8830  0.5917 11.8519 21.7467  0.0000 20.5959  1.3960  4.7798  0.1230  0.4713  0.926407813374      0
jxl:d0.8        19988  4621848    1.8498401   1.896  14.837   2.46835184  92.43040933   0.51415877  41.35   2.234 10.9896 21.3458  0.6948  8.9487 19.6251  0.0000 30.5039  1.6829  6.3731  0.1947  0.3689  0.951111526097      0
jxl:d1          19988  4001660    1.6016172   1.861  15.135   3.32989001  89.66220905   0.59952517  40.22   2.281  9.7184 19.6411  0.7515  7.8360 18.0690  0.0000 32.2624  2.7050  9.2625  0.2357  0.2459  0.960209819225      0
jxl:d1.1        19988  3764938    1.5068720   1.941  16.036   3.10730362  88.44737966   0.63869863  39.74   2.255  9.2410 18.9188  0.7793  7.4364 17.3133  0.0000 32.2893  3.3505 10.9070  0.2459  0.2459  0.962437089917      0
jxl:d1.2        19988  3556651    1.4235076   1.965  16.136   3.75642824  87.38688667   0.67733697  39.29   2.312  8.7748 18.3572  0.8072  7.0570 16.6781  0.0000 31.9140  4.1574 12.5515  0.2869  0.1434  0.964194329451      0
jxl:d1.3        19988  3417189    1.3676896   2.025  16.342   4.04370308  86.55533435   0.70717028  39.18   2.342  8.3595 17.7859  0.8245  6.7576 16.3432  0.0000 31.0508  5.0718 14.0423  0.3074  0.1844  0.967189425609      0
jxl:d1.4        19988  3251580    1.3014065   2.052  16.412   3.62227726  85.48530156   0.74163146  38.80   2.331  8.0262 17.3662  0.8453  6.4711 15.8417  0.0000 30.1018  6.0145 15.4972  0.3586  0.2049  0.965164025654      0
jxl:d1.5        19988  3102264    1.2416446   1.977  15.239   3.75548553  84.62102096   0.77616139  38.44   2.342  7.7060 16.8724  0.8610  6.2415 15.5081  0.0000 29.2142  6.9161 16.7421  0.4201  0.2459  0.963716573868      0
jxl:d1.6        19988  2968473    1.1880963   2.031  14.926   4.17105150  83.72178738   0.81098880  38.14   2.344  7.4082 16.5023  0.8773  6.0023 15.2987  0.0000 28.2139  7.7717 17.8641  0.4406  0.3484  0.963532792394      0
jxl:d1.7        19988  2847400    1.1396383   1.968  15.525   4.94135141  82.80868791   0.84505208  37.84   2.371  7.1287 16.1699  0.9116  5.9165 15.0720  0.0000 27.0728  8.6042 18.9809  0.3996  0.4713  0.963053677405      0
jxl:d1.8        19988  2739372    1.0964013   2.050  15.798   4.75907946  82.01346260   0.87610111  37.58   2.362  6.8790 15.8302  0.9282  5.7516 14.8556  0.0000 26.2697  9.4700 19.7698  0.4406  0.5328  0.960558411247      0
jxl:d1.8        19988  2739372    1.0964013   2.031  15.617   4.75907946  82.01346260   0.87610111  37.58   2.362  6.8790 15.8302  0.9282  5.7516 14.8556  0.0000 26.2697  9.4700 19.7698  0.4406  0.5328  0.960558411247      0
jxl:d1.9        19988  2640755    1.0569310   2.073  16.092   5.36407852  81.29366500   0.91594333  37.32   2.395  6.6612 15.4748  0.9481  5.5640 14.6923  0.0000 25.4603 10.3076 20.6049  0.5021  0.5123  0.968088927280      0
jxl:d2.0        19988  2548218    1.0198942   1.985  15.863   5.84711552  80.38867597   0.94580905  37.09   2.421  6.4304 15.2196  0.9433  5.4855 14.5110  0.0000 24.6713 11.0171 21.4758  0.4611  0.5123  0.964625155947      0
jxl:d2.1        19988  2463104    0.9858283   2.100  16.013   7.50370598  79.68979747   0.98040641  36.87   2.418  6.1950 14.7982  0.9734  5.3257 14.3727  0.0000 24.1103 11.7548 22.1418  0.4816  0.5738  0.966512400152      0
jxl:d2.2        19988  2383002    0.9537684   2.026  15.205   7.30928326  78.84330677   1.01165840  36.64   2.432  6.0045 14.5709  0.9743  5.2796 14.2043  0.0000 23.3073 12.5643 22.7873  0.5021  0.5328  0.964887846769      0
jxl:d2.3        19988  2308938    0.9241252   2.089  15.938   7.72858810  78.16517537   1.04772021  36.43   2.455  5.8809 14.2613  0.9980  5.1346 14.0608  0.0000 22.8245 13.3046 23.1767  0.5328  0.5533  0.968224637144      0
jxl:d2.4        19988  2238863    0.8960785   2.026  16.277   7.20261240  77.51032368   1.07533794  36.23   2.452  5.7077 13.9901  0.9971  5.0036 13.9891  0.0000 22.2686 14.0474 23.4738  0.6148  0.6353  0.963587209948      0
jxl:d2.5        19988  2174938    0.8704933   2.105  15.562   6.84310198  76.77170182   1.10431746  36.04   2.431  5.5486 13.7128  1.0022  4.9271 13.8463  0.0000 21.7742 14.6903 23.9246  0.6045  0.6967  0.961300918652      0
jxl:d2.6        19988  2113931    0.8460759   2.073  15.735   7.03736973  76.08792436   1.13587997  35.85   2.435  5.3754 13.4563  1.0323  4.8253 13.7816  0.0000 21.3080 15.3691 24.2679  0.5943  0.7172  0.961040714365      0
jxl:d2.7        19988  2056676    0.8231603   1.987  14.409   6.96750259  75.53600650   1.17344879  35.68   2.447  5.2386 13.2687  1.0345  4.7356 13.6542  0.0000 20.7509 16.0300 24.6521  0.6660  0.6967  0.965936461206      0
jxl:d2.8        19988  2000986    0.8008710   2.104  16.012   6.37797117  74.87827698   1.20527611  35.49   2.417  5.1163 13.0372  1.0525  4.6732 13.6222  0.0000 20.3026 16.5961 24.8826  0.7275  0.7172  0.965270729293      0
jxl:d2.9        19988  1952769    0.7815728   2.065  15.623   5.43846607  74.18574474   1.22448170  35.32   2.387  5.0023 12.8172  1.0618  4.6437 13.5242  0.0000 19.7993 17.1520 25.2310  0.6967  0.7992  0.957021531903      0
jxl:d3          19988  1907485    0.7634484   1.903  15.616   5.54277325  73.58231618   1.25782196  35.18   2.432  4.8166 12.6309  1.0355  4.5355 13.3840  0.0000 19.4701 18.0203 25.3796  0.6762  0.7787  0.960282119887      0
jxl:d5          19988  1309448    0.5240911   1.974   8.879   6.23492336  61.58675224   1.78064639  32.90   2.425  3.3450  8.3083  0.9350  2.9326 10.7789  0.0000 15.3973 27.3238 29.6573  0.6967  1.3525  0.933220947459      0
jxl:d7          19988  1012538    0.4052564   1.930   8.708   8.67738914  51.86084361   2.23287615  31.47   2.397  2.5548  5.8556  0.7665  2.0566  9.1478  0.0000 12.8678 32.8464 32.3572  0.6967  1.5779  0.904887325722      0
jxl:d15         19988   568200    0.2274153   1.930   8.122  12.20489597  22.05944574   3.73495390  28.61   2.242  1.2129  1.7508  0.3000  0.5831  5.4253  0.0000  7.4989 38.0847 40.7077  1.2500  3.9140  0.849385834361      0
jxl:d24         19988   414057    0.1657214   0.296  20.077  55.47967911  -7.27496379   6.30035075  25.87   2.782  1.0131  2.3079  0.1710  0.6871  3.0360  0.0000  3.2685  9.2573  5.7020  0.0102  0.0000  1.044103130070      0
jxl:d32         19988   328092    0.1313150   0.298  20.105  55.35031891 -20.38345542   7.08462557  25.40   2.517  0.7403  1.7265  0.1418  0.4960  2.7223  0.0000  2.8663 10.3358  6.4243  0.0000  0.0000  0.930317267757      0
Aggregate:      19988  2310833    0.9248836   1.741  14.689   5.67165004  76.61354538   1.02694960  36.44   2.479  5.7156 12.2497  0.7519  4.6615 12.3844  0.0000 18.8103  8.7748 16.2795  0.3790  0.4887  0.949808892234      0

After:

Encoding      kPixels    Bytes          BPP  E MP/s  D MP/s     Max norm  SSIMULACRA2        pnorm   PSNR   QABPP  SmallB  DCT4x8     AFV  DCT8x8    8x16    8x32      16   16x32      32   32x64      64       BPP*pnorm   Bugs
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
jxl:d0.1        19988 16601784    6.6446682   1.460   9.055   0.82969904  99.90998011   0.11908622  53.47   6.645 40.1007 19.7260  0.4319 27.7106  5.5950  0.0000  3.0316  0.9350  3.0124  0.1025  0.0820  0.791288402128      0
jxl:d0.5        19988  6346606    2.5401542   1.784  14.125   1.10318422  97.91421661   0.36385938  44.68   2.548 14.2408 24.8730  0.5927 11.8301 21.7710  0.0000 20.6472  1.3781  4.7901  0.1332  0.4713  0.924258931951      0
jxl:d0.8        19988  4707782    1.8842342   1.867  14.992   1.58183396  92.68917733   0.50350849  42.08   2.209 10.9627 21.3810  0.6999  8.9173 19.6290  0.0000 30.4949  1.6650  6.4038  0.2049  0.3689  0.948727916371      0
jxl:d1          19988  4071767    1.6296767   1.892  14.275   1.92241156  89.94289198   0.58689233  40.85   2.240  9.6963 19.6235  0.7633  7.8242 18.1522  0.0000 32.1881  2.7050  9.2830  0.2254  0.2664  0.956444761045      0
jxl:d1.1        19988  3830180    1.5329844   1.947  16.109   2.40128708  88.87152798   0.62624903  40.32   2.252  9.2292 18.9034  0.7777  7.4262 17.3473  0.0000 32.1996  3.3787 10.9941  0.2459  0.2254  0.960029960469      0
jxl:d1.2        19988  3616039    1.4472769   1.967  15.932   2.39814067  87.74596303   0.66297144  39.84   2.288  8.7396 18.3171  0.8005  7.0423 16.7043  0.0000 31.8718  4.1932 12.6488  0.2869  0.1230  0.959503287281      0
jxl:d1.3        19988  3431499    1.3734170   1.976  16.481   3.40160346  86.73824546   0.70084944  39.45   2.320  8.3368 17.8106  0.8174  6.7307 16.3662  0.0000 30.9701  5.1000 14.1038  0.3074  0.1844  0.962558524131      0
jxl:d1.4        19988  3265089    1.3068133   2.009  16.852   2.56032324  85.75221479   0.73708383  39.04   2.302  7.9881 17.3201  0.8450  6.4531 15.9071  0.0000 30.0749  5.9965 15.5792  0.3586  0.2049  0.963230989331      0
jxl:d1.5        19988  3114205    1.2464238   1.988  14.783   3.45833826  84.80671133   0.77530887  38.68   2.362  7.6708 16.8215  0.8767  6.2267 15.5741  0.0000 29.1437  6.9648 16.7934  0.4098  0.2459  0.966363439216      0
jxl:d1.6        19988  2980863    1.1930552   1.990  14.241   3.16020727  83.91688319   0.80838085  38.37   2.327  7.3929 16.4600  0.8783  6.0013 15.3115  0.0000 28.1588  7.8306 17.8948  0.4303  0.3689  0.964443013540      0
jxl:d1.7        19988  2859310    1.1444051   1.976  15.779   3.60080242  83.06170603   0.84183210  38.06   2.341  7.1140 16.1017  0.9065  5.9091 15.1149  0.0000 27.0151  8.6580 19.0782  0.3996  0.4303  0.963396946456      0
jxl:d1.8        19988  2751313    1.1011806   2.025  16.361   3.73933816  82.27808266   0.87478322  37.75   2.349  6.8815 15.7713  0.9237  5.7612 14.8901  0.0000 26.1941  9.4700 19.8211  0.4611  0.5533  0.963294286151      0
jxl:d1.8        19988  2751313    1.1011806   1.961  15.259   3.73933816  82.27808266   0.87478322  37.75   2.349  6.8815 15.7713  0.9237  5.7612 14.8901  0.0000 26.1941  9.4700 19.8211  0.4611  0.5533  0.963294286151      0
jxl:d1.9        19988  2652116    1.0614781   2.039  16.076   4.02581120  81.42563037   0.90809343  37.48   2.358  6.6475 15.4892  0.9503  5.5534 14.7140  0.0000 25.4411 10.2871 20.6408  0.4713  0.5328  0.963921320206      0
jxl:d2.0        19988  2557929    1.0237809   2.007  16.065   3.88086057  80.68857727   0.93844669  37.25   2.363  6.4205 15.1687  0.9500  5.4634 14.5667  0.0000 24.6483 10.9736 21.5527  0.4713  0.5123  0.960763795369      0
jxl:d2.1        19988  2472377    0.9895397   2.057  15.374   4.29033232  79.94314684   0.96997953  37.01   2.362  6.1649 14.8271  0.9747  5.3046 14.3862  0.0000 23.9976 11.7933 22.2135  0.4918  0.5738  0.959833277073      0
jxl:d2.2        19988  2391247    0.9570684   1.993  16.192   4.44864178  79.18147899   1.00254030  36.78   2.390  5.9856 14.5555  0.9763  5.2409 14.2882  0.0000 23.2023 12.6309 22.7924  0.5021  0.5533  0.959499641876      0
jxl:d2.3        19988  2317790    0.9276681   2.083  15.825   4.47229528  78.40603710   1.03217934  36.56   2.394  5.8489 14.2501  0.9974  5.1298 14.0724  0.0000 22.7899 13.3455 23.1767  0.5430  0.5738  0.957519850293      0
jxl:d2.4        19988  2248693    0.9000128   2.024  16.166   4.42168045  77.73581839   1.06186871  36.36   2.379  5.6891 13.9536  0.9968  4.9758 13.9981  0.0000 22.2430 14.0858 23.5455  0.6045  0.6353  0.955695474932      0
jxl:d2.5        19988  2183770    0.8740282   2.091  15.942   4.56121588  77.03420949   1.09243212  36.16   2.386  5.5444 13.6891  1.0150  4.9024 13.8732  0.0000 21.6871 14.7441 23.9400  0.6148  0.7172  0.954816456843      0
jxl:d2.6        19988  2122621    0.8495540   2.039  15.879   4.64250898  76.43478540   1.12086616  35.97   2.408  5.3658 13.4057  1.0246  4.8041 13.8220  0.0000 21.2824 15.4076 24.2423  0.6148  0.7582  0.952236341909      0
jxl:d2.7        19988  2064486    0.8262862   1.983  15.823   5.21976519  75.72768170   1.15196616  35.78   2.403  5.2396 13.2504  1.0307  4.7138 13.6766  0.0000 20.6484 16.0608 24.7238  0.7070  0.6762  0.951853698451      0
jxl:d2.8        19988  2009846    0.8044171   2.050  16.177   5.17107391  75.07544792   1.18543546  35.59   2.386  5.1176 13.0045  1.0521  4.6652 13.6440  0.0000 20.2719 16.6448 24.8826  0.7275  0.7172  0.953584610373      0
jxl:d2.9        19988  1959274    0.7841763   2.046  15.632   5.03520775  74.37060575   1.21463582  35.42   2.368  4.9713 12.8188  1.0630  4.6232 13.5165  0.0000 19.7506 17.1955 25.3130  0.6967  0.7787  0.952488624504      0
jxl:d3          19988  1914693    0.7663333   1.901  16.149   4.88739634  73.77555992   1.24098735  35.27   2.398  4.7852 12.6056  1.0336  4.5057 13.4288  0.0000 19.4420 18.0408 25.4308  0.6762  0.7787  0.951009909644      0
jxl:d5          19988  1315486    0.5265078   1.970   9.016   5.81681013  61.85173462   1.76062806  32.94   2.400  3.3386  8.2667  0.9289  2.9240 10.7891  0.0000 15.3499 27.4186 29.6420  0.7172  1.3525  0.926984319055      0
jxl:d7          19988  1016578    0.4068734   1.899   8.600   7.30537558  52.08452493   2.22183583  31.49   2.377  2.5574  5.8099  0.7675  2.0495  9.1318  0.0000 12.9050 32.7926 32.4391  0.6762  1.5984  0.904005787108      0
jxl:d15         19988   567846    0.2272737   1.926   8.289  11.95916557  21.95374887   3.74686557  28.60   2.261  1.2100  1.7409  0.3000  0.5786  5.4055  0.0000  7.4771 38.1180 40.6514  1.3320  3.9140  0.851563858329      0
jxl:d24         19988   413263    0.1654036   0.294  20.647  55.19729996  -7.55829099   6.31257119  25.86   2.792  1.0064  2.3083  0.1681  0.6855  3.0175  0.0000  3.2647  9.2702  5.7224  0.0102  0.0000  1.044122251967      0
jxl:d32         19988   327135    0.1309319   0.298  19.834  55.65047455 -20.65641211   7.09924398  25.39   2.524  0.7384  1.7172  0.1425  0.5001  2.7159  0.0000  2.8638 10.3358  6.4397  0.0000  0.0000  0.929517674235      0
Aggregate:      19988  2324349    0.9302933   1.727  14.745   4.29788299  76.82899409   1.01718800  36.65   2.454  5.7004 12.2268  0.7515  4.6494 12.4057  0.0000 18.7797  8.7892 16.3188  0.3827  0.4893  0.946283212428      0
```