### PR TITLE
Detect gamma when appropriate

### DIFF
--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -35,7 +35,7 @@ jobs:
       with:
         repository: libjxl/conformance
         # TODO(eustas): move ref to a global variable / file?
-        ref: 5399ecf01e50ec5230912aa2df82286dc1c379c9
+        ref: 3e55a021da11b98f0a0f523e2966057ae892c221
         path: conformance
     - name: Cache
       uses: actions/cache@v2
@@ -167,7 +167,7 @@ jobs:
       uses: actions/checkout@v2
       with:
         repository: libjxl/conformance
-        ref: 5399ecf01e50ec5230912aa2df82286dc1c379c9
+        ref: 3e55a021da11b98f0a0f523e2966057ae892c221
         path: conformance
     - name: Cache
       uses: actions/cache@v2

--- a/lib/jxl/color_management.cc
+++ b/lib/jxl/color_management.cc
@@ -601,8 +601,7 @@ Status MaybeCreateProfile(const ColorEncoding& c,
   } else {
     if (c.tf.IsGamma()) {
       float gamma = 1.0 / c.tf.GetGamma();
-      JXL_RETURN_IF_ERROR(
-          CreateICCCurvParaTag({gamma, 1.0, 0.0, 1.0, 0.0}, 3, &tags));
+      JXL_RETURN_IF_ERROR(CreateICCCurvParaTag({gamma}, 0, &tags));
     } else if (c.GetColorSpace() != ColorSpace::kXYB) {
       switch (c.tf.GetTransferFunction()) {
         case TransferFunction::kHLG:


### PR DESCRIPTION
Before:

```console
$ tools/cjxl adobench.png output.jxl && tools/jxlinfo output.jxl
JPEG XL encoder v0.9.0 f8c984d67 [AVX2,SSE4,SSSE3,SSE2]
Read 500x606 image, 694182 bytes, 94.6 MP/s
Encoding [VarDCT, d1.000, effort: 7], 
Compressed to 130817 bytes (3.454 bpp).
500 x 606, 4.25 MP/s [4.25, 4.25], 1 reps, 56 threads.
JPEG XL image, 500x606, lossy, 8-bit RGB
Color space: 888-byte ICC profile, CMM type: "lcms", color space: "RGB ", rendering intent: 0
```

After:

```console
$ tools/cjxl adobench.png output.jxl && tools/jxlinfo output.jxl
JPEG XL encoder v0.9.0 8b7a98417 [AVX2,SSE4,SSSE3,SSE2]
Read 500x606 image, 694182 bytes, 96.4 MP/s
Encoding [VarDCT, d1.000, effort: 7], 
Compressed to 130553 bytes (3.447 bpp).
500 x 606, 4.73 MP/s [4.73, 4.73], 1 reps, 56 threads.
JPEG XL image, 500x606, lossy, 8-bit RGB
Color space: RGB, D65, Custom primaries: red(x=0.639998,y=0.329996),  green(x=0.210011,y=0.710000),  blue(x=0.150000,y=0.060005)gamma(0.454707) transfer function, rendering intent: Perceptual
```