### PR TITLE
difficult images: ~2 % improvement to max error

### DIFF
--- a/lib/jxl/decode_test.cc
+++ b/lib/jxl/decode_test.cc
@@ -1677,7 +1677,7 @@ TEST(DecodeTest, PixelTestWithICCProfileLossy) {
   jxl::ButteraugliParams ba;
   EXPECT_THAT(ButteraugliDistance(io0.frames, io1.frames, ba, jxl::GetJxlCms(),
                                   /*distmap=*/nullptr, nullptr),
-              IsSlightlyBelow(0.6f));
+              IsSlightlyBelow(0.75f));
 
   JxlDecoderDestroy(dec);
 }

--- a/lib/jxl/enc_adaptive_quantization.cc
+++ b/lib/jxl/enc_adaptive_quantization.cc
@@ -717,7 +717,7 @@ ImageF TileDistMap(const ImageF& distmap, int tile_size, int margin,
 
 constexpr float kDcQuantPow = 0.87f;
 static const float kDcQuant = 1.295f;
-static const float kAcQuant = 0.825f;
+static const float kAcQuant = 0.8265f;
 
 void FindBestQuantization(const ImageBundle& linear, const Image3F& opsin,
                           PassesEncoderState* enc_state,

--- a/lib/jxl/enc_frame.cc
+++ b/lib/jxl/enc_frame.cc
@@ -529,12 +529,15 @@ struct PixelStatsForChromacityAdjustment {
         float cur_y = plane_y->Row(ty)[tx];
         float cur_b = plane_b->Row(ty)[tx];
         float exposed_b = cur_b - cur_y * 1.2;
+        float diff_b = cur_b - cur_y;
         float prev_row = plane_b->Row(ty - 1)[tx];
         float prev = plane_b->Row(ty)[tx - 1];
-        xmax = std::max(xmax, std::abs(cur_b - prev));
-        ymax = std::max(ymax, std::abs(cur_b - prev_row));
+        float diff_prev_row = prev_row - plane_y->Row(ty - 1)[tx];
+        float diff_prev = prev - plane_y->Row(ty)[tx - 1];
+        xmax = std::max(xmax, std::abs(diff_b - diff_prev));
+        ymax = std::max(ymax, std::abs(diff_b - diff_prev_row));
         if (exposed_b >= 0) {
-          exposed_b *= fabs(cur_b - 0.5 * (prev_row + prev));
+          exposed_b *= fabs(cur_b - prev) + fabs(cur_b - prev_row);
           eb = std::max(eb, exposed_b);
         }
       }
@@ -550,20 +553,20 @@ struct PixelStatsForChromacityAdjustment {
     if (dx >= 0.03) {
       return 2;
     }
-    if (dx >= 0.01) {
+    if (dx >= 0.017) {
       return 1;
     }
     return 0;
   }
   int HowMuchIsBChannelPixelized() {
-    int add = exposed_blue >= 0.055 ? 1 : 0;
-    if (db > 0.8) {
+    int add = exposed_blue >= 0.13 ? 1 : 0;
+    if (db > 0.38) {
       return 2 + add;
     }
-    if (db > 0.75) {
+    if (db > 0.33) {
       return 1 + add;
     }
-    if (db > 0.7) {
+    if (db > 0.28) {
       return add;
     }
     return 0;

--- a/lib/jxl/encode_test.cc
+++ b/lib/jxl/encode_test.cc
@@ -503,7 +503,7 @@ TEST(EncodeTest, LossyEncoderUseOriginalProfileTest) {
     ASSERT_NE(nullptr, enc.get());
     JxlEncoderFrameSettings* frame_settings =
         JxlEncoderFrameSettingsCreate(enc.get(), NULL);
-    VerifyFrameEncoding(63, 129, enc.get(), frame_settings, 5694, true);
+    VerifyFrameEncoding(63, 129, enc.get(), frame_settings, 5740, true);
   }
   {
     JxlEncoderPtr enc = JxlEncoderMake(nullptr);
@@ -513,7 +513,7 @@ TEST(EncodeTest, LossyEncoderUseOriginalProfileTest) {
     EXPECT_EQ(JXL_ENC_SUCCESS,
               JxlEncoderFrameSettingsSetOption(
                   frame_settings, JXL_ENC_FRAME_SETTING_PROGRESSIVE_DC, 2));
-    VerifyFrameEncoding(63, 129, enc.get(), frame_settings, 6046, true);
+    VerifyFrameEncoding(63, 129, enc.get(), frame_settings, 6091, true);
   }
   {
     JxlEncoderPtr enc = JxlEncoderMake(nullptr);

--- a/lib/jxl/jxl_test.cc
+++ b/lib/jxl/jxl_test.cc
@@ -238,7 +238,7 @@ TEST(JxlTest, RoundtripResample4) {
   cparams.AddOption(JXL_ENC_FRAME_SETTING_RESAMPLING, 4);
 
   PackedPixelFile ppf_out;
-  EXPECT_NEAR(Roundtrip(t.ppf(), cparams, {}, pool, &ppf_out), 5923, 50);
+  EXPECT_NEAR(Roundtrip(t.ppf(), cparams, {}, pool, &ppf_out), 5818, 50);
   EXPECT_THAT(ButteraugliDistance(t.ppf(), ppf_out), IsSlightlyBelow(22));
 }
 
@@ -454,7 +454,7 @@ TEST(JxlTest, RoundtripSmallNL) {
   t.SetDimensions(xsize, ysize);
 
   PackedPixelFile ppf_out;
-  EXPECT_NEAR(Roundtrip(t.ppf(), {}, {}, pool, &ppf_out), 729, 20);
+  EXPECT_NEAR(Roundtrip(t.ppf(), {}, {}, pool, &ppf_out), 750, 25);
   EXPECT_THAT(ButteraugliDistance(t.ppf(), ppf_out), IsSlightlyBelow(1.1));
 }
 
@@ -470,7 +470,7 @@ TEST(JxlTest, RoundtripNoGaborishNoAR) {
   cparams.AddOption(JXL_ENC_FRAME_SETTING_GABORISH, 0);
 
   PackedPixelFile ppf_out;
-  EXPECT_NEAR(Roundtrip(t.ppf(), cparams, {}, pool, &ppf_out), 37764, 100);
+  EXPECT_NEAR(Roundtrip(t.ppf(), cparams, {}, pool, &ppf_out), 37218, 100);
   EXPECT_THAT(ButteraugliDistance(t.ppf(), ppf_out), IsSlightlyBelow(1.8));
 }
 


### PR DESCRIPTION
improving pixel based heuristics for chromacity adjustment further

0.15 % improvement to BPP * pnorm

```
Before:

Encoding      kPixels    Bytes          BPP  E MP/s  D MP/s     Max norm  SSIMULACRA2        pnorm   PSNR   QABPP  SmallB  DCT4x8     AFV  DCT8x8    8x16    8x32      16   16x32      32   32x64      64       BPP*pnorm   Bugs
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
jxl:d0.1        19988 16601784    6.6446682   1.447   8.966   0.82969904  99.90998011   0.11908622  53.47   6.645 40.1007 19.7260  0.4319 27.7106  5.5950  0.0000  3.0316  0.9350  3.0124  0.1025  0.0820  0.791288402128      0
jxl:d0.5        19988  6346606    2.5401542   1.770  14.374   1.10318422  97.91421661   0.36385938  44.68   2.548 14.2408 24.8730  0.5927 11.8301 21.7710  0.0000 20.6472  1.3781  4.7901  0.1332  0.4713  0.924258931951      0
jxl:d0.8        19988  4707782    1.8842342   1.872  15.066   1.58183396  92.68917733   0.50350849  42.08   2.209 10.9627 21.3810  0.6999  8.9173 19.6290  0.0000 30.4949  1.6650  6.4038  0.2049  0.3689  0.948727916371      0
jxl:d1          19988  4071767    1.6296767   1.863  15.094   1.92241156  89.94289198   0.58689233  40.85   2.240  9.6963 19.6235  0.7633  7.8242 18.1522  0.0000 32.1881  2.7050  9.2830  0.2254  0.2664  0.956444761045      0
jxl:d1.1        19988  3830180    1.5329844   1.898  15.977   2.40128708  88.87152798   0.62624903  40.32   2.252  9.2292 18.9034  0.7777  7.4262 17.3473  0.0000 32.1996  3.3787 10.9941  0.2459  0.2254  0.960029960469      0
jxl:d1.2        19988  3616039    1.4472769   1.962  16.434   2.39814067  87.74596303   0.66297144  39.84   2.288  8.7396 18.3171  0.8005  7.0423 16.7043  0.0000 31.8718  4.1932 12.6488  0.2869  0.1230  0.959503287281      0
jxl:d1.3        19988  3431499    1.3734170   1.908  16.221   3.40160346  86.73824546   0.70084944  39.45   2.320  8.3368 17.8106  0.8174  6.7307 16.3662  0.0000 30.9701  5.1000 14.1038  0.3074  0.1844  0.962558524131      0
jxl:d1.4        19988  3265089    1.3068133   2.004  16.576   2.56032324  85.75221479   0.73708383  39.04   2.302  7.9881 17.3201  0.8450  6.4531 15.9071  0.0000 30.0749  5.9965 15.5792  0.3586  0.2049  0.963230989331      0
jxl:d1.5        19988  3114205    1.2464238   1.885  15.776   3.45833826  84.80671133   0.77530887  38.68   2.362  7.6708 16.8215  0.8767  6.2267 15.5741  0.0000 29.1437  6.9648 16.7934  0.4098  0.2459  0.966363439216      0
jxl:d1.6        19988  2980863    1.1930552   2.002  15.293   3.16020727  83.91688319   0.80838085  38.37   2.327  7.3929 16.4600  0.8783  6.0013 15.3115  0.0000 28.1588  7.8306 17.8948  0.4303  0.3689  0.964443013540      0
jxl:d1.7        19988  2859310    1.1444051   1.960  15.473   3.60080242  83.06170603   0.84183210  38.06   2.341  7.1140 16.1017  0.9065  5.9091 15.1149  0.0000 27.0151  8.6580 19.0782  0.3996  0.4303  0.963396946456      0
jxl:d1.8        19988  2751313    1.1011806   2.007  15.672   3.73933816  82.27808266   0.87478322  37.75   2.349  6.8815 15.7713  0.9237  5.7612 14.8901  0.0000 26.1941  9.4700 19.8211  0.4611  0.5533  0.963294286151      0
jxl:d1.8        19988  2751313    1.1011806   1.943  15.732   3.73933816  82.27808266   0.87478322  37.75   2.349  6.8815 15.7713  0.9237  5.7612 14.8901  0.0000 26.1941  9.4700 19.8211  0.4611  0.5533  0.963294286151      0
jxl:d1.9        19988  2652116    1.0614781   1.985  15.536   4.02581120  81.42563037   0.90809343  37.48   2.358  6.6475 15.4892  0.9503  5.5534 14.7140  0.0000 25.4411 10.2871 20.6408  0.4713  0.5328  0.963921320206      0
jxl:d2.0        19988  2557929    1.0237809   2.008  15.690   3.88086057  80.68857727   0.93844669  37.25   2.363  6.4205 15.1687  0.9500  5.4634 14.5667  0.0000 24.6483 10.9736 21.5527  0.4713  0.5123  0.960763795369      0
jxl:d2.1        19988  2472377    0.9895397   2.090  15.252   4.29033232  79.94314684   0.96997953  37.01   2.362  6.1649 14.8271  0.9747  5.3046 14.3862  0.0000 23.9976 11.7933 22.2135  0.4918  0.5738  0.959833277073      0
jxl:d2.2        19988  2391247    0.9570684   1.963  15.851   4.44864178  79.18147899   1.00254030  36.78   2.390  5.9856 14.5555  0.9763  5.2409 14.2882  0.0000 23.2023 12.6309 22.7924  0.5021  0.5533  0.959499641876      0
jxl:d2.3        19988  2317790    0.9276681   2.070  15.852   4.47229528  78.40603710   1.03217934  36.56   2.394  5.8489 14.2501  0.9974  5.1298 14.0724  0.0000 22.7899 13.3455 23.1767  0.5430  0.5738  0.957519850293      0
jxl:d2.4        19988  2248693    0.9000128   1.964  16.018   4.42168045  77.73581839   1.06186871  36.36   2.379  5.6891 13.9536  0.9968  4.9758 13.9981  0.0000 22.2430 14.0858 23.5455  0.6045  0.6353  0.955695474932      0
jxl:d2.5        19988  2183770    0.8740282   2.095  16.011   4.56121588  77.03420949   1.09243212  36.16   2.386  5.5444 13.6891  1.0150  4.9024 13.8732  0.0000 21.6871 14.7441 23.9400  0.6148  0.7172  0.954816456843      0
jxl:d2.6        19988  2122621    0.8495540   1.978  15.909   4.64250898  76.43478540   1.12086616  35.97   2.408  5.3658 13.4057  1.0246  4.8041 13.8220  0.0000 21.2824 15.4076 24.2423  0.6148  0.7582  0.952236341909      0
jxl:d2.7        19988  2064486    0.8262862   2.061  15.465   5.21976519  75.72768170   1.15196616  35.78   2.403  5.2396 13.2504  1.0307  4.7138 13.6766  0.0000 20.6484 16.0608 24.7238  0.7070  0.6762  0.951853698451      0
jxl:d2.8        19988  2009846    0.8044171   2.011  15.661   5.17107391  75.07544792   1.18543546  35.59   2.386  5.1176 13.0045  1.0521  4.6652 13.6440  0.0000 20.2719 16.6448 24.8826  0.7275  0.7172  0.953584610373      0
jxl:d2.9        19988  1959274    0.7841763   2.050  15.971   5.03520775  74.37060575   1.21463582  35.42   2.368  4.9713 12.8188  1.0630  4.6232 13.5165  0.0000 19.7506 17.1955 25.3130  0.6967  0.7787  0.952488624504      0
jxl:d3          19988  1914693    0.7663333   1.874  15.594   4.88739634  73.77555992   1.24098735  35.27   2.398  4.7852 12.6056  1.0336  4.5057 13.4288  0.0000 19.4420 18.0408 25.4308  0.6762  0.7787  0.951009909644      0
jxl:d5          19988  1315486    0.5265078   1.961   8.916   5.81681013  61.85173462   1.76062806  32.94   2.400  3.3386  8.2667  0.9289  2.9240 10.7891  0.0000 15.3499 27.4186 29.6420  0.7172  1.3525  0.926984319055      0
jxl:d7          19988  1016578    0.4068734   1.938   8.672   7.30537558  52.08452493   2.22183583  31.49   2.377  2.5574  5.8099  0.7675  2.0495  9.1318  0.0000 12.9050 32.7926 32.4391  0.6762  1.5984  0.904005787108      0
jxl:d15         19988   567846    0.2272737   1.937   8.201  11.95916557  21.95374887   3.74686557  28.60   2.261  1.2100  1.7409  0.3000  0.5786  5.4055  0.0000  7.4771 38.1180 40.6514  1.3320  3.9140  0.851563858329      0
jxl:d24         19988   413263    0.1654036   0.297  20.524  55.19729996  -7.55829099   6.31257119  25.86   2.792  1.0064  2.3083  0.1681  0.6855  3.0175  0.0000  3.2647  9.2702  5.7224  0.0102  0.0000  1.044122251967      0
jxl:d32         19988   327135    0.1309319   0.299  19.747  55.65047455 -20.65641211   7.09924398  25.39   2.524  0.7384  1.7172  0.1425  0.5001  2.7159  0.0000  2.8638 10.3358  6.4397  0.0000  0.0000  0.929517674235      0
Aggregate:      19988  2324349    0.9302933   1.714  14.736   4.29788299  76.82899409   1.01718800  36.65   2.454  5.7004 12.2268  0.7515  4.6494 12.4057  0.0000 18.7797  8.7892 16.3188  0.3827  0.4893  0.946283212428      0

After:

Encoding      kPixels    Bytes          BPP  E MP/s  D MP/s     Max norm  SSIMULACRA2        pnorm   PSNR   QABPP  SmallB  DCT4x8     AFV  DCT8x8    8x16    8x32      16   16x32      32   32x64      64       BPP*pnorm   Bugs
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
jxl:d0.1        19988 16557623    6.6269933   1.357   8.711   0.83253759  99.91563915   0.11898343  53.46   6.627 40.1468 19.6738  0.4364 27.7147  5.5886  0.0000  3.0380  0.9324  3.0124  0.1025  0.0820  0.788502360183      0
jxl:d0.5        19988  6306297    2.5240210   1.707  13.430   1.11764216  97.81447834   0.36433938  44.69   2.533 14.2581 24.8516  0.5892 11.8326 21.7685  0.0000 20.6523  1.3755  4.7952  0.1332  0.4713  0.919600229944      0
jxl:d0.8        19988  4686547    1.8757351   1.743  14.403   1.58766067  92.65023463   0.50411074  42.09   2.203 10.9832 21.3583  0.6955  8.9292 19.6226  0.0000 30.4834  1.6727  6.4089  0.2049  0.3689  0.945578239732      0
jxl:d1          19988  4054997    1.6229647   1.695  13.973   1.88078141  89.90291219   0.58737295  40.90   2.214  9.6992 19.6331  0.7582  7.8232 18.0933  0.0000 32.2483  2.7024  9.2983  0.2254  0.2459  0.953285573238      0
jxl:d1.1        19988  3815238    1.5270040   1.779  14.378   2.17969394  88.78194631   0.62649217  40.37   2.235  9.2375 18.8832  0.7838  7.4326 17.3262  0.0000 32.2355  3.3838 10.9633  0.2562  0.2254  0.956656043646      0
jxl:d1.2        19988  3604242    1.4425553   1.800  14.856   2.25499773  87.66213011   0.66381495  39.88   2.273  8.7463 18.3168  0.8040  7.0560 16.6871  0.0000 31.8859  4.1983 12.6232  0.2869  0.1230  0.957589804295      0
jxl:d1.3        19988  3429086    1.3724512   1.832  15.139   2.97434020  86.72411628   0.69982493  39.51   2.301  8.3355 17.8125  0.8229  6.7631 16.3240  0.0000 30.9919  5.0974 14.0884  0.3074  0.1844  0.960475576458      0
jxl:d1.4        19988  3261792    1.3054938   1.851  14.722   2.51594043  85.73546826   0.73679964  39.11   2.289  7.9958 17.3444  0.8437  6.4614 15.8782  0.0000 30.0877  5.9888 15.5536  0.3689  0.2049  0.961887341341      0
jxl:d1.5        19988  3112752    1.2458423   1.806  14.066   2.85840535  84.78881777   0.77444067  38.75   2.352  7.6679 16.8398  0.8735  6.2293 15.5401  0.0000 29.2014  6.9469 16.7729  0.4098  0.2459  0.964830919923      0
jxl:d1.6        19988  2978362    1.1920543   1.868  14.220   3.19726753  83.89525858   0.80714296  38.42   2.336  7.3830 16.4898  0.8773  6.0081 15.3205  0.0000 28.1601  7.8203 17.8794  0.4406  0.3484  0.962158195651      0
jxl:d1.7        19988  2858262    1.1439856   1.859  14.616   3.57072639  83.05587241   0.84095020  38.10   2.350  7.1191 16.1165  0.9061  5.9114 15.1136  0.0000 27.0126  8.6093 19.0680  0.3996  0.4713  0.962034959708      0
jxl:d1.8        19988  2749347    1.1003937   1.909  13.345   3.31805015  82.22789264   0.87389962  37.78   2.335  6.8793 15.7896  0.9215  5.7493 14.8524  0.0000 26.2582  9.4571 19.8262  0.4406  0.5533  0.961633631017      0
jxl:d1.8        19988  2749347    1.1003937   1.840  14.387   3.31805015  82.22789264   0.87389962  37.78   2.335  6.8793 15.7896  0.9215  5.7493 14.8524  0.0000 26.2582  9.4571 19.8262  0.4406  0.5533  0.961633631017      0
jxl:d1.9        19988  2650099    1.0606709   1.923  14.243   3.81296635  81.42803085   0.90627200  37.50   2.338  6.6523 15.4674  0.9471  5.5569 14.7281  0.0000 25.4154 10.2999 20.6561  0.5123  0.4918  0.961256298878      0
jxl:d2.0        19988  2557074    1.0234387   1.817  14.823   3.77866483  80.66032673   0.93760008  37.27   2.370  6.4243 15.2132  0.9474  5.4541 14.5533  0.0000 24.6431 10.9915 21.5271  0.4611  0.5123  0.959576207347      0
jxl:d2.1        19988  2472105    0.9894309   1.900  14.902   4.19620609  79.97448270   0.96872111  37.04   2.369  6.1762 14.8267  0.9747  5.3193 14.3721  0.0000 24.0399 11.7651 22.2084  0.4918  0.5533  0.958482556078      0
jxl:d2.2        19988  2392479    0.9575615   1.891  14.868   4.37509441  79.17452238   1.00015559  36.83   2.380  5.9898 14.5543  0.9731  5.2546 14.2683  0.0000 23.2343 12.6258 22.7720  0.5021  0.5533  0.957710478720      0
jxl:d2.3        19988  2317214    0.9274376   1.916  15.370   4.49667549  78.43420001   1.03098381  36.59   2.394  5.8534 14.2603  0.9968  5.1426 14.0711  0.0000 22.7873 13.3122 23.1767  0.5533  0.5738  0.956173114839      0
jxl:d2.4        19988  2247521    0.8995438   1.852  15.461   4.33576155  77.74187347   1.06077665  36.39   2.375  5.6949 13.9699  0.9968  4.9786 13.9808  0.0000 22.2635 14.0986 23.4943  0.6148  0.6353  0.954215015505      0
jxl:d2.5        19988  2182792    0.8736367   1.949  14.951   4.49277687  76.99965928   1.09745781  36.20   2.390  5.5361 13.7061  1.0134  4.9082 13.8719  0.0000 21.6987 14.7518 23.9093  0.6148  0.7172  0.958779467349      0
jxl:d2.6        19988  2122756    0.8496080   1.898  14.619   4.87247944  76.43946144   1.11946472  36.01   2.400  5.3664 13.4637  1.0236  4.8131 13.7951  0.0000 21.2478 15.4178 24.2576  0.6045  0.7377  0.951106228210      0
jxl:d2.7        19988  2065040    0.8265079   1.873  14.470   5.13113499  75.68515195   1.15574604  35.81   2.397  5.2329 13.2697  1.0336  4.7260 13.6593  0.0000 20.6561 16.0736 24.6931  0.7070  0.6762  0.955233232158      0
jxl:d2.8        19988  2010364    0.8046245   1.951  14.661   5.43591213  75.06713902   1.18200376  35.62   2.398  5.1160 13.0132  1.0569  4.6751 13.6491  0.0000 20.2450 16.6140 24.9031  0.7377  0.7172  0.951069148233      0
jxl:d2.9        19988  1959701    0.7843472   1.889  13.958   4.92358208  74.41542229   1.21304642  35.45   2.374  4.9748 12.8329  1.0637  4.6402 13.4954  0.0000 19.7980 17.1340 25.3335  0.6762  0.7787  0.951449565701      0
jxl:d3          19988  1915651    0.7667167   1.766  14.009   5.15968609  73.75573023   1.23933298  35.29   2.409  4.8099 12.5883  1.0345  4.5262 13.4077  0.0000 19.4676 18.0536 25.3847  0.6762  0.7787  0.950217309045      0
jxl:d5          19988  1315264    0.5264189   1.876   8.240   6.45225143  61.88179883   1.75847762  32.95   2.405  3.3325  8.3025  0.9308  2.9224 10.7949  0.0000 15.3807 27.3622 29.6522  0.6967  1.3525  0.925695852872      0
jxl:d7          19988  1017601    0.4072828   1.755   8.243   7.63666773  52.14422859   2.21413928  31.50   2.387  2.5590  5.8268  0.7637  2.0521  9.1389  0.0000 12.9165 32.8131 32.3828  0.6762  1.5984  0.901780833016      0
jxl:d15         19988   568191    0.2274117   1.840   8.210  11.95917511  22.03143132   3.74581602  28.60   2.267  1.2119  1.7374  0.3007  0.5795  5.4157  0.0000  7.4822 38.1283 40.6360  1.3013  3.9345  0.851842553751      0
jxl:d24         19988   413531    0.1655109   0.296  18.498  56.26187134  -7.52104123   6.31349118  25.87   2.792  1.0182  2.3079  0.1697  0.6865  3.0328  0.0000  3.2634  9.2369  5.7276  0.0102  0.0000  1.044951631388      0
jxl:d32         19988   326756    0.1307802   0.300  19.074  55.78639984 -20.47122140   7.10397484  25.40   2.522  0.7368  1.7261  0.1425  0.5017  2.7184  0.0000  2.8548 10.3178  6.4550  0.0000  0.0000  0.929059491268      0
Aggregate:      19988  2322077    0.9293839   1.615  13.694   4.21210548  76.82610923   1.01666908  36.67   2.450  5.7049 12.2364  0.7516  4.6553 12.3980  0.0000 18.7909  8.7825 16.3131  0.3829  0.4861  0.944875852139      0
```