### PR TITLE
Support jpegli_read_coefficients() in buffered image mode.

### DIFF
--- a/lib/jpegli/decode_scan.cc
+++ b/lib/jpegli/decode_scan.cc
@@ -98,7 +98,7 @@ struct BitReaderState {
       return false;
     }
     *pos = pos_;
-    if (*pos == next_marker_pos_) {
+    if (*pos == next_marker_pos_ && *pos + 1 < len_) {
       cinfo->unread_marker = data_[*pos + 1];
     }
     return true;

--- a/lib/jpegli/test_utils.h
+++ b/lib/jpegli/test_utils.h
@@ -210,6 +210,9 @@ void SetScanDecompressParams(const DecompressParams& dparams,
                              j_decompress_ptr cinfo, int scan_number,
                              bool is_jpegli);
 
+void CopyCoefficients(j_decompress_ptr cinfo, jvirt_barray_ptr* coef_arrays,
+                      TestImage* output);
+
 void UnmapColors(uint8_t* row, size_t xsize, int components,
                  JSAMPARRAY colormap, size_t num_colors);
 


### PR DESCRIPTION
drive-by: fix previous asan/msan failures