### PR TITLE
Support cinfo reuse in jpegli encoder and decoder.

### DIFF
--- a/lib/extras/enc/jpegli.cc
+++ b/lib/extras/enc/jpegli.cc
@@ -105,6 +105,106 @@ Status WriteAppData(j_compress_ptr cinfo,
   return true;
 }
 
+static constexpr int kICCMarker = 0xe2;
+constexpr unsigned char kICCSignature[12] = {
+    0x49, 0x43, 0x43, 0x5F, 0x50, 0x52, 0x4F, 0x46, 0x49, 0x4C, 0x45, 0x00};
+static constexpr uint8_t kUnknownTf = 2;
+static constexpr unsigned char kCICPTagSignature[4] = {0x63, 0x69, 0x63, 0x70};
+static constexpr size_t kCICPTagSize = 12;
+
+bool FindCICPTag(const uint8_t* icc_data, size_t len, bool is_first_chunk,
+                 size_t* cicp_offset, size_t* cicp_length, uint8_t* cicp_tag,
+                 size_t* cicp_pos) {
+  if (is_first_chunk) {
+    // Look up the offset of the CICP tag from the first chunk of ICC data.
+    if (len < 132) {
+      return false;
+    }
+    uint32_t tag_count = LoadBE32(&icc_data[128]);
+    if (len < 132 + 12 * tag_count) {
+      return false;
+    }
+    for (uint32_t i = 0; i < tag_count; ++i) {
+      if (memcmp(&icc_data[132 + 12 * i], kCICPTagSignature, 4) == 0) {
+        *cicp_offset = LoadBE32(&icc_data[136 + 12 * i]);
+        *cicp_length = LoadBE32(&icc_data[140 + 12 * i]);
+      }
+    }
+    if (*cicp_length < kCICPTagSize) {
+      return false;
+    }
+  }
+  if (*cicp_offset < len) {
+    size_t n_bytes = std::min(len - *cicp_offset, kCICPTagSize - *cicp_pos);
+    memcpy(&cicp_tag[*cicp_pos], &icc_data[*cicp_offset], n_bytes);
+    *cicp_pos += n_bytes;
+    *cicp_offset = 0;
+  } else {
+    *cicp_offset -= len;
+  }
+  return true;
+}
+
+uint8_t LookupCICPTransferFunctionFromAppData(const uint8_t* app_data,
+                                              size_t len) {
+  size_t last_index = 0;
+  size_t cicp_offset = 0;
+  size_t cicp_length = 0;
+  uint8_t cicp_tag[kCICPTagSize] = {};
+  size_t cicp_pos = 0;
+  size_t pos = 0;
+  while (pos < len) {
+    const uint8_t* marker = &app_data[pos];
+    if (pos + 4 > len) {
+      return kUnknownTf;
+    }
+    size_t marker_size = (marker[2] << 8) + marker[3] + 2;
+    if (pos + marker_size > len) {
+      return kUnknownTf;
+    }
+    if (marker_size < 18 || marker[0] != 0xff || marker[1] != kICCMarker ||
+        memcmp(&marker[4], kICCSignature, 12) != 0) {
+      pos += marker_size;
+      continue;
+    }
+    uint8_t index = marker[16];
+    uint8_t total = marker[17];
+    const uint8_t* payload = marker + 18;
+    const size_t payload_size = marker_size - 18;
+    if (index != last_index + 1 || index > total) {
+      return kUnknownTf;
+    }
+    if (!FindCICPTag(payload, payload_size, last_index == 0, &cicp_offset,
+                     &cicp_length, &cicp_tag[0], &cicp_pos)) {
+      return kUnknownTf;
+    }
+    if (cicp_pos == kCICPTagSize) {
+      break;
+    }
+    ++last_index;
+  }
+  if (cicp_pos >= kCICPTagSize && memcmp(cicp_tag, kCICPTagSignature, 4) == 0) {
+    return cicp_tag[9];
+  }
+  return kUnknownTf;
+}
+
+uint8_t LookupCICPTransferFunctionFromICCProfile(const uint8_t* icc_data,
+                                                 size_t len) {
+  size_t cicp_offset = 0;
+  size_t cicp_length = 0;
+  uint8_t cicp_tag[kCICPTagSize] = {};
+  size_t cicp_pos = 0;
+  if (!FindCICPTag(icc_data, len, true, &cicp_offset, &cicp_length,
+                   &cicp_tag[0], &cicp_pos)) {
+    return kUnknownTf;
+  }
+  if (cicp_pos >= kCICPTagSize && memcmp(cicp_tag, kCICPTagSignature, 4) == 0) {
+    return cicp_tag[9];
+  }
+  return kUnknownTf;
+}
+
 JpegliDataType ConvertDataType(JxlDataType type) {
   switch (type) {
     case JXL_TYPE_UINT8:
@@ -269,6 +369,15 @@ Status EncodeJpeg(const PackedPixelFile& ppf, const JpegSettings& jpeg_settings,
     } else if (jpeg_settings.use_std_quant_tables) {
       jpegli_use_standard_quant_tables(&cinfo);
     }
+    uint8_t cicp_tf = kUnknownTf;
+    if (!jpeg_settings.app_data.empty()) {
+      cicp_tf = LookupCICPTransferFunctionFromAppData(
+          jpeg_settings.app_data.data(), jpeg_settings.app_data.size());
+    } else if (!output_encoding.IsSRGB()) {
+      cicp_tf = LookupCICPTransferFunctionFromICCProfile(
+          output_encoding.ICC().data(), output_encoding.ICC().size());
+    }
+    jpegli_set_cicp_transfer_function(&cinfo, cicp_tf);
     jpegli_set_defaults(&cinfo);
     if (!jpeg_settings.chroma_subsampling.empty()) {
       if (jpeg_settings.chroma_subsampling == "444") {
@@ -293,7 +402,7 @@ Status EncodeJpeg(const PackedPixelFile& ppf, const JpegSettings& jpeg_settings,
     }
     jpegli_enable_adaptive_quantization(
         &cinfo, jpeg_settings.use_adaptive_quantization);
-    jpegli_set_distance(&cinfo, jpeg_settings.distance);
+    jpegli_set_distance(&cinfo, jpeg_settings.distance, TRUE);
     jpegli_set_progressive_level(&cinfo, jpeg_settings.progressive_level);
     cinfo.optimize_coding = jpeg_settings.optimize_coding;
     if (!jpeg_settings.app_data.empty()) {

--- a/lib/jpegli/bitstream.cc
+++ b/lib/jpegli/bitstream.cc
@@ -548,7 +548,6 @@ void WriteOutput(j_compress_ptr cinfo, const uint8_t* buf, size_t bufsize) {
   while (pos < bufsize) {
     if (cinfo->dest->free_in_buffer == 0 &&
         !(*cinfo->dest->empty_output_buffer)(cinfo)) {
-      JXL_ABORT();
       JPEGLI_ERROR("Destination suspension is not supported in markers.");
     }
     size_t len = std::min<size_t>(cinfo->dest->free_in_buffer, bufsize - pos);

--- a/lib/jpegli/decode.cc
+++ b/lib/jpegli/decode.cc
@@ -44,15 +44,29 @@ void InitializeImage(j_decompress_ptr cinfo) {
   memset(cinfo->arith_dc_U, 0, sizeof(cinfo->arith_dc_U));
   memset(cinfo->arith_ac_K, 0, sizeof(cinfo->arith_ac_K));
   // Initialize the private fields.
-  cinfo->master->colormap_lut_ = nullptr;
-  cinfo->master->pixels_ = nullptr;
-  cinfo->master->scanlines_ = nullptr;
-  cinfo->master->regenerate_inverse_colormap_ = true;
+  jpeg_decomp_master* m = cinfo->master;
+  m->codestream_bits_ahead_ = 0;
+  m->found_soi_ = false;
+  m->found_dri_ = false;
+  m->found_sof_ = false;
+  m->found_eoi_ = false;
+  m->icc_index_ = 0;
+  m->icc_total_ = 0;
+  m->icc_profile_.clear();
+  m->components_.clear();
+  m->dc_huff_lut_.clear();
+  m->ac_huff_lut_.clear();
+  memset(m->huff_slot_defined_, 0, sizeof(m->huff_slot_defined_));
+  m->colormap_lut_ = nullptr;
+  m->pixels_ = nullptr;
+  m->scanlines_ = nullptr;
+  m->regenerate_inverse_colormap_ = true;
   for (int i = 0; i < kMaxComponents; ++i) {
-    cinfo->master->dither_[i] = nullptr;
-    cinfo->master->error_row_[i] = nullptr;
+    m->dither_[i] = nullptr;
+    m->error_row_[i] = nullptr;
   }
-  cinfo->master->output_passes_done_ = 0;
+  m->output_passes_done_ = 0;
+  m->xoffset_ = 0;
 }
 
 void InitializeDecompressParams(j_decompress_ptr cinfo) {

--- a/lib/jpegli/decode_internal.h
+++ b/lib/jpegli/decode_internal.h
@@ -46,17 +46,17 @@ struct jpeg_decomp_master {
   // Input handling state.
   //
   // Number of bits after codestream_pos_ that were already processed.
-  size_t codestream_bits_ahead_ = 0;
+  size_t codestream_bits_ahead_;
 
   //
   // Marker data processing state.
   //
-  bool found_soi_ = false;
-  bool found_dri_ = false;
-  bool found_sof_ = false;
-  bool found_eoi_ = false;
-  size_t icc_index_ = 0;
-  size_t icc_total_ = 0;
+  bool found_soi_;
+  bool found_dri_;
+  bool found_sof_;
+  bool found_eoi_;
+  size_t icc_index_;
+  size_t icc_total_;
   std::vector<uint8_t> icc_profile_;
   std::vector<jpegli::DecJPEGComponent> components_;
   std::vector<jpegli::HuffmanTableEntry> dc_huff_lut_;
@@ -93,10 +93,10 @@ struct jpeg_decomp_master {
   //
   // Rendering state.
   //
-  int output_passes_done_ = 0;
+  int output_passes_done_;
   JpegliDataType output_data_type_ = JPEGLI_TYPE_UINT8;
   bool swap_endianness_ = false;
-  size_t xoffset_ = 0;
+  size_t xoffset_;
 
   int min_scaled_dct_size;
   int scaled_dct_size[jpegli::kMaxComponents];

--- a/lib/jpegli/destination_manager.cc
+++ b/lib/jpegli/destination_manager.cc
@@ -11,7 +11,8 @@
 
 namespace jpegli {
 
-void init_destination(j_compress_ptr cinfo) {}
+void init_stdio_destination(j_compress_ptr cinfo) {}
+void init_mem_destination(j_compress_ptr cinfo) {}
 
 constexpr size_t kDestBufferSize = 64 << 10;
 
@@ -82,32 +83,51 @@ struct MemoryDestinationManager {
 }  // namespace jpegli
 
 void jpegli_stdio_dest(j_compress_ptr cinfo, FILE* outfile) {
-  jpegli::StdioDestinationManager* dest =
-      jpegli::Allocate<jpegli::StdioDestinationManager>(cinfo, 1);
+  if (outfile == nullptr) {
+    JPEGLI_ERROR("jpegli_stdio_dest: Invalid destination.");
+  }
+  if (cinfo->dest &&
+      cinfo->dest->init_destination != jpegli::init_stdio_destination) {
+    JPEGLI_ERROR("jpegli_stdio_dest: a different dest manager was already set");
+  }
+  if (!cinfo->dest) {
+    cinfo->dest = reinterpret_cast<jpeg_destination_mgr*>(
+        jpegli::Allocate<jpegli::StdioDestinationManager>(cinfo, 1));
+  }
+  auto dest = reinterpret_cast<jpegli::StdioDestinationManager*>(cinfo->dest);
   dest->f = outfile;
   dest->buffer = jpegli::Allocate<uint8_t>(cinfo, jpegli::kDestBufferSize);
   dest->pub.next_output_byte = dest->buffer;
   dest->pub.free_in_buffer = jpegli::kDestBufferSize;
-  dest->pub.init_destination = jpegli::init_destination;
+  dest->pub.init_destination = jpegli::init_stdio_destination;
   dest->pub.empty_output_buffer =
       jpegli::StdioDestinationManager::empty_output_buffer;
   dest->pub.term_destination =
       jpegli::StdioDestinationManager::term_destination;
-  cinfo->dest = reinterpret_cast<jpeg_destination_mgr*>(dest);
 }
 
 void jpegli_mem_dest(j_compress_ptr cinfo, unsigned char** outbuffer,
                      unsigned long* outsize) {
-  jpegli::MemoryDestinationManager* dest =
-      jpegli::Allocate<jpegli::MemoryDestinationManager>(cinfo, 1);
-  dest->pub.init_destination = jpegli::init_destination;
+  if (outbuffer == nullptr || outsize == nullptr) {
+    JPEGLI_ERROR("jpegli_mem_dest: Invalid destination.");
+  }
+  if (cinfo->dest &&
+      cinfo->dest->init_destination != jpegli::init_mem_destination) {
+    JPEGLI_ERROR("jpegli_mem_dest: a different dest manager was already set");
+  }
+  if (!cinfo->dest) {
+    auto dest = jpegli::Allocate<jpegli::MemoryDestinationManager>(cinfo, 1);
+    dest->temp_buffer = nullptr;
+    cinfo->dest = reinterpret_cast<jpeg_destination_mgr*>(dest);
+  }
+  auto dest = reinterpret_cast<jpegli::MemoryDestinationManager*>(cinfo->dest);
+  dest->pub.init_destination = jpegli::init_mem_destination;
   dest->pub.empty_output_buffer =
       jpegli::MemoryDestinationManager::empty_output_buffer;
   dest->pub.term_destination =
       jpegli::MemoryDestinationManager::term_destination;
   dest->output = outbuffer;
   dest->output_size = outsize;
-  dest->temp_buffer = nullptr;
   if (*outbuffer == nullptr || *outsize == 0) {
     dest->temp_buffer =
         reinterpret_cast<uint8_t*>(malloc(jpegli::kDestBufferSize));
@@ -118,5 +138,4 @@ void jpegli_mem_dest(j_compress_ptr cinfo, unsigned char** outbuffer,
   dest->buffer_size = *outsize;
   dest->pub.next_output_byte = dest->current_buffer;
   dest->pub.free_in_buffer = dest->buffer_size;
-  cinfo->dest = reinterpret_cast<jpeg_destination_mgr*>(dest);
 }

--- a/lib/jpegli/encode.h
+++ b/lib/jpegli/encode.h
@@ -104,8 +104,12 @@ void jpegli_destroy_compress(j_compress_ptr cinfo);
 // the future.
 //
 
-// Sets the butteraugli target distance for the compressor.
-void jpegli_set_distance(j_compress_ptr cinfo, float distance);
+// Sets the butteraugli target distance for the compressor. This may override
+// the default quantization table indexes based on jpeg colorspace, therefore
+// it must be called after jpegli_set_defaults() or after the last
+// jpegli_set_colorspace() or jpegli_default_colorspace() calls.
+void jpegli_set_distance(j_compress_ptr cinfo, float distance,
+                         boolean force_baseline);
 
 // Returns the butteraugli target distance for the given quality parameter.
 float jpegli_quality_to_distance(int quality);
@@ -114,6 +118,12 @@ float jpegli_quality_to_distance(int quality);
 // matrices and chroma subsampling. Must be called before jpegli_set_defaults()
 // because some default setting depend on the XYB mode.
 void jpegli_set_xyb_mode(j_compress_ptr cinfo);
+
+// Signals to the encoder that the pixel data that will be provided later
+// through jpegli_write_scanlines() has this transfer function. This must be
+// called before jpegli_set_defaults() because it changes the default
+// quantization tables.
+void jpegli_set_cicp_transfer_function(j_compress_ptr cinfo, int code);
 
 void jpegli_set_input_format(j_compress_ptr cinfo, JpegliDataType data_type,
                              JpegliEndianness endianness);
@@ -131,7 +141,7 @@ void jpegli_set_progressive_level(j_compress_ptr cinfo, int level);
 // linear quality parameters will be used to scale the standard quantization
 // tables from Annex K of the JPEG standard. By default jpegli uses a different
 // set of quantization tables and used different scaling parameters for DC and
-// AC coefficients.
+// AC coefficients. Must be called before jpegli_set_defaults().
 void jpegli_use_standard_quant_tables(j_compress_ptr cinfo);
 
 #if defined(__cplusplus) || defined(c_plusplus)

--- a/lib/jpegli/encode_internal.h
+++ b/lib/jpegli/encode_internal.h
@@ -66,15 +66,14 @@ struct jpeg_comp_master {
   float distance = 1.0;
   bool force_baseline = true;
   bool xyb_mode = false;
+  uint8_t cicp_transfer_function = 2;  // unknown transfer function code
   bool use_std_tables = false;
   bool use_adaptive_quantization = true;
   int progressive_level = jpegli::kDefaultProgressiveLevel;
-  size_t xsize_blocks = 0;
-  size_t ysize_blocks = 0;
-  size_t blocks_per_iMCU_row = 0;
+  size_t xsize_blocks;
+  size_t ysize_blocks;
+  size_t blocks_per_iMCU_row;
   std::vector<jpegli::ScanCodingInfo> scan_coding_info;
-  std::vector<std::vector<uint8_t>> special_markers;
-  uint8_t* next_marker_byte = nullptr;
   JpegliDataType data_type = JPEGLI_TYPE_UINT8;
   JpegliEndianness endianness = JPEGLI_NATIVE_ENDIAN;
   void (*input_method)(const uint8_t* row_in, size_t len,

--- a/lib/jpegli/quant.h
+++ b/lib/jpegli/quant.h
@@ -13,7 +13,9 @@
 
 namespace jpegli {
 
-void FinalizeQuantMatrices(j_compress_ptr cinfo);
+void SetQuantMatrices(j_compress_ptr cinfo, bool add_two_chroma_tables);
+
+void InitQuantizer(j_compress_ptr cinfo);
 
 }  // namespace jpegli
 

--- a/lib/jpegli/source_manager.cc
+++ b/lib/jpegli/source_manager.cc
@@ -11,7 +11,8 @@
 
 namespace jpegli {
 
-void init_source(j_decompress_ptr cinfo) {}
+void init_mem_source(j_decompress_ptr cinfo) {}
+void init_stdio_source(j_decompress_ptr cinfo) {}
 
 void skip_input_data(j_decompress_ptr cinfo, long num_bytes) {}
 
@@ -47,13 +48,15 @@ struct StdioSourceManager {
 
 void jpegli_mem_src(j_decompress_ptr cinfo, const unsigned char* inbuffer,
                     unsigned long insize) {
-  if (cinfo->src != nullptr) {
-    JPEGLI_ERROR("jpeg_mem_src: source manager is already set");
+  if (cinfo->src && cinfo->src->init_source != jpegli::init_mem_source) {
+    JPEGLI_ERROR("jpegli_mem_src: a different source manager was already set");
   }
-  cinfo->src = jpegli::Allocate<jpeg_source_mgr>(cinfo, 1);
+  if (!cinfo->src) {
+    cinfo->src = jpegli::Allocate<jpeg_source_mgr>(cinfo, 1);
+  }
   cinfo->src->next_input_byte = inbuffer;
   cinfo->src->bytes_in_buffer = insize;
-  cinfo->src->init_source = jpegli::init_source;
+  cinfo->src->init_source = jpegli::init_mem_source;
   cinfo->src->fill_input_buffer = jpegli::EmitFakeEoiMarker;
   cinfo->src->skip_input_data = jpegli::skip_input_data;
   cinfo->src->resync_to_restart = jpegli_resync_to_restart;
@@ -61,19 +64,21 @@ void jpegli_mem_src(j_decompress_ptr cinfo, const unsigned char* inbuffer,
 }
 
 void jpegli_stdio_src(j_decompress_ptr cinfo, FILE* infile) {
-  if (cinfo->src != nullptr) {
-    JPEGLI_ERROR("jpeg_stdio_src: source manager is already set");
+  if (cinfo->src && cinfo->src->init_source != jpegli::init_stdio_source) {
+    JPEGLI_ERROR("jpeg_stdio_src: a different source manager was already set");
   }
-  jpegli::StdioSourceManager* src =
-      jpegli::Allocate<jpegli::StdioSourceManager>(cinfo, 1);
+  if (!cinfo->src) {
+    cinfo->src = reinterpret_cast<jpeg_source_mgr*>(
+        jpegli::Allocate<jpegli::StdioSourceManager>(cinfo, 1));
+  }
+  auto src = reinterpret_cast<jpegli::StdioSourceManager*>(cinfo->src);
   src->f = infile;
   src->buffer = jpegli::Allocate<uint8_t>(cinfo, jpegli::kStdioBufferSize);
   src->pub.next_input_byte = src->buffer;
   src->pub.bytes_in_buffer = 0;
-  src->pub.init_source = jpegli::init_source;
+  src->pub.init_source = jpegli::init_stdio_source;
   src->pub.fill_input_buffer = jpegli::StdioSourceManager::fill_input_buffer;
   src->pub.skip_input_data = jpegli::skip_input_data;
   src->pub.resync_to_restart = jpegli_resync_to_restart;
   src->pub.term_source = jpegli::term_source;
-  cinfo->src = reinterpret_cast<jpeg_source_mgr*>(src);
 }

--- a/lib/jpegli/test_utils.h
+++ b/lib/jpegli/test_utils.h
@@ -125,6 +125,11 @@ struct TestImage {
     pixels.resize(ysize * xsize * components *
                   jpegli_bytes_per_sample(data_type));
   }
+  void Clear() {
+    pixels.clear();
+    raw_data.clear();
+    coeffs.clear();
+  }
 };
 
 std::ostream& operator<<(std::ostream& os, const TestImage& input);
@@ -256,6 +261,9 @@ void GeneratePixels(TestImage* img);
 void GenerateRawData(const CompressParams& jparams, TestImage* img);
 
 void GenerateCoeffs(const CompressParams& jparams, TestImage* img);
+
+void EncodeWithJpegli(const TestImage& input, const CompressParams& jparams,
+                      j_compress_ptr cinfo);
 
 bool EncodeWithJpegli(const TestImage& input, const CompressParams& jparams,
                       std::vector<uint8_t>* compressed);


### PR DESCRIPTION
To make this work, the quantization matrices have to be defined in the parameter setup phase, which means that we can not look at the ICC profile, so the CICP transfer function has to be communicated separately.

Moreover, to be more compatible with libjpeg API, we only define one chroma quantization table by default, but we define two chroma quant tables if the new jpegli_set_distance() API function was called.