### PR TITLE
quantization improvement

### DIFF
--- a/lib/jxl/decode_test.cc
+++ b/lib/jxl/decode_test.cc
@@ -1935,7 +1935,7 @@ TEST(DecodeTest, PixelTestOpaqueSrgbLossy) {
     EXPECT_THAT(
         ButteraugliDistance(io0.frames, io1.frames, ba, jxl::GetJxlCms(),
                             /*distmap=*/nullptr, nullptr),
-        IsSlightlyBelow(0.85f));
+        IsSlightlyBelow(0.9f));
 
     JxlDecoderDestroy(dec);
   }

--- a/lib/jxl/enc_adaptive_quantization.cc
+++ b/lib/jxl/enc_adaptive_quantization.cc
@@ -717,7 +717,7 @@ ImageF TileDistMap(const ImageF& distmap, int tile_size, int margin,
 
 constexpr float kDcQuantPow = 0.87f;
 static const float kDcQuant = 1.295f;
-static const float kAcQuant = 0.8265f;
+static const float kAcQuant = 0.8365f;
 
 void FindBestQuantization(const ImageBundle& linear, const Image3F& opsin,
                           PassesEncoderState* enc_state,

--- a/lib/jxl/encode_test.cc
+++ b/lib/jxl/encode_test.cc
@@ -503,7 +503,7 @@ TEST(EncodeTest, LossyEncoderUseOriginalProfileTest) {
     ASSERT_NE(nullptr, enc.get());
     JxlEncoderFrameSettings* frame_settings =
         JxlEncoderFrameSettingsCreate(enc.get(), NULL);
-    VerifyFrameEncoding(63, 129, enc.get(), frame_settings, 5740, true);
+    VerifyFrameEncoding(63, 129, enc.get(), frame_settings, 5854, true);
   }
   {
     JxlEncoderPtr enc = JxlEncoderMake(nullptr);
@@ -513,7 +513,7 @@ TEST(EncodeTest, LossyEncoderUseOriginalProfileTest) {
     EXPECT_EQ(JXL_ENC_SUCCESS,
               JxlEncoderFrameSettingsSetOption(
                   frame_settings, JXL_ENC_FRAME_SETTING_PROGRESSIVE_DC, 2));
-    VerifyFrameEncoding(63, 129, enc.get(), frame_settings, 6091, true);
+    VerifyFrameEncoding(63, 129, enc.get(), frame_settings, 6205, true);
   }
   {
     JxlEncoderPtr enc = JxlEncoderMake(nullptr);

--- a/lib/jxl/jxl_test.cc
+++ b/lib/jxl/jxl_test.cc
@@ -182,7 +182,7 @@ TEST(JxlTest, RoundtripResample2MT) {
   cparams.AddOption(JXL_ENC_FRAME_SETTING_EFFORT, 3);  // kFalcon
 
   PackedPixelFile ppf_out;
-  EXPECT_NEAR(Roundtrip(t.ppf(), cparams, {}, &pool, &ppf_out), 205096, 600);
+  EXPECT_NEAR(Roundtrip(t.ppf(), cparams, {}, &pool, &ppf_out), 206857, 1000);
   EXPECT_THAT(ComputeDistance2(t.ppf(), ppf_out), IsSlightlyBelow(340));
 }
 
@@ -223,7 +223,7 @@ TEST(JxlTest, RoundtripOutOfOrderProcessingBorder) {
   cparams.AddOption(JXL_ENC_FRAME_SETTING_RESAMPLING, 2);
 
   PackedPixelFile ppf_out;
-  EXPECT_NEAR(Roundtrip(t.ppf(), cparams, {}, &pool, &ppf_out), 9935, 100);
+  EXPECT_NEAR(Roundtrip(t.ppf(), cparams, {}, &pool, &ppf_out), 9763, 150);
   EXPECT_LE(ButteraugliDistance(t.ppf(), ppf_out), 2.9);
 }
 
@@ -470,7 +470,7 @@ TEST(JxlTest, RoundtripNoGaborishNoAR) {
   cparams.AddOption(JXL_ENC_FRAME_SETTING_GABORISH, 0);
 
   PackedPixelFile ppf_out;
-  EXPECT_NEAR(Roundtrip(t.ppf(), cparams, {}, pool, &ppf_out), 37218, 100);
+  EXPECT_NEAR(Roundtrip(t.ppf(), cparams, {}, pool, &ppf_out), 37346, 200);
   EXPECT_THAT(ButteraugliDistance(t.ppf(), ppf_out), IsSlightlyBelow(1.8));
 }
 
@@ -488,7 +488,7 @@ TEST(JxlTest, RoundtripSmallNoGaborish) {
   cparams.AddOption(JXL_ENC_FRAME_SETTING_GABORISH, 0);
 
   PackedPixelFile ppf_out;
-  EXPECT_NEAR(Roundtrip(t.ppf(), cparams, {}, pool, &ppf_out), 749, 20);
+  EXPECT_NEAR(Roundtrip(t.ppf(), cparams, {}, pool, &ppf_out), 777, 20);
   EXPECT_THAT(ButteraugliDistance(t.ppf(), ppf_out), IsSlightlyBelow(1.05));
 }
 
@@ -845,7 +845,7 @@ TEST(JxlTest, RoundtripAlphaPremultiplied) {
           EXPECT_THAT(ButteraugliDistance(io.frames, io2.frames,
                                           cparams.ba_params, GetJxlCms(),
                                           /*distmap=*/nullptr),
-                      IsSlightlyBelow(1.15));
+                      IsSlightlyBelow(1.2));
           EXPECT_TRUE(UnpremultiplyAlpha(io2));
           EXPECT_FALSE(io2.Main().AlphaIsPremultiplied());
         }
@@ -891,7 +891,7 @@ TEST(JxlTest, RoundtripAlphaResamplingOnlyAlpha) {
   cparams.AddOption(JXL_ENC_FRAME_SETTING_EXTRA_CHANNEL_RESAMPLING, 2);
 
   PackedPixelFile ppf_out;
-  EXPECT_NEAR(Roundtrip(t.ppf(), cparams, {}, pool, &ppf_out), 31951, 300);
+  EXPECT_NEAR(Roundtrip(t.ppf(), cparams, {}, pool, &ppf_out), 32277, 300);
   EXPECT_THAT(ButteraugliDistance(t.ppf(), ppf_out), IsSlightlyBelow(1.85));
 }
 

--- a/tools/optimizer/simplex_fork.py
+++ b/tools/optimizer/simplex_fork.py
@@ -60,8 +60,8 @@ def EvalCacheForget():
 
 def RandomizedJxlCodecs():
   retval = []
-  minval = 0.12
-  maxval = 0.3
+  minval = 0.2
+  maxval = 5.3
   rangeval = maxval/minval
   steps = 11
   for i in range(steps):
@@ -102,7 +102,7 @@ def Eval(vec, binary_name, cached=True):
       (binary_name,
        '--input',
        '/usr/local/google/home/jyrki/newcorpus/split/*.png',
-       '--error_pnorm=10',
+       '--error_pnorm=5',
        '--more_columns',
        '--codec', g_codecs),
       stdout=subprocess.PIPE,
@@ -122,11 +122,10 @@ def Eval(vec, binary_name, cached=True):
     sys.stdout.flush()
     if line[0:3] == b'jxl':
       bpp = line.split()[3]
-      bpp = 1.0
       dist_pnorm = line.split()[8]
       dist_max = line.split()[6]
       vec[0] *= float(dist_pnorm) * float(bpp) / 16.0
-      vec[0] *= (float(dist_max) * float(bpp) / 16.0) ** 0.01
+      #vec[0] *= (float(dist_max) * float(bpp) / 16.0) ** 0.01
       n += 1
       found_score = True
       distance = float(line.split()[0].split(b'd')[-1])


### PR DESCRIPTION
0.16 % improvement on bpp * pnorm

looks slightly better

is faster and removes a hairy goto

```
Before:

Encoding      kPixels    Bytes          BPP  E MP/s  D MP/s     Max norm  SSIMULACRA2        pnorm   PSNR   QABPP  SmallB  DCT4x8     AFV  DCT8x8    8x16    8x32      16   16x32      32   32x64      64       BPP*pnorm   Bugs
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
jxl:d0.1        19988 16558847    6.6274831   1.504   9.130   0.37474449  99.91563915   0.11897888  53.46   6.627 40.1468 19.6738  0.4364 27.7147  5.5886  0.0000  3.0380  0.9324  3.0124  0.1025  0.0820  0.788530544762      0
jxl:d0.5        19988  6306640    2.5241583   1.866  14.535   0.81643534  97.81136849   0.36402127  44.70   2.533 14.2581 24.8516  0.5892 11.8326 21.7685  0.0000 20.6523  1.3755  4.7952  0.1332  0.4713  0.918847295905      0
jxl:d0.8        19988  4687415    1.8760826   1.940  14.339   1.16685872  92.63314730   0.50364642  42.10   2.203 10.9832 21.3583  0.6955  8.9292 19.6226  0.0000 30.4834  1.6727  6.4089  0.2049  0.3689  0.944882259298      0
jxl:d1          19988  4056707    1.6236491   1.848  15.194   1.36569019  89.91325228   0.58682071  40.91   2.215  9.6992 19.6331  0.7582  7.8232 18.0933  0.0000 32.2483  2.7024  9.2983  0.2254  0.2459  0.952790926862      0
jxl:d1.1        19988  3816925    1.5276792   2.010  16.481   1.46096043  88.78835507   0.62586228  40.37   2.236  9.2375 18.8832  0.7838  7.4326 17.3262  0.0000 32.2355  3.3838 10.9633  0.2562  0.2254  0.956116781461      0
jxl:d1.2        19988  3605962    1.4432437   2.040  16.690   1.54923546  87.66472504   0.66304108  39.88   2.275  8.7463 18.3168  0.8040  7.0560 16.6871  0.0000 31.8859  4.1983 12.6232  0.2869  0.1230  0.956929887721      0
jxl:d1.3        19988  3431060    1.3732413   2.059  16.047   1.64152633  86.74197163   0.69920694  39.51   2.308  8.3355 17.8125  0.8229  6.7631 16.3240  0.0000 30.9919  5.0974 14.0884  0.3074  0.1844  0.960179839017      0
jxl:d1.4        19988  3264113    1.3064227   2.087  16.626   1.72731485  85.72670763   0.73588332  39.11   2.289  7.9958 17.3444  0.8437  6.4614 15.8782  0.0000 30.0877  5.9888 15.5536  0.3689  0.2049  0.961374688110      0
jxl:d1.5        19988  3114715    1.2466279   2.030  15.594   1.86588871  84.81615926   0.77342714  38.75   2.355  7.6679 16.8398  0.8735  6.2293 15.5401  0.0000 29.2014  6.9469 16.7729  0.4098  0.2459  0.964175875222      0
jxl:d1.6        19988  2980596    1.1929484   2.084  15.577   1.91412117  83.91114910   0.80609149  38.42   2.341  7.3830 16.4898  0.8773  6.0081 15.3205  0.0000 28.1601  7.8203 17.8794  0.4406  0.3484  0.961625535202      0
jxl:d1.7        19988  2860307    1.1448041   2.078  16.121   2.01438369  83.07405311   0.83948872  38.10   2.349  7.1191 16.1165  0.9061  5.9114 15.1136  0.0000 27.0126  8.6093 19.0680  0.3996  0.4713  0.961050150994      0
jxl:d1.8        19988  2751761    1.1013599   2.121  15.232   2.08197926  82.25830459   0.87234278  37.78   2.331  6.8793 15.7896  0.9215  5.7493 14.8524  0.0000 26.2582  9.4571 19.8262  0.4406  0.5533  0.960763337313      0
jxl:d1.8        19988  2751761    1.1013599   2.028  15.699   2.08197926  82.25830459   0.87234278  37.78   2.331  6.8793 15.7896  0.9215  5.7493 14.8524  0.0000 26.2582  9.4571 19.8262  0.4406  0.5533  0.960763337313      0
jxl:d1.9        19988  2652429    1.0616034   2.121  16.058   2.16564355  81.45161728   0.90469049  37.51   2.333  6.6523 15.4674  0.9471  5.5569 14.7281  0.0000 25.4154 10.2999 20.6561  0.5123  0.4918  0.960422507057      0
jxl:d2.0        19988  2559633    1.0244629   2.105  15.200   2.25328957  80.69132524   0.93611595  37.28   2.376  6.4243 15.2132  0.9474  5.4541 14.5533  0.0000 24.6431 10.9915 21.5271  0.4611  0.5123  0.959016070780      0
jxl:d2.1        19988  2475010    0.9905936   2.122  15.798   2.33789644  80.00670609   0.96734500  37.04   2.377  6.1762 14.8267  0.9747  5.3193 14.3721  0.0000 24.0399 11.7651 22.2084  0.4918  0.5533  0.958245714515      0
jxl:d2.2        19988  2395072    0.9585993   2.126  16.449   2.42583481  79.21648477   0.99860481  36.83   2.383  5.9898 14.5543  0.9731  5.2546 14.2683  0.0000 23.2343 12.6258 22.7720  0.5021  0.5533  0.957261884070      0
jxl:d2.3        19988  2320123    0.9286019   2.141  16.215   2.50604195  78.45253988   1.02942954  36.60   2.396  5.8534 14.2603  0.9968  5.1426 14.0711  0.0000 22.7873 13.3122 23.1767  0.5533  0.5738  0.955930187054      0
jxl:d2.4        19988  2250497    0.9007349   2.113  15.895   2.56693730  77.76466397   1.05909649  36.40   2.379  5.6949 13.9699  0.9968  4.9786 13.9808  0.0000 22.2635 14.0986 23.4943  0.6148  0.6353  0.953965143514      0
jxl:d2.5        19988  2185531    0.8747330   2.147  15.737   2.64604254  77.03580189   1.09552865  36.20   2.389  5.5361 13.7061  1.0134  4.9082 13.8719  0.0000 21.6987 14.7518 23.9093  0.6148  0.7172  0.958295056908      0
jxl:d2.6        19988  2126065    0.8509324   2.138  16.028   2.72037247  76.46475047   1.11717610  36.01   2.399  5.3664 13.4637  1.0236  4.8131 13.7951  0.0000 21.2478 15.4178 24.2576  0.6045  0.7377  0.950641376855      0
jxl:d2.7        19988  2068401    0.8278531   2.082  14.546   2.78981209  75.72588670   1.15339320  35.82   2.399  5.2329 13.2697  1.0336  4.7260 13.6593  0.0000 20.6561 16.0736 24.6931  0.7070  0.6762  0.954840129261      0
jxl:d2.8        19988  2013730    0.8059717   2.167  16.033   2.86785532  75.11316262   1.17944459  35.62   2.395  5.1160 13.0132  1.0569  4.6751 13.6491  0.0000 20.2450 16.6140 24.9031  0.7377  0.7172  0.950598928499      0
jxl:d2.9        19988  1963136    0.7857220   2.125  16.175   2.90620390  74.46673208   1.20975767  35.46   2.364  4.9748 12.8329  1.0637  4.6402 13.4954  0.0000 19.7980 17.1340 25.3335  0.6762  0.7787  0.950533244723      0
jxl:d3          19988  1919252    0.7681580   1.984  15.758   3.02356241  73.80419899   1.23657584  35.30   2.404  4.8099 12.5883  1.0345  4.5262 13.4077  0.0000 19.4676 18.0536 25.3847  0.6762  0.7787  0.949885583523      0
jxl:d5          19988  1319568    0.5281415   2.016   8.844   4.43124551  61.96106298   1.75283771  32.96   2.413  3.3325  8.3025  0.9308  2.9224 10.7949  0.0000 15.3807 27.3622 29.6522  0.6967  1.3525  0.925746378233      0
jxl:d7          19988  1021729    0.4089350   1.965   8.547   5.68208206  52.22884366   2.20701088  31.52   2.395  2.5590  5.8268  0.7637  2.0521  9.1389  0.0000 12.9165 32.8131 32.3828  0.6762  1.5984  0.902523945958      0
jxl:d15         19988   569307    0.2278584   1.992   8.506   9.75560111  22.11346664   3.73338004  28.62   2.255  1.2119  1.7374  0.3007  0.5795  5.4157  0.0000  7.4822 38.1283 40.6360  1.3013  3.9345  0.850682039815      0
jxl:d24         19988   415156    0.1661613   0.294  20.480  20.01764206  -7.32152644   6.29854544  25.87   2.791  1.0182  2.3079  0.1697  0.6865  3.0328  0.0000  3.2634  9.2369  5.7276  0.0102  0.0000  1.046574441056      0
jxl:d32         19988   328449    0.1314578   0.298  19.728  21.84212024 -20.25262655   7.08427702  25.40   2.525  0.7368  1.7261  0.1425  0.5017  2.7184  0.0000  2.8548 10.3178  6.4550  0.0000  0.0000  0.931283735021      0
Aggregate:      19988  2325300    0.9306739   1.787  14.793   2.50707975  76.86349777   1.01489981  36.68   2.451  5.7049 12.2364  0.7516  4.6553 12.3980  0.0000 18.7909  8.7825 16.3131  0.3829  0.4861  0.944540816950      0

After:

Encoding      kPixels    Bytes          BPP  E MP/s  D MP/s     Max norm  SSIMULACRA2        pnorm   PSNR   QABPP  SmallB  DCT4x8     AFV  DCT8x8    8x16    8x32      16   16x32      32   32x64      64       BPP*pnorm   Bugs
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
jxl:d0.1        19988 16631666    6.6566281   1.520   8.860   0.37648740  99.92763374   0.11894861  53.49   6.657 40.3459 19.5387  0.4390 27.7660  5.4849  0.0000  3.0136  0.9221  3.0328  0.1025  0.0820  0.791796646022      0
jxl:d0.5        19988  6314769    2.5274118   1.914  14.097   0.83195520  97.86423784   0.36321044  44.72   2.544 14.3353 24.8769  0.6000 11.9088 21.6250  0.0000 20.6062  1.3602  4.8413  0.1434  0.4303  0.917982338922      0
jxl:d0.8        19988  4694940    1.8790943   1.994  13.897   1.16315666  92.60532324   0.50246013  42.12   2.197 11.0107 21.3942  0.7031  8.9996 19.6065  0.0000 30.4681  1.6496  6.3218  0.2049  0.3689  0.944169996390      0
jxl:d1          19988  4059854    1.6249087   1.890  14.462   1.37774263  89.90347524   0.58551421  40.93   2.242  9.7821 19.6482  0.7374  7.8459 18.0024  0.0000 32.3725  2.6819  9.1959  0.2357  0.2254  0.951407110163      0
jxl:d1.1        19988  3821432    1.5294831   2.050  15.467   1.45178366  88.85146933   0.62411786  40.39   2.236  9.2990 18.9684  0.7822  7.4457 17.2973  0.0000 32.3162  3.3172 10.8096  0.2459  0.2459  0.954577702690      0
jxl:d1.2        19988  3606877    1.4436100   2.081  15.122   1.53838725  87.67597806   0.66096810  39.90   2.251  8.8011 18.3332  0.8056  7.1095 16.6313  0.0000 32.0946  4.0779 12.4541  0.2766  0.1434  0.954180135064      0
jxl:d1.3        19988  3432496    1.3738160   2.047  15.081   1.63847996  86.78175991   0.69783852  39.52   2.294  8.4159 17.7949  0.8239  6.7820 16.3425  0.0000 31.0726  5.0283 13.9757  0.3074  0.1844  0.958701748970      0
jxl:d1.4        19988  3268745    1.3082766   2.063  15.576   1.72673552  85.81237653   0.73282063  39.12   2.305  8.0509 17.3812  0.8331  6.4787 15.8270  0.0000 30.2324  5.9504 15.4101  0.3586  0.2049  0.958732092207      0
jxl:d1.5        19988  3118458    1.2481260   2.025  15.228   1.86932410  84.86342306   0.77125910  38.76   2.375  7.7323 16.9326  0.8501  6.2396 15.4588  0.0000 29.4306  6.8137 16.6140  0.3894  0.2664  0.962628546990      0
jxl:d1.6        19988  2983216    1.1939970   2.102  15.501   1.91422069  83.99808456   0.80479393  38.45   2.323  7.4275 16.5196  0.8776  6.0007 15.2929  0.0000 28.3484  7.6743 17.8487  0.3894  0.3484  0.960921544620      0
jxl:d1.7        19988  2863792    1.1461990   2.061  14.744   2.00960072  83.06852054   0.83773394  38.11   2.349  7.1662 16.2036  0.9071  5.9222 15.0214  0.0000 27.2303  8.5837 18.8323  0.4303  0.4303  0.960209766106      0
jxl:d1.8        19988  2751393    1.1012126   2.137  15.747   2.07598227  82.25978581   0.87040040  37.78   2.322  6.9104 15.8863  0.9180  5.7263 14.8319  0.0000 26.3491  9.4392 19.7647  0.4303  0.4713  0.958495880534      0
jxl:d1.8        19988  2751393    1.1012126   2.063  15.178   2.07598227  82.25978581   0.87040040  37.78   2.322  6.9104 15.8863  0.9180  5.7263 14.8319  0.0000 26.3491  9.4392 19.7647  0.4303  0.4713  0.958495880534      0
jxl:d1.9        19988  2654530    1.0624443   2.121  14.838   2.17516161  81.50389246   0.90270106  37.51   2.339  6.6734 15.5219  0.9369  5.6177 14.7160  0.0000 25.4090 10.3306 20.5690  0.4201  0.5328  0.959069609881      0
jxl:d2.0        19988  2559938    1.0245850   2.095  14.773   2.27214952  80.70602830   0.93518189  37.27   2.386  6.4493 15.2475  0.9442  5.4884 14.5270  0.0000 24.7226 10.9659 21.4195  0.4713  0.4918  0.958173317200      0
jxl:d2.1        19988  2476449    0.9911695   2.101  15.194   2.34925298  79.96133070   0.96518492  37.05   2.390  6.2184 14.8664  0.9763  5.3959 14.3196  0.0000 24.1193 11.7318 22.0445  0.5021  0.5533  0.956661846823      0
jxl:d2.2        19988  2396348    0.9591100   2.110  14.982   2.45232335  79.20494297   0.99925685  36.82   2.390  6.0202 14.6097  0.9839  5.2566 14.2517  0.0000 23.4059 12.4746 22.6797  0.5123  0.5328  0.958397254634      0
jxl:d2.3        19988  2320415    0.9287187   2.145  15.340   2.52920270  78.48482908   1.02946501  36.60   2.416  5.9066 14.3045  1.0054  5.1295 14.0820  0.0000 22.7937 13.2482 23.2330  0.5123  0.5123  0.956083429162      0
jxl:d2.4        19988  2251189    0.9010118   2.093  14.978   2.58586697  77.82291540   1.05833903  36.41   2.411  5.7321 14.0397  1.0016  5.0404 13.9430  0.0000 22.2609 13.9859 23.4738  0.5943  0.6558  0.953575997575      0
jxl:d2.5        19988  2186556    0.8751432   2.170  15.908   2.65657311  77.10349709   1.09425325  36.21   2.401  5.5716 13.8066  0.9974  4.9565 13.7983  0.0000 21.7192 14.7032 23.9041  0.5943  0.6762  0.957628336320      0
jxl:d2.6        19988  2126126    0.8509568   2.148  15.557   2.73122621  76.44288110   1.11704927  36.03   2.396  5.4112 13.4893  1.0352  4.8515 13.7887  0.0000 21.3208 15.2872 24.2115  0.5943  0.7377  0.950560724038      0
jxl:d2.7        19988  2065740    0.8267881   2.049  14.968   2.79169492  75.74781435   1.15347317  35.80   2.400  5.2578 13.2722  1.0313  4.7782 13.6856  0.0000 20.6984 15.9481 24.7136  0.6660  0.6762  0.953677851027      0
jxl:d2.8        19988  2013216    0.8057660   2.131  15.716   2.87618513  75.08394253   1.18117530  35.63   2.414  5.1375 13.0734  1.0528  4.7033 13.5882  0.0000 20.3462 16.6217 24.7392  0.7480  0.7172  0.951750838237      0
jxl:d2.9        19988  1962263    0.7853726   2.117  14.906   2.90998174  74.46330594   1.20766426  35.45   2.374  5.0203 12.8605  1.0605  4.6594 13.5101  0.0000 19.8838 17.0162 25.2720  0.6865  0.7582  0.948466435390      0
jxl:d3          19988  1917097    0.7672955   1.913  14.631   3.02006196  73.80582101   1.23487713  35.29   2.395  4.8384 12.6693  1.0422  4.5371 13.4307  0.0000 19.4420 17.9332 25.3898  0.6865  0.7582  0.947515611606      0
jxl:d5          19988  1315320    0.5264413   2.031   8.550   4.42744618  61.97193727   1.74941341  32.96   2.404  3.3575  8.3237  0.9414  2.9643 10.7923  0.0000 15.4357 27.3084 29.5549  0.6762  1.3730  0.920963489679      0
jxl:d7          19988  1019668    0.4081101   2.029   8.533   5.66417362  52.22776715   2.21269381  31.51   2.382  2.5615  5.9261  0.7761  2.0665  9.1920  0.0000 12.8960 32.7388 32.2957  0.6967  1.5779  0.903022662928      0
jxl:d15         19988   572670    0.2292044   1.988   8.261   9.71446992  22.40033290   3.71887972  28.63   2.248  1.2238  1.7831  0.3083  0.5924  5.4810  0.0000  7.5283 37.9541 40.7743  1.2090  3.8730  0.852383635158      0
jxl:d24         19988   410721    0.1643862   0.308  19.518  19.93493138  -7.37978673   6.30189568  25.86   2.767  1.0262  2.3108  0.1719  0.6913  3.0316  0.0000  3.2570  9.2573  5.7071  0.0000  0.0000  1.035944900652      0
jxl:d32         19988   325877    0.1304284   0.312  18.650  21.59978236 -20.37676073   7.06166502  25.39   2.473  0.7573  1.7476  0.1380  0.5059  2.7127  0.0000  2.8446 10.3383  6.4089  0.0000  0.0000  0.921041842737      0
Aggregate:      19988  2325009    0.9305575   1.798  14.195   2.51045902  76.91537982   1.01340070  36.69   2.451  5.7445 12.2895  0.7517  4.6817 12.3756  0.0000 18.8346  8.7176 16.2448  0.4277  0.4779  0.943027589505      0
```