### PR TITLE
Add default implementation for skip_input_data() callback.

### DIFF
--- a/lib/jpegli/decode.cc
+++ b/lib/jpegli/decode.cc
@@ -349,6 +349,7 @@ void jpegli_abort_decompress(j_decompress_ptr cinfo) {
 
 void jpegli_save_markers(j_decompress_ptr cinfo, int marker_code,
                          unsigned int length_limit) {
+  // TODO(szabadka) Limit our memory usage by taking into account length_limit.
   jpeg_decomp_master* m = cinfo->master;
   m->markers_to_save_.insert(marker_code);
 }

--- a/lib/jpegli/source_manager.cc
+++ b/lib/jpegli/source_manager.cc
@@ -12,7 +12,15 @@ namespace jpegli {
 void init_mem_source(j_decompress_ptr cinfo) {}
 void init_stdio_source(j_decompress_ptr cinfo) {}
 
-void skip_input_data(j_decompress_ptr cinfo, long num_bytes) {}
+void skip_input_data(j_decompress_ptr cinfo, long num_bytes) {
+  if (num_bytes <= 0) return;
+  while (num_bytes > static_cast<long>(cinfo->src->bytes_in_buffer)) {
+    num_bytes -= cinfo->src->bytes_in_buffer;
+    (*cinfo->src->fill_input_buffer)(cinfo);
+  }
+  cinfo->src->next_input_byte += num_bytes;
+  cinfo->src->bytes_in_buffer -= num_bytes;
+}
 
 void term_source(j_decompress_ptr cinfo) {}
 


### PR DESCRIPTION
drive-by: add some more TODO's regarding marker processing