### PR TITLE
Check version of Apple clang correctly

### DIFF
--- a/lib/jxl/enc_fast_lossless.cc
+++ b/lib/jxl/enc_fast_lossless.cc
@@ -52,8 +52,9 @@ _mm512_cvtsi512_si32(__m512i __A) {
 
 #ifndef FJXL_ENABLE_AVX512
 // On clang-7 or earlier, and gcc-10 or earlier, AVX512 seems broken.
-#if (defined(__clang__) && __clang_major__ > 7) || \
-    (defined(__GNUC__) && __GNUC__ > 10)
+#if (defined(__clang__) && (!defined(__apple_build_version__) && __clang_major__ > 7) \
+    || (defined(__apple_build_version__) && __apple_build_version__ > 10010046)) \
+    || (defined(__GNUC__) && __GNUC__ > 10)
 #define FJXL_ENABLE_AVX512 1
 #endif
 #endif

--- a/lib/jxl/enc_fast_lossless.cc
+++ b/lib/jxl/enc_fast_lossless.cc
@@ -52,9 +52,11 @@ _mm512_cvtsi512_si32(__m512i __A) {
 
 #ifndef FJXL_ENABLE_AVX512
 // On clang-7 or earlier, and gcc-10 or earlier, AVX512 seems broken.
-#if (defined(__clang__) && (!defined(__apple_build_version__) && __clang_major__ > 7) \
-    || (defined(__apple_build_version__) && __apple_build_version__ > 10010046)) \
-    || (defined(__GNUC__) && __GNUC__ > 10)
+#if (defined(__clang__) &&                                             \
+         (!defined(__apple_build_version__) && __clang_major__ > 7) || \
+     (defined(__apple_build_version__) &&                              \
+      __apple_build_version__ > 10010046)) ||                          \
+    (defined(__GNUC__) && __GNUC__ > 10)
 #define FJXL_ENABLE_AVX512 1
 #endif
 #endif

--- a/lib/jxl/image.cc
+++ b/lib/jxl/image.cc
@@ -111,8 +111,10 @@ void PlaneBase::InitializePadding(const size_t sizeof_t, Padding padding) {
 
   for (size_t y = 0; y < ysize_; ++y) {
     uint8_t* JXL_RESTRICT row = static_cast<uint8_t*>(VoidRow(y));
-#if defined(__clang__) && ((!defined(__apple_build_version__) && __clang_major__ <= 6) \
-    || (defined(__apple_build_version__) && __apple_build_version__ <= 10001145))
+#if defined(__clang__) &&                                           \
+    ((!defined(__apple_build_version__) && __clang_major__ <= 6) || \
+     (defined(__apple_build_version__) &&                           \
+      __apple_build_version__ <= 10001145))
     // There's a bug in msan in clang-6 when handling AVX2 operations. This
     // workaround allows tests to pass on msan, although it is slower and
     // prevents msan warnings from uninitialized images.

--- a/lib/jxl/image.cc
+++ b/lib/jxl/image.cc
@@ -111,7 +111,8 @@ void PlaneBase::InitializePadding(const size_t sizeof_t, Padding padding) {
 
   for (size_t y = 0; y < ysize_; ++y) {
     uint8_t* JXL_RESTRICT row = static_cast<uint8_t*>(VoidRow(y));
-#if defined(__clang__) && (__clang_major__ <= 6)
+#if defined(__clang__) && ((!defined(__apple_build_version__) && __clang_major__ <= 6) \
+    || (defined(__apple_build_version__) && __apple_build_version__ <= 10001145))
     // There's a bug in msan in clang-6 when handling AVX2 operations. This
     // workaround allows tests to pass on msan, although it is slower and
     // prevents msan warnings from uninitialized images.


### PR DESCRIPTION
The `__clang_major__` macro provides a marketing version which is not required to be consistent between vendors[[1]]. And indeed, Apple uses a versioning scheme for its Clang releases that is unrelated to that of the llvm.org releases on which they are based. The correspondences between the versions can however be determined[[2]].

So, checking whether `__apple_build_version__` is defined is necessary to determine whether an Apple version of Clang is being used, so that the correct version check can be done. Checking the value of that macro is simpler for the purposes of this code than checking (a different value of) `__clang_major__`, because distinguishing between the relevant versions of Apple Clang would also require checking `__clang_minor__` and `__clang_patchlevel__`.

Closes: #2260

[1]: https://clang.llvm.org/docs/LanguageExtensions.html#builtin-macros
[2]: https://en.wikipedia.org/wiki/Xcode#Toolchain_versions