### PR TITLE
Unbreak build on macOS with GCC: add __STDC_FORMAT_MACROS where needed

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -55,6 +55,7 @@ Pieter Wuille
 roland-rollo
 Samuel Leong <wvvwvvvvwvvw@gmail.com>
 Sandro <sandro.jaeckel@gmail.com>
+Sergey Fedorov <vital.had@gmail.com>
 Stephan T. Lavavej <stl@nuwen.net>
 Thomas Bonfort <thomas.bonfort@airbus.com>
 tmkk <tmkkmac@gmail.com>

--- a/examples/decode_oneshot.cc
+++ b/examples/decode_oneshot.cc
@@ -7,6 +7,10 @@
 // available at once). The example outputs the pixels and color information to a
 // floating point image and an ICC profile on disk.
 
+#ifndef __STDC_FORMAT_MACROS
+#define __STDC_FORMAT_MACROS
+#endif
+
 #include <inttypes.h>
 #include <jxl/decode.h>
 #include <jxl/decode_cxx.h>

--- a/examples/decode_progressive.cc
+++ b/examples/decode_progressive.cc
@@ -6,6 +6,10 @@
 // This C++ example decodes a JPEG XL image progressively (input bytes are
 // passed in chunks). The example outputs the intermediate steps to PAM files.
 
+#ifndef __STDC_FORMAT_MACROS
+#define __STDC_FORMAT_MACROS
+#endif
+
 #include <inttypes.h>
 #include <jxl/decode.h>
 #include <jxl/decode_cxx.h>

--- a/lib/jxl/base/status.h
+++ b/lib/jxl/base/status.h
@@ -94,12 +94,17 @@ inline JXL_NOINLINE bool Debug(const char* format, ...) {
 //   #ifndef JXL_DEBUG_MYMODULE
 //   #define JXL_DEBUG_MYMODULE 0
 //   #endif JXL_DEBUG_MYMODULE
-#define JXL_DEBUG(enabled, format, ...)                         \
-  do {                                                          \
-    if (enabled) {                                              \
-      ::jxl::Debug(("%s:%d: " format "\n"), __FILE__, __LINE__, ##__VA_ARGS__); \
-    }                                                           \
+#define JXL_DEBUG_TMP(format, ...) \
+  ::jxl::Debug(("%s:%d: " format "\n"), __FILE__, __LINE__, ##__VA_ARGS__)
+
+#define JXL_DEBUG(enabled, format, ...)     \
+  do {                                      \
+    if (enabled) {                          \
+      JXL_DEBUG_TMP(format, ##__VA_ARGS__); \
+    }                                       \
   } while (0)
+
+#undef JXL_DEBUG_TMP
 
 // JXL_DEBUG version that prints the debug message if the global verbose level
 // defined at compile time by JXL_DEBUG_V_LEVEL is greater or equal than the

--- a/lib/jxl/base/status.h
+++ b/lib/jxl/base/status.h
@@ -97,8 +97,7 @@ inline JXL_NOINLINE bool Debug(const char* format, ...) {
 #define JXL_DEBUG(enabled, format, ...)                         \
   do {                                                          \
     if (enabled) {                                              \
-      ::jxl::Debug(("%s:%d: " format "\n"), __FILE__, __LINE__, \
-                   ##__VA_ARGS__);                              \
+      ::jxl::Debug(("%s:%d: " format "\n"), __FILE__, __LINE__, ##__VA_ARGS__); \
     }                                                           \
   } while (0)
 

--- a/lib/jxl/base/status.h
+++ b/lib/jxl/base/status.h
@@ -104,8 +104,6 @@ inline JXL_NOINLINE bool Debug(const char* format, ...) {
     }                                       \
   } while (0)
 
-#undef JXL_DEBUG_TMP
-
 // JXL_DEBUG version that prints the debug message if the global verbose level
 // defined at compile time by JXL_DEBUG_V_LEVEL is greater or equal than the
 // passed level.

--- a/lib/jxl/image_test_utils.h
+++ b/lib/jxl/image_test_utils.h
@@ -6,6 +6,11 @@
 #ifndef LIB_JXL_IMAGE_TEST_UTILS_H_
 #define LIB_JXL_IMAGE_TEST_UTILS_H_
 
+#ifndef __STDC_FORMAT_MACROS
+#define __STDC_FORMAT_MACROS
+#endif
+
+#include <inttypes.h>
 #include <stddef.h>
 #include <stdint.h>
 

--- a/tools/speed_stats.cc
+++ b/tools/speed_stats.cc
@@ -5,6 +5,10 @@
 
 #include "tools/speed_stats.h"
 
+#ifndef __STDC_FORMAT_MACROS
+#define __STDC_FORMAT_MACROS
+#endif
+
 #include <inttypes.h>
 #include <math.h>
 #include <stddef.h>


### PR DESCRIPTION
This is well-known error:
```
:info:build [ 71%] Building C object tools/CMakeFiles/jxlinfo.dir/jxlinfo.c.o
:info:build cd /opt/local/var/macports/build/_opt_local_var_macports_sources_rsync.macports.org_macports_release_tarballs_ports_graphics_libjxl/libjxl/work/build/tools && /opt/local/bin/gcc-mp-12 -DHWY_DISABLED_TARGETS="(HWY_SVE|HWY_SVE2|HWY_SVE_256|HWY_SVE2_128|HWY_RVV)" -D__DATE__=\"redacted\" -D__TIMESTAMP__=\"redacted\" -D__TIME__=\"redacted\" -I/opt/local/var/macports/build/_opt_local_var_macports_sources_rsync.macports.org_macports_release_tarballs_ports_graphics_libjxl/libjxl/work/libjxl-0.8.1/lib/include -I/opt/local/var/macports/build/_opt_local_var_macports_sources_rsync.macports.org_macports_release_tarballs_ports_graphics_libjxl/libjxl/work/build/lib/include -pipe -Os -DNDEBUG -arch ppc -mmacosx-version-min=10.6 -fPIE -fmacro-prefix-map=/opt/local/var/macports/build/_opt_local_var_macports_sources_rsync.macports.org_macports_release_tarballs_ports_graphics_libjxl/libjxl/work/libjxl-0.8.1=. -Wno-builtin-macro-redefined -Wall -MD -MT tools/CMakeFiles/jxlinfo.dir/jxlinfo.c.o -MF CMakeFiles/jxlinfo.dir/jxlinfo.c.o.d -o CMakeFiles/jxlinfo.dir/jxlinfo.c.o -c /opt/local/var/macports/build/_opt_local_var_macports_sources_rsync.macports.org_macports_release_tarballs_ports_graphics_libjxl/libjxl/work/libjxl-0.8.1/tools/jxlinfo.c
:info:build /opt/local/var/macports/build/_opt_local_var_macports_sources_rsync.macports.org_macports_release_tarballs_ports_graphics_libjxl/libjxl/work/libjxl-0.8.1/examples/decode_progressive.cc: In function 'bool WritePAM(const char*, const uint8_t*, size_t, size_t)':
:info:build /opt/local/var/macports/build/_opt_local_var_macports_sources_rsync.macports.org_macports_release_tarballs_ports_graphics_libjxl/libjxl/work/libjxl-0.8.1/examples/decode_progressive.cc:29:24: error: expected ')' before 'PRIu64'
:info:build    29 |           "P7\nWIDTH %" PRIu64 "\nHEIGHT %" PRIu64
:info:build       |                        ^~~~~~~
:info:build       |                        )
:info:build /opt/local/var/macports/build/_opt_local_var_macports_sources_rsync.macports.org_macports_release_tarballs_ports_graphics_libjxl/libjxl/work/libjxl-0.8.1/examples/decode_progressive.cc:28:10: note: to match this '('
:info:build    28 |   fprintf(fp,
:info:build       |          ^
:info:build /opt/local/var/macports/build/_opt_local_var_macports_sources_rsync.macports.org_macports_release_tarballs_ports_graphics_libjxl/libjxl/work/libjxl-0.8.1/examples/decode_progressive.cc:21:1: note: 'PRIu64' is defined in header '<cinttypes>'; did you forget to '#include <cinttypes>'?
:info:build    20 | #include "jxl/resizable_parallel_runner_cxx.h"
:info:build   +++ |+#include <cinttypes>
:info:build    21 | 
:info:build /opt/local/var/macports/build/_opt_local_var_macports_sources_rsync.macports.org_macports_release_tarballs_ports_graphics_libjxl/libjxl/work/libjxl-0.8.1/examples/decode_progressive.cc:29:22: warning: spurious trailing '%' in format [-Wformat=]
:info:build    29 |           "P7\nWIDTH %" PRIu64 "\nHEIGHT %" PRIu64
:info:build       |                      ^
:info:build /opt/local/var/macports/build/_opt_local_var_macports_sources_rsync.macports.org_macports_release_tarballs_ports_graphics_libjxl/libjxl/work/libjxl-0.8.1/examples/decode_progressive.cc:29:11: warning: too many arguments for format [-Wformat-extra-args]
:info:build    29 |           "P7\nWIDTH %" PRIu64 "\nHEIGHT %" PRIu64
:info:build       |           ^~~~~~~~~~~~~
:info:build /opt/local/var/macports/build/_opt_local_var_macports_sources_rsync.macports.org_macports_release_tarballs_ports_graphics_libjxl/libjxl/work/libjxl-0.8.1/examples/decode_oneshot.cc: In function 'bool DecodeJpegXlOneShot(const uint8_t*, size_t, std::vector<float>*, size_t*, size_t*, std::vector<unsigned char>*)':
:info:build /opt/local/var/macports/build/_opt_local_var_macports_sources_rsync.macports.org_macports_release_tarballs_ports_graphics_libjxl/libjxl/work/libjxl-0.8.1/examples/decode_oneshot.cc:101:52: error: expected ')' before 'PRIu64'
:info:build   101 |         fprintf(stderr, "Invalid out buffer size %" PRIu64 " %" PRIu64 "\n",
:info:build       |                ~                                   ^~~~~~~
:info:build       |                                                    )
:info:build /opt/local/var/macports/build/_opt_local_var_macports_sources_rsync.macports.org_macports_release_tarballs_ports_graphics_libjxl/libjxl/work/libjxl-0.8.1/examples/decode_oneshot.cc:22:1: note: 'PRIu64' is defined in header '<cinttypes>'; did you forget to '#include <cinttypes>'?
:info:build    21 | #include "jxl/resizable_parallel_runner_cxx.h"
:info:build   +++ |+#include <cinttypes>
:info:build    22 | 
:info:build /opt/local/var/macports/build/_opt_local_var_macports_sources_rsync.macports.org_macports_release_tarballs_ports_graphics_libjxl/libjxl/work/libjxl-0.8.1/examples/decode_oneshot.cc:101:50: warning: spurious trailing '%' in format [-Wformat=]
:info:build   101 |         fprintf(stderr, "Invalid out buffer size %" PRIu64 " %" PRIu64 "\n",
:info:build       |                                                  ^
:info:build /opt/local/var/macports/build/_opt_local_var_macports_sources_rsync.macports.org_macports_release_tarballs_ports_graphics_libjxl/libjxl/work/libjxl-0.8.1/examples/decode_oneshot.cc:101:25: warning: too many arguments for format [-Wformat-extra-args]
:info:build   101 |         fprintf(stderr, "Invalid out buffer size %" PRIu64 " %" PRIu64 "\n",
:info:build       |                         ^~~~~~~~~~~~~~~~~~~~~~~~~~~
:info:build /opt/local/var/macports/build/_opt_local_var_macports_sources_rsync.macports.org_macports_release_tarballs_ports_graphics_libjxl/libjxl/work/libjxl-0.8.1/examples/decode_progressive.cc: In function 'bool DecodeJpegXlProgressive(const uint8_t*, size_t, const char*, size_t)':
:info:build /opt/local/var/macports/build/_opt_local_var_macports_sources_rsync.macports.org_macports_release_tarballs_ports_graphics_libjxl/libjxl/work/libjxl-0.8.1/examples/decode_progressive.cc:84:32: error: expected ')' before 'PRIu64'
:info:build    84 |       printf("Flushing after %" PRIu64 " bytes\n", static_cast<uint64_t>(seen));
:info:build       |             ~                  ^~~~~~~
:info:build       |                                )
:info:build /opt/local/var/macports/build/_opt_local_var_macports_sources_rsync.macports.org_macports_release_tarballs_ports_graphics_libjxl/libjxl/work/libjxl-0.8.1/examples/decode_progressive.cc:84:33: note: 'PRIu64' is defined in header '<cinttypes>'; did you forget to '#include <cinttypes>'?
:info:build    84 |       printf("Flushing after %" PRIu64 " bytes\n", static_cast<uint64_t>(seen));
:info:build       |                                 ^~~~~~
:info:build /opt/local/var/macports/build/_opt_local_var_macports_sources_rsync.macports.org_macports_release_tarballs_ports_graphics_libjxl/libjxl/work/libjxl-0.8.1/examples/decode_progressive.cc:84:30: warning: spurious trailing '%' in format [-Wformat=]
:info:build    84 |       printf("Flushing after %" PRIu64 " bytes\n", static_cast<uint64_t>(seen));
:info:build       |                              ^
:info:build /opt/local/var/macports/build/_opt_local_var_macports_sources_rsync.macports.org_macports_release_tarballs_ports_graphics_libjxl/libjxl/work/libjxl-0.8.1/examples/decode_progressive.cc:84:14: warning: too many arguments for format [-Wformat-extra-args]
:info:build    84 |       printf("Flushing after %" PRIu64 " bytes\n", static_cast<uint64_t>(seen));
:info:build       |              ^~~~~~~~~~~~~~~~~~
:info:build /opt/local/var/macports/build/_opt_local_var_macports_sources_rsync.macports.org_macports_release_tarballs_ports_graphics_libjxl/libjxl/work/libjxl-0.8.1/examples/decode_progressive.cc:90:41: error: expected ')' before 'PRIu64'
:info:build    90 |         if (snprintf(fname, 1024, "%s-%" PRIu64 ".pam", filename,
:info:build       |                     ~                   ^~~~~~~
:info:build       |                                         )
:info:build /opt/local/var/macports/build/_opt_local_var_macports_sources_rsync.macports.org_macports_release_tarballs_ports_graphics_libjxl/libjxl/work/libjxl-0.8.1/examples/decode_progressive.cc:90:42: note: 'PRIu64' is defined in header '<cinttypes>'; did you forget to '#include <cinttypes>'?
:info:build    90 |         if (snprintf(fname, 1024, "%s-%" PRIu64 ".pam", filename,
:info:build       |                                          ^~~~~~
:info:build /opt/local/var/macports/build/_opt_local_var_macports_sources_rsync.macports.org_macports_release_tarballs_ports_graphics_libjxl/libjxl/work/libjxl-0.8.1/examples/decode_progressive.cc:90:39: warning: spurious trailing '%' in format [-Wformat=]
:info:build    90 |         if (snprintf(fname, 1024, "%s-%" PRIu64 ".pam", filename,
:info:build       |                                       ^
:info:build /opt/local/var/macports/build/_opt_local_var_macports_sources_rsync.macports.org_macports_release_tarballs_ports_graphics_libjxl/libjxl/work/libjxl-0.8.1/examples/decode_progressive.cc:90:35: warning: too many arguments for format [-Wformat-extra-args]
:info:build    90 |         if (snprintf(fname, 1024, "%s-%" PRIu64 ".pam", filename,
:info:build       |                                   ^~~~~~
:info:build /opt/local/var/macports/build/_opt_local_var_macports_sources_rsync.macports.org_macports_release_tarballs_ports_graphics_libjxl/libjxl/work/libjxl-0.8.1/examples/decode_progressive.cc:146:52: error: expected ')' before 'PRIu64'
:info:build   146 |         fprintf(stderr, "Invalid out buffer size %" PRIu64 " != %" PRIu64 "\n",
:info:build       |                ~                                   ^~~~~~~
:info:build       |                                                    )
:info:build /opt/local/var/macports/build/_opt_local_var_macports_sources_rsync.macports.org_macports_release_tarballs_ports_graphics_libjxl/libjxl/work/libjxl-0.8.1/examples/decode_progressive.cc:146:53: note: 'PRIu64' is defined in header '<cinttypes>'; did you forget to '#include <cinttypes>'?
:info:build   146 |         fprintf(stderr, "Invalid out buffer size %" PRIu64 " != %" PRIu64 "\n",
:info:build       |                                                     ^~~~~~
:info:build /opt/local/var/macports/build/_opt_local_var_macports_sources_rsync.macports.org_macports_release_tarballs_ports_graphics_libjxl/libjxl/work/libjxl-0.8.1/examples/decode_progressive.cc:146:50: warning: spurious trailing '%' in format [-Wformat=]
:info:build   146 |         fprintf(stderr, "Invalid out buffer size %" PRIu64 " != %" PRIu64 "\n",
:info:build       |                                                  ^
:info:build /opt/local/var/macports/build/_opt_local_var_macports_sources_rsync.macports.org_macports_release_tarballs_ports_graphics_libjxl/libjxl/work/libjxl-0.8.1/examples/decode_progressive.cc:146:25: warning: too many arguments for format [-Wformat-extra-args]
:info:build   146 |         fprintf(stderr, "Invalid out buffer size %" PRIu64 " != %" PRIu64 "\n",
:info:build       |                         ^~~~~~~~~~~~~~~~~~~~~~~~~~~
:info:build make[2]: *** [CMakeFiles/decode_progressive.dir/examples/decode_progressive.cc.o] Error 1
```
See, for example: https://github.com/unicode-org/icu/commit/c9e1c1343a7b25510462afea36c83260ee6a6da9