### PR TITLE
Fix condition for defining _mm512_cvtsi512_si32

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -37,6 +37,7 @@ gi-man
 Heiko Becker <heirecka@exherbo.org>
 Jim Robinson <jimbo2150@gmail.com>
 Jon Sneyers <jon@cloudinary.com>
+Joshua Root <jmr@macports.org>
 Kai Hollberg <Schweinepriester@users.noreply.github.com>
 Kleis Auke Wolthuizen <github@kleisauke.nl>
 L. E. Segovia

--- a/lib/jxl/enc_fast_lossless.cc
+++ b/lib/jxl/enc_fast_lossless.cc
@@ -33,10 +33,9 @@
 // manually add _mm512_cvtsi512_si32 definition if missing
 // (e.g. with Xcode on macOS Mojave)
 // copied from gcc 11.1.0 include/avx512fintrin.h line 14367-14373
-#if defined(__clang__) \
-    && ((!defined(__apple_build_version__) && __clang_major__ < 10) \
-    || (defined(__apple_build_version__) \
-        && __apple_build_version__ < 12000032))
+#if defined(__clang__) &&                                           \
+    ((!defined(__apple_build_version__) && __clang_major__ < 10) || \
+     (defined(__apple_build_version__) && __apple_build_version__ < 12000032))
 inline int __attribute__((__gnu_inline__, __always_inline__, __artificial__))
 _mm512_cvtsi512_si32(__m512i __A) {
   __v16si __B = (__v16si)__A;

--- a/lib/jxl/enc_fast_lossless.cc
+++ b/lib/jxl/enc_fast_lossless.cc
@@ -30,9 +30,13 @@
 #elif (defined(__x86_64__) || defined(_M_X64)) && !defined(_MSC_VER)
 #include <immintrin.h>
 
-// manually add _mm512_cvtsi512_si32 definition on MacOS Mojave
+// manually add _mm512_cvtsi512_si32 definition if missing
+// (e.g. with Xcode on macOS Mojave)
 // copied from gcc 11.1.0 include/avx512fintrin.h line 14367-14373
-#if __APPLE__ && defined(__clang__) && defined(__MAC_10_0)
+#if defined(__clang__) \
+    && ((!defined(__apple_build_version__) && __clang_major__ < 10) \
+    || (defined(__apple_build_version__) \
+        && __apple_build_version__ < 12000032))
 inline int __attribute__((__gnu_inline__, __always_inline__, __artificial__))
 _mm512_cvtsi512_si32(__m512i __A) {
   __v16si __B = (__v16si)__A;


### PR DESCRIPTION
The previous check was incorrect for a few reasons:
 - The definition is missing in all Clang versions older than 10, not just Apple's[[1]].
 - The OS version doesn't determine which compiler is used; a Mojave system could be running the latest Clang release.
 - Whether `__MAC_10_0` is defined doesn't tell you which OS version you are building on or for, so a conflicting definition was added on newer OS versions where the default compiler already has it.

Closes: #2291

[1]: https://github.com/llvm/llvm-project/commit/caac097fbf4e0883a675feb2ee38407def08b5a6