### PR TITLE
Use jpegli's own memory manager for heap allocations more often.

### DIFF
--- a/lib/jpegli/bit_writer.cc
+++ b/lib/jpegli/bit_writer.cc
@@ -14,8 +14,8 @@ void JpegBitWriterInit(j_compress_ptr cinfo) {
   JpegBitWriter* bw = &m->bw;
   size_t buffer_size = m->blocks_per_iMCU_row * (DCTSIZE2 * 16 + 8) + (1 << 16);
   bw->cinfo = cinfo;
-  bw->buffer.resize(buffer_size);
-  bw->data = bw->buffer.data();
+  bw->data = Allocate<uint8_t>(cinfo, buffer_size, JPOOL_IMAGE);
+  bw->len = buffer_size;
   bw->pos = 0;
   bw->output_pos = 0;
   bw->put_buffer = 0;

--- a/lib/jpegli/bit_writer.h
+++ b/lib/jpegli/bit_writer.h
@@ -13,8 +13,6 @@
 #include <string.h>
 /* clang-format on */
 
-#include <vector>
-
 #include "lib/jxl/base/compiler_specific.h"
 
 namespace jpegli {
@@ -22,8 +20,8 @@ namespace jpegli {
 // Handles the packing of bits into output bytes.
 struct JpegBitWriter {
   j_compress_ptr cinfo;
-  std::vector<uint8_t> buffer;
   uint8_t* data;
+  size_t len;
   size_t pos;
   size_t output_pos;
   uint64_t put_buffer;

--- a/lib/jpegli/common.cc
+++ b/lib/jpegli/common.cc
@@ -30,7 +30,6 @@ void jpegli_destroy(j_common_ptr cinfo) {
     delete reinterpret_cast<j_decompress_ptr>(cinfo)->master;
   } else {
     cinfo->global_state = jpegli::kEncNull;
-    delete reinterpret_cast<j_compress_ptr>(cinfo)->master;
   }
 }
 

--- a/lib/jpegli/common_internal.h
+++ b/lib/jpegli/common_internal.h
@@ -138,10 +138,10 @@ class RowBuffer {
   }
 
  private:
-  size_t xsize_ = 0;
-  size_t ysize_ = 0;
-  size_t stride_ = 0;
-  size_t offset_ = 0;
+  size_t xsize_;
+  size_t ysize_;
+  size_t stride_;
+  size_t offset_;
   T* data_;
 };
 

--- a/lib/jpegli/encode_internal.h
+++ b/lib/jpegli/encode_internal.h
@@ -12,9 +12,6 @@
 #include <jpeglib.h>
 /* clang-format on */
 
-#include <array>
-#include <vector>
-
 #include "lib/jpegli/bit_writer.h"
 #include "lib/jpegli/common_internal.h"
 #include "lib/jpegli/encode.h"
@@ -27,13 +24,13 @@ constexpr int kICCMarker = JPEG_APP0 + 2;
 
 struct JPEGHuffmanCode {
   // Bit length histogram.
-  std::array<uint32_t, kJpegHuffmanMaxBitLength + 1> counts = {};
+  uint32_t counts[kJpegHuffmanMaxBitLength + 1];
   // Symbol values sorted by increasing bit lengths.
-  std::array<uint32_t, kJpegHuffmanAlphabetSize + 1> values = {};
+  uint32_t values[kJpegHuffmanAlphabetSize + 1];
   // The index of the Huffman code in the current set of Huffman codes. For AC
   // component Huffman codes, 0x10 is added to the index.
-  int slot_id = 0;
-  boolean sent_table = FALSE;
+  int slot_id;
+  boolean sent_table;
 };
 
 // DCTCodingState: maximum number of correction bits to buffer
@@ -52,7 +49,7 @@ struct ScanCodingInfo {
   uint32_t dc_tbl_idx[MAX_COMPS_IN_SCAN];
   uint32_t ac_tbl_idx[MAX_COMPS_IN_SCAN];
   // Number of Huffman codes defined in the DHT segment preceding this scan.
-  size_t num_huffman_codes = 0;
+  size_t num_huffman_codes;
 };
 
 typedef int16_t coeff_t;
@@ -63,19 +60,19 @@ struct jpeg_comp_master {
   jpegli::RowBuffer<float> input_buffer[jpegli::kMaxComponents];
   jpegli::RowBuffer<float>* smooth_input[jpegli::kMaxComponents];
   jpegli::RowBuffer<float>* raw_data[jpegli::kMaxComponents];
-  float distance = 1.0;
-  bool force_baseline = true;
-  bool xyb_mode = false;
-  uint8_t cicp_transfer_function = 2;  // unknown transfer function code
-  bool use_std_tables = false;
-  bool use_adaptive_quantization = true;
-  int progressive_level = jpegli::kDefaultProgressiveLevel;
+  float distance;
+  bool force_baseline;
+  bool xyb_mode;
+  uint8_t cicp_transfer_function;
+  bool use_std_tables;
+  bool use_adaptive_quantization;
+  int progressive_level;
   size_t xsize_blocks;
   size_t ysize_blocks;
   size_t blocks_per_iMCU_row;
-  std::vector<jpegli::ScanCodingInfo> scan_coding_info;
-  JpegliDataType data_type = JPEGLI_TYPE_UINT8;
-  JpegliEndianness endianness = JPEGLI_NATIVE_ENDIAN;
+  jpegli::ScanCodingInfo* scan_coding_info;
+  JpegliDataType data_type;
+  JpegliEndianness endianness;
   void (*input_method)(const uint8_t* row_in, size_t len,
                        float* row_out[jpegli::kMaxComponents]);
   void (*color_transform)(float* row[jpegli::kMaxComponents], size_t len);
@@ -85,15 +82,14 @@ struct jpeg_comp_master {
   float zero_bias_mul[jpegli::kMaxComponents];
   int h_factor[jpegli::kMaxComponents];
   int v_factor[jpegli::kMaxComponents];
-  std::vector<jpegli::JPEGHuffmanCode> huffman_codes;
+  jpegli::JPEGHuffmanCode* huffman_codes;
+  size_t num_huffman_codes;
   jpegli::HuffmanCodeTable huff_tables[8];
-  std::array<jpegli::HuffmanCodeTable, jpegli::kMaxHuffmanTables> dc_huff_table;
-  std::array<jpegli::HuffmanCodeTable, jpegli::kMaxHuffmanTables> ac_huff_table;
   float* diff_buffer;
   jpegli::RowBuffer<float> fuzzy_erosion_tmp;
   jpegli::RowBuffer<float> pre_erosion;
   jpegli::RowBuffer<float> quant_field;
-  jvirt_barray_ptr* coeff_buffers = nullptr;
+  jvirt_barray_ptr* coeff_buffers;
   size_t next_input_row;
   size_t next_iMCU_row;
   size_t last_dht_index;

--- a/lib/jpegli/entropy_coding.h
+++ b/lib/jpegli/entropy_coding.h
@@ -36,7 +36,7 @@ void ClusterJpegHistograms(const Histogram* histograms, size_t num,
                            JpegClusteredHistograms* clusters);
 
 void AddJpegHuffmanCode(const Histogram& histogram, size_t slot_id,
-                        std::vector<JPEGHuffmanCode>* huff_codes);
+                        JPEGHuffmanCode* huff_codes, size_t* num_huff_codes);
 
 void OptimizeHuffmanCodes(j_compress_ptr cinfo, bool* is_baseline);
 

--- a/lib/jpegli/render.cc
+++ b/lib/jpegli/render.cc
@@ -369,10 +369,7 @@ void PrepareForOutput(j_decompress_ptr cinfo) {
   m->sumabs_ = Allocate<int>(cinfo, coeffs_per_block, JPOOL_IMAGE_ALIGNED);
   memset(m->nonzeros_, 0, coeffs_per_block * sizeof(m->nonzeros_[0]));
   memset(m->sumabs_, 0, coeffs_per_block * sizeof(m->sumabs_[0]));
-  m->num_processed_blocks_.resize(cinfo->num_components);
-  for (int c = 0; c < cinfo->num_components; ++c) {
-    m->num_processed_blocks_[c] = 0;
-  }
+  memset(m->num_processed_blocks_, 0, sizeof(m->num_processed_blocks_));
   m->biases_ = Allocate<float>(cinfo, coeffs_per_block, JPOOL_IMAGE_ALIGNED);
   memset(m->biases_, 0, coeffs_per_block * sizeof(m->biases_[0]));
   cinfo->output_iMCU_row = 0;


### PR DESCRIPTION
This PR removes some std::vector, std::array, etc. based allocations and replaces them with the cinfo->mem based allocator.