### PR TITLE
small vardct quality improvement (0.1 %)

### DIFF
--- a/lib/jxl/decode_test.cc
+++ b/lib/jxl/decode_test.cc
@@ -1935,7 +1935,7 @@ TEST(DecodeTest, PixelTestOpaqueSrgbLossy) {
     EXPECT_THAT(
         ButteraugliDistance(io0.frames, io1.frames, ba, jxl::GetJxlCms(),
                             /*distmap=*/nullptr, nullptr),
-        IsSlightlyBelow(0.9f));
+        IsSlightlyBelow(0.95f));
 
     JxlDecoderDestroy(dec);
   }
@@ -1986,7 +1986,7 @@ TEST(DecodeTest, PixelTestOpaqueSrgbLossyNoise) {
     EXPECT_THAT(
         ButteraugliDistance(io0.frames, io1.frames, ba, jxl::GetJxlCms(),
                             /*distmap=*/nullptr, nullptr),
-        IsSlightlyBelow(1.55f));
+        IsSlightlyBelow(2.4f));
 
     JxlDecoderDestroy(dec);
   }

--- a/lib/jxl/enc_ac_strategy.cc
+++ b/lib/jxl/enc_ac_strategy.cc
@@ -903,7 +903,6 @@ void ProcessRectACS(PassesEncoderState* JXL_RESTRICT enc_state,
       // FindBestFirstLevelDivisionForSquare looks for DCT32X32 and its
       // subdivisions. {AcStrategy::Type::DCT32X32, 5, 1, 5,
       // 0.9822994906548809f},
-      // TODO(jyrki): re-enable 64x32 and 64x64 if/when possible.
       {AcStrategy::Type::DCT64X32, 6, 1, 3, 1.29f},
       {AcStrategy::Type::DCT32X64, 6, 1, 3, 1.29f},
       // {AcStrategy::Type::DCT64X64, 8, 1, 3, 2.0846542128012948f},
@@ -923,6 +922,7 @@ void ProcessRectACS(PassesEncoderState* JXL_RESTRICT enc_state,
   // Priority is a tricky kludge to avoid collisions so that transforms
   // don't overlap.
   uint8_t priority[64] = {};
+  bool enable_32x32 = cparams.decoding_speed_tier < 4;
   for (auto tx : kTransformsForMerge) {
     if (tx.decoding_speed_tier_max_limit < cparams.decoding_speed_tier) {
       continue;
@@ -961,7 +961,6 @@ void ProcessRectACS(PassesEncoderState* JXL_RESTRICT enc_state,
         if (cy + 3 < rect.ysize() && cx + 3 < rect.xsize()) {
           if (tx.type == AcStrategy::Type::DCT16X32) {
             // We handle both DCT8X16 and DCT16X8 at the same time.
-            bool enable_32x32 = cparams.decoding_speed_tier < 4;
             if ((cy | cx) % 4 == 0) {
               FindBestFirstLevelDivisionForSquare(
                   4, enable_32x32, bx, by, cx, cy, config, cmap_factors,
@@ -1016,19 +1015,32 @@ void ProcessRectACS(PassesEncoderState* JXL_RESTRICT enc_state,
       }
     }
   }
-  // Here we still try to do some non-aligned matching, find a few more
-  // 16X8, 8X16 and 16X16s between the non-2-aligned blocks.
   if (cparams.speed_tier >= SpeedTier::kHare) {
     return;
   }
-  for (int ii = 0; ii < 3; ++ii) {
-    for (size_t cy = 1 - (ii == 1); cy + 1 < rect.ysize(); cy += 2) {
-      for (size_t cx = 1 - (ii == 2); cx + 1 < rect.xsize(); cx += 2) {
+  // Here we still try to do some non-aligned matching, find a few more
+  // 16X8, 8X16 and 16X16s between the non-2-aligned blocks.
+  for (size_t cy = 0; cy + 1 < rect.ysize(); ++cy) {
+    for (size_t cx = 0; cx + 1 < rect.xsize(); ++cx) {
+      if ((cy | cx) % 2 != 0) {
         FindBestFirstLevelDivisionForSquare(
             2, true, bx, by, cx, cy, config, cmap_factors, ac_strategy,
             entropy_mul16X8, entropy_mul16X16, entropy_estimate, block,
             scratch_space, quantized);
       }
+    }
+  }
+  // Non-aligned matching for 32X32, 16X32 and 32X16.
+  size_t step = cparams.speed_tier >= SpeedTier::kTortoise ? 2 : 1;
+  for (size_t cy = 0; cy + 3 < rect.ysize(); cy += step) {
+    for (size_t cx = 0; cx + 3 < rect.xsize(); cx += step) {
+      if ((cy | cx) % 4 == 0) {
+        continue;  // Already tried with loop above (DCT16X32 case).
+      }
+      FindBestFirstLevelDivisionForSquare(
+          4, enable_32x32, bx, by, cx, cy, config, cmap_factors, ac_strategy,
+          entropy_mul16X32, entropy_mul32X32, entropy_estimate, block,
+          scratch_space, quantized);
     }
   }
 }

--- a/lib/jxl/enc_adaptive_quantization.cc
+++ b/lib/jxl/enc_adaptive_quantization.cc
@@ -717,7 +717,7 @@ ImageF TileDistMap(const ImageF& distmap, int tile_size, int margin,
 
 constexpr float kDcQuantPow = 0.87f;
 static const float kDcQuant = 1.295f;
-static const float kAcQuant = 0.8365f;
+static const float kAcQuant = 0.8377f;
 
 void FindBestQuantization(const ImageBundle& linear, const Image3F& opsin,
                           PassesEncoderState* enc_state,

--- a/lib/jxl/encode_test.cc
+++ b/lib/jxl/encode_test.cc
@@ -523,7 +523,7 @@ TEST(EncodeTest, LossyEncoderUseOriginalProfileTest) {
     ASSERT_EQ(JXL_ENC_SUCCESS,
               JxlEncoderFrameSettingsSetOption(
                   frame_settings, JXL_ENC_FRAME_SETTING_EFFORT, 8));
-    VerifyFrameEncoding(63, 129, enc.get(), frame_settings, 5165, true);
+    VerifyFrameEncoding(63, 129, enc.get(), frame_settings, 5175, true);
   }
 }
 

--- a/lib/jxl/jxl_test.cc
+++ b/lib/jxl/jxl_test.cc
@@ -489,7 +489,7 @@ TEST(JxlTest, RoundtripSmallNoGaborish) {
 
   PackedPixelFile ppf_out;
   EXPECT_NEAR(Roundtrip(t.ppf(), cparams, {}, pool, &ppf_out), 777, 20);
-  EXPECT_THAT(ButteraugliDistance(t.ppf(), ppf_out), IsSlightlyBelow(1.05));
+  EXPECT_THAT(ButteraugliDistance(t.ppf(), ppf_out), IsSlightlyBelow(1.1));
 }
 
 TEST(JxlTest, RoundtripSmallPatchesAlpha) {
@@ -940,8 +940,9 @@ TEST(JxlTest, RoundtripAlpha16) {
 
   PackedPixelFile ppf_out;
   // TODO(szabadka) Investigate big size difference on i686
-  EXPECT_NEAR(Roundtrip(t.ppf(), cparams, {}, &pool, &ppf_out), 3515, 50);
-  EXPECT_THAT(ButteraugliDistance(t.ppf(), ppf_out), IsSlightlyBelow(0.8));
+  // This still keeps happening (2023-04-18).
+  EXPECT_NEAR(Roundtrip(t.ppf(), cparams, {}, &pool, &ppf_out), 3515, 100);
+  EXPECT_THAT(ButteraugliDistance(t.ppf(), ppf_out), IsSlightlyBelow(0.9));
 }
 
 namespace {


### PR DESCRIPTION
try non-aligned 32x32 and 16x32 dcts, too

```
Before:

Encoding      kPixels    Bytes          BPP  E MP/s  D MP/s     Max norm  SSIMULACRA2        pnorm   PSNR   QABPP  SmallB  DCT4x8     AFV  DCT8x8    8x16    8x32      16   16x32      32   32x64      64       BPP*pnorm   Bugs
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
jxl:d0.1        19988 16631666    6.6566281   1.516   8.966   0.37648740  99.92763374   0.11894861  53.49   6.657 40.3459 19.5387  0.4390 27.7660  5.4849  0.0000  3.0136  0.9221  3.0328  0.1025  0.0820  0.791796646022      0
jxl:d0.5        19988  6314769    2.5274118   1.998  14.137   0.83195520  97.86423784   0.36321044  44.72   2.544 14.3353 24.8769  0.6000 11.9088 21.6250  0.0000 20.6062  1.3602  4.8413  0.1434  0.4303  0.917982338922      0
jxl:d0.8        19988  4694940    1.8790943   2.033  14.938   1.16315666  92.60532324   0.50246013  42.12   2.197 11.0107 21.3942  0.7031  8.9996 19.6065  0.0000 30.4681  1.6496  6.3218  0.2049  0.3689  0.944169996390      0
jxl:d1          19988  4059854    1.6249087   2.019  15.366   1.37774263  89.90347524   0.58551421  40.93   2.242  9.7821 19.6482  0.7374  7.8459 18.0024  0.0000 32.3725  2.6819  9.1959  0.2357  0.2254  0.951407110163      0
jxl:d1.1        19988  3821432    1.5294831   2.034  15.992   1.45178366  88.85146933   0.62411786  40.39   2.236  9.2990 18.9684  0.7822  7.4457 17.2973  0.0000 32.3162  3.3172 10.8096  0.2459  0.2459  0.954577702690      0
jxl:d1.2        19988  3606877    1.4436100   2.163  16.081   1.53838725  87.67597806   0.66096810  39.90   2.251  8.8011 18.3332  0.8056  7.1095 16.6313  0.0000 32.0946  4.0779 12.4541  0.2766  0.1434  0.954180135064      0
jxl:d1.3        19988  3432496    1.3738160   2.057  16.720   1.63847996  86.78175991   0.69783852  39.52   2.294  8.4159 17.7949  0.8239  6.7820 16.3425  0.0000 31.0726  5.0283 13.9757  0.3074  0.1844  0.958701748970      0
jxl:d1.4        19988  3268745    1.3082766   2.167  16.557   1.72673552  85.81237653   0.73282063  39.12   2.305  8.0509 17.3812  0.8331  6.4787 15.8270  0.0000 30.2324  5.9504 15.4101  0.3586  0.2049  0.958732092207      0
jxl:d1.5        19988  3118458    1.2481260   2.092  15.529   1.86932410  84.86342306   0.77125910  38.76   2.375  7.7323 16.9326  0.8501  6.2396 15.4588  0.0000 29.4306  6.8137 16.6140  0.3894  0.2664  0.962628546990      0
jxl:d1.6        19988  2983216    1.1939970   2.152  15.714   1.91422069  83.99808456   0.80479393  38.45   2.323  7.4275 16.5196  0.8776  6.0007 15.2929  0.0000 28.3484  7.6743 17.8487  0.3894  0.3484  0.960921544620      0
jxl:d1.7        19988  2863792    1.1461990   2.140  16.048   2.00960072  83.06852054   0.83773394  38.11   2.349  7.1662 16.2036  0.9071  5.9222 15.0214  0.0000 27.2303  8.5837 18.8323  0.4303  0.4303  0.960209766106      0
jxl:d1.8        19988  2751393    1.1012126   2.196  16.219   2.07598227  82.25978581   0.87040040  37.78   2.322  6.9104 15.8863  0.9180  5.7263 14.8319  0.0000 26.3491  9.4392 19.7647  0.4303  0.4713  0.958495880534      0
jxl:d1.8        19988  2751393    1.1012126   2.155  16.012   2.07598227  82.25978581   0.87040040  37.78   2.322  6.9104 15.8863  0.9180  5.7263 14.8319  0.0000 26.3491  9.4392 19.7647  0.4303  0.4713  0.958495880534      0
jxl:d1.9        19988  2654530    1.0624443   2.147  15.891   2.17516161  81.50389246   0.90270106  37.51   2.339  6.6734 15.5219  0.9369  5.6177 14.7160  0.0000 25.4090 10.3306 20.5690  0.4201  0.5328  0.959069609881      0
jxl:d2.0        19988  2559938    1.0245850   2.150  16.007   2.27214952  80.70602830   0.93518189  37.27   2.386  6.4493 15.2475  0.9442  5.4884 14.5270  0.0000 24.7226 10.9659 21.4195  0.4713  0.4918  0.958173317200      0
jxl:d2.1        19988  2476449    0.9911695   2.127  15.812   2.34925298  79.96133070   0.96518492  37.05   2.390  6.2184 14.8664  0.9763  5.3959 14.3196  0.0000 24.1193 11.7318 22.0445  0.5021  0.5533  0.956661846823      0
jxl:d2.2        19988  2396348    0.9591100   2.151  16.051   2.45232335  79.20494297   0.99925685  36.82   2.390  6.0202 14.6097  0.9839  5.2566 14.2517  0.0000 23.4059 12.4746 22.6797  0.5123  0.5328  0.958397254634      0
jxl:d2.3        19988  2320415    0.9287187   2.268  15.911   2.52920270  78.48482908   1.02946501  36.60   2.416  5.9066 14.3045  1.0054  5.1295 14.0820  0.0000 22.7937 13.2482 23.2330  0.5123  0.5123  0.956083429162      0
jxl:d2.4        19988  2251189    0.9010118   2.101  15.804   2.58586697  77.82291540   1.05833903  36.41   2.411  5.7321 14.0397  1.0016  5.0404 13.9430  0.0000 22.2609 13.9859 23.4738  0.5943  0.6558  0.953575997575      0
jxl:d2.5        19988  2186556    0.8751432   2.283  15.897   2.65657311  77.10349709   1.09425325  36.21   2.401  5.5716 13.8066  0.9974  4.9565 13.7983  0.0000 21.7192 14.7032 23.9041  0.5943  0.6762  0.957628336320      0
jxl:d2.6        19988  2126126    0.8509568   2.100  16.032   2.73122621  76.44288110   1.11704927  36.03   2.396  5.4112 13.4893  1.0352  4.8515 13.7887  0.0000 21.3208 15.2872 24.2115  0.5943  0.7377  0.950560724038      0
jxl:d2.7        19988  2065740    0.8267881   2.204  15.797   2.79169492  75.74781435   1.15347317  35.80   2.400  5.2578 13.2722  1.0313  4.7782 13.6856  0.0000 20.6984 15.9481 24.7136  0.6660  0.6762  0.953677851027      0
jxl:d2.8        19988  2013216    0.8057660   2.131  16.166   2.87618513  75.08394253   1.18117530  35.63   2.414  5.1375 13.0734  1.0528  4.7033 13.5882  0.0000 20.3462 16.6217 24.7392  0.7480  0.7172  0.951750838237      0
jxl:d2.9        19988  1962263    0.7853726   2.263  15.382   2.90998174  74.46330594   1.20766426  35.45   2.374  5.0203 12.8605  1.0605  4.6594 13.5101  0.0000 19.8838 17.0162 25.2720  0.6865  0.7582  0.948466435390      0
jxl:d3          19988  1917097    0.7672955   2.031  16.082   3.02006196  73.80582101   1.23487713  35.29   2.395  4.8384 12.6693  1.0422  4.5371 13.4307  0.0000 19.4420 17.9332 25.3898  0.6865  0.7582  0.947515611606      0
jxl:d5          19988  1315320    0.5264413   2.046   8.907   4.42744618  61.97193727   1.74941341  32.96   2.404  3.3575  8.3237  0.9414  2.9643 10.7923  0.0000 15.4357 27.3084 29.5549  0.6762  1.3730  0.920963489679      0
jxl:d7          19988  1019668    0.4081101   2.017   8.708   5.66417362  52.22776715   2.21269381  31.51   2.382  2.5615  5.9261  0.7761  2.0665  9.1920  0.0000 12.8960 32.7388 32.2957  0.6967  1.5779  0.903022662928      0
jxl:d15         19988   572670    0.2292044   2.016   8.513   9.71446992  22.40033290   3.71887972  28.63   2.248  1.2238  1.7831  0.3083  0.5924  5.4810  0.0000  7.5283 37.9541 40.7743  1.2090  3.8730  0.852383635158      0
jxl:d24         19988   410721    0.1643862   0.314  20.152  19.93493138  -7.37978673   6.30189568  25.86   2.767  1.0262  2.3108  0.1719  0.6913  3.0316  0.0000  3.2570  9.2573  5.7071  0.0000  0.0000  1.035944900652      0
jxl:d32         19988   325877    0.1304284   0.315  20.297  21.59978236 -20.37676073   7.06166502  25.39   2.473  0.7573  1.7476  0.1380  0.5059  2.7127  0.0000  2.8446 10.3383  6.4089  0.0000  0.0000  0.921041842737      0
Aggregate:      19988  2325009    0.9305575   1.845  14.873   2.51045902  76.91537982   1.01340070  36.69   2.451  5.7445 12.2895  0.7517  4.6817 12.3756  0.0000 18.8346  8.7176 16.2448  0.4277  0.4779  0.943027589505      0

After:

Encoding      kPixels    Bytes          BPP  E MP/s  D MP/s     Max norm  SSIMULACRA2        pnorm   PSNR   QABPP  SmallB  DCT4x8     AFV  DCT8x8    8x16    8x32      16   16x32      32   32x64      64       BPP*pnorm   Bugs
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
jxl:d0.1        19988 16632798    6.6570812   1.499   8.921   0.37712332  99.92071497   0.11893726  53.50   6.657 40.3709 19.4916  0.4367 27.7628  5.4151  0.0000  2.7421  0.9221  3.4017  0.1025  0.0820  0.791774977142      0
jxl:d0.5        19988  6319484    2.5292989   1.930  14.775   0.83471094  97.84770326   0.36269184  44.73   2.549 14.3372 24.8590  0.6013 11.9306 21.5821  0.0000 20.5063  1.3832  4.9540  0.1434  0.4303  0.917356074495      0
jxl:d0.8        19988  4695946    1.8794970   2.024  14.765   1.15833810  92.67294095   0.50194825  42.11   2.189 11.0162 21.3894  0.7035  8.9730 19.5412  0.0000 29.9032  1.7470  6.9007  0.1844  0.3689  0.943410219541      0
jxl:d1          19988  4060710    1.6252513   2.001  14.297   1.37590695  89.94141369   0.58521405  40.90   2.248  9.7876 19.6427  0.7326  7.8559 17.9089  0.0000 31.1930  2.9304 10.2359  0.2357  0.2049  0.951119882716      0
jxl:d1.1        19988  3821550    1.5295303   2.067  15.448   1.44920995  88.81437879   0.62342424  40.38   2.230  9.2881 18.9511  0.7877  7.4345 17.1865  0.0000 31.0777  3.6246 11.8957  0.2357  0.2459  0.953546270480      0
jxl:d1.2        19988  3607865    1.4440054   2.126  16.413   1.54437161  87.68365455   0.66094960  39.89   2.250  8.8056 18.2983  0.8062  7.0881 16.5494  0.0000 30.7421  4.4366 13.5914  0.2664  0.1434  0.954414793548      0
jxl:d1.3        19988  3433197    1.3740966   2.091  16.619   1.63381569  86.75043038   0.69725499  39.51   2.283  8.4271 17.7446  0.8226  6.7634 16.2529  0.0000 29.6612  5.3433 15.2206  0.3074  0.1844  0.958095711872      0
jxl:d1.4        19988  3269767    1.3086857   2.096  16.734   1.71329917  85.79304416   0.73252514  39.12   2.296  8.0538 17.3329  0.8370  6.4832 15.6925  0.0000 28.8671  6.2168 16.6806  0.3586  0.2049  0.958645153518      0
jxl:d1.5        19988  3119822    1.2486719   2.127  15.168   1.86220163  84.88924757   0.77070531  38.76   2.360  7.7406 16.8782  0.8520  6.2351 15.3410  0.0000 28.0116  7.1031 17.9102  0.3894  0.2664  0.962358102178      0
jxl:d1.6        19988  2982866    1.1938569   2.123  15.475   1.91390287  84.01743521   0.80441960  38.43   2.319  7.4454 16.4680  0.8658  5.9757 15.1623  0.0000 27.0228  8.0586 18.9911  0.3894  0.3484  0.960361910526      0
jxl:d1.7        19988  2863835    1.1462162   2.136  16.193   2.01411393  83.15460677   0.83711409  38.11   2.353  7.1662 16.1485  0.9026  5.9101 14.9062  0.0000 25.9726  8.8296 20.0414  0.4201  0.4303  0.959513702327      0
jxl:d1.8        19988  2750842    1.1009921   2.177  15.867   2.06521624  82.29553565   0.86974045  37.79   2.312  6.9014 15.8373  0.9141  5.7170 14.7032  0.0000 25.0684  9.8030 20.8815  0.4303  0.4713  0.957577321991      0
jxl:d1.8        19988  2750842    1.1009921   2.077  15.643   2.06521624  82.29553565   0.86974045  37.79   2.312  6.9014 15.8373  0.9141  5.7170 14.7032  0.0000 25.0684  9.8030 20.8815  0.4303  0.4713  0.957577321991      0
jxl:d1.9        19988  2653898    1.0621914   2.156  15.988   2.16043845  81.52773881   0.90130393  37.52   2.321  6.6833 15.4947  0.9346  5.6046 14.5706  0.0000 24.1219 10.6944 21.6705  0.4201  0.5328  0.957357248338      0
jxl:d2.0        19988  2560647    1.0248688   2.140  15.556   2.24410684  80.70102616   0.93390204  37.28   2.358  6.4490 15.2100  0.9462  5.4724 14.3573  0.0000 23.4328 11.3399 22.5363  0.4918  0.4918  0.957127020339      0
jxl:d2.1        19988  2476384    0.9911435   2.169  16.161   2.34406339  79.99344032   0.96459014  37.05   2.382  6.2088 14.8261  0.9788  5.3632 14.1857  0.0000 22.8398 12.1083 23.1920  0.5123  0.5123  0.956047223936      0
jxl:d2.2        19988  2396338    0.9591060   2.129  16.014   2.44463536  79.23151761   0.99834557  36.83   2.391  6.0119 14.5671  0.9833  5.2210 14.1274  0.0000 22.1341 12.8460 23.7914  0.5123  0.5328  0.957519240615      0
jxl:d2.3        19988  2320912    0.9289176   2.201  16.182   2.51850044  78.53207677   1.02853207  36.60   2.403  5.9043 14.2600  1.0041  5.1038 13.9148  0.0000 21.6001 13.6171 24.2986  0.5123  0.5123  0.955421583995      0
jxl:d2.4        19988  2251880    0.9012884   2.165  16.481   2.57791350  77.83826018   1.05653074  36.41   2.397  5.7327 13.9808  1.0016  5.0199 13.8143  0.0000 21.1057 14.2831 24.5394  0.5738  0.6762  0.952238897941      0
jxl:d2.5        19988  2187470    0.8755091   2.231  16.024   2.64483794  77.11814365   1.08689127  36.21   2.390  5.5694 13.7413  0.9987  4.9319 13.6702  0.0000 20.6062 14.9491 25.0107  0.5943  0.6558  0.951583150223      0
jxl:d2.6        19988  2127353    0.8514479   2.153  15.418   2.73578089  76.48556175   1.12137865  36.03   2.395  5.4039 13.4294  1.0323  4.8243 13.6516  0.0000 20.1643 15.6176 25.2618  0.6045  0.7377  0.954795544846      0
jxl:d2.7        19988  2067763    0.8275977   2.146  15.590   2.78267667  75.77889161   1.15079294  35.82   2.389  5.2681 13.2072  1.0278  4.7532 13.5140  0.0000 19.6085 16.2119 25.7741  0.6660  0.6967  0.952393642881      0
jxl:d2.8        19988  2013478    0.8058708   2.157  15.989   2.85150598  75.12693975   1.17585944  35.63   2.397  5.1349 13.0122  1.0509  4.6889 13.4339  0.0000 19.2435 16.8779 25.8304  0.7377  0.7172  0.947590802125      0
jxl:d2.9        19988  1962208    0.7853506   2.225  16.230   2.92524696  74.45686583   1.20627258  35.46   2.386  5.0299 12.8009  1.0576  4.6168 13.3648  0.0000 18.8413 17.2596 26.3222  0.6762  0.7582  0.947346893813      0
jxl:d3          19988  1917647    0.7675156   1.985  16.082   3.01778212  73.79989776   1.23457934  35.30   2.394  4.8448 12.6142  1.0345  4.5032 13.2879  0.0000 18.4455 18.1177 26.4349  0.6865  0.7582  0.947558885647      0
jxl:d5          19988  1314300    0.5260331   2.108   8.956   4.46939744  61.97162492   1.75040122  32.95   2.446  3.3367  8.2526  0.9385  2.9080 10.6207  0.0000 14.4752 27.3263 30.8408  0.6762  1.3525  0.920768926816      0
jxl:d7          19988  1017836    0.4073769   2.015   8.861   5.64320733  52.28984357   2.20493314  31.50   2.377  2.5253  5.8409  0.7723  2.0290  9.0102  0.0000 11.9598 32.3495 33.9453  0.6967  1.5984  0.898238717129      0
jxl:d15         19988   571314    0.2286617   2.059   8.090   9.75350889  22.52804180   3.71464592  28.64   2.244  1.1998  1.7514  0.3035  0.5837  5.3645  0.0000  6.9430 36.5837 42.9260  1.1988  3.8730  0.849397205321      0
jxl:d24         19988   410771    0.1644062   0.311  20.898  19.93134273  -7.32566143   6.30206166  25.86   2.763  1.0185  2.2916  0.1719  0.6778  3.0027  0.0000  3.0700  9.1498  6.0708  0.0000  0.0000  1.036098301742      0
jxl:d32         19988   325717    0.1303644   0.316  20.952  21.81475941 -20.32457799   7.07985684  25.40   2.492  0.7540  1.7239  0.1354  0.4957  2.6678  0.0000  2.6858 10.1308  6.8598  0.0000  0.0000  0.922961192798      0
Aggregate:      19988  2324976    0.9305442   1.837  14.856   2.50680083  76.95009569   1.01243697  36.69   2.447  5.7355 12.2340  0.7496  4.6549 12.2526  0.0000 17.8808  8.9611 17.2539  0.4247  0.4754  0.942117386566      0
```