### PR TITLE
remove constructor for HuffmanTableEntry

### DIFF
--- a/lib/jpegli/decode.cc
+++ b/lib/jpegli/decode.cc
@@ -59,6 +59,14 @@ void InitializeImage(j_decompress_ptr cinfo) {
   m->icc_profile_.clear();
   memset(m->dc_huff_lut_, 0, sizeof(m->dc_huff_lut_));
   memset(m->ac_huff_lut_, 0, sizeof(m->ac_huff_lut_));
+  // Initialize the values to an invalid symbol so that we can recognize it
+  // when reading the bit stream using a Huffman code with space > 0.
+  for (size_t i = 0; i < kAllHuffLutSize; ++i) {
+    m->dc_huff_lut_[i].bits = 0;
+    m->dc_huff_lut_[i].value = 0xffff;
+    m->ac_huff_lut_[i].bits = 0;
+    m->ac_huff_lut_[i].value = 0xffff;
+  }
   m->colormap_lut_ = nullptr;
   m->pixels_ = nullptr;
   m->scanlines_ = nullptr;

--- a/lib/jpegli/huffman.h
+++ b/lib/jpegli/huffman.h
@@ -21,10 +21,6 @@ constexpr int kJpegHuffmanRootTableBits = 8;
 constexpr int kJpegHuffmanLutSize = 758;
 
 struct HuffmanTableEntry {
-  // Initialize the value to an invalid symbol so that we can recognize it
-  // when reading the bit stream using a Huffman code with space > 0.
-  HuffmanTableEntry() : bits(0), value(0xffff) {}
-
   uint8_t bits;    // number of bits used for this symbol
   uint16_t value;  // symbol value or table offset
 };


### PR DESCRIPTION
This fixes -Werror=class-memaccess an error introduced in https://github.com/libjxl/libjxl/commit/1112ef0e263600f9bc7f0cbc735fcd0d004af33d
assuming the constructor is not used anymore