### PR TITLE
update ssimulacra 2 to 2.1

### DIFF
--- a/tools/ssimulacra2.cc
+++ b/tools/ssimulacra2.cc
@@ -7,9 +7,10 @@
 SSIMULACRA 2
 Structural SIMilarity Unveiling Local And Compression Related Artifacts
 
-Perceptual metric developed by Jon Sneyers (Cloudinary) in July 2022.
+Perceptual metric developed by Jon Sneyers (Cloudinary) in July 2022,
+updated in April 2023.
 Design:
-- XYB color space (X+0.5, Y, Y-B+1.0)
+- XYB color space (rescaled to a 0..1 range and with B-Y)
 - SSIM map (with correction: no double gamma correction)
 - 'blockiness/ringing' map (distorted has edges where original is smooth)
 - 'smoothing' map (distorted is smooth where original has edges)
@@ -17,8 +18,8 @@ Design:
 - downscaling is done in linear RGB
 - for all 6*3*3=54 maps, two norms are computed: 1-norm (mean) and 4-norm
 - a weighted sum of these 54*2=108 norms leads to the final score
-- weights were tuned based on a large set of subjective scores for images
-  compressed with JPEG, JPEG 2000, JPEG XL, WebP, AVIF, and HEIC.
+- weights were tuned based on a large set of subjective scores
+  (CID22, TID2013, Kadid10k, KonFiG-IQA).
 */
 
 #include "tools/ssimulacra2.h"
@@ -129,10 +130,26 @@ void SSIMMap(const Image3F& m1, const Image3F& m2, const Image3F& s11,
         float mu11 = mu1 * mu1;
         float mu22 = mu2 * mu2;
         float mu12 = mu1 * mu2;
+        /* Correction applied compared to the original SSIM formula, which has:
+
+             luma_err = 2 * mu1 * mu2 / (mu1^2 + mu2^2)
+                      = 1 - (mu1 - mu2)^2 / (mu1^2 + mu2^2)
+
+           The denominator causes error in the darks (low mu1 and mu2) to weigh
+           more than error in the brights (high mu1 and mu2). This would make
+           sense if values correspond to linear luma. However, the actual values
+           are either gamma-compressed luma (which supposedly is already
+           perceptually uniform) or chroma (where weighing green more than red
+           or blue more than yellow does not make any sense at all). So it is
+           better to simply drop this denominator.
+        */
         float num_m = 1.0 - (mu1 - mu2) * (mu1 - mu2);
         float num_s = 2 * (row_s12[x] - mu12) + kC2;
         float denom_s = (row_s11[x] - mu11) + (row_s22[x] - mu22) + kC2;
-        double d = 1.0 - ((num_m * num_s) / (denom_s));
+
+        // Use 1 - SSIM' so it becomes an error score instead of a quality
+        // index. This makes it make sense to compute an L_4 norm.
+        double d = 1.0 - (num_m * num_s / denom_s);
         d = std::max(d, 0.0);
         sum1[0] += d;
         sum1[1] += tothe4th(d);
@@ -157,13 +174,15 @@ void EdgeDiffMap(const Image3F& img1, const Image3F& mu1, const Image3F& img2,
         double d1 = (1.0 + std::abs(row2[x] - rowm2[x])) /
                         (1.0 + std::abs(row1[x] - rowm1[x])) -
                     1.0;
+
         // d1 > 0: distorted has an edge where original is smooth
         //         (indicating ringing, color banding, blockiness, etc)
-        // d1 < 0: original has an edge where distorted is smooth
-        //         (indicating smoothing, blurring, smearing, etc)
         double artifact = std::max(d1, 0.0);
         sum1[0] += artifact;
         sum1[1] += tothe4th(artifact);
+
+        // d1 < 0: original has an edge where distorted is smooth
+        //         (indicating smoothing, blurring, smearing, etc)
         double detail_lost = std::max(-d1, 0.0);
         sum1[2] += detail_lost;
         sum1[3] += tothe4th(detail_lost);
@@ -176,17 +195,27 @@ void EdgeDiffMap(const Image3F& img1, const Image3F& mu1, const Image3F& img2,
   }
 }
 
-// Add 0.5 to X and turn B into 1 + B-Y
-// (SSIM expects non-negative ranges)
+/* Get all components in more or less 0..1 range
+   Range of Rec2020 with these adjustments:
+    X: 0.017223..0.998838
+    Y: 0.010000..0.855303
+    B: 0.048759..0.989551
+   Range of sRGB:
+    X: 0.204594..0.813402
+    Y: 0.010000..0.855308
+    B: 0.272295..0.938012
+   The maximum pixel-wise difference has to be <= 1 for the ssim formula to make
+   sense.
+*/
 void MakePositiveXYB(jxl::Image3F& img) {
   for (size_t y = 0; y < img.ysize(); ++y) {
     float* JXL_RESTRICT rowY = img.PlaneRow(1, y);
     float* JXL_RESTRICT rowB = img.PlaneRow(2, y);
     float* JXL_RESTRICT rowX = img.PlaneRow(0, y);
     for (size_t x = 0; x < img.xsize(); ++x) {
-      rowB[x] += 1.1f - rowY[x];
-      rowX[x] += 0.5f;
-      rowY[x] += 0.05f;
+      rowB[x] = (rowB[x] - rowY[x]) + 0.55f;
+      rowX[x] = rowX[x] * 14.f + 0.42f;
+      rowY[x] += 0.01f;
     }
   }
 }
@@ -209,91 +238,94 @@ void AlphaBlend(jxl::ImageBundle& img, float bg) {
 
 /*
 The final score is based on a weighted sum of 108 sub-scores:
-- for 6 scales (1:1 to 1:32)
-- for 3 components (X + 0.5, Y, B - Y + 1.0)
+- for 6 scales (1:1 to 1:32, downsampled in linear RGB)
+- for 3 components (X, Y, B-Y, rescaled to 0..1 range)
 - using 2 norms (the 1-norm and the 4-norm)
 - over 3 error maps:
-    - SSIM
+    - SSIM' (SSIM without the spurious gamma correction term)
     - "ringing" (distorted edges where there are no orig edges)
     - "blurring" (orig edges where there are no distorted edges)
 
 The weights were obtained by running Nelder-Mead simplex search,
-optimizing to minimize MSE and maximize Kendall and Pearson correlation
-for training data consisting of 17611 subjective quality scores,
-validated on separate validation data consisting of 4292 scores.
+optimizing to minimize MSE for the CID22 training set and to
+maximize Kendall rank correlation (and with a lower weight,
+also Pearson correlation) with the CID22 training set and the
+TID2013, Kadid10k and KonFiG-IQA datasets.
+Validation was done on the CID22 validation set.
+
+Final results after tuning (Kendall | Spearman | Pearson):
+   CID22:     0.6903 | 0.8805 | 0.8583
+   TID2013:   0.6590 | 0.8445 | 0.8471
+   KADID-10k: 0.6175 | 0.8133 | 0.8030
+   KonFiG(F): 0.7668 | 0.9194 | 0.9136
 */
 double Msssim::Score() const {
   double ssim = 0.0;
   constexpr double weight[108] = {0.0,
+                                  0.0007376606707406586,
                                   0.0,
                                   0.0,
-                                  1.0035479352512353,
-                                  0.00011322061110474735,
-                                  0.00040442991823685936,
-                                  0.0018953834105783773,
+                                  0.0007793481682867309,
                                   0.0,
                                   0.0,
-                                  8.982542997575905,
-                                  0.9899785796045556,
+                                  0.0004371155730107379,
                                   0.0,
-                                  0.9748315131207942,
-                                  0.9581575169937973,
+                                  1.1041726426657346,
+                                  0.00066284834129271,
+                                  0.00015231632783718752,
                                   0.0,
-                                  0.5133611777952946,
-                                  1.0423189317331243,
-                                  0.000308010928520841,
-                                  12.149584966240063,
-                                  0.9565577248115467,
+                                  0.0016406437456599754,
                                   0.0,
-                                  1.0406668123136824,
-                                  81.51139046057362,
-                                  0.30593391895330946,
-                                  1.0752214433626779,
-                                  1.1039042369464611,
+                                  1.8422455520539298,
+                                  11.441172603757666,
                                   0.0,
-                                  1.021911638819618,
-                                  1.1141823296855722,
-                                  0.9730845751441705,
+                                  0.0007989109436015163,
+                                  0.000176816438078653,
                                   0.0,
+                                  1.8787594979546387,
+                                  10.94906990605142,
                                   0.0,
+                                  0.0007289346991508072,
+                                  0.9677937080626833,
                                   0.0,
-                                  0.9833918426095505,
-                                  0.7920385137059867,
-                                  0.9710740411514053,
+                                  0.00014003424285435884,
+                                  0.9981766977854967,
+                                  0.00031949755934435053,
+                                  0.0004550992113792063,
                                   0.0,
                                   0.0,
-                                  0.0,
-                                  0.5387077903152638,
-                                  0.0,
-                                  3.4036945601155804,
-                                  0.0,
-                                  0.0,
-                                  0.0,
-                                  2.337569295661117,
-                                  0.0,
-                                  5.707946510901609,
-                                  37.83086423878157,
-                                  0.0,
-                                  0.0,
-                                  3.8258200594305185,
-                                  0.0,
-                                  0.0,
-                                  24.073659674271497,
-                                  0.0,
-                                  0.0,
-                                  13.181871265286068,
+                                  0.0013648766163243398,
                                   0.0,
                                   0.0,
                                   0.0,
                                   0.0,
                                   0.0,
-                                  10.00750121262895,
+                                  7.466890328078848,
+                                  0.0,
+                                  17.445833984131262,
+                                  0.0006235601634041466,
+                                  0.0,
+                                  0.0,
+                                  6.683678146179332,
+                                  0.00037724407979611296,
+                                  1.027889937768264,
+                                  225.20515300849274,
+                                  0.0,
+                                  0.0,
+                                  19.213238186143016,
+                                  0.0011401524586618361,
+                                  0.001237755635509985,
+                                  176.39317598450694,
+                                  0.0,
+                                  0.0,
+                                  24.43300999870476,
+                                  0.28520802612117757,
+                                  0.0004485436923833408,
                                   0.0,
                                   0.0,
                                   0.0,
-                                  0.0,
-                                  0.0,
-                                  52.51428385603891,
+                                  34.77906344483772,
+                                  44.835625328877896,
                                   0.0,
                                   0.0,
                                   0.0,
@@ -302,36 +334,41 @@ double Msssim::Score() const {
                                   0.0,
                                   0.0,
                                   0.0,
+                                  0.0008680556573291698,
                                   0.0,
                                   0.0,
                                   0.0,
                                   0.0,
                                   0.0,
+                                  0.0005313191874358747,
+                                  0.0,
+                                  0.00016533814161379112,
                                   0.0,
                                   0.0,
-                                  0.9946464267894417,
                                   0.0,
                                   0.0,
-                                  0.0006040447715934816,
+                                  0.0,
+                                  0.0004179171803251336,
+                                  0.0017290828234722833,
+                                  0.0,
+                                  0.0020827005846636437,
                                   0.0,
                                   0.0,
-                                  0.9945171491374072,
+                                  8.826982764996862,
+                                  23.19243343998926,
                                   0.0,
-                                  2.8260043809454376,
-                                  1.0052642766534516,
-                                  8.201441997546244e-05,
-                                  12.154041855876695,
-                                  32.292928706201266,
-                                  0.992837130387521,
-                                  0.0,
-                                  30.71925517844603,
-                                  0.00012309907022278743,
-                                  0.0,
-                                  0.9826260237051734,
+                                  95.1080498811086,
+                                  0.9863978034400682,
+                                  0.9834382792465353,
+                                  0.0012286405048278493,
+                                  171.2667255897307,
+                                  0.9807858872435379,
                                   0.0,
                                   0.0,
-                                  0.9980928367837651,
-                                  0.012142430067163312};
+                                  0.0,
+                                  0.0005130064588990679,
+                                  0.0,
+                                  0.00010854057858411537};
 
   size_t i = 0;
   char ch[] = "XYB";
@@ -345,7 +382,7 @@ double Msssim::Score() const {
                scales[scale].avg_edgediff[c * 4 + 2 + n]);
 #endif
         if (verbose) {
-          printf("%f from channel %c, scale 1:%i, %" PRIuS
+          printf("%f from channel %c ssim, scale 1:%i, %" PRIuS
                  "-norm (weight %f)\n",
                  weight[i] * std::abs(scales[scale].avg_ssim[c * 2 + n]), ch[c],
                  1 << scale, n * 3 + 1, weight[i]);
@@ -371,10 +408,11 @@ double Msssim::Score() const {
     }
   }
 
-  ssim = ssim * 17.829717797575952 - 1.634169143917183;
-
+  ssim = ssim * 0.9562382616834844;
+  ssim = 2.326765642916932 * ssim - 0.020884521182843837 * ssim * ssim +
+         6.248496625763138e-05 * ssim * ssim * ssim;
   if (ssim > 0) {
-    ssim = 100.0 - 10.0 * pow(ssim, 0.5453261009510213);
+    ssim = 100.0 - 10.0 * pow(ssim, 0.6276336467831387);
   } else {
     ssim = 100.0;
   }


### PR DESCRIPTION
Updates the weight tuning to make ssimulacra 2 more robust to different kinds of artifacts and distortion amplitudes. Instead of tuning only on CID22 training data, tuning was also using data from TID2013, KADID-10k and KonFiG-IQA (Experiment I, with flicker boosting).

Besides the weight retuning, also the XYB scaling is done a bit differently to ensure that everything is in 0..1 range and makes sense for the SSIM computation.

Also adding some comments to document how exactly the SSIM computation was 'fixed' (no change there though).

See https://github.com/cloudinary/ssimulacra2 for more info and correlation numbers.