### PR TITLE
Adjust HfModulation in initial adaptive quant

### DIFF
--- a/lib/jxl/decode_test.cc
+++ b/lib/jxl/decode_test.cc
@@ -1935,7 +1935,7 @@ TEST(DecodeTest, PixelTestOpaqueSrgbLossy) {
     EXPECT_THAT(
         ButteraugliDistance(io0.frames, io1.frames, ba, jxl::GetJxlCms(),
                             /*distmap=*/nullptr, nullptr),
-        IsSlightlyBelow(0.95f));
+        IsSlightlyBelow(0.7f));
 
     JxlDecoderDestroy(dec);
   }

--- a/lib/jxl/enc_ac_strategy.cc
+++ b/lib/jxl/enc_ac_strategy.cc
@@ -863,26 +863,26 @@ void ProcessRectACS(PassesEncoderState* JXL_RESTRICT enc_state,
     float entropy_mul;
   };
   static const float k8X16mul1 = -0.55;
-  static const float k8X16mul2 = 0.867;
+  static const float k8X16mul2 = 0.865;
   static const float k8X16base = 1.6;
   const float entropy_mul16X8 =
       k8X16mul2 + k8X16mul1 / (butteraugli_target + k8X16base);
   //  const float entropy_mul16X8 = mul8X16 * 0.91195782912371126f;
 
   static const float k16X16mul1 = -0.35;
-  static const float k16X16mul2 = 0.80;
+  static const float k16X16mul2 = 0.798;
   static const float k16X16base = 2.0;
   const float entropy_mul16X16 =
       k16X16mul2 + k16X16mul1 / (butteraugli_target + k16X16base);
   //  const float entropy_mul16X16 = mul16X16 * 0.83183417727960129f;
 
   static const float k32X16mul1 = -0.1;
-  static const float k32X16mul2 = 0.86;
+  static const float k32X16mul2 = 0.854;
   static const float k32X16base = 2.5;
   const float entropy_mul16X32 =
       k32X16mul2 + k32X16mul1 / (butteraugli_target + k32X16base);
 
-  const float entropy_mul32X32 = 0.94;
+  const float entropy_mul32X32 = 0.93;
   const float entropy_mul64X64 = 1.52f;
   // TODO(jyrki): Consider this feedback in further changes:
   // Also effectively when the multipliers for smaller blocks are

--- a/lib/jxl/jxl_test.cc
+++ b/lib/jxl/jxl_test.cc
@@ -67,14 +67,14 @@ TEST(JxlTest, RoundtripSinglePixel) {
   TestImage t;
   t.SetDimensions(1, 1).AddFrame().ZeroFill();
   PackedPixelFile ppf_out;
-  EXPECT_EQ(Roundtrip(t.ppf(), {}, {}, nullptr, &ppf_out), 54);
+  EXPECT_EQ(Roundtrip(t.ppf(), {}, {}, nullptr, &ppf_out), 55);
 }
 
 TEST(JxlTest, RoundtripSinglePixelWithAlpha) {
   TestImage t;
   t.SetDimensions(1, 1).SetChannels(4).AddFrame().ZeroFill();
   PackedPixelFile ppf_out;
-  EXPECT_EQ(Roundtrip(t.ppf(), {}, {}, nullptr, &ppf_out), 58);
+  EXPECT_EQ(Roundtrip(t.ppf(), {}, {}, nullptr, &ppf_out), 59);
 }
 
 // Changing serialized signature causes Decode to fail.
@@ -122,7 +122,7 @@ TEST(JxlTest, RoundtripSmallD1) {
 
   {
     PackedPixelFile ppf_out;
-    EXPECT_NEAR(Roundtrip(t.ppf(), {}, {}, pool, &ppf_out), 729, 30);
+    EXPECT_NEAR(Roundtrip(t.ppf(), {}, {}, pool, &ppf_out), 766, 40);
     EXPECT_THAT(ButteraugliDistance(t.ppf(), ppf_out), IsSlightlyBelow(1.2));
   }
 
@@ -132,7 +132,7 @@ TEST(JxlTest, RoundtripSmallD1) {
 
   {
     PackedPixelFile ppf_out;
-    EXPECT_NEAR(Roundtrip(t.ppf(), {}, {}, pool, &ppf_out), 593, 20);
+    EXPECT_NEAR(Roundtrip(t.ppf(), {}, {}, pool, &ppf_out), 637, 20);
     EXPECT_THAT(ButteraugliDistance(t.ppf(), ppf_out), IsSlightlyBelow(1.3));
     EXPECT_EQ(ppf_out.info.intensity_target, t.ppf().info.intensity_target);
   }
@@ -203,7 +203,7 @@ TEST(JxlTest, RoundtripOutOfOrderProcessing) {
   cparams.AddOption(JXL_ENC_FRAME_SETTING_EPF, 3);
 
   PackedPixelFile ppf_out;
-  EXPECT_NEAR(Roundtrip(t.ppf(), cparams, {}, &pool, &ppf_out), 20741, 400);
+  EXPECT_NEAR(Roundtrip(t.ppf(), cparams, {}, &pool, &ppf_out), 22584, 400);
   EXPECT_LE(ButteraugliDistance(t.ppf(), ppf_out), 1.35);
 }
 
@@ -223,7 +223,7 @@ TEST(JxlTest, RoundtripOutOfOrderProcessingBorder) {
   cparams.AddOption(JXL_ENC_FRAME_SETTING_RESAMPLING, 2);
 
   PackedPixelFile ppf_out;
-  EXPECT_NEAR(Roundtrip(t.ppf(), cparams, {}, &pool, &ppf_out), 9763, 150);
+  EXPECT_NEAR(Roundtrip(t.ppf(), cparams, {}, &pool, &ppf_out), 10741, 150);
   EXPECT_LE(ButteraugliDistance(t.ppf(), ppf_out), 2.9);
 }
 
@@ -238,7 +238,7 @@ TEST(JxlTest, RoundtripResample4) {
   cparams.AddOption(JXL_ENC_FRAME_SETTING_RESAMPLING, 4);
 
   PackedPixelFile ppf_out;
-  EXPECT_NEAR(Roundtrip(t.ppf(), cparams, {}, pool, &ppf_out), 5818, 50);
+  EXPECT_NEAR(Roundtrip(t.ppf(), cparams, {}, pool, &ppf_out), 5705, 100);
   EXPECT_THAT(ButteraugliDistance(t.ppf(), ppf_out), IsSlightlyBelow(22));
 }
 
@@ -253,7 +253,7 @@ TEST(JxlTest, RoundtripResample8) {
   cparams.AddOption(JXL_ENC_FRAME_SETTING_RESAMPLING, 8);
 
   PackedPixelFile ppf_out;
-  EXPECT_NEAR(Roundtrip(t.ppf(), cparams, {}, pool, &ppf_out), 2162, 40);
+  EXPECT_NEAR(Roundtrip(t.ppf(), cparams, {}, pool, &ppf_out), 2081, 40);
   EXPECT_THAT(ButteraugliDistance(t.ppf(), ppf_out), IsSlightlyBelow(50));
 }
 
@@ -271,7 +271,7 @@ TEST(JxlTest, RoundtripUnalignedD2) {
   cparams.distance = 2.0;
 
   PackedPixelFile ppf_out;
-  EXPECT_NEAR(Roundtrip(t.ppf(), cparams, {}, pool, &ppf_out), 475, 20);
+  EXPECT_NEAR(Roundtrip(t.ppf(), cparams, {}, pool, &ppf_out), 506, 30);
   EXPECT_THAT(ButteraugliDistance(t.ppf(), ppf_out), IsSlightlyBelow(1.72));
 }
 
@@ -296,9 +296,9 @@ TEST(JxlTest, RoundtripMultiGroup) {
   };
 
   auto run_kitten = std::async(std::launch::async, test, SpeedTier::kKitten,
-                               1.0f, 51595u, 11.7);
+                               1.0f, 54895u, 11.7);
   auto run_wombat = std::async(std::launch::async, test, SpeedTier::kWombat,
-                               2.0f, 31722u, 20.0);
+                               2.0f, 33507u, 20.0);
 }
 
 TEST(JxlTest, RoundtripRGBToGrayscale) {
@@ -357,7 +357,7 @@ TEST(JxlTest, RoundtripLargeFast) {
   cparams.AddOption(JXL_ENC_FRAME_SETTING_EFFORT, 7);  // kSquirrel
 
   PackedPixelFile ppf_out;
-  EXPECT_NEAR(Roundtrip(t.ppf(), cparams, {}, &pool, &ppf_out), 412757, 5000);
+  EXPECT_NEAR(Roundtrip(t.ppf(), cparams, {}, &pool, &ppf_out), 434654, 5000);
   EXPECT_THAT(ComputeDistance2(t.ppf(), ppf_out), IsSlightlyBelow(100));
 }
 
@@ -470,7 +470,7 @@ TEST(JxlTest, RoundtripNoGaborishNoAR) {
   cparams.AddOption(JXL_ENC_FRAME_SETTING_GABORISH, 0);
 
   PackedPixelFile ppf_out;
-  EXPECT_NEAR(Roundtrip(t.ppf(), cparams, {}, pool, &ppf_out), 37346, 200);
+  EXPECT_NEAR(Roundtrip(t.ppf(), cparams, {}, pool, &ppf_out), 37964, 200);
   EXPECT_THAT(ButteraugliDistance(t.ppf(), ppf_out), IsSlightlyBelow(1.8));
 }
 
@@ -514,8 +514,8 @@ TEST(JxlTest, RoundtripSmallPatchesAlpha) {
   cparams.distance = 0.1f;
 
   PackedPixelFile ppf_out;
-  EXPECT_NEAR(Roundtrip(t.ppf(), cparams, {}, pool, &ppf_out), 636, 70);
-  EXPECT_THAT(ButteraugliDistance(t.ppf(), ppf_out), IsSlightlyBelow(0.02f));
+  EXPECT_NEAR(Roundtrip(t.ppf(), cparams, {}, pool, &ppf_out), 735, 100);
+  EXPECT_THAT(ButteraugliDistance(t.ppf(), ppf_out), IsSlightlyBelow(0.012f));
 }
 
 TEST(JxlTest, RoundtripSmallPatches) {
@@ -540,7 +540,7 @@ TEST(JxlTest, RoundtripSmallPatches) {
 
   PackedPixelFile ppf_out;
   EXPECT_NEAR(Roundtrip(t.ppf(), cparams, {}, pool, &ppf_out), 605, 100);
-  EXPECT_THAT(ButteraugliDistance(t.ppf(), ppf_out), IsSlightlyBelow(0.02f));
+  EXPECT_THAT(ButteraugliDistance(t.ppf(), ppf_out), IsSlightlyBelow(0.012f));
 }
 
 // TODO(szabadka) Add encoder and decoder API functions that accept frame
@@ -852,7 +852,7 @@ TEST(JxlTest, RoundtripAlphaPremultiplied) {
         EXPECT_THAT(ButteraugliDistance(io_nopremul.frames, io2.frames,
                                         cparams.ba_params, GetJxlCms(),
                                         /*distmap=*/nullptr),
-                    IsSlightlyBelow(1.4));
+                    IsSlightlyBelow(1.42));
       }
     }
   }
@@ -873,7 +873,7 @@ TEST(JxlTest, RoundtripAlphaResampling) {
   cparams.AddOption(JXL_ENC_FRAME_SETTING_EXTRA_CHANNEL_RESAMPLING, 2);
 
   PackedPixelFile ppf_out;
-  EXPECT_NEAR(Roundtrip(t.ppf(), cparams, {}, pool, &ppf_out), 12272, 130);
+  EXPECT_NEAR(Roundtrip(t.ppf(), cparams, {}, pool, &ppf_out), 12803, 130);
   EXPECT_THAT(ButteraugliDistance(t.ppf(), ppf_out), IsSlightlyBelow(5.2));
 }
 
@@ -907,7 +907,7 @@ TEST(JxlTest, RoundtripAlphaNonMultipleOf8) {
 
   PackedPixelFile ppf_out;
   EXPECT_NEAR(Roundtrip(t.ppf(), {}, {}, pool, &ppf_out), 107, 10);
-  EXPECT_THAT(ButteraugliDistance(t.ppf(), ppf_out), IsSlightlyBelow(0.9));
+  EXPECT_THAT(ButteraugliDistance(t.ppf(), ppf_out), IsSlightlyBelow(0.95));
 }
 
 TEST(JxlTest, RoundtripAlpha16) {
@@ -941,7 +941,7 @@ TEST(JxlTest, RoundtripAlpha16) {
   PackedPixelFile ppf_out;
   // TODO(szabadka) Investigate big size difference on i686
   // This still keeps happening (2023-04-18).
-  EXPECT_NEAR(Roundtrip(t.ppf(), cparams, {}, &pool, &ppf_out), 3515, 100);
+  EXPECT_NEAR(Roundtrip(t.ppf(), cparams, {}, &pool, &ppf_out), 3624, 120);
   EXPECT_THAT(ButteraugliDistance(t.ppf(), ppf_out), IsSlightlyBelow(0.9));
 }
 
@@ -1128,7 +1128,7 @@ TEST(JxlTest, RoundtripDots) {
   cparams.distance = 0.04;
 
   PackedPixelFile ppf_out;
-  EXPECT_NEAR(Roundtrip(t.ppf(), cparams, {}, pool, &ppf_out), 279836, 3000);
+  EXPECT_NEAR(Roundtrip(t.ppf(), cparams, {}, pool, &ppf_out), 288272, 3000);
   EXPECT_THAT(ButteraugliDistance(t.ppf(), ppf_out), IsSlightlyBelow(0.35));
 }
 
@@ -1187,7 +1187,7 @@ TEST(JxlTest, RoundtripAnimation) {
 
   PackedPixelFile ppf_out;
   EXPECT_THAT(Roundtrip(t.ppf(), {}, dparams, pool, &ppf_out),
-              IsSlightlyBelow(2500));
+              IsSlightlyBelow(2600));
 
   t.CoalesceGIFAnimationWithAlpha();
   ASSERT_EQ(ppf_out.frames.size(), t.ppf().frames.size());
@@ -1236,10 +1236,10 @@ TEST(JxlTest, RoundtripAnimationPatches) {
   PackedPixelFile ppf_out;
   // 40k with no patches, 27k with patch frames encoded multiple times.
   EXPECT_THAT(Roundtrip(t.ppf(), cparams, dparams, pool, &ppf_out),
-              IsSlightlyBelow(16200));
+              IsSlightlyBelow(16700));
   EXPECT_EQ(ppf_out.frames.size(), t.ppf().frames.size());
   // >10 with broken patches
-  EXPECT_THAT(ButteraugliDistance(t.ppf(), ppf_out), IsSlightlyBelow(0.9));
+  EXPECT_THAT(ButteraugliDistance(t.ppf(), ppf_out), IsSlightlyBelow(1.05));
 }
 
 #endif  // JPEGXL_ENABLE_GIF
@@ -1443,7 +1443,7 @@ TEST(JxlTest, RoundtripProgressive) {
   cparams.AddOption(JXL_ENC_FRAME_SETTING_RESPONSIVE, 1);
 
   PackedPixelFile ppf_out;
-  EXPECT_NEAR(Roundtrip(t.ppf(), cparams, {}, &pool, &ppf_out), 55352, 750);
+  EXPECT_NEAR(Roundtrip(t.ppf(), cparams, {}, &pool, &ppf_out), 60080, 750);
   EXPECT_THAT(ButteraugliDistance(t.ppf(), ppf_out), IsSlightlyBelow(1.4));
 }
 
@@ -1460,7 +1460,7 @@ TEST(JxlTest, RoundtripProgressiveLevel2Slow) {
   cparams.AddOption(JXL_ENC_FRAME_SETTING_RESPONSIVE, 1);
 
   PackedPixelFile ppf_out;
-  EXPECT_NEAR(Roundtrip(t.ppf(), cparams, {}, &pool, &ppf_out), 69534, 1000);
+  EXPECT_NEAR(Roundtrip(t.ppf(), cparams, {}, &pool, &ppf_out), 72841, 1000);
   EXPECT_THAT(ButteraugliDistance(t.ppf(), ppf_out), IsSlightlyBelow(1.17));
 }
 

--- a/tools/optimizer/simplex_fork.py
+++ b/tools/optimizer/simplex_fork.py
@@ -60,15 +60,14 @@ def EvalCacheForget():
 
 def RandomizedJxlCodecs():
   retval = []
-  minval = 0.2
-  maxval = 5.3
+  minval = 0.5
+  maxval = 8.3
   rangeval = maxval/minval
-  steps = 11
+  steps = 9
   for i in range(steps):
     mul = minval * rangeval**(float(i)/(steps - 1))
     mul *= 0.99 + 0.05 * random.random()
     retval.append("jxl:d%.4f" % mul)
-  steps = 11
   for i in range(steps - 1):
     mul = minval * rangeval**(float(i+0.5)/(steps - 1))
     mul *= 0.99 + 0.05 * random.random()
@@ -102,7 +101,7 @@ def Eval(vec, binary_name, cached=True):
       (binary_name,
        '--input',
        '/usr/local/google/home/jyrki/newcorpus/split/*.png',
-       '--error_pnorm=5',
+       '--error_pnorm=4',
        '--more_columns',
        '--codec', g_codecs),
       stdout=subprocess.PIPE,


### PR DESCRIPTION
0.5 % improvement on image quality (BPP * pnorm)
close to 2 % improvement at d1

looks ok in manual viewing, too

```
Before:

Encoding      kPixels    Bytes          BPP  E MP/s  D MP/s     Max norm  SSIMULACRA2        pnorm   PSNR   QABPP  SmallB  DCT4x8     AFV  DCT8x8    8x16    8x32      16   16x32      32   32x64      64       BPP*pnorm   Bugs
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
jxl:d0.1        19988 16632798    6.6570812   1.524   8.861   0.37712332  99.92071497   0.11893726  53.50   6.657 40.3709 19.4916  0.4367 27.7628  5.4151  0.0000  2.7421  0.9221  3.4017  0.1025  0.0820  0.791774977142      0
jxl:d0.5        19988  6319484    2.5292989   1.951  14.394   0.83471094  97.84770326   0.36269184  44.73   2.549 14.3372 24.8590  0.6013 11.9306 21.5821  0.0000 20.5063  1.3832  4.9540  0.1434  0.4303  0.917356074495      0
jxl:d0.8        19988  4695946    1.8794970   2.038  14.514   1.15833810  92.67294095   0.50194825  42.11   2.189 11.0162 21.3894  0.7035  8.9730 19.5412  0.0000 29.9032  1.7470  6.9007  0.1844  0.3689  0.943410219541      0
jxl:d1          19988  4060710    1.6252513   1.947  15.310   1.37590695  89.94141369   0.58521405  40.90   2.248  9.7876 19.6427  0.7326  7.8559 17.9089  0.0000 31.1930  2.9304 10.2359  0.2357  0.2049  0.951119882716      0
jxl:d1.1        19988  3821550    1.5295303   2.078  15.451   1.44920995  88.81437879   0.62342424  40.38   2.230  9.2881 18.9511  0.7877  7.4345 17.1865  0.0000 31.0777  3.6246 11.8957  0.2357  0.2459  0.953546270480      0
jxl:d1.2        19988  3607865    1.4440054   2.093  16.525   1.54437161  87.68365455   0.66094960  39.89   2.250  8.8056 18.2983  0.8062  7.0881 16.5494  0.0000 30.7421  4.4366 13.5914  0.2664  0.1434  0.954414793548      0
jxl:d1.3        19988  3433197    1.3740966   2.130  16.739   1.63381569  86.75043038   0.69725499  39.51   2.283  8.4271 17.7446  0.8226  6.7634 16.2529  0.0000 29.6612  5.3433 15.2206  0.3074  0.1844  0.958095711872      0
jxl:d1.4        19988  3269767    1.3086857   2.138  16.587   1.71329917  85.79304416   0.73252514  39.12   2.296  8.0538 17.3329  0.8370  6.4832 15.6925  0.0000 28.8671  6.2168 16.6806  0.3586  0.2049  0.958645153518      0
jxl:d1.5        19988  3119822    1.2486719   2.073  15.473   1.86220163  84.88924757   0.77070531  38.76   2.360  7.7406 16.8782  0.8520  6.2351 15.3410  0.0000 28.0116  7.1031 17.9102  0.3894  0.2664  0.962358102178      0
jxl:d1.6        19988  2982866    1.1938569   2.124  15.098   1.91390287  84.01743521   0.80441960  38.43   2.319  7.4454 16.4680  0.8658  5.9757 15.1623  0.0000 27.0228  8.0586 18.9911  0.3894  0.3484  0.960361910526      0
jxl:d1.7        19988  2863835    1.1462162   2.090  15.895   2.01411393  83.15460677   0.83711409  38.11   2.353  7.1662 16.1485  0.9026  5.9101 14.9062  0.0000 25.9726  8.8296 20.0414  0.4201  0.4303  0.959513702327      0
jxl:d1.8        19988  2750842    1.1009921   2.195  15.836   2.06521624  82.29553565   0.86974045  37.79   2.312  6.9014 15.8373  0.9141  5.7170 14.7032  0.0000 25.0684  9.8030 20.8815  0.4303  0.4713  0.957577321991      0
jxl:d1.8        19988  2750842    1.1009921   2.116  16.186   2.06521624  82.29553565   0.86974045  37.79   2.312  6.9014 15.8373  0.9141  5.7170 14.7032  0.0000 25.0684  9.8030 20.8815  0.4303  0.4713  0.957577321991      0
jxl:d1.9        19988  2653898    1.0621914   2.192  16.098   2.16043845  81.52773881   0.90130393  37.52   2.321  6.6833 15.4947  0.9346  5.6046 14.5706  0.0000 24.1219 10.6944 21.6705  0.4201  0.5328  0.957357248338      0
jxl:d2.0        19988  2560647    1.0248688   2.145  15.406   2.24410684  80.70102616   0.93390204  37.28   2.358  6.4490 15.2100  0.9462  5.4724 14.3573  0.0000 23.4328 11.3399 22.5363  0.4918  0.4918  0.957127020339      0
jxl:d2.1        19988  2476384    0.9911435   2.177  15.313   2.34406339  79.99344032   0.96459014  37.05   2.382  6.2088 14.8261  0.9788  5.3632 14.1857  0.0000 22.8398 12.1083 23.1920  0.5123  0.5123  0.956047223936      0
jxl:d2.2        19988  2396338    0.9591060   2.155  16.052   2.44463536  79.23151761   0.99834557  36.83   2.391  6.0119 14.5671  0.9833  5.2210 14.1274  0.0000 22.1341 12.8460 23.7914  0.5123  0.5328  0.957519240615      0
jxl:d2.3        19988  2320912    0.9289176   2.175  16.094   2.51850044  78.53207677   1.02853207  36.60   2.403  5.9043 14.2600  1.0041  5.1038 13.9148  0.0000 21.6001 13.6171 24.2986  0.5123  0.5123  0.955421583995      0
jxl:d2.4        19988  2251880    0.9012884   2.136  16.423   2.57791350  77.83826018   1.05653074  36.41   2.397  5.7327 13.9808  1.0016  5.0199 13.8143  0.0000 21.1057 14.2831 24.5394  0.5738  0.6762  0.952238897941      0
jxl:d2.5        19988  2187470    0.8755091   2.230  15.567   2.64483794  77.11814365   1.08689127  36.21   2.390  5.5694 13.7413  0.9987  4.9319 13.6702  0.0000 20.6062 14.9491 25.0107  0.5943  0.6558  0.951583150223      0
jxl:d2.6        19988  2127353    0.8514479   2.187  16.253   2.73578089  76.48556175   1.12137865  36.03   2.395  5.4039 13.4294  1.0323  4.8243 13.6516  0.0000 20.1643 15.6176 25.2618  0.6045  0.7377  0.954795544846      0
jxl:d2.7        19988  2067763    0.8275977   2.186  14.757   2.78267667  75.77889161   1.15079294  35.82   2.389  5.2681 13.2072  1.0278  4.7532 13.5140  0.0000 19.6085 16.2119 25.7741  0.6660  0.6967  0.952393642881      0
jxl:d2.8        19988  2013478    0.8058708   2.212  16.471   2.85150598  75.12693975   1.17585944  35.63   2.397  5.1349 13.0122  1.0509  4.6889 13.4339  0.0000 19.2435 16.8779 25.8304  0.7377  0.7172  0.947590802125      0
jxl:d2.9        19988  1962208    0.7853506   2.257  15.854   2.92524696  74.45686583   1.20627258  35.46   2.386  5.0299 12.8009  1.0576  4.6168 13.3648  0.0000 18.8413 17.2596 26.3222  0.6762  0.7582  0.947346893813      0
jxl:d3          19988  1917647    0.7675156   1.988  15.621   3.01778212  73.79989776   1.23457934  35.30   2.394  4.8448 12.6142  1.0345  4.5032 13.2879  0.0000 18.4455 18.1177 26.4349  0.6865  0.7582  0.947558885647      0
jxl:d5          19988  1314300    0.5260331   2.095   9.045   4.46939744  61.97162492   1.75040122  32.95   2.446  3.3367  8.2526  0.9385  2.9080 10.6207  0.0000 14.4752 27.3263 30.8408  0.6762  1.3525  0.920768926816      0
jxl:d7          19988  1017836    0.4073769   2.034   8.702   5.64320733  52.28984357   2.20493314  31.50   2.377  2.5253  5.8409  0.7723  2.0290  9.0102  0.0000 11.9598 32.3495 33.9453  0.6967  1.5984  0.898238717129      0
jxl:d15         19988   571314    0.2286617   2.018   8.489   9.75350889  22.52804180   3.71464592  28.64   2.244  1.1998  1.7514  0.3035  0.5837  5.3645  0.0000  6.9430 36.5837 42.9260  1.1988  3.8730  0.849397205321      0
jxl:d24         19988   410771    0.1644062   0.312  19.944  19.93134273  -7.32566143   6.30206166  25.86   2.763  1.0185  2.2916  0.1719  0.6778  3.0027  0.0000  3.0700  9.1498  6.0708  0.0000  0.0000  1.036098301742      0
jxl:d32         19988   325717    0.1303644   0.318  20.311  21.81475941 -20.32457799   7.07985684  25.40   2.492  0.7540  1.7239  0.1354  0.4957  2.6678  0.0000  2.6858 10.1308  6.8598  0.0000  0.0000  0.922961192798      0
Aggregate:      19988  2324976    0.9305442   1.843  14.796   2.50680083  76.95009569   1.01243697  36.69   2.447  5.7355 12.2340  0.7496  4.6549 12.2526  0.0000 17.8808  8.9611 17.2539  0.4247  0.4754  0.942117386566      0

After:

Encoding      kPixels    Bytes          BPP  E MP/s  D MP/s     Max norm  SSIMULACRA2        pnorm   PSNR   QABPP  SmallB  DCT4x8     AFV  DCT8x8    8x16    8x32      16   16x32      32   32x64      64       BPP*pnorm   Bugs
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
jxl:d0.1        19988 16900604    6.7642674   1.476   8.702   0.37410482  99.91963513   0.11561354  53.54   6.764 41.8880 18.7084  0.4624 27.5303  5.0264  0.0000  2.4347  0.9017  3.5913  0.1025  0.0820  0.782040912825      0
jxl:d0.5        19988  6379591    2.5533560   1.881  14.068   0.80290941  97.73428164   0.35035067  44.90   2.561 14.2984 25.4100  0.5872 12.1605 20.7259  0.0000 20.8495  1.3935  4.9028  0.1332  0.2664  0.894569986306      0
jxl:d0.8        19988  4703233    1.8824135   1.906  14.746   1.13245886  92.66602038   0.49070592  42.10   2.166 10.8391 22.0512  0.7118  9.0883 19.2108  0.0000 29.2795  1.7700  7.3465  0.1434  0.2869  0.923711455759      0
jxl:d1          19988  4060885    1.6253213   1.910  15.465   1.34929895  89.95353870   0.57392122  40.87   2.220  9.5702 20.2553  0.7605  7.9638 17.7956  0.0000 30.6013  2.6998 10.5996  0.1947  0.2869  0.932806393613      0
jxl:d1.1        19988  3818173    1.5281787   1.976  14.699   1.45899099  88.78337879   0.61496435  40.34   2.262  9.0925 19.4657  0.7761  7.4947 17.1507  0.0000 30.4207  3.5400 12.2953  0.1844  0.3074  0.939775419450      0
jxl:d1.2        19988  3600232    1.4409504   1.994  15.447   1.54110079  87.65052992   0.65330205  39.86   2.241  8.6458 18.7741  0.8283  7.1636 16.6377  0.0000 29.9711  4.2854 13.9296  0.1844  0.3074  0.941375837994      0
jxl:d1.3        19988  3429951    1.3727974   1.997  15.664   1.61467219  86.80396556   0.68746733  39.48   2.252  8.2154 18.2685  0.8325  6.8460 16.0351  0.0000 29.3179  5.1615 15.4767  0.2254  0.3484  0.943753375110      0
jxl:d1.4        19988  3264571    1.3066060   2.045  15.497   1.71909939  85.82639131   0.72488165  39.07   2.293  7.8482 17.7751  0.8498  6.5764 15.7162  0.0000 28.3471  6.1297 16.8190  0.2562  0.4098  0.947134729626      0
jxl:d1.5        19988  3116671    1.2474108   1.968  15.047   1.83065087  84.91138325   0.76212627  38.75   2.320  7.5706 17.3140  0.8741  6.3795 15.4261  0.0000 27.2021  7.0160 18.2073  0.2869  0.4508  0.950684538445      0
jxl:d1.6        19988  2979803    1.1926310   2.023  14.404   1.88996636  84.05984581   0.79544344  38.38   2.291  7.2398 16.8945  0.8866  6.1643 15.2097  0.0000 26.4298  7.9074 19.1961  0.3484  0.4508  0.948670503351      0
jxl:d1.7        19988  2860558    1.1449046   1.995  15.280   1.98529938  83.19770829   0.83180497  38.06   2.309  7.0170 16.4709  0.9161  6.0366 14.9516  0.0000 25.4936  8.8321 20.1899  0.3484  0.4713  0.952337328106      0
jxl:d1.8        19988  2752861    1.1018001   2.078  15.084   2.08377683  82.39428643   0.86498671  37.77   2.343  6.7759 16.1475  0.9254  5.8547 14.7794  0.0000 24.6764  9.7287 21.0813  0.3689  0.3894  0.953042470959      0
jxl:d1.8        19988  2752861    1.1018001   2.049  15.301   2.08377683  82.39428643   0.86498671  37.77   2.343  6.7759 16.1475  0.9254  5.8547 14.7794  0.0000 24.6764  9.7287 21.0813  0.3689  0.3894  0.953042470959      0
jxl:d1.9        19988  2652095    1.0614697   2.109  15.211   2.17537588  81.54410472   0.89855322  37.49   2.351  6.5565 15.7873  0.9564  5.7974 14.6372  0.0000 23.7108 10.5253 21.8959  0.3689  0.4918  0.953787051145      0
jxl:d2.0        19988  2558935    1.0241835   2.030  15.839   2.26097387  80.78868370   0.93148455  37.23   2.371  6.3247 15.5075  0.9766  5.5985 14.4822  0.0000 23.0115 11.3629 22.6131  0.4201  0.4303  0.954011150804      0
jxl:d2.1        19988  2473260    0.9898931   2.072  15.207   2.33827363  80.03424448   0.96372495  36.98   2.364  6.1585 15.0848  0.9795  5.4576 14.3868  0.0000 22.4095 12.0904 23.2586  0.3894  0.5123  0.953984708558      0
jxl:d2.2        19988  2393631    0.9580226   2.062  15.689   2.43738927  79.26826583   0.99699936  36.73   2.385  5.9619 14.8520  0.9948  5.3946 14.1403  0.0000 21.7473 12.7641 23.9298  0.3689  0.5738  0.955147885728      0
jxl:d2.3        19988  2319565    0.9283785   2.085  16.022   2.49570086  78.54071951   1.02759242  36.52   2.373  5.7759 14.5578  1.0176  5.2944 14.0602  0.0000 21.1582 13.4736 24.3960  0.4201  0.5738  0.953994735856      0
jxl:d2.4        19988  2248383    0.8998888   2.045  15.775   2.57845142  77.84335500   1.05794498  36.29   2.380  5.6197 14.2117  1.0355  5.1871 14.0141  0.0000 20.6715 14.1883 24.7033  0.4611  0.6353  0.952032803444      0
jxl:d2.5        19988  2186111    0.8749651   2.107  15.085   2.65164243  77.18565273   1.08920449  36.08   2.375  5.5134 13.9651  1.0233  5.0930 13.8764  0.0000 20.0772 14.8671 25.1849  0.4713  0.6558  0.953015955159      0
jxl:d2.6        19988  2124846    0.8504445   2.043  15.247   2.74094556  76.47264721   1.12057780  35.89   2.395  5.3536 13.6974  1.0419  4.9947 13.8188  0.0000 19.5636 15.5920 25.4564  0.5123  0.6967  0.952989274009      0
jxl:d2.7        19988  2066717    0.8271791   2.078  15.467   2.78868703  75.86920344   1.14946239  35.69   2.381  5.2073 13.3891  1.0457  4.9165 13.7919  0.0000 19.1282 16.0556 25.9534  0.6045  0.6353  0.950811259291      0
jxl:d2.8        19988  2013496    0.8058780   2.160  16.306   2.89414178  75.16826504   1.17908161  35.49   2.408  5.0862 13.1358  1.0685  4.8448 13.5825  0.0000 18.6953 16.8548 26.2095  0.5738  0.6762  0.950195948515      0
jxl:d2.9        19988  1962155    0.7853294   2.106  15.433   2.94524321  74.53368590   1.20899464  35.32   2.382  4.9790 12.9600  1.0790  4.7862 13.4153  0.0000 18.3328 17.4901 26.4042  0.6045  0.6762  0.949459018968      0
jxl:d3          19988  1917406    0.7674191   1.939  14.721   3.00877147  73.88170099   1.23792434  35.16   2.392  4.7968 12.7052  1.0576  4.7068 13.3218  0.0000 17.8807 18.2355 26.6911  0.6558  0.6762  0.950006819894      0
jxl:d5          19988  1314619    0.5261607   1.969   8.646   4.56618069  62.10047061   1.76584172  32.82   2.472  3.3566  8.3442  0.9535  3.1042 10.9422  0.0000 13.9232 27.2085 31.0303  0.6762  1.1885  0.929116594795      0
jxl:d7          19988  1027476    0.4112351   1.912   8.337   5.67068242  52.88383008   2.21328609  31.45   2.384  2.5503  5.8710  0.8098  2.1446  9.3387  0.0000 11.5435 32.2189 33.9863  0.6455  1.6189  0.910181030559      0
jxl:d15         19988   572270    0.2290443   1.987   8.178   9.82880733  22.41351718   3.72527737  28.63   2.265  1.1757  1.6951  0.2949  0.5619  5.2780  0.0000  6.5767 36.4812 44.0941  0.9426  3.6271  0.853253606640      0
jxl:d24         19988   405086    0.1621309   0.292  19.638  20.04450614  -7.90415637   6.37192028  25.82   2.755  1.0163  2.2471  0.1745  0.7073  3.0661  0.0000  3.0213  9.2010  6.0196  0.0000  0.0000  1.033085120305      0
jxl:d32         19988   323345    0.1294150   0.295  19.682  21.49104655 -20.32727701   7.07730912  25.37   2.445  0.7396  1.6944  0.1399  0.4985  2.7376  0.0000  2.6192 10.1231  6.9007  0.0000  0.0000  0.915910110879      0
Aggregate:      19988  2325096    0.9305923   1.756  14.355   2.50104334  76.99998540   1.00677645  36.63   2.443  5.6620 12.3963  0.7626  4.7689 12.2889  0.0000 17.4264  8.8775 17.4803  0.3525  0.5053  0.936898384399      0
```