### PR TITLE
Improve Adaptive Quantization after AC Strategy

### DIFF
--- a/lib/jxl/decode_test.cc
+++ b/lib/jxl/decode_test.cc
@@ -1677,7 +1677,7 @@ TEST(DecodeTest, PixelTestWithICCProfileLossy) {
   jxl::ButteraugliParams ba;
   EXPECT_THAT(ButteraugliDistance(io0.frames, io1.frames, ba, jxl::GetJxlCms(),
                                   /*distmap=*/nullptr, nullptr),
-              IsSlightlyBelow(0.75f));
+              IsSlightlyBelow(0.79f));
 
   JxlDecoderDestroy(dec);
 }
@@ -1986,7 +1986,7 @@ TEST(DecodeTest, PixelTestOpaqueSrgbLossyNoise) {
     EXPECT_THAT(
         ButteraugliDistance(io0.frames, io1.frames, ba, jxl::GetJxlCms(),
                             /*distmap=*/nullptr, nullptr),
-        IsSlightlyBelow(2.4f));
+        IsSlightlyBelow(1.7f));
 
     JxlDecoderDestroy(dec);
   }

--- a/lib/jxl/jxl_test.cc
+++ b/lib/jxl/jxl_test.cc
@@ -149,7 +149,7 @@ TEST(JxlTest, RoundtripResample2) {
   cparams.AddOption(JXL_ENC_FRAME_SETTING_EFFORT, 3);  // kFalcon
 
   PackedPixelFile ppf_out;
-  EXPECT_NEAR(Roundtrip(t.ppf(), cparams, {}, pool, &ppf_out), 18843, 50);
+  EXPECT_NEAR(Roundtrip(t.ppf(), cparams, {}, pool, &ppf_out), 18563, 50);
   EXPECT_THAT(ComputeDistance2(t.ppf(), ppf_out), IsSlightlyBelow(90));
 }
 
@@ -182,7 +182,7 @@ TEST(JxlTest, RoundtripResample2MT) {
   cparams.AddOption(JXL_ENC_FRAME_SETTING_EFFORT, 3);  // kFalcon
 
   PackedPixelFile ppf_out;
-  EXPECT_NEAR(Roundtrip(t.ppf(), cparams, {}, &pool, &ppf_out), 206857, 1000);
+  EXPECT_NEAR(Roundtrip(t.ppf(), cparams, {}, &pool, &ppf_out), 222690, 1000);
   EXPECT_THAT(ComputeDistance2(t.ppf(), ppf_out), IsSlightlyBelow(340));
 }
 
@@ -253,7 +253,7 @@ TEST(JxlTest, RoundtripResample8) {
   cparams.AddOption(JXL_ENC_FRAME_SETTING_RESAMPLING, 8);
 
   PackedPixelFile ppf_out;
-  EXPECT_NEAR(Roundtrip(t.ppf(), cparams, {}, pool, &ppf_out), 2081, 40);
+  EXPECT_NEAR(Roundtrip(t.ppf(), cparams, {}, pool, &ppf_out), 2036, 50);
   EXPECT_THAT(ButteraugliDistance(t.ppf(), ppf_out), IsSlightlyBelow(50));
 }
 
@@ -320,7 +320,7 @@ TEST(JxlTest, RoundtripRGBToGrayscale) {
   size_t compressed_size;
   JXL_EXPECT_OK(
       Roundtrip(&io, cparams, dparams, &io2, _, &compressed_size, &pool));
-  EXPECT_LE(compressed_size, 61000u);
+  EXPECT_LE(compressed_size, 63000u);
   EXPECT_TRUE(io2.Main().IsGray());
 
   // Convert original to grayscale here, because TransformTo refuses to
@@ -344,7 +344,7 @@ TEST(JxlTest, RoundtripRGBToGrayscale) {
   EXPECT_THAT(
       ButteraugliDistance(io.frames, io2.frames, cparams.ba_params, GetJxlCms(),
                           /*distmap=*/nullptr, &pool),
-      IsSlightlyBelow(1.7));
+      IsSlightlyBelow(1.36));
 }
 
 TEST(JxlTest, RoundtripLargeFast) {
@@ -374,7 +374,7 @@ TEST(JxlTest, RoundtripDotsForceEpf) {
   cparams.AddOption(JXL_ENC_FRAME_SETTING_DOTS, 1);
 
   PackedPixelFile ppf_out;
-  EXPECT_NEAR(Roundtrip(t.ppf(), cparams, {}, &pool, &ppf_out), 41736, 300);
+  EXPECT_NEAR(Roundtrip(t.ppf(), cparams, {}, &pool, &ppf_out), 42346, 300);
   EXPECT_THAT(ComputeDistance2(t.ppf(), ppf_out), IsSlightlyBelow(18));
 }
 
@@ -470,7 +470,7 @@ TEST(JxlTest, RoundtripNoGaborishNoAR) {
   cparams.AddOption(JXL_ENC_FRAME_SETTING_GABORISH, 0);
 
   PackedPixelFile ppf_out;
-  EXPECT_NEAR(Roundtrip(t.ppf(), cparams, {}, pool, &ppf_out), 37964, 200);
+  EXPECT_NEAR(Roundtrip(t.ppf(), cparams, {}, pool, &ppf_out), 38561, 200);
   EXPECT_THAT(ButteraugliDistance(t.ppf(), ppf_out), IsSlightlyBelow(1.8));
 }
 
@@ -891,8 +891,8 @@ TEST(JxlTest, RoundtripAlphaResamplingOnlyAlpha) {
   cparams.AddOption(JXL_ENC_FRAME_SETTING_EXTRA_CHANNEL_RESAMPLING, 2);
 
   PackedPixelFile ppf_out;
-  EXPECT_NEAR(Roundtrip(t.ppf(), cparams, {}, pool, &ppf_out), 32277, 300);
-  EXPECT_THAT(ButteraugliDistance(t.ppf(), ppf_out), IsSlightlyBelow(1.85));
+  EXPECT_NEAR(Roundtrip(t.ppf(), cparams, {}, pool, &ppf_out), 33201, 300);
+  EXPECT_THAT(ButteraugliDistance(t.ppf(), ppf_out), IsSlightlyBelow(1.44));
 }
 
 TEST(JxlTest, RoundtripAlphaNonMultipleOf8) {
@@ -1128,7 +1128,7 @@ TEST(JxlTest, RoundtripDots) {
   cparams.distance = 0.04;
 
   PackedPixelFile ppf_out;
-  EXPECT_NEAR(Roundtrip(t.ppf(), cparams, {}, pool, &ppf_out), 288272, 3000);
+  EXPECT_NEAR(Roundtrip(t.ppf(), cparams, {}, pool, &ppf_out), 284295, 3000);
   EXPECT_THAT(ButteraugliDistance(t.ppf(), ppf_out), IsSlightlyBelow(0.35));
 }
 
@@ -1148,8 +1148,8 @@ TEST(JxlTest, RoundtripNoise) {
   cparams.AddOption(JXL_ENC_FRAME_SETTING_NOISE, 1);
 
   PackedPixelFile ppf_out;
-  EXPECT_NEAR(Roundtrip(t.ppf(), cparams, {}, pool, &ppf_out), 41456, 750);
-  EXPECT_THAT(ButteraugliDistance(t.ppf(), ppf_out), IsSlightlyBelow(1.7));
+  EXPECT_NEAR(Roundtrip(t.ppf(), cparams, {}, pool, &ppf_out), 42287, 750);
+  EXPECT_THAT(ButteraugliDistance(t.ppf(), ppf_out), IsSlightlyBelow(1.31));
 }
 
 TEST(JxlTest, RoundtripLossless8Gray) {
@@ -1236,7 +1236,7 @@ TEST(JxlTest, RoundtripAnimationPatches) {
   PackedPixelFile ppf_out;
   // 40k with no patches, 27k with patch frames encoded multiple times.
   EXPECT_THAT(Roundtrip(t.ppf(), cparams, dparams, pool, &ppf_out),
-              IsSlightlyBelow(16700));
+              IsSlightlyBelow(16710));
   EXPECT_EQ(ppf_out.frames.size(), t.ppf().frames.size());
   // >10 with broken patches
   EXPECT_THAT(ButteraugliDistance(t.ppf(), ppf_out), IsSlightlyBelow(1.05));


### PR DESCRIPTION
1.2 % improvement in BPP * pnorm

~2 % improvement on Max norm

looks nicer, especially text/graphics

```
Before:

Encoding      kPixels    Bytes          BPP  E MP/s  D MP/s     Max norm  SSIMULACRA2        pnorm   PSNR   QABPP  SmallB  DCT4x8     AFV  DCT8x8    8x16    8x32      16   16x32      32   32x64      64       BPP*pnorm   Bugs
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
jxl:d0.1        19988 16900604    6.7642674   1.516   9.094   0.37410482  95.47297329   0.11561354  53.54   6.764 41.8880 18.7084  0.4624 27.5303  5.0264  0.0000  2.4347  0.9017  3.5913  0.1025  0.0820  0.782040912825      0
jxl:d0.5        19988  6379591    2.5533560   1.952  14.147   0.80290941  91.34147575   0.35035067  44.90   2.561 14.2984 25.4100  0.5872 12.1605 20.7259  0.0000 20.8495  1.3935  4.9028  0.1332  0.2664  0.894569986306      0
jxl:d0.8        19988  4703233    1.8824135   2.018  14.709   1.13245886  88.56215783   0.49070592  42.10   2.166 10.8391 22.0512  0.7118  9.0883 19.2108  0.0000 29.2795  1.7700  7.3465  0.1434  0.2869  0.923711455759      0
jxl:d1          19988  4060885    1.6253213   1.961  14.064   1.34929895  86.83229456   0.57392122  40.87   2.220  9.5702 20.2553  0.7605  7.9638 17.7956  0.0000 30.6013  2.6998 10.5996  0.1947  0.2869  0.932806393613      0
jxl:d1.1        19988  3818173    1.5281787   2.040  15.689   1.45899099  85.98810947   0.61496435  40.34   2.262  9.0925 19.4657  0.7761  7.4947 17.1507  0.0000 30.4207  3.5400 12.2953  0.1844  0.3074  0.939775419450      0
jxl:d1.2        19988  3600232    1.4409504   2.057  15.800   1.54110079  85.17483673   0.65330205  39.86   2.241  8.6458 18.7741  0.8283  7.1636 16.6377  0.0000 29.9711  4.2854 13.9296  0.1844  0.3074  0.941375837994      0
jxl:d1.3        19988  3429951    1.3727974   2.074  15.732   1.61467219  84.55257136   0.68746733  39.48   2.252  8.2154 18.2685  0.8325  6.8460 16.0351  0.0000 29.3179  5.1615 15.4767  0.2254  0.3484  0.943753375110      0
jxl:d1.4        19988  3264571    1.3066060   2.127  16.459   1.71909939  83.75182054   0.72488165  39.07   2.293  7.8482 17.7751  0.8498  6.5764 15.7162  0.0000 28.3471  6.1297 16.8190  0.2562  0.4098  0.947134729626      0
jxl:d1.5        19988  3116671    1.2474108   2.091  15.193   1.83065087  83.00429290   0.76212627  38.75   2.320  7.5706 17.3140  0.8741  6.3795 15.4261  0.0000 27.2021  7.0160 18.2073  0.2869  0.4508  0.950684538445      0
jxl:d1.6        19988  2979803    1.1926310   2.115  15.205   1.88996636  82.28539333   0.79544344  38.38   2.291  7.2398 16.8945  0.8866  6.1643 15.2097  0.0000 26.4298  7.9074 19.1961  0.3484  0.4508  0.948670503351      0
jxl:d1.7        19988  2860558    1.1449046   2.101  15.746   1.98529938  81.55515159   0.83180497  38.06   2.309  7.0170 16.4709  0.9161  6.0366 14.9516  0.0000 25.4936  8.8321 20.1899  0.3484  0.4713  0.952337328106      0
jxl:d1.8        19988  2752861    1.1018001   2.210  16.076   2.08377683  80.85756962   0.86498671  37.77   2.343  6.7759 16.1475  0.9254  5.8547 14.7794  0.0000 24.6764  9.7287 21.0813  0.3689  0.3894  0.953042470959      0
jxl:d1.8        19988  2752861    1.1018001   2.085  15.458   2.08377683  80.85756962   0.86498671  37.77   2.343  6.7759 16.1475  0.9254  5.8547 14.7794  0.0000 24.6764  9.7287 21.0813  0.3689  0.3894  0.953042470959      0
jxl:d1.9        19988  2652095    1.0614697   2.162  16.055   2.17537588  80.11253079   0.89855322  37.49   2.351  6.5565 15.7873  0.9564  5.7974 14.6372  0.0000 23.7108 10.5253 21.8959  0.3689  0.4918  0.953787051145      0
jxl:d2.0        19988  2558935    1.0241835   2.128  16.141   2.26097387  79.43702084   0.93148455  37.23   2.371  6.3247 15.5075  0.9766  5.5985 14.4822  0.0000 23.0115 11.3629 22.6131  0.4201  0.4303  0.954011150804      0
jxl:d2.1        19988  2473260    0.9898931   2.128  15.583   2.33827363  78.75679530   0.96372495  36.98   2.364  6.1585 15.0848  0.9795  5.4576 14.3868  0.0000 22.4095 12.0904 23.2586  0.3894  0.5123  0.953984708558      0
jxl:d2.2        19988  2393631    0.9580226   2.132  15.981   2.43738927  78.06523240   0.99699936  36.73   2.385  5.9619 14.8520  0.9948  5.3946 14.1403  0.0000 21.7473 12.7641 23.9298  0.3689  0.5738  0.955147885728      0
jxl:d2.3        19988  2319565    0.9283785   2.211  16.196   2.49570086  77.38511949   1.02759242  36.52   2.373  5.7759 14.5578  1.0176  5.2944 14.0602  0.0000 21.1582 13.4736 24.3960  0.4201  0.5738  0.953994735856      0
jxl:d2.4        19988  2248383    0.8998888   2.164  15.926   2.57845142  76.72758883   1.05794498  36.29   2.380  5.6197 14.2117  1.0355  5.1871 14.0141  0.0000 20.6715 14.1883 24.7033  0.4611  0.6353  0.952032803444      0
jxl:d2.5        19988  2186111    0.8749651   2.202  16.090   2.65164243  76.12465720   1.08920449  36.08   2.375  5.5134 13.9651  1.0233  5.0930 13.8764  0.0000 20.0772 14.8671 25.1849  0.4713  0.6558  0.953015955159      0
jxl:d2.6        19988  2124846    0.8504445   2.154  16.167   2.74094556  75.47847527   1.12057780  35.89   2.395  5.3536 13.6974  1.0419  4.9947 13.8188  0.0000 19.5636 15.5920 25.4564  0.5123  0.6967  0.952989274009      0
jxl:d2.7        19988  2066717    0.8271791   2.155  15.907   2.78868703  74.93238773   1.14946239  35.69   2.381  5.2073 13.3891  1.0457  4.9165 13.7919  0.0000 19.1282 16.0556 25.9534  0.6045  0.6353  0.950811259291      0
jxl:d2.8        19988  2013496    0.8058780   2.215  16.142   2.89414178  74.27580237   1.17908161  35.49   2.408  5.0862 13.1358  1.0685  4.8448 13.5825  0.0000 18.6953 16.8548 26.2095  0.5738  0.6762  0.950195948515      0
jxl:d2.9        19988  1962155    0.7853294   2.226  15.631   2.94524321  73.66150222   1.20899464  35.32   2.382  4.9790 12.9600  1.0790  4.7862 13.4153  0.0000 18.3328 17.4901 26.4042  0.6045  0.6762  0.949459018968      0
jxl:d3          19988  1917406    0.7674191   1.994  15.375   3.00877147  73.04221813   1.23792434  35.16   2.392  4.7968 12.7052  1.0576  4.7068 13.3218  0.0000 17.8807 18.2355 26.6911  0.6558  0.6762  0.950006819894      0
jxl:d5          19988  1314619    0.5261607   2.090   8.889   4.56618069  61.82024478   1.76584172  32.82   2.472  3.3566  8.3442  0.9535  3.1042 10.9422  0.0000 13.9232 27.2085 31.0303  0.6762  1.1885  0.929116594795      0
jxl:d7          19988  1027476    0.4112351   1.988   8.771   5.67068242  52.87399243   2.21328609  31.45   2.384  2.5503  5.8710  0.8098  2.1446  9.3387  0.0000 11.5435 32.2189 33.9863  0.6455  1.6189  0.910181030559      0
jxl:d15         19988   572270    0.2290443   2.049   8.181   9.82880733  23.97669920   3.72527737  28.63   2.265  1.1757  1.6951  0.2949  0.5619  5.2780  0.0000  6.5767 36.4812 44.0941  0.9426  3.6271  0.853253606640      0
jxl:d24         19988   405086    0.1621309   0.310  20.319  20.04450614   1.37914509   6.37192028  25.82   2.755  1.0163  2.2471  0.1745  0.7073  3.0661  0.0000  3.0213  9.2010  6.0196  0.0000  0.0000  1.033085120305      0
jxl:d32         19988   323345    0.1294150   0.313  20.301  21.49104655  -8.67836465   7.07730912  25.37   2.445  0.7396  1.6944  0.1399  0.4985  2.7376  0.0000  2.6192 10.1231  6.9007  0.0000  0.0000  0.915910110879      0
Aggregate:      19988  2325096    0.9305923   1.832  14.718   2.50104334  65.85040464   1.00677645  36.63   2.443  5.6620 12.3963  0.7626  4.7689 12.2889  0.0000 17.4264  8.8775 17.4803  0.3525  0.5053  0.936898384399      0

After:

Encoding      kPixels    Bytes          BPP  E MP/s  D MP/s     Max norm  SSIMULACRA2        pnorm   PSNR   QABPP  SmallB  DCT4x8     AFV  DCT8x8    8x16    8x32      16   16x32      32   32x64      64       BPP*pnorm   Bugs
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
jxl:d0.1        19988 16532207    6.6168208   1.464   8.803   0.37578786  95.36829096   0.11717108  53.21   6.617 41.9680 18.6764  0.4598 27.4964  4.9995  0.0000  2.4399  0.9068  3.5964  0.1025  0.0820  0.775300009145      0
jxl:d0.5        19988  6380103    2.5535610   1.857  13.759   0.81999622  91.34936554   0.35410554  44.88   2.574 14.3010 25.4033  0.5866 12.1672 20.6882  0.0000 20.8854  1.3935  4.9028  0.1332  0.2664  0.904230085569      0
jxl:d0.8        19988  4709815    1.8850479   1.930  14.247   1.10544033  88.67076027   0.48371677  41.74   2.167 10.8481 22.0438  0.7159  9.0832 19.1769  0.0000 29.3102  1.7777  7.3413  0.1434  0.2869  0.911829277618      0
jxl:d1          19988  4069988    1.6289647   1.858  14.578   1.32030153  86.99369013   0.56559975  40.54   2.215  9.5807 20.2453  0.7579  7.9651 17.7834  0.0000 30.5961  2.6973 10.6201  0.1947  0.2869  0.921342013172      0
jxl:d1.1        19988  3829565    1.5327382   1.971  15.054   1.41670351  86.12536654   0.60527806  40.04   2.233  9.0957 19.4721  0.7765  7.5046 17.1372  0.0000 30.4040  3.5400 12.2851  0.2049  0.3074  0.927732813493      0
jxl:d1.2        19988  3611681    1.4455327   2.019  14.373   1.51402836  85.35743265   0.64416359  39.59   2.244  8.6544 18.7827  0.8274  7.1723 16.6205  0.0000 29.9993  4.2496 13.9296  0.1844  0.3074  0.931159539569      0
jxl:d1.3        19988  3438677    1.3762899   2.005  15.303   1.57712108  84.71600705   0.67742052  39.22   2.248  8.2241 18.2710  0.8325  6.8495 16.0114  0.0000 29.3295  5.1538 15.4716  0.2357  0.3484  0.932327025709      0
jxl:d1.4        19988  3274033    1.3103931   2.019  15.446   1.67201653  83.94658632   0.71481191  38.84   2.275  7.8488 17.7626  0.8463  6.5905 15.7111  0.0000 28.3868  6.1272 16.7882  0.2562  0.4098  0.936684586840      0
jxl:d1.5        19988  3126256    1.2512471   1.986  14.911   1.75669690  83.17867691   0.74855244  38.52   2.280  7.5664 17.3124  0.8754  6.3923 15.4242  0.0000 27.2290  7.0186 18.1715  0.2869  0.4508  0.936624053460      0
jxl:d1.6        19988  2990762    1.1970172   2.065  14.882   1.85749035  82.47329277   0.78340172  38.16   2.293  7.2501 16.9134  0.8856  6.1739 15.2129  0.0000 26.3760  7.8844 19.2524  0.3484  0.4303  0.937745342314      0
jxl:d1.7        19988  2869658    1.1485468   2.032  15.091   1.93103999  81.73315832   0.81701945  37.87   2.293  7.0173 16.4744  0.9154  6.0487 14.9209  0.0000 25.5141  8.8270 20.1899  0.3279  0.4918  0.938385037425      0
jxl:d1.8        19988  2757860    1.1038009   2.052  15.429   2.02108888  81.09595022   0.85058498  37.57   2.319  6.7727 16.1581  0.9241  5.8736 14.7723  0.0000 24.6278  9.7440 21.1275  0.3586  0.3689  0.938876490029      0
jxl:d1.8        19988  2757860    1.1038009   2.029  15.064   2.02108888  81.09595022   0.85058498  37.57   2.319  6.7727 16.1581  0.9241  5.8736 14.7723  0.0000 24.6278  9.7440 21.1275  0.3586  0.3689  0.938876490029      0
jxl:d1.9        19988  2660815    1.0649598   2.051  15.265   2.11749288  80.35521320   0.88331549  37.33   2.340  6.5569 15.8011  0.9538  5.8025 14.6282  0.0000 23.6851 10.5637 21.8754  0.3689  0.4918  0.940695500476      0
jxl:d2.0        19988  2566873    1.0273606   2.020  14.981   2.21170678  79.66310567   0.91588183  37.06   2.368  6.3270 15.5139  0.9753  5.6117 14.4797  0.0000 23.0319 11.3501 22.5978  0.4098  0.4303  0.940940934850      0
jxl:d2.1        19988  2481570    0.9932191   2.030  15.164   2.29424556  78.94880267   0.94755211  36.83   2.369  6.1678 15.0925  0.9827  5.4625 14.3567  0.0000 22.4146 12.1211 23.2279  0.3894  0.5123  0.941126871384      0
jxl:d2.2        19988  2399491    0.9603680   2.034  15.267   2.36644529  78.28448894   0.98046106  36.59   2.368  5.9664 14.8476  0.9923  5.3818 14.1492  0.0000 21.7947 12.7590 23.8939  0.3689  0.5738  0.941603387420      0
jxl:d2.3        19988  2324321    0.9302821   2.097  15.276   2.44105183  77.60322481   1.01254880  36.38   2.366  5.7762 14.5847  1.0160  5.3059 14.0461  0.0000 21.1915 13.4326 24.3806  0.4201  0.5738  0.941955985159      0
jxl:d2.4        19988  2255067    0.9025640   2.044  15.838   2.52628867  76.92972968   1.04170865  36.17   2.380  5.6312 14.2168  1.0339  5.1989 14.0051  0.0000 20.6869 14.1704 24.7085  0.4611  0.6148  0.940208681857      0
jxl:d2.5        19988  2192093    0.8773594   2.110  15.358   2.60248455  76.33935384   1.07285659  35.99   2.385  5.5047 13.9856  1.0224  5.1026 13.8931  0.0000 20.0836 14.8543 25.1542  0.4713  0.6558  0.941280773352      0
jxl:d2.6        19988  2129914    0.8524729   2.093  15.439   2.66191278  75.71312869   1.10196728  35.80   2.371  5.3542 13.6997  1.0406  4.9995 13.8329  0.0000 19.5944 15.5459 25.4616  0.5226  0.6762  0.939397294580      0
jxl:d2.7        19988  2070821    0.8288217   2.019  15.799   2.74594302  75.11075378   1.13015470  35.61   2.390  5.2117 13.3900  1.0397  4.9152 13.7503  0.0000 19.1820 16.0454 25.9636  0.5738  0.6558  0.936696713005      0
jxl:d2.8        19988  2016947    0.8072592   2.112  15.743   2.84754288  74.45280004   1.16242203  35.43   2.429  5.0782 13.1445  1.0662  4.8432 13.5806  0.0000 18.6978 16.8676 26.1993  0.5738  0.6762  0.938375921327      0
jxl:d2.9        19988  1965845    0.7868063   2.081  14.951   2.91386253  73.85682227   1.19215082  35.26   2.409  4.9838 12.9431  1.0794  4.7981 13.4025  0.0000 18.2995 17.5157 26.4247  0.6045  0.6762  0.937991733546      0
jxl:d3          19988  1921289    0.7689733   1.883  15.407   2.95485334  73.27285232   1.22018311  35.12   2.401  4.8041 12.7032  1.0550  4.7090 13.2911  0.0000 17.9115 18.2509 26.6706  0.6558  0.6762  0.938288174302      0
jxl:d5          19988  1316707    0.5269964   2.022   8.799   4.46804889  62.04935943   1.74501641  32.87   2.468  3.3614  8.3570  0.9538  3.1042 10.9358  0.0000 13.9244 27.2264 30.9893  0.6865  1.1885  0.919617438220      0
jxl:d7          19988  1024105    0.4098859   1.934   8.563   5.61972052  52.99135567   2.19441698  31.45   2.404  2.5532  5.8838  0.8082  2.1517  9.3406  0.0000 11.5947 32.1907 33.9402  0.6455  1.6189  0.899460676142      0
jxl:d15         19988   567965    0.2273213   1.953   8.156   9.80054732  23.94146640   3.72400180  28.60   2.257  1.1741  1.6980  0.2965  0.5648  5.2863  0.0000  6.5626 36.4556 44.1197  0.9426  3.6271  0.846544895042      0
jxl:d24         19988   399982    0.1600881   0.311  20.046  19.94373647   1.56176876   6.33658629  25.81   2.676  1.0188  2.2506  0.1735  0.7073  3.0700  0.0000  3.0252  9.1933  6.0145  0.0000  0.0000  1.014411910987      0
jxl:d32         19988   320832    0.1284092   0.313  20.313  21.51099558  -8.68163297   7.07466248  25.37   2.436  0.7364  1.7009  0.1406  0.4992  2.7498  0.0000  2.6307 10.1001  6.8956  0.0000  0.0000  0.908451910648      0
Aggregate:      19988  2325638    0.9308092   1.757  14.277   2.45540833  66.27032290   0.99462172  36.49   2.435  5.6640 12.4026  0.7619  4.7748 12.2818  0.0000 17.4380  8.8757 17.4777  0.3524  0.5027  0.925803018614      0
```