### PR TITLE
splines: trigger limits earlier

### DIFF
--- a/lib/jxl/splines.cc
+++ b/lib/jxl/splines.cc
@@ -607,8 +607,7 @@ Status Splines::InitializeDrawCache(const size_t image_xsize,
     }
     splines.push_back(spline);
   }
-  for (Spline& spline: splines) {
-    Spline spline = splines[i];
+  for (Spline& spline : splines) {
     std::vector<std::pair<Spline::Point, float>> points_to_draw;
     auto add_point = [&](const Spline::Point& point, const float multiplier) {
       points_to_draw.emplace_back(point, multiplier);


### PR DESCRIPTION
This makes sure that we first hit the `total_estimated_area_reached`, before calculating intermediate points and `points_to_draw`.