### PR TITLE
Create MAX_COMPONENTS size comp_info array in jpegli encoder.

### DIFF
--- a/lib/jpegli/encode.cc
+++ b/lib/jpegli/encode.cc
@@ -683,7 +683,7 @@ void jpegli_set_colorspace(j_compress_ptr cinfo, J_COLOR_SPACE colorspace) {
   cinfo->write_Adobe_marker = (cinfo->jpeg_color_space == JCS_YCCK);
   if (cinfo->comp_info == nullptr) {
     cinfo->comp_info =
-        jpegli::Allocate<jpeg_component_info>(cinfo, jpegli::kMaxComponents);
+        jpegli::Allocate<jpeg_component_info>(cinfo, MAX_COMPONENTS);
   }
   memset(cinfo->comp_info, 0,
          jpegli::kMaxComponents * sizeof(jpeg_component_info));


### PR DESCRIPTION
This is because cjpeg assumes that the comp_info array has this size and otherwise it crashes with any -sample HxV command-line param.