### PR TITLE
Non-linear quantization matrix scaling in jpegli encoder.

### DIFF
--- a/lib/jpegli/adaptive_quantization.cc
+++ b/lib/jpegli/adaptive_quantization.cc
@@ -504,21 +504,9 @@ HWY_EXPORT(PerBlockModulations);
 
 namespace {
 
-constexpr float kDcQuantPow = 0.66f;
-static const float kDcQuant = 1.913f;
 static constexpr int kPreErosionBorder = 1;
 
 }  // namespace
-
-float InitialQuantDC(float butteraugli_target) {
-  const float kDcMul = 1.5;  // Butteraugli target where non-linearity kicks in.
-  const float butteraugli_target_dc = std::max<float>(
-      0.5f * butteraugli_target,
-      std::min<float>(butteraugli_target,
-                      kDcMul * std::pow((1.0f / kDcMul) * butteraugli_target,
-                                        kDcQuantPow)));
-  return kDcQuant / butteraugli_target_dc;
-}
 
 void ComputeAdaptiveQuantField(j_compress_ptr cinfo) {
   jpeg_comp_master* m = cinfo->master;

--- a/lib/jpegli/adaptive_quantization.h
+++ b/lib/jpegli/adaptive_quantization.h
@@ -16,8 +16,6 @@ namespace jpegli {
 
 void ComputeAdaptiveQuantField(j_compress_ptr cinfo);
 
-float InitialQuantDC(float butteraugli_target);
-
 }  // namespace jpegli
 
 #endif  // LIB_JPEGLI_ADAPTIVE_QUANTIZATION_H_

--- a/tools/scripts/jpegli_tools_test.sh
+++ b/tools/scripts/jpegli_tools_test.sh
@@ -48,7 +48,7 @@ cjpegli_test_target_size() {
   "${decoder}" "${jpgfn}" "${outfn}"
   local size="$(wc -c "${jpgfn}" | cut -d' ' -f1)"
   python3 -c "import sys; sys.exit(not ${target_size} * 0.995 <= ${size})"
-  python3 -c "import sys; sys.exit(not ${target_size} * 1.005 >= ${size})"
+  python3 -c "import sys; sys.exit(not ${target_size} * 1.007 >= ${size})"
 }
 
 djpegli_test() {


### PR DESCRIPTION
Benchmarks on jyrki31 corpus:
```
Encoding                      kPixels    Bytes          BPP  E MP/s  D MP/s     Max norm  SSIMULACRA2        pnorm       BPP*pnorm   Bugs
-----------------------------------------------------------------------------------------------------------------------------------------
BEFORE:
jpeg:enc-jpegli:Q65:YUV420      13270  1430697    0.8624860   1.120  46.304   3.94868069  65.09968044   1.61473877  1.392689527227      0
jpeg:enc-jpegli:Q75:YUV420      13270  1776531    1.0709696   1.051  50.961   3.19333309  71.40137002   1.32800514  1.422253188587      0
jpeg:enc-jpegli:Q80:YUV420      13270  2086102    1.2575924   1.045  47.581   2.74619906  75.35488383   1.14550312  1.440576029150      0
jpeg:enc-jpegli:Q85:YUV420      13270  2455852    1.4804937   0.967  45.160   2.37790402  79.06007025   0.98115218  1.452589617350      0
AFTER:
jpeg:enc-jpegli:Q65:YUV420      13270  1431011    0.8626753   0.796  39.210   3.66042956  66.14836390   1.54443788  1.332348348600      0
jpeg:enc-jpegli:Q75:YUV420      13270  1777605    1.0716171   0.716  40.712   3.15155799  72.40497612   1.28942660  1.381771589604      0
jpeg:enc-jpegli:Q80:YUV420      13270  2086694    1.2579493   0.720  37.508   2.73064679  75.76542112   1.12705453  1.417777455760      0
jpeg:enc-jpegli:Q85:YUV420      13270  2455064    1.4800186   0.682  33.176   2.32925398  79.26441116   0.97484242  1.442784965646      0
```

Benchmarks on captioned jyrki31 corpus:
```
Encoding                      kPixels    Bytes          BPP  E MP/s  D MP/s     Max norm  SSIMULACRA2        pnorm       BPP*pnorm   Bugs
-----------------------------------------------------------------------------------------------------------------------------------------
BEFORE:
jpeg:enc-jpegli:Q65:YUV420       5522   709413    1.0276952   1.122  53.139   4.16588033  68.30837000   1.52805865  1.570378564678      0
jpeg:enc-jpegli:Q75:YUV420       5522   855055    1.2386803   1.145  55.094   3.47097185  73.24792753   1.28619190  1.593180624294      0
jpeg:enc-jpegli:Q80:YUV420       5522   986294    1.4288005   1.081  45.931   3.00317199  76.51566818   1.12469474  1.606964374409      0
jpeg:enc-jpegli:Q85:YUV420       5522  1143253    1.6561800   1.106  45.389   2.70485028  79.72770168   0.98096858  1.624660578692      0
AFTER:
jpeg:enc-jpegli:Q65:YUV420       5522   709435    1.0277271   0.770  43.358   4.23129960  69.07700691   1.49756188  1.539084911872      0
jpeg:enc-jpegli:Q75:YUV420       5522   856164    1.2402869   0.706  38.009   3.39596138  73.78678186   1.26492742  1.568872905321      0
jpeg:enc-jpegli:Q80:YUV420       5522   985296    1.4273547   0.726  38.099   2.86551994  76.81740159   1.11212801  1.587401162770      0
jpeg:enc-jpegli:Q85:YUV420       5522  1143275    1.6562119   0.678  34.907   2.57751421  79.66874761   0.97748810  1.618927421018      0
```

Benchmarks on CID22 validation corpus:
```
Encoding                      kPixels    Bytes          BPP  E MP/s  D MP/s     Max norm  SSIMULACRA2        pnorm       BPP*pnorm   Bugs
-----------------------------------------------------------------------------------------------------------------------------------------
BEFORE:
jpeg:enc-jpegli:Q65:YUV420      12845  1340155    0.8346589   0.707  44.460   3.77947957  66.66997004   1.59660128  1.332617432389      0
jpeg:enc-jpegli:Q75:YUV420      12845  1645391    1.0247622   0.700  42.110   3.12898702  72.50949057   1.30276351  1.335022812349      0
jpeg:enc-jpegli:Q80:YUV420      12845  1911073    1.1902310   0.649  38.321   2.65718134  76.19349641   1.11052356  1.321779580532      0
jpeg:enc-jpegli:Q85:YUV420      12845  2232373    1.3903391   0.635  37.932   2.24323793  79.81775338   0.93886861  1.305345772288      0
AFTER:
jpeg:enc-jpegli:Q65:YUV420      12845  1341301    0.8353726   0.575  39.846   3.62552994  67.24230873   1.54975295  1.294621168749      0
jpeg:enc-jpegli:Q75:YUV420      12845  1646516    1.0254629   0.589  39.377   3.04906913  73.35327369   1.27288970  1.305301128100      0
jpeg:enc-jpegli:Q80:YUV420      12845  1914534    1.1923865   0.544  35.649   2.60393620  76.59125291   1.10888415  1.322218550950      0
jpeg:enc-jpegli:Q85:YUV420      12845  2233137    1.3908150   0.524  33.884   2.24916856  79.81560579   0.93935112  1.306463584332      0
```

Images for viewing:
BEFORE:
https://storage.googleapis.com/jxl-quality/eval/szabadka/jyrki31/6b1e5b03/exp/index.jpeg_enc-jpegli_Q75_YUV420.html https://storage.googleapis.com/jxl-quality/eval/szabadka/jyrki_cap/6b1e5b03/exp/index.jpeg_enc-jpegli_Q75_YUV420.html

AFTER:
https://storage.googleapis.com/jxl-quality/eval/szabadka/jyrki31/58ee3bc3/exp/index.jpeg_enc-jpegli_Q75_YUV420.html https://storage.googleapis.com/jxl-quality/eval/szabadka/jyrki_cap/58ee3bc3/exp/index.jpeg_enc-jpegli_Q75_YUV420.html