### PR TITLE
merging adaptive quantization based on distance

### DIFF
--- a/lib/jxl/decode_test.cc
+++ b/lib/jxl/decode_test.cc
@@ -1677,7 +1677,7 @@ TEST(DecodeTest, PixelTestWithICCProfileLossy) {
   jxl::ButteraugliParams ba;
   EXPECT_THAT(ButteraugliDistance(io0.frames, io1.frames, ba, jxl::GetJxlCms(),
                                   /*distmap=*/nullptr, nullptr),
-              IsSlightlyBelow(0.79f));
+              IsSlightlyBelow(0.611f));
 
   JxlDecoderDestroy(dec);
 }

--- a/lib/jxl/enc_adaptive_quantization.h
+++ b/lib/jxl/enc_adaptive_quantization.h
@@ -50,7 +50,7 @@ ImageF InitialQuantField(float butteraugli_target, const Image3F& opsin,
 float InitialQuantDC(float butteraugli_target);
 
 void AdjustQuantField(const AcStrategyImage& ac_strategy, const Rect& rect,
-                      ImageF* quant_field);
+                      float original_butteraugli, ImageF* quant_field);
 
 // Returns a quantizer that uses an adjusted version of the provided
 // quant_field. Also computes the dequant_map corresponding to the given

--- a/lib/jxl/enc_heuristics.cc
+++ b/lib/jxl/enc_heuristics.cc
@@ -904,6 +904,7 @@ Status DefaultEncoderHeuristics::LossyFrameHeuristics(
     // adjusting the quant field with butteraugli when all the other encoding
     // parameters are fixed is likely a more reliable choice anyway.
     AdjustQuantField(enc_state->shared.ac_strategy, r,
+                     cparams.butteraugli_distance,
                      &enc_state->initial_quant_field);
     quantizer.SetQuantFieldRect(enc_state->initial_quant_field, r,
                                 &enc_state->shared.raw_quant_field);

--- a/lib/jxl/jxl_test.cc
+++ b/lib/jxl/jxl_test.cc
@@ -203,7 +203,7 @@ TEST(JxlTest, RoundtripOutOfOrderProcessing) {
   cparams.AddOption(JXL_ENC_FRAME_SETTING_EPF, 3);
 
   PackedPixelFile ppf_out;
-  EXPECT_NEAR(Roundtrip(t.ppf(), cparams, {}, &pool, &ppf_out), 22584, 400);
+  EXPECT_NEAR(Roundtrip(t.ppf(), cparams, {}, &pool, &ppf_out), 23042, 400);
   EXPECT_LE(ButteraugliDistance(t.ppf(), ppf_out), 1.35);
 }
 
@@ -873,7 +873,7 @@ TEST(JxlTest, RoundtripAlphaResampling) {
   cparams.AddOption(JXL_ENC_FRAME_SETTING_EXTRA_CHANNEL_RESAMPLING, 2);
 
   PackedPixelFile ppf_out;
-  EXPECT_NEAR(Roundtrip(t.ppf(), cparams, {}, pool, &ppf_out), 12803, 130);
+  EXPECT_NEAR(Roundtrip(t.ppf(), cparams, {}, pool, &ppf_out), 12936, 130);
   EXPECT_THAT(ButteraugliDistance(t.ppf(), ppf_out), IsSlightlyBelow(5.2));
 }
 
@@ -1236,10 +1236,10 @@ TEST(JxlTest, RoundtripAnimationPatches) {
   PackedPixelFile ppf_out;
   // 40k with no patches, 27k with patch frames encoded multiple times.
   EXPECT_THAT(Roundtrip(t.ppf(), cparams, dparams, pool, &ppf_out),
-              IsSlightlyBelow(16710));
+              IsSlightlyBelow(16789));
   EXPECT_EQ(ppf_out.frames.size(), t.ppf().frames.size());
   // >10 with broken patches
-  EXPECT_THAT(ButteraugliDistance(t.ppf(), ppf_out), IsSlightlyBelow(1.05));
+  EXPECT_THAT(ButteraugliDistance(t.ppf(), ppf_out), IsSlightlyBelow(1.0777));
 }
 
 #endif  // JPEGXL_ENABLE_GIF

--- a/tools/optimizer/simplex_fork.py
+++ b/tools/optimizer/simplex_fork.py
@@ -130,8 +130,8 @@ def Eval(vec, binary_name, cached=True):
       n += 1
       found_score = True
       distance = float(line.split()[0].split(b'd')[-1])
-      faultybpp = 1.0 + 0.43 * ((float(bpp) * distance ** 0.69) - 1.595) ** 2
-      vec[0] *= faultybpp
+      #faultybpp = 1.0 + 0.43 * ((float(bpp) * distance ** 0.69) - 1.595) ** 2
+      #vec[0] *= faultybpp
 
   print("eval: ", vec)
   if (vec[0] <= 0.0):


### PR DESCRIPTION
0.16 % improvement in BPP * pnorm

```
Before:

Encoding      kPixels    Bytes          BPP  E MP/s  D MP/s     Max norm  SSIMULACRA2        pnorm   PSNR   QABPP  SmallB  DCT4x8     AFV  DCT8x8    8x16    8x32      16   16x32      32   32x64      64       BPP*pnorm   Bugs
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
jxl:d0.1        19988 16571766    6.6326538   1.429   9.556   0.35375724  95.48140318   0.11566954  53.18   6.633 42.0702 18.3139  0.4611 27.5998  4.8720  0.0000  2.4001  0.8965  3.9294  0.1025  0.0820  0.767196019168      0
jxl:d0.5        19988  6400108    2.5615677   1.813  14.956   0.78447949  91.44334318   0.34880302  44.73   2.587 14.2927 25.2746  0.5773 12.1983 20.7906  0.0000 20.8188  1.2270  5.0974  0.1434  0.3074  0.893482551597      0
jxl:d0.8        19988  4734762    1.8950326   1.898  15.671   1.10199697  88.73933524   0.48217473  41.63   2.170 10.8554 21.9968  0.7102  9.0326 19.2230  0.0000 29.4319  1.5830  7.1979  0.2049  0.4918  0.913736838257      0
jxl:d1          19988  4083123    1.6342218   2.032  16.455   1.29853095  87.00864437   0.56565035  40.45   2.195  9.5875 20.1358  0.7451  7.8879 17.8493  0.0000 30.8279  2.4949 10.5945  0.1947  0.4098  0.924398145188      0
jxl:d1.1        19988  3846568    1.5395435   2.062  17.078   1.41116153  86.14539722   0.60528561  39.98   2.251  9.0969 19.3712  0.7733  7.4716 17.2999  0.0000 30.5487  3.3018 12.1980  0.2152  0.4508  0.931863495548      0
jxl:d1.2        19988  3632432    1.4538381   1.969  16.118   1.51141977  85.32579235   0.64282141  39.54   2.270  8.6717 18.6924  0.8133  7.1114 16.6211  0.0000 30.2183  4.0959 13.8066  0.2049  0.4918  0.934558221501      0
jxl:d1.3        19988  3458398    1.3841830   2.051  17.882   1.58015319  84.72077358   0.67544740  39.15   2.279  8.2276 18.1173  0.8296  6.8566 16.1511  0.0000 29.5382  4.9104 15.3282  0.2562  0.5123  0.934942808547      0
jxl:d1.4        19988  3289403    1.3165447   2.053  17.016   1.66324929  83.95246779   0.71320935  38.78   2.295  7.8866 17.6178  0.8501  6.5546 15.8052  0.0000 28.5469  5.9299 16.6038  0.2562  0.6762  0.938972024612      0
jxl:d1.5        19988  3141642    1.2574051   2.107  16.253   1.75568027  83.16810392   0.74911435  38.44   2.307  7.5834 17.0873  0.8764  6.3548 15.5344  0.0000 27.5172  6.7522 18.0587  0.2869  0.6762  0.941940241850      0
jxl:d1.6        19988  3002274    1.2016247   1.928  16.139   1.82805301  82.39419215   0.78310651  38.13   2.285  7.2430 16.8036  0.8895  6.1268 15.2372  0.0000 26.7141  7.6103 19.1500  0.3176  0.6353  0.941000163652      0
jxl:d1.7        19988  2883307    1.1540096   2.119  16.524   1.93002601  81.68226420   0.81675988  37.84   2.313  6.9872 16.4091  0.8985  5.9555 14.9036  0.0000 25.7805  8.6195 20.1899  0.3074  0.6762  0.942548749038      0
jxl:d1.8        19988  2773704    1.1101423   2.086  16.000   2.04346899  81.02700112   0.85069149  37.58   2.356  6.7634 16.0492  0.9218  5.8313 14.8248  0.0000 24.7943  9.4059 21.0301  0.4098  0.6967  0.944388603943      0
jxl:d1.9        19988  2674172    1.0703058   2.045  16.264   2.11684097  80.31169184   0.88150198  37.29   2.361  6.5322 15.6925  0.9388  5.7055 14.7249  0.0000 23.9900 10.2692 21.7883  0.3689  0.7172  0.943476671423      0
jxl:d2.0        19988  2579487    1.0324092   2.028  16.379   2.17974755  79.63189565   0.91585594  37.05   2.353  6.3459 15.3743  0.9766  5.5947 14.5110  0.0000 23.1139 11.2297 22.4441  0.3381  0.7992  0.945538131106      0
jxl:d2.1        19988  2493169    0.9978615   2.056  17.346   2.30527605  78.89798339   0.94752397  36.80   2.404  6.1573 14.9961  0.9920  5.4231 14.3426  0.0000 22.5248 11.8445 23.1869  0.3791  0.8812  0.945497670674      0
jxl:d2.2        19988  2414120    0.9662230   2.118  16.794   2.39558932  78.25941301   0.97970905  36.59   2.420  5.9571 14.7198  0.9865  5.3254 14.2075  0.0000 21.9561 12.5592 23.7248  0.4303  0.8607  0.946617466833      0
jxl:d2.3        19988  2338423    0.9359262   2.033  16.547   2.44817704  77.53624711   1.01432697  36.39   2.383  5.7759 14.3977  1.0054  5.2585 14.0557  0.0000 21.2145 13.4352 24.2218  0.4406  0.9221  0.949335202869      0
jxl:d2.4        19988  2268442    0.9079171   2.024  16.769   2.57942648  76.88611539   1.04962937  36.19   2.437  5.6216 14.1281  1.0304  5.1676 14.0231  0.0000 20.6689 14.1089 24.4728  0.4611  1.0451  0.952976499700      0
jxl:d2.5        19988  2200778    0.8808354   2.066  16.859   2.60162839  76.27527686   1.07695606  35.98   2.383  5.5025 13.8348  1.0153  5.0776 13.9065  0.0000 20.1963 14.6724 25.0466  0.4508  1.0246  0.948621049421      0
jxl:d2.6        19988  2140281    0.8566222   2.161  17.381   2.65897212  75.64318806   1.10808142  35.79   2.373  5.3904 13.5665  1.0320  4.9790 13.8374  0.0000 19.6571 15.4511 25.2874  0.5021  1.0246  0.949207164040      0
jxl:d2.7        19988  2083991    0.8340928   2.161  17.063   2.76154419  75.02326002   1.13753659  35.62   2.430  5.2239 13.2700  1.0339  4.8970 13.7400  0.0000 19.1423 16.1709 25.6818  0.5021  1.0656  0.948811092868      0
jxl:d2.8        19988  2030606    0.8127261   2.239  16.656   2.83965686  74.44020919   1.16692713  35.44   2.436  5.0933 12.9892  1.0611  4.8150 13.6196  0.0000 18.8170 16.6473 26.0353  0.5226  1.1271  0.948392131148      0
jxl:d2.9        19988  1980459    0.7926553   2.123  17.623   2.85661875  73.84795899   1.19490120  35.30   2.372  4.9674 12.8086  1.0653  4.7414 13.4896  0.0000 18.3572 17.4542 26.1941  0.5635  1.0861  0.947144827813      0
jxl:d3          19988  1934891    0.7744173   1.994  16.071   2.94787664  73.23659185   1.22088246  35.15   2.386  4.8134 12.5947  1.0454  4.6809 13.2578  0.0000 17.9998 17.9691 26.7474  0.5328  1.0861  0.945472494675      0
jxl:d5          19988  1317494    0.5273114   1.941   9.128   4.42116711  62.00109139   1.74643412  32.84   2.448  3.3434  8.2593  0.9430  3.0668 10.8858  0.0000 13.9309 27.2802 30.9176  0.2766  1.8238  0.920914672395      0
jxl:d7          19988  1020899    0.4086028   2.025   9.055   5.68170072  52.64631794   2.20354436  31.38   2.420  2.5349  5.7753  0.7995  2.1168  9.2791  0.0000 11.6268 32.1292 34.0170  0.2562  2.1927  0.900374352395      0
jxl:d15         19988   561202    0.2246145   2.088   9.022  10.03534289  23.20941470   3.78625511  28.49   2.287  1.1239  1.5747  0.2824  0.5174  5.1346  0.0000  6.5242 36.4966 43.6535  0.8709  4.5493  0.850447720204      0
jxl:d24         19988   400568    0.1603226   0.302  20.666  16.95564047   3.26366225   5.91935286  25.85   2.642  0.9926  2.2071  0.1771  0.6961  3.0629  0.0000  2.9791  9.0422  6.2552  0.0410  0.0000  0.949006134957      0
jxl:d32         19988   321666    0.1287430   0.304  18.180  18.63235554  -7.11102012   6.65813916  25.41   2.371  0.7275  1.6647  0.1386  0.4899  2.7191  0.0000  2.6281  9.8567  7.1364  0.0922  0.0000  0.857188952215      0
Aggregate:      19988  2320981    0.9289452   1.771  15.456   2.43672075  67.44103134   0.99599786  36.43   2.448  5.6129 12.1440  0.7513  4.6916 12.1987  0.0000 17.2842  8.6011 17.3911  0.2927  0.7711  0.925227395224      0

After:

Encoding      kPixels    Bytes          BPP  E MP/s  D MP/s     Max norm  SSIMULACRA2        pnorm   PSNR   QABPP  SmallB  DCT4x8     AFV  DCT8x8    8x16    8x32      16   16x32      32   32x64      64       BPP*pnorm   Bugs
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
jxl:d0.1        19988 16609459    6.6477400   1.441   9.828   0.35353178  95.48321280   0.11547700  53.20   6.648 42.2069 18.2557  0.4579 27.5521  4.8560  0.0000  2.3809  0.8991  3.9345  0.1025  0.0820  0.767661102927      0
jxl:d0.5        19988  6418230    2.5688208   1.854  14.707   0.78360793  91.47222570   0.34784750  44.76   2.595 14.3282 25.2637  0.5715 12.2537 20.7266  0.0000 20.8162  1.2295  5.1077  0.1434  0.2869  0.893557915201      0
jxl:d0.8        19988  4748997    1.9007300   1.942  15.615   1.09299541  88.76910888   0.48042532  41.66   2.162 10.8798 21.9981  0.7060  9.0476 19.1608  0.0000 29.4831  1.5625  7.1928  0.2049  0.4918  0.913158824007      0
jxl:d1          19988  4097550    1.6399960   2.011  16.729   1.28714387  87.04977497   0.56373878  40.48   2.183  9.6156 20.1582  0.7457  7.8969 17.8032  0.0000 30.8395  2.5000 10.5535  0.1844  0.4303  0.924529370650      0
jxl:d1.1        19988  3858562    1.5443439   2.007  16.997   1.40323481  86.18913181   0.60289883  40.01   2.237  9.1302 19.3792  0.7675  7.4957 17.2929  0.0000 30.5423  3.2762 12.2082  0.2049  0.4303  0.931083143066      0
jxl:d1.2        19988  3643808    1.4583912   2.023  16.824   1.50159330  85.37331677   0.64052088  39.57   2.258  8.6874 18.7363  0.8069  7.1069 16.6313  0.0000 30.1850  4.0703 13.8476  0.1844  0.4713  0.934129982884      0
jxl:d1.3        19988  3468072    1.3880549   1.980  16.912   1.55456911  84.73540423   0.67335696  39.17   2.238  8.2587 18.1455  0.8290  6.8716 16.1389  0.0000 29.5638  4.8848 15.2872  0.2562  0.4918  0.934656429131      0
jxl:d1.4        19988  3299554    1.3206076   2.041  17.748   1.65134373  83.95808974   0.71050048  38.81   2.283  7.9058 17.6345  0.8626  6.5485 15.7681  0.0000 28.6109  5.9069 16.5679  0.2664  0.6558  0.938292310936      0
jxl:d1.5        19988  3152889    1.2619066   2.001  15.495   1.74920984  83.23248501   0.74411338  38.48   2.299  7.5866 17.1011  0.8751  6.3788 15.5356  0.0000 27.6734  6.7291 17.8846  0.2869  0.6762  0.939001608255      0
jxl:d1.6        19988  3012656    1.2057800   1.861  14.791   1.83253313  82.45912463   0.78064911  38.15   2.300  7.2706 16.8148  0.8808  6.1589 15.1918  0.0000 26.7282  7.6103 19.1192  0.3176  0.6353  0.941291100414      0
jxl:d1.7        19988  2888579    1.1561197   2.077  17.147   1.93669216  81.73198269   0.81526439  37.86   2.314  7.0058 16.4194  0.8937  5.9821 14.9055  0.0000 25.7997  8.5837 20.1336  0.3074  0.6967  0.942543188130      0
jxl:d1.8        19988  2778533    1.1120751   2.057  16.736   2.01501361  81.03872051   0.84886291  37.59   2.322  6.7788 16.0428  0.9237  5.8358 14.8338  0.0000 24.8647  9.4290 20.9533  0.4098  0.6558  0.943999266875      0
jxl:d1.9        19988  2677932    1.0718107   2.132  17.355   2.12369407  80.33511266   0.88028235  37.29   2.374  6.5431 15.7335  0.9442  5.7237 14.7083  0.0000 23.9797 10.1693 21.8191  0.3894  0.7172  0.943496033965      0
jxl:d2.0        19988  2584244    1.0343132   2.035  16.078   2.17759993  79.64471880   0.91392713  37.06   2.350  6.3481 15.4117  0.9737  5.5950 14.5187  0.0000 23.2125 11.1119 22.4287  0.3279  0.7992  0.945286866703      0
jxl:d2.1        19988  2496136    0.9990490   2.111  17.471   2.29749150  78.92568037   0.94598818  36.82   2.395  6.1915 15.0265  0.9849  5.4416 14.3548  0.0000 22.5286 11.8138 23.0947  0.3894  0.9017  0.945088527285      0
jxl:d2.2        19988  2417251    0.9674762   2.144  17.500   2.37253000  78.27215579   0.97795938  36.62   2.412  5.9716 14.7294  0.9910  5.3238 14.1972  0.0000 21.9292 12.5848 23.6685  0.4303  0.9017  0.946152418613      0
jxl:d2.3        19988  2338562    0.9359818   2.007  17.924   2.44720064  77.57634514   1.01122825  36.37   2.394  5.8019 14.4297  1.0083  5.2809 14.0685  0.0000 21.2081 13.3353 24.2423  0.4508  0.9017  0.946491284993      0
jxl:d2.4        19988  2268753    0.9080416   2.004  17.251   2.53334947  76.87528656   1.04431474  36.19   2.397  5.6504 14.1316  1.0246  5.1711 13.9891  0.0000 20.6625 14.1806 24.4421  0.4508  1.0246  0.948281253066      0
jxl:d2.5        19988  2199453    0.8803051   2.099  17.149   2.60654511  76.26022560   1.07689064  35.98   2.387  5.5002 13.8694  1.0236  5.0798 13.8342  0.0000 20.2770 14.6878 25.0005  0.4508  1.0041  0.947992333918      0
jxl:d2.6        19988  2137036    0.8553234   2.082  17.808   2.66204847  75.64946472   1.10468095  35.77   2.379  5.4035 13.5748  1.0301  5.0075 13.8034  0.0000 19.6815 15.3666 25.3232  0.5123  1.0246  0.944859513633      0
jxl:d2.7        19988  2080629    0.8327472   2.165  17.153   2.78720629  74.99937394   1.13844502  35.62   2.455  5.2386 13.2934  1.0425  4.9207 13.7029  0.0000 19.1909 16.1607 25.6306  0.5021  1.0451  0.948036913914      0
jxl:d2.8        19988  2024008    0.8100853   2.107  16.929   2.83310005  74.36929543   1.16900299  35.43   2.419  5.0958 13.0455  1.0573  4.8266 13.6196  0.0000 18.7990 16.6140 26.0200  0.5430  1.1066  0.946992164158      0
jxl:d2.9        19988  1972941    0.7896464   2.138  17.653   2.86636066  73.76487699   1.19741541  35.27   2.382  4.9825 12.8134  1.0627  4.7529 13.5069  0.0000 18.3674 17.3774 26.2249  0.5533  1.0861  0.945534719131      0
jxl:d3          19988  1927869    0.7716068   1.984  16.729   2.95772989  73.16140113   1.22364420  35.13   2.397  4.8224 12.5982  1.0371  4.6818 13.2834  0.0000 18.0152 18.0254 26.6655  0.5943  1.0041  0.944172208639      0
jxl:d5          19988  1306120    0.5227591   1.939   9.435   4.47670928  61.73033085   1.75678887  32.79   2.455  3.3489  8.2846  0.9554  3.0761 10.9345  0.0000 13.9629 27.1368 30.9278  0.2766  1.8238  0.918377402689      0
jxl:d7          19988  1009404    0.4040020   1.936   9.049   5.67270051  52.32787088   2.22276051  31.31   2.389  2.5337  5.8083  0.8002  2.1293  9.2753  0.0000 11.6703 32.0857 33.9761  0.2562  2.1927  0.897999783206      0
jxl:d15         19988   561055    0.2245556   1.976   9.025  10.07380638  23.13463053   3.77459295  28.51   2.287  1.1341  1.5859  0.2875  0.5280  5.1563  0.0000  6.5191 36.4479 43.6791  0.8402  4.5493  0.847606151388      0
jxl:d24         19988   395816    0.1584207   0.309  19.097  17.01197931   2.56942282   5.95401180  25.83   2.616  0.9987  2.2135  0.1735  0.6987  3.0553  0.0000  2.9931  9.0396  6.2399  0.0410  0.0000  0.943238621901      0
jxl:d32         19988   318267    0.1273826   0.306  20.068  18.78487804  -7.72162133   6.68414743  25.39   2.367  0.7329  1.6692  0.1377  0.4905  2.7299  0.0000  2.6128  9.8055  7.1928  0.0820  0.0000  0.851444157511      0
Aggregate:      19988  2319622    0.9284015   1.758  15.647   2.43230882  66.84090429   0.99497885  36.43   2.442  5.6295 12.1632  0.7504  4.7054 12.1917  0.0000 17.2961  8.5775 17.3756  0.2914  0.7620  0.923739882798      0
```