### PR TITLE
Use frequency dependent dead zone multipliers.

### DIFF
--- a/lib/extras/jpegli_test.cc
+++ b/lib/extras/jpegli_test.cc
@@ -231,8 +231,8 @@ TEST(JpegliTest, JpegliYUVEncodeTestNoAq) {
 
   PackedPixelFile ppf_out;
   ASSERT_TRUE(DecodeWithLibjpeg(compressed, &ppf_out));
-  EXPECT_THAT(BitsPerPixel(ppf_in, compressed), IsSlightlyBelow(1.76f));
-  EXPECT_THAT(ButteraugliDistance(ppf_in, ppf_out), IsSlightlyBelow(1.32f));
+  EXPECT_THAT(BitsPerPixel(ppf_in, compressed), IsSlightlyBelow(1.85f));
+  EXPECT_THAT(ButteraugliDistance(ppf_in, ppf_out), IsSlightlyBelow(1.25f));
 }
 
 TEST(JpegliTest, JpegliHDRRoundtripTest) {

--- a/lib/jpegli/adaptive_quantization.cc
+++ b/lib/jpegli/adaptive_quantization.cc
@@ -554,7 +554,7 @@ void ComputeAdaptiveQuantField(j_compress_ptr cinfo) {
   for (int y = 0; y < cinfo->max_v_samp_factor; ++y) {
     float* row = m->quant_field.Row(yb0 + y);
     for (size_t x = 0; x < xsize_blocks; ++x) {
-      row[x] = (0.6f / row[x]) - 1.0f;
+      row[x] = std::max(0.0f, (0.6f / row[x]) - 1.0f);
     }
   }
 }

--- a/lib/jpegli/dct.cc
+++ b/lib/jpegli/dct.cc
@@ -13,32 +13,13 @@
 #include <hwy/highway.h>
 
 #include "lib/jpegli/dct-inl.h"
+#include "lib/jpegli/encode_internal.h"
 #include "lib/jpegli/memory_manager.h"
 
 HWY_BEFORE_NAMESPACE();
 namespace jpegli {
 namespace HWY_NAMESPACE {
 namespace {
-
-void ComputeCoefficientBlock(const float* JXL_RESTRICT pixels, size_t stride,
-                             const float* JXL_RESTRICT qmc, float aq_strength,
-                             float zero_bias_mul, float* JXL_RESTRICT tmp,
-                             JCOEF* block) {
-  float* JXL_RESTRICT dct = tmp;
-  float* JXL_RESTRICT scratch_space = tmp + DCTSIZE2;
-  TransformFromPixels(pixels, stride, dct, scratch_space);
-  if (aq_strength > 0.0f) {
-    // Create more zeros in areas where jpeg xl would have used a lower
-    // quantization multiplier.
-    float zero_bias = 0.5f + zero_bias_mul * aq_strength;
-    zero_bias = std::min(1.5f, zero_bias);
-    QuantizeBlock(dct, qmc, zero_bias, block);
-  } else {
-    QuantizeBlockNoAQ(dct, qmc, block);
-  }
-  // Center DC values around zero.
-  block[0] = std::round((dct[0] - kDCBias) * qmc[0]);
-}
 
 void ComputeDCTCoefficients(j_compress_ptr cinfo) {
   jpeg_comp_master* m = cinfo->master;
@@ -55,7 +36,8 @@ void ComputeDCTCoefficients(j_compress_ptr cinfo) {
     RowBuffer<float>* plane = m->raw_data[c];
     const int h_factor = m->h_factor[c];
     const int v_factor = m->v_factor[c];
-    const float zero_bias_mul = m->zero_bias_mul[c];
+    const float* zero_bias_offset = m->zero_bias_offset[c];
+    const float* zero_bias_mul = m->zero_bias_mul[c];
     float aq_strength = 0.0f;
     for (int iy = 0; iy < comp->v_samp_factor; iy++) {
       size_t by = by0 + iy;
@@ -68,7 +50,7 @@ void ComputeDCTCoefficients(j_compress_ptr cinfo) {
           aq_strength = m->quant_field.Row(by * v_factor)[bx * h_factor];
         }
         ComputeCoefficientBlock(row + 8 * bx, plane->stride(), qmc, aq_strength,
-                                zero_bias_mul, tmp, block);
+                                zero_bias_offset, zero_bias_mul, tmp, block);
       }
     }
   }
@@ -83,16 +65,7 @@ HWY_AFTER_NAMESPACE();
 #if HWY_ONCE
 namespace jpegli {
 
-HWY_EXPORT(ComputeCoefficientBlock);
 HWY_EXPORT(ComputeDCTCoefficients);
-
-void ComputeCoefficientBlock(const float* JXL_RESTRICT pixels, size_t stride,
-                             const float* JXL_RESTRICT qmc, float aq_strength,
-                             float zero_bias_mul, float* JXL_RESTRICT tmp,
-                             JCOEF* block) {
-  HWY_DYNAMIC_DISPATCH(ComputeCoefficientBlock)
-  (pixels, stride, qmc, aq_strength, zero_bias_mul, tmp, block);
-}
 
 void ComputeDCTCoefficients(j_compress_ptr cinfo) {
   HWY_DYNAMIC_DISPATCH(ComputeDCTCoefficients)(cinfo);

--- a/lib/jpegli/dct.h
+++ b/lib/jpegli/dct.h
@@ -11,16 +11,7 @@
 #include <jpeglib.h>
 /* clang-format on */
 
-#include <vector>
-
-#include "lib/jpegli/encode_internal.h"
-
 namespace jpegli {
-
-void ComputeCoefficientBlock(const float* JXL_RESTRICT pixels, size_t stride,
-                             const float* JXL_RESTRICT qmc, float aq_strength,
-                             float zero_bias_mul, float* JXL_RESTRICT tmp,
-                             JCOEF* block);
 
 void ComputeDCTCoefficients(j_compress_ptr cinfo);
 

--- a/lib/jpegli/decode_api_test.cc
+++ b/lib/jpegli/decode_api_test.cc
@@ -477,7 +477,7 @@ TEST(DecodeAPITest, ReuseCinfoSameMemSource) {
     jpegli_destroy_decompress(&cinfo);
   }
   for (size_t i = 0; i < all_configs.size(); ++i) {
-    VerifyOutputImage(all_configs[i].input, all_outputs[i], 2.3f);
+    VerifyOutputImage(all_configs[i].input, all_outputs[i], 2.35f);
   }
   if (buffer) free(buffer);
 }
@@ -518,7 +518,7 @@ TEST(DecodeAPITest, ReuseCinfoSameStdSource) {
     jpegli_destroy_decompress(&cinfo);
   }
   for (size_t i = 0; i < all_configs.size(); ++i) {
-    VerifyOutputImage(all_configs[i].input, all_outputs[i], 2.3f);
+    VerifyOutputImage(all_configs[i].input, all_outputs[i], 2.35f);
   }
   fclose(tmpf);
 }
@@ -759,7 +759,7 @@ std::vector<TestConfig> GenerateTests(bool buffered) {
             // The last partially available block can behave differently.
             // TODO(szabadka) Figure out if we can make the behaviour more
             // similar.
-            config.max_rms_dist = samp == 1 ? 1.7f : 3.0f;
+            config.max_rms_dist = samp == 1 ? 1.75f : 3.0f;
             config.max_diff = 255.0f;
             all_tests.push_back(config);
           }

--- a/lib/jpegli/encode.cc
+++ b/lib/jpegli/encode.cc
@@ -399,6 +399,12 @@ void AllocateBuffers(j_compress_ptr cinfo) {
     m->fuzzy_erosion_tmp.Allocate(cinfo, 2, xsize_padded);
     m->pre_erosion.Allocate(cinfo, 6 * cinfo->max_v_samp_factor, xsize_padded);
     m->quant_field.Allocate(cinfo, cinfo->max_v_samp_factor, xsize_blocks);
+    for (int c = 0; c < cinfo->num_components; ++c) {
+      m->zero_bias_offset[c] =
+          Allocate<float>(cinfo, DCTSIZE2, JPOOL_IMAGE_ALIGNED);
+      m->zero_bias_mul[c] =
+          Allocate<float>(cinfo, DCTSIZE2, JPOOL_IMAGE_ALIGNED);
+    }
   }
 }
 

--- a/lib/jpegli/encode_api_test.cc
+++ b/lib/jpegli/encode_api_test.cc
@@ -107,7 +107,7 @@ std::vector<TestConfig> GenerateBasicConfigs() {
         config.jparams.v_sampling = {samp, 1, 1};
         config.jparams.progressive_mode = progr;
         config.jparams.optimize_coding = optimize;
-        config.max_dist = 2.35f;
+        config.max_dist = 2.4f;
         GeneratePixels(&config.input);
         all_configs.push_back(config);
       }
@@ -389,8 +389,8 @@ std::vector<TestConfig> GenerateTests() {
           if (!progr) {
             config.jparams.optimize_coding = optimize;
           }
-          const float kMaxBpp[4] = {1.6, 1.45, 1.45, 1.35};
-          const float kMaxDist[4] = {1.9, 2.1, 2.1, 2.25};
+          const float kMaxBpp[4] = {1.55, 1.45, 1.45, 1.32};
+          const float kMaxDist[4] = {1.95, 2.1, 2.1, 2.3};
           const int idx = v_samp * 2 + h_samp - 3;
           config.max_bpp =
               kMaxBpp[idx] * (optimize ? 0.97 : 1.0) * (progr ? 0.97 : 1.0);
@@ -428,7 +428,7 @@ std::vector<TestConfig> GenerateTests() {
           config.jparams.optimize_coding = optimize;
         }
         config.jparams.use_adaptive_quantization = false;
-        config.max_bpp = 2.0f;
+        config.max_bpp = 2.05f;
         config.max_dist = 2.3f;
         all_tests.push_back(config);
       }
@@ -531,8 +531,8 @@ std::vector<TestConfig> GenerateTests() {
       config.input.color_space = in_color_space;
       config.jparams.set_jpeg_colorspace = true;
       config.jparams.jpeg_color_space = jpeg_color_space;
-      config.max_bpp = jpeg_color_space == JCS_RGB ? 4.5 : 1.9;
-      config.max_dist = jpeg_color_space == JCS_RGB ? 1.4 : 2.0;
+      config.max_bpp = jpeg_color_space == JCS_RGB ? 4.5 : 1.85;
+      config.max_dist = jpeg_color_space == JCS_RGB ? 1.4 : 2.05;
       all_tests.push_back(config);
     }
   }
@@ -640,8 +640,8 @@ std::vector<TestConfig> GenerateTests() {
       table.slot_idx = slot_idx;
       table.Generate();
       config.jparams.quant_tables.push_back(table);
-      config.max_bpp = 2.4;
-      config.max_dist = 2.8;
+      config.max_bpp = 2.3;
+      config.max_dist = 2.9;
       all_tests.push_back(config);
     }
   }
@@ -666,8 +666,8 @@ std::vector<TestConfig> GenerateTests() {
         table.Generate();
         config.jparams.quant_tables.push_back(table);
       }
-      config.max_bpp = 2.05;
-      config.max_dist = 3.75;
+      config.max_bpp = 2.0;
+      config.max_dist = 3.85;
       all_tests.push_back(config);
     }
   }
@@ -724,15 +724,15 @@ std::vector<TestConfig> GenerateTests() {
   {
     TestConfig config;
     config.input.xsize = config.input.ysize = 256;
-    config.max_bpp = 1.9;
-    config.max_dist = 2.0;
+    config.max_bpp = 1.85;
+    config.max_dist = 2.05;
     config.jparams.add_marker = true;
     all_tests.push_back(config);
   }
   for (size_t icc_size : {728, 70000, 1000000}) {
     TestConfig config;
     config.input.xsize = config.input.ysize = 256;
-    config.max_dist = 2.0;
+    config.max_dist = 2.05;
     config.jparams.icc.resize(icc_size);
     for (size_t i = 0; i < icc_size; ++i) {
       config.jparams.icc[i] = (i * 17) & 0xff;
@@ -748,8 +748,8 @@ std::vector<TestConfig> GenerateTests() {
     }
     config.jparams.progressive_mode = 0;
     config.jparams.optimize_coding = 0;
-    config.max_bpp = 1.9;
-    config.max_dist = 2.0;
+    config.max_bpp = 1.85;
+    config.max_dist = 2.05;
     if (input_mode == COEFFICIENTS) {
       config.max_bpp = 3.5;
       config.max_dist = 0.0;
@@ -813,8 +813,8 @@ std::vector<TestConfig> GenerateTests() {
         config.jparams.smoothing_factor = smoothing;
         config.jparams.h_sampling = {h_sampling, 1, 1};
         config.jparams.v_sampling = {v_sampling, 1, 1};
-        config.max_bpp = 1.9;
-        config.max_dist = 3.0f;
+        config.max_bpp = 1.85;
+        config.max_dist = 3.05f;
         all_tests.push_back(config);
       }
     }

--- a/lib/jpegli/encode_internal.h
+++ b/lib/jpegli/encode_internal.h
@@ -36,8 +36,6 @@ struct JPEGHuffmanCode {
 // DCTCodingState: maximum number of correction bits to buffer
 const int kJPEGMaxCorrectionBits = 1u << 16;
 
-static constexpr float kDCBias = 128.0f;
-
 constexpr int kDefaultProgressiveLevel = 0;
 
 struct HuffmanCodeTable {
@@ -78,7 +76,8 @@ struct jpeg_comp_master {
   void (*downsample_method[jpegli::kMaxComponents])(
       float* rows_in[MAX_SAMP_FACTOR], size_t len, float* row_out);
   float* quant_mul[jpegli::kMaxComponents];
-  float zero_bias_mul[jpegli::kMaxComponents];
+  float* zero_bias_offset[jpegli::kMaxComponents];
+  float* zero_bias_mul[jpegli::kMaxComponents];
   int h_factor[jpegli::kMaxComponents];
   int v_factor[jpegli::kMaxComponents];
   jpegli::JPEGHuffmanCode* huffman_codes;

--- a/lib/jpegli/input_suspension_test.cc
+++ b/lib/jpegli/input_suspension_test.cc
@@ -540,7 +540,7 @@ std::vector<TestConfig> GenerateTests() {
           // The last partially available block can behave differently.
           // TODO(szabadka) Figure out if we can make the behaviour more
           // similar.
-          config.max_rms_dist = samp == 1 ? 1.7f : 3.0f;
+          config.max_rms_dist = samp == 1 ? 1.75f : 3.0f;
           all_tests.push_back(config);
         }
       }

--- a/lib/jpegli/transpose-inl.h
+++ b/lib/jpegli/transpose-inl.h
@@ -10,6 +10,8 @@
 #define LIB_JPEGLI_TRANSPOSE_INL_H_
 #endif
 
+#include "lib/jxl/base/compiler_specific.h"
+
 HWY_BEFORE_NAMESPACE();
 namespace jpegli {
 namespace HWY_NAMESPACE {

--- a/tools/optimizer/update_jpegli_global_scale.py
+++ b/tools/optimizer/update_jpegli_global_scale.py
@@ -18,7 +18,7 @@ def SourceFileName():
   return "lib/jpegli/quant.cc"
 
 def ScalePattern(scale_type):
-  return "  constexpr float kGlobalScale" + scale_type + " = ";
+  return "constexpr float kGlobalScale" + scale_type + " = ";
 
 def CodecName(scale_type):
   if scale_type == "YCbCr":

--- a/tools/scripts/jpegli_tools_test.sh
+++ b/tools/scripts/jpegli_tools_test.sh
@@ -118,7 +118,7 @@ main() {
   cjpegli_test "${rgb_in}" "--chroma_subsampling 422" 88 1.6
   cjpegli_test "${rgb_in}" "--xyb" 87 1.5
   cjpegli_test "${rgb_in}" "--std_quant" 91 2.2
-  cjpegli_test "${rgb_in}" "--noadaptive_quantization" 90 1.8
+  cjpegli_test "${rgb_in}" "--noadaptive_quantization" 90 1.85
   cjpegli_test "${rgb_in}" "-p 1" 89 1.72
   cjpegli_test "${rgb_in}" "-p 0" 89 1.75
   cjpegli_test "${rgb_in}" "-p 0 --fixed_code" 89 1.8


### PR DESCRIPTION
Benchmark results on jyrki31 corpus:

```
Encoding                      kPixels    Bytes          BPP  E MP/s  D MP/s     Max norm  SSIMULACRA2        pnorm       BPP*pnorm   Bugs
-----------------------------------------------------------------------------------------------------------------------------------------
BEFORE:
jpeg:enc-jpegli:Q90             13270  4681116    2.8219790   0.598  26.349   1.27255321  88.00687122   0.53531399  1.510644830124      0
jpeg:enc-jpegli:Q85             13270  3573716    2.1543904   0.632  30.351   1.61245817  84.91516370   0.68812425  1.482488278521      0
jpeg:enc-jpegli:Q85:YUV422      13270  2856952    1.7222941   0.784  32.775   1.99105390  81.71974604   0.85125798  1.466116598017      0
jpeg:enc-jpegli:Q85:YUV420      13270  2455115    1.4800494   0.856  35.033   2.34670996  79.26104785   0.97480043  1.442752787763      0
jpeg:enc-jpegli:Q80:YUV420      13270  2086232    1.2576708   0.884  37.081   2.73492653  75.76084987   1.12740183  1.417900349646      0
jpeg:enc-jpegli:Q75:YUV420      13270  1776791    1.0711264   0.896  38.732   3.15430111  72.34765706   1.29004893  1.381805438970      0
jpeg:enc-jpegli:Q70:YUV420      13270  1576739    0.9505264   0.955  38.752   3.45378293  68.94098276   1.42740129  1.356782599397      0
jpeg:enc-jpegli:Q65:YUV420      13270  1430810    0.8625541   0.998  42.413   3.70200534  66.14409738   1.54507861  1.332713869234      0
jpeg:enc-jpegli:Q50:YUV420      13270  1116007    0.6727772   1.031  44.889   4.69019982  56.42639081   1.90691741  1.282930626852      0
Aggregate:                      13270  2176291    1.3119620   0.835  35.829   2.57400145  74.21089068   1.07200350  1.406427818799      0
AFTER:
jpeg:enc-jpegli:Q90             13270  4682992    2.8231099   0.489  21.987   1.25844994  87.83375690   0.53040985  1.497405291359      0
jpeg:enc-jpegli:Q85             13270  3573091    2.1540136   0.598  26.686   1.57421330  84.48232018   0.68297088  1.471128574751      0
jpeg:enc-jpegli:Q85:YUV422      13270  2857695    1.7227420   0.580  28.691   1.98518980  81.08751310   0.83572849  1.439744582459      0
jpeg:enc-jpegli:Q85:YUV420      13270  2454954    1.4799523   0.691  26.527   2.27528616  78.51725496   0.96075085  1.421865461821      0
jpeg:enc-jpegli:Q80:YUV420      13270  2086244    1.2576780   0.771  31.916   2.66861557  75.38795415   1.10763879  1.393052963205      0
jpeg:enc-jpegli:Q75:YUV420      13270  1776263    1.0708081   0.751  32.175   3.03662027  71.80555786   1.26903836  1.358896532924      0
jpeg:enc-jpegli:Q70:YUV420      13270  1577005    0.9506867   0.752  34.097   3.36908444  68.87782346   1.40366388  1.334444650024      0
jpeg:enc-jpegli:Q65:YUV420      13270  1431325    0.8628645   0.824  37.068   3.67035296  66.14497472   1.52221030  1.313461306680      0
jpeg:enc-jpegli:Q50:YUV420      13270  1115472    0.6724547   0.817  38.825   4.53930222  57.45007810   1.87262800  1.259257530591      0
Aggregate:                      13270  2176334    1.3119879   0.688  30.450   2.51807819  74.04900968   1.05620986  1.385734539291      0
```

Benchmark results on CID22 validation corpus:

```
Encoding                      kPixels    Bytes          BPP  E MP/s  D MP/s     Max norm  SSIMULACRA2        pnorm       BPP*pnorm   Bugs
-----------------------------------------------------------------------------------------------------------------------------------------
BEFORE:
jpeg:enc-jpegli:Q90             12845  4006297    2.4951527   0.527  27.040   1.16623143  88.21497059   0.50929648  1.270772472736      0
jpeg:enc-jpegli:Q85             12845  3113542    1.9391380   0.690  31.303   1.56205293  85.12256581   0.67701268  1.312820997213      0
jpeg:enc-jpegli:Q85:YUV422      12845  2553138    1.5901140   0.772  34.898   1.94215793  82.31696927   0.81629070  1.297995302349      0
jpeg:enc-jpegli:Q85:YUV420      12845  2232777    1.3905907   0.801  35.701   2.24832791  79.80405580   0.93941920  1.306347649942      0
jpeg:enc-jpegli:Q80:YUV420      12845  1912794    1.1913029   0.804  38.100   2.63389905  76.57741414   1.11378377  1.326853795603      0
jpeg:enc-jpegli:Q75:YUV420      12845  1644734    1.0243530   0.872  39.426   3.05002732  73.32518891   1.27442846  1.305464655051      0
jpeg:enc-jpegli:Q70:YUV420      12845  1469150    0.9149980   0.842  41.223   3.36959080  69.96003910   1.41769379  1.297186921202      0
jpeg:enc-jpegli:Q65:YUV420      12845  1340208    0.8346919   0.843  41.786   3.61797810  67.21636442   1.55121858  1.294789562794      0
jpeg:enc-jpegli:Q50:YUV420      12845  1056717    0.6581315   0.791  44.587   4.54424721  57.73860056   1.97265472  1.298266211262      0
Aggregate:                      12845  1978932    1.2324943   0.764  36.730   2.47934495  75.01334022   1.05565406  1.301087618565      0
AFTER:
jpeg:enc-jpegli:Q90             12845  4006141    2.4950555   0.572  27.326   1.16247004  88.00078593   0.50791673  1.267280453689      0
jpeg:enc-jpegli:Q85             12845  3114019    1.9394351   0.679  31.579   1.53191501  84.67221642   0.66408297  1.287945793577      0
jpeg:enc-jpegli:Q85:YUV422      12845  2553203    1.5901545   0.629  34.211   1.90352311  81.45017077   0.81102224  1.289650689952      0
jpeg:enc-jpegli:Q85:YUV420      12845  2231975    1.3900913   0.696  35.854   2.19160654  79.21549136   0.92380823  1.284177734414      0
jpeg:enc-jpegli:Q80:YUV420      12845  1912356    1.1910301   0.699  35.048   2.55097285  76.11420459   1.08663970  1.294220560174      0
jpeg:enc-jpegli:Q75:YUV420      12845  1645258    1.0246794   0.713  38.829   3.00152883  72.62325235   1.25722022  1.288247637330      0
jpeg:enc-jpegli:Q70:YUV420      12845  1468621    0.9146685   0.701  37.320   3.34347633  69.71062523   1.39940829  1.279994671403      0
jpeg:enc-jpegli:Q65:YUV420      12845  1340781    0.8350488   0.714  41.043   3.73456385  67.14261872   1.52434977  1.272906376463      0
jpeg:enc-jpegli:Q50:YUV420      12845  1057024    0.6583227   0.801  45.284   4.49598727  58.54722155   1.91505119  1.260721680506      0
Aggregate:                      12845  1978982    1.2325255   0.687  35.935   2.45109968  74.74567377   1.03894575  1.280527126550      0
```

Images for viewing:
BEFORE:
https://storage.googleapis.com/jxl-quality/eval/szabadka/jyrki31/d86b8ca0/base/index.jpeg_enc-jpegli_Q75_YUV420.html https://storage.googleapis.com/jxl-quality/eval/szabadka/jyrki31/d86b8ca0/base/index.jpeg_enc-jpegli_Q90.html 

AFTER:
https://storage.googleapis.com/jxl-quality/eval/szabadka/jyrki31/8c2c74e5/exp/index.jpeg_enc-jpegli_Q75_YUV420.html https://storage.googleapis.com/jxl-quality/eval/szabadka/jyrki31/8c2c74e5/exp/index.jpeg_enc-jpegli_Q90.html