### PR TITLE
Use different quant matrices for 444 and 420 modes.

### DIFF
--- a/lib/jpegli/encode_api_test.cc
+++ b/lib/jpegli/encode_api_test.cc
@@ -399,7 +399,7 @@ std::vector<TestConfig> GenerateTests() {
             config.jparams.optimize_coding = optimize;
           }
           const float kMaxBpp[4] = {1.55, 1.45, 1.45, 1.32};
-          const float kMaxDist[4] = {1.95, 2.1, 2.1, 2.3};
+          const float kMaxDist[4] = {1.95, 2.1, 2.1, 2.0};
           const int idx = v_samp * 2 + h_samp - 3;
           config.max_bpp =
               kMaxBpp[idx] * (optimize ? 0.97 : 1.0) * (progr ? 0.97 : 1.0);

--- a/lib/jpegli/entropy_coding.cc
+++ b/lib/jpegli/entropy_coding.cc
@@ -470,7 +470,7 @@ void CopyHuffmanTable(j_compress_ptr cinfo, int index, bool is_dc,
   JHUFF_TBL* table =
       is_dc ? cinfo->dc_huff_tbl_ptrs[index] : cinfo->ac_huff_tbl_ptrs[index];
   if (table == nullptr) {
-    JPEGLI_ERROR("Missing %s Huffman table %d", table, index);
+    JPEGLI_ERROR("Missing %s Huffman table %d", type, index);
   }
   ValidateHuffmanTable(reinterpret_cast<j_common_ptr>(cinfo), table, is_dc);
   JPEGHuffmanCode huff = {};

--- a/lib/jpegli/test_utils.cc
+++ b/lib/jpegli/test_utils.cc
@@ -485,7 +485,6 @@ void EncodeWithJpegli(const TestImage& input, const CompressParams& jparams,
   jpegli_set_defaults(cinfo);
   cinfo->in_color_space = input.color_space;
   jpegli_default_colorspace(cinfo);
-  jpegli_set_quality(cinfo, jparams.quality, TRUE);
   if (jparams.override_JFIF >= 0) {
     cinfo->write_JFIF_header = jparams.override_JFIF;
   }
@@ -506,6 +505,7 @@ void EncodeWithJpegli(const TestImage& input, const CompressParams& jparams,
       cinfo->comp_info[c].v_samp_factor = jparams.v_sampling[c];
     }
   }
+  jpegli_set_quality(cinfo, jparams.quality, TRUE);
   if (!jparams.quant_indexes.empty()) {
     for (int c = 0; c < cinfo->num_components; ++c) {
       cinfo->comp_info[c].quant_tbl_no = jparams.quant_indexes[c];

--- a/tools/scripts/jpegli_tools_test.sh
+++ b/tools/scripts/jpegli_tools_test.sh
@@ -160,7 +160,7 @@ main() {
   cjpegli_test "${rgb_in}" "-q 80" 84 1.2
   cjpegli_test "${rgb_in}" "-q 95" 91.5 2.4
   cjpegli_test "${rgb_in}" "-d 0.5" 92 2.6
-  cjpegli_test "${rgb_in}" "--chroma_subsampling 420" 85.5 1.5
+  cjpegli_test "${rgb_in}" "--chroma_subsampling 420" 87 1.5
   cjpegli_test "${rgb_in}" "--chroma_subsampling 440" 87 1.6
   cjpegli_test "${rgb_in}" "--chroma_subsampling 422" 87 1.6
   cjpegli_test "${rgb_in}" "--std_quant" 91 2.2


### PR DESCRIPTION
Benchmark on jyrki31 corpus:

```
Encoding                             kPixels    Bytes          BPP  E MP/s  D MP/s     Max norm  SSIMULACRA2        pnorm       BPP*pnorm   Bugs
------------------------------------------------------------------------------------------------------------------------------------------------
BEFORE:
jpeg:enc-jpegli:yuv420                 13270  3065816    1.8482063  14.104  54.140   3.22283839  76.87140839   1.02752502  1.899078256579      0
jpeg:enc-jpegli:yuv420:Q85:YUV420      13270  2454814    1.4798679   1.242  60.195   3.61167194  72.99267191   1.18053870  1.747041371858      0
jpeg:enc-jpegli:yuv420:Q75:YUV420      13270  1776259    1.0708057   1.506  70.731   4.30828297  65.92608268   1.48627252  1.591509038309      0
jpeg:enc-jpegli:yuv420:Q65:YUV420      13270  1430266    0.8622261   1.619  78.259   5.19631320  60.66837901   1.74783017  1.507024858728      0
Aggregate:                             13270  2091086    1.2605971   2.556  65.171   4.01778405  68.82812525   1.33234771  1.679553700538      0
AFTER:
jpeg:enc-jpegli:yuv420                 13270  3055710    1.8421140  11.052  38.893   2.81253866  80.76922056   0.94469674  1.740239091139      0
jpeg:enc-jpegli:yuv420:Q85:YUV420      13270  2454388    1.4796111   0.963  41.855   3.01110105  77.51595506   1.06563770  1.576729398082      0
jpeg:enc-jpegli:yuv420:Q75:YUV420      13270  1776864    1.0711704   1.202  50.952   3.42097622  71.25655744   1.31499581  1.408584569621      0
jpeg:enc-jpegli:yuv420:Q65:YUV420      13270  1431127    0.8627452   1.121  57.855   4.00559916  65.79418837   1.54049991  1.329058883797      0
Aggregate:                             13270  2089762    1.2597991   1.946  46.803   3.28216449  73.60585151   1.19501129  1.505474170206      0
```

Benchmark on CID22 validation corpus:

```
Encoding                             kPixels    Bytes          BPP  E MP/s  D MP/s     Max norm  SSIMULACRA2        pnorm       BPP*pnorm   Bugs
------------------------------------------------------------------------------------------------------------------------------------------------
BEFORE:
jpeg:enc-jpegli:yuv420                 12845  2772359    1.7266466  11.924  59.158   3.23885945  78.43622260   1.00433947  1.734139317543      0
jpeg:enc-jpegli:yuv420:Q85:YUV420      12845  2232164    1.3902090   1.146  61.650   3.60996073  74.58302957   1.16778051  1.623458934026      0
jpeg:enc-jpegli:yuv420:Q75:YUV420      12845  1645594    1.0248886   1.381  76.587   4.62293383  68.04288919   1.46695799  1.503468582645      0
jpeg:enc-jpegli:yuv420:Q65:YUV420      12845  1340561    0.8349117   1.454  84.748   5.36054913  62.89450449   1.72583282  1.440918074536      0
Aggregate:                             12845  1922190    1.1971545   2.289  69.752   4.12577352  70.73559878   1.31269714  1.571501264083      0
AFTER:
jpeg:enc-jpegli:yuv420                 12845  2759074    1.7183726   8.695  41.276   2.83599517  81.50844080   0.96197146  1.653025386161      0
jpeg:enc-jpegli:yuv420:Q85:YUV420      12845  2232274    1.3902775   0.948  47.538   3.01113478  78.27419424   1.07915926  1.500330811612      0
jpeg:enc-jpegli:yuv420:Q75:YUV420      12845  1645427    1.0247846   1.019  52.923   3.53979471  72.41135790   1.33083206  1.363816241317      0
jpeg:enc-jpegli:yuv420:Q65:YUV420      12845  1340200    0.8346869   0.988  59.539   3.98547815  67.08223383   1.56186725  1.303670136322      0
Aggregate:                             12845  1919728    1.1956216   1.698  49.865   3.31301611  74.61202889   1.21200323  1.449097247945      0
```