### PR TITLE
Add read-only token permissions

### DIFF
--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -17,6 +17,9 @@ on:
       - '**.md'
       - 'AUTHORS'
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event_name }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}

--- a/.github/workflows/build_test_cross.yml
+++ b/.github/workflows/build_test_cross.yml
@@ -17,6 +17,9 @@ on:
       - '**.md'
       - 'AUTHORS'
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event_name }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}

--- a/.github/workflows/build_test_md.yml
+++ b/.github/workflows/build_test_md.yml
@@ -11,6 +11,10 @@ on:
     types: [opened, reopened, labeled, synchronize]
     paths:
       - '**.md'
+
+permissions:
+  contents: read
+
 jobs:
   ubuntu-build:
     name: Ubuntu Build ${{ matrix.name }}

--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -17,6 +17,9 @@ on:
       - '**.md'
       - 'AUTHORS'
 
+permissions:
+  contents: read
+
 env:
   LIBJXL_VERSION:  0.9.0
   LIBJXL_ABI_VERSION:  0.9

--- a/.github/workflows/debug_ci.yml
+++ b/.github/workflows/debug_ci.yml
@@ -11,6 +11,9 @@ on:
     branches:
       - ci-*-debug
 
+permissions:
+  contents: read
+
 jobs:
   cross_compile_ubuntu:
     name: Cross-compiling ${{ matrix.build_target }} ${{ matrix.variant }} 

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -19,6 +19,9 @@ on:
       - '**CMakeLists.txt'
       - .github/workflows/fuzz.yml
 
+permissions:
+  contents: read
+
 concurrency: 
   group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event_name }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -10,6 +10,9 @@ on:
   pull_request:
     types: [opened, reopened, synchronize]
 
+permissions:
+  contents: read
+
 jobs:
   # Checks that the AUTHORS files is updated with new contributors.
   authors:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -25,6 +25,9 @@ on:
   release:
     types: [ published ]
 
+permissions:
+  contents: read
+
 jobs:
   ubuntu_static_x86_64:
     name: Release linux x86_64 static

--- a/.github/workflows/test_new_highway.yml
+++ b/.github/workflows/test_new_highway.yml
@@ -12,6 +12,9 @@ on:
   schedule:
     - cron: '37 2 * * *' # Daily on 02:37 UTC
 
+permissions:
+  contents: read
+
 jobs:
   update:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Fixes #2484.

As described in the issue, this PR ensures workflows run with minimal permissions, protecting the project from supply-chain attacks.