### PR TITLE
Don't use full image buffer in optimized-code jpegli encoder.

### DIFF
--- a/lib/jpegli/bitstream.h
+++ b/lib/jpegli/bitstream.h
@@ -32,6 +32,8 @@ void EncodeSingleScan(j_compress_ptr cinfo);
 
 void WriteiMCURow(j_compress_ptr cinfo);
 
+void ProgressMonitorEncodePass(j_compress_ptr cinfo, size_t scan_index);
+
 }  // namespace jpegli
 
 #endif  // LIB_JPEGLI_BITSTREAM_H_

--- a/lib/jpegli/encode_internal.h
+++ b/lib/jpegli/encode_internal.h
@@ -52,6 +52,18 @@ struct ScanCodingInfo {
 
 typedef int16_t coeff_t;
 
+struct Token {
+  uint8_t histo_idx;
+  uint8_t symbol;
+  uint16_t bits;
+  Token(int i, int s, int b) : histo_idx(i), symbol(s), bits(b) {}
+};
+
+struct TokenArray {
+  Token* tokens;
+  size_t num_tokens;
+};
+
 }  // namespace jpegli
 
 struct jpeg_comp_master {
@@ -96,6 +108,11 @@ struct jpeg_comp_master {
   jpegli::JpegBitWriter bw;
   float* dct_buffer;
   int32_t* block_tmp;
+  jpegli::TokenArray* token_arrays;
+  size_t cur_token_array;
+  jpegli::Token* next_token;
+  size_t num_tokens;
+  size_t total_num_tokens;
 };
 
 #endif  // LIB_JPEGLI_ENCODE_INTERNAL_H_

--- a/lib/jpegli/entropy_coding.cc
+++ b/lib/jpegli/entropy_coding.cc
@@ -565,7 +565,8 @@ void OptimizeHuffmanCodes(j_compress_ptr cinfo, bool* is_baseline) {
   // Add the first 4 DC and AC histograms in the first DHT segment.
   std::vector<uint32_t> dc_slot_histograms;
   std::vector<uint32_t> ac_slot_histograms;
-  m->huffman_codes = Allocate<JPEGHuffmanCode>(cinfo, num_histo, JPOOL_IMAGE);
+  m->huffman_codes =
+      Allocate<JPEGHuffmanCode>(cinfo, 2 * num_histo, JPOOL_IMAGE);
   for (size_t i = 0; i < dc_clusters.histograms.size(); ++i) {
     if (i >= 4) break;
     JXL_ASSERT(dc_clusters.slot_ids[i] == i);


### PR DESCRIPTION
Memory benchmarking results:

```
                                                   cjpeg    per       djpeg    per
Input           Encode args          Pixels     peak mem  pixel    peak mem  pixel
----------------------------------------------------------------------------------
BEFORE:
tiny.ppm        -sample 2x2             256       295468             243923
tiny.ppm        -sample 2x2 -o          256       336785             243560
tiny.ppm        -sample 2x2 -p          256       598884             243708
stp2.ppm        -sample 2x2          960000      1574892   1.64      918424   0.96
stp2.ppm        -sample 2x2 -o       960000      7527369   7.84      918765   0.96
stp2.ppm        -sample 2x2 -p       960000      5947204   6.20     4869331   5.07
NC003.ppm       -sample 2x2        45441024      9203724   0.20     4212018   0.09
NC003.ppm       -sample 2x2 -o     45441024    233570985   5.14     4212633   0.09
NC003.ppm       -sample 2x2 -p     45441024    156027940   3.43   150270602   3.31
AFTER:
tiny.ppm        -sample 2x2             256       295508             243923
tiny.ppm        -sample 2x2 -o          256       302713             243560
tiny.ppm        -sample 2x2 -p          256       615484             243708
stp2.ppm        -sample 2x2          960000      1574932   1.64      918424   0.96
stp2.ppm        -sample 2x2 -o       960000      3429281   3.57      918765   0.96
stp2.ppm        -sample 2x2 -p       960000      5963804   6.21     4869331   5.07
NC003.ppm       -sample 2x2        45441024      9203764   0.20     4212018   0.09
NC003.ppm       -sample 2x2 -o     45441024     87025377   1.92     4212633   0.09
NC003.ppm       -sample 2x2 -p     45441024    156044540   3.43   150270602   3.31
```