### PR TITLE
Move horizontal upsampling after vertical upsampling.

### DIFF
--- a/lib/jpegli/decode.cc
+++ b/lib/jpegli/decode.cc
@@ -491,8 +491,9 @@ void AllocateOutputBuffers(j_decompress_ptr cinfo) {
   for (int c = 0; c < cinfo->num_components; ++c) {
     const auto& comp = cinfo->comp_info[c];
     size_t cheight = comp.v_samp_factor * m->scaled_dct_size[c];
+    int downsampled_width = output_stride / m->h_factor[c];
     m->raw_height_[c] = cinfo->total_iMCU_rows * cheight;
-    m->raw_output_[c].Allocate(cinfo, 3 * cheight, output_stride);
+    m->raw_output_[c].Allocate(cinfo, 3 * cheight, downsampled_width);
   }
   int num_all_components =
       std::max(cinfo->out_color_components, cinfo->num_components);


### PR DESCRIPTION
Memory benchmark results:

```
                                                   cjpeg    per       djpeg    per
Input           Encode args          Pixels     peak mem  pixel    peak mem  pixel
----------------------------------------------------------------------------------
BEFORE:
tiny.ppm        -sample 2x2             256       295508             211923
tiny.ppm        -sample 2x2 -o          256       302713             211560
tiny.ppm        -sample 2x2 -p          256       583484             211708
stp2.ppm        -sample 2x2          960000      1574932   1.64      894104   0.93
stp2.ppm        -sample 2x2 -o       960000      3429281   3.57      894445   0.93
stp2.ppm        -sample 2x2 -p       960000      4747804   4.95     3714771   3.87
NC003.ppm       -sample 2x2        45441024      9203764   0.20     4182322   0.09
NC003.ppm       -sample 2x2 -o     45441024     87025377   1.92     4182937   0.09
NC003.ppm       -sample 2x2 -p     45441024    145829116   3.21   140116630   3.08
AFTER:
tiny.ppm        -sample 2x2             256       295508             208851
tiny.ppm        -sample 2x2 -o          256       302713             208488
tiny.ppm        -sample 2x2 -p          256       583484             208636
stp2.ppm        -sample 2x2          960000      1574932   1.64      777368   0.81
stp2.ppm        -sample 2x2 -o       960000      3429281   3.57      777709   0.81
stp2.ppm        -sample 2x2 -p       960000      4747804   4.95     3598035   3.75
NC003.ppm       -sample 2x2        45441024      9203764   0.20     3389746   0.07
NC003.ppm       -sample 2x2 -o     45441024     87025377   1.92     3390361   0.07
NC003.ppm       -sample 2x2 -p     45441024    145829116   3.21   139324054   3.07
```