### PR TITLE
Don't use context rows for non-chroma-subsampled images.

### DIFF
--- a/lib/jpegli/decode_internal.h
+++ b/lib/jpegli/decode_internal.h
@@ -98,6 +98,7 @@ struct jpeg_decomp_master {
   JpegliDataType output_data_type_ = JPEGLI_TYPE_UINT8;
   bool swap_endianness_ = false;
   size_t xoffset_;
+  bool need_context_rows_;
 
   int min_scaled_dct_size;
   int scaled_dct_size[jpegli::kMaxComponents];

--- a/lib/jpegli/render.cc
+++ b/lib/jpegli/render.cc
@@ -667,17 +667,19 @@ void ProcessOutput(j_decompress_ptr cinfo, size_t* num_output_rows,
   jpeg_decomp_master* m = cinfo->master;
   const int vfactor = cinfo->max_v_samp_factor;
   const int hfactor = cinfo->max_h_samp_factor;
+  const size_t context = m->need_context_rows_ ? 1 : 0;
   const size_t imcu_row = cinfo->output_iMCU_row;
   const size_t imcu_height = vfactor * m->min_scaled_dct_size;
   const size_t imcu_width = hfactor * m->min_scaled_dct_size;
   const size_t output_width = m->iMCU_cols_ * imcu_width;
   if (imcu_row == cinfo->total_iMCU_rows ||
-      (imcu_row > 1 && cinfo->output_scanline < (imcu_row - 1) * imcu_height)) {
+      (imcu_row > context &&
+       cinfo->output_scanline < (imcu_row - context) * imcu_height)) {
     // We are ready to output some scanlines.
     size_t ybegin = cinfo->output_scanline;
-    size_t yend =
-        (imcu_row == cinfo->total_iMCU_rows ? cinfo->output_height
-                                            : (imcu_row - 1) * imcu_height);
+    size_t yend = (imcu_row == cinfo->total_iMCU_rows
+                       ? cinfo->output_height
+                       : (imcu_row - context) * imcu_height);
     yend = std::min<size_t>(yend, ybegin + max_output_rows - *num_output_rows);
     size_t yb = (ybegin / vfactor) * vfactor;
     size_t ye = DivCeil(yend, vfactor) * vfactor;


### PR DESCRIPTION
Memory benchmark results:

```
                                                   cjpeg    per       djpeg    per
Input           Encode args          Pixels     peak mem  pixel    peak mem  pixel
----------------------------------------------------------------------------------
BEFORE:
tiny.ppm        -sample 1x1             256       272996             206739
tiny.ppm        -sample 1x1 -o          256       281913             206381
tiny.ppm        -sample 1x1 -p          256       561572             207314
stp2.ppm        -sample 1x1          960000      1090276   1.14      760958   0.79
stp2.ppm        -sample 1x1 -o       960000      2947513   3.07      761577   0.79
stp2.ppm        -sample 1x1 -p       960000      7143764   7.44     6462516   6.73
NC003.ppm       -sample 1x1        45441024      5962308   0.13     3287009   0.07
NC003.ppm       -sample 1x1 -o     45441024     92902437   2.04     3287354   0.07
NC003.ppm       -sample 1x1 -p     45441024    278916052   6.14   275549821   6.06
AFTER:
tiny.ppm        -sample 1x1             256       272996             197523
tiny.ppm        -sample 1x1 -o          256       281913             197165
tiny.ppm        -sample 1x1 -p          256       561572             198098
stp2.ppm        -sample 1x1          960000      1090276   1.14      524414   0.55
stp2.ppm        -sample 1x1 -o       960000      2947513   3.07      525033   0.55
stp2.ppm        -sample 1x1 -p       960000      7143764   7.44     6225972   6.49
NC003.ppm       -sample 1x1        45441024      5962308   0.13     1695713   0.04
NC003.ppm       -sample 1x1 -o     45441024     92902437   2.04     1696058   0.04
NC003.ppm       -sample 1x1 -p     45441024    278916052   6.14   273958525   6.03
```