### PR TITLE
Accumulate refinement bits in fixed size array instead of vector.

### DIFF
--- a/lib/jpegli/encode_internal.h
+++ b/lib/jpegli/encode_internal.h
@@ -33,9 +33,6 @@ struct JPEGHuffmanCode {
   boolean sent_table;
 };
 
-// DCTCodingState: maximum number of correction bits to buffer
-const int kJPEGMaxCorrectionBits = 1u << 16;
-
 constexpr int kDefaultProgressiveLevel = 0;
 
 struct HuffmanCodeTable {

--- a/lib/jpegli/entropy_coding.cc
+++ b/lib/jpegli/entropy_coding.cc
@@ -179,8 +179,7 @@ static JXL_INLINE void ProcessEndOfBand(DCTState* s, size_t new_refinement_bits,
   }
   ++s->eob_run;
   s->num_refinement_bits += new_refinement_bits;
-  if (s->eob_run == 0x7FFF ||
-      s->num_refinement_bits > kJPEGMaxCorrectionBits - kDCTBlockSize + 1) {
+  if (s->eob_run == 0x7FFF) {
     ProcessFlush(s);
   }
 }
@@ -316,8 +315,8 @@ bool ProcessRefinementBits(const coeff_t* coeffs, Histogram* ac_histo, int Ss,
       r++;
       continue;
     }
+    ProcessFlush(s);
     while (r > 15 && k <= eob) {
-      ProcessFlush(s);
       ++ac_histo->count[0xf0];
       r -= 16;
       num_refinement_bits = 0;
@@ -326,7 +325,6 @@ bool ProcessRefinementBits(const coeff_t* coeffs, Histogram* ac_histo, int Ss,
       ++num_refinement_bits;
       continue;
     }
-    ProcessFlush(s);
     int symbol = (r << 4u) + 1;
     ++ac_histo->count[symbol];
     num_refinement_bits = 0;


### PR DESCRIPTION
Benchmark results (encoder only):

```
Encoding               kPixels    Bytes          BPP  E MP/s  D MP/s     Max norm  SSIMULACRA2        pnorm       BPP*pnorm   Bugs
----------------------------------------------------------------------------------------------------------------------------------
BEFORE:
jpeg:enc-jpegli:q90      13270  3540894    2.1346039  19.456  70.956   0.99999997   0.00000000   0.00000000  0.000000000000      0
jpeg:enc-jpegli:q75      13270  2093320    1.2619437  22.268  91.640   0.99999997   0.00000000   0.00000000  0.000000000000      0
AFTER:
jpeg:enc-jpegli:q90      13270  3542281    2.1354400  21.752  67.721   0.99999997   0.00000000   0.00000000  0.000000000000      0
jpeg:enc-jpegli:q75      13270  2093148    1.2618400  25.933  91.867   0.99999997   0.00000000   0.00000000  0.000000000000      0
```