### PR TITLE
0.1 % quality improvement

### DIFF
--- a/lib/jxl/decode_test.cc
+++ b/lib/jxl/decode_test.cc
@@ -1677,7 +1677,7 @@ TEST(DecodeTest, PixelTestWithICCProfileLossy) {
   jxl::ButteraugliParams ba;
   EXPECT_THAT(ButteraugliDistance(io0.frames, io1.frames, ba, jxl::GetJxlCms(),
                                   /*distmap=*/nullptr, nullptr),
-              IsSlightlyBelow(0.611f));
+              IsSlightlyBelow(0.89898f));
 
   JxlDecoderDestroy(dec);
 }
@@ -1986,7 +1986,7 @@ TEST(DecodeTest, PixelTestOpaqueSrgbLossyNoise) {
     EXPECT_THAT(
         ButteraugliDistance(io0.frames, io1.frames, ba, jxl::GetJxlCms(),
                             /*distmap=*/nullptr, nullptr),
-        IsSlightlyBelow(1.7f));
+        IsSlightlyBelow(1.74444f));
 
     JxlDecoderDestroy(dec);
   }

--- a/lib/jxl/enc_adaptive_quantization.cc
+++ b/lib/jxl/enc_adaptive_quantization.cc
@@ -729,7 +729,7 @@ ImageF TileDistMap(const ImageF& distmap, int tile_size, int margin,
 
 static const float kDcQuantPow = 0.83;
 static const float kDcQuant = 1.095924047623553f;
-static const float kAcQuant = 0.81151132443618624f;
+static const float kAcQuant = 0.762;
 
 void FindBestQuantization(const ImageBundle& linear, const Image3F& opsin,
                           PassesEncoderState* enc_state,

--- a/lib/jxl/jxl_test.cc
+++ b/lib/jxl/jxl_test.cc
@@ -107,7 +107,7 @@ TEST(JxlTest, RoundtripTinyFast) {
   cparams.distance = 4.0f;
 
   PackedPixelFile ppf_out;
-  EXPECT_NEAR(Roundtrip(t.ppf(), cparams, {}, pool, &ppf_out), 192, 10);
+  EXPECT_NEAR(Roundtrip(t.ppf(), cparams, {}, pool, &ppf_out), 181, 15);
 }
 
 TEST(JxlTest, RoundtripSmallD1) {
@@ -203,7 +203,7 @@ TEST(JxlTest, RoundtripOutOfOrderProcessing) {
   cparams.AddOption(JXL_ENC_FRAME_SETTING_EPF, 3);
 
   PackedPixelFile ppf_out;
-  EXPECT_NEAR(Roundtrip(t.ppf(), cparams, {}, &pool, &ppf_out), 23042, 400);
+  EXPECT_NEAR(Roundtrip(t.ppf(), cparams, {}, &pool, &ppf_out), 24102, 400);
   EXPECT_LE(ButteraugliDistance(t.ppf(), ppf_out), 1.35);
 }
 
@@ -238,7 +238,7 @@ TEST(JxlTest, RoundtripResample4) {
   cparams.AddOption(JXL_ENC_FRAME_SETTING_RESAMPLING, 4);
 
   PackedPixelFile ppf_out;
-  EXPECT_NEAR(Roundtrip(t.ppf(), cparams, {}, pool, &ppf_out), 5824, 100);
+  EXPECT_NEAR(Roundtrip(t.ppf(), cparams, {}, pool, &ppf_out), 5635, 100);
   EXPECT_THAT(ButteraugliDistance(t.ppf(), ppf_out), IsSlightlyBelow(22));
 }
 
@@ -296,9 +296,9 @@ TEST(JxlTest, RoundtripMultiGroup) {
   };
 
   auto run_kitten = std::async(std::launch::async, test, SpeedTier::kKitten,
-                               1.0f, 54895u, 11.7);
+                               1.0f, 56570u, 11.7);
   auto run_wombat = std::async(std::launch::async, test, SpeedTier::kWombat,
-                               2.0f, 33507u, 20.0);
+                               2.0f, 35274u, 20.0);
 }
 
 TEST(JxlTest, RoundtripRGBToGrayscale) {
@@ -374,7 +374,7 @@ TEST(JxlTest, RoundtripDotsForceEpf) {
   cparams.AddOption(JXL_ENC_FRAME_SETTING_DOTS, 1);
 
   PackedPixelFile ppf_out;
-  EXPECT_NEAR(Roundtrip(t.ppf(), cparams, {}, &pool, &ppf_out), 41472, 300);
+  EXPECT_NEAR(Roundtrip(t.ppf(), cparams, {}, &pool, &ppf_out), 41087, 300);
   EXPECT_THAT(ComputeDistance2(t.ppf(), ppf_out), IsSlightlyBelow(18));
 }
 
@@ -515,7 +515,7 @@ TEST(JxlTest, RoundtripSmallPatchesAlpha) {
 
   PackedPixelFile ppf_out;
   EXPECT_NEAR(Roundtrip(t.ppf(), cparams, {}, pool, &ppf_out), 597, 100);
-  EXPECT_THAT(ButteraugliDistance(t.ppf(), ppf_out), IsSlightlyBelow(0.012f));
+  EXPECT_THAT(ButteraugliDistance(t.ppf(), ppf_out), IsSlightlyBelow(0.019f));
 }
 
 TEST(JxlTest, RoundtripSmallPatches) {
@@ -540,7 +540,7 @@ TEST(JxlTest, RoundtripSmallPatches) {
 
   PackedPixelFile ppf_out;
   EXPECT_NEAR(Roundtrip(t.ppf(), cparams, {}, pool, &ppf_out), 486, 100);
-  EXPECT_THAT(ButteraugliDistance(t.ppf(), ppf_out), IsSlightlyBelow(0.012f));
+  EXPECT_THAT(ButteraugliDistance(t.ppf(), ppf_out), IsSlightlyBelow(0.019f));
 }
 
 // TODO(szabadka) Add encoder and decoder API functions that accept frame
@@ -1128,7 +1128,7 @@ TEST(JxlTest, RoundtripDots) {
   cparams.distance = 0.04;
 
   PackedPixelFile ppf_out;
-  EXPECT_NEAR(Roundtrip(t.ppf(), cparams, {}, pool, &ppf_out), 284295, 3000);
+  EXPECT_NEAR(Roundtrip(t.ppf(), cparams, {}, pool, &ppf_out), 274240, 3000);
   EXPECT_THAT(ButteraugliDistance(t.ppf(), ppf_out), IsSlightlyBelow(0.35));
 }
 
@@ -1239,7 +1239,7 @@ TEST(JxlTest, RoundtripAnimationPatches) {
               IsSlightlyBelow(16789));
   EXPECT_EQ(ppf_out.frames.size(), t.ppf().frames.size());
   // >10 with broken patches
-  EXPECT_THAT(ButteraugliDistance(t.ppf(), ppf_out), IsSlightlyBelow(1.0777));
+  EXPECT_THAT(ButteraugliDistance(t.ppf(), ppf_out), IsSlightlyBelow(1.0999));
 }
 
 #endif  // JPEGXL_ENABLE_GIF
@@ -1443,7 +1443,7 @@ TEST(JxlTest, RoundtripProgressive) {
   cparams.AddOption(JXL_ENC_FRAME_SETTING_RESPONSIVE, 1);
 
   PackedPixelFile ppf_out;
-  EXPECT_NEAR(Roundtrip(t.ppf(), cparams, {}, &pool, &ppf_out), 61635, 750);
+  EXPECT_NEAR(Roundtrip(t.ppf(), cparams, {}, &pool, &ppf_out), 63570, 750);
   EXPECT_THAT(ButteraugliDistance(t.ppf(), ppf_out), IsSlightlyBelow(1.4));
 }
 
@@ -1460,7 +1460,7 @@ TEST(JxlTest, RoundtripProgressiveLevel2Slow) {
   cparams.AddOption(JXL_ENC_FRAME_SETTING_RESPONSIVE, 1);
 
   PackedPixelFile ppf_out;
-  EXPECT_NEAR(Roundtrip(t.ppf(), cparams, {}, &pool, &ppf_out), 72841, 1000);
+  EXPECT_NEAR(Roundtrip(t.ppf(), cparams, {}, &pool, &ppf_out), 74621, 1000);
   EXPECT_THAT(ButteraugliDistance(t.ppf(), ppf_out), IsSlightlyBelow(1.17));
 }
 

--- a/lib/jxl/passes_test.cc
+++ b/lib/jxl/passes_test.cc
@@ -96,7 +96,7 @@ TEST(PassesTest, RoundtripMultiGroupPasses) {
   };
 
   auto run1 = std::async(std::launch::async, test, 1.0f, 0.5f);
-  auto run2 = std::async(std::launch::async, test, 2.0f, 0.5f);
+  auto run2 = std::async(std::launch::async, test, 2.0f, 0.0f);
 }
 
 TEST(PassesTest, RoundtripLargeFastPasses) {


### PR DESCRIPTION
reduce quantization when large blocks are used with lots of quantization error, but not large coefficient values and the masking is low

```
Before:

Encoding      kPixels    Bytes          BPP  E MP/s  D MP/s     Max norm  SSIMULACRA2        pnorm   PSNR   QABPP  SmallB  DCT4x8     AFV  DCT8x8    8x16    8x32      16   16x32      32   32x64      64       BPP*pnorm   Bugs
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
jxl:d0.1        19988 16609463    6.6477416   1.360   9.336   0.35353178  95.48321280   0.11547700  53.20   6.648 42.2069 18.2557  0.4579 27.5521  4.8560  0.0000  2.3809  0.8991  3.9345  0.1025  0.0820  0.767661287801      0
jxl:d0.5        19988  6418235    2.5688228   1.849  15.256   0.78360793  91.47222570   0.34784750  44.76   2.595 14.3282 25.2637  0.5715 12.2537 20.7266  0.0000 20.8162  1.2295  5.1077  0.1434  0.2869  0.893558611311      0
jxl:d0.8        19988  4749001    1.9007316   1.908  15.667   1.09299541  88.76910888   0.48042532  41.66   2.162 10.8798 21.9981  0.7060  9.0476 19.1608  0.0000 29.4831  1.5625  7.1928  0.2049  0.4918  0.913159593145      0
jxl:d1          19988  4097554    1.6399976   1.918  16.132   1.28714387  87.04977497   0.56373878  40.48   2.183  9.6156 20.1582  0.7457  7.8969 17.8032  0.0000 30.8395  2.5000 10.5535  0.1844  0.4303  0.924530273169      0
jxl:d1.1        19988  3858566    1.5443455   2.078  17.331   1.40323481  86.18913181   0.60289883  40.01   2.237  9.1302 19.3792  0.7675  7.4957 17.2929  0.0000 30.5423  3.2762 12.2082  0.2049  0.4303  0.931084108279      0
jxl:d1.2        19988  3643813    1.4583932   1.970  17.008   1.50159330  85.37331677   0.64052088  39.57   2.258  8.6874 18.7363  0.8069  7.1069 16.6313  0.0000 30.1850  4.0703 13.8476  0.1844  0.4713  0.934131264689      0
jxl:d1.3        19988  3468075    1.3880561   1.980  17.043   1.55456911  84.73540423   0.67335696  39.17   2.238  8.2587 18.1455  0.8290  6.8716 16.1389  0.0000 29.5638  4.8848 15.2872  0.2562  0.4918  0.934657237641      0
jxl:d1.4        19988  3299558    1.3206092   2.011  17.072   1.65134373  83.95808974   0.71050048  38.81   2.283  7.9058 17.6345  0.8626  6.5485 15.7681  0.0000 28.6109  5.9069 16.5679  0.2664  0.6558  0.938293448414      0
jxl:d1.5        19988  3152892    1.2619078   2.062  16.496   1.74920984  83.23248501   0.74411338  38.48   2.299  7.5866 17.1011  0.8751  6.3788 15.5356  0.0000 27.6734  6.7291 17.8846  0.2869  0.6762  0.939002501723      0
jxl:d1.6        19988  3012660    1.2057816   1.873  16.303   1.83253313  82.45912463   0.78064911  38.15   2.300  7.2706 16.8148  0.8808  6.1589 15.1918  0.0000 26.7282  7.6103 19.1192  0.3176  0.6353  0.941292350196      0
jxl:d1.7        19988  2888582    1.1561209   2.062  16.752   1.93669216  81.73198269   0.81526439  37.86   2.314  7.0058 16.4194  0.8937  5.9821 14.9055  0.0000 25.7997  8.5837 20.1336  0.3074  0.6967  0.942544167030      0
jxl:d1.8        19988  2778537    1.1120767   2.003  16.895   2.01501361  81.03872051   0.84886291  37.59   2.322  6.7788 16.0428  0.9237  5.8358 14.8338  0.0000 24.8647  9.4290 20.9533  0.4098  0.6558  0.944000625864      0
jxl:d1.9        19988  2677936    1.0718123   2.073  16.627   2.12369407  80.33511266   0.88028235  37.29   2.374  6.5431 15.7335  0.9442  5.7237 14.7083  0.0000 23.9797 10.1693 21.8191  0.3894  0.7172  0.943497443256      0
jxl:d2.0        19988  2584248    1.0343148   2.162  16.252   2.17759993  79.64471880   0.91392713  37.06   2.350  6.3481 15.4117  0.9737  5.5950 14.5187  0.0000 23.2125 11.1119 22.4287  0.3279  0.7992  0.945288329857      0
jxl:d2.1        19988  2496139    0.9990502   2.031  16.661   2.29749150  78.92568037   0.94598818  36.82   2.395  6.1915 15.0265  0.9849  5.4416 14.3548  0.0000 22.5286 11.8138 23.0947  0.3894  0.9017  0.945089663147      0
jxl:d2.2        19988  2417255    0.9674778   2.145  17.363   2.37253000  78.27215579   0.97795938  36.62   2.412  5.9716 14.7294  0.9910  5.3238 14.1972  0.0000 21.9292 12.5848 23.6685  0.4303  0.9017  0.946153984280      0
jxl:d2.3        19988  2338566    0.9359835   2.018  17.115   2.44720064  77.57634514   1.01122825  36.37   2.394  5.8019 14.4297  1.0083  5.2809 14.0685  0.0000 21.2081 13.3353 24.2423  0.4508  0.9017  0.946492903922      0
jxl:d2.4        19988  2268757    0.9080432   2.112  17.364   2.53334947  76.87528656   1.04431474  36.19   2.397  5.6504 14.1316  1.0246  5.1711 13.9891  0.0000 20.6625 14.1806 24.4421  0.4508  1.0246  0.948282924964      0
jxl:d2.5        19988  2199458    0.8803071   2.039  16.961   2.60654511  76.26022560   1.07689064  35.98   2.387  5.5002 13.8694  1.0236  5.0798 13.8342  0.0000 20.2770 14.6878 25.0005  0.4508  1.0041  0.947994488982      0
jxl:d2.6        19988  2137039    0.8553246   2.210  17.125   2.66204847  75.64946472   1.10468095  35.77   2.379  5.4035 13.5748  1.0301  5.0075 13.8034  0.0000 19.6815 15.3666 25.3232  0.5123  1.0246  0.944860840039      0
jxl:d2.7        19988  2080633    0.8327488   2.149  17.205   2.78720629  74.99937394   1.13844502  35.62   2.455  5.2386 13.2934  1.0425  4.9207 13.7029  0.0000 19.1909 16.1607 25.6306  0.5021  1.0451  0.948038736511      0
jxl:d2.8        19988  2024012    0.8100869   2.136  17.345   2.83310005  74.36929543   1.16900299  35.43   2.419  5.0958 13.0455  1.0573  4.8266 13.6196  0.0000 18.7990 16.6140 26.0200  0.5430  1.1066  0.946994035676      0
jxl:d2.9        19988  1972944    0.7896476   2.176  16.667   2.86636066  73.76487699   1.19741541  35.27   2.382  4.9825 12.8134  1.0627  4.7529 13.5069  0.0000 18.3674 17.3774 26.2249  0.5533  1.0861  0.945536156885      0
jxl:d3          19988  1927911    0.7716236   1.984  17.213   2.95772989  73.16140113   1.22364420  35.13   2.397  4.8224 12.5982  1.0371  4.6818 13.2834  0.0000 18.0152 18.0254 26.6655  0.5943  1.0041  0.944192778103      0
jxl:d5          19988  1306159    0.5227747   1.955   9.751   4.47670928  61.73033085   1.75678887  32.79   2.455  3.3489  8.2846  0.9554  3.0761 10.9345  0.0000 13.9629 27.1368 30.9278  0.2766  1.8238  0.918404824915      0
jxl:d7          19988  1009442    0.4040173   1.973   9.203   5.67270051  52.32787088   2.22276051  31.31   2.389  2.5337  5.8083  0.8002  2.1293  9.2753  0.0000 11.6703 32.0857 33.9761  0.2562  2.1927  0.898033589285      0
jxl:d15         19988   561102    0.2245745   2.030   8.872  10.07380638  23.13463053   3.77459295  28.51   2.287  1.1341  1.5859  0.2875  0.5280  5.1563  0.0000  6.5191 36.4479 43.6791  0.8402  4.5493  0.847677155994      0
jxl:d24         19988   395831    0.1584267   0.308  21.202  17.01197931   2.56942282   5.95401180  25.83   2.617  0.9987  2.2135  0.1735  0.6987  3.0553  0.0000  2.9931  9.0396  6.2399  0.0410  0.0000  0.943274367246      0
jxl:d32         19988   318285    0.1273898   0.310  20.083  18.78487804  -7.72162133   6.68414743  25.39   2.367  0.7329  1.6692  0.1377  0.4905  2.7299  0.0000  2.6128  9.8055  7.1928  0.0820  0.0000  0.851492312032      0
Aggregate:      19988  2319646    0.9284111   1.761  15.677   2.43230882  66.84090429   0.99497885  36.43   2.442  5.6295 12.1632  0.7504  4.7054 12.1917  0.0000 17.2961  8.5775 17.3756  0.2914  0.7620  0.923749376899      0

After:

Encoding      kPixels    Bytes          BPP  E MP/s  D MP/s     Max norm  SSIMULACRA2        pnorm   PSNR   QABPP  SmallB  DCT4x8     AFV  DCT8x8    8x16    8x32      16   16x32      32   32x64      64       BPP*pnorm   Bugs
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
jxl:d0.1        19988 16168561    6.4712758   1.330   9.451   0.35357817  95.44301818   0.11810353  52.99   6.471 40.6501 19.1672  0.4425 27.6286  5.2825  0.0000  2.4847  0.9068  3.9704  0.1127  0.0820  0.764280538111      0
jxl:d0.5        19988  6327432    2.5324800   1.633  16.037   0.79171598  91.42061585   0.34789744  44.46   2.559 13.7692 25.2259  0.6039 11.7981 21.6237  0.0000 20.8495  1.2167  5.1999  0.1537  0.2869  0.881043303519      0
jxl:d0.8        19988  4690827    1.8774482   1.876  15.965   1.10850910  88.66095412   0.48305821  41.50   2.178 10.5407 21.7265  0.7035  8.8174 19.8428  0.0000 29.2142  1.6547  7.5924  0.2254  0.4098  0.906916740921      0
jxl:d1          19988  4054905    1.6229279   1.789  15.934   1.30433495  86.94378361   0.56656991  40.36   2.180  9.2766 19.9008  0.7729  7.6971 18.3187  0.0000 30.3733  2.7383 11.0043  0.2152  0.4303  0.919502109348      0
jxl:d1.1        19988  3818397    1.5282683   1.708  16.956   1.42198944  86.09455375   0.60736824  39.90   2.240  8.8341 19.0926  0.7809  7.3196 17.6002  0.0000 30.2196  3.4837 12.7718  0.1947  0.4303  0.928221661284      0
jxl:d1.2        19988  3605968    1.4432461   1.887  16.309   1.50573627  85.26274567   0.64475804  39.43   2.242  8.3826 18.4369  0.8210  6.9818 16.9483  0.0000 29.8994  4.3341 14.2472  0.2049  0.4713  0.930544552593      0
jxl:d1.3        19988  3437341    1.3757552   1.967  17.128   1.56507151  84.62146326   0.67815547  39.06   2.234  7.9868 17.9524  0.8498  6.6478 16.4981  0.0000 28.8914  5.2460 15.7636  0.2357  0.6558  0.932975905593      0
jxl:d1.4        19988  3270570    1.3090071   1.772  16.521   1.66940303  83.88447009   0.71485001  38.69   2.270  7.6253 17.3540  0.8706  6.4278 16.1805  0.0000 27.9680  6.1605 17.1468  0.2766  0.7172  0.935743708027      0
jxl:d1.5        19988  3116987    1.2475373   1.876  15.530   1.75683078  83.11438364   0.75042670  38.36   2.281  7.3080 16.9819  0.8776  6.1931 15.7451  0.0000 26.9869  7.0698 18.6530  0.2971  0.6148  0.936185279897      0
jxl:d1.6        19988  2983002    1.1939114   1.918  16.507   1.84675205  82.36186610   0.78783673  38.03   2.300  7.0234 16.5519  0.8860  5.9908 15.4140  0.0000 26.1826  8.0124 19.6110  0.3381  0.7172  0.940607221274      0
jxl:d1.7        19988  2862547    1.1457007   1.851  14.845   1.92910980  81.67718413   0.81958554  37.76   2.306  6.7701 16.1757  0.9145  5.8508 15.2981  0.0000 25.2310  8.8629 20.5281  0.3996  0.6967  0.938999693443      0
jxl:d1.8        19988  2752424    1.1016252   1.855  15.146   2.01723008  80.96728252   0.85427462  37.45   2.328  6.5377 15.7470  0.9356  5.7269 15.1194  0.0000 24.3652  9.7543 21.3939  0.3484  0.7992  0.941090475822      0
jxl:d1.8        19988  2752424    1.1016252   1.897  16.229   2.01723008  80.96728252   0.85427462  37.45   2.328  6.5377 15.7470  0.9356  5.7269 15.1194  0.0000 24.3652  9.7543 21.3939  0.3484  0.7992  0.941090475822      0
jxl:d1.9        19988  2648670    1.0600989   1.741  16.132   2.11036388  80.23440356   0.89019284  37.19   2.340  6.3340 15.4089  0.9641  5.5838 14.9279  0.0000 23.4405 10.7072 22.2033  0.3381  0.8197  0.943692469332      0
jxl:d2.0        19988  2554646    1.0224669   1.954  15.270   2.22933808  79.53745967   0.92152027  36.94   2.394  6.1541 15.0077  0.9820  5.4003 14.7563  0.0000 22.8680 11.3732 22.9666  0.3381  0.8812  0.942223998121      0
jxl:d2.1        19988  2468418    0.9879552   1.906  15.459   2.29715909  78.85725061   0.95448590  36.70   2.387  5.9421 14.7605  0.9843  5.2995 14.5059  0.0000 22.0906 12.3081 23.4636  0.4713  0.9017  0.942989289511      0
jxl:d2.2        19988  2388314    0.9558945   1.940  15.983   2.38892049  78.15608401   0.99070341  36.50   2.375  5.7596 14.4233  1.0144  5.2313 14.3887  0.0000 21.5693 12.9357 24.0835  0.3996  0.9221  0.947007943018      0
jxl:d2.3        19988  2312592    0.9255877   1.983  16.600   2.47287406  77.49161628   1.02150646  36.27   2.390  5.5931 14.0980  1.0096  5.1221 14.3093  0.0000 20.9481 13.7451 24.4882  0.4303  0.9836  0.945493776750      0
jxl:d2.4        19988  2240685    0.8968077   1.976  16.295   2.52888642  76.86753662   1.05024513  36.05   2.367  5.4913 13.7669  1.0060  5.0091 14.1838  0.0000 20.3936 14.4572 24.8212  0.5533  1.0451  0.941867954837      0
jxl:d2.5        19988  2176079    0.8709499   1.844  17.263   2.61787283  76.19127300   1.08617515  35.87   2.390  5.3331 13.4663  1.0329  4.9402 14.0890  0.0000 19.8160 15.2923 25.1900  0.5021  1.0656  0.946004190908      0
jxl:d2.6        19988  2114187    0.8461784   1.951  17.376   2.74227027  75.58784708   1.12074961  35.68   2.443  5.1589 13.1726  1.0326  4.8288 13.9910  0.0000 19.4151 15.8379 25.6409  0.5021  1.1476  0.948354111630      0
jxl:d2.7        19988  2057434    0.8234637   1.874  16.395   2.79357921  74.99180524   1.14909654  35.51   2.425  5.0430 12.9322  1.0569  4.7612 13.7938  0.0000 18.9899 16.5987 25.9124  0.5328  1.1066  0.946239272942      0
jxl:d2.8        19988  2003098    0.8017163   1.859  16.451   2.85544554  74.34756861   1.17714426  35.35   2.406  4.9450 12.7442  1.0509  4.7151 13.6030  0.0000 18.4635 17.3057 26.2300  0.5840  1.0861  0.943735787238      0
jxl:d2.9        19988  1950924    0.7808343   1.981  16.622   2.93520785  73.66769117   1.20834307  35.20   2.405  4.8173 12.4855  1.0678  4.6402 13.6094  0.0000 18.0920 17.8077 26.5374  0.4816  1.1885  0.943515731302      0
jxl:d3          19988  1904599    0.7622933   1.891  17.031   3.02034789  73.13820701   1.23500272  35.04   2.431  4.6405 12.2326  1.0640  4.5800 13.4346  0.0000 17.7104 18.4788 26.7628  0.5328  1.2910  0.941434274622      0
jxl:d5          19988  1303893    0.5218678   1.789   8.931   4.45726190  62.04613633   1.75931368  32.74   2.440  3.2125  7.9071  0.9446  2.9451 10.8385  0.0000 13.7362 27.7003 31.2506  0.2664  1.9263  0.918129143296      0
jxl:d7          19988  1019574    0.4080725   1.901   9.102   5.73712076  52.94850030   2.21224432  31.34   2.433  2.4469  5.4810  0.7560  2.0547  9.1229  0.0000 11.4334 32.5262 34.3757  0.2562  2.2746  0.902755991584      0
jxl:d15         19988   576525    0.2307473   1.869   8.740   9.96225175  24.47643927   3.69453040  28.69   2.327  1.0640  1.3944  0.2728  0.4636  4.9527  0.0000  6.3231 36.0919 44.2119  1.0553  4.8976  0.852503023674      0
jxl:d24         19988   407843    0.1632343   0.292  19.796  16.68665143   4.51409337   5.84382701  25.92   2.635  0.9526  2.0860  0.1668  0.6554  3.0034  0.0000  2.9816  9.2753  6.2911  0.0410  0.0000  0.953913297501      0
jxl:d32         19988   331510    0.1326830   0.285  18.971  18.38951150  -5.26792992   6.50097476  25.51   2.403  0.6878  1.5792  0.1332  0.4476  2.6973  0.0000  2.6204 10.0232  7.1518  0.1127  0.0000  0.862568615199      0
Aggregate:      19988  2319558    0.9283757   1.631  15.198   2.42989704  68.72571844   0.99433579  36.39   2.439  5.4539 11.9688  0.7574  4.5848 12.4419  0.0000 17.2635  8.9073 17.8263  0.3058  0.8052  0.923117196477      0
```