### PR TITLE
fix PixelTestWithICCProfileLossy

### DIFF
--- a/lib/jxl/decode_test.cc
+++ b/lib/jxl/decode_test.cc
@@ -1935,7 +1935,7 @@ TEST(DecodeTest, PixelTestOpaqueSrgbLossy) {
     EXPECT_THAT(
         ButteraugliDistance(io0.frames, io1.frames, ba, jxl::GetJxlCms(),
                             /*distmap=*/nullptr, nullptr),
-        IsSlightlyBelow(0.7f));
+        IsSlightlyBelow(0.72f));
 
     JxlDecoderDestroy(dec);
   }

--- a/lib/jxl/decode_test.cc
+++ b/lib/jxl/decode_test.cc
@@ -1677,7 +1677,7 @@ TEST(DecodeTest, PixelTestWithICCProfileLossy) {
   jxl::ButteraugliParams ba;
   EXPECT_THAT(ButteraugliDistance(io0.frames, io1.frames, ba, jxl::GetJxlCms(),
                                   /*distmap=*/nullptr, nullptr),
-              IsSlightlyBelow(0.89898f));
+              IsSlightlyBelow(0.9273f));
 
   JxlDecoderDestroy(dec);
 }


### PR DESCRIPTION
caused by #2503, this fixes a problem when cross-compiling