### PR TITLE
Rewrite progressive part of jpegli encoder.

### DIFF
--- a/lib/jpegli/bitstream.h
+++ b/lib/jpegli/bitstream.h
@@ -24,15 +24,11 @@ void EncodeSOS(j_compress_ptr cinfo, int scan_index);
 void EncodeDHT(j_compress_ptr cinfo, const JPEGHuffmanCode* huffman_codes,
                size_t num_huffman_codes, bool pre_shifted = false);
 void EncodeDQT(j_compress_ptr cinfo, bool write_all_tables, bool* is_baseline);
-bool EncodeDRI(j_compress_ptr cinfo);
+void EncodeDRI(j_compress_ptr cinfo);
 
-bool EncodeScan(j_compress_ptr cinfo, int scan_index);
-
-void EncodeSingleScan(j_compress_ptr cinfo);
+void WriteScanData(j_compress_ptr cinfo, int scan_index);
 
 void EncodeiMCURow(j_compress_ptr cinfo, bool streaming);
-
-void ProgressMonitorEncodePass(j_compress_ptr cinfo, size_t scan_index);
 
 }  // namespace jpegli
 

--- a/lib/jpegli/encode_api_test.cc
+++ b/lib/jpegli/encode_api_test.cc
@@ -491,12 +491,26 @@ std::vector<TestConfig> GenerateTests() {
     }
   }
   for (int p = 0; p < 3 + kNumTestScripts; ++p) {
-    TestConfig config;
-    config.jparams.progressive_mode = p;
-    const float kMaxBpp[] = {1.59, 1.51, 1.48, 1.59, 1.55, 1.55, 1.51};
-    config.max_bpp = kMaxBpp[p];
-    config.max_dist = 2.0;
-    all_tests.push_back(config);
+    for (int samp : {1, 2}) {
+      for (int quality : {100, 90, 1}) {
+        for (int r : {0, 1024, 1}) {
+          TestConfig config;
+          config.input.xsize = 273;
+          config.input.ysize = 265;
+          config.jparams.progressive_mode = p;
+          config.jparams.h_sampling = {samp, 1, 1};
+          config.jparams.v_sampling = {samp, 1, 1};
+          config.jparams.quality = quality;
+          config.jparams.restart_interval = r;
+          config.max_bpp = quality == 100 ? 8.0 : 2.0;
+          if (r == 1) {
+            config.max_bpp += 10.0;
+          }
+          config.max_dist = quality == 1 ? 20.0 : 2.0;
+          all_tests.push_back(config);
+        }
+      }
+    }
   }
   {
     TestConfig config;

--- a/lib/jpegli/encode_internal.h
+++ b/lib/jpegli/encode_internal.h
@@ -61,6 +61,28 @@ struct TokenArray {
   size_t num_tokens;
 };
 
+struct RefToken {
+  uint8_t symbol;
+  uint8_t refbits;
+};
+
+struct ScanTokenInfo {
+  RefToken* tokens;
+  size_t num_tokens;
+  uint8_t* refbits;
+  uint16_t* eobruns;
+  size_t* restarts;
+  size_t num_restarts;
+  size_t num_nonzeros;
+  size_t num_future_nonzeros;
+  size_t token_offset;
+  size_t restart_interval;
+  size_t MCUs_per_row;
+  size_t MCU_rows_in_scan;
+  size_t blocks_in_MCU;
+  size_t num_blocks;
+};
+
 }  // namespace jpegli
 
 struct jpeg_comp_master {
@@ -77,6 +99,7 @@ struct jpeg_comp_master {
   size_t ysize_blocks;
   size_t blocks_per_iMCU_row;
   jpegli::ScanCodingInfo* scan_coding_info;
+  jpegli::ScanTokenInfo* scan_token_info;
   JpegliDataType data_type;
   JpegliEndianness endianness;
   void (*input_method)(const uint8_t* row_in, size_t len,
@@ -110,6 +133,11 @@ struct jpeg_comp_master {
   jpegli::Token* next_token;
   size_t num_tokens;
   size_t total_num_tokens;
+  jpegli::RefToken* next_refinement_token;
+  uint8_t* next_refinement_bit;
+  size_t num_histograms;
+  uint8_t* ac_histogram_offset;
+  uint8_t* context_map;
 };
 
 #endif  // LIB_JPEGLI_ENCODE_INTERNAL_H_

--- a/lib/jpegli/entropy_coding-inl.h
+++ b/lib/jpegli/entropy_coding-inl.h
@@ -1,0 +1,222 @@
+// Copyright (c) the JPEG XL Project Authors. All rights reserved.
+//
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+#if defined(LIB_JPEGLI_ENTROPY_CODING_INL_H_) == defined(HWY_TARGET_TOGGLE)
+#ifdef LIB_JPEGLI_ENTROPY_CODING_INL_H_
+#undef LIB_JPEGLI_ENTROPY_CODING_INL_H_
+#else
+#define LIB_JPEGLI_ENTROPY_CODING_INL_H_
+#endif
+
+#include "lib/jxl/base/compiler_specific.h"
+
+HWY_BEFORE_NAMESPACE();
+namespace jpegli {
+namespace HWY_NAMESPACE {
+namespace {
+
+// These templates are not found via ADL.
+using hwy::HWY_NAMESPACE::Abs;
+using hwy::HWY_NAMESPACE::Add;
+using hwy::HWY_NAMESPACE::And;
+using hwy::HWY_NAMESPACE::AndNot;
+using hwy::HWY_NAMESPACE::Compress;
+using hwy::HWY_NAMESPACE::CountTrue;
+using hwy::HWY_NAMESPACE::Eq;
+using hwy::HWY_NAMESPACE::GetLane;
+using hwy::HWY_NAMESPACE::MaskFromVec;
+using hwy::HWY_NAMESPACE::Max;
+using hwy::HWY_NAMESPACE::Not;
+using hwy::HWY_NAMESPACE::Or;
+using hwy::HWY_NAMESPACE::ShiftRight;
+using hwy::HWY_NAMESPACE::Shl;
+using hwy::HWY_NAMESPACE::Sub;
+
+using DI = HWY_FULL(int32_t);
+constexpr DI di;
+
+void ZigZagShuffle(int32_t* JXL_RESTRICT block) {
+  // TODO(szabadka) SIMDify this.
+  int32_t tmp[DCTSIZE2];
+  for (int k = 0; k < DCTSIZE2; ++k) {
+    tmp[k] = block[kJPEGNaturalOrder[k]];
+  }
+  memcpy(block, tmp, DCTSIZE2 * sizeof(tmp[0]));
+}
+
+template <typename DI, class V>
+JXL_INLINE V NumBits(DI di, const V x) {
+  // TODO(szabadka) Add faster implementations for some specific architectures.
+  const auto b1 = And(x, Set(di, 1));
+  const auto b2 = And(x, Set(di, 2));
+  const auto b3 = Sub((And(x, Set(di, 4))), Set(di, 1));
+  const auto b4 = Sub((And(x, Set(di, 8))), Set(di, 4));
+  const auto b5 = Sub((And(x, Set(di, 16))), Set(di, 11));
+  const auto b6 = Sub((And(x, Set(di, 32))), Set(di, 26));
+  const auto b7 = Sub((And(x, Set(di, 64))), Set(di, 57));
+  const auto b8 = Sub((And(x, Set(di, 128))), Set(di, 120));
+  const auto b9 = Sub((And(x, Set(di, 256))), Set(di, 247));
+  const auto b10 = Sub((And(x, Set(di, 512))), Set(di, 502));
+  const auto b11 = Sub((And(x, Set(di, 1024))), Set(di, 1013));
+  const auto b12 = Sub((And(x, Set(di, 2048))), Set(di, 2036));
+  return Max(Max(Max(Max(b1, b2), Max(b3, b4)), Max(Max(b5, b6), Max(b7, b8))),
+             Max(Max(b9, b10), Max(b11, b12)));
+}
+
+// Coefficient indexes pre-multiplied by 16 for the symbol calculation.
+HWY_ALIGN constexpr int32_t kIndexes[64] = {
+    0,   16,  32,  48,  64,  80,  96,  112, 128, 144, 160, 176,  192,
+    208, 224, 240, 256, 272, 288, 304, 320, 336, 352, 368, 384,  400,
+    416, 432, 448, 464, 480, 496, 512, 528, 544, 560, 576, 592,  608,
+    624, 640, 656, 672, 688, 704, 720, 736, 752, 768, 784, 800,  816,
+    832, 848, 864, 880, 896, 912, 928, 944, 960, 976, 992, 1008,
+};
+
+JXL_INLINE int CompactBlock(int32_t* JXL_RESTRICT block,
+                            int32_t* JXL_RESTRICT nonzero_idx) {
+  const auto zero = Zero(di);
+  HWY_ALIGN constexpr int32_t dc_mask_lanes[HWY_LANES(DI)] = {-1};
+  const auto dc_mask = MaskFromVec(Load(di, dc_mask_lanes));
+  int num_nonzeros = 0;
+  int k = 0;
+  {
+    const auto coef = Load(di, block);
+    const auto idx = Load(di, kIndexes);
+    const auto nonzero_mask = Or(dc_mask, Not(Eq(coef, zero)));
+    const auto nzero_coef = Compress(coef, nonzero_mask);
+    const auto nzero_idx = Compress(idx, nonzero_mask);
+    StoreU(nzero_coef, di, &block[num_nonzeros]);
+    StoreU(nzero_idx, di, &nonzero_idx[num_nonzeros]);
+    num_nonzeros += CountTrue(di, nonzero_mask);
+    k += Lanes(di);
+  }
+  for (; k < DCTSIZE2; k += Lanes(di)) {
+    const auto coef = Load(di, &block[k]);
+    const auto idx = Load(di, &kIndexes[k]);
+    const auto nonzero_mask = Not(Eq(coef, zero));
+    const auto nzero_coef = Compress(coef, nonzero_mask);
+    const auto nzero_idx = Compress(idx, nonzero_mask);
+    StoreU(nzero_coef, di, &block[num_nonzeros]);
+    StoreU(nzero_idx, di, &nonzero_idx[num_nonzeros]);
+    num_nonzeros += CountTrue(di, nonzero_mask);
+  }
+  return num_nonzeros;
+}
+
+JXL_INLINE void ComputeSymbols(const int num_nonzeros,
+                               int32_t* JXL_RESTRICT nonzero_idx,
+                               int32_t* JXL_RESTRICT block,
+                               int32_t* JXL_RESTRICT symbols) {
+  nonzero_idx[-1] = -16;
+  const auto one = Set(di, 1);
+  const auto offset = Set(di, 16);
+  for (int i = 0; i < num_nonzeros; i += Lanes(di)) {
+    const auto idx = Load(di, &nonzero_idx[i]);
+    const auto prev_idx = LoadU(di, &nonzero_idx[i - 1]);
+    const auto coeff = Load(di, &block[i]);
+    const auto nbits = NumBits(di, Abs(coeff));
+    const auto mask = ShiftRight<8 * sizeof(int32_t) - 1>(coeff);
+    const auto bits = And(Add(coeff, mask), Sub(Shl(one, nbits), one));
+    const auto symbol = Sub(Add(nbits, idx), Add(prev_idx, offset));
+    Store(symbol, di, symbols + i);
+    Store(bits, di, block + i);
+  }
+}
+
+template <typename T>
+int NumNonZero8x8ExceptDC(const T* block) {
+  const HWY_CAPPED(T, 8) di;
+
+  const auto zero = Zero(di);
+  // Add FFFF for every zero coefficient, negate to get #zeros.
+  auto neg_sum_zero = zero;
+  {
+    // First row has DC, so mask
+    const size_t y = 0;
+    HWY_ALIGN const T dc_mask_lanes[8] = {-1};
+
+    for (size_t x = 0; x < 8; x += Lanes(di)) {
+      const auto dc_mask = Load(di, dc_mask_lanes + x);
+
+      // DC counts as zero so we don't include it in nzeros.
+      const auto coef = AndNot(dc_mask, Load(di, &block[y * 8 + x]));
+
+      neg_sum_zero = Add(neg_sum_zero, VecFromMask(di, Eq(coef, zero)));
+    }
+  }
+  // Remaining rows: no mask
+  for (size_t y = 1; y < 8; y++) {
+    for (size_t x = 0; x < 8; x += Lanes(di)) {
+      const auto coef = Load(di, &block[y * 8 + x]);
+      neg_sum_zero = Add(neg_sum_zero, VecFromMask(di, Eq(coef, zero)));
+    }
+  }
+
+  // We want 64 - sum_zero, add because neg_sum_zero is already negated.
+  return kDCTBlockSize + GetLane(SumOfLanes(di, neg_sum_zero));
+}
+
+template <typename T, bool zig_zag_order>
+void ComputeTokensForBlock(const T* block, int last_dc, int histo_dc,
+                           int histo_ac, Token** tokens_ptr) {
+  Token* next_token = *tokens_ptr;
+  coeff_t temp2;
+  coeff_t temp;
+  temp = block[0] - last_dc;
+  if (temp == 0) {
+    *next_token++ = Token(histo_dc, 0, 0);
+  } else {
+    temp2 = temp;
+    if (temp < 0) {
+      temp = -temp;
+      temp2--;
+    }
+    int dc_nbits = jxl::FloorLog2Nonzero<uint32_t>(temp) + 1;
+    int dc_mask = (1 << dc_nbits) - 1;
+    *next_token++ = Token(histo_dc, dc_nbits, temp2 & dc_mask);
+  }
+  int num_nonzeros = NumNonZero8x8ExceptDC(block);
+  for (int k = 1; k < 64; ++k) {
+    if (num_nonzeros == 0) {
+      *next_token++ = Token(histo_ac, 0, 0);
+      break;
+    }
+    int r = 0;
+    if (zig_zag_order) {
+      while ((temp = block[k]) == 0) {
+        r++;
+        k++;
+      }
+    } else {
+      while ((temp = block[kJPEGNaturalOrder[k]]) == 0) {
+        r++;
+        k++;
+      }
+    }
+    --num_nonzeros;
+    if (temp < 0) {
+      temp = -temp;
+      temp2 = ~temp;
+    } else {
+      temp2 = temp;
+    }
+    while (r > 15) {
+      *next_token++ = Token(histo_ac, 0xf0, 0);
+      r -= 16;
+    }
+    int ac_nbits = jxl::FloorLog2Nonzero<uint32_t>(temp) + 1;
+    int ac_mask = (1 << ac_nbits) - 1;
+    int symbol = (r << 4u) + ac_nbits;
+    *next_token++ = Token(histo_ac, symbol, temp2 & ac_mask);
+  }
+  *tokens_ptr = next_token;
+}
+
+// NOLINTNEXTLINE(google-readability-namespace-comments)
+}  // namespace
+}  // namespace HWY_NAMESPACE
+}  // namespace jpegli
+HWY_AFTER_NAMESPACE();
+#endif  // LIB_JPEGLI_ENTROPY_CODING_INL_H_

--- a/lib/jpegli/entropy_coding.h
+++ b/lib/jpegli/entropy_coding.h
@@ -38,6 +38,13 @@ void ClusterJpegHistograms(const Histogram* histograms, size_t num,
 void AddJpegHuffmanCode(const Histogram& histogram, size_t slot_id,
                         JPEGHuffmanCode* huff_codes, size_t* num_huff_codes);
 
+size_t MaxNumTokensPerMCURow(j_compress_ptr cinfo);
+
+void TokenizeJpeg(j_compress_ptr cinfo);
+
+size_t EstimateNumTokens(j_compress_ptr cinfo, size_t mcu_y, size_t ysize_mcus,
+                         size_t num_tokens, size_t max_per_row);
+
 void OptimizeHuffmanCodes(j_compress_ptr cinfo, bool* is_baseline);
 
 }  // namespace jpegli

--- a/lib/jpegli/test_utils.h
+++ b/lib/jpegli/test_utils.h
@@ -75,6 +75,50 @@ static constexpr jpeg_scan_info kScript4[] = {
     {1, {2}, 1, 63, 0, 1},      {1, {0}, 1, 63, 1, 0}, {1, {1}, 1, 63, 1, 0},
     {1, {2}, 1, 63, 1, 0},
 };
+static constexpr jpeg_scan_info kScript5[] = {
+    {3, {0, 1, 2}, 0, 0, 0, 2},  //
+    {3, {0, 1, 2}, 0, 0, 2, 1},  //
+    {3, {0, 1, 2}, 0, 0, 1, 0},  //
+    {1, {0}, 1, 63, 0, 0},      {1, {1}, 1, 63, 0, 0}, {1, {2}, 1, 63, 0, 0},
+};
+
+static constexpr jpeg_scan_info kScript6[] = {
+    {1, {0}, 0, 0, 0, 2},  {1, {1}, 0, 0, 0, 2},  {1, {2}, 0, 0, 0, 2},   //
+    {1, {0}, 0, 0, 2, 1},  {1, {1}, 0, 0, 2, 1},  {1, {2}, 0, 0, 2, 1},   //
+    {1, {0}, 0, 0, 1, 0},  {1, {1}, 0, 0, 1, 0},  {1, {2}, 0, 0, 1, 0},   //
+    {1, {0}, 1, 63, 0, 0}, {1, {1}, 1, 63, 0, 0}, {1, {2}, 1, 63, 0, 0},  //
+};
+
+static constexpr jpeg_scan_info kScript7[] = {
+    {1, {0}, 0, 0, 0, 2},    {1, {1}, 0, 0, 0, 2},  {1, {2}, 0, 0, 0, 2},   //
+    {2, {0, 1}, 0, 0, 2, 1}, {1, {2}, 0, 0, 2, 1},                          //
+    {2, {1, 2}, 0, 0, 1, 0}, {1, {0}, 0, 0, 1, 0},                          //
+    {1, {0}, 1, 63, 0, 0},   {1, {1}, 1, 63, 0, 0}, {1, {2}, 1, 63, 0, 0},  //
+};
+
+static constexpr jpeg_scan_info kScript8[] = {
+    {3, {0, 1, 2}, 0, 0, 0, 0},                          //
+    {1, {0}, 1, 6, 0, 1},       {1, {0}, 7, 63, 0, 1},   //
+    {1, {0}, 1, 63, 1, 0},                               //
+    {1, {1}, 1, 63, 0, 1},                               //
+    {1, {1}, 1, 6, 1, 0},       {1, {1}, 7, 63, 1, 0},   //
+    {1, {2}, 1, 6, 0, 1},       {1, {2}, 7, 63, 0, 1},   //
+    {1, {2}, 1, 16, 1, 0},      {1, {2}, 17, 63, 1, 0},  //
+};
+
+static constexpr jpeg_scan_info kScript9[] = {
+    {3, {0, 1, 2}, 0, 0, 0, 0},                          //
+    {1, {0}, 1, 16, 0, 1},      {1, {1}, 1, 16, 0, 1},   //
+    {1, {2}, 1, 16, 0, 1},                               //
+    {1, {0}, 1, 8, 1, 0},       {1, {0}, 9, 16, 1, 0},   //
+    {1, {1}, 1, 8, 1, 0},       {1, {1}, 9, 16, 1, 0},   //
+    {1, {2}, 1, 8, 1, 0},       {1, {2}, 9, 16, 1, 0},   //
+    {1, {0}, 17, 63, 0, 1},     {1, {1}, 17, 63, 0, 1},  //
+    {1, {2}, 17, 63, 0, 1},                              //
+    {1, {0}, 17, 28, 1, 0},     {1, {0}, 29, 63, 1, 0},  //
+    {1, {1}, 17, 28, 1, 0},     {1, {1}, 29, 63, 1, 0},  //
+    {1, {2}, 17, 28, 1, 0},     {1, {2}, 29, 63, 1, 0},  //
+};
 
 struct ScanScript {
   int num_scans;
@@ -82,10 +126,11 @@ struct ScanScript {
 };
 
 static constexpr ScanScript kTestScript[] = {
-    {ARRAY_SIZE(kScript1), kScript1},
-    {ARRAY_SIZE(kScript2), kScript2},
-    {ARRAY_SIZE(kScript3), kScript3},
-    {ARRAY_SIZE(kScript4), kScript4},
+    {ARRAY_SIZE(kScript1), kScript1}, {ARRAY_SIZE(kScript2), kScript2},
+    {ARRAY_SIZE(kScript3), kScript3}, {ARRAY_SIZE(kScript4), kScript4},
+    {ARRAY_SIZE(kScript5), kScript5}, {ARRAY_SIZE(kScript6), kScript6},
+    {ARRAY_SIZE(kScript7), kScript7}, {ARRAY_SIZE(kScript8), kScript8},
+    {ARRAY_SIZE(kScript9), kScript9},
 };
 static constexpr int kNumTestScripts = ARRAY_SIZE(kTestScript);
 

--- a/lib/jxl_lists.bzl
+++ b/lib/jxl_lists.bzl
@@ -479,6 +479,7 @@ libjxl_jpegli_sources = [
     "jpegli/encode.cc",
     "jpegli/encode.h",
     "jpegli/encode_internal.h",
+    "jpegli/entropy_coding-inl.h",
     "jpegli/entropy_coding.cc",
     "jpegli/entropy_coding.h",
     "jpegli/error.cc",

--- a/lib/jxl_lists.cmake
+++ b/lib/jxl_lists.cmake
@@ -479,6 +479,7 @@ set(JPEGXL_INTERNAL_JPEGLI_SOURCES
   jpegli/encode.cc
   jpegli/encode.h
   jpegli/encode_internal.h
+  jpegli/entropy_coding-inl.h
   jpegli/entropy_coding.cc
   jpegli/entropy_coding.h
   jpegli/error.cc


### PR DESCRIPTION
With this change the progressive and multi-scan sequential code paths also go through tokenization first, and then we build histograms from the tokens and then encode the tokens using the Huffman codes built from the histograms.

This makes progressive encoding 50% faster while using 50% more memory.

Benchmark results:
```
Encoding                             kPixels    Bytes          BPP  E MP/s  D MP/s     Max norm  SSIMULACRA2        pnorm       BPP*pnorm   Bugs
-----------------------------------------------------------------------------------------------------------------------------------------
BEFORE:
jpeg:enc-jpegli:q90:p0:fix             13270  3805508    2.2941246 101.189 190.896   1.58508737  84.51521884   0.68271017  1.566222227305      0
jpeg:enc-jpegli:q90:p0                 13270  3621255    2.1830490  88.253 204.142   1.58508737  84.51521884   0.68271017  1.490389738174      0
jpeg:enc-jpegli:q90:p1                 13270  3586623    2.1621713  31.646  92.791   1.58508737  84.51521884   0.68271017  1.476136343311      0
jpeg:enc-jpegli:q90                    13270  3542281    2.1354400  24.459  71.709   1.58508737  84.51521884   0.68271017  1.457886631051      0
jpeg:enc-jpegli:q75:yuv420:p0:fix      13270  1917558    1.1559868 154.927 315.386   3.47601534  71.10028406   1.32644721  1.533355479794      0
jpeg:enc-jpegli:q75:yuv420:p0          13270  1819107    1.0966363 131.904 333.347   3.47601534  71.10028406   1.32644721  1.454630152924      0
jpeg:enc-jpegli:q75:yuv420:p1          13270  1798558    1.0842485  54.137 160.237   3.47601534  71.10028406   1.32644721  1.438198356987      0
jpeg:enc-jpegli:q75:yuv420             13270  1785053    1.0761071  43.928 131.343   3.47601534  71.10028406   1.32644721  1.427399223008      0
AFTER
jpeg:enc-jpegli:q90:p0:fix             13270  3805508    2.2941246 102.043 193.158   1.58508737  84.51521884   0.68271017  1.566222227305      0
jpeg:enc-jpegli:q90:p0                 13270  3621255    2.1830490  88.296 202.043   1.58508737  84.51521884   0.68271017  1.490389738174      0
jpeg:enc-jpegli:q90:p1                 13270  3584647    2.1609801  47.855  91.684   1.58508737  84.51521884   0.68271017  1.475323086547      0
jpeg:enc-jpegli:q90                    13270  3540894    2.1346039  39.908  71.667   1.58508737  84.51521884   0.68271017  1.457315787361      0
jpeg:enc-jpegli:q75:yuv420:p0:fix      13270  1917558    1.1559868 153.228 308.705   3.47601534  71.10028406   1.32644721  1.533355479794      0
jpeg:enc-jpegli:q75:yuv420:p0          13270  1819107    1.0966363 133.417 335.785   3.47601534  71.10028406   1.32644721  1.454630152924      0
jpeg:enc-jpegli:q75:yuv420:p1          13270  1799079    1.0845625  78.307 156.804   3.47601534  71.10028406   1.32644721  1.438614969264      0
jpeg:enc-jpegli:q75:yuv420             13270  1785335    1.0762771  67.191 127.351   3.47601534  71.10028406   1.32644721  1.427624721400      0
```

Memory benchmark results:
```
                                                   cjpeg    per       djpeg    per
Input           Encode args          Pixels     peak mem  pixel    peak mem  pixel
----------------------------------------------------------------------------------
BEFORE:
tiny.ppm        -sample 2x2             256       295508             208851
tiny.ppm        -sample 2x2 -o          256       302713             208488
tiny.ppm        -sample 2x2 -p          256       359557             208636
stp2.ppm        -sample 2x2          960000      1574932   1.64      777368   0.81
stp2.ppm        -sample 2x2 -o       960000      3429281   3.57      777709   0.81
stp2.ppm        -sample 2x2 -p       960000      4529985   4.72     3598035   3.75
NC003.ppm       -sample 2x2        45441024      9203764   0.20     3389746   0.07
NC003.ppm       -sample 2x2 -o     45441024     87025377   1.92     3390361   0.07
NC003.ppm       -sample 2x2 -p     45441024    145619681   3.20   139324054   3.07
AFTER:
tiny.ppm        -sample 2x2             256       295749             208851
tiny.ppm        -sample 2x2 -o          256       309018             208488
tiny.ppm        -sample 2x2 -p          256       333605             208636
stp2.ppm        -sample 2x2          960000      1575173   1.64      777368   0.81
stp2.ppm        -sample 2x2 -o       960000      3436386   3.58      777709   0.81
stp2.ppm        -sample 2x2 -p       960000      6250495   6.51     3598035   3.75
NC003.ppm       -sample 2x2        45441024      9204005   0.20     3389746   0.07
NC003.ppm       -sample 2x2 -o     45441024     87037130   1.92     3390361   0.07
NC003.ppm       -sample 2x2 -p     45441024    228802787   5.04   139324054   3.07
```