### PR TITLE
do more palette

### DIFF
--- a/lib/jxl/enc_modular.cc
+++ b/lib/jxl/enc_modular.cc
@@ -653,21 +653,20 @@ Status ModularFrameEncoder::ComputeEncodingData(
 
   // if few colors, do all-channel palette before trying channel palette
   // Logic is as follows:
-  // - if you can make a palette with few colors (arbitrary threshold: 200),
+  // - if you can make a palette with few colors (threshold: 256, e.g. png8),
   //   then you can also make channel palettes, but they will just be extra
   //   signaling cost for almost no benefit
   // - if the palette needs more colors, then channel palette might help to
   //   reduce palette signaling cost
-  if (cparams_.palette_colors != 0 &&
-      cparams_.speed_tier < SpeedTier::kFalcon) {
+  if (cparams_.palette_colors != 0) {
     // all-channel palette (e.g. RGBA)
     if (gi.channel.size() > 1) {
       Transform maybe_palette(TransformId::kPalette);
       maybe_palette.begin_c = gi.nb_meta_channels;
       maybe_palette.num_c = gi.channel.size() - gi.nb_meta_channels;
       maybe_palette.nb_colors =
-          std::min(std::min(200, (int)(xsize * ysize / 8)),
-                   std::abs(cparams_.palette_colors) / 16);
+          std::min(std::min(256, (int)(xsize * ysize / 2)),
+                   std::abs(cparams_.palette_colors) / 4);
       maybe_palette.ordered_palette = cparams_.palette_colors >= 0;
       maybe_palette.lossy_palette = false;
       do_transform(gi, maybe_palette, weighted::Header(), pool);


### PR DESCRIPTION
Fixes https://github.com/libjxl/libjxl/issues/2508

Make lossless more likely to use a palette, in particular if the original had at most 256 colors (which is quite common considering GIF and PNG8). Also do this at e2 and e3, to avoid having the weird behavior where e1 uses a palette, e2 and e3 don't, and then e4+ does use it again (which can lead to e2/e3 file sizes being significantly larger than e1).

Before (for a png8 input):
```
JPEG XL encoder v0.9.0 c81a5a46 [SSE4,SSSE3,Unknown]
Read 3526x358 image, 627101 bytes, 158.1 MP/s
Encoding [Container | Modular, lossless, effort: 3 | 14-byte Exif], 
Compressed to 2164034 bytes including container (13.715 bpp).
3526 x 358, geomean: 4.51 MP/s [3.43, 4.59], 10 reps, 0 threads.
```

After:
```
jon@macdeb:~/dev/libjxl/test-dev$ ../build/tools/cjxl 1.png 1.png.jxl --num_threads=0 --num_reps=10 -d 0 -e 3
JPEG XL encoder v0.9.0 a5e69b42 [SSE4,SSSE3,SSE2]
Read 3526x358 image, 627101 bytes, 272.9 MP/s
Encoding [Container | Modular, lossless, effort: 3 | 14-byte Exif], 
Compressed to 850353 bytes including container (5.389 bpp).
3526 x 358, geomean: 3.98 MP/s [3.59, 4.07], 10 reps, 0 threads.
```

Before: (for photographic input)
```
JPEG XL encoder v0.9.0 c81a5a46 [SSE4,SSSE3,Unknown]
Read 500x606 image, 691120 bytes, 91.1 MP/s
Encoding [Modular, lossless, effort: 3], 
Compressed to 541178 bytes (14.289 bpp).
500 x 606, geomean: 4.51 MP/s [3.39, 4.64], 10 reps, 0 threads.
```

After:
```
JPEG XL encoder v0.9.0 a5e69b42 [SSE4,SSSE3,SSE2]
Read 500x606 image, 691120 bytes, 86.8 MP/s
Encoding [Modular, lossless, effort: 3], 
Compressed to 541178 bytes (14.289 bpp).
500 x 606, geomean: 4.52 MP/s [3.54, 4.64], 10 reps, 0 threads.
```
(nothing changes except it tries to make a palette and quickly fails)

For the small emoji images from https://github.com/libjxl/libjxl/issues/2508:

Before:
```
JPEG XL encoder v0.9.0 c81a5a46 [SSE4,SSSE3,Unknown]
Read 16x16 image, 579 bytes, 10.4 MP/s
Encoding [Modular, lossless, effort: 7], 
Compressed to 748 bytes (23.375 bpp).
16 x 16, geomean: 0.14 MP/s [0.06, 0.18], 100 reps, 0 threads.

JPEG XL encoder v0.9.0 c81a5a46 [SSE4,SSSE3,Unknown]
Read 16x16 image, 586 bytes, 2.9 MP/s
Encoding [Modular, lossless, effort: 7], 
Compressed to 711 bytes (22.219 bpp).
16 x 16, geomean: 0.15 MP/s [0.05, 0.18], 100 reps, 0 threads.

JPEG XL encoder v0.9.0 c81a5a46 [SSE4,SSSE3,Unknown]
Read 16x16 image, 586 bytes, 7.8 MP/s
Encoding [Modular, lossless, effort: 7], 
Compressed to 696 bytes (21.750 bpp).
16 x 16, geomean: 0.17 MP/s [0.06, 0.21], 100 reps, 0 threads.
```

After:
```
JPEG XL encoder v0.9.0 a5e69b42 [SSE4,SSSE3,SSE2]
Read 16x16 image, 579 bytes, 9.6 MP/s
Encoding [Modular, lossless, effort: 7], 
Compressed to 502 bytes (15.688 bpp).
16 x 16, geomean: 0.23 MP/s [0.06, 0.30], 100 reps, 0 threads.

JPEG XL encoder v0.9.0 a5e69b42 [SSE4,SSSE3,SSE2]
Read 16x16 image, 586 bytes, 8.2 MP/s
Encoding [Modular, lossless, effort: 7], 
Compressed to 521 bytes (16.281 bpp).
16 x 16, geomean: 0.20 MP/s [0.04, 0.24], 100 reps, 0 threads.

JPEG XL encoder v0.9.0 a5e69b42 [SSE4,SSSE3,SSE2]
Read 16x16 image, 586 bytes, 7.4 MP/s
Encoding [Modular, lossless, effort: 7], 
Compressed to 501 bytes (15.656 bpp).
16 x 16, geomean: 0.22 MP/s [0.08, 0.31], 100 reps, 0 threads.
```

So it now produces files smaller than the input png and the lossless webp for these small images.

This might occasionally be counterproductive for density or speed but I think those cases should be rare enough — and in any case you can always manually disable palette but without this change there was no way to make it use a palette in these cases where it clearly helps.