### PR TITLE
improve palette ordering and encode speed

### DIFF
--- a/lib/jxl/encode_test.cc
+++ b/lib/jxl/encode_test.cc
@@ -321,7 +321,7 @@ TEST(EncodeTest, frame_settingsTest) {
         JxlEncoderFrameSettingsCreate(enc.get(), NULL);
     EXPECT_EQ(JXL_ENC_SUCCESS,
               JxlEncoderSetFrameLossless(frame_settings, JXL_TRUE));
-    VerifyFrameEncoding(63, 129, enc.get(), frame_settings, 3600, false);
+    VerifyFrameEncoding(63, 129, enc.get(), frame_settings, 3000, false);
     EXPECT_EQ(true, enc->last_used_cparams.IsLossless());
   }
 


### PR DESCRIPTION
Use the luma * alpha palette sorting from e1 also at higher effort settings, as opposed to the lexicographic sorting that was there (which kind of makes sense for YCoCg pixels, but not really when there's alpha or when the data is still RGB).
Also use `unordered_set` to keep track of which colors have been seen (doesn't have to be ordered anymore since we're not using that order anymore anyway), and use an `unordered_map` to converts pixels to palette indices (instead of doing a naive linear search).

Net result is an encoder speedup and generally some density improvement, though that's not guaranteed on a per-image basis (palette ordering is weird).

On the jyrki31 corpus, converted to png8 with default pngquant:

Before:
```
Encoding      kPixels    Bytes          BPP  E MP/s  D MP/s     Max norm  SSIMULACRA2        pnorm       BPP*pnorm   Bugs
-------------------------------------------------------------------------------------------------------------------------
jxl:d0:4        13270  7294204    4.3972613   0.678   5.189         -nan 100.00000000   0.00000000  0.000000000000      0
jxl:d0:6        13270  7105322    4.2833951   0.576   5.299         -nan 100.00000000   0.00000000  0.000000000000      0
jxl:d0:7        13270  6944452    4.1864157   0.399   4.992         -nan 100.00000000   0.00000000  0.000000000000      0
jxl:d0:8        13270  6856609    4.1334601   0.213   4.503         -nan 100.00000000   0.00000000  0.000000000000      0
Aggregate:      13270  7048184    4.2489501   0.427   4.986   0.00000000 100.00000000   0.00000000  0.000000000000      0
```

After:
```
Encoding      kPixels    Bytes          BPP  E MP/s  D MP/s     Max norm  SSIMULACRA2        pnorm       BPP*pnorm   Bugs
-------------------------------------------------------------------------------------------------------------------------
jxl:d0:4        13270  7256193    4.3743466   1.116   6.540         -nan 100.00000000   0.00000000  0.000000000000      0
jxl:d0:6        13270  7052290    4.2514251   0.826   6.594         -nan 100.00000000   0.00000000  0.000000000000      0
jxl:d0:7        13270  6880832    4.1480628   0.585   6.223         -nan 100.00000000   0.00000000  0.000000000000      0
jxl:d0:8        13270  6791408    4.0941542   0.287   5.710         -nan 100.00000000   0.00000000  0.000000000000      0
Aggregate:      13270  6992942    4.2156477   0.627   6.257   0.00000000 100.00000000   0.00000000  0.000000000000      0
```

On some manga with alpha (also converted to png8 with pngquant):

Before:
```
Encoding      kPixels    Bytes          BPP  E MP/s  D MP/s     Max norm  SSIMULACRA2        pnorm       BPP*pnorm   Bugs
-------------------------------------------------------------------------------------------------------------------------
jxl:d0:4         4945   527465    0.8532975   1.372   9.456         -nan 100.00000000   0.00000000  0.000000000000      0
jxl:d0:6         4945   496081    0.8025266   0.923   8.585         -nan 100.00000000   0.00000000  0.000000000000      0
jxl:d0:7         4945   450107    0.7281529   0.900   6.199         -nan 100.00000000   0.00000000  0.000000000000      0
jxl:d0:8         4945   422527    0.6835358   0.501   5.941         -nan 100.00000000   0.00000000  0.000000000000      0
Aggregate:       4945   472312    0.7640749   0.869   7.394   0.00000000 100.00000000   0.00000000  0.000000000000      0
```

After:
```
Encoding      kPixels    Bytes          BPP  E MP/s  D MP/s     Max norm  SSIMULACRA2        pnorm       BPP*pnorm   Bugs
-------------------------------------------------------------------------------------------------------------------------
jxl:d0:4         4945   509826    0.8247623   1.813   8.655         -nan 100.00000000   0.00000000  0.000000000000      0
jxl:d0:6         4945   481004    0.7781360   1.107   8.565         -nan 100.00000000   0.00000000  0.000000000000      0
jxl:d0:7         4945   436016    0.7053574   1.035   8.038         -nan 100.00000000   0.00000000  0.000000000000      0
jxl:d0:8         4945   412052    0.6665901   0.545   7.538         -nan 100.00000000   0.00000000  0.000000000000      0
Aggregate:       4945   458149    0.7411619   1.031   8.186   0.00000000 100.00000000   0.00000000  0.000000000000      0
```

So on these images that's something like a 0.5% to 3% density improvement and something like a 10% (or more at the lower effort settings) encode speedup.