### PR TITLE
Simplify Huffman coding data structures, more consistent naming.

### DIFF
--- a/lib/jpegli/bitstream.h
+++ b/lib/jpegli/bitstream.h
@@ -13,22 +13,27 @@
 
 namespace jpegli {
 
+void EncodeiMCURow(j_compress_ptr cinfo, bool streaming);
+
 void WriteOutput(j_compress_ptr cinfo, const uint8_t* buf, size_t bufsize);
 void WriteOutput(j_compress_ptr cinfo, const std::vector<uint8_t>& bytes);
 void WriteOutput(j_compress_ptr cinfo, std::initializer_list<uint8_t> bytes);
 
 void EncodeAPP0(j_compress_ptr cinfo);
 void EncodeAPP14(j_compress_ptr cinfo);
+void WriteFileHeader(j_compress_ptr cinfo);
+
+// Returns true of only baseline 8-bit tables are used.
+bool EncodeDQT(j_compress_ptr cinfo, bool write_all_tables);
 void EncodeSOF(j_compress_ptr cinfo, bool is_baseline);
-void EncodeSOS(j_compress_ptr cinfo, int scan_index);
-void EncodeDHT(j_compress_ptr cinfo, const JPEGHuffmanCode* huffman_codes,
-               size_t num_huffman_codes, bool pre_shifted = false);
-void EncodeDQT(j_compress_ptr cinfo, bool write_all_tables, bool* is_baseline);
+void WriteFrameHeader(j_compress_ptr cinfo);
+
 void EncodeDRI(j_compress_ptr cinfo);
+void EncodeDHT(j_compress_ptr cinfo, size_t offset, size_t num);
+void EncodeSOS(j_compress_ptr cinfo, int scan_index);
+void WriteScanHeader(j_compress_ptr cinfo, int scan_index);
 
 void WriteScanData(j_compress_ptr cinfo, int scan_index);
-
-void EncodeiMCURow(j_compress_ptr cinfo, bool streaming);
 
 }  // namespace jpegli
 

--- a/lib/jpegli/encode_api_test.cc
+++ b/lib/jpegli/encode_api_test.cc
@@ -494,20 +494,27 @@ std::vector<TestConfig> GenerateTests() {
     for (int samp : {1, 2}) {
       for (int quality : {100, 90, 1}) {
         for (int r : {0, 1024, 1}) {
-          TestConfig config;
-          config.input.xsize = 273;
-          config.input.ysize = 265;
-          config.jparams.progressive_mode = p;
-          config.jparams.h_sampling = {samp, 1, 1};
-          config.jparams.v_sampling = {samp, 1, 1};
-          config.jparams.quality = quality;
-          config.jparams.restart_interval = r;
-          config.max_bpp = quality == 100 ? 8.0 : 2.0;
-          if (r == 1) {
-            config.max_bpp += 10.0;
+          for (int optimize : {0, 1}) {
+            bool progressive = p == 1 || p == 2 || p > 4;
+            if (progressive && !optimize) continue;
+            TestConfig config;
+            config.input.xsize = 273;
+            config.input.ysize = 265;
+            config.jparams.progressive_mode = p;
+            if (!progressive) {
+              config.jparams.optimize_coding = optimize;
+            }
+            config.jparams.h_sampling = {samp, 1, 1};
+            config.jparams.v_sampling = {samp, 1, 1};
+            config.jparams.quality = quality;
+            config.jparams.restart_interval = r;
+            config.max_bpp = quality == 100 ? 8.0 : 2.0;
+            if (r == 1) {
+              config.max_bpp += 10.0;
+            }
+            config.max_dist = quality == 1 ? 20.0 : 2.0;
+            all_tests.push_back(config);
           }
-          config.max_dist = quality == 1 ? 20.0 : 2.0;
-          all_tests.push_back(config);
         }
       }
     }

--- a/lib/jpegli/encode_internal.h
+++ b/lib/jpegli/encode_internal.h
@@ -22,38 +22,20 @@ constexpr unsigned char kICCSignature[12] = {
     0x49, 0x43, 0x43, 0x5F, 0x50, 0x52, 0x4F, 0x46, 0x49, 0x4C, 0x45, 0x00};
 constexpr int kICCMarker = JPEG_APP0 + 2;
 
-struct JPEGHuffmanCode {
-  // Bit length histogram.
-  uint32_t counts[kJpegHuffmanMaxBitLength + 1];
-  // Symbol values sorted by increasing bit lengths.
-  uint32_t values[kJpegHuffmanAlphabetSize + 1];
-  // The index of the Huffman code in the current set of Huffman codes. For AC
-  // component Huffman codes, 0x10 is added to the index.
-  int slot_id;
-  boolean sent_table;
-};
-
 constexpr int kDefaultProgressiveLevel = 0;
+
+typedef int16_t coeff_t;
 
 struct HuffmanCodeTable {
   int depth[256];
   int code[256];
 };
 
-struct ScanCodingInfo {
-  uint32_t dc_tbl_idx[MAX_COMPS_IN_SCAN];
-  uint32_t ac_tbl_idx[MAX_COMPS_IN_SCAN];
-  // Number of Huffman codes defined in the DHT segment preceding this scan.
-  size_t num_huffman_codes;
-};
-
-typedef int16_t coeff_t;
-
 struct Token {
-  uint8_t histo_idx;
+  uint8_t context;
   uint8_t symbol;
   uint16_t bits;
-  Token(int i, int s, int b) : histo_idx(i), symbol(s), bits(b) {}
+  Token(int c, int s, int b) : context(c), symbol(s), bits(b) {}
 };
 
 struct TokenArray {
@@ -98,7 +80,6 @@ struct jpeg_comp_master {
   size_t xsize_blocks;
   size_t ysize_blocks;
   size_t blocks_per_iMCU_row;
-  jpegli::ScanCodingInfo* scan_coding_info;
   jpegli::ScanTokenInfo* scan_token_info;
   JpegliDataType data_type;
   JpegliEndianness endianness;
@@ -112,9 +93,28 @@ struct jpeg_comp_master {
   float* zero_bias_mul[jpegli::kMaxComponents];
   int h_factor[jpegli::kMaxComponents];
   int v_factor[jpegli::kMaxComponents];
-  jpegli::JPEGHuffmanCode* huffman_codes;
-  size_t num_huffman_codes;
-  jpegli::HuffmanCodeTable huff_tables[8];
+  // Array of Huffman tables that will be encoded in one or more DHT segments.
+  // In progressive mode we compute all Huffman tables that will be used in any
+  // of the scans, thus we can have more than 4 tables here.
+  JHUFF_TBL* huffman_tables;
+  size_t num_huffman_tables;
+  // Array of num_huffman_tables slot ids, where the ith element is the slot id
+  // of the ith Huffman table, as it appears in the DHT segment. The range of
+  // the slot ids is 0..3 for DC and 16..19 for AC Huffman codes.
+  uint8_t* slot_id_map;
+  // Maps context ids to an index in the huffman_tables array. Each component in
+  // each scan has a DC and AC context id, which are defined as follows:
+  //   - DC context id is the component index (relative to cinfo->comp_info) of
+  //     the scan component
+  //   - AC context ids start at 4 and are increased for each component of each
+  //     scan that have AC components (i.e. Se > 0)
+  uint8_t* context_map;
+  size_t num_contexts;
+  // Array of cinfo->num_scans context ids, where the ith element is the context
+  // id of the first AC component of the ith scan.
+  uint8_t* ac_ctx_offset;
+  // Array of num_huffman tables derived coding tables.
+  jpegli::HuffmanCodeTable* coding_tables;
   float* diff_buffer;
   jpegli::RowBuffer<float> fuzzy_erosion_tmp;
   jpegli::RowBuffer<float> pre_erosion;
@@ -122,7 +122,7 @@ struct jpeg_comp_master {
   jvirt_barray_ptr* coeff_buffers;
   size_t next_input_row;
   size_t next_iMCU_row;
-  size_t last_dht_index;
+  size_t next_dht_index;
   size_t last_restart_interval;
   JCOEF last_dc_coeff[MAX_COMPS_IN_SCAN];
   jpegli::JpegBitWriter bw;
@@ -135,9 +135,6 @@ struct jpeg_comp_master {
   size_t total_num_tokens;
   jpegli::RefToken* next_refinement_token;
   uint8_t* next_refinement_bit;
-  size_t num_histograms;
-  uint8_t* ac_histogram_offset;
-  uint8_t* context_map;
 };
 
 #endif  // LIB_JPEGLI_ENCODE_INTERNAL_H_

--- a/lib/jpegli/entropy_coding-inl.h
+++ b/lib/jpegli/entropy_coding-inl.h
@@ -159,14 +159,14 @@ int NumNonZero8x8ExceptDC(const T* block) {
 }
 
 template <typename T, bool zig_zag_order>
-void ComputeTokensForBlock(const T* block, int last_dc, int histo_dc,
-                           int histo_ac, Token** tokens_ptr) {
+void ComputeTokensForBlock(const T* block, int last_dc, int dc_ctx, int ac_ctx,
+                           Token** tokens_ptr) {
   Token* next_token = *tokens_ptr;
   coeff_t temp2;
   coeff_t temp;
   temp = block[0] - last_dc;
   if (temp == 0) {
-    *next_token++ = Token(histo_dc, 0, 0);
+    *next_token++ = Token(dc_ctx, 0, 0);
   } else {
     temp2 = temp;
     if (temp < 0) {
@@ -175,12 +175,12 @@ void ComputeTokensForBlock(const T* block, int last_dc, int histo_dc,
     }
     int dc_nbits = jxl::FloorLog2Nonzero<uint32_t>(temp) + 1;
     int dc_mask = (1 << dc_nbits) - 1;
-    *next_token++ = Token(histo_dc, dc_nbits, temp2 & dc_mask);
+    *next_token++ = Token(dc_ctx, dc_nbits, temp2 & dc_mask);
   }
   int num_nonzeros = NumNonZero8x8ExceptDC(block);
   for (int k = 1; k < 64; ++k) {
     if (num_nonzeros == 0) {
-      *next_token++ = Token(histo_ac, 0, 0);
+      *next_token++ = Token(ac_ctx, 0, 0);
       break;
     }
     int r = 0;
@@ -203,13 +203,13 @@ void ComputeTokensForBlock(const T* block, int last_dc, int histo_dc,
       temp2 = temp;
     }
     while (r > 15) {
-      *next_token++ = Token(histo_ac, 0xf0, 0);
+      *next_token++ = Token(ac_ctx, 0xf0, 0);
       r -= 16;
     }
     int ac_nbits = jxl::FloorLog2Nonzero<uint32_t>(temp) + 1;
     int ac_mask = (1 << ac_nbits) - 1;
     int symbol = (r << 4u) + ac_nbits;
-    *next_token++ = Token(histo_ac, symbol, temp2 & ac_mask);
+    *next_token++ = Token(ac_ctx, symbol, temp2 & ac_mask);
   }
   *tokens_ptr = next_token;
 }

--- a/lib/jpegli/entropy_coding.cc
+++ b/lib/jpegli/entropy_coding.cc
@@ -5,6 +5,8 @@
 
 #include "lib/jpegli/entropy_coding.h"
 
+#include <vector>
+
 #include "lib/jpegli/encode_internal.h"
 #include "lib/jpegli/error.h"
 #include "lib/jpegli/huffman.h"
@@ -21,9 +23,9 @@ HWY_BEFORE_NAMESPACE();
 namespace jpegli {
 namespace HWY_NAMESPACE {
 
-void ComputeTokensSequential(const coeff_t* block, int last_dc, int histo_dc,
-                             int histo_ac, Token** tokens_ptr) {
-  ComputeTokensForBlock<coeff_t, true>(block, last_dc, histo_dc, histo_ac,
+void ComputeTokensSequential(const coeff_t* block, int last_dc, int dc_ctx,
+                             int ac_ctx, Token** tokens_ptr) {
+  ComputeTokensForBlock<coeff_t, true>(block, last_dc, dc_ctx, ac_ctx,
                                        tokens_ptr);
 }
 
@@ -34,153 +36,34 @@ HWY_AFTER_NAMESPACE();
 
 #if HWY_ONCE
 namespace jpegli {
+
+size_t MaxNumTokensPerMCURow(j_compress_ptr cinfo) {
+  int MCUs_per_row = DivCeil(cinfo->image_width, 8 * cinfo->max_h_samp_factor);
+  size_t blocks_per_mcu = 0;
+  for (int c = 0; c < cinfo->num_components; ++c) {
+    jpeg_component_info* comp = &cinfo->comp_info[c];
+    blocks_per_mcu += comp->h_samp_factor * comp->v_samp_factor;
+  }
+  return kDCTBlockSize * blocks_per_mcu * MCUs_per_row;
+}
+
+size_t EstimateNumTokens(j_compress_ptr cinfo, size_t mcu_y, size_t ysize_mcus,
+                         size_t num_tokens, size_t max_per_row) {
+  size_t estimate;
+  if (mcu_y == 0) {
+    estimate = 16 * max_per_row;
+  } else {
+    estimate = (4 * ysize_mcus * num_tokens) / (3 * mcu_y);
+  }
+  size_t mcus_left = ysize_mcus - mcu_y;
+  return std::min(mcus_left * max_per_row,
+                  std::max(max_per_row, estimate - num_tokens));
+}
+
 namespace {
 HWY_EXPORT(ComputeTokensSequential);
 
-float HistogramCost(const Histogram& histo) {
-  std::vector<uint32_t> counts(kJpegHuffmanAlphabetSize + 1);
-  std::vector<uint8_t> depths(kJpegHuffmanAlphabetSize + 1);
-  for (size_t i = 0; i < kJpegHuffmanAlphabetSize; ++i) {
-    counts[i] = histo.count[i];
-  }
-  counts[kJpegHuffmanAlphabetSize] = 1;
-  CreateHuffmanTree(counts.data(), counts.size(), kJpegHuffmanMaxBitLength,
-                    &depths[0]);
-  size_t header_bits = (1 + kJpegHuffmanMaxBitLength) * 8;
-  size_t data_bits = 0;
-  for (size_t i = 0; i < kJpegHuffmanAlphabetSize; ++i) {
-    if (depths[i] > 0) {
-      header_bits += 8;
-      data_bits += counts[i] * depths[i];
-    }
-  }
-  return header_bits + data_bits;
-}
-
-void AddHistograms(const Histogram& a, const Histogram& b, Histogram* c) {
-  for (size_t i = 0; i < kJpegHuffmanAlphabetSize; ++i) {
-    c->count[i] = a.count[i] + b.count[i];
-  }
-}
-
-bool IsEmptyHistogram(const Histogram& histo) {
-  for (size_t i = 0; i < kJpegHuffmanAlphabetSize; ++i) {
-    if (histo.count[i]) return false;
-  }
-  return true;
-}
-
-}  // namespace
-
-void ClusterJpegHistograms(const Histogram* histograms, size_t num,
-                           JpegClusteredHistograms* clusters) {
-  clusters->histogram_indexes.resize(num);
-  std::vector<uint32_t> slot_histograms;
-  std::vector<float> slot_costs;
-  for (size_t i = 0; i < num; ++i) {
-    const Histogram& cur = histograms[i];
-    if (IsEmptyHistogram(cur)) {
-      continue;
-    }
-    float best_cost = HistogramCost(cur);
-    size_t best_slot = slot_histograms.size();
-    for (size_t j = 0; j < slot_histograms.size(); ++j) {
-      size_t prev_idx = slot_histograms[j];
-      const Histogram& prev = clusters->histograms[prev_idx];
-      Histogram combined;
-      AddHistograms(prev, cur, &combined);
-      float combined_cost = HistogramCost(combined);
-      float cost = combined_cost - slot_costs[j];
-      if (cost < best_cost) {
-        best_cost = cost;
-        best_slot = j;
-      }
-    }
-    if (best_slot == slot_histograms.size()) {
-      // Create new histogram.
-      size_t histogram_index = clusters->histograms.size();
-      clusters->histograms.push_back(cur);
-      clusters->histogram_indexes[i] = histogram_index;
-      if (best_slot < 4) {
-        // We have a free slot, so we put the new histogram there.
-        slot_histograms.push_back(histogram_index);
-        slot_costs.push_back(best_cost);
-      } else {
-        // TODO(szabadka) Find the best histogram to replce.
-        best_slot = (clusters->slot_ids.back() + 1) % 4;
-      }
-      slot_histograms[best_slot] = histogram_index;
-      slot_costs[best_slot] = best_cost;
-      clusters->slot_ids.push_back(best_slot);
-    } else {
-      // Merge this histogram with a previous one.
-      size_t histogram_index = slot_histograms[best_slot];
-      const Histogram& prev = clusters->histograms[histogram_index];
-      AddHistograms(prev, cur, &clusters->histograms[histogram_index]);
-      clusters->histogram_indexes[i] = histogram_index;
-      JXL_ASSERT(clusters->slot_ids[histogram_index] == best_slot);
-      slot_costs[best_slot] += best_cost;
-    }
-  }
-}
-
-void BuildJpegHuffmanCode(const Histogram& histo, JPEGHuffmanCode* huff) {
-  std::vector<uint32_t> counts(kJpegHuffmanAlphabetSize + 1);
-  std::vector<uint8_t> depths(kJpegHuffmanAlphabetSize + 1);
-  for (size_t j = 0; j < kJpegHuffmanAlphabetSize; ++j) {
-    counts[j] = histo.count[j];
-  }
-  counts[kJpegHuffmanAlphabetSize] = 1;
-  CreateHuffmanTree(counts.data(), counts.size(), kJpegHuffmanMaxBitLength,
-                    &depths[0]);
-  std::fill(std::begin(huff->counts), std::end(huff->counts), 0);
-  std::fill(std::begin(huff->values), std::end(huff->values), 0);
-  for (size_t i = 0; i <= kJpegHuffmanAlphabetSize; ++i) {
-    if (depths[i] > 0) {
-      ++huff->counts[depths[i]];
-    }
-  }
-  int offset[kJpegHuffmanMaxBitLength + 1] = {0};
-  for (size_t i = 1; i <= kJpegHuffmanMaxBitLength; ++i) {
-    offset[i] = offset[i - 1] + huff->counts[i - 1];
-  }
-  for (size_t i = 0; i <= kJpegHuffmanAlphabetSize; ++i) {
-    if (depths[i] > 0) {
-      huff->values[offset[depths[i]]++] = i;
-    }
-  }
-}
-
-void AddJpegHuffmanCode(const Histogram& histogram, size_t slot_id,
-                        JPEGHuffmanCode* huff_codes, size_t* num_huff_codes) {
-  JPEGHuffmanCode huff_code = {};
-  huff_code.slot_id = slot_id;
-  BuildJpegHuffmanCode(histogram, &huff_code);
-  memcpy(&huff_codes[*num_huff_codes], &huff_code, sizeof(huff_code));
-  ++(*num_huff_codes);
-}
-
-namespace {
-void SetJpegHuffmanCode(const JpegClusteredHistograms& clusters,
-                        size_t histogram_id, size_t slot_id_offset,
-                        std::vector<uint32_t>& slot_histograms,
-                        uint32_t* slot_id, bool* is_baseline,
-                        JPEGHuffmanCode* huff_codes, size_t* num_huff_codes) {
-  JXL_ASSERT(histogram_id < clusters.histogram_indexes.size());
-  uint32_t histogram_index = clusters.histogram_indexes[histogram_id];
-  uint32_t id = clusters.slot_ids[histogram_index];
-  if (id > 1) {
-    *is_baseline = false;
-  }
-  *slot_id = id + (slot_id_offset / 4);
-  if (slot_histograms[id] != histogram_index) {
-    AddJpegHuffmanCode(clusters.histograms[histogram_index],
-                       slot_id_offset + id, huff_codes, num_huff_codes);
-    slot_histograms[id] = histogram_index;
-  }
-}
-
-void TokenizeProgressiveDC(const coeff_t* coeffs, int histo_idx, int Al,
+void TokenizeProgressiveDC(const coeff_t* coeffs, int context, int Al,
                            coeff_t* last_dc_coeff, Token** next_token) {
   coeff_t temp2;
   coeff_t temp;
@@ -194,11 +77,11 @@ void TokenizeProgressiveDC(const coeff_t* coeffs, int histo_idx, int Al,
   }
   int nbits = (temp == 0) ? 0 : (jxl::FloorLog2Nonzero<uint32_t>(temp) + 1);
   int bits = temp2 & ((1 << nbits) - 1);
-  *(*next_token)++ = Token(histo_idx, nbits, bits);
+  *(*next_token)++ = Token(context, nbits, bits);
 }
 
 void TokenizeACProgressiveScan(j_compress_ptr cinfo, int scan_index,
-                               int histo_idx, ScanTokenInfo* sti) {
+                               int context, ScanTokenInfo* sti) {
   jpeg_comp_master* m = cinfo->master;
   const jpeg_scan_info* scan_info = &cinfo->scan_info[scan_index];
   const int comp_idx = scan_info->component_index[0];
@@ -239,7 +122,7 @@ void TokenizeACProgressiveScan(j_compress_ptr cinfo, int scan_index,
           int nbits = jxl::FloorLog2Nonzero<uint32_t>(eob_run);
           int symbol = nbits << 4u;
           *m->next_token++ =
-              Token(histo_idx, symbol, eob_run & ((1 << nbits) - 1));
+              Token(context, symbol, eob_run & ((1 << nbits) - 1));
           eob_run = 0;
         }
         ta->num_tokens = m->next_token - ta->tokens;
@@ -274,16 +157,16 @@ void TokenizeACProgressiveScan(j_compress_ptr cinfo, int scan_index,
           int nbits = jxl::FloorLog2Nonzero<uint32_t>(eob_run);
           int symbol = nbits << 4u;
           *m->next_token++ =
-              Token(histo_idx, symbol, eob_run & ((1 << nbits) - 1));
+              Token(context, symbol, eob_run & ((1 << nbits) - 1));
           eob_run = 0;
         }
         while (r > 15) {
-          *m->next_token++ = Token(histo_idx, 0xf0, 0);
+          *m->next_token++ = Token(context, 0xf0, 0);
           r -= 16;
         }
         int nbits = jxl::FloorLog2Nonzero<uint32_t>(temp) + 1;
         int symbol = (r << 4u) + nbits;
-        *m->next_token++ = Token(histo_idx, symbol, temp2 & ((1 << nbits) - 1));
+        *m->next_token++ = Token(context, symbol, temp2 & ((1 << nbits) - 1));
         ++num_nzeros;
         r = 0;
       }
@@ -293,7 +176,7 @@ void TokenizeACProgressiveScan(j_compress_ptr cinfo, int scan_index,
           int nbits = jxl::FloorLog2Nonzero<uint32_t>(eob_run);
           int symbol = nbits << 4u;
           *m->next_token++ =
-              Token(histo_idx, symbol, eob_run & ((1 << nbits) - 1));
+              Token(context, symbol, eob_run & ((1 << nbits) - 1));
           eob_run = 0;
         }
       }
@@ -306,7 +189,7 @@ void TokenizeACProgressiveScan(j_compress_ptr cinfo, int scan_index,
   if (eob_run > 0) {
     int nbits = jxl::FloorLog2Nonzero<uint32_t>(eob_run);
     int symbol = nbits << 4u;
-    *m->next_token++ = Token(histo_idx, symbol, eob_run & ((1 << nbits) - 1));
+    *m->next_token++ = Token(context, symbol, eob_run & ((1 << nbits) - 1));
     ++ta->num_tokens;
     eob_run = 0;
   }
@@ -431,12 +314,12 @@ void TokenizeACRefinementScan(j_compress_ptr cinfo, int scan_index,
   m->next_refinement_bit = next_ref_bit;
 }
 
-void TokenizeScan(j_compress_ptr cinfo, size_t scan_index, int ac_histo_offset,
+void TokenizeScan(j_compress_ptr cinfo, size_t scan_index, int ac_ctx_offset,
                   ScanTokenInfo* sti) {
   const jpeg_scan_info* scan_info = &cinfo->scan_info[scan_index];
   if (scan_info->Ss > 0) {
     if (scan_info->Ah == 0) {
-      TokenizeACProgressiveScan(cinfo, scan_index, ac_histo_offset, sti);
+      TokenizeACProgressiveScan(cinfo, scan_index, ac_ctx_offset, sti);
     } else {
       TokenizeACRefinementScan(cinfo, scan_index, sti);
     }
@@ -532,7 +415,7 @@ void TokenizeScan(j_compress_ptr cinfo, size_t scan_index, int ac_histo_offset,
             }
             if (!is_progressive) {
               HWY_DYNAMIC_DISPATCH(ComputeTokensSequential)
-              (block, last_dc_coeff[i], comp_idx, ac_histo_offset + i,
+              (block, last_dc_coeff[i], comp_idx, ac_ctx_offset + i,
                &m->next_token);
               last_dc_coeff[i] = block[0];
             } else {
@@ -575,7 +458,7 @@ void TokenizeJpeg(j_compress_ptr cinfo) {
     const jpeg_scan_info* si = &cinfo->scan_info[i];
     ScanTokenInfo* sti = &m->scan_token_info[i];
     if (si->Ss > 0 && si->Ah == 0 && si->Al > 0) {
-      int offset = m->ac_histogram_offset[i];
+      int offset = m->ac_ctx_offset[i];
       TokenizeScan(cinfo, i, offset, sti);
       processed[i] = 1;
       max_refinement_tokens += sti->num_future_nonzeros;
@@ -606,7 +489,7 @@ void TokenizeJpeg(j_compress_ptr cinfo) {
       ScanTokenInfo* sti = &m->scan_token_info[i];
       if (si->Ss > 0 && si->Ah > 0 &&
           si->Ah == num_refinement_scans[si->Ss] - j) {
-        int offset = m->ac_histogram_offset[i];
+        int offset = m->ac_ctx_offset[i];
         TokenizeScan(cinfo, i, offset, sti);
         processed[i] = 1;
         new_refinement_bits += sti->num_nonzeros;
@@ -620,119 +503,18 @@ void TokenizeJpeg(j_compress_ptr cinfo) {
     if (processed[i]) {
       continue;
     }
-    int offset = m->ac_histogram_offset[i];
+    int offset = m->ac_ctx_offset[i];
     TokenizeScan(cinfo, i, offset, &m->scan_token_info[i]);
     processed[i] = 1;
   }
 }
 
-void CopyHuffmanTable(j_compress_ptr cinfo, int index, bool is_dc,
-                      JPEGHuffmanCode* huffman_codes,
-                      size_t* num_huffman_codes) {
-  const char* type = is_dc ? "DC" : "AC";
-  if (index < 0 || index >= NUM_HUFF_TBLS) {
-    JPEGLI_ERROR("Invalid %s Huffman table index %d", type, index);
-  }
-  JHUFF_TBL* table =
-      is_dc ? cinfo->dc_huff_tbl_ptrs[index] : cinfo->ac_huff_tbl_ptrs[index];
-  if (table == nullptr) {
-    JPEGLI_ERROR("Missing %s Huffman table %d", type, index);
-  }
-  ValidateHuffmanTable(reinterpret_cast<j_common_ptr>(cinfo), table, is_dc);
-  JPEGHuffmanCode huff = {};
-  size_t max_depth = 0;
-  for (size_t i = 1; i <= kJpegHuffmanMaxBitLength; ++i) {
-    if (table->bits[i] != 0) max_depth = i;
-    huff.counts[i] = table->bits[i];
-  }
-  ++huff.counts[max_depth];
-  for (size_t i = 0; i < kJpegHuffmanAlphabetSize; ++i) {
-    huff.values[i] = table->huffval[i];
-  }
-  huff.slot_id = index + (is_dc ? 0 : 0x10);
-  huff.sent_table = table->sent_table;
-  bool have_slot = false;
-  for (size_t i = 0; i < *num_huffman_codes; ++i) {
-    if (huffman_codes[i].slot_id == huff.slot_id) have_slot = true;
-  }
-  if (!have_slot) {
-    memcpy(&huffman_codes[*num_huffman_codes], &huff, sizeof(huff));
-    ++(*num_huffman_codes);
-  }
-}
+namespace {
 
-void CopyHuffmanCodes(j_compress_ptr cinfo, bool* is_baseline) {
-  jpeg_comp_master* m = cinfo->master;
-  m->huffman_codes =
-      Allocate<JPEGHuffmanCode>(cinfo, 2 * cinfo->num_components, JPOOL_IMAGE);
-  for (int c = 0; c < cinfo->num_components; ++c) {
-    jpeg_component_info* comp = &cinfo->comp_info[c];
-    if (comp->dc_tbl_no > 1 || comp->ac_tbl_no > 1) {
-      *is_baseline = false;
-    }
-    CopyHuffmanTable(cinfo, comp->dc_tbl_no, /*is_dc=*/true, m->huffman_codes,
-                     &m->num_huffman_codes);
-    CopyHuffmanTable(cinfo, comp->ac_tbl_no, /*is_dc=*/false, m->huffman_codes,
-                     &m->num_huffman_codes);
-  }
-  m->context_map = Allocate<uint8_t>(cinfo, 8, JPOOL_IMAGE);
-  memset(m->context_map, 0, 8);
-  size_t ac_histogram_id = 0;
-  for (int i = 0; i < cinfo->num_scans; ++i) {
-    const jpeg_scan_info* si = &cinfo->scan_info[i];
-    ScanCodingInfo sci = {};
-    for (int j = 0; j < si->comps_in_scan; ++j) {
-      int ci = si->component_index[j];
-      sci.dc_tbl_idx[j] = cinfo->comp_info[ci].dc_tbl_no;
-      sci.ac_tbl_idx[j] = cinfo->comp_info[ci].ac_tbl_no + 4;
-      m->context_map[ci] = sci.dc_tbl_idx[j];
-      m->context_map[4 + ac_histogram_id] = sci.ac_tbl_idx[j];
-      ++ac_histogram_id;
-    }
-    if (i == 0) {
-      sci.num_huffman_codes = m->num_huffman_codes;
-    }
-    memcpy(&m->scan_coding_info[i], &sci, sizeof(sci));
-  }
-}
-
-size_t MaxNumTokensPerMCURow(j_compress_ptr cinfo) {
-  int MCUs_per_row = DivCeil(cinfo->image_width, 8 * cinfo->max_h_samp_factor);
-  size_t blocks_per_mcu = 0;
-  for (int c = 0; c < cinfo->num_components; ++c) {
-    jpeg_component_info* comp = &cinfo->comp_info[c];
-    blocks_per_mcu += comp->h_samp_factor * comp->v_samp_factor;
-  }
-  return kDCTBlockSize * blocks_per_mcu * MCUs_per_row;
-}
-
-size_t EstimateNumTokens(j_compress_ptr cinfo, size_t mcu_y, size_t ysize_mcus,
-                         size_t num_tokens, size_t max_per_row) {
-  size_t estimate;
-  if (mcu_y == 0) {
-    estimate = 16 * max_per_row;
-  } else {
-    estimate = (4 * ysize_mcus * num_tokens) / (3 * mcu_y);
-  }
-  size_t mcus_left = ysize_mcus - mcu_y;
-  return std::min(mcus_left * max_per_row,
-                  std::max(max_per_row, estimate - num_tokens));
-}
-
-size_t RestartIntervalForScan(j_compress_ptr cinfo, size_t scan_index) {
-  if (cinfo->restart_in_rows <= 0) {
-    return cinfo->restart_interval;
-  } else {
-    const jpeg_scan_info* scan_info = &cinfo->scan_info[scan_index];
-    const bool is_interleaved = (scan_info->comps_in_scan > 1);
-    jpeg_component_info* base_comp =
-        &cinfo->comp_info[scan_info->component_index[0]];
-    const int h_group = is_interleaved ? 1 : base_comp->h_samp_factor;
-    int MCUs_per_row =
-        DivCeil(cinfo->image_width * h_group, 8 * cinfo->max_h_samp_factor);
-    return std::min<size_t>(MCUs_per_row * cinfo->restart_in_rows, 65535u);
-  }
-}
+struct Histogram {
+  int count[kJpegHuffmanAlphabetSize];
+  Histogram() { memset(count, 0, sizeof(count)); }
+};
 
 void BuildHistograms(j_compress_ptr cinfo, Histogram* histograms) {
   jpeg_comp_master* m = cinfo->master;
@@ -742,14 +524,15 @@ void BuildHistograms(j_compress_ptr cinfo, Histogram* histograms) {
     size_t num_tokens = m->token_arrays[i].num_tokens;
     for (size_t j = 0; j < num_tokens; ++j) {
       Token t = tokens[j];
-      ++histograms[t.histo_idx].count[t.symbol];
+      ++histograms[t.context].count[t.symbol];
     }
   }
   for (int i = 0; i < cinfo->num_scans; ++i) {
     const jpeg_scan_info& si = cinfo->scan_info[i];
     const ScanTokenInfo& sti = m->scan_token_info[i];
     if (si.Ss > 0 && si.Ah > 0) {
-      int* ac_histo = &histograms[m->ac_histogram_offset[i]].count[0];
+      int context = m->ac_ctx_offset[i];
+      int* ac_histo = &histograms[context].count[0];
       for (size_t j = 0; j < sti.num_tokens; ++j) {
         ++ac_histo[sti.tokens[j].symbol & 253];
       }
@@ -757,9 +540,189 @@ void BuildHistograms(j_compress_ptr cinfo, Histogram* histograms) {
   }
 }
 
-void OptimizeHuffmanCodes(j_compress_ptr cinfo, bool* is_baseline) {
+struct JpegClusteredHistograms {
+  std::vector<Histogram> histograms;
+  std::vector<uint32_t> histogram_indexes;
+  std::vector<uint32_t> slot_ids;
+};
+
+float HistogramCost(const Histogram& histo) {
+  std::vector<uint32_t> counts(kJpegHuffmanAlphabetSize + 1);
+  std::vector<uint8_t> depths(kJpegHuffmanAlphabetSize + 1);
+  for (size_t i = 0; i < kJpegHuffmanAlphabetSize; ++i) {
+    counts[i] = histo.count[i];
+  }
+  counts[kJpegHuffmanAlphabetSize] = 1;
+  CreateHuffmanTree(counts.data(), counts.size(), kJpegHuffmanMaxBitLength,
+                    &depths[0]);
+  size_t header_bits = (1 + kJpegHuffmanMaxBitLength) * 8;
+  size_t data_bits = 0;
+  for (size_t i = 0; i < kJpegHuffmanAlphabetSize; ++i) {
+    if (depths[i] > 0) {
+      header_bits += 8;
+      data_bits += counts[i] * depths[i];
+    }
+  }
+  return header_bits + data_bits;
+}
+
+void AddHistograms(const Histogram& a, const Histogram& b, Histogram* c) {
+  for (size_t i = 0; i < kJpegHuffmanAlphabetSize; ++i) {
+    c->count[i] = a.count[i] + b.count[i];
+  }
+}
+
+bool IsEmptyHistogram(const Histogram& histo) {
+  for (size_t i = 0; i < kJpegHuffmanAlphabetSize; ++i) {
+    if (histo.count[i]) return false;
+  }
+  return true;
+}
+
+void ClusterJpegHistograms(const Histogram* histograms, size_t num,
+                           JpegClusteredHistograms* clusters) {
+  clusters->histogram_indexes.resize(num);
+  std::vector<uint32_t> slot_histograms;
+  std::vector<float> slot_costs;
+  for (size_t i = 0; i < num; ++i) {
+    const Histogram& cur = histograms[i];
+    if (IsEmptyHistogram(cur)) {
+      continue;
+    }
+    float best_cost = HistogramCost(cur);
+    size_t best_slot = slot_histograms.size();
+    for (size_t j = 0; j < slot_histograms.size(); ++j) {
+      size_t prev_idx = slot_histograms[j];
+      const Histogram& prev = clusters->histograms[prev_idx];
+      Histogram combined;
+      AddHistograms(prev, cur, &combined);
+      float combined_cost = HistogramCost(combined);
+      float cost = combined_cost - slot_costs[j];
+      if (cost < best_cost) {
+        best_cost = cost;
+        best_slot = j;
+      }
+    }
+    if (best_slot == slot_histograms.size()) {
+      // Create new histogram.
+      size_t histogram_index = clusters->histograms.size();
+      clusters->histograms.push_back(cur);
+      clusters->histogram_indexes[i] = histogram_index;
+      if (best_slot < 4) {
+        // We have a free slot, so we put the new histogram there.
+        slot_histograms.push_back(histogram_index);
+        slot_costs.push_back(best_cost);
+      } else {
+        // TODO(szabadka) Find the best histogram to replce.
+        best_slot = (clusters->slot_ids.back() + 1) % 4;
+      }
+      slot_histograms[best_slot] = histogram_index;
+      slot_costs[best_slot] = best_cost;
+      clusters->slot_ids.push_back(best_slot);
+    } else {
+      // Merge this histogram with a previous one.
+      size_t histogram_index = slot_histograms[best_slot];
+      const Histogram& prev = clusters->histograms[histogram_index];
+      AddHistograms(prev, cur, &clusters->histograms[histogram_index]);
+      clusters->histogram_indexes[i] = histogram_index;
+      JXL_ASSERT(clusters->slot_ids[histogram_index] == best_slot);
+      slot_costs[best_slot] += best_cost;
+    }
+  }
+}
+
+void CopyHuffmanTable(j_compress_ptr cinfo, int index, bool is_dc,
+                      int* inv_slot_map, uint8_t* slot_id_map,
+                      JHUFF_TBL* huffman_tables, size_t* num_huffman_tables) {
+  const char* type = is_dc ? "DC" : "AC";
+  if (index < 0 || index >= NUM_HUFF_TBLS) {
+    JPEGLI_ERROR("Invalid %s Huffman table index %d", type, index);
+  }
+  // Check if we have alreay copied this Huffman table.
+  int slot_idx = index + (is_dc ? 0 : NUM_HUFF_TBLS);
+  if (inv_slot_map[slot_idx] != -1) {
+    return;
+  }
+  inv_slot_map[slot_idx] = *num_huffman_tables;
+  // Look up and validate Huffman table.
+  JHUFF_TBL* table =
+      is_dc ? cinfo->dc_huff_tbl_ptrs[index] : cinfo->ac_huff_tbl_ptrs[index];
+  if (table == nullptr) {
+    JPEGLI_ERROR("Missing %s Huffman table %d", type, index);
+  }
+  ValidateHuffmanTable(reinterpret_cast<j_common_ptr>(cinfo), table, is_dc);
+  // Copy Huffman table to the end of the list and save slot id.
+  slot_id_map[*num_huffman_tables] = index + (is_dc ? 0 : 0x10);
+  memcpy(&huffman_tables[*num_huffman_tables], table, sizeof(JHUFF_TBL));
+  ++(*num_huffman_tables);
+}
+
+void BuildJpegHuffmanTable(const Histogram& histo, JHUFF_TBL* table) {
+  std::vector<uint32_t> counts(kJpegHuffmanAlphabetSize + 1);
+  std::vector<uint8_t> depths(kJpegHuffmanAlphabetSize + 1);
+  for (size_t j = 0; j < kJpegHuffmanAlphabetSize; ++j) {
+    counts[j] = histo.count[j];
+  }
+  counts[kJpegHuffmanAlphabetSize] = 1;
+  CreateHuffmanTree(counts.data(), counts.size(), kJpegHuffmanMaxBitLength,
+                    &depths[0]);
+  memset(table, 0, sizeof(JHUFF_TBL));
+  for (size_t i = 0; i < kJpegHuffmanAlphabetSize; ++i) {
+    if (depths[i] > 0) {
+      ++table->bits[depths[i]];
+    }
+  }
+  int offset[kJpegHuffmanMaxBitLength + 1] = {0};
+  for (size_t i = 1; i <= kJpegHuffmanMaxBitLength; ++i) {
+    offset[i] = offset[i - 1] + table->bits[i - 1];
+  }
+  for (size_t i = 0; i < kJpegHuffmanAlphabetSize; ++i) {
+    if (depths[i] > 0) {
+      table->huffval[offset[depths[i]]++] = i;
+    }
+  }
+}
+
+}  // namespace
+
+void CopyHuffmanTables(j_compress_ptr cinfo) {
   jpeg_comp_master* m = cinfo->master;
-  std::vector<Histogram> histograms(m->num_histograms);
+  size_t max_huff_tables = 2 * cinfo->num_components;
+  // Copy Huffman tables and save slot ids.
+  m->huffman_tables = Allocate<JHUFF_TBL>(cinfo, max_huff_tables, JPOOL_IMAGE);
+  m->slot_id_map = Allocate<uint8_t>(cinfo, max_huff_tables, JPOOL_IMAGE);
+  m->num_huffman_tables = 0;
+  int inv_slot_map[8] = {-1, -1, -1, -1, -1, -1, -1, -1};
+  for (int c = 0; c < cinfo->num_components; ++c) {
+    jpeg_component_info* comp = &cinfo->comp_info[c];
+    CopyHuffmanTable(cinfo, comp->dc_tbl_no, /*is_dc=*/true, &inv_slot_map[0],
+                     m->slot_id_map, m->huffman_tables, &m->num_huffman_tables);
+    CopyHuffmanTable(cinfo, comp->ac_tbl_no, /*is_dc=*/false, &inv_slot_map[0],
+                     m->slot_id_map, m->huffman_tables, &m->num_huffman_tables);
+  }
+  // Compute context map.
+  m->context_map = Allocate<uint8_t>(cinfo, 8, JPOOL_IMAGE);
+  memset(m->context_map, 0, 8);
+  for (int c = 0; c < cinfo->num_components; ++c) {
+    m->context_map[c] = inv_slot_map[cinfo->comp_info[c].dc_tbl_no];
+  }
+  int ac_ctx = 4;
+  for (int i = 0; i < cinfo->num_scans; ++i) {
+    const jpeg_scan_info* si = &cinfo->scan_info[i];
+    if (si->Se > 0) {
+      for (int j = 0; j < si->comps_in_scan; ++j) {
+        int c = si->component_index[j];
+        jpeg_component_info* comp = &cinfo->comp_info[c];
+        m->context_map[ac_ctx++] = inv_slot_map[comp->ac_tbl_no + 4];
+      }
+    }
+  }
+}
+
+void OptimizeHuffmanCodes(j_compress_ptr cinfo) {
+  jpeg_comp_master* m = cinfo->master;
+  // Build DC and AC histograms.
+  std::vector<Histogram> histograms(m->num_contexts);
   BuildHistograms(cinfo, &histograms[0]);
 
   // Cluster DC histograms.
@@ -768,57 +731,89 @@ void OptimizeHuffmanCodes(j_compress_ptr cinfo, bool* is_baseline) {
 
   // Cluster AC histograms.
   JpegClusteredHistograms ac_clusters;
-  ClusterJpegHistograms(histograms.data() + 4, m->num_histograms - 4,
+  ClusterJpegHistograms(histograms.data() + 4, m->num_contexts - 4,
                         &ac_clusters);
 
-  // Add the first 4 DC and AC histograms in the first DHT segment.
-  std::vector<uint32_t> dc_slot_histograms;
-  std::vector<uint32_t> ac_slot_histograms;
-  size_t num_histo = m->num_histograms;
-  m->huffman_codes = Allocate<JPEGHuffmanCode>(cinfo, num_histo, JPOOL_IMAGE);
-  for (size_t i = 0; i < dc_clusters.histograms.size(); ++i) {
-    JXL_ASSERT(dc_clusters.slot_ids[i] == i);
-    AddJpegHuffmanCode(dc_clusters.histograms[i], i, m->huffman_codes,
-                       &m->num_huffman_codes);
-    dc_slot_histograms.push_back(i);
-  }
-  for (size_t i = 0; i < ac_clusters.histograms.size(); ++i) {
-    if (i >= 4) break;
-    JXL_ASSERT(ac_clusters.slot_ids[i] == i);
-    AddJpegHuffmanCode(ac_clusters.histograms[i], 0x10 + i, m->huffman_codes,
-                       &m->num_huffman_codes);
-    ac_slot_histograms.push_back(i);
+  // Create Huffman tables and slot ids clusters.
+  size_t num_dc_huff = dc_clusters.histograms.size();
+  m->num_huffman_tables = num_dc_huff + ac_clusters.histograms.size();
+  m->huffman_tables =
+      Allocate<JHUFF_TBL>(cinfo, m->num_huffman_tables, JPOOL_IMAGE);
+  m->slot_id_map = Allocate<uint8_t>(cinfo, m->num_huffman_tables, JPOOL_IMAGE);
+  for (size_t i = 0; i < m->num_huffman_tables; ++i) {
+    JHUFF_TBL huff_table = {};
+    if (i < dc_clusters.histograms.size()) {
+      m->slot_id_map[i] = i;
+      BuildJpegHuffmanTable(dc_clusters.histograms[i], &huff_table);
+    } else {
+      m->slot_id_map[i] = 16 + ac_clusters.slot_ids[i - num_dc_huff];
+      BuildJpegHuffmanTable(ac_clusters.histograms[i - num_dc_huff],
+                            &huff_table);
+    }
+    memcpy(&m->huffman_tables[i], &huff_table, sizeof(huff_table));
   }
 
-  // Set the Huffman table indexes in the scan_infos and emit additional DHT
-  // segments if necessary.
-  size_t ac_histogram_id = 0;
-  size_t num_huffman_codes_sent = 0;
-  m->context_map = Allocate<uint8_t>(cinfo, m->num_histograms, JPOOL_IMAGE);
-  memset(m->context_map, 0, m->num_histograms);
-  for (int i = 0; i < cinfo->num_scans; ++i) {
-    ScanCodingInfo sci = {};
-    for (int j = 0; j < cinfo->scan_info[i].comps_in_scan; ++j) {
-      if (cinfo->scan_info[i].Ss == 0) {
-        uint32_t dc_histogram_id = cinfo->scan_info[i].component_index[j];
-        SetJpegHuffmanCode(dc_clusters, dc_histogram_id, 0, dc_slot_histograms,
-                           &sci.dc_tbl_idx[j], is_baseline, m->huffman_codes,
-                           &m->num_huffman_codes);
-        m->context_map[dc_histogram_id] = sci.dc_tbl_idx[j];
-      }
-      if (cinfo->scan_info[i].Se > 0) {
-        SetJpegHuffmanCode(ac_clusters, ac_histogram_id, 0x10,
-                           ac_slot_histograms, &sci.ac_tbl_idx[j], is_baseline,
-                           m->huffman_codes, &m->num_huffman_codes);
-        m->context_map[4 + ac_histogram_id] = sci.ac_tbl_idx[j];
-        ++ac_histogram_id;
-      } else {
-        sci.ac_tbl_idx[j] = 4;
-      }
+  // Create context map from clustered histogram indexes.
+  m->context_map = Allocate<uint8_t>(cinfo, m->num_contexts, JPOOL_IMAGE);
+  memset(m->context_map, 0, m->num_contexts);
+  for (size_t i = 0; i < m->num_contexts; ++i) {
+    if (i < (size_t)cinfo->num_components) {
+      m->context_map[i] = dc_clusters.histogram_indexes[i];
+    } else if (i >= 4) {
+      m->context_map[i] = num_dc_huff + ac_clusters.histogram_indexes[i - 4];
     }
-    sci.num_huffman_codes = m->num_huffman_codes - num_huffman_codes_sent;
-    num_huffman_codes_sent = m->num_huffman_codes;
-    memcpy(&m->scan_coding_info[i], &sci, sizeof(sci));
+  }
+}
+
+namespace {
+
+void BuildHuffmanCodeTable(const JHUFF_TBL& table, HuffmanCodeTable* code_table,
+                           bool pre_shifted = false) {
+  int huff_code[kJpegHuffmanAlphabetSize];
+  // +1 for a sentinel element.
+  uint32_t huff_size[kJpegHuffmanAlphabetSize + 1];
+  int p = 0;
+  for (size_t l = 1; l <= kJpegHuffmanMaxBitLength; ++l) {
+    int i = table.bits[l];
+    while (i--) huff_size[p++] = l;
+  }
+
+  // Reuse sentinel element.
+  int last_p = p;
+  huff_size[last_p] = 0;
+
+  int code = 0;
+  uint32_t si = huff_size[0];
+  p = 0;
+  while (huff_size[p]) {
+    while ((huff_size[p]) == si) {
+      huff_code[p++] = code;
+      code++;
+    }
+    code <<= 1;
+    si++;
+  }
+  for (p = 0; p < last_p; p++) {
+    int i = table.huffval[p];
+    code_table->depth[i] = huff_size[p];
+    code_table->code[i] = huff_code[p];
+    if (pre_shifted) {
+      int nbits = i & 0xf;
+      code_table->depth[i] += nbits;
+      code_table->code[i] <<= nbits;
+    }
+  }
+}
+
+}  // namespace
+
+void InitEntropyCoder(j_compress_ptr cinfo, bool pre_shifted) {
+  jpeg_comp_master* m = cinfo->master;
+  m->coding_tables =
+      Allocate<HuffmanCodeTable>(cinfo, m->num_huffman_tables, JPOOL_IMAGE);
+  for (size_t i = 0; i < m->num_huffman_tables; ++i) {
+    BuildHuffmanCodeTable(m->huffman_tables[i], &m->coding_tables[i],
+                          pre_shifted);
   }
 }
 

--- a/lib/jpegli/entropy_coding.h
+++ b/lib/jpegli/entropy_coding.h
@@ -11,41 +11,20 @@
 #include <jpeglib.h>
 /* clang-format on */
 
-#include <vector>
-
-#include "lib/jpegli/encode_internal.h"
-
 namespace jpegli {
 
-void CopyHuffmanCodes(j_compress_ptr cinfo, bool* is_baseline);
-
-size_t RestartIntervalForScan(j_compress_ptr cinfo, size_t scan_index);
-
-struct Histogram {
-  int count[kJpegHuffmanAlphabetSize];
-  Histogram() { memset(count, 0, sizeof(count)); }
-};
-
-struct JpegClusteredHistograms {
-  std::vector<Histogram> histograms;
-  std::vector<uint32_t> histogram_indexes;
-  std::vector<uint32_t> slot_ids;
-};
-
-void ClusterJpegHistograms(const Histogram* histograms, size_t num,
-                           JpegClusteredHistograms* clusters);
-
-void AddJpegHuffmanCode(const Histogram& histogram, size_t slot_id,
-                        JPEGHuffmanCode* huff_codes, size_t* num_huff_codes);
-
 size_t MaxNumTokensPerMCURow(j_compress_ptr cinfo);
-
-void TokenizeJpeg(j_compress_ptr cinfo);
 
 size_t EstimateNumTokens(j_compress_ptr cinfo, size_t mcu_y, size_t ysize_mcus,
                          size_t num_tokens, size_t max_per_row);
 
-void OptimizeHuffmanCodes(j_compress_ptr cinfo, bool* is_baseline);
+void TokenizeJpeg(j_compress_ptr cinfo);
+
+void CopyHuffmanTables(j_compress_ptr cinfo);
+
+void OptimizeHuffmanCodes(j_compress_ptr cinfo);
+
+void InitEntropyCoder(j_compress_ptr cinfo, bool pre_shifted);
 
 }  // namespace jpegli
 

--- a/lib/jpegli/test_utils.cc
+++ b/lib/jpegli/test_utils.cc
@@ -246,10 +246,8 @@ std::ostream& operator<<(std::ostream& os, const CompressParams& jparams) {
     os << "Psimple";
   }
   if (jparams.optimize_coding == 1) {
-    JXL_CHECK(jparams.progressive_mode <= 0 && !jparams.simple_progression);
     os << "OptimizedCode";
   } else if (jparams.optimize_coding == 0) {
-    JXL_CHECK(jparams.progressive_mode <= 0 && !jparams.simple_progression);
     os << "FixedCode";
     if (jparams.use_flat_dc_luma_code) {
       os << "FlatDCLuma";

--- a/lib/jpegli/test_utils.h
+++ b/lib/jpegli/test_utils.h
@@ -54,70 +54,148 @@ static constexpr uint8_t kMarkerSequence[] = {0xe6, 0xe8, 0xe7,
                                               0xe6, 0xe7, 0xe8};
 static constexpr size_t kMarkerSequenceLen = ARRAY_SIZE(kMarkerSequence);
 
+// Sequential non-interleaved.
 static constexpr jpeg_scan_info kScript1[] = {
     {1, {0}, 0, 63, 0, 0},
     {1, {1}, 0, 63, 0, 0},
     {1, {2}, 0, 63, 0, 0},
 };
-
+// Sequential partially interleaved, chroma first.
 static constexpr jpeg_scan_info kScript2[] = {
+    {2, {1, 2}, 0, 63, 0, 0},
+    {1, {0}, 0, 63, 0, 0},
+};
+
+// Rest of the scan scripts are progressive.
+
+static constexpr jpeg_scan_info kScript3[] = {
+    // Interleaved full DC.
     {3, {0, 1, 2}, 0, 0, 0, 0},
+    // Full AC scans.
     {1, {0}, 1, 63, 0, 0},
     {1, {1}, 1, 63, 0, 0},
     {1, {2}, 1, 63, 0, 0},
 };
-static constexpr jpeg_scan_info kScript3[] = {
-    {1, {0}, 0, 0, 0, 0},  {1, {1}, 0, 0, 0, 0},  {1, {2}, 0, 0, 0, 0},
-    {1, {0}, 1, 63, 0, 0}, {1, {1}, 1, 63, 0, 0}, {1, {2}, 1, 63, 0, 0},
-};
 static constexpr jpeg_scan_info kScript4[] = {
-    {3, {0, 1, 2}, 0, 0, 0, 0}, {1, {0}, 1, 63, 0, 1}, {1, {1}, 1, 63, 0, 1},
-    {1, {2}, 1, 63, 0, 1},      {1, {0}, 1, 63, 1, 0}, {1, {1}, 1, 63, 1, 0},
-    {1, {2}, 1, 63, 1, 0},
+    // Non-interleaved full DC.
+    {1, {0}, 0, 0, 0, 0},
+    {1, {1}, 0, 0, 0, 0},
+    {1, {2}, 0, 0, 0, 0},
+    // Full AC scans.
+    {1, {0}, 1, 63, 0, 0},
+    {1, {1}, 1, 63, 0, 0},
+    {1, {2}, 1, 63, 0, 0},
 };
 static constexpr jpeg_scan_info kScript5[] = {
-    {3, {0, 1, 2}, 0, 0, 0, 2},  //
-    {3, {0, 1, 2}, 0, 0, 2, 1},  //
-    {3, {0, 1, 2}, 0, 0, 1, 0},  //
-    {1, {0}, 1, 63, 0, 0},      {1, {1}, 1, 63, 0, 0}, {1, {2}, 1, 63, 0, 0},
+    // Partially interleaved full DC, chroma first.
+    {2, {1, 2}, 0, 0, 0, 0},
+    {1, {0}, 0, 0, 0, 0},
+    // AC shifted by 1 bit.
+    {1, {0}, 1, 63, 0, 1},
+    {1, {1}, 1, 63, 0, 1},
+    {1, {2}, 1, 63, 0, 1},
+    // AC refinement scan.
+    {1, {0}, 1, 63, 1, 0},
+    {1, {1}, 1, 63, 1, 0},
+    {1, {2}, 1, 63, 1, 0},
 };
-
 static constexpr jpeg_scan_info kScript6[] = {
-    {1, {0}, 0, 0, 0, 2},  {1, {1}, 0, 0, 0, 2},  {1, {2}, 0, 0, 0, 2},   //
-    {1, {0}, 0, 0, 2, 1},  {1, {1}, 0, 0, 2, 1},  {1, {2}, 0, 0, 2, 1},   //
-    {1, {0}, 0, 0, 1, 0},  {1, {1}, 0, 0, 1, 0},  {1, {2}, 0, 0, 1, 0},   //
-    {1, {0}, 1, 63, 0, 0}, {1, {1}, 1, 63, 0, 0}, {1, {2}, 1, 63, 0, 0},  //
+    // Interleaved DC shifted by 2 bits.
+    {3, {0, 1, 2}, 0, 0, 0, 2},
+    // Interleaved DC refinement scans.
+    {3, {0, 1, 2}, 0, 0, 2, 1},
+    {3, {0, 1, 2}, 0, 0, 1, 0},
+    // Full AC scans.
+    {1, {0}, 1, 63, 0, 0},
+    {1, {1}, 1, 63, 0, 0},
+    {1, {2}, 1, 63, 0, 0},
 };
 
 static constexpr jpeg_scan_info kScript7[] = {
-    {1, {0}, 0, 0, 0, 2},    {1, {1}, 0, 0, 0, 2},  {1, {2}, 0, 0, 0, 2},   //
-    {2, {0, 1}, 0, 0, 2, 1}, {1, {2}, 0, 0, 2, 1},                          //
-    {2, {1, 2}, 0, 0, 1, 0}, {1, {0}, 0, 0, 1, 0},                          //
-    {1, {0}, 1, 63, 0, 0},   {1, {1}, 1, 63, 0, 0}, {1, {2}, 1, 63, 0, 0},  //
+    // Non-interleaved DC shifted by 2 bits.
+    {1, {0}, 0, 0, 0, 2},
+    {1, {1}, 0, 0, 0, 2},
+    {1, {2}, 0, 0, 0, 2},
+    // Non-interleaved DC first refinement scans.
+    {1, {0}, 0, 0, 2, 1},
+    {1, {1}, 0, 0, 2, 1},
+    {1, {2}, 0, 0, 2, 1},
+    // Non-interleaved DC second refinement scans.
+    {1, {0}, 0, 0, 1, 0},
+    {1, {1}, 0, 0, 1, 0},
+    {1, {2}, 0, 0, 1, 0},
+    // Full AC scans.
+    {1, {0}, 1, 63, 0, 0},
+    {1, {1}, 1, 63, 0, 0},
+    {1, {2}, 1, 63, 0, 0},
 };
 
 static constexpr jpeg_scan_info kScript8[] = {
-    {3, {0, 1, 2}, 0, 0, 0, 0},                          //
-    {1, {0}, 1, 6, 0, 1},       {1, {0}, 7, 63, 0, 1},   //
-    {1, {0}, 1, 63, 1, 0},                               //
-    {1, {1}, 1, 63, 0, 1},                               //
-    {1, {1}, 1, 6, 1, 0},       {1, {1}, 7, 63, 1, 0},   //
-    {1, {2}, 1, 6, 0, 1},       {1, {2}, 7, 63, 0, 1},   //
-    {1, {2}, 1, 16, 1, 0},      {1, {2}, 17, 63, 1, 0},  //
+    // Partially interleaved DC shifted by 2 bits, chroma first
+    {2, {1, 2}, 0, 0, 0, 2},
+    {1, {0}, 0, 0, 0, 2},
+    // Partially interleaved DC first refinement scans.
+    {2, {0, 2}, 0, 0, 2, 1},
+    {1, {1}, 0, 0, 2, 1},
+    // Partially interleaved DC first refinement scans, chroma first.
+    {2, {1, 2}, 0, 0, 1, 0},
+    {1, {0}, 0, 0, 1, 0},
+    // Full AC scans.
+    {1, {0}, 1, 63, 0, 0},
+    {1, {1}, 1, 63, 0, 0},
+    {1, {2}, 1, 63, 0, 0},
 };
 
 static constexpr jpeg_scan_info kScript9[] = {
-    {3, {0, 1, 2}, 0, 0, 0, 0},                          //
-    {1, {0}, 1, 16, 0, 1},      {1, {1}, 1, 16, 0, 1},   //
-    {1, {2}, 1, 16, 0, 1},                               //
-    {1, {0}, 1, 8, 1, 0},       {1, {0}, 9, 16, 1, 0},   //
-    {1, {1}, 1, 8, 1, 0},       {1, {1}, 9, 16, 1, 0},   //
-    {1, {2}, 1, 8, 1, 0},       {1, {2}, 9, 16, 1, 0},   //
-    {1, {0}, 17, 63, 0, 1},     {1, {1}, 17, 63, 0, 1},  //
-    {1, {2}, 17, 63, 0, 1},                              //
-    {1, {0}, 17, 28, 1, 0},     {1, {0}, 29, 63, 1, 0},  //
-    {1, {1}, 17, 28, 1, 0},     {1, {1}, 29, 63, 1, 0},  //
-    {1, {2}, 17, 28, 1, 0},     {1, {2}, 29, 63, 1, 0},  //
+    // Interleaved full DC.
+    {3, {0, 1, 2}, 0, 0, 0, 0},
+    // AC scans for component 0
+    // shifted by 1 bit, two spectral ranges
+    {1, {0}, 1, 6, 0, 1},
+    {1, {0}, 7, 63, 0, 1},
+    // refinement scan, full
+    {1, {0}, 1, 63, 1, 0},
+    // AC scans for component 1
+    // shifted by 1 bit, full
+    {1, {1}, 1, 63, 0, 1},
+    // refinement scan, two spectral ranges
+    {1, {1}, 1, 6, 1, 0},
+    {1, {1}, 7, 63, 1, 0},
+    // AC scans for component 2
+    // shifted by 1 bit, two spectral ranges
+    {1, {2}, 1, 6, 0, 1},
+    {1, {2}, 7, 63, 0, 1},
+    // refinement scan, two spectral ranges (but different from above)
+    {1, {2}, 1, 16, 1, 0},
+    {1, {2}, 17, 63, 1, 0},
+};
+
+static constexpr jpeg_scan_info kScript10[] = {
+    // Interleaved full DC.
+    {3, {0, 1, 2}, 0, 0, 0, 0},
+    // AC scans for spectral range 1..16
+    // shifted by 1
+    {1, {0}, 1, 16, 0, 1},
+    {1, {1}, 1, 16, 0, 1},
+    {1, {2}, 1, 16, 0, 1},
+    // refinement scans, two sub-ranges
+    {1, {0}, 1, 8, 1, 0},
+    {1, {0}, 9, 16, 1, 0},
+    {1, {1}, 1, 8, 1, 0},
+    {1, {1}, 9, 16, 1, 0},
+    {1, {2}, 1, 8, 1, 0},
+    {1, {2}, 9, 16, 1, 0},
+    // AC scans for spectral range 17..63
+    {1, {0}, 17, 63, 0, 1},
+    {1, {1}, 17, 63, 0, 1},
+    {1, {2}, 17, 63, 0, 1},
+    // refinement scans, two sub-ranges
+    {1, {0}, 17, 28, 1, 0},
+    {1, {0}, 29, 63, 1, 0},
+    {1, {1}, 17, 28, 1, 0},
+    {1, {1}, 29, 63, 1, 0},
+    {1, {2}, 17, 28, 1, 0},
+    {1, {2}, 29, 63, 1, 0},
 };
 
 struct ScanScript {
@@ -130,7 +208,7 @@ static constexpr ScanScript kTestScript[] = {
     {ARRAY_SIZE(kScript3), kScript3}, {ARRAY_SIZE(kScript4), kScript4},
     {ARRAY_SIZE(kScript5), kScript5}, {ARRAY_SIZE(kScript6), kScript6},
     {ARRAY_SIZE(kScript7), kScript7}, {ARRAY_SIZE(kScript8), kScript8},
-    {ARRAY_SIZE(kScript9), kScript9},
+    {ARRAY_SIZE(kScript9), kScript9}, {ARRAY_SIZE(kScript10), kScript10},
 };
 static constexpr int kNumTestScripts = ARRAY_SIZE(kTestScript);
 


### PR DESCRIPTION
Define a context id for each component of each scan and gather histograms for each context. Clustering outputs a list of Huffman tables (JHUFF_TBL can be resued here), and a slot id for each together with a context map, then we build coding tables for each Huffman table and use the context map and coding tables for entropy coding. All Huffman tables and corresponding coding tables are built in advance for all scans, and the bitstream functions for writing DHT and SOS segments also use the context map and list of slot ids.