### PR TITLE
don't print errors when sniffing files to decode

### DIFF
--- a/lib/extras/dec/exr.cc
+++ b/lib/extras/dec/exr.cc
@@ -71,7 +71,8 @@ Status DecodeImageEXR(Span<const uint8_t> bytes, const ColorHints& color_hints,
   try {
     input_ptr.reset(new OpenEXR::RgbaInputFile(is));
   } catch (...) {
-    return JXL_FAILURE("OpenEXR failed to parse input");
+    // silently return false if it is not an EXR file
+    return false;
   }
   OpenEXR::RgbaInputFile& input = *input_ptr;
 #else

--- a/lib/extras/dec/jxl.cc
+++ b/lib/extras/dec/jxl.cc
@@ -108,6 +108,10 @@ void UpdateBitDepth(JxlBitDepth bit_depth, JxlDataType data_type, T* info) {
 bool DecodeImageJXL(const uint8_t* bytes, size_t bytes_size,
                     const JXLDecompressParams& dparams, size_t* decoded_bytes,
                     PackedPixelFile* ppf, std::vector<uint8_t>* jpeg_bytes) {
+  JxlSignature sig = JxlSignatureCheck(bytes, bytes_size);
+  // silently return false if this is not a JXL file
+  if (sig == JXL_SIG_INVALID) return false;
+
   auto decoder = JxlDecoderMake(/*memory_manager=*/nullptr);
   JxlDecoder* dec = decoder.get();
   ppf->frames.clear();

--- a/tools/ssimulacra2_main.cc
+++ b/tools/ssimulacra2_main.cc
@@ -43,14 +43,21 @@ int main(int argc, char** argv) {
 
   jxl::CodecInOut io1;
   jxl::CodecInOut io2;
-  JXL_CHECK(SetFromFile(argv[1], jxl::extras::ColorHints(), &io1));
+  if (!SetFromFile(argv[1], jxl::extras::ColorHints(), &io1)) {
+    fprintf(stderr, "Could not load original image: %s\n", argv[1]);
+    return 1;
+  }
 
   if (io1.xsize() < 8 || io1.ysize() < 8) {
     fprintf(stderr, "Minimum image size is 8x8 pixels\n");
     return 1;
   }
 
-  JXL_CHECK(SetFromFile(argv[2], jxl::extras::ColorHints(), &io2));
+  if (!SetFromFile(argv[2], jxl::extras::ColorHints(), &io2)) {
+    fprintf(stderr, "Could not load distorted image: %s\n", argv[2]);
+    return 1;
+  }
+
   if (io1.xsize() != io2.xsize() || io1.ysize() != io2.ysize()) {
     fprintf(stderr, "Image size mismatch\n");
     return 1;


### PR DESCRIPTION
Fixes https://github.com/libjxl/libjxl/issues/2524

When trying to load an image that is in none of the supported formats, currently you will see an error message showing that it failed to decode as a JXL and that it failed to decode as an EXR file. This removes those spurious errors: if the signature doesn't match, just silently fail instead of printing an error.

Also replaces the JXL_CHECK in ssimulacra2_main with something that actually prints an error and exits when feeding it images that don't exist or cannot be decoded.