### PR TITLE
Always use pre-shifted prefix code tables.

### DIFF
--- a/lib/jpegli/encode.cc
+++ b/lib/jpegli/encode.cc
@@ -497,8 +497,7 @@ void InitCompress(j_compress_ptr cinfo, boolean write_all_tables) {
   }
   if (!cinfo->optimize_coding && !cinfo->progressive_mode) {
     CopyHuffmanTables(cinfo);
-    bool pre_shifted = IsStreamingSupported(cinfo);
-    InitEntropyCoder(cinfo, pre_shifted);
+    InitEntropyCoder(cinfo);
   }
   (*cinfo->dest->init_destination)(cinfo);
   WriteFileHeader(cinfo);
@@ -1186,7 +1185,7 @@ void jpegli_finish_compress(j_compress_ptr cinfo) {
 
   if (cinfo->optimize_coding || cinfo->progressive_mode) {
     jpegli::OptimizeHuffmanCodes(cinfo);
-    jpegli::InitEntropyCoder(cinfo, /*pre_shifted=*/false);
+    jpegli::InitEntropyCoder(cinfo);
   }
 
   if (!bitstream_done) {

--- a/lib/jpegli/entropy_coding.h
+++ b/lib/jpegli/entropy_coding.h
@@ -24,7 +24,7 @@ void CopyHuffmanTables(j_compress_ptr cinfo);
 
 void OptimizeHuffmanCodes(j_compress_ptr cinfo);
 
-void InitEntropyCoder(j_compress_ptr cinfo, bool pre_shifted);
+void InitEntropyCoder(j_compress_ptr cinfo);
 
 }  // namespace jpegli
 


### PR DESCRIPTION
Benchmark results:
```
Encoding                  kPixels    Bytes          BPP  E MP/s  D MP/s     Max norm  SSIMULACRA2        pnorm       BPP*pnorm   Bugs
-------------------------------------------------------------------------------------------------------------------------------------
BEFORE:
jpeg:enc-jpegli:q90:p0      13270  3621255    2.1830490  87.032 203.926   0.99999997   0.00000000   0.00000000  0.000000000000      0
jpeg:enc-jpegli:q90         13270  3540894    2.1346039  40.410  71.981   0.99999997   0.00000000   0.00000000  0.000000000000      0
AFTER:
jpeg:enc-jpegli:q90:p0      13270  3621255    2.1830490  99.742 204.198   0.99999997   0.00000000   0.00000000  0.000000000000      0
jpeg:enc-jpegli:q90         13270  3540894    2.1346039  41.476  70.090   0.99999997   0.00000000   0.00000000  0.000000000000      0
```