### PR TITLE
faster jpeg reconstruction

### DIFF
--- a/lib/extras/dec/jxl.cc
+++ b/lib/extras/dec/jxl.cc
@@ -146,7 +146,9 @@ bool DecodeImageJXL(const uint8_t* bytes, size_t bytes_size,
   bool can_reconstruct_jpeg = false;
   std::vector<uint8_t> jpeg_data_chunk;
   if (jpeg_bytes != nullptr) {
-    jpeg_data_chunk.resize(16384);
+    // This bound is very likely to be enough to hold the entire
+    // reconstructed JPEG, to avoid having to do expensive retries.
+    jpeg_data_chunk.resize(bytes_size * 3 / 2 + 1024);
     jpeg_bytes->resize(0);
   }
 


### PR DESCRIPTION
Reconstruction of losslessly recompressed JPEG files was rather slow. A big reason for this was that a small initial output buffer size was used, leading to JXL_DEC_JPEG_NEED_MORE_OUTPUT, which with the current (non-streaming) implementation in `dec_jpeg_data_writer.cc` causes it to basically redo all of the work several times.
This gets particularly bad if the jpeg file is quite large — the initial buffer size was 16 kb and basically it would reconstruct the first 16 kb, then run out of output buffer, restart and reconstruct the first 32 kb, then 64 kb, and so on until the buffer size is large enough to store the entire jpeg file.

Besides the small change to set the initial output buffer size large enough to likely store the entire result on the first try, I also 'ported' some tricks from libjpeg-turbo to make the huffman coding itself a bit more efficient.

Before:
```
JPEG XL decoder v0.9.0 e11e728b [AVX3,AVX2,SSE4,SSSE3,SSE2]
Read 3487622 compressed bytes.
Reconstructed to JPEG.
2400 x 2400, geomean: 5.38 MP/s [5.26, 5.38], geomean: 4.13 MB/s [4.04, 4.13], 30 reps, 1 threads.
```

After:
```
JPEG XL decoder v0.9.0 e11e728b [AVX3,AVX2,SSE4,SSSE3,SSE2]
Read 3487622 compressed bytes.
Reconstructed to JPEG.
2400 x 2400, geomean: 22.39 MP/s [21.96, 22.49], geomean: 17.19 MB/s [16.85, 17.26], 30 reps, 1 threads.
```