### PR TITLE
vardct encoding heuristics improvements

### DIFF
--- a/lib/jxl/decode_test.cc
+++ b/lib/jxl/decode_test.cc
@@ -1677,7 +1677,7 @@ TEST(DecodeTest, PixelTestWithICCProfileLossy) {
   jxl::ButteraugliParams ba;
   EXPECT_THAT(ButteraugliDistance(io0.frames, io1.frames, ba, jxl::GetJxlCms(),
                                   /*distmap=*/nullptr, nullptr),
-              IsSlightlyBelow(0.9273f));
+              IsSlightlyBelow(0.666666f));
 
   JxlDecoderDestroy(dec);
 }
@@ -1935,7 +1935,7 @@ TEST(DecodeTest, PixelTestOpaqueSrgbLossy) {
     EXPECT_THAT(
         ButteraugliDistance(io0.frames, io1.frames, ba, jxl::GetJxlCms(),
                             /*distmap=*/nullptr, nullptr),
-        IsSlightlyBelow(0.72f));
+        IsSlightlyBelow(0.74f));
 
     JxlDecoderDestroy(dec);
   }
@@ -1986,7 +1986,7 @@ TEST(DecodeTest, PixelTestOpaqueSrgbLossyNoise) {
     EXPECT_THAT(
         ButteraugliDistance(io0.frames, io1.frames, ba, jxl::GetJxlCms(),
                             /*distmap=*/nullptr, nullptr),
-        IsSlightlyBelow(1.74444f));
+        IsSlightlyBelow(2.04444f));
 
     JxlDecoderDestroy(dec);
   }

--- a/lib/jxl/enc_adaptive_quantization.cc
+++ b/lib/jxl/enc_adaptive_quantization.cc
@@ -724,7 +724,7 @@ ImageF TileDistMap(const ImageF& distmap, int tile_size, int margin,
 
 static const float kDcQuantPow = 0.83;
 static const float kDcQuant = 1.095924047623553f;
-static const float kAcQuant = 0.762;
+static const float kAcQuant = 0.7738;
 
 void FindBestQuantization(const ImageBundle& linear, const Image3F& opsin,
                           PassesEncoderState* enc_state,

--- a/lib/jxl/jxl_test.cc
+++ b/lib/jxl/jxl_test.cc
@@ -357,7 +357,7 @@ TEST(JxlTest, RoundtripLargeFast) {
   cparams.AddOption(JXL_ENC_FRAME_SETTING_EFFORT, 7);  // kSquirrel
 
   PackedPixelFile ppf_out;
-  EXPECT_NEAR(Roundtrip(t.ppf(), cparams, {}, &pool, &ppf_out), 445684, 5000);
+  EXPECT_NEAR(Roundtrip(t.ppf(), cparams, {}, &pool, &ppf_out), 453713, 5000);
   EXPECT_THAT(ComputeDistance2(t.ppf(), ppf_out), IsSlightlyBelow(100));
 }
 
@@ -470,7 +470,7 @@ TEST(JxlTest, RoundtripNoGaborishNoAR) {
   cparams.AddOption(JXL_ENC_FRAME_SETTING_GABORISH, 0);
 
   PackedPixelFile ppf_out;
-  EXPECT_NEAR(Roundtrip(t.ppf(), cparams, {}, pool, &ppf_out), 38561, 200);
+  EXPECT_NEAR(Roundtrip(t.ppf(), cparams, {}, pool, &ppf_out), 38009, 200);
   EXPECT_THAT(ButteraugliDistance(t.ppf(), ppf_out), IsSlightlyBelow(1.8));
 }
 
@@ -515,7 +515,7 @@ TEST(JxlTest, RoundtripSmallPatchesAlpha) {
 
   PackedPixelFile ppf_out;
   EXPECT_NEAR(Roundtrip(t.ppf(), cparams, {}, pool, &ppf_out), 597, 100);
-  EXPECT_THAT(ButteraugliDistance(t.ppf(), ppf_out), IsSlightlyBelow(0.019f));
+  EXPECT_THAT(ButteraugliDistance(t.ppf(), ppf_out), IsSlightlyBelow(0.015f));
 }
 
 TEST(JxlTest, RoundtripSmallPatches) {
@@ -540,7 +540,7 @@ TEST(JxlTest, RoundtripSmallPatches) {
 
   PackedPixelFile ppf_out;
   EXPECT_NEAR(Roundtrip(t.ppf(), cparams, {}, pool, &ppf_out), 486, 100);
-  EXPECT_THAT(ButteraugliDistance(t.ppf(), ppf_out), IsSlightlyBelow(0.019f));
+  EXPECT_THAT(ButteraugliDistance(t.ppf(), ppf_out), IsSlightlyBelow(0.015f));
 }
 
 // TODO(szabadka) Add encoder and decoder API functions that accept frame
@@ -1128,7 +1128,7 @@ TEST(JxlTest, RoundtripDots) {
   cparams.distance = 0.04;
 
   PackedPixelFile ppf_out;
-  EXPECT_NEAR(Roundtrip(t.ppf(), cparams, {}, pool, &ppf_out), 274240, 3000);
+  EXPECT_NEAR(Roundtrip(t.ppf(), cparams, {}, pool, &ppf_out), 277976, 4000);
   EXPECT_THAT(ButteraugliDistance(t.ppf(), ppf_out), IsSlightlyBelow(0.35));
 }
 


### PR DESCRIPTION
0.13 % quality improvement

```
Before:

Encoding      kPixels    Bytes          BPP  E MP/s  D MP/s     Max norm  SSIMULACRA2        pnorm   PSNR   QABPP  SmallB  DCT4x8     AFV  DCT8x8    8x16    8x32      16   16x32      32   32x64      64       BPP*pnorm   Bugs
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
jxl:d0.1        19988 16168561    6.4712758   1.364   9.630   0.35357815  95.44301818   0.11810353  52.99   6.471 40.6501 19.1672  0.4425 27.6286  5.2825  0.0000  2.4847  0.9068  3.9704  0.1127  0.0820  0.764280538314      0
jxl:d0.5        19988  6327432    2.5324800   1.798  15.641   0.79171594  91.42061585   0.34789744  44.46   2.559 13.7692 25.2259  0.6039 11.7981 21.6237  0.0000 20.8495  1.2167  5.1999  0.1537  0.2869  0.881043303275      0
jxl:d0.8        19988  4690827    1.8774482   1.795  14.719   1.10850910  88.66095412   0.48305821  41.50   2.178 10.5407 21.7265  0.7035  8.8174 19.8428  0.0000 29.2142  1.6547  7.5924  0.2254  0.4098  0.906916740953      0
jxl:d1          19988  4054905    1.6229279   1.982  16.446   1.30433495  86.94378361   0.56656991  40.36   2.180  9.2766 19.9008  0.7729  7.6971 18.3187  0.0000 30.3733  2.7383 11.0043  0.2152  0.4303  0.919502109486      0
jxl:d1.1        19988  3818397    1.5282683   1.982  16.579   1.42198944  86.09455375   0.60736824  39.90   2.240  8.8341 19.0926  0.7809  7.3196 17.6002  0.0000 30.2196  3.4837 12.7718  0.1947  0.4303  0.928221662008      0
jxl:d1.2        19988  3605968    1.4432461   1.974  16.491   1.50573635  85.26274567   0.64475804  39.43   2.242  8.3826 18.4369  0.8210  6.9818 16.9483  0.0000 29.8994  4.3341 14.2472  0.2049  0.4713  0.930544552789      0
jxl:d1.3        19988  3437341    1.3757552   1.942  17.278   1.56507151  84.62146326   0.67815547  39.06   2.234  7.9868 17.9524  0.8498  6.6478 16.4981  0.0000 28.8914  5.2460 15.7636  0.2357  0.6558  0.932975905587      0
jxl:d1.4        19988  3270570    1.3090071   1.980  17.024   1.66940303  83.88447009   0.71485001  38.69   2.270  7.6253 17.3540  0.8706  6.4278 16.1805  0.0000 27.9680  6.1605 17.1468  0.2766  0.7172  0.935743709451      0
jxl:d1.5        19988  3116987    1.2475373   2.109  16.723   1.75683078  83.11438364   0.75042670  38.36   2.281  7.3080 16.9819  0.8776  6.1931 15.7451  0.0000 26.9869  7.0698 18.6530  0.2971  0.6148  0.936185280029      0
jxl:d1.6        19988  2983002    1.1939114   1.924  16.754   1.84675205  82.36186610   0.78783673  38.03   2.300  7.0234 16.5519  0.8860  5.9908 15.4140  0.0000 26.1826  8.0124 19.6110  0.3381  0.7172  0.940607221222      0
jxl:d1.7        19988  2862547    1.1457007   2.092  17.260   1.92910980  81.67718413   0.81958554  37.76   2.306  6.7701 16.1757  0.9145  5.8508 15.2981  0.0000 25.2310  8.8629 20.5281  0.3996  0.6967  0.938999693569      0
jxl:d1.8        19988  2752424    1.1016252   2.071  16.146   2.01723020  80.96728252   0.85427462  37.45   2.328  6.5377 15.7470  0.9356  5.7269 15.1194  0.0000 24.3652  9.7543 21.3939  0.3484  0.7992  0.941090475995      0
jxl:d1.9        19988  2648661    1.0600953   2.008  16.753   2.11036388  80.23421815   0.89019467  37.19   2.340  6.3340 15.4089  0.9641  5.5838 14.9279  0.0000 23.4405 10.7072 22.2033  0.3381  0.8197  0.943691201807      0
jxl:d2.0        19988  2554646    1.0224669   2.032  16.771   2.22933808  79.53745967   0.92152028  36.94   2.394  6.1541 15.0077  0.9820  5.4003 14.7563  0.0000 22.8680 11.3732 22.9666  0.3381  0.8812  0.942223999025      0
jxl:d2.1        19988  2468418    0.9879552   2.077  16.468   2.29715909  78.85725061   0.95448590  36.70   2.387  5.9421 14.7605  0.9843  5.2995 14.5059  0.0000 22.0906 12.3081 23.4636  0.4713  0.9017  0.942989289708      0
jxl:d2.2        19988  2388314    0.9558945   2.061  16.034   2.38892049  78.15608401   0.99070341  36.50   2.375  5.7596 14.4233  1.0144  5.2313 14.3887  0.0000 21.5693 12.9357 24.0835  0.3996  0.9221  0.947007943001      0
jxl:d2.3        19988  2312592    0.9255877   2.026  16.300   2.47287406  77.49161628   1.02150646  36.27   2.390  5.5931 14.0980  1.0096  5.1221 14.3093  0.0000 20.9481 13.7451 24.4882  0.4303  0.9836  0.945493777081      0
jxl:d2.4        19988  2240685    0.8968077   1.990  15.500   2.52888642  76.86753662   1.05024513  36.05   2.367  5.4913 13.7669  1.0060  5.0091 14.1838  0.0000 20.3936 14.4572 24.8212  0.5533  1.0451  0.941867955110      0
jxl:d2.5        19988  2176079    0.8709499   1.987  17.237   2.61787283  76.19127300   1.08617515  35.87   2.390  5.3331 13.4663  1.0329  4.9402 14.0890  0.0000 19.8160 15.2923 25.1900  0.5021  1.0656  0.946004191364      0
jxl:d2.6        19988  2114187    0.8461784   2.017  15.631   2.74227027  75.58784708   1.12074961  35.68   2.443  5.1589 13.1726  1.0326  4.8288 13.9910  0.0000 19.4151 15.8379 25.6409  0.5021  1.1476  0.948354111897      0
jxl:d2.7        19988  2057434    0.8234637   2.084  17.045   2.79357921  74.99180524   1.14909654  35.51   2.425  5.0430 12.9322  1.0569  4.7612 13.7938  0.0000 18.9899 16.5987 25.9124  0.5328  1.1066  0.946239272979      0
jxl:d2.8        19988  2003098    0.8017163   2.135  17.390   2.85544554  74.34756861   1.17714426  35.35   2.406  4.9450 12.7442  1.0509  4.7151 13.6030  0.0000 18.4635 17.3057 26.2300  0.5840  1.0861  0.943735787351      0
jxl:d2.9        19988  1950924    0.7808343   2.099  16.689   2.93520785  73.66769117   1.20834307  35.20   2.405  4.8173 12.4855  1.0678  4.6402 13.6094  0.0000 18.0920 17.8077 26.5374  0.4816  1.1885  0.943515732155      0
jxl:d3          19988  1904599    0.7622933   1.928  16.441   3.02034789  73.13820701   1.23500272  35.04   2.431  4.6405 12.2326  1.0640  4.5800 13.4346  0.0000 17.7104 18.4788 26.7628  0.5328  1.2910  0.941434274946      0
jxl:d5          19988  1303893    0.5218678   1.923   9.402   4.45726190  62.04613633   1.75931368  32.74   2.440  3.2125  7.9071  0.9446  2.9451 10.8385  0.0000 13.7362 27.7003 31.2506  0.2664  1.9263  0.918129142862      0
jxl:d7          19988  1019574    0.4080725   1.962   9.576   5.73712043  52.94850030   2.21224432  31.34   2.433  2.4469  5.4810  0.7560  2.0547  9.1229  0.0000 11.4334 32.5262 34.3757  0.2562  2.2746  0.902755991675      0
jxl:d15         19988   576525    0.2307473   2.038   9.291   9.96225175  24.47643927   3.69453040  28.69   2.327  1.0640  1.3944  0.2728  0.4636  4.9527  0.0000  6.3231 36.0919 44.2119  1.0553  4.8976  0.852503023067      0
jxl:d24         19988   407843    0.1632343   0.289  19.187  16.68665052   4.51409337   5.84382697  25.92   2.635  0.9526  2.0860  0.1668  0.6554  3.0034  0.0000  2.9816  9.2753  6.2911  0.0410  0.0000  0.953913290248      0
jxl:d32         19988   331510    0.1326830   0.290  20.971  18.38951067  -5.26792992   6.50097472  25.51   2.403  0.6878  1.5792  0.1332  0.4476  2.6973  0.0000  2.6204 10.0232  7.1518  0.1127  0.0000  0.862568609513      0
Aggregate:      19988  2305912    0.9229141   1.727  15.476   2.44554239  68.32454416   0.99955511  36.35   2.442  5.4199 11.8561  0.7519  4.5497 12.3586  0.0000 17.0596  8.8794 17.7145  0.3044  0.8054  0.922503545580      0

After:

Encoding      kPixels    Bytes          BPP  E MP/s  D MP/s     Max norm  SSIMULACRA2        pnorm   PSNR   QABPP  SmallB  DCT4x8     AFV  DCT8x8    8x16    8x32      16   16x32      32   32x64      64       BPP*pnorm   Bugs
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
jxl:d0.1        19988 16262919    6.5090415   1.425   9.109   0.35504593  95.44944669   0.11776069  53.03   6.509 41.0113 18.9684  0.4505 27.6395  5.1307  0.0000  2.4680  0.9042  3.9704  0.1025  0.0820  0.766509194521      0
jxl:d0.5        19988  6328890    2.5330636   1.743  15.020   0.79249374  91.39411257   0.34830485  44.51   2.557 13.8988 25.2547  0.5994 11.8951 21.3932  0.0000 20.8162  1.2193  5.2101  0.1537  0.2869  0.882278322147      0
jxl:d0.8        19988  4689931    1.8770895   1.859  15.156   1.10084689  88.64919654   0.48230585  41.49   2.157 10.6166 21.7605  0.7105  8.8965 19.7263  0.0000 29.2347  1.6522  7.5155  0.2049  0.4098  0.905331266148      0
jxl:d1          19988  4053610    1.6224096   1.920  16.425   1.30339278  86.93459238   0.56547718  40.36   2.190  9.3531 19.9981  0.7630  7.7630 18.1618  0.0000 30.4898  2.6409 10.9223  0.2049  0.4303  0.917435600195      0
jxl:d1.1        19988  3821070    1.5293382   2.003  16.864   1.41387120  86.14262428   0.60569149  39.90   2.237  8.9035 19.1688  0.7768  7.3240 17.4991  0.0000 30.3438  3.4837 12.6129  0.2049  0.4098  0.926307128008      0
jxl:d1.2        19988  3606605    1.4435011   2.045  17.374   1.51745110  85.33350648   0.64196585  39.42   2.265  8.4421 18.5038  0.8261  7.0461 16.8869  0.0000 29.8315  4.2573 14.2370  0.2049  0.4918  0.926678417401      0
jxl:d1.3        19988  3432924    1.3739873   1.943  16.974   1.56597324  84.63295917   0.67665636  39.06   2.237  8.0246 18.0245  0.8488  6.6670 16.4405  0.0000 29.1079  5.1589 15.6151  0.2254  0.6148  0.929717270191      0
jxl:d1.4        19988  3267344    1.3077159   2.039  17.064   1.66724310  83.87641540   0.71469067  38.71   2.283  7.7102 17.4561  0.8588  6.4608 16.0915  0.0000 28.0026  6.0990 17.1059  0.2664  0.6762  0.934612340961      0
jxl:d1.5        19988  3115789    1.2470578   2.039  17.085   1.76594311  83.13356260   0.75105989  38.37   2.298  7.3871 17.0159  0.8815  6.2434 15.7290  0.0000 27.0868  6.9878 18.5249  0.2766  0.5943  0.936615088490      0
jxl:d1.6        19988  2982469    1.1936980   1.859  16.084   1.82568281  82.38628562   0.78338533  38.05   2.268  7.0698 16.5670  0.8863  6.0564 15.3903  0.0000 26.2736  7.9305 19.5086  0.3279  0.7172  0.935125525978      0
jxl:d1.7        19988  2861613    1.1453268   1.986  16.211   1.92715294  81.67227880   0.81889633  37.76   2.288  6.8354 16.1828  0.9170  5.8765 15.2552  0.0000 25.3527  8.8014 20.4717  0.4201  0.6148  0.937903944695      0
jxl:d1.8        19988  2754066    1.1022824   2.029  16.328   1.99735956  81.00047201   0.85121488  37.47   2.306  6.6010 15.8718  0.9385  5.7279 15.0400  0.0000 24.4139  9.6749 21.3426  0.3996  0.7172  0.938279198067      0
jxl:d1.9        19988  2652654    1.0616935   2.037  16.373   2.10065268  80.28409394   0.88484434  37.21   2.329  6.3808 15.4905  0.9731  5.6142 14.8882  0.0000 23.6582 10.5253 22.0701  0.3279  0.7992  0.939433460001      0
jxl:d2.0        19988  2557620    1.0236572   2.037  16.917   2.19524039  79.56970125   0.91843825  36.95   2.357  6.1986 15.1431  0.9823  5.4506 14.6820  0.0000 22.9039 11.3245 22.8027  0.3586  0.8812  0.940165953181      0
jxl:d2.1        19988  2471537    0.9892035   2.088  17.028   2.32635728  78.89246731   0.95202863  36.73   2.413  5.9994 14.8248  0.9827  5.3312 14.4873  0.0000 22.2596 12.0468 23.4533  0.4611  0.8812  0.941750073009      0
jxl:d2.2        19988  2390445    0.9567474   2.098  16.442   2.35829572  78.19880522   0.98463004  36.51   2.343  5.8067 14.4886  1.0003  5.2719 14.3151  0.0000 21.5501 12.9921 23.9503  0.4508  0.9017  0.942042236368      0
jxl:d2.3        19988  2315294    0.9266691   2.010  16.962   2.49174520  77.50363870   1.01914124  36.30   2.405  5.6414 14.1976  1.0195  5.1467 14.2690  0.0000 20.9674 13.6811 24.3294  0.4303  1.0451  0.944406701128      0
jxl:d2.4        19988  2244792    0.8984515   2.022  17.545   2.52123625  76.87360276   1.05173887  36.08   2.369  5.5121 13.8758  1.0137  5.0574 14.1249  0.0000 20.5050 14.3420 24.7904  0.4816  1.0246  0.944936382209      0
jxl:d2.5        19988  2178754    0.8720206   1.984  16.939   2.60929697  76.24669928   1.08008468  35.87   2.378  5.4035 13.5982  1.0240  4.9934 14.0641  0.0000 19.9146 15.1053 25.0671  0.5123  1.0451  0.941856069672      0
jxl:d2.6        19988  2120895    0.8488632   2.030  16.028   2.70401948  75.63012652   1.11168528  35.71   2.416  5.2236 13.2831  1.0336  4.8666 13.9590  0.0000 19.4048 15.7892 25.5691  0.5123  1.0861  0.943668722308      0
jxl:d2.7        19988  2061281    0.8250034   2.108  15.766   2.76701320  75.01076324   1.14539711  35.52   2.407  5.0968 13.0125  1.0669  4.7843 13.7919  0.0000 18.9937 16.3886 25.9329  0.5533  1.1066  0.944956507451      0
jxl:d2.8        19988  2006941    0.8032545   2.060  16.996   2.83852804  74.40730245   1.17294856  35.36   2.395  4.9630 12.8294  1.0627  4.7103 13.6632  0.0000 18.5851 17.1161 26.1173  0.5738  1.1066  0.942176159882      0
jxl:d2.9        19988  1956537    0.7830809   2.078  16.626   2.90963974  73.73571764   1.20157787  35.22   2.392  4.8647 12.5297  1.0678  4.6504 13.5421  0.0000 18.2240 17.6412 26.5784  0.5226  1.1066  0.940932622865      0
jxl:d3          19988  1908976    0.7640451   1.977  16.480   2.97093875  73.16970054   1.23116890  35.06   2.393  4.6770 12.3158  1.0585  4.5893 13.4301  0.0000 17.8397 18.3789 26.6655  0.5021  1.2705  0.940668593765      0
jxl:d5          19988  1302662    0.5213751   1.924   9.481   4.47636288  61.93081328   1.76245191  32.77   2.449  3.2547  8.0249  0.9382  2.9566 10.8769  0.0000 13.7579 27.6286 31.1379  0.2664  1.8853  0.918898536801      0
jxl:d7          19988  1011818    0.4049682   1.932   9.002   5.71113154  52.57509044   2.22633686  31.35   2.403  2.4796  5.5591  0.7816  2.0655  9.1754  0.0000 11.3898 32.4161 34.3398  0.2459  2.2746  0.901595667624      0
jxl:d15         19988   568085    0.2273693   2.000   8.780  10.00935537  23.61668488   3.76770718  28.60   2.309  1.0826  1.4527  0.2757  0.4723  5.0052  0.0000  6.3487 36.3096 44.0019  1.0246  4.7542  0.856661015461      0
jxl:d24         19988   408410    0.1634613   0.304  18.817  16.81616443   4.48142796   5.84684282  25.93   2.658  0.9567  2.1405  0.1710  0.6644  3.0264  0.0000  2.9816  9.1395  6.3321  0.0410  0.0000  0.955732434044      0
jxl:d32         19988   332280    0.1329911   0.309  19.911  18.57719112  -5.52425782   6.50511876  25.52   2.442  0.7044  1.6061  0.1313  0.4592  2.7184  0.0000  2.6307  9.9387  7.1518  0.1127  0.0000  0.865123222584      0
Aggregate:      19988  2306342    0.9230861   1.731  15.395   2.43965505  68.21685983   0.99806086  36.36   2.437  5.4715 11.9455  0.7537  4.5818 12.3270  0.0000 17.1044  8.8037 17.6528  0.3025  0.7871  0.921296129416      0
```