### PR TITLE
Don't emit error message in CreateICC().

### DIFF
--- a/lib/jxl/color_encoding_internal.cc
+++ b/lib/jxl/color_encoding_internal.cc
@@ -417,10 +417,7 @@ Status ColorEncoding::SetPrimaries(const PrimariesCIExy& xy) {
 
 Status ColorEncoding::CreateICC() {
   InternalRemoveICC();
-  if (!MaybeCreateProfile(*this, &icc_)) {
-    return JXL_FAILURE("Failed to create profile from fields");
-  }
-  return true;
+  return MaybeCreateProfile(*this, &icc_);
 }
 
 std::string Description(const ColorEncoding& c_in) {


### PR DESCRIPTION
Since returning false from MaybeCreateProfile is not an error in some cases, this error message can cause some extra noise.