### PR TITLE
Use some fixed dead-zone quantization in :noaq mode as well.

### DIFF
--- a/lib/jpegli/quant.cc
+++ b/lib/jpegli/quant.cc
@@ -745,6 +745,13 @@ void InitQuantizer(j_compress_ptr cinfo) {
         }
       }
     }
+  } else if (cinfo->jpeg_color_space == JCS_YCbCr) {
+    for (int c = 0; c < cinfo->num_components; ++c) {
+      for (int k = 0; k < DCTSIZE2; ++k) {
+        m->zero_bias_offset[c][k] =
+            k == 0 ? kZeroBiasOffsetYCbCrDC[c] : kZeroBiasOffsetYCbCrAC[c];
+      }
+    }
   }
 }
 


### PR DESCRIPTION
Benchmark results:
```
Encoding                       kPixels    Bytes          BPP  E MP/s  D MP/s     Max norm  SSIMULACRA2        pnorm       BPP*pnorm   Bugs
------------------------------------------------------------------------------------------------------------------------------------------
BEFORE:
jpeg:enc-jpegli:q90:p0           13270  3621255    2.1830490  94.474 195.784   1.58508737  84.51521884   0.68271017  1.490389738174      0
jpeg:enc-jpegli:q90:p0:noaq      13270  4283894    2.5825164  96.507 173.256   1.51445576  87.30502011   0.63342515  1.635830838152      0
AFTER:
jpeg:enc-jpegli:q90:p0           13270  3620412    2.1825408  94.136 193.894   1.58508737  84.50913605   0.68283419  1.490313465273      0
jpeg:enc-jpegli:q90:p0:noaq      13270  4053215    2.4434531  99.378 175.863   1.49191457  86.88418867   0.63697658  1.556422421912      0
```