### PR TITLE
return JXL_ENC_ERR_OOM instead of aborting when out of memory

### DIFF
--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -104,7 +104,6 @@ else ()
   else()  # WIN32
     list(APPEND JPEGXL_INTERNAL_FLAGS
       -fsized-deallocation
-      -fno-exceptions
 
       # Language flags
       -fmath-errno
@@ -113,7 +112,6 @@ else ()
     if (CMAKE_CXX_COMPILER_ID MATCHES "Clang")
       list(APPEND JPEGXL_INTERNAL_FLAGS
         -fnew-alignment=8
-        -fno-cxx-exceptions
         -fno-slp-vectorize
         -fno-vectorize
 

--- a/lib/include/jxl/encode.h
+++ b/lib/include/jxl/encode.h
@@ -96,7 +96,6 @@ typedef enum {
   JXL_ENC_ERR_GENERIC = 1,
 
   /** Out of memory
-   *  TODO(jon): actually catch this and return this error
    */
   JXL_ENC_ERR_OOM = 2,
 

--- a/lib/jxl/base/cache_aligned.cc
+++ b/lib/jxl/base/cache_aligned.cc
@@ -81,12 +81,12 @@ void* CacheAligned::Allocate(const size_t payload_size, size_t offset) {
   const int flags = MAP_PRIVATE | MAP_ANONYMOUS | MAP_POPULATE;
   void* allocated =
       mmap(nullptr, allocated_size, PROT_READ | PROT_WRITE, flags, -1, 0);
-  if (allocated == MAP_FAILED) return nullptr;
+  if (allocated == MAP_FAILED) throw std::bad_alloc();
   const uintptr_t aligned = reinterpret_cast<uintptr_t>(allocated);
 #else
   const size_t allocated_size = kAlias + offset + payload_size;
   void* allocated = malloc(allocated_size);
-  if (allocated == nullptr) return nullptr;
+  if (allocated == nullptr) throw std::bad_alloc();
   // Always round up even if already aligned - we already asked for kAlias
   // extra bytes and there's no way to give them back.
   uintptr_t aligned = reinterpret_cast<uintptr_t>(allocated) + kAlias;

--- a/lib/threads/thread_parallel_runner_internal.h
+++ b/lib/threads/thread_parallel_runner_internal.h
@@ -150,6 +150,7 @@ class ThreadParallelRunner {
   uint32_t workers_ready_ = 0;
   std::condition_variable worker_start_cv_;
   WorkerCommand worker_start_command_;
+  bool oom_ = false;
 
   // Written by main thread, read by workers (after mutex lock/unlock).
   JxlParallelRunFunction data_func_;


### PR DESCRIPTION
See #762 and #1450 : currently when allocations fail (out of memory), libjxl will just abort. For a command line tool like cjxl that is fine, but when integrated in a bigger application (when not taking specific sandboxing precautions), this will bring down the entire application which of course is not so nice. In particular, when an artist is working on a large image, and trying to save the image causes the application to crash, it could be very frustrating...

This PR is a first step in the direction of trying to fix that, starting with the encoder.

I probably missed many spots, but basically the goal is to make sure that `std::bad_alloc` gets thrown whenever something running out of memory and then it gets caught at the API interface (in `encode.cc`).

Probably there are other places where allocs are happening, but the main allocations are done in `CacheAligned::Allocate` (e.g. to allocate image buffers) and when using things like std::vector (which already does throw that exception).

Probably there are other places where the exception needs to be caught, but these are the main ones: when passing frames to the encoder (since it then makes a copy of it, allocating a big buffer) and when doing an actual frame encode (since that allocates all kinds of auxiliary data structures).

When running cjxl with `ulimit` to reduce the available memory to something small, I now get nice errors instead of aborts when trying to encode images that are too large, e.g.

```
JPEG XL encoder v0.9.0 7b50c120 [SSE4,SSSE3,SSE2]
Read 3072x2048 image, 7607002 bytes, 75.7 MP/s
Encoding [VarDCT, d1.000, effort: 7], 
./lib/jxl/encode.cc:1912: Not enough memory to allocate input buffer
JxlEncoderAddImageFrame() failed.
EncodeImageJXL() failed.
```

if the image is too large to copy the input to an internal buffer, and something like this:

```
JPEG XL encoder v0.9.0 7b50c120 [SSE4,SSSE3,SSE2]
Read 1361x907 image, 7406580 bytes, 665.2 MP/s
Encoding [VarDCT, d1.000, effort: 7], 
./lib/jxl/encode.cc:581: Out of memory during frame encoding
JxlEncoderProcessOutput failed.
EncodeImageJXL() failed.
```

if the OOM happens somewhere during the encoding.

Further work is needed to make sure we're not missing anything (since uncaught exceptions will still cause an abort), and to also do this for decoding. And then I guess we also need to look at all places where we do an explicit abort and replace those with returning error instead.