### PR TITLE
allow using cjxl/djxl with stdin/stdout

### DIFF
--- a/tools/file_io.cc
+++ b/tools/file_io.cc
@@ -9,44 +9,110 @@
 #include <limits.h>
 #include <stdio.h>
 #include <string.h>
+#include <sys/stat.h>
+
+#include <list>
+#include <string>
 
 namespace jpegxl {
 namespace tools {
 
-bool ReadFile(const char* filename, std::vector<uint8_t>* out) {
-  FILE* file = fopen(filename, "rb");
-  if (!file) {
-    return false;
+// RAII, ensures files are closed even when returning early.
+class FileWrapper {
+ public:
+  FileWrapper(const FileWrapper& other) = delete;
+  FileWrapper& operator=(const FileWrapper& other) = delete;
+
+  explicit FileWrapper(const std::string& pathname, const char* mode)
+      : file_(pathname == "-" ? (mode[0] == 'r' ? stdin : stdout)
+                              : fopen(pathname.c_str(), mode)),
+        close_on_delete_(pathname != "-") {
+#ifdef _WIN32
+    struct __stat64 s = {};
+    const int err = _stat64(pathname.c_str(), &s);
+    const bool is_file = (s.st_mode & S_IFREG) != 0;
+#else
+    struct stat s = {};
+    const int err = stat(pathname.c_str(), &s);
+    const bool is_file = S_ISREG(s.st_mode);
+#endif
+    if (err == 0 && is_file) {
+      size_ = s.st_size;
+    }
   }
 
-  if (fseek(file, 0, SEEK_END) != 0) {
-    fclose(file);
-    return false;
+  ~FileWrapper() {
+    if (file_ != nullptr && close_on_delete_) {
+      const int err = fclose(file_);
+      if (err) {
+        fprintf(stderr,
+                "Could not close file\n"
+                "Error: %s",
+                strerror(errno));
+      }
+    }
   }
 
-  long size = ftell(file);
-  // Avoid invalid file or directory.
-  if (size >= LONG_MAX || size < 0) {
-    fclose(file);
-    return false;
+  // We intend to use FileWrapper as a replacement of FILE.
+  // NOLINTNEXTLINE(google-explicit-constructor)
+  operator FILE*() const { return file_; }
+
+  int64_t size() { return size_; }
+
+ private:
+  FILE* const file_;
+  bool close_on_delete_ = true;
+  int64_t size_ = -1;
+};
+
+bool ReadFile(const char* filename, std::vector<uint8_t>* bytes) {
+  FileWrapper f(filename, "rb");
+
+  if (!f) return false;
+
+  // Get size of file in bytes
+  const int64_t size = f.size();
+  if (size < 0) {
+    // Size is unknown, loop reading chunks until EOF.
+    bytes->clear();
+    std::list<std::vector<uint8_t>> chunks;
+
+    size_t total_size = 0;
+    while (true) {
+      std::vector<uint8_t> chunk(16 * 1024);
+      const size_t bytes_read = fread(chunk.data(), 1, chunk.size(), f);
+      if (ferror(f) || bytes_read > chunk.size()) {
+        return false;
+      }
+
+      chunk.resize(bytes_read);
+      total_size += bytes_read;
+      if (bytes_read != 0) {
+        chunks.emplace_back(std::move(chunk));
+      }
+      if (feof(f)) {
+        break;
+      }
+    }
+    bytes->resize(total_size);
+    size_t pos = 0;
+    for (const auto& chunk : chunks) {
+      memcpy(bytes->data() + pos, chunk.data(), chunk.size());
+      pos += chunk.size();
+    }
+  } else {
+    // Size is known, read the file directly.
+    bytes->resize(static_cast<size_t>(size));
+
+    const size_t bytes_read = fread(bytes->data(), 1, bytes->size(), f);
+    if (bytes_read != static_cast<size_t>(size)) return false;
   }
 
-  if (fseek(file, 0, SEEK_SET) != 0) {
-    fclose(file);
-    return false;
-  }
-
-  out->resize(size);
-  size_t readsize = fread(out->data(), 1, size, file);
-  if (fclose(file) != 0) {
-    return false;
-  }
-
-  return readsize == static_cast<size_t>(size);
+  return true;
 }
 
 bool WriteFile(const char* filename, const std::vector<uint8_t>& bytes) {
-  FILE* file = fopen(filename, "wb");
+  FileWrapper file(filename, "wb");
   if (!file) {
     fprintf(stderr,
             "Could not open %s for writing\n"
@@ -57,14 +123,6 @@ bool WriteFile(const char* filename, const std::vector<uint8_t>& bytes) {
   if (fwrite(bytes.data(), 1, bytes.size(), file) != bytes.size()) {
     fprintf(stderr,
             "Could not write to file\n"
-            "Error: %s",
-            strerror(errno));
-    fclose(file);
-    return false;
-  }
-  if (fclose(file) != 0) {
-    fprintf(stderr,
-            "Could not close file\n"
             "Error: %s",
             strerror(errno));
     return false;


### PR DESCRIPTION
Replaces https://github.com/libjxl/libjxl/pull/1958

As is the convention in many other tools, the filename `-` is treated as stdin/stdout. So `cjxl - - < input.png > output.jxl` will work. For djxl, `djxl - - < input.jxl > output.png` does not work since djxl needs to know what format to output.

So this adds syntax similar to what ImageMagick's tools do: besides communicating the output format via the filename extension (e.g. `output.png`) you can also communicate it with a prefix (e.g. `jpg:output`). This allows you to do `djxl - png:- < input.jxl > output.png`.

In the case where multiple output files would be generated (e.g. when decoding an animation to ppm, where it generates one output file per frame), it will simply concatenate everything to stdout. Tools like ffmpeg do take concatenated frames as input, so that seems reasonable (unfortunately timing info will be lost but that's also the case when decoding to separate files).