### PR TITLE
Let djxl write OpenEXR again

### DIFF
--- a/lib/extras/enc/exr.cc
+++ b/lib/extras/enc/exr.cc
@@ -162,7 +162,7 @@ class EXREncoder : public Encoder {
   std::vector<JxlPixelFormat> AcceptedFormats() const override {
     std::vector<JxlPixelFormat> formats;
     for (const uint32_t num_channels : {1, 2, 3, 4}) {
-      for (const JxlDataType data_type : {JXL_TYPE_FLOAT, JXL_TYPE_FLOAT16}) {
+      for (const JxlDataType data_type : {JXL_TYPE_FLOAT}) {
         for (JxlEndianness endianness : {JXL_BIG_ENDIAN, JXL_LITTLE_ENDIAN}) {
           formats.push_back(JxlPixelFormat{/*num_channels=*/num_channels,
                                            /*data_type=*/data_type,


### PR DESCRIPTION
The EXR encoder should not advertise support for FLOAT16 if it does not actually support it.