### PR TITLE
fix spacing in version number

### DIFF
--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -21,8 +21,8 @@ permissions:
   contents: read
 
 env:
-  LIBJXL_VERSION:  0.9.0
-  LIBJXL_ABI_VERSION:  0.9
+  LIBJXL_VERSION: 0.9.0
+  LIBJXL_ABI_VERSION: 0.9
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event_name }}


### PR DESCRIPTION
This makes the `./ci.sh bump_version` script work again.