### PR TITLE
fix --already_downsampled

### DIFF
--- a/lib/extras/enc/jxl.cc
+++ b/lib/extras/enc/jxl.cc
@@ -88,6 +88,8 @@ bool EncodeImageJXL(const JXLCompressParams& params, const PackedPixelFile& ppf,
   } else {
     size_t num_alpha_channels = 0;  // Adjusted below.
     JxlBasicInfo basic_info = ppf.info;
+    basic_info.xsize *= params.already_downsampled;
+    basic_info.ysize *= params.already_downsampled;
     if (basic_info.alpha_bits > 0) num_alpha_channels = 1;
     if (params.intensity_target > 0) {
       basic_info.intensity_target = params.intensity_target;

--- a/lib/extras/enc/jxl.h
+++ b/lib/extras/enc/jxl.h
@@ -48,6 +48,7 @@ struct JXLCompressParams {
   // Upper bound on the intensity level present in the image in nits (zero means
   // that the library chooses a default).
   float intensity_target = 0;
+  int already_downsampled = 1;
   // Overrides for bitdepth, codestream level and alpha premultiply.
   size_t override_bitdepth = 0;
   int32_t codestream_level = -1;

--- a/tools/cjxl_main.cc
+++ b/tools/cjxl_main.cc
@@ -711,6 +711,7 @@ void ProcessFlags(const jxl::extras::Codec codec,
   ProcessFlag("already_downsampled",
               static_cast<int64_t>(args->already_downsampled),
               JXL_ENC_FRAME_SETTING_ALREADY_DOWNSAMPLED, params);
+  if (args->already_downsampled) params->already_downsampled = args->resampling;
 
   SetDistanceFromFlags(cmdline, args, params, codec);
 


### PR DESCRIPTION
The cjxl option `--already_downsampled` was broken: it would produce an image with the non-upsampled size, and then pass it a buffer with that size, which is too large since the encoder is expecting to get an already-downsampled frame. So it would just cause an error:

```
./lib/jxl/enc_external_image.cc:84: JXL_FAILURE: Buffer size is too large
./lib/jxl/enc_external_image.cc:133: JXL_RETURN_IF_ERROR code=1: ConvertFromExternal(bytes, xsize, ysize, bits_per_sample, format, c, pool, &color.Plane(c))
./lib/jxl/encode.cc:1896: Invalid input buffer
JxlEncoderAddImageFrame() failed.
EncodeImageJXL() failed.
```

This fixes that by setting the nominal image dimensions correctly in the JxlBasicInfo (to the upsampled size), so the expected frame dimensions will correspond to the input.