### PR TITLE
add a way to do custom upsampling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `JXL_ENC_FRAME_SETTING_JPEG_KEEP_EXIF`
   - `JXL_ENC_FRAME_SETTING_JPEG_KEEP_XMP`
   - `JXL_ENC_FRAME_SETTING_JPEG_KEEP_JUMBF`
+ - encoder API: new function `JxlEncoderSetUpsamplingMode` to change the upsampling
+   method, e.g. to use nearest-neighbor upsampling for pixel art
  - cjxl can now be used to explicitly add/update/strip Exif/XMP/JUMBF metadata using
    the decoder-hints syntax, e.g. `cjxl input.ppm -x exif=input.exif output.jxl`
  - djxl can now be used to extract Exif/XMP/JUMBF metadata
@@ -63,6 +65,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed / clarified
  - encoder API: `JxlEncoderProcessOutput` requires at least 32 bytes of output
    space to proceed and guarantees that at least one byte will be written
+
 ## [0.7] - 2022-07-21
 
 ### Added

--- a/lib/extras/enc/jxl.cc
+++ b/lib/extras/enc/jxl.cc
@@ -147,6 +147,12 @@ bool EncodeImageJXL(const JXLCompressParams& params, const PackedPixelFile& ppf,
       return false;
     }
     if (JXL_ENC_SUCCESS !=
+        JxlEncoderSetUpsamplingMode(enc, params.already_downsampled,
+                                    params.upsampling_mode)) {
+      fprintf(stderr, "JxlEncoderSetUpsamplingMode() failed.\n");
+      return false;
+    }
+    if (JXL_ENC_SUCCESS !=
         JxlEncoderSetFrameBitDepth(settings, &params.input_bitdepth)) {
       fprintf(stderr, "JxlEncoderSetFrameBitDepth() failed.\n");
       return false;

--- a/lib/extras/enc/jxl.h
+++ b/lib/extras/enc/jxl.h
@@ -52,6 +52,7 @@ struct JXLCompressParams {
   // that the library chooses a default).
   float intensity_target = 0;
   int already_downsampled = 1;
+  int upsampling_mode = -1;
   // Overrides for bitdepth, codestream level and alpha premultiply.
   size_t override_bitdepth = 0;
   int32_t codestream_level = -1;

--- a/lib/include/jxl/encode.h
+++ b/lib/include/jxl/encode.h
@@ -957,6 +957,26 @@ JXL_EXPORT JxlEncoderStatus JxlEncoderSetBasicInfo(JxlEncoder* enc,
                                                    const JxlBasicInfo* info);
 
 /**
+ * Sets the upsampling method the decoder will use in case there are frames
+ * with JXL_ENC_FRAME_SETTING_RESAMPLING set. This is useful in combination
+ * with the JXL_ENC_FRAME_SETTING_ALREADY_DOWNSAMPLED option, to control the
+ * type of upsampling that will be used.
+ *
+ * @param enc encoder object.
+ * @param factor upsampling factor to configure (1, 2, 4 or 8; for 1 this
+ * function has no effect at all)
+ * @param mode upsampling mode to use for this upsampling:
+ * -1: default (good for photographic images, no signaling overhead)
+ * 0: nearest neighbor (good for pixel art)
+ * 1: 'pixel dots' (same as NN for 2x, diamond-shaped 'pixel dots' for 4x/8x)
+ * @return JXL_ENC_SUCCESS if the operation was successful,
+ * JXL_ENC_ERROR or JXL_ENC_NOT_SUPPORTED otherwise
+ */
+JXL_EXPORT JxlEncoderStatus JxlEncoderSetUpsamplingMode(JxlEncoder* enc,
+                                                        const int64_t factor,
+                                                        const int64_t mode);
+
+/**
  * Initializes a JxlExtraChannelInfo struct to default values.
  * For forwards-compatibility, this function has to be called before values
  * are assigned to the struct fields.

--- a/tools/cjxl_main.cc
+++ b/tools/cjxl_main.cc
@@ -308,6 +308,13 @@ struct CompressArgs {
                            &already_downsampled, &SetBooleanTrue, 2);
 
     cmdline->AddOptionValue(
+        '\0', "upsampling_mode", "-1|0|1",
+        "Upsampling mode the decoder should use. Mostly useful in combination "
+        "with --already_downsampled. Value -1 means default (non-separable "
+        "upsampling), 0 means nearest neighbor (useful for pixel art)",
+        &upsampling_mode, &ParseInt64, 2);
+
+    cmdline->AddOptionValue(
         '\0', "epf", "-1|0|1|2|3",
         "Edge preserving filter level, 0-3. "
         "Default -1 means encoder chooses, 0-3 set a strength.",
@@ -478,6 +485,7 @@ struct CompressArgs {
   bool modular_lossy_palette = false;
   int32_t premultiply = -1;
   bool already_downsampled = false;
+  int64_t upsampling_mode = -1;
   jxl::Override jpeg_reconstruction_cfl = jxl::Override::kDefault;
   jxl::Override modular = jxl::Override::kDefault;
   jxl::Override keep_invisible = jxl::Override::kDefault;
@@ -894,6 +902,7 @@ void ProcessFlags(const jxl::extras::Codec codec,
   params->codestream_level = args->codestream_level;
   params->premultiply = args->premultiply;
   params->compress_boxes = args->compress_boxes != jxl::Override::kOff;
+  params->upsampling_mode = args->upsampling_mode;
   if (codec == jxl::extras::Codec::kPNM &&
       ppf.info.exponent_bits_per_sample == 0) {
     params->input_bitdepth.type = JXL_BIT_DEPTH_FROM_CODESTREAM;


### PR DESCRIPTION
Currently the default upsampling weights are always used by the libjxl encoder. This adds a function to use custom upsampling weights. This is in particular useful when encoding pixel art with JXL_ENC_FRAME_SETTING_ALREADY_DOWNSAMPLED, since the default upsampling is great for photographic images but it's not what you typically want for pixel art.

For example, for this original image:
![mario](https://github.com/libjxl/libjxl/assets/15010068/5f18029f-2f9a-470b-9ceb-c54663cbb967)

encoding with `cjxl -d 0 --already_downsampled --resampling 8` produces this:

![mario png default jxl](https://github.com/libjxl/libjxl/assets/15010068/310974e5-8a79-4c13-978c-0437daf26f10)

while when setting the upsampling mode to nearest neighbor (`--upsampling_mode 0`), it will look like this:

![mario png NN jxl](https://github.com/libjxl/libjxl/assets/15010068/ae2e1029-bcfb-4f83-98b9-a400d1a6b904)

Just for fun I also added another upsampling mode which I called "pixel dots" and it looks like this:

![mario png funky2 jxl](https://github.com/libjxl/libjxl/assets/15010068/c4867758-e2c8-45ea-b578-bd37d58a6b0e)


For truly customized upsampling we would need a function that allows you to set the actual weights as opposed to picking from some presets, but that would be pretty inconvenient to use. This is of course less flexible, but we can always add more presets later if we want.
