### PR TITLE
Harden current directory is a Git repository

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -28,6 +28,7 @@ CanadianBaconBoi <beamconnor@gmail.com>
 Damiano Albani <damiano.albani@gmail.com>
 Daniel Novomeský <dnovomesky@gmail.com>
 David Burnett <vargolsoft@gmail.com>
+Diego Pino <dpino@igalia.com>
 Dirk Lemstra <dirk@lemstra.org>
 Don Olmstead <don.j.olmstead@gmail.com>
 Dong Xu <xdong181@gmail.com>

--- a/deps.sh
+++ b/deps.sh
@@ -57,9 +57,16 @@ download_github() {
   mv "${local_fn}.tmp" "${local_fn}"
 }
 
+is_git_repository() {
+    local dir="$1"
+    local toplevel=$(git rev-parse --show-toplevel)
+
+    [[ "${dir}" == "${toplevel}" ]]
+}
+
 
 main() {
-  if git -C "${MYDIR}" rev-parse; then
+  if is_git_repository "${MYDIR}"; then
     cat >&2 <<EOF
 Current directory is a git repository, downloading dependencies via git:
 


### PR DESCRIPTION
I've pulled libjxl as tarball inside a project which is managed by Git. When executing `deps.sh` the script detects `libjxl` is a Git repository, but because it's inside a parent Git repository. However, the provision of the submodules fails (tries to provision the submodules of the parent Git repository, which are none).

To correctly provision `libjxl` submodules the script should not only check libjxl is a Git repository but its toplevel directory is the absolute path of libjxl.