### PR TITLE
improve djxl help

### DIFF
--- a/tools/cjxl_main.cc
+++ b/tools/cjxl_main.cc
@@ -88,7 +88,7 @@ struct CompressArgs {
 #if JPEGXL_ENABLE_EXR
                                  "EXR, "
 #endif
-                                 "PPM, PFM, PGX, or JXL",
+                                 "PPM, PFM, PAM, PGX, or JXL",
                                  &file_in);
     cmdline->AddPositionalOption("OUTPUT", /* required = */ true,
                                  "the compressed JXL output file", &file_out);


### PR DESCRIPTION
Similar to how `cjxl` does it, make `djxl` a bit more user-friendly by not showing all the options but only the most important ones (and with more verbosity `-v -v -v` you get to see more options). Also improve the phrasing and layout a bit (e.g. making sure everything fits in a terminal width of 100 characters).

Before:

```
$ djxl
JPEG XL decoder v0.9.0 2d05683c [SSE4,SSSE3,SSE2]
Missing INPUT filename.
Use 'djxl -h' for more information
$ djxl -h
JPEG XL decoder v0.9.0 2d05683c [SSE4,SSSE3,SSE2]
Usage: djxl INPUT OUTPUT [OPTIONS...]
 INPUT
    The compressed input file.
 OUTPUT
    The output can be (A)PNG with ICC, JPG, or PPM/PFM.
 -V, --version
    Print version number and exit.
 --num_reps=N
    Sets the number of times to decompress the image. Used for benchmarking, the default is 1.
 --disable_output
    No output file will be written (for benchmarking)
 --num_threads=N
    Number of worker threads (-1 == use machine default, 0 == do not use multithreading).
 --bits_per_sample=N
    Sets the output bit depth. The 0 value (default for PNM output) means the original (input) bit depth. The -1 value (default for other codecs) means the full bit depth of the output pixel format.
 --display_nits=N
    If set to a non-zero value, tone maps the image the given peak display luminance.
 --color_space=COLORSPACE_DESC
    Sets the output color space of the image. This flag has no effect if the image is not XYB encoded.
 -s N, --downsampling=N
    If set and the input JXL stream is progressive and contains hints for target downsampling ratios, the decoder will skip any progressive passes that are not needed to produce a partially decoded image intended for this downsampling ratio.
 --allow_partial_files
    Allow decoding of truncated files.
 -j, --pixels_to_jpeg
    By default, if the input JPEG XL contains a recompressed JPEG file, djxl reconstructs the exact original JPEG file. This flag causes the decoder to instead decode the image to pixels and encode a new (lossy) JPEG. The output file if provided must be a .jpg or .jpeg file.
 -q N, --jpeg_quality=N
    Sets the JPEG output quality, default is 95. Setting an output quality implies --pixels_to_jpeg.
 --norender_spotcolors
    Disables rendering spot colors.
 --preview_out=FILENAME
    If specified, writes the preview image to this file.
 --icc_out=FILENAME
    If specified, writes the ICC profile of the decoded image to this file.
 --orig_icc_out=FILENAME
    If specified, writes the ICC profile of the original image to this file. This can be different from the ICC profile of the decoded image if --color_space was specified, or if the image was XYB encoded and the color conversion to the original profile was not supported by the decoder.
 --metadata_out=FILENAME
    If specified, writes decoded metadata info to this file in JSON format. Used by the conformance test script
 --print_read_bytes
    Print total number of decoded bytes.
 --quiet
    Silence output (except for errors).
 -h, --help
    Prints this help message.
```

After:

```
$ djxl 
JPEG XL decoder v0.9.0 0bd33dd6 [SSE4,SSSE3,SSE2]
Usage: tools/djxl INPUT OUTPUT [OPTIONS...]
 INPUT
    The compressed input file (JXL). Use '-' for input from stdin.
 OUTPUT
    The output can be PNG, APNG, JPEG, EXR, PPM, PFM, or PAM. Use '-' for output to stdout.
    The output format is selected based on the extension or a prefix (e.g. 'png:-')
 -v, --verbose
    Verbose output; can be repeated and also applies to help (!).
 -h, --help
    Prints this help message (use -v to see more options).
```

At verbosity 1:
```
$ djxl -v
JPEG XL decoder v0.9.0 0bd33dd6 [SSE4,SSSE3,SSE2]
Usage: tools/djxl INPUT OUTPUT [OPTIONS...]
 INPUT
    The compressed input file (JXL). Use '-' for input from stdin.
 OUTPUT
    The output can be PNG, APNG, JPEG, EXR, PPM, PFM, or PAM. Use '-' for output to stdout.
    The output format is selected based on the extension or a prefix (e.g. 'png:-')
 -V, --version
    Print version number and exit.
 --num_threads=N
    Number of worker threads (-1 == use machine default, 0 == do not use multithreading).
 --display_nits=N
    If set to a non-zero value, tone maps the image the given peak display luminance.
 --color_space=COLORSPACE_DESC
    Sets the desired output color space of the image. For example:
      --color_space=RGB_D65_SRG_Per_SRG is sRGB with perceptual rendering intent
      --color_space=RGB_D65_202_Rel_PeQ is Rec.2100 PQ with relative rendering intent
 -v, --verbose
    Verbose output; can be repeated and also applies to help (!).
 -h, --help
    Prints this help message (use -v to see more options).
```

At verbosity 2:
```
$ djxl -v -v
JPEG XL decoder v0.9.0 0bd33dd6 [SSE4,SSSE3,SSE2]
Usage: tools/djxl INPUT OUTPUT [OPTIONS...]
 INPUT
    The compressed input file (JXL). Use '-' for input from stdin.
 OUTPUT
    The output can be PNG, APNG, JPEG, EXR, PPM, PFM, or PAM. Use '-' for output to stdout.
    The output format is selected based on the extension or a prefix (e.g. 'png:-')
 -V, --version
    Print version number and exit.
 --num_reps=N
    Sets the number of times to decompress the image. Useful for benchmarking. Default is 1.
 --disable_output
    No output file will be written (for benchmarking)
 --num_threads=N
    Number of worker threads (-1 == use machine default, 0 == do not use multithreading).
 --bits_per_sample=N
    Sets the output bit depth. The value 0 (default for PNM) means the original (input) bit depth.
    The value -1 (default for other codecs) means it depends on the output format capabilities
    and the input bit depth (e.g. decoding a 12-bit image to PNG will produce a 16-bit PNG).
 --display_nits=N
    If set to a non-zero value, tone maps the image the given peak display luminance.
 --color_space=COLORSPACE_DESC
    Sets the desired output color space of the image. For example:
      --color_space=RGB_D65_SRG_Per_SRG is sRGB with perceptual rendering intent
      --color_space=RGB_D65_202_Rel_PeQ is Rec.2100 PQ with relative rendering intent
 -s 1|2|4|8, --downsampling=1|2|4|8
    If the input JXL stream is contains hints for target downsampling ratios,
    only decode what is needed to produce an image intended for this downsampling ratio.
 --allow_partial_files
    Allow decoding of truncated files.
 -j, --pixels_to_jpeg
    By default, if the input JXL is a recompressed JPEG file, djxl reconstructs that JPEG file.
    This flag causes the decoder to instead decode to pixels and encode a new (lossy) JPEG.
 -q N, --jpeg_quality=N
    Sets the JPEG output quality, default is 95. Setting this option implies --pixels_to_jpeg.
 --norender_spotcolors
    Disables rendering of spot colors.
 --preview_out=FILENAME
    If specified, writes the preview image to this file.
 --icc_out=FILENAME
    If specified, writes the ICC profile of the decoded image to this file.
 --quiet
    Silence output (except for errors).
 -v, --verbose
    Verbose output; can be repeated and also applies to help (!).
 -h, --help
    Prints this help message (use -v to see more options).
```

At full verbosity:
```
$ djxl -v -v -v
JPEG XL decoder v0.9.0 0bd33dd6 [SSE4,SSSE3,SSE2]
Usage: tools/djxl INPUT OUTPUT [OPTIONS...]
 INPUT
    The compressed input file (JXL). Use '-' for input from stdin.
 OUTPUT
    The output can be PNG, APNG, JPEG, EXR, PPM, PFM, or PAM. Use '-' for output to stdout.
    The output format is selected based on the extension or a prefix (e.g. 'png:-')
 -V, --version
    Print version number and exit.
 --num_reps=N
    Sets the number of times to decompress the image. Useful for benchmarking. Default is 1.
 --disable_output
    No output file will be written (for benchmarking)
 --num_threads=N
    Number of worker threads (-1 == use machine default, 0 == do not use multithreading).
 --bits_per_sample=N
    Sets the output bit depth. The value 0 (default for PNM) means the original (input) bit depth.
    The value -1 (default for other codecs) means it depends on the output format capabilities
    and the input bit depth (e.g. decoding a 12-bit image to PNG will produce a 16-bit PNG).
 --display_nits=N
    If set to a non-zero value, tone maps the image the given peak display luminance.
 --color_space=COLORSPACE_DESC
    Sets the desired output color space of the image. For example:
      --color_space=RGB_D65_SRG_Per_SRG is sRGB with perceptual rendering intent
      --color_space=RGB_D65_202_Rel_PeQ is Rec.2100 PQ with relative rendering intent
 -s 1|2|4|8, --downsampling=1|2|4|8
    If the input JXL stream is contains hints for target downsampling ratios,
    only decode what is needed to produce an image intended for this downsampling ratio.
 --allow_partial_files
    Allow decoding of truncated files.
 -j, --pixels_to_jpeg
    By default, if the input JXL is a recompressed JPEG file, djxl reconstructs that JPEG file.
    This flag causes the decoder to instead decode to pixels and encode a new (lossy) JPEG.
 -q N, --jpeg_quality=N
    Sets the JPEG output quality, default is 95. Setting this option implies --pixels_to_jpeg.
 --norender_spotcolors
    Disables rendering of spot colors.
 --preview_out=FILENAME
    If specified, writes the preview image to this file.
 --icc_out=FILENAME
    If specified, writes the ICC profile of the decoded image to this file.
 --orig_icc_out=FILENAME
    If specified, writes the ICC profile of the original image to this file
    This can be different from the ICC profile of the decoded image if --color_space was specified.
 --metadata_out=FILENAME
    If specified, writes metadata info to a JSON file. Used by the conformance test script
 --print_read_bytes
    Print total number of decoded bytes.
 --quiet
    Silence output (except for errors).
 -v, --verbose
    Verbose output; can be repeated and also applies to help (!).
 -h, --help
    Prints this help message.
```