### PR TITLE
adjust adaptive quantization for deadzone blocks

### DIFF
--- a/lib/jxl/decode_test.cc
+++ b/lib/jxl/decode_test.cc
@@ -1678,9 +1678,9 @@ TEST(DecodeTest, PixelTestWithICCProfileLossy) {
   EXPECT_THAT(ButteraugliDistance(io0.frames, io1.frames, ba, jxl::GetJxlCms(),
                                   /*distmap=*/nullptr, nullptr),
 #if JXL_HIGH_PRECISION
-              IsSlightlyBelow(0.666666f));
+              IsSlightlyBelow(0.70f));
 #else
-              IsSlightlyBelow(0.68f));
+              IsSlightlyBelow(0.72f));
 #endif
 
   JxlDecoderDestroy(dec);

--- a/lib/jxl/enc_adaptive_quantization.cc
+++ b/lib/jxl/enc_adaptive_quantization.cc
@@ -724,7 +724,7 @@ ImageF TileDistMap(const ImageF& distmap, int tile_size, int margin,
 
 static const float kDcQuantPow = 0.83;
 static const float kDcQuant = 1.095924047623553f;
-static const float kAcQuant = 0.7738;
+static const float kAcQuant = 0.7784;
 
 // Computes the decoded image for a given set of compression parameters.
 ImageBundle RoundtripImage(const Image3F& opsin, PassesEncoderState* enc_state,

--- a/lib/jxl/enc_group.cc
+++ b/lib/jxl/enc_group.cc
@@ -148,16 +148,16 @@ void AdjustQuantBlockAC(const Quantizer& quantizer, size_t c,
   }
   if (c == 1 && sum_of_vals < std::max(xsize, ysize)) {
     static const double kLimit[4] = {
-      0.46,
-      0.46,
-      0.46,
-      0.46,
+        0.46,
+        0.46,
+        0.46,
+        0.46,
     };
     static const double kMul[4] = {
-      0.9999,
-      0.9999,
-      0.9999,
-      0.9999,
+        0.9999,
+        0.9999,
+        0.9999,
+        0.9999,
     };
     const int32_t orig_quant = *quant;
     int32_t new_quant = *quant;
@@ -178,7 +178,6 @@ void AdjustQuantBlockAC(const Quantizer& quantizer, size_t c,
     } else if (hfNonZeros[0] == 0.0 && hfMaxError[0] > kLimit[0]) {
       thresholds[0] = kMul[0] * hfMaxError[0] * new_quant / orig_quant;
     }
-
   }
   // Heuristic for improving accuracy of high-frequency patterns
   // occurring in an environment with no medium-frequency masking

--- a/lib/jxl/enc_group.cc
+++ b/lib/jxl/enc_group.cc
@@ -99,11 +99,11 @@ void AdjustQuantBlockAC(const Quantizer& quantizer, size_t c,
       (1 << AcStrategy::Type::DCT8X4) | (1 << AcStrategy::Type::AFV0) |
       (1 << AcStrategy::Type::AFV1) | (1 << AcStrategy::Type::AFV2) |
       (1 << AcStrategy::Type::AFV3);
-  if ((1 << quant_kind) & kPartialBlockKinds) return;
+  if ((1 << quant_kind) & kPartialBlockKinds) {
+    return;
+  }
 
   const float* JXL_RESTRICT qm = quantizer.InvDequantMatrix(quant_kind, c);
-  const float kQuantNormalizer = 2.9037220690527175;
-  float orig_quant = kQuantNormalizer;
   float qac = quantizer.Scale() * (*quant);
   if (xsize > 1 || ysize > 1) {
     for (int i = 0; i < 4; ++i) {
@@ -146,13 +146,39 @@ void AdjustQuantBlockAC(const Quantizer& quantizer, size_t c,
       }
     }
   }
-  if (c == 1) {
-    static const double kLimit = 0.49f;
+  if (c == 1 && sum_of_vals < std::max(xsize, ysize)) {
+    static const double kLimit[4] = {
+      0.46,
+      0.46,
+      0.46,
+      0.46,
+    };
+    static const double kMul[4] = {
+      0.9999,
+      0.9999,
+      0.9999,
+      0.9999,
+    };
+    const int32_t orig_quant = *quant;
+    int32_t new_quant = *quant;
     for (int i = 1; i < 4; ++i) {
-      if (hfNonZeros[i] == 0.0 && hfMaxError[i] > kLimit) {
-        thresholds[i] = 0.9999 * hfMaxError[i];
+      if (hfNonZeros[i] == 0.0 && hfMaxError[i] > kLimit[i]) {
+        new_quant = orig_quant + 1;
+        break;
       }
     }
+    *quant = new_quant;
+    if (hfNonZeros[3] == 0.0 && hfMaxError[3] > kLimit[3]) {
+      thresholds[3] = kMul[3] * hfMaxError[3] * new_quant / orig_quant;
+    } else if ((hfNonZeros[1] == 0.0 && hfMaxError[1] > kLimit[1]) ||
+               (hfNonZeros[2] == 0.0 && hfMaxError[2] > kLimit[2])) {
+      thresholds[1] = kMul[1] * std::max(hfMaxError[1], hfMaxError[2]) *
+                      new_quant / orig_quant;
+      thresholds[2] = thresholds[1];
+    } else if (hfNonZeros[0] == 0.0 && hfMaxError[0] > kLimit[0]) {
+      thresholds[0] = kMul[0] * hfMaxError[0] * new_quant / orig_quant;
+    }
+
   }
   // Heuristic for improving accuracy of high-frequency patterns
   // occurring in an environment with no medium-frequency masking
@@ -220,8 +246,9 @@ void AdjustQuantBlockAC(const Quantizer& quantizer, size_t c,
             0.3793181712352986,
         },
     };
-    sum_of_error *= orig_quant;
-    sum_of_vals *= orig_quant;
+    const float kQuantNormalizer = 2.9037220690527175;
+    sum_of_error *= kQuantNormalizer;
+    sum_of_vals *= kQuantNormalizer;
     if (quant_kind >= AcStrategy::Type::DCT16X16) {
       int ix = 2;
       if (quant_kind == AcStrategy::Type::DCT32X16 ||
@@ -251,6 +278,11 @@ void AdjustQuantBlockAC(const Quantizer& quantizer, size_t c,
       activity = 15;
     }
     int32_t qp = *quant - activity;
+    if (c == 1) {
+      for (int i = 1; i < 4; ++i) {
+        thresholds[i] += 0.01 * activity;
+      }
+    }
     if (qp < orig_qp_limit) {
       qp = orig_qp_limit;
     }

--- a/lib/jxl/jxl_test.cc
+++ b/lib/jxl/jxl_test.cc
@@ -182,7 +182,7 @@ TEST(JxlTest, RoundtripResample2MT) {
   cparams.AddOption(JXL_ENC_FRAME_SETTING_EFFORT, 3);  // kFalcon
 
   PackedPixelFile ppf_out;
-  EXPECT_NEAR(Roundtrip(t.ppf(), cparams, {}, &pool, &ppf_out), 228283, 1000);
+  EXPECT_NEAR(Roundtrip(t.ppf(), cparams, {}, &pool, &ppf_out), 223310, 2000);
   EXPECT_THAT(ComputeDistance2(t.ppf(), ppf_out), IsSlightlyBelow(340));
 }
 
@@ -203,7 +203,7 @@ TEST(JxlTest, RoundtripOutOfOrderProcessing) {
   cparams.AddOption(JXL_ENC_FRAME_SETTING_EPF, 3);
 
   PackedPixelFile ppf_out;
-  EXPECT_NEAR(Roundtrip(t.ppf(), cparams, {}, &pool, &ppf_out), 24102, 400);
+  EXPECT_NEAR(Roundtrip(t.ppf(), cparams, {}, &pool, &ppf_out), 23553, 400);
   EXPECT_LE(ButteraugliDistance(t.ppf(), ppf_out), 1.35);
 }
 
@@ -238,7 +238,7 @@ TEST(JxlTest, RoundtripResample4) {
   cparams.AddOption(JXL_ENC_FRAME_SETTING_RESAMPLING, 4);
 
   PackedPixelFile ppf_out;
-  EXPECT_NEAR(Roundtrip(t.ppf(), cparams, {}, pool, &ppf_out), 5635, 100);
+  EXPECT_NEAR(Roundtrip(t.ppf(), cparams, {}, pool, &ppf_out), 5758, 100);
   EXPECT_THAT(ButteraugliDistance(t.ppf(), ppf_out), IsSlightlyBelow(22));
 }
 
@@ -454,7 +454,7 @@ TEST(JxlTest, RoundtripSmallNL) {
   t.SetDimensions(xsize, ysize);
 
   PackedPixelFile ppf_out;
-  EXPECT_NEAR(Roundtrip(t.ppf(), {}, {}, pool, &ppf_out), 783, 25);
+  EXPECT_NEAR(Roundtrip(t.ppf(), {}, {}, pool, &ppf_out), 753, 45);
   EXPECT_THAT(ButteraugliDistance(t.ppf(), ppf_out), IsSlightlyBelow(1.1));
 }
 
@@ -873,7 +873,7 @@ TEST(JxlTest, RoundtripAlphaResampling) {
   cparams.AddOption(JXL_ENC_FRAME_SETTING_EXTRA_CHANNEL_RESAMPLING, 2);
 
   PackedPixelFile ppf_out;
-  EXPECT_NEAR(Roundtrip(t.ppf(), cparams, {}, pool, &ppf_out), 12936, 130);
+  EXPECT_NEAR(Roundtrip(t.ppf(), cparams, {}, pool, &ppf_out), 12745, 130);
   EXPECT_THAT(ButteraugliDistance(t.ppf(), ppf_out), IsSlightlyBelow(5.2));
 }
 


### PR DESCRIPTION
0.1 % improvement in BPP * pnorm

```
before:

Encoding      kPixels    Bytes          BPP  E MP/s  D MP/s     Max norm  SSIMULACRA2        pnorm   PSNR   QABPP  SmallB  DCT4x8     AFV  DCT8x8    8x16    8x32      16   16x32      32   32x64      64       BPP*pnorm   Bugs
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
jxl:d0.1        19988 16262919    6.5090415   1.453   9.648   0.35504593  95.44944669   0.11776069  55.38   6.509 41.0113 18.9684  0.4505 27.6395  5.1307  0.0000  2.4680  0.9042  3.9704  0.1025  0.0820  0.766509194521      0
jxl:d0.5        19988  6328890    2.5330636   1.875  15.535   0.79249374  91.39411257   0.34830485  46.43   2.557 13.8988 25.2547  0.5994 11.8951 21.3932  0.0000 20.8162  1.2193  5.2101  0.1537  0.2869  0.882278322147      0
jxl:d0.8        19988  4689931    1.8770895   1.900  15.963   1.10084689  88.64919654   0.48230585  43.84   2.157 10.6166 21.7605  0.7105  8.8965 19.7263  0.0000 29.2347  1.6522  7.5155  0.2049  0.4098  0.905331266148      0
jxl:d1          19988  4053610    1.6224096   2.034  16.337   1.30339278  86.93459238   0.56547718  42.66   2.190  9.3531 19.9981  0.7630  7.7630 18.1618  0.0000 30.4898  2.6409 10.9223  0.2049  0.4303  0.917435600195      0
jxl:d1.1        19988  3821070    1.5293382   2.138  16.756   1.41387120  86.14262428   0.60569149  42.17   2.237  8.9035 19.1688  0.7768  7.3240 17.4991  0.0000 30.3438  3.4837 12.6129  0.2049  0.4098  0.926307128008      0
jxl:d1.2        19988  3606605    1.4435011   2.108  16.799   1.51745110  85.33350648   0.64196585  41.71   2.265  8.4421 18.5038  0.8261  7.0461 16.8869  0.0000 29.8315  4.2573 14.2370  0.2049  0.4918  0.926678417401      0
jxl:d1.3        19988  3432924    1.3739873   2.057  17.253   1.56597324  84.63295917   0.67665636  41.36   2.237  8.0246 18.0245  0.8488  6.6670 16.4405  0.0000 29.1079  5.1589 15.6151  0.2254  0.6148  0.929717270191      0
jxl:d1.4        19988  3267344    1.3077159   2.121  17.672   1.66724310  83.87641540   0.71469067  41.00   2.283  7.7102 17.4561  0.8588  6.4608 16.0915  0.0000 28.0026  6.0990 17.1059  0.2664  0.6762  0.934612340961      0
jxl:d1.5        19988  3115789    1.2470578   2.030  16.044   1.76594311  83.13356260   0.75105989  40.67   2.298  7.3871 17.0159  0.8815  6.2434 15.7290  0.0000 27.0868  6.9878 18.5249  0.2766  0.5943  0.936615088490      0
jxl:d1.6        19988  2982469    1.1936980   1.973  16.286   1.82568281  82.38628562   0.78338533  40.36   2.268  7.0698 16.5670  0.8863  6.0564 15.3903  0.0000 26.2736  7.9305 19.5086  0.3279  0.7172  0.935125525978      0
jxl:d1.7        19988  2861613    1.1453268   2.142  17.214   1.92715294  81.67227880   0.81889633  40.06   2.288  6.8354 16.1828  0.9170  5.8765 15.2552  0.0000 25.3527  8.8014 20.4717  0.4201  0.6148  0.937903944695      0
jxl:d1.8        19988  2754066    1.1022824   2.080  17.442   1.99735956  81.00047201   0.85121488  39.79   2.306  6.6010 15.8718  0.9385  5.7279 15.0400  0.0000 24.4139  9.6749 21.3426  0.3996  0.7172  0.938279198067      0
jxl:d1.9        19988  2652654    1.0616935   2.177  16.852   2.10065268  80.28409394   0.88484434  39.53   2.329  6.3808 15.4905  0.9731  5.6142 14.8882  0.0000 23.6582 10.5253 22.0701  0.3279  0.7992  0.939433460001      0
jxl:d2.0        19988  2557620    1.0236572   2.137  17.395   2.19524039  79.56970125   0.91843825  39.29   2.357  6.1986 15.1431  0.9823  5.4506 14.6820  0.0000 22.9039 11.3245 22.8027  0.3586  0.8812  0.940165953181      0
jxl:d2.1        19988  2471537    0.9892035   2.156  16.274   2.32635728  78.89246731   0.95202863  39.05   2.413  5.9994 14.8248  0.9827  5.3312 14.4873  0.0000 22.2596 12.0468 23.4533  0.4611  0.8812  0.941750073009      0
jxl:d2.2        19988  2390445    0.9567474   2.196  17.301   2.35829572  78.19880522   0.98463004  38.83   2.343  5.8067 14.4886  1.0003  5.2719 14.3151  0.0000 21.5501 12.9921 23.9503  0.4508  0.9017  0.942042236368      0
jxl:d2.3        19988  2315294    0.9266691   2.065  16.816   2.49174520  77.50363870   1.01914124  38.62   2.405  5.6414 14.1976  1.0195  5.1467 14.2690  0.0000 20.9674 13.6811 24.3294  0.4303  1.0451  0.944406701128      0
jxl:d2.4        19988  2244792    0.8984515   2.088  17.122   2.52123625  76.87360276   1.05173887  38.41   2.369  5.5121 13.8758  1.0137  5.0574 14.1249  0.0000 20.5050 14.3420 24.7904  0.4816  1.0246  0.944936382209      0
jxl:d2.5        19988  2178754    0.8720206   2.141  17.053   2.60929697  76.24669928   1.08008468  38.21   2.378  5.4035 13.5982  1.0240  4.9934 14.0641  0.0000 19.9146 15.1053 25.0671  0.5123  1.0451  0.941856069672      0
jxl:d2.6        19988  2120895    0.8488632   2.164  17.414   2.70401948  75.63012652   1.11168528  38.03   2.416  5.2236 13.2831  1.0336  4.8666 13.9590  0.0000 19.4048 15.7892 25.5691  0.5123  1.0861  0.943668722308      0
jxl:d2.7        19988  2061281    0.8250034   2.150  17.754   2.76701320  75.01076324   1.14539711  37.85   2.407  5.0968 13.0125  1.0669  4.7843 13.7919  0.0000 18.9937 16.3886 25.9329  0.5533  1.1066  0.944956507451      0
jxl:d2.8        19988  2006941    0.8032545   2.166  16.997   2.83852804  74.40730245   1.17294856  37.67   2.395  4.9630 12.8294  1.0627  4.7103 13.6632  0.0000 18.5851 17.1161 26.1173  0.5738  1.1066  0.942176159882      0
jxl:d2.9        19988  1956537    0.7830809   2.174  17.420   2.90963974  73.73571764   1.20157787  37.51   2.392  4.8647 12.5297  1.0678  4.6504 13.5421  0.0000 18.2240 17.6412 26.5784  0.5226  1.1066  0.940932622865      0
jxl:d3          19988  1908976    0.7640451   1.955  16.505   2.97093875  73.16970054   1.23116890  37.37   2.393  4.6770 12.3158  1.0585  4.5893 13.4301  0.0000 17.8397 18.3789 26.6655  0.5021  1.2705  0.940668593765      0
jxl:d5          19988  1302662    0.5213751   1.967   9.691   4.47636288  61.93081328   1.76245191  35.18   2.449  3.2547  8.0249  0.9382  2.9566 10.8769  0.0000 13.7579 27.6286 31.1379  0.2664  1.8853  0.918898536801      0
jxl:d7          19988  1011818    0.4049682   2.067   9.429   5.71113154  52.57509044   2.22633686  33.78   2.403  2.4796  5.5591  0.7816  2.0655  9.1754  0.0000 11.3898 32.4161 34.3398  0.2459  2.2746  0.901595667624      0
jxl:d15         19988   568085    0.2273693   2.078   9.002  10.00935537  23.61668488   3.76770718  30.93   2.309  1.0826  1.4527  0.2757  0.4723  5.0052  0.0000  6.3487 36.3096 44.0019  1.0246  4.7542  0.856661015461      0
jxl:d24         19988   408410    0.1634613   0.313  20.162  16.81616443   4.48142796   5.84684282  29.37   2.658  0.9567  2.1405  0.1710  0.6644  3.0264  0.0000  2.9816  9.1395  6.3321  0.0410  0.0000  0.955732434044      0
jxl:d32         19988   332280    0.1329911   0.313  21.161  18.57719112  -5.52425782   6.50511876  28.78   2.442  0.7044  1.6061  0.1313  0.4592  2.7184  0.0000  2.6307  9.9387  7.1518  0.1127  0.0000  0.865123222584      0
Aggregate:      19988  2306342    0.9230861   1.803  15.789   2.43965505  68.21685983   0.99806086  38.79   2.437  5.4715 11.9455  0.7537  4.5818 12.3270  0.0000 17.1044  8.8037 17.6528  0.3025  0.7871  0.921296129416      0

after:

Encoding      kPixels    Bytes          BPP  E MP/s  D MP/s     Max norm  SSIMULACRA2        pnorm   PSNR   QABPP  SmallB  DCT4x8     AFV  DCT8x8    8x16    8x32      16   16x32      32   32x64      64       BPP*pnorm   Bugs
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
jxl:d0.1        19988 16269656    6.5117379   1.360   9.689   0.35786152  95.44599548   0.11870870  55.33   6.512 41.1900 18.9223  0.4502 27.5694  5.1275  0.0000  2.4168  0.9017  3.9652  0.1025  0.0820  0.772999940911      0
jxl:d0.5        19988  6323359    2.5308498   1.752  14.694   0.79260734  91.38549443   0.34883548  46.40   2.558 13.9933 25.2365  0.5968 11.9207 21.2901  0.0000 20.8354  1.2090  5.1845  0.1537  0.3074  0.882850225619      0
jxl:d0.8        19988  4685041    1.8751324   1.834  15.066   1.10381946  88.62843721   0.48257337  43.83   2.177 10.6540 21.7787  0.7073  8.8856 19.6501  0.0000 29.2718  1.6547  7.5001  0.1947  0.4303  0.904888956607      0
jxl:d1          19988  4050728    1.6212561   1.943  16.698   1.30618178  86.94530734   0.56561812  42.65   2.194  9.3883 20.0270  0.7653  7.7717 18.1010  0.0000 30.5449  2.6435 10.8711  0.2049  0.4098  0.917011818183      0
jxl:d1.1        19988  3819004    1.5285113   2.015  16.720   1.41216733  86.11501949   0.60584908  42.16   2.250  8.9317 19.1528  0.7803  7.3826 17.4798  0.0000 30.3835  3.4657 12.5156  0.2049  0.4303  0.926047153460      0
jxl:d1.2        19988  3605412    1.4430236   2.074  17.360   1.49669999  85.35278898   0.64141782  41.71   2.232  8.4706 18.4980  0.8235  7.0496 16.8542  0.0000 29.9429  4.2675 14.1345  0.2152  0.4713  0.925581066066      0
jxl:d1.3        19988  3432771    1.3739261   1.988  16.521   1.58055924  84.62024637   0.67668612  41.35   2.269  8.0637 18.0117  0.8440  6.6897 16.3848  0.0000 29.1706  5.1230 15.6304  0.2152  0.5943  0.929716719993      0
jxl:d1.4        19988  3268064    1.3080041   2.024  16.643   1.67048359  83.89110784   0.71527175  40.99   2.292  7.7489 17.4773  0.8568  6.4656 16.0275  0.0000 28.0653  6.0939 17.0700  0.2664  0.6558  0.935578347566      0
jxl:d1.5        19988  3114256    1.2464442   2.037  16.860   1.76132976  83.12474942   0.74847317  40.67   2.290  7.4115 17.0361  0.8840  6.2482 15.7361  0.0000 27.1534  6.8828 18.4532  0.2459  0.6762  0.932930058371      0
jxl:d1.6        19988  2981718    1.1933975   1.876  16.006   1.83769343  82.40217642   0.78435516  40.35   2.290  7.0906 16.5849  0.8911  6.0660 15.3935  0.0000 26.3606  7.8434 19.5137  0.3279  0.6558  0.936047442329      0
jxl:d1.7        19988  2861697    1.1453605   2.047  16.484   1.94437493  81.69271518   0.81892188  40.06   2.315  6.8377 16.2100  0.9141  5.9146 15.2174  0.0000 25.4154  8.6964 20.4871  0.4201  0.6148  0.937960738539      0
jxl:d1.8        19988  2753565    1.1020819   2.072  15.466   1.99587803  80.99612252   0.84978102  39.78   2.309  6.6177 15.8680  0.9343  5.7314 15.0137  0.0000 24.5330  9.6877 21.2555  0.3689  0.7172  0.936528279158      0
jxl:d1.9        19988  2653142    1.0618888   2.066  17.075   2.11523235  80.28319255   0.88426440  39.53   2.343  6.4038 15.4985  0.9635  5.6261 14.8729  0.0000 23.6813 10.4485 22.1162  0.3381  0.7787  0.938990442889      0
jxl:d2.0        19988  2558358    1.0239526   1.982  16.668   2.21120686  79.58548879   0.91806372  39.29   2.368  6.2043 15.1962  0.9753  5.4647 14.6763  0.0000 22.9000 11.3399 22.7720  0.3586  0.8402  0.940053735420      0
jxl:d2.1        19988  2470832    0.9889214   1.998  16.239   2.32608209  78.87283869   0.95118409  39.06   2.408  6.0289 14.8178  0.9791  5.3398 14.4790  0.0000 22.3019 12.0571 23.3304  0.4508  0.9426  0.940646260786      0
jxl:d2.2        19988  2390456    0.9567518   2.041  16.647   2.39269830  78.18647266   0.98275058  38.83   2.389  5.8281 14.5363  0.9932  5.2879 14.2997  0.0000 21.5975 12.8665 23.9656  0.4508  0.9017  0.940248399310      0
jxl:d2.3        19988  2316600    0.9271918   1.985  16.968   2.47905570  77.48916735   1.01731429  38.62   2.399  5.6683 14.2117  1.0137  5.1628 14.2549  0.0000 21.0122 13.6709 24.2884  0.4201  1.0246  0.943245486661      0
jxl:d2.4        19988  2243828    0.8980657   1.938  17.241   2.53043993  76.86305980   1.04950786  38.41   2.369  5.5271 13.9065  1.0140  5.0753 14.0724  0.0000 20.6164 14.2446 24.7853  0.4816  1.0041  0.942526998220      0
jxl:d2.5        19988  2181105    0.8729615   1.972  16.964   2.60849359  76.27538761   1.08128992  38.22   2.374  5.4135 13.6372  1.0214  4.9873 14.0378  0.0000 19.9799 15.0310 25.0620  0.5123  1.0451  0.943924517459      0
jxl:d2.6        19988  2120603    0.8487463   2.082  17.670   2.71693456  75.66679922   1.11022361  38.04   2.434  5.2479 13.3004  1.0323  4.9012 13.9392  0.0000 19.4932 15.7329 25.5128  0.5021  1.0656  0.942298214817      0
jxl:d2.7        19988  2061829    0.8252227   2.103  16.603   2.76071239  75.00931153   1.14353168  37.86   2.400  5.1115 13.0439  1.0569  4.8051 13.8079  0.0000 18.9796 16.3605 25.9226  0.5123  1.1271  0.943668338520      0
jxl:d2.8        19988  2007767    0.8035851   2.140  17.969   2.81158297  74.40506717   1.17233927  37.68   2.369  4.9748 12.8393  1.0585  4.7382 13.6741  0.0000 18.6364 17.0393 26.0866  0.5738  1.1066  0.942074311708      0
jxl:d2.9        19988  1958460    0.7838505   2.104  17.201   2.89888857  73.79942124   1.19902593  37.52   2.383  4.8944 12.6129  1.0672  4.6674 13.4781  0.0000 18.2714 17.5695 26.5374  0.5226  1.1066  0.939857086218      0
jxl:d3          19988  1910160    0.7645190   1.966  16.835   2.96752037  73.16647415   1.22873683  37.38   2.377  4.6930 12.3245  1.0576  4.6123 13.3961  0.0000 17.8449 18.3713 26.6860  0.4918  1.2500  0.939392654038      0
jxl:d5          19988  1303028    0.5215216   1.892   9.364   4.49221361  61.95757538   1.75539372  35.19   2.457  3.2615  8.0105  0.9468  2.9768 10.8647  0.0000 13.7772 27.6517 31.0867  0.2664  1.8853  0.915475714877      0
jxl:d7          19988  1011349    0.4047805   1.953   9.101   5.66080456  52.63229304   2.21759805  33.78   2.382  2.5000  5.5611  0.7797  2.0796  9.1715  0.0000 11.4308 32.4007 34.3142  0.2357  2.2541  0.897640456825      0
jxl:d15         19988   569610    0.2279797   1.968   9.242  10.00913584  23.81830737   3.76037186  30.94   2.324  1.0838  1.4790  0.2750  0.4755  5.0340  0.0000  6.3846 36.2712 44.0070  0.9836  4.7337  0.857288382078      0
jxl:d24         19988   406608    0.1627401   0.307  19.918  16.83272609   4.59884381   5.83881192  29.37   2.649  0.9580  2.1526  0.1703  0.6721  3.0213  0.0000  2.9944  9.1165  6.3270  0.0410  0.0000  0.950208572123      0
jxl:d32         19988   331492    0.1326758   0.312  19.399  18.51195985  -5.29077468   6.48794561  28.78   2.417  0.7022  1.6064  0.1313  0.4675  2.7184  0.0000  2.6371  9.9310  7.1467  0.1127  0.0000  0.860793127237      0
Aggregate:      19988  2305979    0.9229410   1.729  15.528   2.44202778  68.30692593   0.99732443  38.79   2.440  5.4896 11.9658  0.7521  4.5995 12.3098  0.0000 17.1328  8.7728 17.6222  0.2977  0.7863  0.920471642111      0
```