### PR TITLE
Add CMake flag PROVISION_DEPENDENCIES

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -50,6 +50,19 @@ if(CHECK_PIE_SUPPORTED)
   endif()
 endif()
 
+if(PROVISION_DEPENDENCIES)
+  # Run script to provision dependencies.
+  find_program (BASH_PROGRAM bash)
+  if(BASH_PROGRAM)
+    execute_process(
+      COMMAND ${BASH_PROGRAM} ${CMAKE_CURRENT_SOURCE_DIR}/deps.sh
+      RESULT_VARIABLE PROVISION_DEPENDENCIES_RESULT)
+  endif()
+  if(NOT PROVISION_DEPENDENCIES_RESULT EQUAL "0")
+    message(FATAL_ERROR "${CMAKE_CURRENT_SOURCE_DIR}/deps.sh failed with ${PROVISION_DEPENDENCIES_RESULT}")
+  endif()
+endif()
+
 ### Project build options:
 if(CXX_FUZZERS_SUPPORTED)
   # Enabled by default except on arm64, Windows and Apple builds.


### PR DESCRIPTION
When this flag is set, CMake will call script 'deps.sh' to provision dependencies.

The need of adding this new CMake flag comes from a real use case scenario. I've recently added libjxl to WebKitGTK and I had some trouble to build it as part of a JHBuild moduleset. 

https://github.com/webkit/webkit/pull/15132

JHBuild expects that CMake modules follow the standard CMake flow:

```
$ mkdir build
$ cd build
$ cmake <FLAGS> ..
$ make
```

There's no margin for executing steps before the build process. Libjxl requires to provision dependencies before running cmake so I added this new CMake flag to perform this task directly from `cmake`. Example:

```
cmake -DPROVISION_DEPENDENCIES=ON ...
```