### PR TITLE
preserve bitdepth when recompressing jxl

### DIFF
--- a/lib/extras/dec/jxl.h
+++ b/lib/extras/dec/jxl.h
@@ -55,7 +55,7 @@ struct JXLDecompressParams {
   bool unpremultiply_alpha = false;
 
   // Controls the effective bit depth of the output pixels.
-  JxlBitDepth output_bitdepth = {JXL_BIT_DEPTH_FROM_PIXEL_FORMAT, 0, 0};
+  JxlBitDepth output_bitdepth = {JXL_BIT_DEPTH_FROM_CODESTREAM, 0, 0};
 };
 
 bool DecodeImageJXL(const uint8_t* bytes, size_t bytes_size,

--- a/lib/extras/enc/encode.cc
+++ b/lib/extras/enc/encode.cc
@@ -58,9 +58,7 @@ Status Encoder::VerifyBitDepth(JxlDataType data_type, uint32_t bits_per_sample,
       (data_type == JXL_TYPE_UINT16 &&
        (bits_per_sample <= 8 || bits_per_sample > 16 || exponent_bits != 0)) ||
       (data_type == JXL_TYPE_FLOAT16 &&
-       (bits_per_sample != 16 || exponent_bits != 5)) ||
-      (data_type == JXL_TYPE_FLOAT &&
-       (bits_per_sample != 32 || exponent_bits != 8))) {
+       (bits_per_sample > 16 || exponent_bits > 5))) {
     return JXL_FAILURE(
         "Incompatible data_type %d and bit depth %u with exponent bits %u",
         (int)data_type, bits_per_sample, exponent_bits);

--- a/lib/include/jxl/types.h
+++ b/lib/include/jxl/types.h
@@ -109,7 +109,8 @@ typedef struct {
   size_t align;
 } JxlPixelFormat;
 
-/** Settings for the interpretation of the input and output buffers.
+/** Settings for the interpretation of UINT input and output buffers.
+ *  (buffers using a FLOAT data type are not affected by this)
  */
 typedef enum {
   /** This is the default setting, where the encoder expects the input pixels

--- a/lib/jxl/decode.cc
+++ b/lib/jxl/decode.cc
@@ -2775,21 +2775,14 @@ namespace {
 template <typename T>
 JxlDecoderStatus VerifyOutputBitDepth(JxlBitDepth bit_depth, const T& metadata,
                                       JxlPixelFormat format) {
-  if ((format.data_type == JXL_TYPE_FLOAT ||
-       format.data_type == JXL_TYPE_FLOAT16) &&
-      bit_depth.type != JXL_BIT_DEPTH_FROM_PIXEL_FORMAT) {
-    return JXL_API_ERROR(
-        "Only JXL_BIT_DEPTH_FROM_PIXEL_FORMAT is implemented "
-        "for float types.");
-  }
   uint32_t bits_per_sample = GetBitDepth(bit_depth, metadata, format);
   if (format.data_type == JXL_TYPE_UINT8 &&
       (bits_per_sample == 0 || bits_per_sample > 8)) {
-    return JXL_API_ERROR("Inavlid bit depth %u for uint8 output",
+    return JXL_API_ERROR("Invalid bit depth %u for uint8 output",
                          bits_per_sample);
   } else if (format.data_type == JXL_TYPE_UINT16 &&
              (bits_per_sample == 0 || bits_per_sample > 16)) {
-    return JXL_API_ERROR("Inavlid bit depth %u for uint16 output",
+    return JXL_API_ERROR("Invalid bit depth %u for uint16 output",
                          bits_per_sample);
   }
   return JXL_DEC_SUCCESS;

--- a/lib/jxl/enc_external_image.cc
+++ b/lib/jxl/enc_external_image.cc
@@ -50,11 +50,8 @@ Status ConvertFromExternal(Span<const uint8_t> bytes, size_t xsize,
     JXL_RETURN_IF_ERROR(bits_per_sample > 0 && bits_per_sample <= 8);
   } else if (format.data_type == JXL_TYPE_UINT16) {
     JXL_RETURN_IF_ERROR(bits_per_sample > 8 && bits_per_sample <= 16);
-  } else if (format.data_type == JXL_TYPE_FLOAT16) {
-    JXL_RETURN_IF_ERROR(bits_per_sample == 16);
-  } else if (format.data_type == JXL_TYPE_FLOAT) {
-    JXL_RETURN_IF_ERROR(bits_per_sample == 32);
-  } else {
+  } else if (format.data_type != JXL_TYPE_FLOAT16 &&
+             format.data_type != JXL_TYPE_FLOAT) {
     JXL_FAILURE("unsupported pixel format data type %d", format.data_type);
   }
   size_t bytes_per_channel = JxlDataTypeBytes(format.data_type);

--- a/lib/jxl/encode.cc
+++ b/lib/jxl/encode.cc
@@ -258,13 +258,6 @@ JxlEncoderStatus CheckValidBitdepth(uint32_t bits_per_sample,
 
 JxlEncoderStatus VerifyInputBitDepth(JxlBitDepth bit_depth,
                                      JxlPixelFormat format) {
-  if ((format.data_type == JXL_TYPE_FLOAT ||
-       format.data_type == JXL_TYPE_FLOAT16) &&
-      bit_depth.type != JXL_BIT_DEPTH_FROM_PIXEL_FORMAT) {
-    return JXL_API_ERROR_NOSET(
-        "Only JXL_BIT_DEPTH_FROM_PIXEL_FORMAT is "
-        "implemented for float types.");
-  }
   return JXL_ENC_SUCCESS;
 }
 


### PR DESCRIPTION
Partially fixes https://github.com/libjxl/libjxl/issues/2581

(it will still convert enum colorspace to icc, but at least the bit depth is preserved with this change)


On the API side, we currently don't allow JXL_BIT_DEPTH_FROM_CODESTREAM in combination with float buffers (we return "not implemented"), but I don't think there's a reason to disallow that. I think we can just define it to not have any impact on the interpretation of float buffers (they always use nominal range 0..1) and call it a day.