### PR TITLE
organize cjxl/djxl help a bit

### DIFF
--- a/tools/cjxl_main.cc
+++ b/tools/cjxl_main.cc
@@ -1028,8 +1028,13 @@ int main(int argc, char** argv) {
     }
   }
   if (!args.quiet) {
-    cmdline.VerbosePrintf(0, "Compressed to %" PRIuS " bytes ",
-                          compressed.size());
+    if (compressed.size() < 100000) {
+      cmdline.VerbosePrintf(0, "Compressed to %" PRIuS " bytes ",
+                            compressed.size());
+    } else {
+      cmdline.VerbosePrintf(0, "Compressed to %.1f kB ",
+                            compressed.size() * 0.001);
+    }
     // For lossless jpeg-reconstruction, we don't print some stats, since we
     // don't have easy access to the image dimensions.
     if (args.container == jxl::Override::kOn) {
@@ -1040,9 +1045,7 @@ int main(int argc, char** argv) {
           static_cast<double>(compressed.size() * jxl::kBitsPerByte) / pixels;
       cmdline.VerbosePrintf(0, "(%.3f bpp%s).\n", bpp / ppf.frames.size(),
                             ppf.frames.size() == 1 ? "" : "/frame");
-      if (cmdline.verbosity > 0) {
-        JXL_CHECK(stats.Print(num_worker_threads));
-      }
+      JXL_CHECK(stats.Print(num_worker_threads));
     } else {
       cmdline.VerbosePrintf(0, "\n");
     }

--- a/tools/cmdline.cc
+++ b/tools/cmdline.cc
@@ -29,7 +29,9 @@ void CommandLineParser::PrintHelp() const {
   fprintf(out, " [OPTIONS...]\n");
 
   bool showed_all = true;
+  int max_verbosity = 0;
   for (const auto& option : options_) {
+    max_verbosity = std::max(option->verbosity_level(), max_verbosity);
     if (option->verbosity_level() > verbosity) {
       showed_all = false;
       continue;
@@ -44,9 +46,13 @@ void CommandLineParser::PrintHelp() const {
       fprintf(out, "    %s\n", help_text);
     }
   }
-  fprintf(out, "\n -h, --help\n    Prints this help message. %s\n",
-          (showed_all ? "All options are shown above."
-                      : "Add -v to see more options."));
+  fprintf(out, "\n -h, --help\n    Prints this help message. ");
+  if (showed_all) {
+    fprintf(out, "All options are shown above.\n");
+  } else {
+    fprintf(out, "Add -v (up to a total of %i times) to see more options.\n",
+            max_verbosity);
+  }
 }
 
 bool CommandLineParser::Parse(int argc, const char* argv[]) {

--- a/tools/cmdline.cc
+++ b/tools/cmdline.cc
@@ -44,8 +44,9 @@ void CommandLineParser::PrintHelp() const {
       fprintf(out, "    %s\n", help_text);
     }
   }
-  fprintf(out, " -h, --help\n    Prints this help message%s.\n",
-          (showed_all ? "" : " (use -v to see more options)"));
+  fprintf(out, "\n -h, --help\n    Prints this help message. %s\n",
+          (showed_all ? "All options are shown above."
+                      : "Add -v to see more options."));
 }
 
 bool CommandLineParser::Parse(int argc, const char* argv[]) {
@@ -93,6 +94,16 @@ bool CommandLineParser::Parse(int argc, const char* argv[]) {
     }
   }
   return true;
+}
+
+void CommandLineParser::VerbosePrintf(int min_verbosity, const char* format,
+                                      ...) const {
+  if (min_verbosity > verbosity) return;
+  va_list args;
+  va_start(args, format);
+  vfprintf(stderr, format, args);
+  fflush(stderr);
+  va_end(args);
 }
 
 }  // namespace tools

--- a/tools/cmdline.cc
+++ b/tools/cmdline.cc
@@ -34,6 +34,10 @@ void CommandLineParser::PrintHelp() const {
       showed_all = false;
       continue;
     }
+    if (option->help_only()) {
+      fprintf(out, "%s\n", option->help_text());
+      continue;
+    }
     fprintf(out, " %s\n", option->help_flags().c_str());
     const char* help_text = option->help_text();
     if (help_text) {

--- a/tools/cmdline.h
+++ b/tools/cmdline.h
@@ -6,6 +6,7 @@
 #ifndef TOOLS_CMDLINE_H_
 #define TOOLS_CMDLINE_H_
 
+#include <stdarg.h>
 #include <stdio.h>
 #include <string.h>
 
@@ -120,6 +121,9 @@ class CommandLineParser {
 
   // Return the remaining positional args
   std::vector<const char*> PositionalArgs() const;
+
+  // Conditionally print a message to stderr
+  void VerbosePrintf(int min_verbosity, const char* format, ...) const;
 
  private:
   // Help text only.

--- a/tools/djxl_main.cc
+++ b/tools/djxl_main.cc
@@ -63,17 +63,18 @@ struct DecompressArgs {
         "(e.g. 'png:-')",
         &file_out);
 
+    cmdline->AddHelpText("\nBasic options:", 0);
+
     cmdline->AddOptionFlag('V', "version", "Print version number and exit.",
-                           &version, &SetBooleanTrue, 1);
+                           &version, &SetBooleanTrue, 0);
+    cmdline->AddOptionFlag('\0', "quiet", "Silence output (except for errors).",
+                           &quiet, &SetBooleanTrue, 0);
+    cmdline->AddOptionFlag('v', "verbose",
+                           "Verbose output; can be repeated and also applies "
+                           "to help (!).",
+                           &verbose, &SetBooleanTrue);
 
-    cmdline->AddOptionValue('\0', "num_reps", "N",
-                            "Sets the number of times to decompress the image. "
-                            "Useful for benchmarking. Default is 1.",
-                            &num_reps, &ParseUnsigned, 2);
-
-    cmdline->AddOptionFlag('\0', "disable_output",
-                           "No output file will be written (for benchmarking)",
-                           &disable_output, &SetBooleanTrue, 2);
+    cmdline->AddHelpText("\nAdvanced options:", 1);
 
     cmdline->AddOptionValue('\0', "num_threads", "N",
                             "Number of worker threads (-1 == use machine "
@@ -88,7 +89,7 @@ struct DecompressArgs {
         "output format capabilities\n"
         "    and the input bit depth (e.g. decoding a 12-bit image to PNG will "
         "produce a 16-bit PNG).",
-        &bits_per_sample, &ParseSigned, 2);
+        &bits_per_sample, &ParseSigned, 1);
 
     cmdline->AddOptionValue('\0', "display_nits", "N",
                             "If set to a non-zero value, tone maps the image "
@@ -109,11 +110,11 @@ struct DecompressArgs {
                             "target downsampling ratios,\n"
                             "    only decode what is needed to produce an "
                             "image intended for this downsampling ratio.",
-                            &downsampling, &ParseUint32, 2);
+                            &downsampling, &ParseUint32, 1);
 
     cmdline->AddOptionFlag('\0', "allow_partial_files",
                            "Allow decoding of truncated files.",
-                           &allow_partial_files, &SetBooleanTrue, 2);
+                           &allow_partial_files, &SetBooleanTrue, 1);
 
 #if JPEGXL_ENABLE_JPEG
     cmdline->AddOptionFlag(
@@ -122,19 +123,30 @@ struct DecompressArgs {
         "djxl reconstructs that JPEG file.\n"
         "    This flag causes the decoder to instead decode to pixels and "
         "encode a new (lossy) JPEG.",
-        &pixels_to_jpeg, &SetBooleanTrue, 2);
+        &pixels_to_jpeg, &SetBooleanTrue, 1);
 
     opt_jpeg_quality_id =
         cmdline->AddOptionValue('q', "jpeg_quality", "N",
                                 "Sets the JPEG output quality, default is 95. "
                                 "Setting this option implies --pixels_to_jpeg.",
-                                &jpeg_quality, &ParseUnsigned, 2);
+                                &jpeg_quality, &ParseUnsigned, 1);
 #endif
+
+    cmdline->AddHelpText("\nOptions for experimentation / benchmarking:", 2);
+
+    cmdline->AddOptionValue('\0', "num_reps", "N",
+                            "Sets the number of times to decompress the image. "
+                            "Useful for benchmarking. Default is 1.",
+                            &num_reps, &ParseUnsigned, 2);
+
+    cmdline->AddOptionFlag('\0', "disable_output",
+                           "No output file will be written (for benchmarking)",
+                           &disable_output, &SetBooleanTrue, 2);
 
 #if JPEGXL_ENABLE_SJPEG
     cmdline->AddOptionFlag('\0', "use_sjpeg",
                            "Use sjpeg instead of libjpeg for JPEG output.",
-                           &use_sjpeg, &SetBooleanTrue, 3);
+                           &use_sjpeg, &SetBooleanTrue, 2);
 #endif
 
     cmdline->AddOptionFlag('\0', "norender_spotcolors",
@@ -158,24 +170,16 @@ struct DecompressArgs {
         "this file\n"
         "    This can be different from the ICC profile of the "
         "decoded image if --color_space was specified.",
-        &orig_icc_out, &ParseString, 3);
+        &orig_icc_out, &ParseString, 2);
 
     cmdline->AddOptionValue('\0', "metadata_out", "FILENAME",
                             "If specified, writes metadata info to a JSON "
                             "file. Used by the conformance test script",
-                            &metadata_out, &ParseString, 3);
+                            &metadata_out, &ParseString, 2);
 
     cmdline->AddOptionFlag('\0', "print_read_bytes",
                            "Print total number of decoded bytes.",
-                           &print_read_bytes, &SetBooleanTrue, 3);
-
-    cmdline->AddOptionFlag('\0', "quiet", "Silence output (except for errors).",
-                           &quiet, &SetBooleanTrue, 2);
-
-    cmdline->AddOptionFlag('v', "verbose",
-                           "Verbose output; can be repeated and also applies "
-                           "to help (!).",
-                           &verbose, &SetBooleanTrue);
+                           &print_read_bytes, &SetBooleanTrue, 2);
   }
 
   // Validate the passed arguments, checking whether all passed options are

--- a/tools/djxl_main.cc
+++ b/tools/djxl_main.cc
@@ -362,7 +362,8 @@ int main(int argc, const char* argv[]) {
     return EXIT_FAILURE;
   }
   if (!args.quiet) {
-    fprintf(stderr, "Read %" PRIuS " compressed bytes.\n", compressed.size());
+    cmdline.VerbosePrintf(1, "Read %" PRIuS " compressed bytes.\n",
+                          compressed.size());
   }
 
   if (!args.file_out && !args.disable_output) {
@@ -436,7 +437,7 @@ int main(int argc, const char* argv[]) {
       }
     }
     if (!bytes.empty()) {
-      if (!args.quiet) fprintf(stderr, "Reconstructed to JPEG.\n");
+      if (!args.quiet) cmdline.VerbosePrintf(0, "Reconstructed to JPEG.\n");
       if (!filename_out.empty() &&
           !jxl::WriteFile(base == "-" ? "-" : filename_out.c_str(), bytes)) {
         return EXIT_FAILURE;
@@ -465,7 +466,7 @@ int main(int argc, const char* argv[]) {
         return EXIT_FAILURE;
       }
     }
-    if (!args.quiet) fprintf(stderr, "Decoded to pixels.\n");
+    if (!args.quiet) cmdline.VerbosePrintf(0, "Decoded to pixels.\n");
     if (args.print_read_bytes) {
       fprintf(stderr, "Decoded bytes: %" PRIuS "\n", decoded_bytes);
     }
@@ -483,6 +484,7 @@ int main(int argc, const char* argv[]) {
 #endif
     jxl::extras::EncodedImage encoded_image;
     if (encoder) {
+      if (!args.quiet) cmdline.VerbosePrintf(2, "Encoding decoded image\n");
       if (!encoder->Encode(ppf, &encoded_image)) {
         fprintf(stderr, "Encode failed\n");
         return EXIT_FAILURE;
@@ -499,6 +501,8 @@ int main(int argc, const char* argv[]) {
         if (!jxl::WriteFile(fn.c_str(), bitstream)) {
           return EXIT_FAILURE;
         }
+        if (!args.quiet)
+          cmdline.VerbosePrintf(1, "Wrote output to %s\n", fn.c_str());
       }
     }
     if (!WriteOptionalOutput(args.preview_out,
@@ -509,7 +513,7 @@ int main(int argc, const char* argv[]) {
       return EXIT_FAILURE;
     }
   }
-  if (!args.quiet) {
+  if (!args.quiet && cmdline.verbosity > 0) {
     stats.Print(num_worker_threads);
   }
   return EXIT_SUCCESS;

--- a/tools/djxl_main.cc
+++ b/tools/djxl_main.cc
@@ -513,7 +513,7 @@ int main(int argc, const char* argv[]) {
       return EXIT_FAILURE;
     }
   }
-  if (!args.quiet && cmdline.verbosity > 0) {
+  if (!args.quiet) {
     stats.Print(num_worker_threads);
   }
   return EXIT_SUCCESS;

--- a/tools/speed_stats.cc
+++ b/tools/speed_stats.cc
@@ -58,21 +58,19 @@ bool SpeedStats::GetSummary(SpeedStats::Summary* s) {
     s->central_tendency = pow(product, 1.0 / (elapsed_.size() - 1));
     s->variability = 0.0;
     s->type = " geomean:";
-    return true;
+    if (isnormal(s->central_tendency)) return true;
   }
 
   // Else: median
   std::sort(elapsed_.begin(), elapsed_.end());
   s->central_tendency = elapsed_.data()[elapsed_.size() / 2];
-  std::vector<double> deviations(elapsed_.size());
+  double stdev = 0;
   for (size_t i = 0; i < elapsed_.size(); i++) {
-    deviations[i] = fabs(elapsed_[i] - s->central_tendency);
+    double diff = elapsed_[i] - s->central_tendency;
+    stdev += diff * diff;
   }
-  std::nth_element(deviations.begin(),
-                   deviations.begin() + deviations.size() / 2,
-                   deviations.end());
-  s->variability = deviations[deviations.size() / 2];
-  s->type = "median: ";
+  s->variability = sqrt(stdev);
+  s->type = " median:";
   return true;
 }
 
@@ -87,9 +85,15 @@ std::string SummaryStat(double value, const char* unit,
   // Note flipped order: higher elapsed = lower mpps.
   const double value_min = value / s.max;
   const double value_max = value / s.min;
+  const double stdev = value / s.variability;
 
-  snprintf(stat_str, sizeof(stat_str), ",%s %.2f %s/s [%.2f, %.2f]", s.type,
-           value_tendency, unit, value_min, value_max);
+  char variability[20] = {'\0'};
+  if (s.variability != 0.0) {
+    snprintf(variability, sizeof(variability), " (stdev %.3f)", stdev);
+  }
+
+  snprintf(stat_str, sizeof(stat_str), ",%s %.3f %s/s [%.2f, %.2f]%s", s.type,
+           value_tendency, unit, value_min, value_max, variability);
   return stat_str;
 }
 
@@ -103,16 +107,11 @@ bool SpeedStats::Print(size_t worker_threads) {
   std::string mps_stats = SummaryStat(xsize_ * ysize_ * 1e-6, "MP", s);
   std::string mbs_stats = SummaryStat(file_size_ * 1e-6, "MB", s);
 
-  char variability[20] = {'\0'};
-  if (s.variability != 0.0) {
-    snprintf(variability, sizeof(variability), " (var %.2f)", s.variability);
-  }
-
   fprintf(stderr,
-          "%" PRIu64 " x %" PRIu64 "%s%s%s, %" PRIu64 " reps, %" PRIu64
+          "%" PRIu64 " x %" PRIu64 "%s%s, %" PRIu64 " reps, %" PRIu64
           " threads.\n",
           static_cast<uint64_t>(xsize_), static_cast<uint64_t>(ysize_),
-          mps_stats.c_str(), mbs_stats.c_str(), variability,
+          mps_stats.c_str(), mbs_stats.c_str(),
           static_cast<uint64_t>(elapsed_.size()),
           static_cast<uint64_t>(worker_threads));
   return true;


### PR DESCRIPTION
Currently the help screens for cjxl/djxl are one long list and making the help more verbose shows more options in random places, which makes it hard to distinguish the basic options from the more advanced ones.

This reorders the options and adds some structure to it.

For `cjxl`, I made five tiers of options (so you need four `-v` to see them all). The first tier is always shown in the help screen and each additional `-v` 'unlocks' another tier.

- Basic options
- Advanced options
- Expert options
- Options for experimentation / benchmarking
- Modular mode options

Those last two tiers should not really be useful for normal users, they're intended more for encoder development than for actual use.

The full `cjxl` help looks like this then:

```
$ cjxl -v -v -v -v
JPEG XL encoder v0.9.0 87202f32 [SSE4,SSSE3,SSE2]
Usage: tools/cjxl INPUT OUTPUT [OPTIONS...]
 INPUT
    the input can be PNG, APNG, GIF, JPEG, EXR, PPM, PFM, PAM, PGX, or JXL
 OUTPUT
    the compressed JXL output file

Basic options:
 -d DISTANCE, --distance=DISTANCE
    Target visual distance in JND units, lower = higher quality.
    0.0 = mathematically lossless. Default for already-lossy input (JPEG/GIF).
    1.0 = visually lossless. Default for other input.
    Recommended range: 0.5 .. 3.0. Allowed range: 0.0 ... 25.0. Mutually exclusive with --quality.
 -q QUALITY, --quality=QUALITY
    Quality setting, higher value = higher quality. This is internally mapped to --distance.
    100 = mathematically lossless. 90 = visually lossless.
    Quality values roughly match libjpeg quality.
    Recommended range: 68 .. 96. Allowed range: 0 .. 100. Mutually exclusive with --distance.
 -e EFFORT, --effort=EFFORT
    Encoder effort setting. Range: 1 .. 9.
    Default: 7. Higher numbers allow more computation at the expense of time.
    For lossless, generally it will produce smaller files.
    For lossy, higher effort should more accurately reach the target quality.
 -V, --version
    Print encoder library version number and exit.
 --quiet
    Be more silent
 -v, --verbose
    Verbose output; can be repeated and also applies to help (!).

Advanced options:
 -a A_DISTANCE, --alpha_distance=A_DISTANCE
    Target visual distance for the alpha channel, lower = higher quality.
    0.0 = mathematically lossless. 1.0 = visually lossless.
    Default is to use the same value as for the color image.
    Recommended range: 0.5 .. 3.0. Allowed range: 0.0 ... 25.0.
 -p, --progressive
    Enable (more) progressive/responsive decoding.
 --group_order=0|1
    Order in which 256x256 groups are stored in the codestream for progressive rendering.
    0 = scanline order, 1 = center-first order. Default: 0.
 --container=0|1
    0 = Do not encode using container format (strip Exif/XMP/JPEG bitstream reconstruction data).
    1 = Force using container format. Default: use only if needed.
 --compress_boxes=0|1
    Disable/enable Brotli compression for metadata boxes. Default is 1 (enabled).
 --brotli_effort=B_EFFORT
    Brotli effort setting. Range: 0 .. 11.
    Default: 9. Higher number is more effort (slower).
 -m 0|1, --modular=0|1
    Use modular mode (default = encoder chooses, 0 = enforce VarDCT, 1 = enforce modular mode).
 -j 0|1, --lossless_jpeg=0|1
    If the input is JPEG, losslessly transcode JPEG, rather than using reencode pixels.
 --num_threads=N
    Number of worker threads (-1 == use machine default, 0 == do not use multithreading).
 --photon_noise_iso=ISO_FILM_SPEED
    Adds noise to the image emulating photographic film or sensor noise.
    Higher number = grainier image, e.g. 100 gives a low amount of noise,
    3200 gives a lot of noise. Default is 0.
 --intensity_target=N
    Upper bound on the intensity level present in the image, in nits.
    Default is 0, which means 'choose a sensible default value based on the color encoding.
 -x key=value, --dec-hints=key=value
    This is useful for 'raw' formats like PPM that do not contain colorspace information.
    The key 'color_space' indicates an enumerated ColorEncoding, for example:
      -x color_space=RGB_D65_SRG_Per_SRG is sRGB with perceptual rendering intent
      -x color_space=RGB_D65_202_Rel_PeQ is Rec.2100 PQ with relative rendering intent
    The key 'icc_pathname' refers to a binary file containing an ICC profile.

Expert options:
 --jpeg_store_metadata=0|1
    If --lossless_jpeg=1, store JPEG reconstruction metadata in the JPEG XL container.
    This allows reconstruction of the JPEG codestream. Default: 1.
 --codestream_level=K
    The codestream level. Either `-1`, `5` or `10`.
 --faster_decoding=0|1|2|3|4
    0 = default, higher values improve decode speed at the expense of quality or density.
 --premultiply=-1|0|1
    Force premultiplied (associated) alpha.
 --keep_invisible=0|1
    disable/enable preserving color of invisible pixels (default: 1 if lossless, 0 if lossy).
 --center_x=-1..XSIZE
    Determines the horizontal position of center for the center-first group order.
    Default -1 means 'middle of the image', values [0..xsize) set this to a particular coordinate.
 --center_y=-1..YSIZE
    Determines the vertical position of center for the center-first group order.
    Default -1 means 'middle of the image', values [0..ysize) set this to a particular coordinate.
 --progressive_ac
    Use the progressive mode for AC.
 --qprogressive_ac
    Use the progressive mode for AC with shift quantization.
 --progressive_dc=num_dc_frames
    Progressive-DC setting. Valid values are: -1, 0, 1, 2.
 --resampling=-1|1|2|4|8
    Resampling for color channels. Default of -1 applies resampling only for very low quality.
    1 = downsampling (1x1), 2 = 2x2 downsampling, 4 = 4x4 downsampling, 8 = 8x8 downsampling.
 --ec_resampling=-1|1|2|4|8
    Resampling for extra channels. Same as --resampling but for extra channels like alpha.
 --already_downsampled
    Do not downsample before encoding, but still signal that the decoder should upsample.
 --epf=-1|0|1|2|3
    Edge preserving filter level, 0-3. Default -1 means encoder chooses, 0-3 set a strength.
 --gaborish=0|1
    Force disable/enable the gaborish filter. Default is 'encoder chooses'
 --override_bitdepth=BITDEPTH
    Default is zero (use the input image bit depth); if nonzero, override the bit depth

Options for experimentation / benchmarking:
 --jpeg_reconstruction_cfl=0|1
    Enable/disable chroma-from-luma (CFL) for lossless JPEG reconstruction.
 --num_reps=N
    How many times to compress. (For benchmarking).
 --disable_output
    No output file will be written (for benchmarking)
 --dots=0|1
    Force disable/enable dots generation. (not provided = default, 0 = disable, 1 = enable).
 --patches=0|1
    Force disable/enable patches generation. (not provided = default, 0 = disable, 1 = enable).
 --frame_indexing=INDICES
    INDICES is of the form '^(0*|1[01]*)'. The i-th position indicates whether the
    i-th frame will be indexed in the frame index box.
 --allow_expert_options
    Allow specifying advanced options; this allows setting effort to 10, for
    somewhat better lossless compression at the cost of a massive speed hit.

Modular mode options:
 -I PERCENT, --iterations=PERCENT
    Percentage of pixels used to learn MA trees. Higher values use
    more encoder memory and can result in better compression. Default of -1 means
    the encoder chooses. Zero means no MA trees are used.
 -C K, --modular_colorspace=K
    Color transform: -1 = default (try several per group, depending
    on effort), 0 = RGB (none), 1-41 = fixed RCT (6 = YCoCg).
 -g K, --modular_group_size=K
    Group size: -1 = default (let the encoder choose),
    0 = 128x128, 1 = 256x256, 2 = 512x512, 3 = 1024x1024.
 -P K, --modular_predictor=K
    Predictor(s) to use: 0=zero, 1=left, 2=top, 3=avg0, 4=select,
    5=gradient, 6=weighted, 7=topright, 8=topleft, 9=leftleft, 10=avg1, 11=avg2, 12=avg3,
    13=toptop predictive average, 14=mix 5 and 6, 15=mix everything.
    Default is 14 at effort < 9 and 15 at effort 9.
 -E K, --modular_nb_prev_channels=K
    Number of extra (previous-channel) MA tree properties to use.
 --modular_palette_colors=K
    Use palette if number of colors is smaller than or equal to this.
 --modular_lossy_palette
    Use delta palette in a lossy way; it is recommended to also
    set --modular_palette_colors=0 with this option to use the default palette only.
 -X PERCENT, --pre-compact=PERCENT
    Use global channel palette if the number of sample values is smaller
    than this percentage of the nominal range. 
 -Y PERCENT, --post-compact=PERCENT
    Use local (per-group) channel palette if the number of sample values is
    smaller than this percentage of the nominal range.
 -R K, --responsive=K
    Do the Squeeze transform, 0=false, 1=true (default: 1 if lossy, 0 if lossless)
 -h, --help
    Prints this help message.
```


For `djxl`, I reduced it to three tiers of options:

- Basic options
- Advanced options
- Options for experimentation / benchmarking

That last tier should not really be useful for normal users.

The full `djxl` help screen looks like this then:

```
$ djxl -v -v 
JPEG XL decoder v0.9.0 87202f32 [SSE4,SSSE3,SSE2]
Usage: tools/djxl INPUT OUTPUT [OPTIONS...]
 INPUT
    The compressed input file (JXL). Use '-' for input from stdin.
 OUTPUT
    The output can be PNG, APNG, JPEG, EXR, PPM, PFM, or PAM. Use '-' for output to stdout.
    The output format is selected based on the extension or a prefix (e.g. 'png:-')

Basic options:
 -V, --version
    Print version number and exit.
 --quiet
    Silence output (except for errors).
 -v, --verbose
    Verbose output; can be repeated and also applies to help (!).

Advanced options:
 --num_threads=N
    Number of worker threads (-1 == use machine default, 0 == do not use multithreading).
 --bits_per_sample=N
    Sets the output bit depth. The value 0 (default for PNM) means the original (input) bit depth.
    The value -1 (default for other codecs) means it depends on the output format capabilities
    and the input bit depth (e.g. decoding a 12-bit image to PNG will produce a 16-bit PNG).
 --display_nits=N
    If set to a non-zero value, tone maps the image the given peak display luminance.
 --color_space=COLORSPACE_DESC
    Sets the desired output color space of the image. For example:
      --color_space=RGB_D65_SRG_Per_SRG is sRGB with perceptual rendering intent
      --color_space=RGB_D65_202_Rel_PeQ is Rec.2100 PQ with relative rendering intent
 -s 1|2|4|8, --downsampling=1|2|4|8
    If the input JXL stream is contains hints for target downsampling ratios,
    only decode what is needed to produce an image intended for this downsampling ratio.
 --allow_partial_files
    Allow decoding of truncated files.
 -j, --pixels_to_jpeg
    By default, if the input JXL is a recompressed JPEG file, djxl reconstructs that JPEG file.
    This flag causes the decoder to instead decode to pixels and encode a new (lossy) JPEG.
 -q N, --jpeg_quality=N
    Sets the JPEG output quality, default is 95. Setting this option implies --pixels_to_jpeg.

Options for experimentation / benchmarking:
 --num_reps=N
    Sets the number of times to decompress the image. Useful for benchmarking. Default is 1.
 --disable_output
    No output file will be written (for benchmarking)
 --norender_spotcolors
    Disables rendering of spot colors.
 --preview_out=FILENAME
    If specified, writes the preview image to this file.
 --icc_out=FILENAME
    If specified, writes the ICC profile of the decoded image to this file.
 --orig_icc_out=FILENAME
    If specified, writes the ICC profile of the original image to this file
    This can be different from the ICC profile of the decoded image if --color_space was specified.
 --metadata_out=FILENAME
    If specified, writes metadata info to a JSON file. Used by the conformance test script
 --print_read_bytes
    Print total number of decoded bytes.
 -h, --help
    Prints this help message.
```

