### PR TITLE
better default modular group size

### DIFF
--- a/lib/jxl/decode_test.cc
+++ b/lib/jxl/decode_test.cc
@@ -4533,6 +4533,7 @@ TEST(DecodeTest, FlushTestLosslessProgressiveAlpha) {
   params.cparams.SetLossless();
   params.cparams.speed_tier = jxl::SpeedTier::kThunder;
   params.cparams.responsive = 1;
+  params.cparams.modular_group_size_shift = 1;
   params.preview_mode = jxl::kSmallPreview;
   jxl::PaddedBytes data = jxl::CreateTestJXLCodestream(
       jxl::Span<const uint8_t>(pixels.data(), pixels.size()), xsize, ysize,

--- a/lib/jxl/enc_params.h
+++ b/lib/jxl/enc_params.h
@@ -89,8 +89,9 @@ struct CompressParams {
   // If true, the "modular mode options" members below are used.
   bool modular_mode = false;
 
-  // Change group size in modular mode (0=128, 1=256, 2=512, 3=1024).
-  size_t modular_group_size_shift = 1;
+  // Change group size in modular mode (0=128, 1=256, 2=512, 3=1024, -1=encoder
+  // chooses).
+  int modular_group_size_shift = -1;
 
   Override preview = Override::kDefault;
   Override noise = Override::kDefault;

--- a/lib/jxl/encode.cc
+++ b/lib/jxl/encode.cc
@@ -1239,15 +1239,7 @@ JxlEncoderStatus JxlEncoderFrameSettingsSetOption(
         return JXL_API_ERROR(frame_settings->enc, JXL_ENC_ERR_API_USAGE,
                              "Option value has to be in [-1..3]");
       }
-      // TODO(lode): the default behavior of this parameter for cjxl is
-      // to choose 1 or 2 depending on the situation. This behavior needs to be
-      // implemented either in the C++ library by allowing to set this to -1, or
-      // kept in cjxl and set it to 1 or 2 using this API.
-      if (value == -1) {
-        frame_settings->values.cparams.modular_group_size_shift = 1;
-      } else {
-        frame_settings->values.cparams.modular_group_size_shift = value;
-      }
+      frame_settings->values.cparams.modular_group_size_shift = value;
       return JXL_ENC_SUCCESS;
     case JXL_ENC_FRAME_SETTING_MODULAR_PREDICTOR:
       if (value < -1 || value > 15) {

--- a/tools/cjxl_main.cc
+++ b/tools/cjxl_main.cc
@@ -776,9 +776,6 @@ void ProcessFlags(const jxl::extras::Codec codec,
   }
 
   // Modular mode related.
-  // TODO(firsching): consider doing more validation after image size is
-  // known, i.e. set to 512 if 256 would be silly using
-  // opt_modular_group_size_id.
   ProcessFlag("modular_group_size", args->modular_group_size,
               JXL_ENC_FRAME_SETTING_MODULAR_GROUP_SIZE, params,
               [](int64_t x) -> std::string {


### PR DESCRIPTION
In the old cjxl (before it used the API) the modular group size was chosen depending on the image dimensions. This brings back that behavior, but now as a default setting for that option.
Also uses the frame dimensions rather than the image dimensions to make the choice, which makes more sense in case it is e.g. a 300x300 cropped frame in an animation or multi-layer image that is larger, or in case resampling is used.

On the jyrki31 images, resized with `convert -resize 400x400` to fit within a 400x400 box:
Before:

benchmark_xl v0.9.0 fb76c60b [SSE4,SSSE3,SSE2]
4 total threads, 31 tasks, 4 threads, 0 inner threads
```
Encoding      kPixels    Bytes          BPP  E MP/s  D MP/s     Max norm  SSIMULACRA2        pnorm       BPP*pnorm   Bugs
-------------------------------------------------------------------------------------------------------------------------
jxl:d0           3620  4956830   10.9543204   0.248   2.462         -nan 100.00000000   0.00000000  0.000000000000      0
Aggregate:       3620  4956830   10.9543204   0.248   2.462   0.00000000 100.00000000   0.00000000  0.000000000000      0
```

After:
benchmark_xl v0.9.0 b170f409 [SSE4,SSSE3,SSE2]
4 total threads, 31 tasks, 4 threads, 0 inner threads
```
Encoding      kPixels    Bytes          BPP  E MP/s  D MP/s     Max norm  SSIMULACRA2        pnorm       BPP*pnorm   Bugs
-------------------------------------------------------------------------------------------------------------------------
jxl:d0           3620  4938085   10.9128950   0.288   2.737         -nan 100.00000000   0.00000000  0.000000000000      0
Aggregate:       3620  4938085   10.9128950   0.288   2.737   0.00000000 100.00000000   0.00000000  0.000000000000      0
```

So it does help a little for images of that size (0.38% better compression). Perhaps we can in the future come up with better heuristics to decide the group size, since there might be other relevant things besides the dimensions: e.g. if the image has very low entropy (e.g. only few distinct colors / large well-predicted regions) then probably larger group sizes will be better, while if it has high entropy, smaller group sizes might be a better choice (because a more fine-grained local RCT/Palette could help in such cases).
