### PR TITLE
Factor out the libjpeg-decoding parts of test_utils.cc

### DIFF
--- a/lib/BUILD
+++ b/lib/BUILD
@@ -23,6 +23,7 @@ load(
     "libjxl_extras_for_tools_sources",
     "libjxl_extras_sources",
     #'libjxl_gbench_sources',
+    "libjxl_jpegli_libjpeg_helper_files",
     "libjxl_jpegli_sources",
     "libjxl_jpegli_testlib_files",
     "libjxl_jpegli_tests",
@@ -214,7 +215,7 @@ cc_library(
     ] + libjxl_deps_exr + libjxl_deps_gif + libjxl_deps_jpeg + libjxl_deps_png,
 )
 
-TESTLIB_FILES = libjxl_testlib_files + libjxl_jpegli_testlib_files
+TESTLIB_FILES = libjxl_testlib_files + libjxl_jpegli_testlib_files + libjxl_jpegli_libjpeg_helper_files
 
 cc_library(
     name = "test_utils",

--- a/lib/jpegli.cmake
+++ b/lib/jpegli.cmake
@@ -36,7 +36,10 @@ file(MAKE_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/tests)
 foreach (TESTFILE IN LISTS JPEGXL_INTERNAL_JPEGLI_TESTS)
   # The TESTNAME is the name without the extension or directory.
   get_filename_component(TESTNAME ${TESTFILE} NAME_WE)
-  add_executable(${TESTNAME} ${TESTFILE} ${JPEGXL_INTERNAL_JPEGLI_TESTLIB_FILES})
+  add_executable(${TESTNAME} ${TESTFILE}
+    ${JPEGXL_INTERNAL_JPEGLI_TESTLIB_FILES}
+    ${JPEGXL_INTERNAL_JPEGLI_LIBJPEG_HELPER_FILES}
+  )
   target_compile_options(${TESTNAME} PRIVATE
     ${JPEGXL_INTERNAL_FLAGS}
     # Add coverage flags to the test binary so code in the private headers of

--- a/lib/jpegli/common.h
+++ b/lib/jpegli/common.h
@@ -25,6 +25,8 @@
 #include <jpeglib.h>
 /* clang-format on */
 
+#include "lib/jpegli/types.h"
+
 #if defined(__cplusplus) || defined(c_plusplus)
 extern "C" {
 #endif
@@ -38,27 +40,6 @@ void jpegli_destroy(j_common_ptr cinfo);
 JQUANT_TBL* jpegli_alloc_quant_table(j_common_ptr cinfo);
 
 JHUFF_TBL* jpegli_alloc_huff_table(j_common_ptr cinfo);
-
-//
-// New API structs and functions that are not available in libjpeg
-//
-// NOTE: This part of the API is still experimental and will probably change in
-// the future.
-//
-
-typedef enum {
-  JPEGLI_TYPE_FLOAT = 0,
-  JPEGLI_TYPE_UINT8 = 2,
-  JPEGLI_TYPE_UINT16 = 3,
-} JpegliDataType;
-
-typedef enum {
-  JPEGLI_NATIVE_ENDIAN = 0,
-  JPEGLI_LITTLE_ENDIAN = 1,
-  JPEGLI_BIG_ENDIAN = 2,
-} JpegliEndianness;
-
-int jpegli_bytes_per_sample(JpegliDataType data_type);
 
 #if defined(__cplusplus) || defined(c_plusplus)
 }  // extern "C"

--- a/lib/jpegli/encode_api_test.cc
+++ b/lib/jpegli/encode_api_test.cc
@@ -134,25 +134,13 @@ TEST(EncodeAPITest, ReuseCinfoSameMemOutput) {
     EXPECT_TRUE(try_catch_block());
     jpegli_destroy_compress(&cinfo);
   }
-  std::vector<TestImage> all_outputs(all_configs.size());
-  {
-    jpeg_decompress_struct cinfo = {};
-    const auto try_catch_block = [&]() -> bool {
-      ERROR_HANDLER_SETUP(jpegli);
-      jpeg_create_decompress(&cinfo);
-      jpeg_mem_src(&cinfo, buffer, buffer_size);
-      for (size_t i = 0; i < all_configs.size(); ++i) {
-        DecodeWithLibjpeg(all_configs[i].jparams, DecompressParams(), &cinfo,
-                          &all_outputs[i]);
-      }
-      return true;
-    };
-    EXPECT_TRUE(try_catch_block());
-    jpeg_destroy_decompress(&cinfo);
-  }
+  size_t pos = 0;
   for (size_t i = 0; i < all_configs.size(); ++i) {
-    VerifyOutputImage(all_configs[i].input, all_outputs[i],
-                      all_configs[i].max_dist);
+    TestImage output;
+    pos +=
+        DecodeWithLibjpeg(all_configs[i].jparams, DecompressParams(), nullptr,
+                          0, buffer + pos, buffer_size - pos, &output);
+    VerifyOutputImage(all_configs[i].input, output, all_configs[i].max_dist);
   }
   if (buffer) free(buffer);
 }
@@ -175,28 +163,19 @@ TEST(EncodeAPITest, ReuseCinfoSameStdOutput) {
     EXPECT_TRUE(try_catch_block());
     jpegli_destroy_compress(&cinfo);
   }
+  size_t total_size = ftell(tmpf);
   rewind(tmpf);
-  std::vector<TestImage> all_outputs(all_configs.size());
-  {
-    jpeg_decompress_struct cinfo = {};
-    const auto try_catch_block = [&]() -> bool {
-      ERROR_HANDLER_SETUP(jpegli);
-      jpeg_create_decompress(&cinfo);
-      jpeg_stdio_src(&cinfo, tmpf);
-      for (size_t i = 0; i < all_configs.size(); ++i) {
-        DecodeWithLibjpeg(all_configs[i].jparams, DecompressParams(), &cinfo,
-                          &all_outputs[i]);
-      }
-      return true;
-    };
-    EXPECT_TRUE(try_catch_block());
-    jpeg_destroy_decompress(&cinfo);
-  }
-  for (size_t i = 0; i < all_configs.size(); ++i) {
-    VerifyOutputImage(all_configs[i].input, all_outputs[i],
-                      all_configs[i].max_dist);
-  }
+  std::vector<uint8_t> compressed(total_size);
+  JXL_CHECK(total_size == fread(&compressed[0], 1, total_size, tmpf));
   fclose(tmpf);
+  size_t pos = 0;
+  for (size_t i = 0; i < all_configs.size(); ++i) {
+    TestImage output;
+    pos += DecodeWithLibjpeg(all_configs[i].jparams, DecompressParams(),
+                             nullptr, 0, &compressed[pos],
+                             compressed.size() - pos, &output);
+    VerifyOutputImage(all_configs[i].input, output, all_configs[i].max_dist);
+  }
 }
 
 TEST(EncodeAPITest, ReuseCinfoChangeParams) {
@@ -298,32 +277,15 @@ TEST(EncodeAPITest, AbbreviatedStreams) {
     EXPECT_LT(data_stream_size, 50);
     jpegli_destroy_compress(&cinfo);
   }
-  {
-    jpeg_decompress_struct cinfo = {};
-    const auto try_catch_block = [&]() -> bool {
-      ERROR_HANDLER_SETUP(jpeg);
-      jpeg_create_decompress(&cinfo);
-      jpeg_mem_src(&cinfo, table_stream, table_stream_size);
-      jpeg_read_header(&cinfo, FALSE);
-      jpeg_mem_src(&cinfo, data_stream, data_stream_size);
-      jpeg_read_header(&cinfo, TRUE);
-      EXPECT_EQ(1, cinfo.image_width);
-      EXPECT_EQ(1, cinfo.image_height);
-      EXPECT_EQ(3, cinfo.num_components);
-      jpeg_start_decompress(&cinfo);
-      JSAMPLE image[3] = {0};
-      JSAMPROW row[] = {image};
-      jpeg_read_scanlines(&cinfo, row, 1);
-      jxl::msan::UnpoisonMemory(image, 3);
-      EXPECT_EQ(0, image[0]);
-      EXPECT_EQ(0, image[1]);
-      EXPECT_EQ(0, image[2]);
-      jpeg_finish_decompress(&cinfo);
-      return true;
-    };
-    EXPECT_TRUE(try_catch_block());
-    jpeg_destroy_decompress(&cinfo);
-  }
+  TestImage output;
+  DecodeWithLibjpeg(CompressParams(), DecompressParams(), table_stream,
+                    table_stream_size, data_stream, data_stream_size, &output);
+  EXPECT_EQ(1, output.xsize);
+  EXPECT_EQ(1, output.ysize);
+  EXPECT_EQ(3, output.components);
+  EXPECT_EQ(0, output.pixels[0]);
+  EXPECT_EQ(0, output.pixels[1]);
+  EXPECT_EQ(0, output.pixels[2]);
   if (table_stream) free(table_stream);
   if (data_stream) free(data_stream);
 }
@@ -490,7 +452,7 @@ std::vector<TestConfig> GenerateTests() {
       all_tests.push_back(config);
     }
   }
-  for (int p = 0; p < 3 + kNumTestScripts; ++p) {
+  for (int p = 0; p < 3 + NumTestScanScripts(); ++p) {
     for (int samp : {1, 2}) {
       for (int quality : {100, 90, 1}) {
         for (int r : {0, 1024, 1}) {

--- a/lib/jpegli/error_handling_test.cc
+++ b/lib/jpegli/error_handling_test.cc
@@ -36,27 +36,13 @@ TEST(EncoderErrorHandlingTest, MinimalSuccess) {
     EXPECT_TRUE(try_catch_block());
     jpegli_destroy_compress(&cinfo);
   }
-  {
-    jpeg_decompress_struct cinfo = {};
-    const auto try_catch_block = [&]() -> bool {
-      ERROR_HANDLER_SETUP(jpeg);
-      jpeg_create_decompress(&cinfo);
-      jpeg_mem_src(&cinfo, buffer, buffer_size);
-      jpeg_read_header(&cinfo, TRUE);
-      EXPECT_EQ(1, cinfo.image_width);
-      EXPECT_EQ(1, cinfo.image_height);
-      jpeg_start_decompress(&cinfo);
-      JSAMPLE image[1];
-      JSAMPROW row[] = {image};
-      jpeg_read_scanlines(&cinfo, row, 1);
-      jxl::msan::UnpoisonMemory(image, 1);
-      EXPECT_EQ(0, image[0]);
-      jpeg_finish_decompress(&cinfo);
-      return true;
-    };
-    EXPECT_TRUE(try_catch_block());
-    jpeg_destroy_decompress(&cinfo);
-  }
+  TestImage output;
+  DecodeWithLibjpeg(CompressParams(), DecompressParams(), nullptr, 0, buffer,
+                    buffer_size, &output);
+  EXPECT_EQ(1, output.xsize);
+  EXPECT_EQ(1, output.ysize);
+  EXPECT_EQ(1, output.components);
+  EXPECT_EQ(0, output.pixels[0]);
   if (buffer) free(buffer);
 }
 

--- a/lib/jpegli/input_suspension_test.cc
+++ b/lib/jpegli/input_suspension_test.cc
@@ -243,7 +243,8 @@ TEST_P(InputSuspensionTestParam, InputOutputLockStepNonBuffered) {
     while (jpegli_read_header(&cinfo, TRUE) == JPEG_SUSPENDED) {
       JXL_CHECK(src.LoadNextChunk());
     }
-    SetDecompressParams(dparams, &cinfo, true);
+    SetDecompressParams(dparams, &cinfo);
+    jpegli_set_output_format(&cinfo, dparams.data_type, dparams.endianness);
     if (config.jparams.add_marker) {
       EXPECT_EQ(num_markers_seen, kMarkerSequenceLen);
       EXPECT_EQ(0, memcmp(markers_seen, kMarkerSequence, num_markers_seen));
@@ -299,7 +300,8 @@ TEST_P(InputSuspensionTestParam, InputOutputLockStepBuffered) {
     while (jpegli_read_header(&cinfo, TRUE) == JPEG_SUSPENDED) {
       JXL_CHECK(src.LoadNextChunk());
     }
-    SetDecompressParams(dparams, &cinfo, true);
+    SetDecompressParams(dparams, &cinfo);
+    jpegli_set_output_format(&cinfo, dparams.data_type, dparams.endianness);
 
     cinfo.buffered_image = TRUE;
     cinfo.raw_data_out = dparams.output_mode == RAW_DATA;

--- a/lib/jpegli/libjpeg_test_util.cc
+++ b/lib/jpegli/libjpeg_test_util.cc
@@ -1,0 +1,261 @@
+// Copyright (c) the JPEG XL Project Authors. All rights reserved.
+//
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+#include "lib/jpegli/libjpeg_test_util.h"
+
+/* clang-format off */
+#include <stdio.h>
+#include <jpeglib.h>
+#include <setjmp.h>
+/* clang-format on */
+
+#include "lib/jxl/sanitizers.h"
+
+namespace jpegli {
+
+namespace {
+
+#define JPEG_API_FN(name) jpeg_##name
+#include "lib/jpegli/test_utils-inl.h"
+#undef JPEG_API_FN
+
+void ReadOutputPass(j_decompress_ptr cinfo, const DecompressParams& dparams,
+                    TestImage* output) {
+  JDIMENSION xoffset = 0;
+  JDIMENSION yoffset = 0;
+  JDIMENSION xsize_cropped = cinfo->output_width;
+  JDIMENSION ysize_cropped = cinfo->output_height;
+  if (dparams.crop_output) {
+    xoffset = xsize_cropped = cinfo->output_width / 3;
+    yoffset = ysize_cropped = cinfo->output_height / 3;
+    jpeg_crop_scanline(cinfo, &xoffset, &xsize_cropped);
+    JXL_CHECK(xsize_cropped == cinfo->output_width);
+  }
+  output->xsize = xsize_cropped;
+  output->ysize = ysize_cropped;
+  output->components = cinfo->out_color_components;
+  if (cinfo->quantize_colors) {
+    jxl::msan::UnpoisonMemory(cinfo->colormap, cinfo->out_color_components *
+                                                   sizeof(cinfo->colormap[0]));
+    for (int c = 0; c < cinfo->out_color_components; ++c) {
+      jxl::msan::UnpoisonMemory(
+          cinfo->colormap[c],
+          cinfo->actual_number_of_colors * sizeof(cinfo->colormap[c][0]));
+    }
+  }
+  if (!cinfo->raw_data_out) {
+    size_t stride = output->xsize * output->components;
+    output->pixels.resize(output->ysize * stride);
+    output->color_space = cinfo->out_color_space;
+    if (yoffset > 0) {
+      jpeg_skip_scanlines(cinfo, yoffset);
+    }
+    for (size_t y = 0; y < output->ysize; ++y) {
+      JSAMPROW rows[] = {
+          reinterpret_cast<JSAMPLE*>(&output->pixels[y * stride])};
+      JXL_CHECK(1 == jpeg_read_scanlines(cinfo, rows, 1));
+      jxl::msan::UnpoisonMemory(
+          rows[0], sizeof(JSAMPLE) * cinfo->output_components * output->xsize);
+      if (cinfo->quantize_colors) {
+        UnmapColors(rows[0], cinfo->output_width, cinfo->out_color_components,
+                    cinfo->colormap, cinfo->actual_number_of_colors);
+      }
+    }
+    if (cinfo->output_scanline < cinfo->output_height) {
+      jpeg_skip_scanlines(cinfo, cinfo->output_height - cinfo->output_scanline);
+    }
+  } else {
+    output->color_space = cinfo->jpeg_color_space;
+    for (int c = 0; c < cinfo->num_components; ++c) {
+      size_t xsize = cinfo->comp_info[c].width_in_blocks * DCTSIZE;
+      size_t ysize = cinfo->comp_info[c].height_in_blocks * DCTSIZE;
+      std::vector<uint8_t> plane(ysize * xsize);
+      output->raw_data.emplace_back(std::move(plane));
+    }
+    while (cinfo->output_scanline < cinfo->output_height) {
+      size_t iMCU_height = cinfo->max_v_samp_factor * DCTSIZE;
+      JXL_CHECK(cinfo->output_scanline == cinfo->output_iMCU_row * iMCU_height);
+      std::vector<std::vector<JSAMPROW>> rowdata(cinfo->num_components);
+      std::vector<JSAMPARRAY> data(cinfo->num_components);
+      for (int c = 0; c < cinfo->num_components; ++c) {
+        size_t xsize = cinfo->comp_info[c].width_in_blocks * DCTSIZE;
+        size_t ysize = cinfo->comp_info[c].height_in_blocks * DCTSIZE;
+        size_t num_lines = cinfo->comp_info[c].v_samp_factor * DCTSIZE;
+        rowdata[c].resize(num_lines);
+        size_t y0 = cinfo->output_iMCU_row * num_lines;
+        for (size_t i = 0; i < num_lines; ++i) {
+          rowdata[c][i] =
+              y0 + i < ysize ? &output->raw_data[c][(y0 + i) * xsize] : nullptr;
+        }
+        data[c] = &rowdata[c][0];
+      }
+      JXL_CHECK(iMCU_height ==
+                jpeg_read_raw_data(cinfo, &data[0], iMCU_height));
+    }
+  }
+  JXL_CHECK(cinfo->total_iMCU_rows ==
+            DivCeil(cinfo->image_height, cinfo->max_v_samp_factor * DCTSIZE));
+}
+
+void DecodeWithLibjpeg(const CompressParams& jparams,
+                       const DecompressParams& dparams, j_decompress_ptr cinfo,
+                       TestImage* output) {
+  if (jparams.add_marker) {
+    jpeg_save_markers(cinfo, kSpecialMarker0, 0xffff);
+    jpeg_save_markers(cinfo, kSpecialMarker1, 0xffff);
+  }
+  if (!jparams.icc.empty()) {
+    jpeg_save_markers(cinfo, JPEG_APP0 + 2, 0xffff);
+  }
+  JXL_CHECK(JPEG_REACHED_SOS ==
+            jpeg_read_header(cinfo, /*require_image=*/TRUE));
+  if (!jparams.icc.empty()) {
+    uint8_t* icc_data = nullptr;
+    unsigned int icc_len;
+    JXL_CHECK(jpeg_read_icc_profile(cinfo, &icc_data, &icc_len));
+    JXL_CHECK(icc_data);
+    jxl::msan::UnpoisonMemory(icc_data, icc_len);
+    JXL_CHECK(0 == memcmp(jparams.icc.data(), icc_data, icc_len));
+    free(icc_data);
+  }
+  SetDecompressParams(dparams, cinfo);
+  VerifyHeader(jparams, cinfo);
+  if (dparams.output_mode == COEFFICIENTS) {
+    jvirt_barray_ptr* coef_arrays = jpeg_read_coefficients(cinfo);
+    JXL_CHECK(coef_arrays != nullptr);
+    CopyCoefficients(cinfo, coef_arrays, output);
+  } else {
+    JXL_CHECK(jpeg_start_decompress(cinfo));
+    VerifyScanHeader(jparams, cinfo);
+    ReadOutputPass(cinfo, dparams, output);
+  }
+  JXL_CHECK(jpeg_finish_decompress(cinfo));
+}
+
+}  // namespace
+
+// Verifies that an image encoded with libjpegli can be decoded with libjpeg,
+// and checks that the jpeg coding metadata matches jparams.
+void DecodeAllScansWithLibjpeg(const CompressParams& jparams,
+                               const DecompressParams& dparams,
+                               const std::vector<uint8_t>& compressed,
+                               std::vector<TestImage>* output_progression) {
+  jpeg_decompress_struct cinfo = {};
+  const auto try_catch_block = [&]() {
+    jpeg_error_mgr jerr;
+    jmp_buf env;
+    cinfo.err = jpeg_std_error(&jerr);
+    if (setjmp(env)) {
+      return false;
+    }
+    cinfo.client_data = reinterpret_cast<void*>(&env);
+    cinfo.err->error_exit = [](j_common_ptr cinfo) {
+      (*cinfo->err->output_message)(cinfo);
+      jmp_buf* env = reinterpret_cast<jmp_buf*>(cinfo->client_data);
+      jpeg_destroy(cinfo);
+      longjmp(*env, 1);
+    };
+    jpeg_create_decompress(&cinfo);
+    jpeg_mem_src(&cinfo, compressed.data(), compressed.size());
+    if (jparams.add_marker) {
+      jpeg_save_markers(&cinfo, kSpecialMarker0, 0xffff);
+      jpeg_save_markers(&cinfo, kSpecialMarker1, 0xffff);
+    }
+    JXL_CHECK(JPEG_REACHED_SOS ==
+              jpeg_read_header(&cinfo, /*require_image=*/TRUE));
+    cinfo.buffered_image = TRUE;
+    SetDecompressParams(dparams, &cinfo);
+    VerifyHeader(jparams, &cinfo);
+    JXL_CHECK(jpeg_start_decompress(&cinfo));
+    // start decompress should not read the whole input in buffered image mode
+    JXL_CHECK(!jpeg_input_complete(&cinfo));
+    JXL_CHECK(cinfo.output_scan_number == 0);
+    int sos_marker_cnt = 1;  // read header reads the first SOS marker
+    while (!jpeg_input_complete(&cinfo)) {
+      JXL_CHECK(cinfo.input_scan_number == sos_marker_cnt);
+      if (dparams.skip_scans && (cinfo.input_scan_number % 2) != 1) {
+        int result = JPEG_SUSPENDED;
+        while (result != JPEG_REACHED_SOS && result != JPEG_REACHED_EOI) {
+          result = jpeg_consume_input(&cinfo);
+        }
+        if (result == JPEG_REACHED_SOS) ++sos_marker_cnt;
+        continue;
+      }
+      SetScanDecompressParams(dparams, &cinfo, cinfo.input_scan_number);
+      JXL_CHECK(jpeg_start_output(&cinfo, cinfo.input_scan_number));
+      // start output sets output_scan_number, but does not change
+      // input_scan_number
+      JXL_CHECK(cinfo.output_scan_number == cinfo.input_scan_number);
+      JXL_CHECK(cinfo.input_scan_number == sos_marker_cnt);
+      VerifyScanHeader(jparams, &cinfo);
+      TestImage output;
+      ReadOutputPass(&cinfo, dparams, &output);
+      output_progression->emplace_back(std::move(output));
+      // read scanlines/read raw data does not change input/output scan number
+      if (!cinfo.progressive_mode) {
+        JXL_CHECK(cinfo.input_scan_number == sos_marker_cnt);
+        JXL_CHECK(cinfo.output_scan_number == cinfo.input_scan_number);
+      }
+      JXL_CHECK(jpeg_finish_output(&cinfo));
+      ++sos_marker_cnt;  // finish output reads the next SOS marker or EOI
+      if (dparams.output_mode == COEFFICIENTS) {
+        jvirt_barray_ptr* coef_arrays = jpeg_read_coefficients(&cinfo);
+        JXL_CHECK(coef_arrays != nullptr);
+        CopyCoefficients(&cinfo, coef_arrays, &output_progression->back());
+      }
+    }
+    JXL_CHECK(jpeg_finish_decompress(&cinfo));
+    return true;
+  };
+  JXL_CHECK(try_catch_block());
+  jpeg_destroy_decompress(&cinfo);
+}
+
+// Returns the number of bytes read from compressed.
+size_t DecodeWithLibjpeg(const CompressParams& jparams,
+                         const DecompressParams& dparams,
+                         const uint8_t* table_stream, size_t table_stream_size,
+                         const uint8_t* compressed, size_t len,
+                         TestImage* output) {
+  jpeg_decompress_struct cinfo = {};
+  size_t bytes_read;
+  const auto try_catch_block = [&]() {
+    jpeg_error_mgr jerr;
+    jmp_buf env;
+    cinfo.err = jpeg_std_error(&jerr);
+    if (setjmp(env)) {
+      return false;
+    }
+    cinfo.client_data = reinterpret_cast<void*>(&env);
+    cinfo.err->error_exit = [](j_common_ptr cinfo) {
+      (*cinfo->err->output_message)(cinfo);
+      jmp_buf* env = reinterpret_cast<jmp_buf*>(cinfo->client_data);
+      jpeg_destroy(cinfo);
+      longjmp(*env, 1);
+    };
+    jpeg_create_decompress(&cinfo);
+    if (table_stream != nullptr) {
+      jpeg_mem_src(&cinfo, table_stream, table_stream_size);
+      jpeg_read_header(&cinfo, FALSE);
+    }
+    jpeg_mem_src(&cinfo, compressed, len);
+    DecodeWithLibjpeg(jparams, dparams, &cinfo, output);
+    bytes_read = len - cinfo.src->bytes_in_buffer;
+    return true;
+  };
+  JXL_CHECK(try_catch_block());
+  jpeg_destroy_decompress(&cinfo);
+  return bytes_read;
+}
+
+void DecodeWithLibjpeg(const CompressParams& jparams,
+                       const DecompressParams& dparams,
+                       const std::vector<uint8_t>& compressed,
+                       TestImage* output) {
+  DecodeWithLibjpeg(jparams, dparams, nullptr, 0, compressed.data(),
+                    compressed.size(), output);
+}
+
+}  // namespace jpegli

--- a/lib/jpegli/libjpeg_test_util.h
+++ b/lib/jpegli/libjpeg_test_util.h
@@ -1,0 +1,37 @@
+// Copyright (c) the JPEG XL Project Authors. All rights reserved.
+//
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+#ifndef LIB_JPEGLI_LIBJPEG_TEST_UTIL_H_
+#define LIB_JPEGLI_LIBJPEG_TEST_UTIL_H_
+
+#include <stddef.h>
+#include <stdint.h>
+
+#include <vector>
+
+#include "lib/jpegli/test_params.h"
+
+namespace jpegli {
+
+// Verifies that an image encoded with libjpegli can be decoded with libjpeg,
+// and checks that the jpeg coding metadata matches jparams.
+void DecodeAllScansWithLibjpeg(const CompressParams& jparams,
+                               const DecompressParams& dparams,
+                               const std::vector<uint8_t>& compressed,
+                               std::vector<TestImage>* output_progression);
+// Returns the number of bytes read from compressed.
+size_t DecodeWithLibjpeg(const CompressParams& jparams,
+                         const DecompressParams& dparams,
+                         const uint8_t* table_stream, size_t table_stream_size,
+                         const uint8_t* compressed, size_t len,
+                         TestImage* output);
+void DecodeWithLibjpeg(const CompressParams& jparams,
+                       const DecompressParams& dparams,
+                       const std::vector<uint8_t>& compressed,
+                       TestImage* output);
+
+}  // namespace jpegli
+
+#endif  // LIB_JPEGLI_LIBJPEG_TEST_UTIL_H_

--- a/lib/jpegli/streaming_test.cc
+++ b/lib/jpegli/streaming_test.cc
@@ -107,7 +107,7 @@ TEST_P(StreamingTestParam, TestStreaming) {
     cinfo.image_width = input.xsize;
     cinfo.image_height = input.ysize;
     cinfo.input_components = input.components;
-    cinfo.in_color_space = input.color_space;
+    cinfo.in_color_space = (J_COLOR_SPACE)input.color_space;
     jpegli_set_defaults(&cinfo);
     cinfo.comp_info[0].v_samp_factor = config.jparams.v_sampling[0];
     jpegli_set_progressive_level(&cinfo, 0);

--- a/lib/jpegli/test_params.h
+++ b/lib/jpegli/test_params.h
@@ -1,0 +1,163 @@
+// Copyright (c) the JPEG XL Project Authors. All rights reserved.
+//
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+#ifndef LIB_JPEGLI_TEST_PARAMS_H_
+#define LIB_JPEGLI_TEST_PARAMS_H_
+
+#include <stddef.h>
+#include <stdint.h>
+
+#include <algorithm>
+#include <vector>
+
+#include "lib/jpegli/types.h"
+
+namespace jpegli {
+
+// We define this here as well to make sure that the *_api_test.cc tests only
+// use the public API and therefore we don't include any *_internal.h headers.
+template <typename T1, typename T2>
+constexpr inline T1 DivCeil(T1 a, T2 b) {
+  return (a + b - 1) / b;
+}
+
+#define ARRAY_SIZE(X) (sizeof(X) / sizeof((X)[0]))
+
+static constexpr int kLastScan = 0xffff;
+
+static uint32_t kTestColorMap[] = {
+    0x000000, 0xff0000, 0x00ff00, 0x0000ff, 0xffff00, 0x00ffff,
+    0xff00ff, 0xffffff, 0x6251fc, 0x45d9c7, 0xa7f059, 0xd9a945,
+    0xfa4e44, 0xceaffc, 0xbad7db, 0xc1f0b1, 0xdbca9a, 0xfacac5,
+    0xf201ff, 0x0063db, 0x00f01c, 0xdbb204, 0xf12f0c, 0x7ba1dc};
+static constexpr int kTestColorMapNumColors = ARRAY_SIZE(kTestColorMap);
+
+static constexpr int kSpecialMarker0 = 0xe5;
+static constexpr int kSpecialMarker1 = 0xe9;
+static constexpr uint8_t kMarkerData[] = {0, 1, 255, 0, 17};
+static constexpr uint8_t kMarkerSequence[] = {0xe6, 0xe8, 0xe7,
+                                              0xe6, 0xe7, 0xe8};
+static constexpr size_t kMarkerSequenceLen = ARRAY_SIZE(kMarkerSequence);
+
+enum JpegIOMode {
+  PIXELS,
+  RAW_DATA,
+  COEFFICIENTS,
+};
+
+struct CustomQuantTable {
+  int slot_idx = 0;
+  uint16_t table_type = 0;
+  int scale_factor = 100;
+  bool add_raw = false;
+  bool force_baseline = true;
+  std::vector<unsigned int> basic_table;
+  std::vector<unsigned int> quantval;
+  void Generate();
+};
+
+struct TestImage {
+  size_t xsize = 2268;
+  size_t ysize = 1512;
+  int color_space = 2;  // JCS_RGB
+  size_t components = 3;
+  JpegliDataType data_type = JPEGLI_TYPE_UINT8;
+  JpegliEndianness endianness = JPEGLI_NATIVE_ENDIAN;
+  std::vector<uint8_t> pixels;
+  std::vector<std::vector<uint8_t>> raw_data;
+  std::vector<std::vector<int16_t>> coeffs;
+  void AllocatePixels() {
+    pixels.resize(ysize * xsize * components *
+                  jpegli_bytes_per_sample(data_type));
+  }
+  void Clear() {
+    pixels.clear();
+    raw_data.clear();
+    coeffs.clear();
+  }
+};
+
+struct CompressParams {
+  int quality = 90;
+  bool set_jpeg_colorspace = false;
+  int jpeg_color_space = 0;  // JCS_UNKNOWN
+  std::vector<int> quant_indexes;
+  std::vector<CustomQuantTable> quant_tables;
+  std::vector<int> h_sampling;
+  std::vector<int> v_sampling;
+  std::vector<int> comp_ids;
+  int override_JFIF = -1;
+  int override_Adobe = -1;
+  bool add_marker = false;
+  bool simple_progression = false;
+  // -1 is library default
+  // 0, 1, 2 is set through jpegli_set_progressive_level()
+  // 2 + N is kScriptN
+  int progressive_mode = -1;
+  unsigned int restart_interval = 0;
+  int restart_in_rows = 0;
+  int smoothing_factor = 0;
+  int optimize_coding = -1;
+  bool use_flat_dc_luma_code = false;
+  bool omit_standard_tables = false;
+  bool xyb_mode = false;
+  bool libjpeg_mode = false;
+  bool use_adaptive_quantization = true;
+  std::vector<uint8_t> icc;
+
+  int h_samp(int c) const { return h_sampling.empty() ? 1 : h_sampling[c]; }
+  int v_samp(int c) const { return v_sampling.empty() ? 1 : v_sampling[c]; }
+  int max_h_sample() const {
+    auto it = std::max_element(h_sampling.begin(), h_sampling.end());
+    return it == h_sampling.end() ? 1 : *it;
+  }
+  int max_v_sample() const {
+    auto it = std::max_element(v_sampling.begin(), v_sampling.end());
+    return it == v_sampling.end() ? 1 : *it;
+  }
+  int comp_width(const TestImage& input, int c) const {
+    return DivCeil(input.xsize * h_samp(c), max_h_sample() * 8) * 8;
+  }
+  int comp_height(const TestImage& input, int c) const {
+    return DivCeil(input.ysize * v_samp(c), max_v_sample() * 8) * 8;
+  }
+};
+
+enum ColorQuantMode {
+  CQUANT_1PASS,
+  CQUANT_2PASS,
+  CQUANT_EXTERNAL,
+  CQUANT_REUSE,
+};
+
+struct ScanDecompressParams {
+  int max_scan_number;
+  int dither_mode;
+  ColorQuantMode color_quant_mode;
+};
+
+struct DecompressParams {
+  float size_factor = 1.0f;
+  size_t chunk_size = 65536;
+  size_t max_output_lines = 16;
+  JpegIOMode output_mode = PIXELS;
+  JpegliDataType data_type = JPEGLI_TYPE_UINT8;
+  JpegliEndianness endianness = JPEGLI_NATIVE_ENDIAN;
+  bool set_out_color_space = false;
+  int out_color_space = 0;  // JCS_UNKNOWN
+  bool crop_output = false;
+  bool do_block_smoothing = false;
+  bool do_fancy_upsampling = true;
+  bool skip_scans = false;
+  int scale_num = 1;
+  int scale_denom = 1;
+  bool quantize_colors = false;
+  int desired_number_of_colors = 256;
+  std::vector<ScanDecompressParams> scan_params;
+};
+
+}  // namespace jpegli
+
+#endif  // LIB_JPEGLI_TEST_PARAMS_H_

--- a/lib/jpegli/test_utils-inl.h
+++ b/lib/jpegli/test_utils-inl.h
@@ -1,0 +1,430 @@
+// Copyright (c) the JPEG XL Project Authors. All rights reserved.
+//
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// This template file is included in both the libjpeg_test_util.cc and the
+// test_utils.cc files with different JPEG_API_FN macros and possibly different
+// include paths for the jpeg headers.
+
+// Sequential non-interleaved.
+static constexpr jpeg_scan_info kScript1[] = {
+    {1, {0}, 0, 63, 0, 0},
+    {1, {1}, 0, 63, 0, 0},
+    {1, {2}, 0, 63, 0, 0},
+};
+// Sequential partially interleaved, chroma first.
+static constexpr jpeg_scan_info kScript2[] = {
+    {2, {1, 2}, 0, 63, 0, 0},
+    {1, {0}, 0, 63, 0, 0},
+};
+
+// Rest of the scan scripts are progressive.
+
+static constexpr jpeg_scan_info kScript3[] = {
+    // Interleaved full DC.
+    {3, {0, 1, 2}, 0, 0, 0, 0},
+    // Full AC scans.
+    {1, {0}, 1, 63, 0, 0},
+    {1, {1}, 1, 63, 0, 0},
+    {1, {2}, 1, 63, 0, 0},
+};
+static constexpr jpeg_scan_info kScript4[] = {
+    // Non-interleaved full DC.
+    {1, {0}, 0, 0, 0, 0},
+    {1, {1}, 0, 0, 0, 0},
+    {1, {2}, 0, 0, 0, 0},
+    // Full AC scans.
+    {1, {0}, 1, 63, 0, 0},
+    {1, {1}, 1, 63, 0, 0},
+    {1, {2}, 1, 63, 0, 0},
+};
+static constexpr jpeg_scan_info kScript5[] = {
+    // Partially interleaved full DC, chroma first.
+    {2, {1, 2}, 0, 0, 0, 0},
+    {1, {0}, 0, 0, 0, 0},
+    // AC shifted by 1 bit.
+    {1, {0}, 1, 63, 0, 1},
+    {1, {1}, 1, 63, 0, 1},
+    {1, {2}, 1, 63, 0, 1},
+    // AC refinement scan.
+    {1, {0}, 1, 63, 1, 0},
+    {1, {1}, 1, 63, 1, 0},
+    {1, {2}, 1, 63, 1, 0},
+};
+static constexpr jpeg_scan_info kScript6[] = {
+    // Interleaved DC shifted by 2 bits.
+    {3, {0, 1, 2}, 0, 0, 0, 2},
+    // Interleaved DC refinement scans.
+    {3, {0, 1, 2}, 0, 0, 2, 1},
+    {3, {0, 1, 2}, 0, 0, 1, 0},
+    // Full AC scans.
+    {1, {0}, 1, 63, 0, 0},
+    {1, {1}, 1, 63, 0, 0},
+    {1, {2}, 1, 63, 0, 0},
+};
+
+static constexpr jpeg_scan_info kScript7[] = {
+    // Non-interleaved DC shifted by 2 bits.
+    {1, {0}, 0, 0, 0, 2},
+    {1, {1}, 0, 0, 0, 2},
+    {1, {2}, 0, 0, 0, 2},
+    // Non-interleaved DC first refinement scans.
+    {1, {0}, 0, 0, 2, 1},
+    {1, {1}, 0, 0, 2, 1},
+    {1, {2}, 0, 0, 2, 1},
+    // Non-interleaved DC second refinement scans.
+    {1, {0}, 0, 0, 1, 0},
+    {1, {1}, 0, 0, 1, 0},
+    {1, {2}, 0, 0, 1, 0},
+    // Full AC scans.
+    {1, {0}, 1, 63, 0, 0},
+    {1, {1}, 1, 63, 0, 0},
+    {1, {2}, 1, 63, 0, 0},
+};
+
+static constexpr jpeg_scan_info kScript8[] = {
+    // Partially interleaved DC shifted by 2 bits, chroma first
+    {2, {1, 2}, 0, 0, 0, 2},
+    {1, {0}, 0, 0, 0, 2},
+    // Partially interleaved DC first refinement scans.
+    {2, {0, 2}, 0, 0, 2, 1},
+    {1, {1}, 0, 0, 2, 1},
+    // Partially interleaved DC first refinement scans, chroma first.
+    {2, {1, 2}, 0, 0, 1, 0},
+    {1, {0}, 0, 0, 1, 0},
+    // Full AC scans.
+    {1, {0}, 1, 63, 0, 0},
+    {1, {1}, 1, 63, 0, 0},
+    {1, {2}, 1, 63, 0, 0},
+};
+
+static constexpr jpeg_scan_info kScript9[] = {
+    // Interleaved full DC.
+    {3, {0, 1, 2}, 0, 0, 0, 0},
+    // AC scans for component 0
+    // shifted by 1 bit, two spectral ranges
+    {1, {0}, 1, 6, 0, 1},
+    {1, {0}, 7, 63, 0, 1},
+    // refinement scan, full
+    {1, {0}, 1, 63, 1, 0},
+    // AC scans for component 1
+    // shifted by 1 bit, full
+    {1, {1}, 1, 63, 0, 1},
+    // refinement scan, two spectral ranges
+    {1, {1}, 1, 6, 1, 0},
+    {1, {1}, 7, 63, 1, 0},
+    // AC scans for component 2
+    // shifted by 1 bit, two spectral ranges
+    {1, {2}, 1, 6, 0, 1},
+    {1, {2}, 7, 63, 0, 1},
+    // refinement scan, two spectral ranges (but different from above)
+    {1, {2}, 1, 16, 1, 0},
+    {1, {2}, 17, 63, 1, 0},
+};
+
+static constexpr jpeg_scan_info kScript10[] = {
+    // Interleaved full DC.
+    {3, {0, 1, 2}, 0, 0, 0, 0},
+    // AC scans for spectral range 1..16
+    // shifted by 1
+    {1, {0}, 1, 16, 0, 1},
+    {1, {1}, 1, 16, 0, 1},
+    {1, {2}, 1, 16, 0, 1},
+    // refinement scans, two sub-ranges
+    {1, {0}, 1, 8, 1, 0},
+    {1, {0}, 9, 16, 1, 0},
+    {1, {1}, 1, 8, 1, 0},
+    {1, {1}, 9, 16, 1, 0},
+    {1, {2}, 1, 8, 1, 0},
+    {1, {2}, 9, 16, 1, 0},
+    // AC scans for spectral range 17..63
+    {1, {0}, 17, 63, 0, 1},
+    {1, {1}, 17, 63, 0, 1},
+    {1, {2}, 17, 63, 0, 1},
+    // refinement scans, two sub-ranges
+    {1, {0}, 17, 28, 1, 0},
+    {1, {0}, 29, 63, 1, 0},
+    {1, {1}, 17, 28, 1, 0},
+    {1, {1}, 29, 63, 1, 0},
+    {1, {2}, 17, 28, 1, 0},
+    {1, {2}, 29, 63, 1, 0},
+};
+
+struct ScanScript {
+  int num_scans;
+  const jpeg_scan_info* scans;
+};
+
+static constexpr ScanScript kTestScript[] = {
+    {ARRAY_SIZE(kScript1), kScript1}, {ARRAY_SIZE(kScript2), kScript2},
+    {ARRAY_SIZE(kScript3), kScript3}, {ARRAY_SIZE(kScript4), kScript4},
+    {ARRAY_SIZE(kScript5), kScript5}, {ARRAY_SIZE(kScript6), kScript6},
+    {ARRAY_SIZE(kScript7), kScript7}, {ARRAY_SIZE(kScript8), kScript8},
+    {ARRAY_SIZE(kScript9), kScript9}, {ARRAY_SIZE(kScript10), kScript10},
+};
+static constexpr int kNumTestScripts = ARRAY_SIZE(kTestScript);
+
+void SetScanDecompressParams(const DecompressParams& dparams,
+                             j_decompress_ptr cinfo, int scan_number) {
+  const ScanDecompressParams* sparams = nullptr;
+  for (const auto& sp : dparams.scan_params) {
+    if (scan_number <= sp.max_scan_number) {
+      sparams = &sp;
+      break;
+    }
+  }
+  if (sparams == nullptr) {
+    return;
+  }
+  if (dparams.quantize_colors) {
+    cinfo->dither_mode = (J_DITHER_MODE)sparams->dither_mode;
+    if (sparams->color_quant_mode == CQUANT_1PASS) {
+      cinfo->two_pass_quantize = FALSE;
+      cinfo->colormap = nullptr;
+    } else if (sparams->color_quant_mode == CQUANT_2PASS) {
+      JXL_CHECK(cinfo->out_color_space == JCS_RGB);
+      cinfo->two_pass_quantize = TRUE;
+      cinfo->colormap = nullptr;
+    } else if (sparams->color_quant_mode == CQUANT_EXTERNAL) {
+      JXL_CHECK(cinfo->out_color_space == JCS_RGB);
+      cinfo->two_pass_quantize = FALSE;
+      bool have_colormap = cinfo->colormap != nullptr;
+      cinfo->actual_number_of_colors = kTestColorMapNumColors;
+      cinfo->colormap = (*cinfo->mem->alloc_sarray)(
+          reinterpret_cast<j_common_ptr>(cinfo), JPOOL_IMAGE,
+          cinfo->actual_number_of_colors, 3);
+      jxl::msan::UnpoisonMemory(cinfo->colormap, 3 * sizeof(JSAMPROW));
+      for (int i = 0; i < kTestColorMapNumColors; ++i) {
+        cinfo->colormap[0][i] = (kTestColorMap[i] >> 16) & 0xff;
+        cinfo->colormap[1][i] = (kTestColorMap[i] >> 8) & 0xff;
+        cinfo->colormap[2][i] = (kTestColorMap[i] >> 0) & 0xff;
+      }
+      if (have_colormap) {
+        JPEG_API_FN(new_colormap)(cinfo);
+      }
+    } else if (sparams->color_quant_mode == CQUANT_REUSE) {
+      JXL_CHECK(cinfo->out_color_space == JCS_RGB);
+      JXL_CHECK(cinfo->colormap);
+    }
+  }
+}
+
+void SetDecompressParams(const DecompressParams& dparams,
+                         j_decompress_ptr cinfo) {
+  cinfo->do_block_smoothing = dparams.do_block_smoothing;
+  cinfo->do_fancy_upsampling = dparams.do_fancy_upsampling;
+  if (dparams.output_mode == RAW_DATA) {
+    cinfo->raw_data_out = TRUE;
+  }
+  if (dparams.set_out_color_space) {
+    cinfo->out_color_space = (J_COLOR_SPACE)dparams.out_color_space;
+    if (dparams.out_color_space == JCS_UNKNOWN) {
+      cinfo->jpeg_color_space = JCS_UNKNOWN;
+    }
+  }
+  cinfo->scale_num = dparams.scale_num;
+  cinfo->scale_denom = dparams.scale_denom;
+  cinfo->quantize_colors = dparams.quantize_colors;
+  cinfo->desired_number_of_colors = dparams.desired_number_of_colors;
+  if (!dparams.scan_params.empty()) {
+    if (cinfo->buffered_image) {
+      for (const auto& sparams : dparams.scan_params) {
+        if (sparams.color_quant_mode == CQUANT_1PASS) {
+          cinfo->enable_1pass_quant = TRUE;
+        } else if (sparams.color_quant_mode == CQUANT_2PASS) {
+          cinfo->enable_2pass_quant = TRUE;
+        } else if (sparams.color_quant_mode == CQUANT_EXTERNAL) {
+          cinfo->enable_external_quant = TRUE;
+        }
+      }
+      SetScanDecompressParams(dparams, cinfo, 1);
+    } else {
+      SetScanDecompressParams(dparams, cinfo, kLastScan);
+    }
+  }
+}
+
+void CheckMarkerPresent(j_decompress_ptr cinfo, uint8_t marker_type) {
+  bool marker_found = false;
+  for (jpeg_saved_marker_ptr marker = cinfo->marker_list; marker != nullptr;
+       marker = marker->next) {
+    jxl::msan::UnpoisonMemory(marker, sizeof(*marker));
+    jxl::msan::UnpoisonMemory(marker->data, marker->data_length);
+    if (marker->marker == marker_type &&
+        marker->data_length == sizeof(kMarkerData) &&
+        memcmp(marker->data, kMarkerData, sizeof(kMarkerData)) == 0) {
+      marker_found = true;
+    }
+  }
+  JXL_CHECK(marker_found);
+}
+
+void VerifyHeader(const CompressParams& jparams, j_decompress_ptr cinfo) {
+  if (jparams.set_jpeg_colorspace) {
+    JXL_CHECK(cinfo->jpeg_color_space == jparams.jpeg_color_space);
+  }
+  if (jparams.override_JFIF >= 0) {
+    JXL_CHECK(cinfo->saw_JFIF_marker == jparams.override_JFIF);
+  }
+  if (jparams.override_Adobe >= 0) {
+    JXL_CHECK(cinfo->saw_Adobe_marker == jparams.override_Adobe);
+  }
+  if (jparams.add_marker) {
+    CheckMarkerPresent(cinfo, kSpecialMarker0);
+    CheckMarkerPresent(cinfo, kSpecialMarker1);
+  }
+  jxl::msan::UnpoisonMemory(
+      cinfo->comp_info, cinfo->num_components * sizeof(cinfo->comp_info[0]));
+  int max_h_samp_factor = 1;
+  int max_v_samp_factor = 1;
+  for (int i = 0; i < cinfo->num_components; ++i) {
+    jpeg_component_info* comp = &cinfo->comp_info[i];
+    if (!jparams.comp_ids.empty()) {
+      JXL_CHECK(comp->component_id == jparams.comp_ids[i]);
+    }
+    if (!jparams.h_sampling.empty()) {
+      JXL_CHECK(comp->h_samp_factor == jparams.h_sampling[i]);
+    }
+    if (!jparams.v_sampling.empty()) {
+      JXL_CHECK(comp->v_samp_factor == jparams.v_sampling[i]);
+    }
+    if (!jparams.quant_indexes.empty()) {
+      JXL_CHECK(comp->quant_tbl_no == jparams.quant_indexes[i]);
+    }
+    max_h_samp_factor = std::max(max_h_samp_factor, comp->h_samp_factor);
+    max_v_samp_factor = std::max(max_v_samp_factor, comp->v_samp_factor);
+  }
+  JXL_CHECK(max_h_samp_factor == cinfo->max_h_samp_factor);
+  JXL_CHECK(max_v_samp_factor == cinfo->max_v_samp_factor);
+  int referenced_tables[NUM_QUANT_TBLS] = {};
+  for (int i = 0; i < cinfo->num_components; ++i) {
+    jpeg_component_info* comp = &cinfo->comp_info[i];
+    JXL_CHECK(comp->width_in_blocks ==
+              DivCeil(cinfo->image_width * comp->h_samp_factor,
+                      max_h_samp_factor * DCTSIZE));
+    JXL_CHECK(comp->height_in_blocks ==
+              DivCeil(cinfo->image_height * comp->v_samp_factor,
+                      max_v_samp_factor * DCTSIZE));
+    referenced_tables[comp->quant_tbl_no] = 1;
+  }
+  for (const auto& table : jparams.quant_tables) {
+    JQUANT_TBL* quant_table = cinfo->quant_tbl_ptrs[table.slot_idx];
+    if (!referenced_tables[table.slot_idx]) {
+      JXL_CHECK(quant_table == nullptr);
+      continue;
+    }
+    JXL_CHECK(quant_table != nullptr);
+    jxl::msan::UnpoisonMemory(quant_table, sizeof(*quant_table));
+    for (int k = 0; k < DCTSIZE2; ++k) {
+      JXL_CHECK(quant_table->quantval[k] == table.quantval[k]);
+    }
+  }
+}
+
+void VerifyScanHeader(const CompressParams& jparams, j_decompress_ptr cinfo) {
+  JXL_CHECK(cinfo->input_scan_number > 0);
+  if (cinfo->progressive_mode) {
+    JXL_CHECK(cinfo->Ss != 0 || cinfo->Se != 63);
+  } else {
+    JXL_CHECK(cinfo->Ss == 0 && cinfo->Se == 63);
+  }
+  if (jparams.progressive_mode > 2) {
+    JXL_CHECK(jparams.progressive_mode < 3 + kNumTestScripts);
+    const ScanScript& script = kTestScript[jparams.progressive_mode - 3];
+    JXL_CHECK(cinfo->input_scan_number <= script.num_scans);
+    const jpeg_scan_info& scan = script.scans[cinfo->input_scan_number - 1];
+    JXL_CHECK(cinfo->comps_in_scan == scan.comps_in_scan);
+    for (int i = 0; i < cinfo->comps_in_scan; ++i) {
+      JXL_CHECK(cinfo->cur_comp_info[i]->component_index ==
+                scan.component_index[i]);
+    }
+    JXL_CHECK(cinfo->Ss == scan.Ss);
+    JXL_CHECK(cinfo->Se == scan.Se);
+    JXL_CHECK(cinfo->Ah == scan.Ah);
+    JXL_CHECK(cinfo->Al == scan.Al);
+  }
+  if (jparams.restart_interval > 0) {
+    JXL_CHECK(cinfo->restart_interval == jparams.restart_interval);
+  } else if (jparams.restart_in_rows > 0) {
+    JXL_CHECK(cinfo->restart_interval ==
+              jparams.restart_in_rows * cinfo->MCUs_per_row);
+  }
+  if (jparams.progressive_mode == 0 && jparams.optimize_coding == 0) {
+    if (cinfo->jpeg_color_space == JCS_RGB) {
+      JXL_CHECK(cinfo->comp_info[0].dc_tbl_no == 0);
+      JXL_CHECK(cinfo->comp_info[1].dc_tbl_no == 0);
+      JXL_CHECK(cinfo->comp_info[2].dc_tbl_no == 0);
+      JXL_CHECK(cinfo->comp_info[0].ac_tbl_no == 0);
+      JXL_CHECK(cinfo->comp_info[1].ac_tbl_no == 0);
+      JXL_CHECK(cinfo->comp_info[2].ac_tbl_no == 0);
+    } else if (cinfo->jpeg_color_space == JCS_YCbCr) {
+      JXL_CHECK(cinfo->comp_info[0].dc_tbl_no == 0);
+      JXL_CHECK(cinfo->comp_info[1].dc_tbl_no == 1);
+      JXL_CHECK(cinfo->comp_info[2].dc_tbl_no == 1);
+      JXL_CHECK(cinfo->comp_info[0].ac_tbl_no == 0);
+      JXL_CHECK(cinfo->comp_info[1].ac_tbl_no == 1);
+      JXL_CHECK(cinfo->comp_info[2].ac_tbl_no == 1);
+    } else if (cinfo->jpeg_color_space == JCS_CMYK) {
+      JXL_CHECK(cinfo->comp_info[0].dc_tbl_no == 0);
+      JXL_CHECK(cinfo->comp_info[1].dc_tbl_no == 0);
+      JXL_CHECK(cinfo->comp_info[2].dc_tbl_no == 0);
+      JXL_CHECK(cinfo->comp_info[3].dc_tbl_no == 0);
+      JXL_CHECK(cinfo->comp_info[0].ac_tbl_no == 0);
+      JXL_CHECK(cinfo->comp_info[1].ac_tbl_no == 0);
+      JXL_CHECK(cinfo->comp_info[2].ac_tbl_no == 0);
+      JXL_CHECK(cinfo->comp_info[3].ac_tbl_no == 0);
+    } else if (cinfo->jpeg_color_space == JCS_YCCK) {
+      JXL_CHECK(cinfo->comp_info[0].dc_tbl_no == 0);
+      JXL_CHECK(cinfo->comp_info[1].dc_tbl_no == 1);
+      JXL_CHECK(cinfo->comp_info[2].dc_tbl_no == 1);
+      JXL_CHECK(cinfo->comp_info[3].dc_tbl_no == 0);
+      JXL_CHECK(cinfo->comp_info[0].ac_tbl_no == 0);
+      JXL_CHECK(cinfo->comp_info[1].ac_tbl_no == 1);
+      JXL_CHECK(cinfo->comp_info[2].ac_tbl_no == 1);
+      JXL_CHECK(cinfo->comp_info[3].ac_tbl_no == 0);
+    }
+    if (jparams.use_flat_dc_luma_code) {
+      JHUFF_TBL* tbl = cinfo->dc_huff_tbl_ptrs[0];
+      jxl::msan::UnpoisonMemory(tbl, sizeof(*tbl));
+      for (int i = 0; i < 15; ++i) {
+        JXL_CHECK(tbl->huffval[i] == i);
+      }
+    }
+  }
+}
+
+void UnmapColors(uint8_t* row, size_t xsize, int components,
+                 JSAMPARRAY colormap, size_t num_colors) {
+  JXL_CHECK(colormap != nullptr);
+  std::vector<uint8_t> tmp(xsize * components);
+  for (size_t x = 0; x < xsize; ++x) {
+    JXL_CHECK(row[x] < num_colors);
+    for (int c = 0; c < components; ++c) {
+      tmp[x * components + c] = colormap[c][row[x]];
+    }
+  }
+  memcpy(row, tmp.data(), tmp.size());
+}
+
+void CopyCoefficients(j_decompress_ptr cinfo, jvirt_barray_ptr* coef_arrays,
+                      TestImage* output) {
+  output->xsize = cinfo->image_width;
+  output->ysize = cinfo->image_height;
+  output->components = cinfo->num_components;
+  output->color_space = cinfo->out_color_space;
+  j_common_ptr comptr = reinterpret_cast<j_common_ptr>(cinfo);
+  for (int c = 0; c < cinfo->num_components; ++c) {
+    jpeg_component_info* comp = &cinfo->comp_info[c];
+    std::vector<JCOEF> coeffs(comp->width_in_blocks * comp->height_in_blocks *
+                              DCTSIZE2);
+    for (size_t by = 0; by < comp->height_in_blocks; ++by) {
+      JBLOCKARRAY ba = (*cinfo->mem->access_virt_barray)(comptr, coef_arrays[c],
+                                                         by, 1, true);
+      size_t stride = comp->width_in_blocks * sizeof(JBLOCK);
+      size_t offset = by * comp->width_in_blocks * DCTSIZE2;
+      memcpy(&coeffs[offset], ba[0], stride);
+    }
+    output->coeffs.emplace_back(std::move(coeffs));
+  }
+}

--- a/lib/jpegli/test_utils.h
+++ b/lib/jpegli/test_utils.h
@@ -20,15 +20,10 @@
 /* clang-format on */
 
 #include "lib/jpegli/common.h"
+#include "lib/jpegli/libjpeg_test_util.h"
+#include "lib/jpegli/test_params.h"
 
 namespace jpegli {
-
-// We define this here as well to make sure that the *_api_test.cc tests only
-// use the public API and therefore we don't include any *_internal.h headers.
-template <typename T1, typename T2>
-constexpr inline T1 DivCeil(T1 a, T2 b) {
-  return (a + b - 1) / b;
-}
 
 #define ERROR_HANDLER_SETUP(flavor)                                \
   jpeg_error_mgr jerr;                                             \
@@ -45,316 +40,24 @@ constexpr inline T1 DivCeil(T1 a, T2 b) {
     longjmp(*env, 1);                                              \
   };
 
-#define ARRAY_SIZE(X) (sizeof(X) / sizeof((X)[0]))
-
-static constexpr int kSpecialMarker0 = 0xe5;
-static constexpr int kSpecialMarker1 = 0xe9;
-static constexpr uint8_t kMarkerData[] = {0, 1, 255, 0, 17};
-static constexpr uint8_t kMarkerSequence[] = {0xe6, 0xe8, 0xe7,
-                                              0xe6, 0xe7, 0xe8};
-static constexpr size_t kMarkerSequenceLen = ARRAY_SIZE(kMarkerSequence);
-
-// Sequential non-interleaved.
-static constexpr jpeg_scan_info kScript1[] = {
-    {1, {0}, 0, 63, 0, 0},
-    {1, {1}, 0, 63, 0, 0},
-    {1, {2}, 0, 63, 0, 0},
-};
-// Sequential partially interleaved, chroma first.
-static constexpr jpeg_scan_info kScript2[] = {
-    {2, {1, 2}, 0, 63, 0, 0},
-    {1, {0}, 0, 63, 0, 0},
-};
-
-// Rest of the scan scripts are progressive.
-
-static constexpr jpeg_scan_info kScript3[] = {
-    // Interleaved full DC.
-    {3, {0, 1, 2}, 0, 0, 0, 0},
-    // Full AC scans.
-    {1, {0}, 1, 63, 0, 0},
-    {1, {1}, 1, 63, 0, 0},
-    {1, {2}, 1, 63, 0, 0},
-};
-static constexpr jpeg_scan_info kScript4[] = {
-    // Non-interleaved full DC.
-    {1, {0}, 0, 0, 0, 0},
-    {1, {1}, 0, 0, 0, 0},
-    {1, {2}, 0, 0, 0, 0},
-    // Full AC scans.
-    {1, {0}, 1, 63, 0, 0},
-    {1, {1}, 1, 63, 0, 0},
-    {1, {2}, 1, 63, 0, 0},
-};
-static constexpr jpeg_scan_info kScript5[] = {
-    // Partially interleaved full DC, chroma first.
-    {2, {1, 2}, 0, 0, 0, 0},
-    {1, {0}, 0, 0, 0, 0},
-    // AC shifted by 1 bit.
-    {1, {0}, 1, 63, 0, 1},
-    {1, {1}, 1, 63, 0, 1},
-    {1, {2}, 1, 63, 0, 1},
-    // AC refinement scan.
-    {1, {0}, 1, 63, 1, 0},
-    {1, {1}, 1, 63, 1, 0},
-    {1, {2}, 1, 63, 1, 0},
-};
-static constexpr jpeg_scan_info kScript6[] = {
-    // Interleaved DC shifted by 2 bits.
-    {3, {0, 1, 2}, 0, 0, 0, 2},
-    // Interleaved DC refinement scans.
-    {3, {0, 1, 2}, 0, 0, 2, 1},
-    {3, {0, 1, 2}, 0, 0, 1, 0},
-    // Full AC scans.
-    {1, {0}, 1, 63, 0, 0},
-    {1, {1}, 1, 63, 0, 0},
-    {1, {2}, 1, 63, 0, 0},
-};
-
-static constexpr jpeg_scan_info kScript7[] = {
-    // Non-interleaved DC shifted by 2 bits.
-    {1, {0}, 0, 0, 0, 2},
-    {1, {1}, 0, 0, 0, 2},
-    {1, {2}, 0, 0, 0, 2},
-    // Non-interleaved DC first refinement scans.
-    {1, {0}, 0, 0, 2, 1},
-    {1, {1}, 0, 0, 2, 1},
-    {1, {2}, 0, 0, 2, 1},
-    // Non-interleaved DC second refinement scans.
-    {1, {0}, 0, 0, 1, 0},
-    {1, {1}, 0, 0, 1, 0},
-    {1, {2}, 0, 0, 1, 0},
-    // Full AC scans.
-    {1, {0}, 1, 63, 0, 0},
-    {1, {1}, 1, 63, 0, 0},
-    {1, {2}, 1, 63, 0, 0},
-};
-
-static constexpr jpeg_scan_info kScript8[] = {
-    // Partially interleaved DC shifted by 2 bits, chroma first
-    {2, {1, 2}, 0, 0, 0, 2},
-    {1, {0}, 0, 0, 0, 2},
-    // Partially interleaved DC first refinement scans.
-    {2, {0, 2}, 0, 0, 2, 1},
-    {1, {1}, 0, 0, 2, 1},
-    // Partially interleaved DC first refinement scans, chroma first.
-    {2, {1, 2}, 0, 0, 1, 0},
-    {1, {0}, 0, 0, 1, 0},
-    // Full AC scans.
-    {1, {0}, 1, 63, 0, 0},
-    {1, {1}, 1, 63, 0, 0},
-    {1, {2}, 1, 63, 0, 0},
-};
-
-static constexpr jpeg_scan_info kScript9[] = {
-    // Interleaved full DC.
-    {3, {0, 1, 2}, 0, 0, 0, 0},
-    // AC scans for component 0
-    // shifted by 1 bit, two spectral ranges
-    {1, {0}, 1, 6, 0, 1},
-    {1, {0}, 7, 63, 0, 1},
-    // refinement scan, full
-    {1, {0}, 1, 63, 1, 0},
-    // AC scans for component 1
-    // shifted by 1 bit, full
-    {1, {1}, 1, 63, 0, 1},
-    // refinement scan, two spectral ranges
-    {1, {1}, 1, 6, 1, 0},
-    {1, {1}, 7, 63, 1, 0},
-    // AC scans for component 2
-    // shifted by 1 bit, two spectral ranges
-    {1, {2}, 1, 6, 0, 1},
-    {1, {2}, 7, 63, 0, 1},
-    // refinement scan, two spectral ranges (but different from above)
-    {1, {2}, 1, 16, 1, 0},
-    {1, {2}, 17, 63, 1, 0},
-};
-
-static constexpr jpeg_scan_info kScript10[] = {
-    // Interleaved full DC.
-    {3, {0, 1, 2}, 0, 0, 0, 0},
-    // AC scans for spectral range 1..16
-    // shifted by 1
-    {1, {0}, 1, 16, 0, 1},
-    {1, {1}, 1, 16, 0, 1},
-    {1, {2}, 1, 16, 0, 1},
-    // refinement scans, two sub-ranges
-    {1, {0}, 1, 8, 1, 0},
-    {1, {0}, 9, 16, 1, 0},
-    {1, {1}, 1, 8, 1, 0},
-    {1, {1}, 9, 16, 1, 0},
-    {1, {2}, 1, 8, 1, 0},
-    {1, {2}, 9, 16, 1, 0},
-    // AC scans for spectral range 17..63
-    {1, {0}, 17, 63, 0, 1},
-    {1, {1}, 17, 63, 0, 1},
-    {1, {2}, 17, 63, 0, 1},
-    // refinement scans, two sub-ranges
-    {1, {0}, 17, 28, 1, 0},
-    {1, {0}, 29, 63, 1, 0},
-    {1, {1}, 17, 28, 1, 0},
-    {1, {1}, 29, 63, 1, 0},
-    {1, {2}, 17, 28, 1, 0},
-    {1, {2}, 29, 63, 1, 0},
-};
-
-struct ScanScript {
-  int num_scans;
-  const jpeg_scan_info* scans;
-};
-
-static constexpr ScanScript kTestScript[] = {
-    {ARRAY_SIZE(kScript1), kScript1}, {ARRAY_SIZE(kScript2), kScript2},
-    {ARRAY_SIZE(kScript3), kScript3}, {ARRAY_SIZE(kScript4), kScript4},
-    {ARRAY_SIZE(kScript5), kScript5}, {ARRAY_SIZE(kScript6), kScript6},
-    {ARRAY_SIZE(kScript7), kScript7}, {ARRAY_SIZE(kScript8), kScript8},
-    {ARRAY_SIZE(kScript9), kScript9}, {ARRAY_SIZE(kScript10), kScript10},
-};
-static constexpr int kNumTestScripts = ARRAY_SIZE(kTestScript);
-
-static constexpr int kLastScan = 0xffff;
-
-static uint32_t kTestColorMap[] = {
-    0x000000, 0xff0000, 0x00ff00, 0x0000ff, 0xffff00, 0x00ffff,
-    0xff00ff, 0xffffff, 0x6251fc, 0x45d9c7, 0xa7f059, 0xd9a945,
-    0xfa4e44, 0xceaffc, 0xbad7db, 0xc1f0b1, 0xdbca9a, 0xfacac5,
-    0xf201ff, 0x0063db, 0x00f01c, 0xdbb204, 0xf12f0c, 0x7ba1dc};
-static constexpr int kTestColorMapNumColors = ARRAY_SIZE(kTestColorMap);
-
 std::string IOMethodName(JpegliDataType data_type, JpegliEndianness endianness);
 
 std::string ColorSpaceName(J_COLOR_SPACE colorspace);
 
-enum JpegIOMode {
-  PIXELS,
-  RAW_DATA,
-  COEFFICIENTS,
-};
-
-struct CustomQuantTable {
-  int slot_idx = 0;
-  uint16_t table_type = 0;
-  int scale_factor = 100;
-  bool add_raw = false;
-  bool force_baseline = true;
-  std::vector<unsigned int> basic_table;
-  std::vector<unsigned int> quantval;
-  void Generate();
-};
-
-struct TestImage {
-  size_t xsize = 2268;
-  size_t ysize = 1512;
-  J_COLOR_SPACE color_space = JCS_RGB;
-  size_t components = 3;
-  JpegliDataType data_type = JPEGLI_TYPE_UINT8;
-  JpegliEndianness endianness = JPEGLI_NATIVE_ENDIAN;
-  std::vector<uint8_t> pixels;
-  std::vector<std::vector<uint8_t>> raw_data;
-  std::vector<std::vector<JCOEF>> coeffs;
-  void AllocatePixels() {
-    pixels.resize(ysize * xsize * components *
-                  jpegli_bytes_per_sample(data_type));
-  }
-  void Clear() {
-    pixels.clear();
-    raw_data.clear();
-    coeffs.clear();
-  }
-};
-
 std::ostream& operator<<(std::ostream& os, const TestImage& input);
 
-struct CompressParams {
-  int quality = 90;
-  bool set_jpeg_colorspace = false;
-  J_COLOR_SPACE jpeg_color_space = JCS_UNKNOWN;
-  std::vector<int> quant_indexes;
-  std::vector<CustomQuantTable> quant_tables;
-  std::vector<int> h_sampling;
-  std::vector<int> v_sampling;
-  std::vector<int> comp_ids;
-  int override_JFIF = -1;
-  int override_Adobe = -1;
-  bool add_marker = false;
-  bool simple_progression = false;
-  // -1 is library default
-  // 0, 1, 2 is set through jpegli_set_progressive_level()
-  // 2 + N is kScriptN
-  int progressive_mode = -1;
-  unsigned int restart_interval = 0;
-  int restart_in_rows = 0;
-  int smoothing_factor = 0;
-  int optimize_coding = -1;
-  bool use_flat_dc_luma_code = false;
-  bool omit_standard_tables = false;
-  bool xyb_mode = false;
-  bool libjpeg_mode = false;
-  bool use_adaptive_quantization = true;
-  std::vector<uint8_t> icc;
-
-  int h_samp(int c) const { return h_sampling.empty() ? 1 : h_sampling[c]; }
-  int v_samp(int c) const { return v_sampling.empty() ? 1 : v_sampling[c]; }
-  int max_h_sample() const {
-    auto it = std::max_element(h_sampling.begin(), h_sampling.end());
-    return it == h_sampling.end() ? 1 : *it;
-  }
-  int max_v_sample() const {
-    auto it = std::max_element(v_sampling.begin(), v_sampling.end());
-    return it == v_sampling.end() ? 1 : *it;
-  }
-  int comp_width(const TestImage& input, int c) const {
-    return DivCeil(input.xsize * h_samp(c), max_h_sample() * DCTSIZE) * DCTSIZE;
-  }
-  int comp_height(const TestImage& input, int c) const {
-    return DivCeil(input.ysize * v_samp(c), max_v_sample() * DCTSIZE) * DCTSIZE;
-  }
-};
-
 std::ostream& operator<<(std::ostream& os, const CompressParams& jparams);
+
+int NumTestScanScripts();
 
 void VerifyHeader(const CompressParams& jparams, j_decompress_ptr cinfo);
 void VerifyScanHeader(const CompressParams& jparams, j_decompress_ptr cinfo);
 
-enum ColorQuantMode {
-  CQUANT_1PASS,
-  CQUANT_2PASS,
-  CQUANT_EXTERNAL,
-  CQUANT_REUSE,
-};
-
-struct ScanDecompressParams {
-  int max_scan_number;
-  J_DITHER_MODE dither_mode;
-  ColorQuantMode color_quant_mode;
-};
-
-struct DecompressParams {
-  float size_factor = 1.0f;
-  size_t chunk_size = 65536;
-  size_t max_output_lines = 16;
-  JpegIOMode output_mode = PIXELS;
-  JpegliDataType data_type = JPEGLI_TYPE_UINT8;
-  JpegliEndianness endianness = JPEGLI_NATIVE_ENDIAN;
-  bool set_out_color_space = false;
-  J_COLOR_SPACE out_color_space = JCS_UNKNOWN;
-  bool crop_output = false;
-  bool do_block_smoothing = false;
-  bool do_fancy_upsampling = true;
-  bool skip_scans = false;
-  int scale_num = 1;
-  int scale_denom = 1;
-  bool quantize_colors = false;
-  int desired_number_of_colors = 256;
-  std::vector<ScanDecompressParams> scan_params;
-};
-
 void SetDecompressParams(const DecompressParams& dparams,
-                         j_decompress_ptr cinfo, bool is_jpegli);
+                         j_decompress_ptr cinfo);
 
 void SetScanDecompressParams(const DecompressParams& dparams,
-                             j_decompress_ptr cinfo, int scan_number,
-                             bool is_jpegli);
+                             j_decompress_ptr cinfo, int scan_number);
 
 void CopyCoefficients(j_decompress_ptr cinfo, jvirt_barray_ptr* coef_arrays,
                       TestImage* output);
@@ -407,20 +110,6 @@ void EncodeWithJpegli(const TestImage& input, const CompressParams& jparams,
 
 bool EncodeWithJpegli(const TestImage& input, const CompressParams& jparams,
                       std::vector<uint8_t>* compressed);
-
-// Verifies that an image encoded with libjpegli can be decoded with libjpeg,
-// and checks that the jpeg coding metadata matches jparams.
-void DecodeAllScansWithLibjpeg(const CompressParams& jparams,
-                               const DecompressParams& dparams,
-                               const std::vector<uint8_t>& compressed,
-                               std::vector<TestImage>* output_progression);
-void DecodeWithLibjpeg(const CompressParams& jparams,
-                       const DecompressParams& dparams, j_decompress_ptr cinfo,
-                       TestImage* output);
-void DecodeWithLibjpeg(const CompressParams& jparams,
-                       const DecompressParams& dparams,
-                       const std::vector<uint8_t>& compressed,
-                       TestImage* output);
 
 double DistanceRms(const TestImage& input, const TestImage& output,
                    size_t start_line, size_t num_lines,

--- a/lib/jpegli/types.h
+++ b/lib/jpegli/types.h
@@ -1,0 +1,38 @@
+// Copyright (c) the JPEG XL Project Authors. All rights reserved.
+//
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+#ifndef LIB_JPEGLI_TYPES_H_
+#define LIB_JPEGLI_TYPES_H_
+
+#if defined(__cplusplus) || defined(c_plusplus)
+extern "C" {
+#endif
+
+//
+// New API structs and functions that are not available in libjpeg
+//
+// NOTE: This part of the API is still experimental and will probably change in
+// the future.
+//
+
+typedef enum {
+  JPEGLI_TYPE_FLOAT = 0,
+  JPEGLI_TYPE_UINT8 = 2,
+  JPEGLI_TYPE_UINT16 = 3,
+} JpegliDataType;
+
+typedef enum {
+  JPEGLI_NATIVE_ENDIAN = 0,
+  JPEGLI_LITTLE_ENDIAN = 1,
+  JPEGLI_BIG_ENDIAN = 2,
+} JpegliEndianness;
+
+int jpegli_bytes_per_sample(JpegliDataType data_type);
+
+#if defined(__cplusplus) || defined(c_plusplus)
+}  // extern "C"
+#endif
+
+#endif  // LIB_JPEGLI_TYPES_H_

--- a/lib/jxl_lists.bzl
+++ b/lib/jxl_lists.bzl
@@ -449,6 +449,11 @@ libjxl_gbench_sources = [
     "jxl/tf_gbench.cc",
 ]
 
+libjxl_jpegli_libjpeg_helper_files = [
+    "jpegli/libjpeg_test_util.cc",
+    "jpegli/libjpeg_test_util.h",
+]
+
 libjxl_jpegli_sources = [
     "jpegli/adaptive_quantization.cc",
     "jpegli/adaptive_quantization.h",
@@ -502,11 +507,14 @@ libjxl_jpegli_sources = [
     "jpegli/simd.h",
     "jpegli/source_manager.cc",
     "jpegli/transpose-inl.h",
+    "jpegli/types.h",
     "jpegli/upsample.cc",
     "jpegli/upsample.h",
 ]
 
 libjxl_jpegli_testlib_files = [
+    "jpegli/test_params.h",
+    "jpegli/test_utils-inl.h",
     "jpegli/test_utils.cc",
     "jpegli/test_utils.h",
 ]

--- a/lib/jxl_lists.cmake
+++ b/lib/jxl_lists.cmake
@@ -449,6 +449,11 @@ set(JPEGXL_INTERNAL_GBENCH_SOURCES
   jxl/tf_gbench.cc
 )
 
+set(JPEGXL_INTERNAL_JPEGLI_LIBJPEG_HELPER_FILES
+  jpegli/libjpeg_test_util.cc
+  jpegli/libjpeg_test_util.h
+)
+
 set(JPEGXL_INTERNAL_JPEGLI_SOURCES
   jpegli/adaptive_quantization.cc
   jpegli/adaptive_quantization.h
@@ -502,11 +507,14 @@ set(JPEGXL_INTERNAL_JPEGLI_SOURCES
   jpegli/simd.h
   jpegli/source_manager.cc
   jpegli/transpose-inl.h
+  jpegli/types.h
   jpegli/upsample.cc
   jpegli/upsample.h
 )
 
 set(JPEGXL_INTERNAL_JPEGLI_TESTLIB_FILES
+  jpegli/test_params.h
+  jpegli/test_utils-inl.h
   jpegli/test_utils.cc
   jpegli/test_utils.h
 )

--- a/tools/scripts/build_cleaner.py
+++ b/tools/scripts/build_cleaner.py
@@ -86,6 +86,8 @@ def SplitLibFiles(repo_files):
   _, jpegli_srcs = Filter(jpegli_srcs, ContainsFn('testing.h'))
   testlib_files, srcs = Filter(srcs, ContainsFn('test'))
   jpegli_testlib_files, jpegli_srcs = Filter(jpegli_srcs, ContainsFn('test'))
+  jpegli_libjpeg_helper_files, jpegli_testlib_files = Filter(
+    jpegli_testlib_files, ContainsFn('libjpeg_test_util'))
   gbench_sources, srcs = Filter(srcs, HasSuffixFn('_gbench.cc'))
 
   extras_sources, srcs = Filter(srcs, HasPrefixFn('extras/'))
@@ -142,6 +144,7 @@ def SplitLibFiles(repo_files):
     'extras_sources': extras_sources, 'gbench_sources': gbench_sources,
     'jpegli_sources': jpegli_sources,
     'jpegli_testlib_files': jpegli_testlib_files,
+    'jpegli_libjpeg_helper_files': jpegli_libjpeg_helper_files,
     'jpegli_tests': jpegli_tests,
     'jpegli_wrapper_sources' : jpegli_wrapper_sources,
     'public_headers': public_headers,


### PR DESCRIPTION
This is preparation for using jpegli's own jpeg headers for compiling the jpegli-static library.