### PR TITLE
simplify/fix local max MA tree size calculation

### DIFF
--- a/lib/jxl/modular/encoding/encoding.cc
+++ b/lib/jxl/modular/encoding/encoding.cc
@@ -515,8 +515,7 @@ Status ModularDecode(BitReader *br, Image &image, GroupHeader &header,
   const ANSCode *code = &code_storage;
   const std::vector<uint8_t> *context_map = &context_map_storage;
   if (!header.use_global_tree) {
-    size_t max_tree_size = 1024;
-    const size_t max_tree_size_cap = static_cast<size_t>(1 << 20);
+    uint64_t max_tree_size = 1024;
     for (size_t i = 0; i < nb_channels; i++) {
       Channel &channel = image.channel[i];
       if (i >= image.nb_meta_channels && (channel.w > options->max_chan_size ||
@@ -525,11 +524,8 @@ Status ModularDecode(BitReader *br, Image &image, GroupHeader &header,
       }
       uint64_t pixels = channel.w * channel.h;
       max_tree_size += pixels;
-      if (max_tree_size < pixels || max_tree_size >= max_tree_size_cap) {
-        max_tree_size = max_tree_size_cap;
-        break;
-      }
     }
+    max_tree_size = std::min(static_cast<uint64_t>(1 << 20), max_tree_size);
     JXL_RETURN_IF_ERROR(DecodeTree(br, &tree_storage, max_tree_size));
     JXL_RETURN_IF_ERROR(DecodeHistograms(br, (tree_storage.size() + 1) / 2,
                                          &code_storage, &context_map_storage));

--- a/lib/jxl/modular/encoding/encoding.cc
+++ b/lib/jxl/modular/encoding/encoding.cc
@@ -516,23 +516,20 @@ Status ModularDecode(BitReader *br, Image &image, GroupHeader &header,
   const std::vector<uint8_t> *context_map = &context_map_storage;
   if (!header.use_global_tree) {
     size_t max_tree_size = 1024;
+    const size_t max_tree_size_cap = static_cast<size_t>(1 << 20);
     for (size_t i = 0; i < nb_channels; i++) {
       Channel &channel = image.channel[i];
-      if (!channel.w || !channel.h) {
-        continue;  // skip empty channels
-      }
       if (i >= image.nb_meta_channels && (channel.w > options->max_chan_size ||
                                           channel.h > options->max_chan_size)) {
         break;
       }
-      size_t pixels = channel.w * channel.h;
-      if (pixels / channel.w != channel.h) {
-        return JXL_FAILURE("Tree size overflow");
-      }
+      uint64_t pixels = channel.w * channel.h;
       max_tree_size += pixels;
-      if (max_tree_size < pixels) return JXL_FAILURE("Tree size overflow");
+      if (max_tree_size < pixels || max_tree_size >= max_tree_size_cap) {
+        max_tree_size = max_tree_size_cap;
+        break;
+      }
     }
-    max_tree_size = std::min(static_cast<size_t>(1 << 20), max_tree_size);
     JXL_RETURN_IF_ERROR(DecodeTree(br, &tree_storage, max_tree_size));
     JXL_RETURN_IF_ERROR(DecodeHistograms(br, (tree_storage.size() + 1) / 2,
                                          &code_storage, &context_map_storage));


### PR DESCRIPTION
Probably doesn't make any difference on realistic examples, and it's a bit nitpicky, but in principle: if `size_t` is small (it can be only uint32) and the size of a local group is very large (e.g. because the image is a multispectral one with lots of channels), presumably the computation of the bound to use for the MA tree size could return failure while the bitstream was actually valid.
