### PR TITLE
Refactor jxl_extras.cmake

### DIFF
--- a/lib/extras/enc/jpegli.cc
+++ b/lib/extras/enc/jpegli.cc
@@ -424,6 +424,9 @@ Status EncodeJpeg(const PackedPixelFile& ppf, const JpegSettings& jpeg_settings,
       jpegli_set_psnr(&cinfo, jpeg_settings.psnr_target,
                       jpeg_settings.search_tolerance,
                       jpeg_settings.min_distance, jpeg_settings.max_distance);
+    } else if (jpeg_settings.quality > 0.0) {
+      float distance = jpegli_quality_to_distance(jpeg_settings.quality);
+      jpegli_set_distance(&cinfo, distance, TRUE);
     } else {
       jpegli_set_distance(&cinfo, jpeg_settings.distance, TRUE);
     }

--- a/lib/extras/enc/jpegli.h
+++ b/lib/extras/enc/jpegli.h
@@ -23,6 +23,7 @@ namespace extras {
 struct JpegSettings {
   bool xyb = false;
   size_t target_size = 0;
+  float quality = 0.0f;
   float distance = 1.f;
   bool use_adaptive_quantization = true;
   bool use_std_quant_tables = false;

--- a/lib/jxl_extras.cmake
+++ b/lib/jxl_extras.cmake
@@ -6,6 +6,10 @@
 include(compatibility.cmake)
 include(jxl_lists.cmake)
 
+# Object library for those parts of extras that do not depend on jxl internals,
+# jpegli, or external codec libraries. We will create two versions of these
+# object files, one with and one without -DJPEGXL_ENABLE_* definitions for
+# external codec support.
 list(APPEND JPEGXL_EXTRAS_CORE_SOURCES
   "${JPEGXL_INTERNAL_EXTRAS_SOURCES}"
   "${JPEGXL_INTERNAL_CODEC_JXL_SOURCES}"
@@ -13,48 +17,30 @@ list(APPEND JPEGXL_EXTRAS_CORE_SOURCES
   "${JPEGXL_INTERNAL_CODEC_PNM_SOURCES}"
   "${JPEGXL_INTERNAL_CODEC_NPY_SOURCES}"
 )
+foreach(LIB jxl_extras_core-obj jxl_extras_core_nocodec-obj)
+  add_library("${LIB}" OBJECT "${JPEGXL_EXTRAS_CORE_SOURCES}")
+  list(APPEND JXL_EXTRAS_OBJECT_LIBRARIES "${LIB}")
+endforeach()
+list(APPEND JXL_EXTRAS_OBJECTS $<TARGET_OBJECTS:jxl_extras_core-obj>)
 
-add_library(jxl_extras_codec-obj OBJECT "${JPEGXL_EXTRAS_CORE_SOURCES}")
-target_compile_options(jxl_extras_codec-obj PRIVATE "${JPEGXL_INTERNAL_FLAGS}")
-target_compile_definitions(jxl_extras_codec-obj PRIVATE -DJXL_EXPORT=)
-set_property(TARGET jxl_extras_codec-obj PROPERTY POSITION_INDEPENDENT_CODE ON)
-target_include_directories(jxl_extras_codec-obj PUBLIC
-  ${PROJECT_SOURCE_DIR}
-  ${CMAKE_CURRENT_SOURCE_DIR}/include
-  ${CMAKE_CURRENT_BINARY_DIR}/include
-  ${JXL_HWY_INCLUDE_DIRS}
-)
+# Object library for those parts of extras that depend on jxl internals, with
+# and without codec support.
+foreach(LIB jxl_extras_internal-obj jxl_extras_internal_nocodec-obj)
+  add_library("${LIB}" OBJECT
+    "${JPEGXL_INTERNAL_EXTRAS_FOR_TOOLS_SOURCES}"
+  )
+  list(APPEND JXL_EXTRAS_OBJECT_LIBRARIES "${LIB}")
+endforeach()
+list(APPEND JXL_EXTRAS_OBJECTS $<TARGET_OBJECTS:jxl_extras_internal-obj>)
+
+# Object library for encoders/decoders that depend on external codec libraries.
+# The actual sources, dependencies and compile definitions will be populated
+# later based on what codecs we find.
+add_library(jxl_extras_codec-obj OBJECT)
+list(APPEND JXL_EXTRAS_OBJECT_LIBRARIES jxl_extras_codec-obj)
+list(APPEND JXL_EXTRAS_OBJECTS $<TARGET_OBJECTS:jxl_extras_codec-obj>)
 set(JXL_EXTRAS_CODEC_INTERNAL_LIBRARIES)
-set(JXL_EXTRAS_CODEC_PUBLIC_COMPILE_DEFINITIONS)
-
-# We only define a static library for jxl_extras since it uses internal parts
-# of jxl library which are not accessible from outside the library in the
-# shared library case.
-add_library(jxl_extras-static STATIC EXCLUDE_FROM_ALL
-  "${JPEGXL_EXTRAS_CORE_SOURCES}"
-  "${JPEGXL_INTERNAL_EXTRAS_FOR_TOOLS_SOURCES}"
-)
-target_compile_options(jxl_extras-static PRIVATE "${JPEGXL_INTERNAL_FLAGS}")
-set_property(TARGET jxl_extras-static PROPERTY POSITION_INDEPENDENT_CODE ON)
-target_include_directories(jxl_extras-static PUBLIC "${PROJECT_SOURCE_DIR}")
-target_link_libraries(jxl_extras-static PUBLIC
-  jxl-static
-  jxl_threads-static
-)
-
-# Define an extras library that does not have the image codecs, only the core
-# extras code. This is needed for some of the fuzzers.
-add_library(jxl_extras_nocodec-static STATIC EXCLUDE_FROM_ALL
-  "${JPEGXL_EXTRAS_CORE_SOURCES}"
-  "${JPEGXL_INTERNAL_EXTRAS_FOR_TOOLS_SOURCES}"
-)
-target_compile_options(jxl_extras_nocodec-static PRIVATE "${JPEGXL_INTERNAL_FLAGS}")
-set_property(TARGET jxl_extras_nocodec-static PROPERTY POSITION_INDEPENDENT_CODE ON)
-target_include_directories(jxl_extras_nocodec-static PUBLIC "${PROJECT_SOURCE_DIR}")
-target_link_libraries(jxl_extras_nocodec-static PUBLIC
-  jxl-static
-  jxl_threads-static
-)
+set(JXL_EXTRAS_CODEC_PUBLIC_DEFINITIONS)
 
 find_package(GIF 5.1)
 if(GIF_FOUND)
@@ -76,26 +62,29 @@ if(JPEG_FOUND)
   target_sources(jxl_extras_codec-obj PRIVATE
     "${JPEGXL_INTERNAL_CODEC_JPG_SOURCES}"
   )
-  target_include_directories(jxl_extras_codec-obj PRIVATE "${JPEG_INCLUDE_DIRS}")
+  target_include_directories(jxl_extras_codec-obj PRIVATE
+    "${JPEG_INCLUDE_DIRS}"
+  )
   list(APPEND JXL_EXTRAS_CODEC_INTERNAL_LIBRARIES ${JPEG_LIBRARIES})
   list(APPEND JXL_EXTRAS_CODEC_PUBLIC_DEFINITIONS -DJPEGXL_ENABLE_JPEG=1)
-  target_sources(jxl_extras-static PRIVATE
-    "${JPEGXL_INTERNAL_CODEC_JPG_SOURCES}"
-  )
-  target_include_directories(jxl_extras-static PRIVATE "${JPEG_INCLUDE_DIRS}")
-  target_link_libraries(jxl_extras-static PRIVATE ${JPEG_LIBRARIES})
-  target_compile_definitions(jxl_extras-static PUBLIC -DJPEGXL_ENABLE_JPEG=1)
-  if(JPEGXL_ENABLE_JPEGLI)
-    target_sources(jxl_extras-static PRIVATE
-      "${JPEGXL_INTERNAL_CODEC_JPEGLI_SOURCES}"
-    )
-    target_link_libraries(jxl_extras-static PRIVATE jpegli-static)
-    target_compile_definitions(jxl_extras-static PUBLIC -DJPEGXL_ENABLE_JPEGLI=1)
-  endif()
   if(JPEGXL_DEP_LICENSE_DIR)
     configure_file("${JPEGXL_DEP_LICENSE_DIR}/libjpeg-dev/copyright"
                    ${PROJECT_BINARY_DIR}/LICENSE.libjpeg COPYONLY)
   endif()  # JPEGXL_DEP_LICENSE_DIR
+endif()
+
+if(JPEG_FOUND AND JPEGXL_ENABLE_JPEGLI)
+  add_library(jxl_extras_jpegli-obj OBJECT
+    "${JPEGXL_INTERNAL_CODEC_JPEGLI_SOURCES}"
+  )
+  target_compile_definitions(jxl_extras_jpegli-obj PRIVATE
+    -DJPEGXL_ENABLE_JPEGLI=1
+  )
+  target_include_directories(jxl_extras_jpegli-obj PRIVATE
+    "${JPEG_INCLUDE_DIRS}"
+  )
+  list(APPEND JXL_EXTRAS_OBJECT_LIBRARIES jxl_extras_jpegli-obj)
+  list(APPEND JXL_EXTRAS_OBJECTS $<TARGET_OBJECTS:jxl_extras_jpegli-obj>)
 endif()
 
 if(NOT JPEGXL_BUNDLE_LIBPNG)
@@ -108,20 +97,9 @@ if(PNG_FOUND)
   target_include_directories(jxl_extras_codec-obj PRIVATE "${PNG_INCLUDE_DIRS}")
   list(APPEND JXL_EXTRAS_CODEC_INTERNAL_LIBRARIES ${PNG_LIBRARIES})
   list(APPEND JXL_EXTRAS_CODEC_PUBLIC_DEFINITIONS -DJPEGXL_ENABLE_APNG=1)
-  target_sources(jxl_extras-static PRIVATE
-    "${JPEGXL_INTERNAL_CODEC_APNG_SOURCES}"
-  )
-  target_include_directories(jxl_extras-static PUBLIC "${PNG_INCLUDE_DIRS}")
-  target_link_libraries(jxl_extras-static PUBLIC ${PNG_LIBRARIES})
-  target_compile_definitions(jxl_extras-static PUBLIC -DJPEGXL_ENABLE_APNG=1)
   configure_file(extras/LICENSE.apngdis
                  ${PROJECT_BINARY_DIR}/LICENSE.apngdis COPYONLY)
 endif()
-
-if (JPEGXL_ENABLE_SJPEG)
-  target_compile_definitions(jxl_extras-static PUBLIC -DJPEGXL_ENABLE_SJPEG=1)
-  target_link_libraries(jxl_extras-static PRIVATE sjpeg)
-endif ()
 
 if (JPEGXL_ENABLE_OPENEXR)
 pkg_check_modules(OpenEXR IMPORTED_TARGET OpenEXR)
@@ -130,13 +108,10 @@ if (OpenEXR_FOUND)
     "${JPEGXL_INTERNAL_CODEC_EXR_SOURCES}"
   )
   list(APPEND JXL_EXTRAS_CODEC_PUBLIC_DEFINITIONS -DJPEGXL_ENABLE_EXR=1)
-  target_include_directories(jxl_extras_codec-obj PRIVATE "${OpenEXR_INCLUDE_DIRS}")
-  list(APPEND JXL_EXTRAS_CODEC_INTERNAL_LIBRARIES PkgConfig::OpenEXR)
-  target_sources(jxl_extras-static PRIVATE
-    "${JPEGXL_INTERNAL_CODEC_EXR_SOURCES}"
+  target_include_directories(jxl_extras_codec-obj PRIVATE
+    "${OpenEXR_INCLUDE_DIRS}"
   )
-  target_compile_definitions(jxl_extras-static PUBLIC -DJPEGXL_ENABLE_EXR=1)
-  target_link_libraries(jxl_extras-static PRIVATE PkgConfig::OpenEXR)
+  list(APPEND JXL_EXTRAS_CODEC_INTERNAL_LIBRARIES PkgConfig::OpenEXR)
   if(JPEGXL_DEP_LICENSE_DIR)
     configure_file("${JPEGXL_DEP_LICENSE_DIR}/libopenexr-dev/copyright"
                    ${PROJECT_BINARY_DIR}/LICENSE.libopenexr COPYONLY)
@@ -144,35 +119,106 @@ if (OpenEXR_FOUND)
   # OpenEXR generates exceptions, so we need exception support to catch them.
   # Actually those flags counteract the ones set in JPEGXL_INTERNAL_FLAGS.
   if (NOT WIN32)
-    set_source_files_properties(extras/dec/exr.cc extras/enc/exr.cc PROPERTIES COMPILE_FLAGS -fexceptions)
+    set_source_files_properties(
+      extras/dec/exr.cc extras/enc/exr.cc PROPERTIES COMPILE_FLAGS -fexceptions)
     if (CMAKE_CXX_COMPILER_ID MATCHES "Clang")
-      set_source_files_properties(extras/dec/exr.cc extras/enc/exr.cc PROPERTIES COMPILE_FLAGS -fcxx-exceptions)
+      set_source_files_properties(
+	extras/dec/exr.cc extras/enc/exr.cc PROPERTIES COMPILE_FLAGS
+	-fcxx-exceptions)
     endif()
   endif()
 endif() # OpenEXR_FOUND
 endif() # JPEGXL_ENABLE_OPENEXR
 
-target_compile_definitions(jxl_extras_codec-obj PRIVATE ${JXL_EXTRAS_CODEC_PUBLIC_DEFINITIONS})
+# Common settings for the object libraries.
+foreach(LIB ${JXL_EXTRAS_OBJECT_LIBRARIES})
+  target_compile_options("${LIB}" PRIVATE "${JPEGXL_INTERNAL_FLAGS}")
+  target_compile_definitions("${LIB}" PRIVATE -DJXL_EXPORT=)
+  set_property(TARGET "${LIB}" PROPERTY POSITION_INDEPENDENT_CODE ON)
+  target_include_directories("${LIB}" PRIVATE
+    ${PROJECT_SOURCE_DIR}
+    ${CMAKE_CURRENT_SOURCE_DIR}/include
+    ${CMAKE_CURRENT_BINARY_DIR}/include
+    ${JXL_HWY_INCLUDE_DIRS}
+  )
+endforeach()
 
-### Static library.
-add_library(jxl_extras_codec-static STATIC $<TARGET_OBJECTS:jxl_extras_codec-obj>)
-target_compile_definitions(jxl_extras_codec-static PUBLIC ${JXL_EXTRAS_CODEC_PUBLIC_DEFINITIONS})
-target_link_libraries(jxl_extras_codec-static PRIVATE ${JXL_EXTRAS_CODEC_INTERNAL_LIBRARIES} jxl)
+foreach(LIB jxl_extras_core-obj jxl_extras_internal-obj jxl_extras_codec-obj)
+  target_compile_definitions("${LIB}" PUBLIC
+    ${JXL_EXTRAS_CODEC_PUBLIC_DEFINITIONS}
+  )
+endforeach()
 
-### Shared library.
+# Define an extras library that does not have the image codecs, only the core
+# extras code. This is needed for some of the fuzzers.
+add_library(jxl_extras_nocodec-static STATIC EXCLUDE_FROM_ALL
+  $<TARGET_OBJECTS:jxl_extras_core_nocodec-obj>
+  $<TARGET_OBJECTS:jxl_extras_internal_nocodec-obj>
+)
+target_link_libraries(jxl_extras_nocodec-static PUBLIC
+  jxl-static
+  jxl_threads-static
+)
+
+# We only define a static library jxl_extras since it uses internal parts of
+# jxl library which are not accessible from outside the library in the
+# shared library case.
+add_library(jxl_extras-static STATIC EXCLUDE_FROM_ALL ${JXL_EXTRAS_OBJECTS})
+target_compile_definitions(jxl_extras-static PUBLIC
+  ${JXL_EXTRAS_CODEC_PUBLIC_DEFINITIONS}
+)
+target_link_libraries(jxl_extras-static PUBLIC
+  ${JXL_EXTRAS_CODEC_INTERNAL_LIBRARIES}
+  jxl-static
+  jxl_threads-static
+)
+if (JPEGXL_ENABLE_SJPEG)
+  target_compile_definitions(jxl_extras-static PUBLIC -DJPEGXL_ENABLE_SJPEG=1)
+  target_link_libraries(jxl_extras-static PRIVATE sjpeg)
+endif ()
+if(JPEG_FOUND AND JPEGXL_ENABLE_JPEGLI)
+  target_compile_definitions(jxl_extras-static PUBLIC -DJPEGXL_ENABLE_JPEGLI=1)
+  target_link_libraries(jxl_extras-static PRIVATE jpegli-static)
+endif()
+
+### Static library that does not depend on internal parts of jxl library.
+add_library(jxl_extras_codec-static STATIC
+  $<TARGET_OBJECTS:jxl_extras_core-obj>
+  $<TARGET_OBJECTS:jxl_extras_codec-obj>
+)
+target_compile_definitions(jxl_extras_codec-static PUBLIC
+  ${JXL_EXTRAS_CODEC_PUBLIC_DEFINITIONS}
+)
+target_link_libraries(jxl_extras_codec-static PRIVATE
+  ${JXL_EXTRAS_CODEC_INTERNAL_LIBRARIES}
+  jxl
+)
+
+### Shared library that does not depend on internal parts of jxl library.
+### Used by cjxl and djxl binaries.
 if (BUILD_SHARED_LIBS)
-add_library(jxl_extras_codec SHARED $<TARGET_OBJECTS:jxl_extras_codec-obj>)
-target_compile_definitions(jxl_extras_codec PUBLIC ${JXL_EXTRAS_CODEC_PUBLIC_DEFINITIONS})
-target_link_libraries(jxl_extras_codec PRIVATE ${JXL_EXTRAS_CODEC_INTERNAL_LIBRARIES} jxl)
+add_library(jxl_extras_codec SHARED
+  $<TARGET_OBJECTS:jxl_extras_codec-obj>
+  $<TARGET_OBJECTS:jxl_extras_core-obj>
+)
+target_compile_definitions(jxl_extras_codec PUBLIC
+  ${JXL_EXTRAS_CODEC_PUBLIC_DEFINITIONS}
+)
+target_link_libraries(jxl_extras_codec PRIVATE
+  ${JXL_EXTRAS_CODEC_INTERNAL_LIBRARIES}
+  jxl
+)
 set_target_properties(jxl_extras_codec PROPERTIES
   VERSION ${JPEGXL_LIBRARY_VERSION}
   SOVERSION ${JPEGXL_LIBRARY_SOVERSION}
   LIBRARY_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}"
-  RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}")
+  RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}"
+)
 install(TARGETS jxl_extras_codec
   RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
   LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
-  ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR})
+  ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+)
 else()
 add_library(jxl_extras_codec ALIAS jxl_extras_codec-static)
 endif()  # BUILD_SHARED_LIBS

--- a/tools/benchmark/benchmark_codec_jpeg.cc
+++ b/tools/benchmark/benchmark_codec_jpeg.cc
@@ -24,9 +24,6 @@
 #include "lib/extras/packed_image.h"
 #include "lib/extras/packed_image_convert.h"
 #include "lib/extras/time.h"
-#if JPEGXL_ENABLE_JPEGLI
-#include "lib/jpegli/encode.h"
-#endif
 #include "lib/jxl/base/padded_bytes.h"
 #include "lib/jxl/base/span.h"
 #include "lib/jxl/codec_in_out.h"
@@ -228,7 +225,7 @@ class JPEGCodec : public ImageCodec {
         settings.use_std_quant_tables = use_std_tables_;
       }
       if (enc_quality_set_) {
-        settings.distance = jpegli_quality_to_distance(q_target_);
+        settings.quality = q_target_;
       } else {
         settings.distance = butteraugli_target_;
       }

--- a/tools/cjpegli.cc
+++ b/tools/cjpegli.cc
@@ -12,7 +12,6 @@
 #include "lib/extras/codec.h"
 #include "lib/extras/enc/jpegli.h"
 #include "lib/extras/time.h"
-#include "lib/jpegli/encode.h"
 #include "lib/jxl/base/printf_macros.h"
 #include "lib/jxl/base/span.h"
 #include "tools/args.h"
@@ -65,7 +64,7 @@ struct Args {
         "Quality setting (is remapped to --distance)."
         "    Default is quality 90.\n"
         "    Quality values roughly match libjpeg quality.\n"
-        "    Recommended range: 68 .. 96. Allowed range: 0 .. 100.\n"
+        "    Recommended range: 68 .. 96. Allowed range: 1 .. 100.\n"
         "    Mutually exclusive with --distance and --target_size.",
         &quality, &ParseSigned);
 
@@ -136,7 +135,7 @@ bool ValidateArgs(const Args& args) {
     fprintf(stderr, "Invalid --distance argument\n");
     return false;
   }
-  if (args.quality < 0 || args.quality > 100) {
+  if (args.quality <= 0 || args.quality > 100) {
     fprintf(stderr, "Invalid --quality argument\n");
     return false;
   }
@@ -169,7 +168,7 @@ bool SetDistance(const Args& args, const CommandLineParser& cmdline,
     return false;
   }
   if (quality_set) {
-    settings->distance = jpegli_quality_to_distance(args.quality);
+    settings->quality = args.quality;
   }
   return true;
 }


### PR DESCRIPTION
First we define all the object libraries we need and then we put together the static/dynamic libraries from them. This also makes it clear that we have to compile some source files twice.