### PR TITLE
conditionally compile debug strings

### DIFF
--- a/lib/jxl/dec_modular.cc
+++ b/lib/jxl/dec_modular.cc
@@ -153,6 +153,7 @@ void int_to_float(const pixel_type* const JXL_RESTRICT row_in,
   }
 }
 
+#if JXL_DEBUG_V_LEVEL >= 1
 std::string ModularStreamId::DebugString() const {
   std::ostringstream os;
   os << (kind == kGlobalData   ? "ModularGlobal"
@@ -174,6 +175,7 @@ std::string ModularStreamId::DebugString() const {
   }
   return os.str();
 }
+#endif
 
 Status ModularFrameDecoder::DecodeGlobalInfo(BitReader* reader,
                                              const FrameHeader& frame_header,

--- a/lib/jxl/frame_header.cc
+++ b/lib/jxl/frame_header.cc
@@ -78,6 +78,7 @@ Status BlendingInfo::VisitFields(Visitor* JXL_RESTRICT visitor) {
   return true;
 }
 
+#if JXL_DEBUG_V_LEVEL >= 1
 std::string BlendingInfo::DebugString() const {
   std::ostringstream os;
   os << (mode == BlendMode::kReplace            ? "Replace"
@@ -96,6 +97,7 @@ std::string BlendingInfo::DebugString() const {
   }
   return os.str();
 }
+#endif
 
 AnimationFrame::AnimationFrame(const CodecMetadata* metadata)
     : nonserialized_metadata(metadata) {
@@ -160,6 +162,7 @@ Status Passes::VisitFields(Visitor* JXL_RESTRICT visitor) {
   return true;
 }
 
+#if JXL_DEBUG_V_LEVEL >= 1
 std::string Passes::DebugString() const {
   std::ostringstream os;
   os << "p=" << num_passes;
@@ -183,6 +186,7 @@ std::string Passes::DebugString() const {
   }
   return os.str();
 }
+#endif
 
 FrameHeader::FrameHeader(const CodecMetadata* metadata)
     : animation_frame(metadata), nonserialized_metadata(metadata) {
@@ -419,6 +423,7 @@ Status FrameHeader::VisitFields(Visitor* JXL_RESTRICT visitor) {
   return visitor->EndExtensions();
 }
 
+#if JXL_DEBUG_V_LEVEL >= 1
 std::string FrameHeader::DebugString() const {
   std::ostringstream os;
   os << (encoding == FrameEncoding::kVarDCT ? "VarDCT" : "Modular");
@@ -490,5 +495,6 @@ std::string FrameHeader::DebugString() const {
   if (is_last) os << ",last";
   return os.str();
 }
+#endif
 
 }  // namespace jxl

--- a/lib/jxl/image_metadata.cc
+++ b/lib/jxl/image_metadata.cc
@@ -59,6 +59,7 @@ Status BitDepth::VisitFields(Visitor* JXL_RESTRICT visitor) {
   return true;
 }
 
+#if JXL_DEBUG_V_LEVEL >= 1
 std::string BitDepth::DebugString() const {
   std::ostringstream os;
   os << (floating_point_sample ? "F" : "U");
@@ -66,6 +67,7 @@ std::string BitDepth::DebugString() const {
   if (floating_point_sample) os << "." << exponent_bits_per_sample;
   return os.str();
 }
+#endif
 
 CustomTransformData::CustomTransformData() { Bundle::Init(this); }
 Status CustomTransformData::VisitFields(Visitor* JXL_RESTRICT visitor) {
@@ -252,6 +254,7 @@ Status ExtraChannelInfo::VisitFields(Visitor* JXL_RESTRICT visitor) {
   return true;
 }
 
+#if JXL_DEBUG_V_LEVEL >= 1
 std::string ExtraChannelInfo::DebugString() const {
   std::ostringstream os;
   os << (type == ExtraChannel::kAlpha           ? "Alpha"
@@ -267,6 +270,7 @@ std::string ExtraChannelInfo::DebugString() const {
   os << " shift: " << dim_shift;
   return os.str();
 }
+#endif
 
 ImageMetadata::ImageMetadata() { Bundle::Init(this); }
 Status ImageMetadata::VisitFields(Visitor* JXL_RESTRICT visitor) {
@@ -437,6 +441,7 @@ void ImageMetadata::SetAlphaBits(uint32_t bits, bool alpha_is_premultiplied) {
   if (bits > 12) modular_16_bit_buffer_sufficient = false;
 }
 
+#if JXL_DEBUG_V_LEVEL >= 1
 std::string ImageMetadata::DebugString() const {
   std::ostringstream os;
   os << bit_depth.DebugString();
@@ -467,5 +472,6 @@ std::string CodecMetadata::DebugString() const {
   os << " " << m.DebugString();
   return os.str();
 }
+#endif
 
 }  // namespace jxl

--- a/lib/jxl/modular/modular_image.cc
+++ b/lib/jxl/modular/modular_image.cc
@@ -60,6 +60,7 @@ Image Image::clone() {
   return c;
 }
 
+#if JXL_DEBUG_V_LEVEL >= 1
 std::string Image::DebugString() const {
   std::ostringstream os;
   os << w << "x" << h << ", depth: " << bitdepth;
@@ -73,5 +74,6 @@ std::string Image::DebugString() const {
   }
   return os.str();
 }
+#endif
 
 }  // namespace jxl


### PR DESCRIPTION
No need to compile the DebugString() functions if they're not going to be used anyway. Probably doesn't make any difference on the final binary size since link-time optimization will probably remove the unused functions anyway, but still, it should improve the code coverage reports and perhaps make compilation slightly faster.