### PR TITLE
conditionally compile low-precision neon-only XYB to RGB code

### DIFF
--- a/lib/jxl/dec_cache.cc
+++ b/lib/jxl/dec_cache.cc
@@ -139,6 +139,7 @@ Status PassesDecoderState::PreparePipeline(ImageBundle* decoded,
   }
 
   if (fast_xyb_srgb8_conversion) {
+#if !JXL_HIGH_PRECISION
     JXL_ASSERT(!NeedsBlending(this));
     JXL_ASSERT(!frame_header.CanBeReferenced() ||
                frame_header.save_before_color_transform);
@@ -149,6 +150,7 @@ Status PassesDecoderState::PreparePipeline(ImageBundle* decoded,
     builder.AddStage(GetFastXYBTosRGB8Stage(rgb_output, main_output.stride,
                                             width, height, is_rgba, has_alpha,
                                             alpha_c));
+#endif
   } else {
     bool linear = false;
     if (frame_header.color_transform == ColorTransform::kYCbCr) {

--- a/lib/jxl/render_pipeline/stage_xyb.cc
+++ b/lib/jxl/render_pipeline/stage_xyb.cc
@@ -113,6 +113,7 @@ std::unique_ptr<RenderPipelineStage> GetXYBStage(
   return HWY_DYNAMIC_DISPATCH(GetXYBStage)(output_encoding_info);
 }
 
+#if !JXL_HIGH_PRECISION
 namespace {
 class FastXYBStage : public RenderPipelineStage {
  public:
@@ -169,6 +170,7 @@ std::unique_ptr<RenderPipelineStage> GetFastXYBTosRGB8Stage(
   return make_unique<FastXYBStage>(rgb, stride, width, height, rgba, has_alpha,
                                    alpha_c);
 }
+#endif
 
 }  // namespace jxl
 #endif


### PR DESCRIPTION
Slightly reduces the binary size of `libjxl.so` for default (high-precision) builds.