### PR TITLE
remove dead or deprecated image_ops functions

### DIFF
--- a/lib/extras/tone_mapping_gbench.cc
+++ b/lib/extras/tone_mapping_gbench.cc
@@ -26,7 +26,9 @@ static void BM_ToneMapping(benchmark::State& state) {
   for (auto _ : state) {
     state.PauseTiming();
     CodecInOut tone_mapping_input;
-    tone_mapping_input.SetFromImage(CopyImage(color), linear_rec2020);
+    Image3F color2(color.xsize(), color.ysize());
+    CopyImageTo(color, &color2);
+    tone_mapping_input.SetFromImage(std::move(color2), linear_rec2020);
     tone_mapping_input.metadata.m.SetIntensityTarget(255);
     state.ResumeTiming();
 

--- a/lib/jxl/color_management_test.cc
+++ b/lib/jxl/color_management_test.cc
@@ -377,7 +377,8 @@ TEST_F(ColorManagementTest, XYBProfile) {
   Image3F opsin(kNumColors, 1);
   ToXYB(ib, nullptr, &opsin, cms, nullptr);
 
-  Image3F opsin2 = CopyImage(opsin);
+  Image3F opsin2(kNumColors, 1);
+  CopyImageTo(opsin, &opsin2);
   ScaleXYB(&opsin2);
 
   float* src = xform.BufSrc(0);

--- a/lib/jxl/enc_adaptive_quantization.cc
+++ b/lib/jxl/enc_adaptive_quantization.cc
@@ -854,7 +854,8 @@ void FindBestQuantization(const ImageBundle& linear, const Image3F& opsin,
   AdjustQuantField(enc_state->shared.ac_strategy, Rect(quant_field),
                    original_butteraugli, &quant_field);
   ImageF tile_distmap;
-  ImageF initial_quant_field = CopyImage(quant_field);
+  ImageF initial_quant_field(quant_field.xsize(), quant_field.ysize());
+  CopyImageTo(quant_field, &initial_quant_field);
 
   float initial_qf_min, initial_qf_max;
   ImageMinMax(initial_quant_field, &initial_qf_min, &initial_qf_max);
@@ -892,7 +893,7 @@ void FindBestQuantization(const ImageBundle& linear, const Image3F& opsin,
     JXL_CHECK(comparator.CompareWith(dec_linear, &diffmap, &score));
     if (!lower_is_better) {
       score = -score;
-      diffmap = ScaleImage(-1.0f, diffmap);
+      ScaleImage(-1.0f, &diffmap);
     }
     tile_distmap = TileDistMap(diffmap, 8 * cparams.resampling, 0,
                                enc_state->shared.ac_strategy);

--- a/lib/jxl/enc_cache.cc
+++ b/lib/jxl/enc_cache.cc
@@ -170,8 +170,10 @@ Status InitializePassesEncoder(const Image3F& opsin, const JxlCmsInterface& cms,
     // dc_frame_info.dc_level = shared.frame_header.dc_level + 1, and
     // dc_frame_info.dc_level is used by EncodeFrame. However, if EncodeFrame
     // outputs multiple frames, this assumption could be wrong.
-    shared.dc_storage =
-        CopyImage(dec_state->shared->dc_frames[shared.frame_header.dc_level]);
+    const Image3F& dc_frame =
+        dec_state->shared->dc_frames[shared.frame_header.dc_level];
+    shared.dc_storage = Image3F(dc_frame.xsize(), dc_frame.ysize());
+    CopyImageTo(dc_frame, &shared.dc_storage);
     ZeroFillImage(&shared.quant_dc);
     shared.dc = &shared.dc_storage;
     JXL_CHECK(encoded_size == 0);

--- a/lib/jxl/enc_detect_dots.cc
+++ b/lib/jxl/enc_detect_dots.cc
@@ -293,7 +293,8 @@ std::vector<ConnectedComponent> FindCC(const ImageF& energy, double t_low,
                                        double t_high, uint32_t maxWindow,
                                        double minScore) {
   const int kExtraRect = 4;
-  ImageF img = CopyImage(energy);
+  ImageF img(energy.xsize(), energy.ysize());
+  CopyImageTo(energy, &img);
   std::vector<ConnectedComponent> ans;
   for (size_t y = 0; y < img.ysize(); y++) {
     float* JXL_RESTRICT row = img.Row(y);

--- a/lib/jxl/enc_frame.cc
+++ b/lib/jxl/enc_frame.cc
@@ -1513,9 +1513,11 @@ Status EncodeFrame(const CompressParams& cparams_orig,
   }
   if (cparams.ec_resampling != 1 && !cparams.already_downsampled) {
     extra_channels = &extra_channels_storage;
-    for (size_t i = 0; i < ib.extra_channels().size(); i++) {
-      extra_channels_storage.emplace_back(CopyImage(ib.extra_channels()[i]));
-      DownsampleImage(&extra_channels_storage.back(), cparams.ec_resampling);
+    for (const ImageF& ec : ib.extra_channels()) {
+      ImageF d_ec(ec.xsize(), ec.ysize());
+      CopyImageTo(ec, &d_ec);
+      DownsampleImage(&d_ec, cparams.ec_resampling);
+      extra_channels_storage.emplace_back(std::move(d_ec));
     }
   }
   // needs to happen *AFTER* VarDCT-ComputeEncodingData.

--- a/lib/jxl/enc_gaborish.cc
+++ b/lib/jxl/enc_gaborish.cc
@@ -46,7 +46,8 @@ void GaborishInverse(Image3F* in_out, float mul[3], ThreadPool* pool) {
   // Note that we cannot *allocate* a plane, as doing so might cause Image3F to
   // have planes of different stride. Instead, we copy one plane in a temporary
   // image and reuse the existing planes of the in/out image.
-  ImageF temp = CopyImage(in_out->Plane(2));
+  ImageF temp(in_out->Plane(2).xsize(), in_out->Plane(2).ysize());
+  CopyImageTo(in_out->Plane(2), &temp);
   Symmetric5(in_out->Plane(0), Rect(*in_out), weights[0], pool,
              &in_out->Plane(2));
   Symmetric5(in_out->Plane(1), Rect(*in_out), weights[1], pool,

--- a/lib/jxl/enc_heuristics.cc
+++ b/lib/jxl/enc_heuristics.cc
@@ -305,7 +305,8 @@ void DownsampleImage2_Sharper(const ImageF& input, ImageF* output) {
   int64_t xsize = input.xsize();
   int64_t ysize = input.ysize();
 
-  ImageF box_downsample = CopyImage(input);
+  ImageF box_downsample(xsize, ysize);
+  CopyImageTo(input, &box_downsample);
   DownsampleImage(&box_downsample, 2);
 
   ImageF mask(box_downsample.xsize(), box_downsample.ysize());
@@ -616,7 +617,8 @@ void DownsampleImage2_Iterative(const ImageF& orig, ImageF* output) {
   int64_t xsize2 = DivCeil(orig.xsize(), 2);
   int64_t ysize2 = DivCeil(orig.ysize(), 2);
 
-  ImageF box_downsample = CopyImage(orig);
+  ImageF box_downsample(xsize, ysize);
+  CopyImageTo(orig, &box_downsample);
   DownsampleImage(&box_downsample, 2);
   ImageF mask(box_downsample.xsize(), box_downsample.ysize());
   CreateMask(box_downsample, mask);
@@ -630,7 +632,8 @@ void DownsampleImage2_Iterative(const ImageF& orig, ImageF* output) {
   initial.ShrinkTo(initial.xsize() - kBlockDim, initial.ysize() - kBlockDim);
   DownsampleImage2_Sharper(orig, &initial);
 
-  ImageF down = CopyImage(initial);
+  ImageF down(initial.xsize(), initial.ysize());
+  CopyImageTo(initial, &down);
   ImageF up(xsize, ysize);
   ImageF corr(xsize, ysize);
   ImageF corr2(xsize2, ysize2);

--- a/lib/jxl/enc_image_bundle.cc
+++ b/lib/jxl/enc_image_bundle.cc
@@ -130,13 +130,17 @@ Status TransformIfNeeded(const ImageBundle& in, const ColorEncoding& c_desired,
   }
   // TODO(janwas): avoid copying via createExternal+copyBackToIO
   // instead of copy+createExternal+copyBackToIO
-  store->SetFromImage(CopyImage(in.color()), in.c_current());
+  Image3F color(in.color().xsize(), in.color().ysize());
+  CopyImageTo(in.color(), &color);
+  store->SetFromImage(std::move(color), in.c_current());
 
   // Must at least copy the alpha channel for use by external_image.
   if (in.HasExtraChannels()) {
     std::vector<ImageF> extra_channels;
     for (const ImageF& extra_channel : in.extra_channels()) {
-      extra_channels.emplace_back(CopyImage(extra_channel));
+      ImageF ec(extra_channel.xsize(), extra_channel.ysize());
+      CopyImageTo(extra_channel, &ec);
+      extra_channels.emplace_back(std::move(ec));
     }
     store->SetExtraChannels(std::move(extra_channels));
   }

--- a/lib/jxl/image.cc
+++ b/lib/jxl/image.cc
@@ -132,48 +132,6 @@ void PlaneBase::Swap(PlaneBase& other) {
   std::swap(bytes_, other.bytes_);
 }
 
-Image3F PadImageMirror(const Image3F& in, const size_t xborder,
-                       const size_t yborder) {
-  size_t xsize = in.xsize();
-  size_t ysize = in.ysize();
-  Image3F out(xsize + 2 * xborder, ysize + 2 * yborder);
-  if (xborder > xsize || yborder > ysize) {
-    for (size_t c = 0; c < 3; c++) {
-      for (int32_t y = 0; y < static_cast<int32_t>(out.ysize()); y++) {
-        float* row_out = out.PlaneRow(c, y);
-        const float* row_in = in.PlaneRow(
-            c, Mirror(y - static_cast<int32_t>(yborder), in.ysize()));
-        for (int32_t x = 0; x < static_cast<int32_t>(out.xsize()); x++) {
-          int32_t xin = Mirror(x - static_cast<int32_t>(xborder), in.xsize());
-          row_out[x] = row_in[xin];
-        }
-      }
-    }
-    return out;
-  }
-  CopyImageTo(in, Rect(xborder, yborder, xsize, ysize), &out);
-  for (size_t c = 0; c < 3; c++) {
-    // Horizontal pad.
-    for (size_t y = 0; y < ysize; y++) {
-      for (size_t x = 0; x < xborder; x++) {
-        out.PlaneRow(c, y + yborder)[x] =
-            in.ConstPlaneRow(c, y)[xborder - x - 1];
-        out.PlaneRow(c, y + yborder)[x + xsize + xborder] =
-            in.ConstPlaneRow(c, y)[xsize - 1 - x];
-      }
-    }
-    // Vertical pad.
-    for (size_t y = 0; y < yborder; y++) {
-      memcpy(out.PlaneRow(c, y), out.ConstPlaneRow(c, 2 * yborder - 1 - y),
-             out.xsize() * sizeof(float));
-      memcpy(out.PlaneRow(c, y + ysize + yborder),
-             out.ConstPlaneRow(c, ysize + yborder - 1 - y),
-             out.xsize() * sizeof(float));
-    }
-  }
-  return out;
-}
-
 void PadImageToBlockMultipleInPlace(Image3F* JXL_RESTRICT in,
                                     size_t block_dim) {
   const size_t xsize_orig = in->xsize();

--- a/lib/jxl/image_bundle.h
+++ b/lib/jxl/image_bundle.h
@@ -46,11 +46,14 @@ class ImageBundle {
 
   ImageBundle Copy() const {
     ImageBundle copy(metadata_);
-    copy.color_ = CopyImage(color_);
+    copy.color_ = Image3F(color_.xsize(), color_.ysize());
+    CopyImageTo(color_, &copy.color_);
     copy.c_current_ = c_current_;
     copy.extra_channels_.reserve(extra_channels_.size());
     for (const ImageF& plane : extra_channels_) {
-      copy.extra_channels_.emplace_back(CopyImage(plane));
+      ImageF ec(plane.xsize(), plane.ysize());
+      CopyImageTo(plane, &ec);
+      copy.extra_channels_.emplace_back(std::move(ec));
     }
 
     copy.jpeg_data =

--- a/lib/jxl/modular/transform/palette.cc
+++ b/lib/jxl/modular/transform/palette.cc
@@ -75,7 +75,8 @@ Status InvPalette(Image &input, uint32_t begin_c, uint32_t nb_colors,
     }
   } else {
     // Parallelized per channel.
-    ImageI indices = CopyImage(input.channel[c0].plane);
+    ImageI indices = std::move(input.channel[c0].plane);
+    input.channel[c0].plane = ImageI(indices.xsize(), indices.ysize());
     if (predictor == Predictor::Weighted) {
       JXL_RETURN_IF_ERROR(RunOnPool(
           pool, 0, nb, ThreadPool::NoInit,

--- a/lib/jxl/opsin_inverse_test.cc
+++ b/lib/jxl/opsin_inverse_test.cc
@@ -25,7 +25,9 @@ TEST(OpsinInverseTest, LinearInverseInverts) {
   CodecInOut io;
   io.metadata.m.SetFloat32Samples();
   io.metadata.m.color_encoding = ColorEncoding::LinearSRGB();
-  io.SetFromImage(CopyImage(linear), io.metadata.m.color_encoding);
+  Image3F linear2(128, 128);
+  CopyImageTo(linear, &linear2);
+  io.SetFromImage(std::move(linear2), io.metadata.m.color_encoding);
   ThreadPool* null_pool = nullptr;
   Image3F opsin(io.xsize(), io.ysize());
   (void)ToXYB(io.Main(), null_pool, &opsin, GetJxlCms());

--- a/lib/jxl/splines_test.cc
+++ b/lib/jxl/splines_test.cc
@@ -311,7 +311,9 @@ TEST(SplinesTest, Drawing) {
   splines.AddTo(&image, Rect(image), Rect(image));
 
   CodecInOut io_actual;
-  io_actual.SetFromImage(CopyImage(image), ColorEncoding::SRGB());
+  Image3F image2(320, 320);
+  CopyImageTo(image, &image2);
+  io_actual.SetFromImage(std::move(image2), ColorEncoding::SRGB());
   ASSERT_TRUE(io_actual.frames[0].TransformTo(io_expected.Main().c_current(),
                                               GetJxlCms()));
 

--- a/tools/benchmark/benchmark_xl.cc
+++ b/tools/benchmark/benchmark_xl.cc
@@ -81,7 +81,8 @@ Status ReadPNG(const std::string& filename, Image3F* image) {
   JXL_CHECK(ReadFile(filename, &encoded));
   JXL_CHECK(jxl::SetFromBytes(jxl::Span<const uint8_t>(encoded),
                               jxl::extras::ColorHints(), &io));
-  *image = CopyImage(*io.Main().color());
+  *image = Image3F(io.xsize(), io.ysize());
+  CopyImageTo(*io.Main().color(), image);
   return true;
 }
 


### PR DESCRIPTION
There are a bunch of functions in `image_ops.h` that are currently dead code — they were probably used at some point during the development of jxl, but they're now no longer used. Some functions like `ScaleImage()` or `AddTo()` had several variants for no good reason, so I simplified that a bit too.

The function `PadImageMirror()` is only used by `tools/hdr/local_tone_map.cc` so it makes more sense to move it there.

Some functions like `CopyImage()` were marked as "deprecated"; they were still used in some places (mostly in tests) so I replaced them with the alternative (e.g. `CopyImageTo()`).
