### PR TITLE
conditionally compile code for standalone-fjxl

### DIFF
--- a/lib/jxl/enc_fast_lossless.cc
+++ b/lib/jxl/enc_fast_lossless.cc
@@ -202,6 +202,11 @@ size_t JxlFastLosslessOutputSize(const JxlFastLosslessFrameState* frame) {
   return frame->header.bytes_written + total_size_groups;
 }
 
+size_t JxlFastLosslessMaxRequiredOutput(
+    const JxlFastLosslessFrameState* frame) {
+  return JxlFastLosslessOutputSize(frame) + 32;
+}
+
 void JxlFastLosslessPrepareHeader(JxlFastLosslessFrameState* frame,
                                   int add_image_header, int is_last) {
   BitWriter* output = &frame->header;
@@ -3810,7 +3815,7 @@ size_t JxlFastLosslessEncode(const unsigned char* rgba, size_t width,
       runner_opaque, runner);
   JxlFastLosslessPrepareHeader(frame_state, /*add_image_header=*/1,
                                /*is_last=*/1);
-  size_t output_size = JxlFastLosslessOutputSize(frame_state) + 32;
+  size_t output_size = JxlFastLosslessMaxRequiredOutput(frame_state);
   *output = (unsigned char*)malloc(output_size);
   size_t written = 0;
   size_t total = 0;

--- a/lib/jxl/enc_fast_lossless.h
+++ b/lib/jxl/enc_fast_lossless.h
@@ -58,8 +58,14 @@ JxlFastLosslessFrameState* JxlFastLosslessPrepareFrame(
 void JxlFastLosslessPrepareHeader(JxlFastLosslessFrameState* frame,
                                   int add_image_header, int is_last);
 
-// Actual size of the frame once it is encoded. Cannot be called before
+// Upper bound on the required output size, including any padding that may be
+// required by JxlFastLosslessWriteOutput. Cannot be called before
 // JxlFastLosslessPrepareHeader.
+size_t JxlFastLosslessMaxRequiredOutput(const JxlFastLosslessFrameState* frame);
+
+// Actual size of the frame once it is encoded. This is not identical to
+// JxlFastLosslessMaxRequiredOutput because JxlFastLosslessWriteOutput may
+// require extra padding.
 size_t JxlFastLosslessOutputSize(const JxlFastLosslessFrameState* frame);
 
 // Writes the frame to the given output buffer. Returns the number of bytes that

--- a/lib/jxl/enc_fast_lossless.h
+++ b/lib/jxl/enc_fast_lossless.h
@@ -7,6 +7,16 @@
 #define LIB_JXL_ENC_FAST_LOSSLESS_H_
 #include <stdlib.h>
 
+// FJXL_STANDALONE=1 for a stand-alone jxl encoder
+// FJXL_STANDALONE=0 for use in libjxl to encode frames (but no image header)
+#ifndef FJXL_STANDALONE
+#ifdef JPEGXL_MAJOR_VERSION
+#define FJXL_STANDALONE 0
+#else
+#define FJXL_STANDALONE 1
+#endif
+#endif
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -18,12 +28,14 @@ extern "C" {
 typedef void(FJxlParallelRunner)(void* runner_opaque, void* opaque,
                                  void fun(void*, size_t), size_t count);
 
+#if FJXL_STANDALONE
 // You may pass `nullptr` as a runner: encoding will be sequential.
 size_t JxlFastLosslessEncode(const unsigned char* rgba, size_t width,
                              size_t row_stride, size_t height, size_t nb_chans,
                              size_t bitdepth, int big_endian, int effort,
                              unsigned char** output, void* runner_opaque,
                              FJxlParallelRunner runner);
+#endif
 
 // More complex API for cases in which you may want to allocate your own buffer
 // and other advanced use cases.
@@ -42,17 +54,12 @@ JxlFastLosslessFrameState* JxlFastLosslessPrepareFrame(
 // the output of multiple frames, of which the first one has add_image_header =
 // 1 and subsequent ones have add_image_header = 0, and all frames but the last
 // one have is_last = 0.
+// (when FJXL_STANDALONE=0, add_image_header has to be 0)
 void JxlFastLosslessPrepareHeader(JxlFastLosslessFrameState* frame,
                                   int add_image_header, int is_last);
 
-// Upper bound on the required output size, including any padding that may be
-// required by JxlFastLosslessWriteOutput. Cannot be called before
+// Actual size of the frame once it is encoded. Cannot be called before
 // JxlFastLosslessPrepareHeader.
-size_t JxlFastLosslessMaxRequiredOutput(const JxlFastLosslessFrameState* frame);
-
-// Actual size of the frame once it is encoded. This is not identical to
-// JxlFastLosslessMaxRequiredOutput because JxlFastLosslessWriteOutput may
-// require extra padding.
 size_t JxlFastLosslessOutputSize(const JxlFastLosslessFrameState* frame);
 
 // Writes the frame to the given output buffer. Returns the number of bytes that


### PR DESCRIPTION
The code for using `enc_fast_lossless` in a standalone way to produce a complete jxl file does not have to be in libjxl. This is the high-level function that produces a full file, and also the code that produces an image header (which is unused in libjxl).
Also removing `JxlFastLosslessMaxRequiredOutput()` since it's not really needed imo.

Slightly reduces `libjxl.so` binary size.