### PR TITLE
add --noise to cjxl and make the noise test actually test noise

### DIFF
--- a/lib/jxl/jxl_test.cc
+++ b/lib/jxl/jxl_test.cc
@@ -1134,7 +1134,7 @@ TEST(JxlTest, RoundtripDots) {
 TEST(JxlTest, RoundtripNoise) {
   ThreadPool* pool = nullptr;
   const PaddedBytes orig = jxl::test::ReadTestData(
-      "external/wesaturate/500px/cvo9xd_keong_macan_srgb8.png");
+      "external/wesaturate/500px/u76c0g_bliznaca_srgb8.png");
   TestImage t;
   t.DecodeFromBytes(orig).ClearMetadata();
   ASSERT_NE(t.ppf().info.xsize, 0);
@@ -1147,8 +1147,8 @@ TEST(JxlTest, RoundtripNoise) {
   cparams.AddOption(JXL_ENC_FRAME_SETTING_NOISE, 1);
 
   PackedPixelFile ppf_out;
-  EXPECT_NEAR(Roundtrip(t.ppf(), cparams, {}, pool, &ppf_out), 41385, 750);
-  EXPECT_THAT(ButteraugliDistance(t.ppf(), ppf_out), IsSlightlyBelow(1.48));
+  EXPECT_NEAR(Roundtrip(t.ppf(), cparams, {}, pool, &ppf_out), 38244, 750);
+  EXPECT_THAT(ButteraugliDistance(t.ppf(), ppf_out), IsSlightlyBelow(1.3));
 }
 
 TEST(JxlTest, RoundtripLossless8Gray) {

--- a/tools/cjxl_main.cc
+++ b/tools/cjxl_main.cc
@@ -322,6 +322,12 @@ struct CompressArgs {
 
     cmdline->AddHelpText("\nOptions for experimentation / benchmarking:", 3);
 
+    cmdline->AddOptionValue('\0', "noise", "0|1",
+                            "Force disable/enable adaptive noise generation "
+                            "(experimental). Default "
+                            "is 'encoder chooses'",
+                            &noise, &ParseOverride, 3);
+
     cmdline->AddOptionValue(
         '\0', "jpeg_reconstruction_cfl", "0|1",
         "Enable/disable chroma-from-luma (CFL) for lossless "
@@ -477,6 +483,7 @@ struct CompressArgs {
   jxl::Override gaborish = jxl::Override::kDefault;
   jxl::Override group_order = jxl::Override::kDefault;
   jxl::Override compress_boxes = jxl::Override::kDefault;
+  jxl::Override noise = jxl::Override::kDefault;
 
   size_t faster_decoding = 0;
   int64_t resampling = -1;
@@ -655,6 +662,7 @@ void ProcessFlags(const jxl::extras::Codec codec,
   ProcessBoolFlag(args->patches, JXL_ENC_FRAME_SETTING_PATCHES, params);
   ProcessBoolFlag(args->gaborish, JXL_ENC_FRAME_SETTING_GABORISH, params);
   ProcessBoolFlag(args->group_order, JXL_ENC_FRAME_SETTING_GROUP_ORDER, params);
+  ProcessBoolFlag(args->noise, JXL_ENC_FRAME_SETTING_NOISE, params);
 
   params->allow_expert_options = args->allow_expert_options;
 


### PR DESCRIPTION
We have an option to enable adaptive noise synthesis in the encode API, but it doesn't exist in `cjxl`. Even though it's still experimental, it's nice to expose it.

Also updating the test for noise to actually test noise by picking a different image. The image that was used was too clean to trigger the noise detection, so it ended up early-aborting and not signaling any noise on that image (which caused most of the code in `enc_noise.cc` to not be reached). This other image does lead to some noise being generated.