### PR TITLE
improve/simplify bound checking on block_idx

### DIFF
--- a/lib/jxl/jpeg/jpeg_data.cc
+++ b/lib/jxl/jpeg/jpeg_data.cc
@@ -302,16 +302,9 @@ Status JPEGData::VisitFields(Visitor* visitor) {
                                        BitsOffset(5, 9), BitsOffset(28, 41), 0,
                                        &block_idx));
       block_idx += last_block_idx + 1;
-      if (static_cast<int>(block_idx) < last_block_idx + 1) {
-        return JXL_FAILURE("Invalid block ID: %u, last block was %d", block_idx,
-                           last_block_idx);
-      }
-      // TODO(eustas): better upper boundary could be given at this point; also
-      //               it could be applied during reset_points reading.
-      if (block_idx > (1u << 30)) {
-        // At most 8K x 8K x num_channels blocks are expected. That is,
-        // typically, 1.5 * 2^27. 2^30 should be sufficient for any sane
-        // image.
+      if (block_idx >= (3u << 26)) {
+        // At most 8K x 8K x num_channels blocks are possible in a JPEG.
+        // So valid block indices are below 3 * 2^26.
         return JXL_FAILURE("Invalid block ID: %u", block_idx);
       }
       last_block_idx = block_idx;
@@ -335,14 +328,7 @@ Status JPEGData::VisitFields(Visitor* visitor) {
                                        BitsOffset(5, 9), BitsOffset(28, 41), 0,
                                        &block_idx));
       block_idx += last_block_idx + 1;
-      if (static_cast<int>(block_idx) < last_block_idx + 1) {
-        return JXL_FAILURE("Invalid block ID: %u, last block was %d", block_idx,
-                           last_block_idx);
-      }
-      if (block_idx > (1u << 30)) {
-        // At most 8K x 8K x num_channels blocks are expected. That is,
-        // typically, 1.5 * 2^27. 2^30 should be sufficient for any sane
-        // image.
+      if (block_idx > (3u << 26)) {
         return JXL_FAILURE("Invalid block ID: %u", block_idx);
       }
       last_block_idx = block_idx;


### PR DESCRIPTION
Small cleanup/tweak: the correct bound for block_idx is `3 << 26` since the largest possible JPEG image has `1<<13` x `1<<13` blocks (e.g. for a 65535x65535 image) and we have at most 3 components (JPEG can do 4 but we don't support that).

Improving the bound also means that there is no need to check for integer overflow in the `block_idx + last_block_idx + 1` calculation since `block_idx` is at most 40+2^28 (`BitsOffset(28, 41)`) and `last_block_idx` is less than `3 << 26`, so the sum is certainly smaller than 2^29 and cannot cause overflow. (actually the overflow check was already redundant with the cruder bound)