### PR TITLE
bump up timeout for cross-compile

### DIFF
--- a/.github/workflows/build_test_cross.yml
+++ b/.github/workflows/build_test_cross.yml
@@ -30,6 +30,7 @@ jobs:
     runs-on: [ubuntu-22.04]
     container:
       image: debian:bullseye
+    timeout-minutes: 600
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
In the `Build/Test Cross` workflow, when pushing to `main`, it runs all tests on builds with `-DCMAKE_CROSSCOMPILING_EMULATOR=/usr/bin/qemu-aarch64-static`. This is pretty slow, and often time-outs. For some reason the time this takes fluctuates quite a lot, probably depending on the overall load the particular workflow runner has — on a good day these tasks complete in 2-3 hours, on a bad day they need more than the 6 hour default time-out. When they time-out, it does look like they are actually not that far from completing when they get killed (e.g. the two most recent time-outs happened at 5510/5946 tests completed and 5458/5946 tests completed).

Bumping up the time-out from 6h to 10h might help to avoid these time-out failures.