### PR TITLE
Various cleanups

### DIFF
--- a/lib/extras/codec_test.cc
+++ b/lib/extras/codec_test.cc
@@ -66,7 +66,7 @@ std::string ExtensionFromCodec(Codec codec, const bool is_gray,
     case Codec::kUnknown:
       return std::string();
   }
-  JXL_UNREACHABLE;
+  JXL_UNREACHABLE("Add codec");
   return std::string();
 }
 

--- a/lib/jxl/base/compiler_specific.h
+++ b/lib/jxl/base/compiler_specific.h
@@ -63,11 +63,11 @@
 #endif
 
 #if JXL_COMPILER_MSVC
-#define JXL_UNREACHABLE __assume(false)
+#define JXL_UNREACHABLE_BUILTIN __assume(false)
 #elif JXL_COMPILER_CLANG || JXL_COMPILER_GCC >= 405
-#define JXL_UNREACHABLE __builtin_unreachable()
+#define JXL_UNREACHABLE_BUILTIN __builtin_unreachable()
 #else
-#define JXL_UNREACHABLE
+#define JXL_UNREACHABLE_BUILTIN
 #endif
 
 #if JXL_COMPILER_MSVC

--- a/lib/jxl/base/status.h
+++ b/lib/jxl/base/status.h
@@ -68,10 +68,10 @@ namespace jxl {
 #define JXL_DEBUG_V_LEVEL 0
 #endif  // JXL_DEBUG_V_LEVEL
 
-// Pass -DJXL_DEBUG_ON_ABORT=0 to disable the debug messages on JXL_ASSERT,
-// JXL_CHECK and JXL_ABORT.
+// Pass -DJXL_DEBUG_ON_ABORT={0,1} to force disable/enable the debug messages on
+// JXL_ASSERT, JXL_CHECK and JXL_ABORT.
 #ifndef JXL_DEBUG_ON_ABORT
-#define JXL_DEBUG_ON_ABORT 1
+#define JXL_DEBUG_ON_ABORT JXL_DEBUG_ON_ERROR
 #endif  // JXL_DEBUG_ON_ABORT
 
 // Print a debug message on standard error. You should use the JXL_DEBUG macro
@@ -150,6 +150,21 @@ JXL_NORETURN inline JXL_NOINLINE bool Abort() {
   ((JXL_DEBUG_ON_ABORT) && ::jxl::Debug(("%s:%d: JXL_ABORT: " format "\n"), \
                                         __FILE__, __LINE__, ##__VA_ARGS__), \
    ::jxl::Abort())
+
+// Use this for code paths that are unreachable unless the code would change
+// to make it reachable, in which case it will print a warning and abort in
+// debug builds. In release builds no code is produced for this, so only use
+// this if this path is really unreachable.
+#define JXL_UNREACHABLE(format, ...)                                   \
+  do {                                                                 \
+    if (JXL_DEBUG_WARNING) {                                           \
+      ::jxl::Debug(("%s:%d: JXL_UNREACHABLE: " format "\n"), __FILE__, \
+                   __LINE__, ##__VA_ARGS__);                           \
+      ::jxl::Abort();                                                  \
+    } else {                                                           \
+      JXL_UNREACHABLE_BUILTIN;                                         \
+    }                                                                  \
+  } while (0)
 
 // Does not guarantee running the code, use only for debug mode checks.
 #if JXL_ENABLE_ASSERT

--- a/lib/jxl/blending.cc
+++ b/lib/jxl/blending.cc
@@ -80,7 +80,7 @@ void PerformBlending(const float* const* bg, const float* const* fg,
     } else if (ec_blending[i].mode == PatchBlendMode::kNone) {
       if (xsize) memcpy(tmp.Row(3 + i), bg[3 + i] + x0, xsize * sizeof(**fg));
     } else {
-      JXL_ABORT("Unreachable");
+      JXL_UNREACHABLE("new PatchBlendMode?");
     }
   }
   size_t alpha = color_blending.alpha_channel;
@@ -142,7 +142,7 @@ void PerformBlending(const float* const* bg, const float* const* fg,
       memcpy(tmp.Row(p), bg[p] + x0, xsize * sizeof(**fg));
     }
   } else {
-    JXL_ABORT("Unreachable");
+    JXL_UNREACHABLE("new PatchBlendMode?");
   }
   for (size_t i = 0; i < 3 + num_ec; i++) {
     if (xsize != 0) memcpy(out[i] + x0, tmp.Row(i), xsize * sizeof(**out));

--- a/lib/jxl/butteraugli/butteraugli.cc
+++ b/lib/jxl/butteraugli/butteraugli.cc
@@ -1758,6 +1758,83 @@ double ButteraugliScoreFromDiffmap(const ImageF& diffmap,
   return retval;
 }
 
+bool ButteraugliDiffmap(const Image3F& rgb0, const Image3F& rgb1,
+                        double hf_asymmetry, double xmul, ImageF& diffmap) {
+  ButteraugliParams params;
+  params.hf_asymmetry = hf_asymmetry;
+  params.xmul = xmul;
+  return ButteraugliDiffmap(rgb0, rgb1, params, diffmap);
+}
+
+bool ButteraugliDiffmap(const Image3F& rgb0, const Image3F& rgb1,
+                        const ButteraugliParams& params, ImageF& diffmap) {
+  const size_t xsize = rgb0.xsize();
+  const size_t ysize = rgb0.ysize();
+  if (xsize < 1 || ysize < 1) {
+    return JXL_FAILURE("Zero-sized image");
+  }
+  if (!SameSize(rgb0, rgb1)) {
+    return JXL_FAILURE("Size mismatch");
+  }
+  static const int kMax = 8;
+  if (xsize < kMax || ysize < kMax) {
+    // Butteraugli values for small (where xsize or ysize is smaller
+    // than 8 pixels) images are non-sensical, but most likely it is
+    // less disruptive to try to compute something than just give up.
+    // Temporarily extend the borders of the image to fit 8 x 8 size.
+    size_t xborder = xsize < kMax ? (kMax - xsize) / 2 : 0;
+    size_t yborder = ysize < kMax ? (kMax - ysize) / 2 : 0;
+    size_t xscaled = std::max<size_t>(kMax, xsize);
+    size_t yscaled = std::max<size_t>(kMax, ysize);
+    Image3F scaled0(xscaled, yscaled);
+    Image3F scaled1(xscaled, yscaled);
+    for (int i = 0; i < 3; ++i) {
+      for (size_t y = 0; y < yscaled; ++y) {
+        for (size_t x = 0; x < xscaled; ++x) {
+          size_t x2 =
+              std::min<size_t>(xsize - 1, x > xborder ? x - xborder : 0);
+          size_t y2 =
+              std::min<size_t>(ysize - 1, y > yborder ? y - yborder : 0);
+          scaled0.PlaneRow(i, y)[x] = rgb0.PlaneRow(i, y2)[x2];
+          scaled1.PlaneRow(i, y)[x] = rgb1.PlaneRow(i, y2)[x2];
+        }
+      }
+    }
+    ImageF diffmap_scaled;
+    const bool ok =
+        ButteraugliDiffmap(scaled0, scaled1, params, diffmap_scaled);
+    diffmap = ImageF(xsize, ysize);
+    for (size_t y = 0; y < ysize; ++y) {
+      for (size_t x = 0; x < xsize; ++x) {
+        diffmap.Row(y)[x] = diffmap_scaled.Row(y + yborder)[x + xborder];
+      }
+    }
+    return ok;
+  }
+  ButteraugliComparator butteraugli(rgb0, params);
+  butteraugli.Diffmap(rgb1, diffmap);
+  return true;
+}
+
+bool ButteraugliInterface(const Image3F& rgb0, const Image3F& rgb1,
+                          float hf_asymmetry, float xmul, ImageF& diffmap,
+                          double& diffvalue) {
+  ButteraugliParams params;
+  params.hf_asymmetry = hf_asymmetry;
+  params.xmul = xmul;
+  return ButteraugliInterface(rgb0, rgb1, params, diffmap, diffvalue);
+}
+
+bool ButteraugliInterface(const Image3F& rgb0, const Image3F& rgb1,
+                          const ButteraugliParams& params, ImageF& diffmap,
+                          double& diffvalue) {
+  if (!ButteraugliDiffmap(rgb0, rgb1, params, diffmap)) {
+    return false;
+  }
+  diffvalue = ButteraugliScoreFromDiffmap(diffmap, &params);
+  return true;
+}
+
 double ButteraugliFuzzyClass(double score) {
   static const double fuzzy_width_up = 4.8;
   static const double fuzzy_width_down = 4.8;

--- a/lib/jxl/butteraugli/butteraugli.h
+++ b/lib/jxl/butteraugli/butteraugli.h
@@ -43,49 +43,6 @@ struct ButteraugliParams {
   float intensity_target = 80.0f;
 };
 
-// ButteraugliInterface defines the public interface for butteraugli.
-//
-// It calculates the difference between rgb0 and rgb1.
-//
-// rgb0 and rgb1 contain the images. rgb0[c][px] and rgb1[c][px] contains
-// the red image for c == 0, green for c == 1, blue for c == 2. Location index
-// px is calculated as y * xsize + x.
-//
-// Value of pixels of images rgb0 and rgb1 need to be represented as raw
-// intensity. Most image formats store gamma corrected intensity in pixel
-// values. This gamma correction has to be removed, by applying the following
-// function to values in the 0-1 range:
-// butteraugli_val = pow(input_val, gamma);
-// A typical value of gamma is 2.2. It is usually stored in the image header.
-// Take care not to confuse that value with its inverse. The gamma value should
-// be always greater than one.
-// Butteraugli does not work as intended if the caller does not perform
-// gamma correction.
-//
-// hf_asymmetry is a multiplier for penalizing new HF artifacts more than
-// blurring away features (1.0 -> neutral).
-//
-// diffmap will contain an image of the size xsize * ysize, containing
-// localized differences for values px (indexed with the px the same as rgb0
-// and rgb1). diffvalue will give a global score of similarity.
-//
-// A diffvalue smaller than kButteraugliGood indicates that images can be
-// observed as the same image.
-// diffvalue larger than kButteraugliBad indicates that a difference between
-// the images can be observed.
-// A diffvalue between kButteraugliGood and kButteraugliBad indicates that
-// a subtle difference can be observed between the images.
-//
-// Returns true on success.
-bool ButteraugliInterface(const Image3F &rgb0, const Image3F &rgb1,
-                          const ButteraugliParams &params, ImageF &diffmap,
-                          double &diffvalue);
-
-// Deprecated (calls the previous function)
-bool ButteraugliInterface(const Image3F &rgb0, const Image3F &rgb1,
-                          float hf_asymmetry, float xmul, ImageF &diffmap,
-                          double &diffvalue);
-
 // Converts the butteraugli score into fuzzy class values that are continuous
 // at the class boundary. The class boundary location is based on human
 // raters, but the slope is arbitrary. Particularly, it does not reflect
@@ -189,13 +146,6 @@ class ButteraugliComparator {
   mutable BlurTemp blur_temp_;
   std::unique_ptr<ButteraugliComparator> sub_;
 };
-
-// Deprecated.
-bool ButteraugliDiffmap(const Image3F &rgb0, const Image3F &rgb1,
-                        double hf_asymmetry, double xmul, ImageF &diffmap);
-
-bool ButteraugliDiffmap(const Image3F &rgb0, const Image3F &rgb1,
-                        const ButteraugliParams &params, ImageF &diffmap);
 
 double ButteraugliScoreFromDiffmap(const ImageF &diffmap,
                                    const ButteraugliParams *params = nullptr);

--- a/lib/jxl/butteraugli/butteraugli.h
+++ b/lib/jxl/butteraugli/butteraugli.h
@@ -43,6 +43,49 @@ struct ButteraugliParams {
   float intensity_target = 80.0f;
 };
 
+// ButteraugliInterface defines the public interface for butteraugli.
+//
+// It calculates the difference between rgb0 and rgb1.
+//
+// rgb0 and rgb1 contain the images. rgb0[c][px] and rgb1[c][px] contains
+// the red image for c == 0, green for c == 1, blue for c == 2. Location index
+// px is calculated as y * xsize + x.
+//
+// Value of pixels of images rgb0 and rgb1 need to be represented as raw
+// intensity. Most image formats store gamma corrected intensity in pixel
+// values. This gamma correction has to be removed, by applying the following
+// function to values in the 0-1 range:
+// butteraugli_val = pow(input_val, gamma);
+// A typical value of gamma is 2.2. It is usually stored in the image header.
+// Take care not to confuse that value with its inverse. The gamma value should
+// be always greater than one.
+// Butteraugli does not work as intended if the caller does not perform
+// gamma correction.
+//
+// hf_asymmetry is a multiplier for penalizing new HF artifacts more than
+// blurring away features (1.0 -> neutral).
+//
+// diffmap will contain an image of the size xsize * ysize, containing
+// localized differences for values px (indexed with the px the same as rgb0
+// and rgb1). diffvalue will give a global score of similarity.
+//
+// A diffvalue smaller than kButteraugliGood indicates that images can be
+// observed as the same image.
+// diffvalue larger than kButteraugliBad indicates that a difference between
+// the images can be observed.
+// A diffvalue between kButteraugliGood and kButteraugliBad indicates that
+// a subtle difference can be observed between the images.
+//
+// Returns true on success.
+bool ButteraugliInterface(const Image3F &rgb0, const Image3F &rgb1,
+                          const ButteraugliParams &params, ImageF &diffmap,
+                          double &diffvalue);
+
+// Deprecated (calls the previous function)
+bool ButteraugliInterface(const Image3F &rgb0, const Image3F &rgb1,
+                          float hf_asymmetry, float xmul, ImageF &diffmap,
+                          double &diffvalue);
+
 // Converts the butteraugli score into fuzzy class values that are continuous
 // at the class boundary. The class boundary location is based on human
 // raters, but the slope is arbitrary. Particularly, it does not reflect
@@ -146,6 +189,13 @@ class ButteraugliComparator {
   mutable BlurTemp blur_temp_;
   std::unique_ptr<ButteraugliComparator> sub_;
 };
+
+// Deprecated.
+bool ButteraugliDiffmap(const Image3F &rgb0, const Image3F &rgb1,
+                        double hf_asymmetry, double xmul, ImageF &diffmap);
+
+bool ButteraugliDiffmap(const Image3F &rgb0, const Image3F &rgb1,
+                        const ButteraugliParams &params, ImageF &diffmap);
 
 double ButteraugliScoreFromDiffmap(const ImageF &diffmap,
                                    const ButteraugliParams *params = nullptr);

--- a/lib/jxl/color_encoding_internal.cc
+++ b/lib/jxl/color_encoding_internal.cc
@@ -35,7 +35,7 @@ std::string ToString(ColorSpace color_space) {
       return "CS?";
   }
   // Should not happen - visitor fails if enum is invalid.
-  JXL_ABORT("Invalid ColorSpace %u", static_cast<uint32_t>(color_space));
+  JXL_UNREACHABLE("Invalid ColorSpace %u", static_cast<uint32_t>(color_space));
 }
 
 std::string ToString(WhitePoint white_point) {
@@ -50,7 +50,7 @@ std::string ToString(WhitePoint white_point) {
       return "DCI";
   }
   // Should not happen - visitor fails if enum is invalid.
-  JXL_ABORT("Invalid WhitePoint %u", static_cast<uint32_t>(white_point));
+  JXL_UNREACHABLE("Invalid WhitePoint %u", static_cast<uint32_t>(white_point));
 }
 
 std::string ToString(Primaries primaries) {
@@ -65,7 +65,7 @@ std::string ToString(Primaries primaries) {
       return "Cst";
   }
   // Should not happen - visitor fails if enum is invalid.
-  JXL_ABORT("Invalid Primaries %u", static_cast<uint32_t>(primaries));
+  JXL_UNREACHABLE("Invalid Primaries %u", static_cast<uint32_t>(primaries));
 }
 
 std::string ToString(TransferFunction transfer_function) {
@@ -86,8 +86,8 @@ std::string ToString(TransferFunction transfer_function) {
       return "TF?";
   }
   // Should not happen - visitor fails if enum is invalid.
-  JXL_ABORT("Invalid TransferFunction %u",
-            static_cast<uint32_t>(transfer_function));
+  JXL_UNREACHABLE("Invalid TransferFunction %u",
+                  static_cast<uint32_t>(transfer_function));
 }
 
 std::string ToString(RenderingIntent rendering_intent) {
@@ -102,8 +102,8 @@ std::string ToString(RenderingIntent rendering_intent) {
       return "Abs";
   }
   // Should not happen - visitor fails if enum is invalid.
-  JXL_ABORT("Invalid RenderingIntent %u",
-            static_cast<uint32_t>(rendering_intent));
+  JXL_UNREACHABLE("Invalid RenderingIntent %u",
+                  static_cast<uint32_t>(rendering_intent));
 }
 
 static double F64FromCustomxyI32(const int32_t i) { return i * 1E-6; }
@@ -314,7 +314,7 @@ CIExy ColorEncoding::GetWhitePoint() const {
       xy.x = xy.y = 1.0 / 3;
       return xy;
   }
-  JXL_ABORT("Invalid WhitePoint %u", static_cast<uint32_t>(white_point));
+  JXL_UNREACHABLE("Invalid WhitePoint %u", static_cast<uint32_t>(white_point));
 }
 
 Status ColorEncoding::SetWhitePoint(const CIExy& xy) {
@@ -376,7 +376,7 @@ PrimariesCIExy ColorEncoding::GetPrimaries() const {
       xy.b.y = 0.060;
       return xy;
   }
-  JXL_ABORT("Invalid Primaries %u", static_cast<uint32_t>(primaries));
+  JXL_UNREACHABLE("Invalid Primaries %u", static_cast<uint32_t>(primaries));
 }
 
 Status ColorEncoding::SetPrimaries(const PrimariesCIExy& xy) {

--- a/lib/jxl/color_management.cc
+++ b/lib/jxl/color_management.cc
@@ -828,8 +828,8 @@ Status MaybeCreateProfile(const ColorEncoding& c,
               CreateICCCurvParaTag({2.6, 1.0, 0.0, 1.0, 0.0}, 3, &tags));
           break;
         default:
-          JXL_ABORT("Unknown TF %u",
-                    static_cast<unsigned int>(c.tf.GetTransferFunction()));
+          JXL_UNREACHABLE("Unknown TF %u", static_cast<unsigned int>(
+                                               c.tf.GetTransferFunction()));
       }
     }
     FinalizeICCTag(&tags, &tag_offset, &tag_size);

--- a/lib/jxl/dec_transforms-inl.h
+++ b/lib/jxl/dec_transforms-inl.h
@@ -685,7 +685,7 @@ HWY_MAYBE_UNUSED void TransformToPixels(const AcStrategy::Type strategy,
       break;
     }
     case Type::kNumValidStrategies:
-      JXL_ABORT("Invalid strategy");
+      JXL_UNREACHABLE("Invalid strategy");
   }
 }
 
@@ -813,7 +813,7 @@ HWY_MAYBE_UNUSED void LowestFrequenciesFromDC(const AcStrategy::Type strategy,
       llf[0] = dc[0];
       break;
     case Type::kNumValidStrategies:
-      JXL_ABORT("Invalid strategy");
+      JXL_UNREACHABLE("Invalid strategy");
   };
 }
 

--- a/lib/jxl/dec_xyb-inl.h
+++ b/lib/jxl/dec_xyb-inl.h
@@ -333,7 +333,7 @@ static inline HWY_MAYBE_UNUSED void FastXYBTosRGB8(const float* input[4],
   (void)output;
   (void)is_rgba;
   (void)xsize;
-  JXL_ABORT("Unreachable");
+  JXL_UNREACHABLE("Unreachable");
 #endif
 }
 

--- a/lib/jxl/decode_to_jpeg.cc
+++ b/lib/jxl/decode_to_jpeg.cc
@@ -12,7 +12,7 @@ namespace jxl {
 JxlDecoderStatus JxlToJpegDecoder::Process(const uint8_t** next_in,
                                            size_t* avail_in) {
   if (!inside_box_) {
-    JXL_ABORT(
+    JXL_UNREACHABLE(
         "processing of JPEG reconstruction data outside JPEG reconstruction "
         "box");
   }
@@ -38,7 +38,7 @@ JxlDecoderStatus JxlToJpegDecoder::Process(const uint8_t** next_in,
     to_decode = Span<const uint8_t>(buffer_.data(), buffer_.size());
   }
   if (!box_until_eof_ && to_decode.size() > box_size_) {
-    JXL_ABORT("JPEG reconstruction data to decode larger than expected");
+    JXL_UNREACHABLE("JPEG reconstruction data to decode larger than expected");
   }
   if (box_until_eof_ || to_decode.size() == box_size_) {
     // If undefined size, or the right size, try to decode.

--- a/lib/jxl/enc_adaptive_quantization.cc
+++ b/lib/jxl/enc_adaptive_quantization.cc
@@ -46,6 +46,12 @@
 #include "lib/jxl/image_ops.h"
 #include "lib/jxl/opsin_params.h"
 #include "lib/jxl/quant_weights.h"
+
+// Set JXL_DEBUG_ADAPTIVE_QUANTIZATION to 1 to enable debugging.
+#ifndef JXL_DEBUG_ADAPTIVE_QUANTIZATION
+#define JXL_DEBUG_ADAPTIVE_QUANTIZATION 0
+#endif
+
 HWY_BEFORE_NAMESPACE();
 namespace jxl {
 namespace HWY_NAMESPACE {
@@ -623,9 +629,8 @@ namespace jxl {
 HWY_EXPORT(AdaptiveQuantizationMap);
 
 namespace {
-// If true, prints the quantization maps at each iteration.
-bool FLAGS_dump_quant_state = false;
 
+#if JXL_DEBUG_ADAPTIVE_QUANTIZATION
 void DumpHeatmap(const AuxOut* aux_out, const std::string& label,
                  const ImageF& image, float good_threshold,
                  float bad_threshold) {
@@ -656,6 +661,7 @@ void DumpHeatmaps(const AuxOut* aux_out, float ba_target,
   DumpHeatmap(aux_out, "bt_diffmap", bt_diffmap, ButteraugliFuzzyInverse(1.5),
               ButteraugliFuzzyInverse(0.5));
 }
+#endif
 
 ImageF TileDistMap(const ImageF& distmap, int tile_size, int margin,
                    const AcStrategyImage& ac_strategy) {
@@ -877,15 +883,15 @@ void FindBestQuantization(const ImageBundle& linear, const Image3F& opsin,
     iters = 2;
   }
   for (int i = 0; i < iters + 1; ++i) {
-    if (FLAGS_dump_quant_state) {
-      printf("\nQuantization field:\n");
-      for (size_t y = 0; y < quant_field.ysize(); ++y) {
-        for (size_t x = 0; x < quant_field.xsize(); ++x) {
-          printf(" %.5f", quant_field.Row(y)[x]);
-        }
-        printf("\n");
+#if JXL_DEBUG_ADAPTIVE_QUANTIZATION
+    printf("\nQuantization field:\n");
+    for (size_t y = 0; y < quant_field.ysize(); ++y) {
+      for (size_t x = 0; x < quant_field.xsize(); ++x) {
+        printf(" %.5f", quant_field.Row(y)[x]);
       }
+      printf("\n");
     }
+#endif
     quantizer.SetQuantField(initial_quant_dc, quant_field, &raw_quant_field);
     ImageBundle dec_linear = RoundtripImage(opsin, enc_state, cms, pool);
     float score;
@@ -897,24 +903,26 @@ void FindBestQuantization(const ImageBundle& linear, const Image3F& opsin,
     }
     tile_distmap = TileDistMap(diffmap, 8 * cparams.resampling, 0,
                                enc_state->shared.ac_strategy);
+#if JXL_DEBUG_ADAPTIVE_QUANTIZATION
     if (WantDebugOutput(aux_out)) {
       aux_out->DumpImage(("dec" + ToString(i)).c_str(), *dec_linear.color());
       DumpHeatmaps(aux_out, butteraugli_target, quant_field, tile_distmap,
                    diffmap);
     }
+#endif
     if (aux_out != nullptr) ++aux_out->num_butteraugli_iters;
-    if (cparams.log_search_state) {
-      float minval, maxval;
-      ImageMinMax(quant_field, &minval, &maxval);
-      printf("\nButteraugli iter: %d/%d\n", i, cparams.max_butteraugli_iters);
-      printf("Butteraugli distance: %f  (target = %f)\n", score,
-             original_butteraugli);
-      printf("quant range: %f ... %f  DC quant: %f\n", minval, maxval,
-             initial_quant_dc);
-      if (FLAGS_dump_quant_state) {
-        quantizer.DumpQuantizationMap(raw_quant_field);
-      }
+#if JXL_DEBUG_ADAPTIVE_QUANTIZATION
+    float minval, maxval;
+    ImageMinMax(quant_field, &minval, &maxval);
+    printf("\nButteraugli iter: %d/%d\n", i, cparams.max_butteraugli_iters);
+    printf("Butteraugli distance: %f  (target = %f)\n", score,
+           original_butteraugli);
+    printf("quant range: %f ... %f  DC quant: %f\n", minval, maxval,
+           initial_quant_dc);
+    if (FLAGS_dump_quant_state) {
+      quantizer.DumpQuantizationMap(raw_quant_field);
     }
+#endif
 
     if (i == iters) break;
 
@@ -1018,14 +1026,17 @@ void FindBestQuantizationMaxError(const Image3F& opsin,
 
   for (int i = 0; i < cparams.max_butteraugli_iters + 1; ++i) {
     quantizer.SetQuantField(initial_quant_dc, quant_field, &raw_quant_field);
+#if JXL_DEBUG_ADAPTIVE_QUANTIZATION
     if (aux_out) {
       aux_out->DumpXybImage(("ops" + ToString(i)).c_str(), opsin);
     }
+#endif
     ImageBundle decoded = RoundtripImage(opsin, enc_state, cms, pool);
+#if JXL_DEBUG_ADAPTIVE_QUANTIZATION
     if (aux_out) {
       aux_out->DumpXybImage(("dec" + ToString(i)).c_str(), *decoded.color());
     }
-
+#endif
     for (size_t by = 0; by < enc_state->shared.frame_dim.ysize_blocks; by++) {
       AcStrategyRow ac_strategy_row =
           enc_state->shared.ac_strategy.ConstRow(by);

--- a/lib/jxl/enc_ans.cc
+++ b/lib/jxl/enc_ans.cc
@@ -1463,7 +1463,7 @@ void ApplyLZ77(const HistogramParams& params, size_t num_contexts,
   } else if (params.lz77_method == HistogramParams::LZ77Method::kOptimal) {
     ApplyLZ77_Optimal(params, num_contexts, tokens, lz77, tokens_lz77);
   } else {
-    JXL_ABORT("Not implemented");
+    JXL_UNREACHABLE("Not implemented");
   }
 }
 }  // namespace

--- a/lib/jxl/enc_aux_out.cc
+++ b/lib/jxl/enc_aux_out.cc
@@ -55,11 +55,12 @@ const char* LayerName(size_t layer) {
     case kLayerModularAcGroup:
       return "ModularAcGroup";
     default:
-      JXL_ABORT("Invalid layer %d\n", static_cast<int>(layer));
+      JXL_UNREACHABLE("Invalid layer %d\n", static_cast<int>(layer));
   }
 }
 
 void AuxOut::LayerTotals::Print(size_t num_inputs) const {
+#if JXL_DEBUG_V_LEVEL > 0
   printf("%10" PRId64, static_cast<int64_t>(total_bits));
   if (histogram_bits != 0) {
     printf("   [c/i:%6.2f | hst:%8" PRId64 " | ex:%8" PRId64 " | h+c+e:%12.3f",
@@ -70,6 +71,7 @@ void AuxOut::LayerTotals::Print(size_t num_inputs) const {
     printf("]");
   }
   printf("\n");
+#endif
 }
 
 void AuxOut::Assimilate(const AuxOut& victim) {
@@ -100,6 +102,7 @@ void AuxOut::Assimilate(const AuxOut& victim) {
 }
 
 void AuxOut::Print(size_t num_inputs) const {
+#if JXL_DEBUG_V_LEVEL > 0
   if (num_inputs == 0) return;
 
   LayerTotals all_layers;
@@ -147,6 +150,7 @@ void AuxOut::Print(size_t num_inputs) const {
            total_blocks, total_positions,
            100.0 * total_blocks / total_positions);
   }
+#endif
 }
 
 template <typename T>

--- a/lib/jxl/enc_aux_out.cc
+++ b/lib/jxl/enc_aux_out.cc
@@ -60,18 +60,19 @@ const char* LayerName(size_t layer) {
 }
 
 void AuxOut::LayerTotals::Print(size_t num_inputs) const {
-#if JXL_DEBUG_V_LEVEL > 0
-  printf("%10" PRId64, static_cast<int64_t>(total_bits));
-  if (histogram_bits != 0) {
-    printf("   [c/i:%6.2f | hst:%8" PRId64 " | ex:%8" PRId64 " | h+c+e:%12.3f",
-           num_clustered_histograms * 1.0 / num_inputs,
-           static_cast<int64_t>(histogram_bits >> 3),
-           static_cast<int64_t>(extra_bits >> 3),
-           (histogram_bits + clustered_entropy + extra_bits) / 8.0);
-    printf("]");
+  if (JXL_DEBUG_V_LEVEL > 0) {
+    printf("%10" PRId64, static_cast<int64_t>(total_bits));
+    if (histogram_bits != 0) {
+      printf("   [c/i:%6.2f | hst:%8" PRId64 " | ex:%8" PRId64
+             " | h+c+e:%12.3f",
+             num_clustered_histograms * 1.0 / num_inputs,
+             static_cast<int64_t>(histogram_bits >> 3),
+             static_cast<int64_t>(extra_bits >> 3),
+             (histogram_bits + clustered_entropy + extra_bits) / 8.0);
+      printf("]");
+    }
+    printf("\n");
   }
-  printf("\n");
-#endif
 }
 
 void AuxOut::Assimilate(const AuxOut& victim) {
@@ -102,55 +103,55 @@ void AuxOut::Assimilate(const AuxOut& victim) {
 }
 
 void AuxOut::Print(size_t num_inputs) const {
-#if JXL_DEBUG_V_LEVEL > 0
-  if (num_inputs == 0) return;
+  if (JXL_DEBUG_V_LEVEL > 0) {
+    if (num_inputs == 0) return;
 
-  LayerTotals all_layers;
-  for (size_t i = 0; i < layers.size(); ++i) {
-    all_layers.Assimilate(layers[i]);
-  }
+    LayerTotals all_layers;
+    for (size_t i = 0; i < layers.size(); ++i) {
+      all_layers.Assimilate(layers[i]);
+    }
 
-  printf("Average butteraugli iters: %10.2f\n",
-         num_butteraugli_iters * 1.0 / num_inputs);
-  if (min_quant_rescale != 1.0 || max_quant_rescale != 1.0) {
-    printf("quant rescale range: %f .. %f\n", min_quant_rescale,
-           max_quant_rescale);
-    printf("bitrate error range: %.3f%% .. %.3f%%\n",
-           100.0f * min_bitrate_error, 100.0f * max_bitrate_error);
-  }
+    printf("Average butteraugli iters: %10.2f\n",
+           num_butteraugli_iters * 1.0 / num_inputs);
+    if (min_quant_rescale != 1.0 || max_quant_rescale != 1.0) {
+      printf("quant rescale range: %f .. %f\n", min_quant_rescale,
+             max_quant_rescale);
+      printf("bitrate error range: %.3f%% .. %.3f%%\n",
+             100.0f * min_bitrate_error, 100.0f * max_bitrate_error);
+    }
 
-  for (size_t i = 0; i < layers.size(); ++i) {
-    if (layers[i].total_bits != 0) {
-      printf("Total layer bits %-10s\t", LayerName(i));
-      printf("%10f%%", 100.0 * layers[i].total_bits / all_layers.total_bits);
-      layers[i].Print(num_inputs);
+    for (size_t i = 0; i < layers.size(); ++i) {
+      if (layers[i].total_bits != 0) {
+        printf("Total layer bits %-10s\t", LayerName(i));
+        printf("%10f%%", 100.0 * layers[i].total_bits / all_layers.total_bits);
+        layers[i].Print(num_inputs);
+      }
+    }
+    printf("Total image size           ");
+    all_layers.Print(num_inputs);
+
+    const uint32_t dc_pred_total =
+        std::accumulate(dc_pred_usage.begin(), dc_pred_usage.end(), 0u);
+    const uint32_t dc_pred_total_xb =
+        std::accumulate(dc_pred_usage_xb.begin(), dc_pred_usage_xb.end(), 0u);
+    if (dc_pred_total + dc_pred_total_xb != 0) {
+      printf("\nDC pred     Y                XB:\n");
+      for (size_t i = 0; i < dc_pred_usage.size(); ++i) {
+        printf("  %6u (%5.2f%%)    %6u (%5.2f%%)\n", dc_pred_usage[i],
+               100.0 * dc_pred_usage[i] / dc_pred_total, dc_pred_usage_xb[i],
+               100.0 * dc_pred_usage_xb[i] / dc_pred_total_xb);
+      }
+    }
+
+    size_t total_blocks = 0;
+    size_t total_positions = 0;
+    if (total_blocks != 0 && total_positions != 0) {
+      printf("\n\t\t  Blocks\t\tPositions\t\t\tBlocks/Position\n");
+      printf(" Total:\t\t    %7" PRIuS "\t\t     %7" PRIuS " \t\t\t%10f%%\n\n",
+             total_blocks, total_positions,
+             100.0 * total_blocks / total_positions);
     }
   }
-  printf("Total image size           ");
-  all_layers.Print(num_inputs);
-
-  const uint32_t dc_pred_total =
-      std::accumulate(dc_pred_usage.begin(), dc_pred_usage.end(), 0u);
-  const uint32_t dc_pred_total_xb =
-      std::accumulate(dc_pred_usage_xb.begin(), dc_pred_usage_xb.end(), 0u);
-  if (dc_pred_total + dc_pred_total_xb != 0) {
-    printf("\nDC pred     Y                XB:\n");
-    for (size_t i = 0; i < dc_pred_usage.size(); ++i) {
-      printf("  %6u (%5.2f%%)    %6u (%5.2f%%)\n", dc_pred_usage[i],
-             100.0 * dc_pred_usage[i] / dc_pred_total, dc_pred_usage_xb[i],
-             100.0 * dc_pred_usage_xb[i] / dc_pred_total_xb);
-    }
-  }
-
-  size_t total_blocks = 0;
-  size_t total_positions = 0;
-  if (total_blocks != 0 && total_positions != 0) {
-    printf("\n\t\t  Blocks\t\tPositions\t\t\tBlocks/Position\n");
-    printf(" Total:\t\t    %7" PRIuS "\t\t     %7" PRIuS " \t\t\t%10f%%\n\n",
-           total_blocks, total_positions,
-           100.0 * total_blocks / total_positions);
-  }
-#endif
 }
 
 template <typename T>

--- a/lib/jxl/enc_bit_writer.cc
+++ b/lib/jxl/enc_bit_writer.cc
@@ -28,7 +28,7 @@ BitWriter::Allotment::Allotment(BitWriter* JXL_RESTRICT writer, size_t max_bits)
 BitWriter::Allotment::~Allotment() {
   if (!called_) {
     // Not calling is a bug - unused storage will not be reclaimed.
-    JXL_ABORT("Did not call Allotment::ReclaimUnused");
+    JXL_UNREACHABLE("Did not call Allotment::ReclaimUnused");
   }
 }
 

--- a/lib/jxl/enc_modular.cc
+++ b/lib/jxl/enc_modular.cc
@@ -178,7 +178,7 @@ Tree PredefinedTree(ModularOptions::TreeKind tree_kind, size_t total_pixels) {
     return MakeFixedTree(kGradientProp, cutoffs, Predictor::Gradient,
                          total_pixels);
   }
-  JXL_ABORT("Unreachable");
+  JXL_UNREACHABLE("Unreachable");
   return {};
 }
 

--- a/lib/jxl/enc_params.h
+++ b/lib/jxl/enc_params.h
@@ -124,7 +124,6 @@ struct CompressParams {
 
   // Prints extra information during/after encoding.
   bool verbose = false;
-  bool log_search_state = false;
 
   ButteraugliParams ba_params;
 

--- a/lib/jxl/enc_patch_dictionary.cc
+++ b/lib/jxl/enc_patch_dictionary.cc
@@ -157,7 +157,8 @@ void PatchDictionaryEncoder::SubtractFrom(const PatchDictionary& pdic,
           } else if (mode == PatchBlendMode::kNone) {
             // Nothing to do.
           } else {
-            JXL_ABORT("Blending mode %u not yet implemented", (uint32_t)mode);
+            JXL_UNREACHABLE("Blending mode %u not yet implemented",
+                            (uint32_t)mode);
           }
         }
       }

--- a/lib/jxl/enc_transforms-inl.h
+++ b/lib/jxl/enc_transforms-inl.h
@@ -657,7 +657,7 @@ HWY_MAYBE_UNUSED void TransformFromPixels(const AcStrategy::Type strategy,
       break;
     }
     case Type::kNumValidStrategies:
-      JXL_ABORT("Invalid strategy");
+      JXL_UNREACHABLE("Invalid strategy");
   }
 }
 
@@ -787,7 +787,7 @@ HWY_MAYBE_UNUSED void DCFromLowestFrequencies(const AcStrategy::Type strategy,
       dc[0] = block[0];
       break;
     case Type::kNumValidStrategies:
-      JXL_ABORT("Invalid strategy");
+      JXL_UNREACHABLE("Invalid strategy");
   }
 }
 

--- a/lib/jxl/fields.cc
+++ b/lib/jxl/fields.cc
@@ -411,19 +411,19 @@ class CanEncodeVisitor : public VisitorBase {
 void Bundle::Init(Fields* fields) {
   InitVisitor visitor;
   if (!visitor.Visit(fields)) {
-    JXL_ABORT("Init should never fail");
+    JXL_UNREACHABLE("Init should never fail");
   }
 }
 void Bundle::SetDefault(Fields* fields) {
   SetDefaultVisitor visitor;
   if (!visitor.Visit(fields)) {
-    JXL_ABORT("SetDefault should never fail");
+    JXL_UNREACHABLE("SetDefault should never fail");
   }
 }
 bool Bundle::AllDefault(const Fields& fields) {
   AllDefaultVisitor visitor;
   if (!visitor.VisitConst(fields)) {
-    JXL_ABORT("AllDefault should never fail");
+    JXL_UNREACHABLE("AllDefault should never fail");
   }
   return visitor.AllDefault();
 }

--- a/lib/jxl/image_bundle.cc
+++ b/lib/jxl/image_bundle.cc
@@ -38,8 +38,9 @@ void ImageBundle::VerifyMetadata() const {
   JXL_CHECK(metadata_->color_encoding.IsGray() == IsGray());
 
   if (metadata_->HasAlpha() && alpha().xsize() == 0) {
-    JXL_ABORT("MD alpha_bits %u IB alpha %" PRIuS " x %" PRIuS "\n",
-              metadata_->GetAlphaBits(), alpha().xsize(), alpha().ysize());
+    JXL_UNREACHABLE("MD alpha_bits %u IB alpha %" PRIuS " x %" PRIuS "\n",
+                    metadata_->GetAlphaBits(), alpha().xsize(),
+                    alpha().ysize());
   }
   const uint32_t alpha_bits = metadata_->GetAlphaBits();
   JXL_CHECK(alpha_bits <= 32);

--- a/lib/jxl/jpeg/jpeg_data.h
+++ b/lib/jxl/jpeg/jpeg_data.h
@@ -173,7 +173,7 @@ struct JPEGData : public Fields {
   Status VisitFields(Visitor* visitor) override;
 #else
   Status VisitFields(Visitor* /* visitor */) override {
-    JXL_ABORT("JPEG transcoding support not enabled");
+    JXL_UNREACHABLE("JPEG transcoding support not enabled");
   }
 #endif  // JPEGXL_ENABLE_TRANSCODE_JPEG
 
@@ -206,7 +206,7 @@ Status SetJPEGDataFromICC(const PaddedBytes& icc, jpeg::JPEGData* jpeg_data);
 #else
 static JXL_INLINE Status SetJPEGDataFromICC(const PaddedBytes& /* icc */,
                                             jpeg::JPEGData* /* jpeg_data */) {
-  JXL_ABORT("JPEG transcoding support not enabled");
+  JXL_UNREACHABLE("JPEG transcoding support not enabled");
 }
 #endif  // JPEGXL_ENABLE_TRANSCODE_JPEG
 

--- a/lib/jxl/render_pipeline/low_memory_render_pipeline.cc
+++ b/lib/jxl/render_pipeline/low_memory_render_pipeline.cc
@@ -294,7 +294,7 @@ void LowMemoryRenderPipeline::Init() {
   }
   for (size_t i = first_image_dim_stage_; i < stages_.size(); i++) {
     if (stages_[i]->SwitchToImageDimensions()) {
-      JXL_ABORT("Cannot switch to image dimensions multiple times");
+      JXL_UNREACHABLE("Cannot switch to image dimensions multiple times");
     }
     std::vector<std::pair<size_t, size_t>> input_sizes(shifts.size());
     for (size_t c = 0; c < shifts.size(); c++) {

--- a/lib/jxl/render_pipeline/stage_blending.cc
+++ b/lib/jxl/render_pipeline/stage_blending.cc
@@ -102,7 +102,8 @@ class BlendingStage : public RenderPipelineStage {
           break;
         }
         default: {
-          JXL_ABORT("Invalid blend mode");  // should have failed to decode
+          JXL_UNREACHABLE(
+              "Invalid blend mode");  // should have failed to decode
         }
       }
     };

--- a/lib/jxl/render_pipeline/stage_epf.cc
+++ b/lib/jxl/render_pipeline/stage_epf.cc
@@ -516,7 +516,7 @@ std::unique_ptr<RenderPipelineStage> GetEPFStage(const LoopFilter& lf,
     case 2:
       return HWY_DYNAMIC_DISPATCH(GetEPFStage2)(lf, sigma);
     default:
-      JXL_ABORT("Invalid EPF stage");
+      JXL_UNREACHABLE("Invalid EPF stage");
   }
 }
 

--- a/lib/jxl/render_pipeline/stage_from_linear.cc
+++ b/lib/jxl/render_pipeline/stage_from_linear.cc
@@ -166,7 +166,7 @@ std::unique_ptr<RenderPipelineStage> GetFromLinearStage(
         MakePerChannelOp(OpGamma{output_encoding_info.inverse_gamma}));
   } else {
     // This is a programming error.
-    JXL_ABORT("Invalid target encoding");
+    JXL_UNREACHABLE("Invalid target encoding");
   }
 }
 

--- a/lib/jxl/render_pipeline/stage_upsampling.cc
+++ b/lib/jxl/render_pipeline/stage_upsampling.cc
@@ -99,7 +99,7 @@ class UpsamplingStage : public RenderPipelineStage {
                     [x % 8 < 4 ? x % 4 : 3 - x % 4][y % 8 < 4 ? iy : 4 - iy]
                     [x % 8 < 4 ? ix : 4 - ix];
     }
-    JXL_ABORT("Invalid upsample");
+    JXL_UNREACHABLE("Invalid upsample");
   }
 
   template <ssize_t N>

--- a/tools/benchmark/benchmark_codec_jxl.cc
+++ b/tools/benchmark/benchmark_codec_jxl.cc
@@ -76,7 +76,6 @@ struct JxlArgs {
   Override dots;
   Override patches;
 
-  bool log_search_state;
   std::string debug_image_dir;
 };
 
@@ -108,9 +107,6 @@ Status AddCommandLineOptionsJxlCodec(BenchmarkArgs* args) {
                     "Enable(1)/disable(0) dots generation.");
   args->AddOverride(&jxlargs->patches, "patches",
                     "Enable(1)/disable(0) patch dictionary.");
-
-  args->AddFlag(&jxlargs->log_search_state, "log_search_state",
-                "Print out debug info for tortoise mode AQ loop.", false);
 
   args->AddString(
       &jxlargs->debug_image_dir, "debug_image_dir",
@@ -320,8 +316,6 @@ class JxlCodec : public ImageCodec {
         cparams_.modular_mode && !has_ctransform_) {
       cparams_.color_transform = ColorTransform::kXYB;
     }
-
-    cparams_.log_search_state = jxlargs->log_search_state;
 
 #if JPEGXL_ENABLE_JPEG
     if (normalize_bitrate_ && cparams_.butteraugli_distance > 0.0f) {


### PR DESCRIPTION
Various cleanups all aimed at reducing the amount of unnecessary strings and debug code in libjxl.so:

1. JXL_ABORT() is often used in unreachable code paths that could only become reachable if the code would change (e.g. if the encoder would use a new blendmode for patches, or some programming error happened that caused a presumably unreachable path to become reachable). However, the compiler cannot know these are unreachable so even release builds still contain the code to print the abort message and to do the actual abort. This replaces these aborts with JXL_NOT_REACHABLE() which is a new macro that keeps the old behavior for debug builds (print message and abort), but in release builds it simply signals JXL_UNREACHABLE to inform the compiler that this is in fact an unreachable path.

2. Butteraugli had some code for generic convolutions that aren't actually used (and there was a printf warning). Replaced it with JXL_NOT_REACHABLE().

3. Removed deprecated dead code from `butteraugli.*`

4. Adaptive quantization debug stuff (dumping debug images and printf'ing stuff) ended up getting compiled in even in release builds. Putting it behind a compile flag `JXL_DEBUG_ADAPTIVE_QUANTIZATION`.

5. There are a bunch of printf strings in enc_aux_out that also end up in libjxl.so. Putting these behind `#if JXL_DEBUG_V_LEVEL > 0`.