### PR TITLE
disable SSSE3 and AVX512 in default builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -171,6 +171,10 @@ set(JPEGXL_FORCE_NEON false CACHE BOOL
     "Set flags to enable NEON in arm if not enabled by your toolchain.")
 set(JPEGXL_TEST_TOOLS false CACHE BOOL
     "Run scripts that test the encoding / decoding tools.")
+set(JPEGXL_ENABLE_AVX512 false CACHE BOOL
+    "Build with AVX512 support (faster on CPUs that support it, but larger binary size).")
+set(JPEGXL_ENABLE_AVX512_ZEN4 false CACHE BOOL
+    "Build with Zen4-optimized AVX512 support (faster on CPUs that support it, but larger binary size).")
 
 # Force system dependencies.
 set(JPEGXL_FORCE_SYSTEM_BROTLI false CACHE BOOL
@@ -205,6 +209,20 @@ endif()
 
 message(STATUS
     "Compiled IDs C:${CMAKE_C_COMPILER_ID}, C++:${CMAKE_CXX_COMPILER_ID}")
+
+# Always disable SSSE3 since it is rare to have SSSE3 but not SSE4
+set(HWY_DISABLED_TARGETS "HWY_SSSE3")
+if (NOT JPEGXL_ENABLE_AVX512)
+  message(STATUS "Disabled AVX512 (set JPEGXL_ENABLE_AVX512 to enable it)")
+  set(HWY_DISABLED_TARGETS "${HWY_DISABLED_TARGETS}|HWY_AVX3")
+  add_definitions(-DFJXL_ENABLE_AVX512=0)
+endif()
+if (NOT JPEGXL_ENABLE_AVX512_ZEN4)
+  message(STATUS "Disabled AVX512_ZEN4 (set JPEGXL_ENABLE_AVX512_ZEN4 to enable it)")
+  set(HWY_DISABLED_TARGETS "${HWY_DISABLED_TARGETS}|HWY_AVX3_ZEN4")
+endif()
+
+
 
 # CMAKE_EXPORT_COMPILE_COMMANDS is used to generate the compilation database
 # used by clang-tidy.
@@ -301,9 +319,10 @@ else ()
 
   # TODO(eustas): JXL currently compiles, but does not pass tests...
   if (NOT JXL_HWY_DISABLED_TARGETS_FORCED AND NOT JPEGXL_ENABLE_SIZELESS_VECTORS)
-    add_definitions(-DHWY_DISABLED_TARGETS=\(HWY_SVE|HWY_SVE2|HWY_SVE_256|HWY_SVE2_128|HWY_RVV\))
+    set(HWY_DISABLED_TARGETS "${HWY_DISABLED_TARGETS}|HWY_SVE|HWY_SVE2|HWY_SVE_256|HWY_SVE2_128|HWY_RVV")
     message("Warning: HWY_SVE, HWY_SVE2, HWY_SVE_256, HWY_SVE2_128 and HWY_RVV CPU targets are disabled")
   endif()
+  add_definitions(-DHWY_DISABLED_TARGETS=\(${HWY_DISABLED_TARGETS}\))
 
   # In CMake before 3.12 it is problematic to pass repeated flags like -Xclang.
   # For this reason we place them in CMAKE_CXX_FLAGS instead.


### PR DESCRIPTION
According to https://store.steampowered.com/hwsurvey/Steam-Hardware-Software-Survey-Welcome-to-Steam (see "Other Settings"), 99.18% of desktop hardware has SSE4 (and 100% has SSE2), so it is a bit unnecessary to have the highway target for SSSE3 enabled since it will only bring a small speedup to < 1% of people while the binary size bloat is for everyone.

Also in this survey we see 90% has AVX2 but less than 10% has AVX512. While of course AVX512 does give additional speedups over AVX2, the question is whether it is worth the binary size bloat (especially because there are two variants of this, the regular one and the Zen4 one). Also I'm assuming the steam survey will contain relatively more beefy gaming machines so it's likely an overestimate of the actual support for AVX512 in the consumer market. In the server market, AVX512 probably does have wider support, but imo we shouldn't aim our default build choices on that — these use cases can make optimized custom builds.

This PR disables the SSSE3, AVX512 and AVX512_ZEN4 targets by default. There are new cmake flags JPEGXL_ENABLE_AVX512 and JPEGXL_ENABLE_AVX512_ZEN4 to enable one or both of the AVX512 flavors, but it's opt-in now. For SSSE3, I didn't bother to add a cmake flag to keep it since the number of affected people is small and is only going to shrink even further.

So the 90% of people with AVX2 will get that, and of the remaining 10% who don't have AVX2, 90% has SSE4 and will get that, and the remaining 10% (1% of the total) will still get SSE2.

This makes the stripped x64 binary size of the default release build of `libjxl.so` (i.e. what will end up going into packages in linux distributions etc) go down from 4.26 MB to 2.83 MB (-33%).
