### PR TITLE
jxl-to-jxl conversion: don't use ICC if not needed

### DIFF
--- a/lib/extras/dec/jxl.cc
+++ b/lib/extras/dec/jxl.cc
@@ -347,9 +347,10 @@ bool DecodeImageJXL(const uint8_t* bytes, size_t bytes_size,
       }
       size_t icc_size = 0;
       JxlColorProfileTarget target = JXL_COLOR_PROFILE_TARGET_DATA;
+      ppf->color_encoding.color_space = JXL_COLOR_SPACE_UNKNOWN;
       if (JXL_DEC_SUCCESS != JxlDecoderGetColorAsEncodedProfile(
-                                 dec, target, &ppf->color_encoding)) {
-        ppf->color_encoding.color_space = JXL_COLOR_SPACE_UNKNOWN;
+                                 dec, target, &ppf->color_encoding) ||
+          dparams.need_icc) {
         // only get ICC if it is not an Enum color encoding
         if (JXL_DEC_SUCCESS !=
             JxlDecoderGetICCProfileSize(dec, target, &icc_size)) {

--- a/lib/extras/dec/jxl.cc
+++ b/lib/extras/dec/jxl.cc
@@ -347,21 +347,22 @@ bool DecodeImageJXL(const uint8_t* bytes, size_t bytes_size,
       }
       size_t icc_size = 0;
       JxlColorProfileTarget target = JXL_COLOR_PROFILE_TARGET_DATA;
-      if (JXL_DEC_SUCCESS !=
-          JxlDecoderGetICCProfileSize(dec, target, &icc_size)) {
-        fprintf(stderr, "JxlDecoderGetICCProfileSize failed\n");
-      }
-      if (icc_size != 0) {
-        ppf->icc.resize(icc_size);
-        if (JXL_DEC_SUCCESS != JxlDecoderGetColorAsICCProfile(
-                                   dec, target, ppf->icc.data(), icc_size)) {
-          fprintf(stderr, "JxlDecoderGetColorAsICCProfile failed\n");
-          return false;
-        }
-      }
       if (JXL_DEC_SUCCESS != JxlDecoderGetColorAsEncodedProfile(
                                  dec, target, &ppf->color_encoding)) {
         ppf->color_encoding.color_space = JXL_COLOR_SPACE_UNKNOWN;
+        // only get ICC if it is not an Enum color encoding
+        if (JXL_DEC_SUCCESS !=
+            JxlDecoderGetICCProfileSize(dec, target, &icc_size)) {
+          fprintf(stderr, "JxlDecoderGetICCProfileSize failed\n");
+        }
+        if (icc_size != 0) {
+          ppf->icc.resize(icc_size);
+          if (JXL_DEC_SUCCESS != JxlDecoderGetColorAsICCProfile(
+                                     dec, target, ppf->icc.data(), icc_size)) {
+            fprintf(stderr, "JxlDecoderGetColorAsICCProfile failed\n");
+            return false;
+          }
+        }
       }
       icc_size = 0;
       target = JXL_COLOR_PROFILE_TARGET_ORIGINAL;

--- a/lib/extras/dec/jxl.h
+++ b/lib/extras/dec/jxl.h
@@ -41,6 +41,10 @@ struct JXLDecompressParams {
   // Whether truncated input should be treated as an error.
   bool allow_partial_input = false;
 
+  // Set to true if an ICC profile has to be synthesized for Enum color
+  // encodings
+  bool need_icc = false;
+
   // How many passes to decode at most. By default, decode everything.
   uint32_t max_passes = std::numeric_limits<uint32_t>::max();
 

--- a/tools/djxl_main.cc
+++ b/tools/djxl_main.cc
@@ -303,6 +303,7 @@ bool DecompressJxlToPackedPixelFile(
   dparams.runner = JxlThreadParallelRunner;
   dparams.runner_opaque = runner;
   dparams.allow_partial_input = args.allow_partial_files;
+  dparams.need_icc = !args.icc_out.empty();
   if (args.bits_per_sample == 0) {
     dparams.output_bitdepth.type = JXL_BIT_DEPTH_FROM_CODESTREAM;
   } else if (args.bits_per_sample > 0) {


### PR DESCRIPTION
Fixes https://github.com/libjxl/libjxl/issues/2581

Now converting lossless jxl to lossless jxl becomes a no-op (if done with the same settings), instead of e.g. converting Enum sRGB to an explicit synthesized ICC profile for sRGB, which then gets stored exactly in the new jxl file.

Lossless jxl to lossless jxl might seem like a silly thing to do, but it could be quite useful to do quick e1 encodes first and then spend more effort on it later.