### PR TITLE
no fuzzer-friendly encoding in release builds

### DIFF
--- a/lib/jxl/enc_ans.cc
+++ b/lib/jxl/enc_ans.cc
@@ -32,7 +32,10 @@ namespace jxl {
 
 namespace {
 
-bool ans_fuzzer_friendly_ = false;
+#if !JXL_IS_DEBUG_BUILD
+constexpr
+#endif
+    bool ans_fuzzer_friendly_ = false;
 
 static const int kMaxNumSymbolsForSmallCode = 4;
 


### PR DESCRIPTION
There's some code in the ANS encoding to do fuzzer-friendly (but very bad) entropy coding. It can only be enabled via a non-exposed function that only works in debug builds, but since it's not guarded by `if (constexpr false)`, the actual code for fuzzer-friendly entropy coding could still end up in release builds.
