### PR TITLE
Use only the public API in jxl benchmark codec.

### DIFF
--- a/lib/extras/enc/jxl.cc
+++ b/lib/extras/enc/jxl.cc
@@ -62,6 +62,13 @@ bool EncodeImageJXL(const JXLCompressParams& params, const PackedPixelFile& ppf,
     fprintf(stderr, "Setting frame distance failed.\n");
     return false;
   }
+  if (params.debug_image) {
+    JxlEncoderSetDebugImageCallback(settings, params.debug_image,
+                                    params.debug_image_opaque);
+  }
+  if (params.stats) {
+    JxlEncoderCollectStats(settings, params.stats);
+  }
 
   bool use_boxes = !ppf.metadata.exif.empty() || !ppf.metadata.xmp.empty() ||
                    !ppf.metadata.jumbf.empty() || !ppf.metadata.iptc.empty();

--- a/lib/extras/enc/jxl.h
+++ b/lib/extras/enc/jxl.h
@@ -58,7 +58,9 @@ struct JXLCompressParams {
   // If runner_opaque is set, the decoder uses this parallel runner.
   JxlParallelRunner runner = JxlThreadParallelRunner;
   void* runner_opaque = nullptr;
-
+  JxlDebugImageCallback debug_image = nullptr;
+  void* debug_image_opaque = nullptr;
+  JxlEncoderStats* stats = nullptr;
   bool allow_expert_options = false;
 
   void AddOption(JxlEncoderFrameSettingId id, int64_t val) {

--- a/lib/include/jxl/encode.h
+++ b/lib/include/jxl/encode.h
@@ -18,6 +18,7 @@
 #include <jxl/jxl_export.h>
 #include <jxl/memory_manager.h>
 #include <jxl/parallel_runner.h>
+#include <jxl/stats.h>
 #include <jxl/version.h>
 
 #if defined(__cplusplus) || defined(c_plusplus)
@@ -1151,6 +1152,57 @@ JXL_EXPORT void JxlColorEncodingSetToLinearSRGB(
  * @param enc encoder object.
  */
 JXL_EXPORT void JxlEncoderAllowExpertOptions(JxlEncoder* enc);
+
+/**
+ * Function type for @ref JxlEncoderSetDebugImageCallback.
+ *
+ * The callback may be called simultaneously by different threads when using a
+ * threaded parallel runner, on different debug images.
+ *
+ * @param opaque optional user data, as given to @ref
+ *   JxlEncoderSetDebugImageCallback.
+ * @param label label of debug image, can be used in filenames
+ * @param xsize width of debug image
+ * @param ysize height of debug image
+ * @param color color encoding of debug image
+ * @param pixels pixel data of debug image as big-endian 16-bit unsigned
+ *   samples. The memory is not owned by the user, and is only valid during the
+ *   time the callback is running.
+ */
+typedef void (*JxlDebugImageCallback)(void* opaque, const char* label,
+                                      size_t xsize, size_t ysize,
+                                      const JxlColorEncoding* color,
+                                      const uint16_t* pixels);
+
+/**
+ * Sets the given debug image callback that will be used by the encoder to
+ * output various debug images during encoding.
+ *
+ * This only has any effect if the encoder was compiled with the appropiate
+ * debug build flags.
+ *
+ * @param frame_settings set of options and metadata for this frame. Also
+ * includes reference to the encoder object.
+ * @param callback used to return the debug image
+ * @param opaque user supplied parameter to the image callback
+ */
+JXL_EXPORT void JxlEncoderSetDebugImageCallback(
+    JxlEncoderFrameSettings* frame_settings, JxlDebugImageCallback callback,
+    void* opaque);
+
+/**
+ * Sets the given stats object for gathering various statistics during encoding.
+ *
+ * This only has any effect if the encoder was compiled with the appropiate
+ * debug build flags.
+ *
+ * @param frame_settings set of options and metadata for this frame. Also
+ * includes reference to the encoder object.
+ * @param stats object that can be used to query the gathered stats (created
+ *   by @ref JxlEncoderStatsCreate)
+ */
+JXL_EXPORT void JxlEncoderCollectStats(JxlEncoderFrameSettings* frame_settings,
+                                       JxlEncoderStats* stats);
 
 #if defined(__cplusplus) || defined(c_plusplus)
 }

--- a/lib/include/jxl/stats.h
+++ b/lib/include/jxl/stats.h
@@ -1,0 +1,103 @@
+/* Copyright (c) the JPEG XL Project Authors. All rights reserved.
+ *
+ * Use of this source code is governed by a BSD-style
+ * license that can be found in the LICENSE file.
+ */
+
+/** @addtogroup libjxl_encoder
+ * @{
+ * @file stats.h
+ * @brief API to collect various statistics from JXL encoder.
+ */
+
+#ifndef JXL_STATS_H_
+#define JXL_STATS_H_
+
+#include <jxl/jxl_export.h>
+#include <stddef.h>
+
+#if defined(__cplusplus) || defined(c_plusplus)
+extern "C" {
+#endif
+
+/**
+ * Opaque structure that holds the encoder statistics.
+ *
+ * Allocated and initialized with JxlEncoderStatsCreate().
+ * Cleaned up and deallocated with JxlEncoderStatsDestroy().
+ */
+typedef struct JxlEncoderStatsStruct JxlEncoderStats;
+
+/**
+ * Creates an instance of JxlEncoderStats and initializes it.
+ *
+ * @return pointer to initialized JxlEncoderStats instance
+ */
+JXL_EXPORT JxlEncoderStats* JxlEncoderStatsCreate();
+
+/**
+ * Deinitializes and frees JxlEncoderStats instance.
+ *
+ * @param stats instance to be cleaned up and deallocated. No-op if stats is
+ * null pointer.
+ */
+JXL_EXPORT void JxlEncoderStatsDestroy(JxlEncoderStats* stats);
+
+/** Data type for querying JxlEncoderStats object
+ */
+typedef enum {
+  JXL_ENC_STAT_HEADER_BITS,
+  JXL_ENC_STAT_TOC_BITS,
+  JXL_ENC_STAT_DICTIONARY_BITS,
+  JXL_ENC_STAT_SPLINES_BITS,
+  JXL_ENC_STAT_NOISE_BITS,
+  JXL_ENC_STAT_QUANT_BITS,
+  JXL_ENC_STAT_MODULAR_TREE_BITS,
+  JXL_ENC_STAT_MODULAR_GLOBAL_BITS,
+  JXL_ENC_STAT_DC_BITS,
+  JXL_ENC_STAT_MODULAR_DC_GROUP_BITS,
+  JXL_ENC_STAT_CONTROL_FIELDS_BITS,
+  JXL_ENC_STAT_COEF_ORDER_BITS,
+  JXL_ENC_STAT_AC_HISTOGRAM_BITS,
+  JXL_ENC_STAT_AC_BITS,
+  JXL_ENC_STAT_MODULAR_AC_GROUP_BITS,
+  JXL_ENC_STAT_NUM_SMALL_BLOCKS,
+  JXL_ENC_STAT_NUM_DCT4X8_BLOCKS,
+  JXL_ENC_STAT_NUM_AFV_BLOCKS,
+  JXL_ENC_STAT_NUM_DCT8_BLOCKS,
+  JXL_ENC_STAT_NUM_DCT8X32_BLOCKS,
+  JXL_ENC_STAT_NUM_DCT16_BLOCKS,
+  JXL_ENC_STAT_NUM_DCT16X32_BLOCKS,
+  JXL_ENC_STAT_NUM_DCT32_BLOCKS,
+  JXL_ENC_STAT_NUM_DCT32X64_BLOCKS,
+  JXL_ENC_STAT_NUM_DCT64_BLOCKS,
+  JXL_ENC_STAT_NUM_BUTTERAUGLI_ITERS,
+  JXL_ENC_NUM_STATS,
+} JxlEncoderStatsKey;
+
+/** Returns the value of the statistics corresponding the given key.
+ *
+ * @param stats object that was passed to the encoder with a
+ *   @ref JxlEncoderCollectStats function
+ * @param key the particular statistics to query
+ *
+ * @return the value of the statistics
+ */
+JXL_EXPORT size_t JxlEncoderStatsGet(const JxlEncoderStats* stats,
+                                     JxlEncoderStatsKey key);
+
+/** Updates the values of the given stats object with that of an other.
+ *
+ * @param stats object whose values will be updated (usually added together)
+ * @param other stats object whose values will be merged with stats
+ */
+JXL_EXPORT void JxlEncoderStatsMerge(JxlEncoderStats* stats,
+                                     const JxlEncoderStats* other);
+
+#if defined(__cplusplus) || defined(c_plusplus)
+}
+#endif
+
+#endif /* JXL_STATS_H_ */
+
+/** @}*/

--- a/lib/jxl/dec_external_image.cc
+++ b/lib/jxl/dec_external_image.cc
@@ -235,18 +235,8 @@ void StoreFloatRow(const float* JXL_RESTRICT* rows_in, size_t num_channels,
 
 void JXL_INLINE Store8(uint32_t value, uint8_t* dest) { *dest = value & 0xff; }
 
-// Maximum number of channels for the ConvertChannelsToExternal function.
-const size_t kConvertMaxChannels = 4;
+}  // namespace
 
-// Converts a list of channels to an interleaved image, applying transformations
-// when needed.
-// The input channels are given as a (non-const!) array of channel pointers and
-// interleaved in that order.
-//
-// Note: if a pointer in channels[] is nullptr, a 1.0 value will be used
-// instead. This is useful for handling when a user requests an alpha channel
-// from an image that doesn't have one. The first channel in the list may not
-// be nullptr, since it is used to determine the image size.
 Status ConvertChannelsToExternal(const ImageF* channels[], size_t num_channels,
                                  size_t bits_per_sample, bool float_out,
                                  JxlEndianness endianness, size_t stride,
@@ -447,8 +437,6 @@ Status ConvertChannelsToExternal(const ImageF* channels[], size_t num_channels,
   }
   return true;
 }
-
-}  // namespace
 
 Status ConvertToExternal(const jxl::ImageBundle& ib, size_t bits_per_sample,
                          bool float_out, size_t num_channels,

--- a/lib/jxl/dec_external_image.h
+++ b/lib/jxl/dec_external_image.h
@@ -21,6 +21,26 @@
 
 namespace jxl {
 
+// Maximum number of channels for the ConvertChannelsToExternal function.
+const size_t kConvertMaxChannels = 4;
+
+// Converts a list of channels to an interleaved image, applying transformations
+// when needed.
+// The input channels are given as a (non-const!) array of channel pointers and
+// interleaved in that order.
+//
+// Note: if a pointer in channels[] is nullptr, a 1.0 value will be used
+// instead. This is useful for handling when a user requests an alpha channel
+// from an image that doesn't have one. The first channel in the list may not
+// be nullptr, since it is used to determine the image size.
+Status ConvertChannelsToExternal(const ImageF* channels[], size_t num_channels,
+                                 size_t bits_per_sample, bool float_out,
+                                 JxlEndianness endianness, size_t stride,
+                                 jxl::ThreadPool* pool, void* out_image,
+                                 size_t out_size,
+                                 const PixelCallback& out_callback,
+                                 jxl::Orientation undo_orientation);
+
 // Converts ib to interleaved void* pixel buffer with the given format.
 // bits_per_sample: must be 16 or 32 if float_out is true, and at most 16
 // if it is false. No bit packing is done.

--- a/lib/jxl/enc_ac_strategy.cc
+++ b/lib/jxl/enc_ac_strategy.cc
@@ -26,6 +26,7 @@
 #include "lib/jxl/convolve.h"
 #include "lib/jxl/dct_scales.h"
 #include "lib/jxl/enc_aux_out.h"
+#include "lib/jxl/enc_debug_image.h"
 #include "lib/jxl/enc_params.h"
 #include "lib/jxl/enc_transforms-inl.h"
 #include "lib/jxl/entropy_coder.h"
@@ -213,7 +214,8 @@ const uint8_t* TypeMask(const uint8_t& raw_strategy) {
 }
 
 void DumpAcStrategy(const AcStrategyImage& ac_strategy, size_t xsize,
-                    size_t ysize, const char* tag, AuxOut* aux_out) {
+                    size_t ysize, const char* tag, AuxOut* aux_out,
+                    const CompressParams& cparams) {
   Image3F color_acs(xsize, ysize);
   for (size_t y = 0; y < ysize; y++) {
     float* JXL_RESTRICT rows[3] = {
@@ -265,7 +267,7 @@ void DumpAcStrategy(const AcStrategyImage& ac_strategy, size_t xsize,
       }
     }
   }
-  aux_out->DumpImage(tag, color_acs);
+  DumpImage(cparams, tag, color_acs);
 }
 
 }  // namespace
@@ -1163,9 +1165,11 @@ void AcStrategyHeuristics::Finalize(AuxOut* aux_out) {
         ac_strategy.CountBlocks(AcStrategy::Type::DCT64X64);
   }
 
-  if (JXL_DEBUG_AC_STRATEGY && WantDebugOutput(aux_out)) {
+  // if (JXL_DEBUG_AC_STRATEGY && WantDebugOutput(aux_out)) {
+  if (JXL_DEBUG_AC_STRATEGY && WantDebugOutput(enc_state->cparams)) {
     DumpAcStrategy(ac_strategy, enc_state->shared.frame_dim.xsize,
-                   enc_state->shared.frame_dim.ysize, "ac_strategy", aux_out);
+                   enc_state->shared.frame_dim.ysize, "ac_strategy", aux_out,
+                   enc_state->cparams);
   }
 }
 

--- a/lib/jxl/enc_adaptive_quantization.cc
+++ b/lib/jxl/enc_adaptive_quantization.cc
@@ -34,6 +34,7 @@
 #include "lib/jxl/enc_aux_out.h"
 #include "lib/jxl/enc_butteraugli_comparator.h"
 #include "lib/jxl/enc_cache.h"
+#include "lib/jxl/enc_debug_image.h"
 #include "lib/jxl/enc_group.h"
 #include "lib/jxl/enc_modular.h"
 #include "lib/jxl/enc_params.h"
@@ -633,23 +634,23 @@ namespace {
 // If true, prints the quantization maps at each iteration.
 constexpr bool FLAGS_dump_quant_state = false;
 
-void DumpHeatmap(const AuxOut* aux_out, const std::string& label,
-                 const ImageF& image, float good_threshold,
-                 float bad_threshold) {
+void DumpHeatmap(const CompressParams& cparams, const AuxOut* aux_out,
+                 const std::string& label, const ImageF& image,
+                 float good_threshold, float bad_threshold) {
   if (JXL_DEBUG_ADAPTIVE_QUANTIZATION) {
     Image3F heatmap = CreateHeatMapImage(image, good_threshold, bad_threshold);
     char filename[200];
     snprintf(filename, sizeof(filename), "%s%05d", label.c_str(),
              aux_out->num_butteraugli_iters);
-    aux_out->DumpImage(filename, heatmap);
+    DumpImage(cparams, filename, heatmap);
   }
 }
 
-void DumpHeatmaps(const AuxOut* aux_out, float ba_target,
-                  const ImageF& quant_field, const ImageF& tile_heatmap,
-                  const ImageF& bt_diffmap) {
+void DumpHeatmaps(const CompressParams& cparams, const AuxOut* aux_out,
+                  float ba_target, const ImageF& quant_field,
+                  const ImageF& tile_heatmap, const ImageF& bt_diffmap) {
   if (JXL_DEBUG_ADAPTIVE_QUANTIZATION) {
-    if (!WantDebugOutput(aux_out)) return;
+    if (!WantDebugOutput(cparams)) return;
     ImageF inv_qmap(quant_field.xsize(), quant_field.ysize());
     for (size_t y = 0; y < quant_field.ysize(); ++y) {
       const float* JXL_RESTRICT row_q = quant_field.ConstRow(y);
@@ -658,13 +659,13 @@ void DumpHeatmaps(const AuxOut* aux_out, float ba_target,
         row_inv_q[x] = 1.0f / row_q[x];  // never zero
       }
     }
-    DumpHeatmap(aux_out, "quant_heatmap", inv_qmap, 4.0f * ba_target,
+    DumpHeatmap(cparams, aux_out, "quant_heatmap", inv_qmap, 4.0f * ba_target,
                 6.0f * ba_target);
-    DumpHeatmap(aux_out, "tile_heatmap", tile_heatmap, ba_target,
+    DumpHeatmap(cparams, aux_out, "tile_heatmap", tile_heatmap, ba_target,
                 1.5f * ba_target);
     // matches heat maps produced by the command line tool.
-    DumpHeatmap(aux_out, "bt_diffmap", bt_diffmap, ButteraugliFuzzyInverse(1.5),
-                ButteraugliFuzzyInverse(0.5));
+    DumpHeatmap(cparams, aux_out, "bt_diffmap", bt_diffmap,
+                ButteraugliFuzzyInverse(1.5), ButteraugliFuzzyInverse(0.5));
   }
 }
 
@@ -810,6 +811,8 @@ ImageBundle RoundtripImage(const Image3F& opsin, PassesEncoderState* enc_state,
   return decoded;
 }
 
+constexpr int kMaxButteraugliIters = 4;
+
 void FindBestQuantization(const ImageBundle& linear, const Image3F& opsin,
                           PassesEncoderState* enc_state,
                           const JxlCmsInterface& cms, ThreadPool* pool,
@@ -849,7 +852,7 @@ void FindBestQuantization(const ImageBundle& linear, const Image3F& opsin,
 
   const float butteraugli_target = cparams.butteraugli_distance;
   const float original_butteraugli = cparams.original_butteraugli_distance;
-  ButteraugliParams params = cparams.ba_params;
+  ButteraugliParams params;
   params.intensity_target = linear.metadata()->IntensityTarget();
   // Hack the default intensity target value to be 80.0, the intensity
   // target of sRGB images and a more reasonable viewing default than
@@ -880,10 +883,7 @@ void FindBestQuantization(const ImageBundle& linear, const Image3F& opsin,
   JXL_ASSERT(qf_higher / qf_lower < 253);
 
   constexpr int kOriginalComparisonRound = 1;
-  int iters = cparams.max_butteraugli_iters;
-  if (iters > 7) {
-    iters = 7;
-  }
+  int iters = kMaxButteraugliIters;
   if (cparams.speed_tier != SpeedTier::kTortoise) {
     iters = 2;
   }
@@ -908,16 +908,16 @@ void FindBestQuantization(const ImageBundle& linear, const Image3F& opsin,
     }
     tile_distmap = TileDistMap(diffmap, 8 * cparams.resampling, 0,
                                enc_state->shared.ac_strategy);
-    if (JXL_DEBUG_ADAPTIVE_QUANTIZATION && WantDebugOutput(aux_out)) {
-      aux_out->DumpImage(("dec" + ToString(i)).c_str(), *dec_linear.color());
-      DumpHeatmaps(aux_out, butteraugli_target, quant_field, tile_distmap,
-                   diffmap);
+    if (JXL_DEBUG_ADAPTIVE_QUANTIZATION && WantDebugOutput(cparams)) {
+      DumpImage(cparams, ("dec" + ToString(i)).c_str(), *dec_linear.color());
+      DumpHeatmaps(cparams, aux_out, butteraugli_target, quant_field,
+                   tile_distmap, diffmap);
     }
     if (aux_out != nullptr) ++aux_out->num_butteraugli_iters;
     if (JXL_DEBUG_ADAPTIVE_QUANTIZATION) {
       float minval, maxval;
       ImageMinMax(quant_field, &minval, &maxval);
-      printf("\nButteraugli iter: %d/%d\n", i, cparams.max_butteraugli_iters);
+      printf("\nButteraugli iter: %d/%d\n", i, kMaxButteraugliIters);
       printf("Butteraugli distance: %f  (target = %f)\n", score,
              original_butteraugli);
       printf("quant range: %f ... %f  DC quant: %f\n", minval, maxval,
@@ -1027,14 +1027,14 @@ void FindBestQuantizationMaxError(const Image3F& opsin,
                                 1.0f / enc_state->cparams.max_error[1],
                                 1.0f / enc_state->cparams.max_error[2]};
 
-  for (int i = 0; i < cparams.max_butteraugli_iters + 1; ++i) {
+  for (int i = 0; i < kMaxButteraugliIters + 1; ++i) {
     quantizer.SetQuantField(initial_quant_dc, quant_field, &raw_quant_field);
     if (JXL_DEBUG_ADAPTIVE_QUANTIZATION && aux_out) {
-      aux_out->DumpXybImage(("ops" + ToString(i)).c_str(), opsin);
+      DumpXybImage(cparams, ("ops" + ToString(i)).c_str(), opsin);
     }
     ImageBundle decoded = RoundtripImage(opsin, enc_state, cms, pool);
     if (JXL_DEBUG_ADAPTIVE_QUANTIZATION && aux_out) {
-      aux_out->DumpXybImage(("dec" + ToString(i)).c_str(), *decoded.color());
+      DumpXybImage(cparams, ("dec" + ToString(i)).c_str(), *decoded.color());
     }
     for (size_t by = 0; by < enc_state->shared.frame_dim.ysize_blocks; by++) {
       AcStrategyRow ac_strategy_row =

--- a/lib/jxl/enc_aux_out.cc
+++ b/lib/jxl/enc_aux_out.cc
@@ -16,9 +16,6 @@
 
 #include "lib/jxl/base/printf_macros.h"
 #include "lib/jxl/base/status.h"
-#include "lib/jxl/color_encoding_internal.h"
-#include "lib/jxl/dec_xyb.h"
-#include "lib/jxl/image_ops.h"
 
 namespace jxl {
 
@@ -92,10 +89,6 @@ void AuxOut::Assimilate(const AuxOut& victim) {
   num_dct32x64_blocks += victim.num_dct32x64_blocks;
   num_dct64_blocks += victim.num_dct64_blocks;
   num_butteraugli_iters += victim.num_butteraugli_iters;
-  max_quant_rescale = std::max(max_quant_rescale, victim.max_quant_rescale);
-  min_quant_rescale = std::min(min_quant_rescale, victim.min_quant_rescale);
-  max_bitrate_error = std::max(max_bitrate_error, victim.max_bitrate_error);
-  min_bitrate_error = std::min(min_bitrate_error, victim.min_bitrate_error);
 }
 
 void AuxOut::Print(size_t num_inputs) const {
@@ -109,12 +102,6 @@ void AuxOut::Print(size_t num_inputs) const {
 
     printf("Average butteraugli iters: %10.2f\n",
            num_butteraugli_iters * 1.0 / num_inputs);
-    if (min_quant_rescale != 1.0 || max_quant_rescale != 1.0) {
-      printf("quant rescale range: %f .. %f\n", min_quant_rescale,
-             max_quant_rescale);
-      printf("bitrate error range: %.3f%% .. %.3f%%\n",
-             100.0f * min_bitrate_error, 100.0f * max_bitrate_error);
-    }
 
     for (size_t i = 0; i < layers.size(); ++i) {
       if (layers[i].total_bits != 0) {
@@ -135,59 +122,6 @@ void AuxOut::Print(size_t num_inputs) const {
              100.0 * total_blocks / total_positions);
     }
   }
-}
-
-template <typename T>
-void AuxOut::DumpImage(const char* label, const Image3<T>& image) const {
-  if (!dump_image) return;
-  if (debug_prefix.empty()) return;
-  std::ostringstream pathname;
-  pathname << debug_prefix << label << ".png";
-  (void)dump_image(ConvertToFloat(image), ColorEncoding::SRGB(),
-                   pathname.str());
-}
-template void AuxOut::DumpImage(const char* label,
-                                const Image3<float>& image) const;
-template void AuxOut::DumpImage(const char* label,
-                                const Image3<uint8_t>& image) const;
-
-template <typename T>
-void AuxOut::DumpPlaneNormalized(const char* label,
-                                 const Plane<T>& image) const {
-  T min;
-  T max;
-  ImageMinMax(image, &min, &max);
-  Image3B normalized(image.xsize(), image.ysize());
-  for (size_t c = 0; c < 3; ++c) {
-    float mul = min == max ? 0 : (255.0f / (max - min));
-    for (size_t y = 0; y < image.ysize(); ++y) {
-      const T* JXL_RESTRICT row_in = image.ConstRow(y);
-      uint8_t* JXL_RESTRICT row_out = normalized.PlaneRow(c, y);
-      for (size_t x = 0; x < image.xsize(); ++x) {
-        row_out[x] = static_cast<uint8_t>((row_in[x] - min) * mul);
-      }
-    }
-  }
-  DumpImage(label, normalized);
-}
-template void AuxOut::DumpPlaneNormalized(const char* label,
-                                          const Plane<float>& image) const;
-template void AuxOut::DumpPlaneNormalized(const char* label,
-                                          const Plane<uint8_t>& image) const;
-
-void AuxOut::DumpXybImage(const char* label, const Image3F& image) const {
-  if (!dump_image) return;
-  if (debug_prefix.empty()) return;
-  std::ostringstream pathname;
-  pathname << debug_prefix << label << ".png";
-
-  Image3F linear(image.xsize(), image.ysize());
-  OpsinParams opsin_params;
-  opsin_params.Init(kDefaultIntensityTarget);
-  OpsinToLinear(image, Rect(linear), nullptr, &linear, opsin_params);
-
-  (void)dump_image(std::move(linear), ColorEncoding::LinearSRGB(),
-                   pathname.str());
 }
 
 }  // namespace jxl

--- a/lib/jxl/enc_aux_out.h
+++ b/lib/jxl/enc_aux_out.h
@@ -14,8 +14,6 @@
 #include <functional>
 #include <string>
 
-#include "lib/jxl/image.h"
-
 namespace jxl {
 
 struct ColorEncoding;
@@ -81,14 +79,6 @@ struct AuxOut {
     return total;
   }
 
-  template <typename T>
-  void DumpImage(const char* label, const Image3<T>& image) const;
-
-  void DumpXybImage(const char* label, const Image3F& image) const;
-
-  template <typename T>
-  void DumpPlaneNormalized(const char* label, const Plane<T>& image) const;
-
   std::array<LayerTotals, kNumImageLayers> layers;
   size_t num_blocks = 0;
 
@@ -106,35 +96,7 @@ struct AuxOut {
   size_t num_dct64_blocks = 0;
 
   int num_butteraugli_iters = 0;
-
-  float max_quant_rescale = 1.0f;
-  float min_quant_rescale = 1.0f;
-  float min_bitrate_error = 0.0f;
-  float max_bitrate_error = 0.0f;
-
-  // If not empty, additional debugging information (e.g. debug images) is
-  // saved in files with this prefix.
-  std::string debug_prefix;
-
-  std::function<Status(Image3F&&, const ColorEncoding&, const std::string&)>
-      dump_image = nullptr;
 };
-
-extern template void AuxOut::DumpImage(const char* label,
-                                       const Image3<float>& image) const;
-extern template void AuxOut::DumpImage(const char* label,
-                                       const Image3<uint8_t>& image) const;
-extern template void AuxOut::DumpPlaneNormalized(
-    const char* label, const Plane<float>& image) const;
-extern template void AuxOut::DumpPlaneNormalized(
-    const char* label, const Plane<uint8_t>& image) const;
-
-// Used to skip image creation if they won't be written to debug directory.
-static inline bool WantDebugOutput(const AuxOut* aux_out) {
-  // Need valid pointer and filename.
-  return aux_out != nullptr && !aux_out->debug_prefix.empty();
-}
-
 }  // namespace jxl
 
 #endif  // LIB_JXL_AUX_OUT_H_

--- a/lib/jxl/enc_cache.cc
+++ b/lib/jxl/enc_cache.cc
@@ -138,9 +138,6 @@ Status InitializePassesEncoder(const Image3F& opsin, const JxlCmsInterface& cms,
     dc_frame_info.ib_needs_color_transform = false;
     dc_frame_info.save_before_color_transform = true;  // Implicitly true
     AuxOut dc_aux_out;
-    if (aux_out) {
-      dc_aux_out.debug_prefix = aux_out->debug_prefix;
-    }
     JXL_CHECK(EncodeFrame(cparams, dc_frame_info, shared.metadata, ib,
                           state.get(), cms, pool, special_frame.get(),
                           aux_out ? &dc_aux_out : nullptr));

--- a/lib/jxl/enc_debug_image.cc
+++ b/lib/jxl/enc_debug_image.cc
@@ -1,0 +1,95 @@
+// Copyright (c) the JPEG XL Project Authors. All rights reserved.
+//
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+#include "lib/jxl/enc_debug_image.h"
+
+#include <stddef.h>
+#include <stdint.h>
+
+#include "lib/jxl/base/status.h"
+#include "lib/jxl/color_encoding_internal.h"
+#include "lib/jxl/dec_external_image.h"
+#include "lib/jxl/enc_color_management.h"
+#include "lib/jxl/enc_params.h"
+#include "lib/jxl/image_ops.h"
+
+namespace jxl {
+
+namespace {
+template <typename T>
+void DumpImageT(const CompressParams& cparams, const char* label,
+                const ColorEncoding& color_encoding, const Image3<T>& image) {
+  if (!cparams.debug_image) return;
+  Image3F float_image = ConvertToFloat(image);
+  JxlColorEncoding color;
+  ConvertInternalToExternalColorEncoding(color_encoding, &color);
+  size_t num_pixels = 3 * image.xsize() * image.ysize();
+  std::vector<uint16_t> pixels(num_pixels);
+  const ImageF* channels[3];
+  for (int c = 0; c < 3; ++c) {
+    channels[c] = &float_image.Plane(c);
+  }
+  JXL_CHECK(ConvertChannelsToExternal(
+      channels, 3, 16, false, JXL_BIG_ENDIAN, 6 * image.xsize(), nullptr,
+      &pixels[0], 2 * num_pixels, PixelCallback(), Orientation::kIdentity));
+  (*cparams.debug_image)(cparams.debug_image_opaque, label, image.xsize(),
+                         image.ysize(), &color, &pixels[0]);
+}
+
+template <typename T>
+void DumpPlaneNormalizedT(const CompressParams& cparams, const char* label,
+                          const Plane<T>& image) {
+  T min;
+  T max;
+  ImageMinMax(image, &min, &max);
+  Image3B normalized(image.xsize(), image.ysize());
+  for (size_t c = 0; c < 3; ++c) {
+    float mul = min == max ? 0 : (255.0f / (max - min));
+    for (size_t y = 0; y < image.ysize(); ++y) {
+      const T* JXL_RESTRICT row_in = image.ConstRow(y);
+      uint8_t* JXL_RESTRICT row_out = normalized.PlaneRow(c, y);
+      for (size_t x = 0; x < image.xsize(); ++x) {
+        row_out[x] = static_cast<uint8_t>((row_in[x] - min) * mul);
+      }
+    }
+  }
+  DumpImageT(cparams, label, ColorEncoding::SRGB(), normalized);
+}
+
+}  // namespace
+
+void DumpImage(const CompressParams& cparams, const char* label,
+               const Image3<float>& image) {
+  DumpImageT(cparams, label, ColorEncoding::SRGB(), image);
+}
+
+void DumpImage(const CompressParams& cparams, const char* label,
+               const Image3<uint8_t>& image) {
+  DumpImageT(cparams, label, ColorEncoding::SRGB(), image);
+}
+
+void DumpXybImage(const CompressParams& cparams, const char* label,
+                  const Image3F& image) {
+  if (!cparams.debug_image) return;
+
+  Image3F linear(image.xsize(), image.ysize());
+  OpsinParams opsin_params;
+  opsin_params.Init(kDefaultIntensityTarget);
+  OpsinToLinear(image, Rect(linear), nullptr, &linear, opsin_params);
+
+  DumpImageT(cparams, label, ColorEncoding::LinearSRGB(), linear);
+}
+
+void DumpPlaneNormalized(const CompressParams& cparams, const char* label,
+                         const Plane<float>& image) {
+  DumpPlaneNormalizedT(cparams, label, image);
+}
+
+void DumpPlaneNormalized(const CompressParams& cparams, const char* label,
+                         const Plane<uint8_t>& image) {
+  DumpPlaneNormalizedT(cparams, label, image);
+}
+
+}  // namespace jxl

--- a/lib/jxl/enc_debug_image.h
+++ b/lib/jxl/enc_debug_image.h
@@ -1,0 +1,37 @@
+// Copyright (c) the JPEG XL Project Authors. All rights reserved.
+//
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+#ifndef LIB_JXL_ENC_DEBUG_IMAGE_H_
+#define LIB_JXL_ENC_DEBUG_IMAGE_H_
+
+// Optional output images for debugging.
+
+#include <stddef.h>
+#include <stdint.h>
+
+#include "lib/jxl/enc_params.h"
+#include "lib/jxl/image.h"
+
+namespace jxl {
+
+void DumpImage(const CompressParams& cparams, const char* label,
+               const Image3<float>& image);
+void DumpImage(const CompressParams& cparams, const char* label,
+               const Image3<uint8_t>& image);
+void DumpXybImage(const CompressParams& cparams, const char* label,
+                  const Image3<float>& image);
+void DumpPlaneNormalized(const CompressParams& cparams, const char* label,
+                         const Plane<float>& image);
+void DumpPlaneNormalized(const CompressParams& cparams, const char* label,
+                         const Plane<uint8_t>& image);
+
+// Used to skip image creation if they won't be written to debug directory.
+static inline bool WantDebugOutput(const CompressParams& cparams) {
+  return cparams.debug_image != nullptr;
+}
+
+}  // namespace jxl
+
+#endif  // LIB_JXL_ENC_DEBUG_IMAGE_H_

--- a/lib/jxl/enc_detect_dots.cc
+++ b/lib/jxl/enc_detect_dots.cc
@@ -35,10 +35,6 @@
 #define JXL_DEBUG_DOT_DETECT 0
 #endif
 
-#if JXL_DEBUG_DOT_DETECT
-#include "lib/jxl/enc_aux_out.h"
-#endif
-
 HWY_BEFORE_NAMESPACE();
 namespace jxl {
 namespace HWY_NAMESPACE {
@@ -162,13 +158,6 @@ ImageF ComputeEnergyImage(const Image3F& orig, Image3F* smooth,
     Separable5(forig.Plane(c), rect, weights3, pool, &smooth->Plane(c));
     Separable5(orig.Plane(c), rect, weights1, pool, &forig.Plane(c));
   }
-
-#if JXL_DEBUG_DOT_DETECT
-  AuxOut aux;
-  aux.debug_prefix = "/tmp/sebastian/";
-  aux.DumpImage("filtered", forig);
-  aux.DumpImage("sm", *smooth);
-#endif
 
   return HWY_DYNAMIC_DISPATCH(SumOfSquareDifferences)(forig, *smooth, pool);
 }
@@ -539,12 +528,6 @@ std::vector<PatchInfo> DetectGaussianEllipses(
   std::vector<PatchInfo> dots;
   Image3F smooth(opsin.xsize(), opsin.ysize());
   ImageF energy = ComputeEnergyImage(opsin, &smooth, pool);
-#if JXL_DEBUG_DOT_DETECT
-  AuxOut aux;
-  aux.debug_prefix = "/tmp/sebastian/";
-  aux.DumpXybImage("smooth", smooth);
-  aux.DumpPlaneNormalized("energy", energy);
-#endif  // JXL_DEBUG_DOT_DETECT
   std::vector<ConnectedComponent> components = FindCC(
       energy, params.t_low, params.t_high, params.maxWinSize, params.minScore);
   size_t numCC =
@@ -597,19 +580,6 @@ std::vector<PatchInfo> DetectGaussianEllipses(
       }
     }
   }
-#if JXL_DEBUG_DOT_DETECT
-  JXL_DEBUG(JXL_DEBUG_DOT_DETECT, "Candidates: %" PRIuS ", Dots: %" PRIuS "\n",
-            components.size(), dots.size());
-  ApplyGaussianEllipses(&smooth, dots, 1.0);
-  aux.DumpXybImage("draw", smooth);
-  ApplyGaussianEllipses(&smooth, dots, -1.0);
-
-  auto qdots = QuantizeGaussianEllipses(dots, qParams);
-  auto deq = DequantizeGaussianEllipses(qdots, qParams);
-  ApplyGaussianEllipses(&smooth, deq, 1.0);
-  aux.DumpXybImage("qdraw", smooth);
-  ApplyGaussianEllipses(&smooth, deq, -1.0);
-#endif  // JXL_DEBUG_DOT_DETECT
   return dots;
 }
 

--- a/lib/jxl/enc_frame.cc
+++ b/lib/jxl/enc_frame.cc
@@ -1142,52 +1142,6 @@ Status EncodeFrame(const CompressParams& cparams_orig,
     cparams = all_params[best_idx];
   }
 
-  if (cparams_orig.target_bitrate > 0.0f &&
-      frame_info.frame_type == FrameType::kRegularFrame) {
-    cparams.target_bitrate = 0.0f;
-    const float target_bitrate = cparams_orig.target_bitrate;
-    float bitrate = 0.0f;
-    float prev_bitrate = 0.0f;
-    float rescale = 1.0f;
-    size_t prev_bits = 0;
-    float error = 0.0f;
-    float best_error = 100.0f;
-    float best_rescale = 1.0f;
-    for (size_t i = 0; i < 10; ++i) {
-      std::unique_ptr<PassesEncoderState> state =
-          jxl::make_unique<PassesEncoderState>();
-      BitWriter bw;
-      JXL_CHECK(EncodeFrame(cparams, frame_info, metadata, ib, state.get(), cms,
-                            pool, &bw, nullptr));
-      bitrate = bw.BitsWritten() * 1.0 / (ib.xsize() * ib.ysize());
-      error = target_bitrate / bitrate - 1.0f;
-      if (std::abs(error) < std::abs(best_error)) {
-        best_error = error;
-        best_rescale = cparams.quant_ac_rescale;
-      }
-      if (bw.BitsWritten() == prev_bits || std::abs(error) < 0.0005f) {
-        break;
-      }
-      float lambda = 1.0f;
-      if (i > 0) {
-        lambda = (((bitrate / prev_bitrate) - 1.0f) / (rescale - 1.0f));
-      }
-      rescale = (1.0f + ((target_bitrate / bitrate) - 1.0f) / lambda);
-      if (rescale < 0.0f) {
-        break;
-      }
-      cparams.quant_ac_rescale *= rescale;
-      prev_bitrate = bitrate;
-      prev_bits = bw.BitsWritten();
-    }
-    if (aux_out) {
-      aux_out->max_quant_rescale = best_rescale;
-      aux_out->min_quant_rescale = best_rescale;
-      aux_out->min_bitrate_error = best_error;
-      aux_out->max_bitrate_error = best_error;
-    }
-    cparams.quant_ac_rescale = best_rescale;
-  }
   ib.VerifyMetadata();
 
   passes_enc_state->special_frames.clear();
@@ -1290,13 +1244,6 @@ Status EncodeFrame(const CompressParams& cparams_orig,
         aux_out->Assimilate(aux_outs[i]);
       }
       aux_outs.resize(num_threads);
-      // Each thread needs these INPUTS. Don't copy the entire AuxOut
-      // because it may contain stats which would be Assimilated multiple
-      // times below.
-      for (size_t i = old_size; i < aux_outs.size(); i++) {
-        aux_outs[i].dump_image = aux_out->dump_image;
-        aux_outs[i].debug_prefix = aux_out->debug_prefix;
-      }
     }
     return true;
   };

--- a/lib/jxl/enc_heuristics.cc
+++ b/lib/jxl/enc_heuristics.cc
@@ -828,14 +828,12 @@ Status DefaultEncoderHeuristics::LossyFrameHeuristics(
   // Call InitialQuantField only in Hare mode or slower. Otherwise, rely
   // on simple heuristics in FindBestAcStrategy, or set a constant for Falcon
   // mode.
-  if (cparams.speed_tier > SpeedTier::kHare || cparams.uniform_quant > 0) {
+  if (cparams.speed_tier > SpeedTier::kHare) {
     enc_state->initial_quant_field =
         ImageF(shared.frame_dim.xsize_blocks, shared.frame_dim.ysize_blocks);
     enc_state->initial_quant_masking =
         ImageF(shared.frame_dim.xsize_blocks, shared.frame_dim.ysize_blocks);
-    float q = cparams.uniform_quant > 0
-                  ? cparams.uniform_quant
-                  : kAcQuant / cparams.butteraugli_distance;
+    float q = kAcQuant / cparams.butteraugli_distance;
     FillImage(q, &enc_state->initial_quant_field);
     FillImage(1.0f / (q + 0.001f), &enc_state->initial_quant_masking);
   } else {

--- a/lib/jxl/enc_modular.cc
+++ b/lib/jxl/enc_modular.cc
@@ -43,7 +43,7 @@
 namespace jxl {
 
 namespace {
-constexpr bool kPrintTree = false;
+// constexpr bool kPrintTree = false;
 
 // Squeeze default quantization factors
 // these quantization factors are for -Q 50  (other qualities simply scale the
@@ -1083,6 +1083,7 @@ Status ModularFrameEncoder::PrepareEncoding(const FrameHeader& frame_header,
   JXL_ASSERT(tree_.size() == decoded_tree.size());
   tree_ = std::move(decoded_tree);
 
+  /* TODO(szabadka) Add text output callback to cparams
   if (kPrintTree && WantDebugOutput(aux_out)) {
     if (frame_header.dc_level > 0) {
       PrintTree(tree_, aux_out->debug_prefix + "/dc_frame_level" +
@@ -1090,17 +1091,13 @@ Status ModularFrameEncoder::PrepareEncoding(const FrameHeader& frame_header,
     } else {
       PrintTree(tree_, aux_out->debug_prefix + "/global_tree");
     }
-  }
+  } */
 
   image_widths_.resize(num_streams);
   JXL_RETURN_IF_ERROR(RunOnPool(
       pool, 0, num_streams, ThreadPool::NoInit,
       [&](const uint32_t stream_id, size_t /* thread */) {
         AuxOut my_aux_out;
-        if (aux_out) {
-          my_aux_out.dump_image = aux_out->dump_image;
-          my_aux_out.debug_prefix = aux_out->debug_prefix;
-        }
         tokens_[stream_id].clear();
         JXL_CHECK(ModularGenericCompress(
             stream_images_[stream_id], stream_options_[stream_id],

--- a/lib/jxl/enc_params.h
+++ b/lib/jxl/enc_params.h
@@ -8,6 +8,7 @@
 
 // Parameters and flags that govern JXL compression.
 
+#include <jxl/encode.h>
 #include <stddef.h>
 #include <stdint.h>
 
@@ -58,13 +59,6 @@ struct CompressParams {
   // explicit distances for extra channels (defaults to butteraugli_distance
   // when not set; value of -1 can be used to represent 'default')
   std::vector<float> ec_distance;
-  size_t target_size = 0;
-  float target_bitrate = 0.0f;
-
-  // 0.0 means search for the adaptive quantization map that matches the
-  // butteraugli distance, positive values mean quantize everywhere with that
-  // value.
-  float uniform_quant = 0.0f;
 
   // Try to achieve a maximum pixel-by-pixel error on each channel.
   bool max_error_mode = false;
@@ -78,12 +72,7 @@ struct CompressParams {
   // 4 = fastest speed, lowest quality
   size_t decoding_speed_tier = 0;
 
-  int max_butteraugli_iters = 4;
-
-  int max_butteraugli_iters_guetzli_mode = 100;
-
   ColorTransform color_transform = ColorTransform::kXYB;
-  YCbCrChromaSubsampling chroma_subsampling;
 
   // If true, the "modular mode options" members below are used.
   bool modular_mode = false;
@@ -117,14 +106,6 @@ struct CompressParams {
   // If on: preserve color of invisible pixels (if off: don't care)
   // Default: on for lossless, off for lossy
   Override keep_invisible = Override::kDefault;
-
-  // Currently unused as of 2020-01.
-  bool clear_metadata = false;
-
-  // Prints extra information during/after encoding.
-  bool verbose = false;
-
-  ButteraugliParams ba_params;
 
   // Force usage of CfL when doing JPEG recompression. This can have unexpected
   // effects on the decoded pixels, while still being JPEG-compliant and
@@ -202,6 +183,9 @@ struct CompressParams {
 
   std::vector<float> manual_noise;
   std::vector<float> manual_xyb_factors;
+
+  JxlDebugImageCallback debug_image = nullptr;
+  void* debug_image_opaque;
 };
 
 static constexpr float kMinButteraugliForDynamicAR = 0.5f;

--- a/lib/jxl/enc_patch_dictionary.cc
+++ b/lib/jxl/enc_patch_dictionary.cc
@@ -29,6 +29,7 @@
 #include "lib/jxl/enc_ans.h"
 #include "lib/jxl/enc_aux_out.h"
 #include "lib/jxl/enc_cache.h"
+#include "lib/jxl/enc_debug_image.h"
 #include "lib/jxl/enc_dot_dictionary.h"
 #include "lib/jxl/enc_frame.h"
 #include "lib/jxl/entropy_coder.h"
@@ -208,8 +209,9 @@ struct PatchColorspaceInfo {
 };
 
 std::vector<PatchInfo> FindTextLikePatches(
-    const Image3F& opsin, const PassesEncoderState* JXL_RESTRICT state,
-    ThreadPool* pool, AuxOut* aux_out, bool is_xyb) {
+    const CompressParams& cparams, const Image3F& opsin,
+    const PassesEncoderState* JXL_RESTRICT state, ThreadPool* pool,
+    AuxOut* aux_out, bool is_xyb) {
   if (state->cparams.patches == Override::kOff) return {};
 
   PatchColorspaceInfo pci(is_xyb);
@@ -298,8 +300,8 @@ std::vector<PatchInfo> FindTextLikePatches(
                       process_row, "IsScreenshotLike"));
 
   // TODO(veluca): also parallelize the rest of this function.
-  if (WantDebugOutput(aux_out)) {
-    aux_out->DumpPlaneNormalized("screenshot_like", is_screenshot_like);
+  if (WantDebugOutput(cparams)) {
+    DumpPlaneNormalized(cparams, "screenshot_like", is_screenshot_like);
   }
 
   constexpr int kSearchRadius = 1;
@@ -379,12 +381,12 @@ std::vector<PatchInfo> FindTextLikePatches(
   ImageF ccs;
   Rng rng(0);
   bool paint_ccs = false;
-  if (WantDebugOutput(aux_out)) {
-    aux_out->DumpPlaneNormalized("is_background", is_background);
+  if (WantDebugOutput(cparams)) {
+    DumpPlaneNormalized(cparams, "is_background", is_background);
     if (is_xyb) {
-      aux_out->DumpXybImage("background", background);
+      DumpXybImage(cparams, "background", background);
     } else {
-      aux_out->DumpImage("background", background);
+      DumpImage(cparams, "background", background);
     }
     ccs = ImageF(opsin.xsize(), opsin.ysize());
     ZeroFillImage(&ccs);
@@ -520,8 +522,8 @@ std::vector<PatchInfo> FindTextLikePatches(
   }
 
   if (paint_ccs) {
-    JXL_ASSERT(WantDebugOutput(aux_out));
-    aux_out->DumpPlaneNormalized("ccs", ccs);
+    JXL_ASSERT(WantDebugOutput(cparams));
+    DumpPlaneNormalized(cparams, "ccs", ccs);
   }
   if (info.empty()) {
     return {};
@@ -568,7 +570,7 @@ void FindBestPatchDictionary(const Image3F& opsin,
                              const JxlCmsInterface& cms, ThreadPool* pool,
                              AuxOut* aux_out, bool is_xyb) {
   std::vector<PatchInfo> info =
-      FindTextLikePatches(opsin, state, pool, aux_out, is_xyb);
+      FindTextLikePatches(state->cparams, opsin, state, pool, aux_out, is_xyb);
 
   // TODO(veluca): this doesn't work if both dots and patches are enabled.
   // For now, since dots and patches are not likely to occur in the same kind of

--- a/lib/jxl/encode.cc
+++ b/lib/jxl/encode.cc
@@ -375,23 +375,26 @@ JxlEncoderStatus JxlEncoderStruct::RefillOutputByteQueue() {
            level_message)
               .c_str());
     }
-
+    jxl::AuxOut* aux_out =
+        input.frame ? input.frame->option_values.aux_out : nullptr;
     jxl::BitWriter writer;
-    if (!WriteCodestreamHeaders(&metadata, &writer, nullptr)) {
+    if (!WriteCodestreamHeaders(&metadata, &writer, aux_out)) {
       return JXL_API_ERROR(this, JXL_ENC_ERR_GENERIC,
                            "Failed to write codestream header");
     }
     // Only send ICC (at least several hundred bytes) if fields aren't enough.
     if (metadata.m.color_encoding.WantICC()) {
       if (!jxl::WriteICC(metadata.m.color_encoding.ICC(), &writer,
-                         jxl::kLayerHeader, nullptr)) {
+                         jxl::kLayerHeader, aux_out)) {
         return JXL_API_ERROR(this, JXL_ENC_ERR_GENERIC,
                              "Failed to write ICC profile");
       }
     }
     // TODO(lode): preview should be added here if a preview image is added
 
+    jxl::BitWriter::Allotment allotment(&writer, 8);
     writer.ZeroPadToByte();
+    allotment.ReclaimAndCharge(&writer, jxl::kLayerHeader, aux_out);
 
     // Not actually the end of frame, but the end of metadata/ICC, but helps
     // the next frame to start here for indexing purposes.
@@ -564,7 +567,7 @@ JxlEncoderStatus JxlEncoderStruct::RefillOutputByteQueue() {
       if (!jxl::EncodeFrame(input_frame->option_values.cparams, frame_info,
                             &metadata, input_frame->frame, &enc_state, cms,
                             thread_pool.get(), &writer,
-                            /*aux_out=*/nullptr)) {
+                            input_frame->option_values.aux_out)) {
         return JXL_API_ERROR(this, JXL_ENC_ERR_GENERIC,
                              "Failed to encode frame");
       }
@@ -2082,4 +2085,93 @@ void JxlColorEncodingSetToLinearSRGB(JxlColorEncoding* color_encoding,
 
 void JxlEncoderAllowExpertOptions(JxlEncoder* enc) {
   enc->allow_expert_options = true;
+}
+
+JXL_EXPORT void JxlEncoderSetDebugImageCallback(
+    JxlEncoderFrameSettings* frame_settings, JxlDebugImageCallback callback,
+    void* opaque) {
+  frame_settings->values.cparams.debug_image = callback;
+  frame_settings->values.cparams.debug_image_opaque = opaque;
+}
+
+JXL_EXPORT JxlEncoderStats* JxlEncoderStatsCreate() {
+  return new JxlEncoderStats();
+}
+
+JXL_EXPORT void JxlEncoderStatsDestroy(JxlEncoderStats* stats) {
+  if (stats) delete stats;
+}
+
+JXL_EXPORT void JxlEncoderCollectStats(JxlEncoderFrameSettings* frame_settings,
+                                       JxlEncoderStats* stats) {
+  if (!stats) return;
+  frame_settings->values.aux_out = &stats->aux_out;
+}
+
+JXL_EXPORT size_t JxlEncoderStatsGet(const JxlEncoderStats* stats,
+                                     JxlEncoderStatsKey key) {
+  if (!stats) return 0;
+  const jxl::AuxOut& aux_out = stats->aux_out;
+  switch (key) {
+    case JXL_ENC_STAT_HEADER_BITS:
+      return aux_out.layers[jxl::kLayerHeader].total_bits;
+    case JXL_ENC_STAT_TOC_BITS:
+      return aux_out.layers[jxl::kLayerTOC].total_bits;
+    case JXL_ENC_STAT_DICTIONARY_BITS:
+      return aux_out.layers[jxl::kLayerDictionary].total_bits;
+    case JXL_ENC_STAT_SPLINES_BITS:
+      return aux_out.layers[jxl::kLayerSplines].total_bits;
+    case JXL_ENC_STAT_NOISE_BITS:
+      return aux_out.layers[jxl::kLayerNoise].total_bits;
+    case JXL_ENC_STAT_QUANT_BITS:
+      return aux_out.layers[jxl::kLayerQuant].total_bits;
+    case JXL_ENC_STAT_MODULAR_TREE_BITS:
+      return aux_out.layers[jxl::kLayerModularTree].total_bits;
+    case JXL_ENC_STAT_MODULAR_GLOBAL_BITS:
+      return aux_out.layers[jxl::kLayerModularGlobal].total_bits;
+    case JXL_ENC_STAT_DC_BITS:
+      return aux_out.layers[jxl::kLayerDC].total_bits;
+    case JXL_ENC_STAT_MODULAR_DC_GROUP_BITS:
+      return aux_out.layers[jxl::kLayerModularDcGroup].total_bits;
+    case JXL_ENC_STAT_CONTROL_FIELDS_BITS:
+      return aux_out.layers[jxl::kLayerControlFields].total_bits;
+    case JXL_ENC_STAT_COEF_ORDER_BITS:
+      return aux_out.layers[jxl::kLayerOrder].total_bits;
+    case JXL_ENC_STAT_AC_HISTOGRAM_BITS:
+      return aux_out.layers[jxl::kLayerAC].total_bits;
+    case JXL_ENC_STAT_AC_BITS:
+      return aux_out.layers[jxl::kLayerACTokens].total_bits;
+    case JXL_ENC_STAT_MODULAR_AC_GROUP_BITS:
+      return aux_out.layers[jxl::kLayerModularAcGroup].total_bits;
+    case JXL_ENC_STAT_NUM_SMALL_BLOCKS:
+      return aux_out.num_small_blocks;
+    case JXL_ENC_STAT_NUM_DCT4X8_BLOCKS:
+      return aux_out.num_dct4x8_blocks;
+    case JXL_ENC_STAT_NUM_AFV_BLOCKS:
+      return aux_out.num_afv_blocks;
+    case JXL_ENC_STAT_NUM_DCT8_BLOCKS:
+      return aux_out.num_dct8_blocks;
+    case JXL_ENC_STAT_NUM_DCT8X32_BLOCKS:
+      return aux_out.num_dct16_blocks;
+    case JXL_ENC_STAT_NUM_DCT16_BLOCKS:
+      return aux_out.num_dct16x32_blocks;
+    case JXL_ENC_STAT_NUM_DCT16X32_BLOCKS:
+      return aux_out.num_dct32_blocks;
+    case JXL_ENC_STAT_NUM_DCT32_BLOCKS:
+      return aux_out.num_dct32x64_blocks;
+    case JXL_ENC_STAT_NUM_DCT32X64_BLOCKS:
+      return aux_out.num_dct32x64_blocks;
+    case JXL_ENC_STAT_NUM_DCT64_BLOCKS:
+      return aux_out.num_dct64_blocks;
+    case JXL_ENC_STAT_NUM_BUTTERAUGLI_ITERS:
+      return aux_out.num_butteraugli_iters;
+    default:
+      return 0;
+  }
+}
+
+JXL_EXPORT void JxlEncoderStatsMerge(JxlEncoderStats* stats,
+                                     const JxlEncoderStats* other) {
+  if (!stats || !other) return;
+  stats->aux_out.Assimilate(other->aux_out);
 }

--- a/lib/jxl/encode_internal.h
+++ b/lib/jxl/encode_internal.h
@@ -16,6 +16,7 @@
 #include <vector>
 
 #include "lib/jxl/base/data_parallel.h"
+#include "lib/jxl/enc_aux_out.h"
 #include "lib/jxl/enc_fast_lossless.h"
 #include "lib/jxl/enc_frame.h"
 #include "lib/jxl/memory_manager_internal.h"
@@ -112,6 +113,7 @@ typedef struct JxlEncoderFrameSettingsValuesStruct {
   std::string frame_name;
   JxlBitDepth image_bit_depth;
   bool frame_index_box = false;
+  jxl::AuxOut* aux_out = nullptr;
 } JxlEncoderFrameSettingsValues;
 
 typedef std::array<uint8_t, 4> BoxType;
@@ -270,6 +272,10 @@ struct JxlEncoderStruct {
 struct JxlEncoderFrameSettingsStruct {
   JxlEncoder* enc;
   jxl::JxlEncoderFrameSettingsValues values;
+};
+
+struct JxlEncoderStatsStruct {
+  jxl::AuxOut aux_out;
 };
 
 #endif  // LIB_JXL_ENCODE_INTERNAL_H_

--- a/lib/jxl/jxl_test.cc
+++ b/lib/jxl/jxl_test.cc
@@ -341,10 +341,10 @@ TEST(JxlTest, RoundtripRGBToGrayscale) {
   ASSERT_TRUE(io.frames[0].TransformTo(srgb_gamma, GetJxlCms()));
   io.metadata.m.color_encoding = io2.Main().c_current();
   io.Main().OverrideProfile(io2.Main().c_current());
-  EXPECT_THAT(
-      ButteraugliDistance(io.frames, io2.frames, cparams.ba_params, GetJxlCms(),
-                          /*distmap=*/nullptr, &pool),
-      IsSlightlyBelow(1.36));
+  EXPECT_THAT(ButteraugliDistance(io.frames, io2.frames, ButteraugliParams(),
+                                  GetJxlCms(),
+                                  /*distmap=*/nullptr, &pool),
+              IsSlightlyBelow(1.36));
 }
 
 TEST(JxlTest, RoundtripLargeFast) {
@@ -645,7 +645,7 @@ TEST(JxlTest, RoundtripGrayscale) {
     EXPECT_TRUE(io2.Main().IsGray());
 
     EXPECT_LE(compressed.size(), 7000u);
-    EXPECT_THAT(ButteraugliDistance(io.frames, io2.frames, cparams.ba_params,
+    EXPECT_THAT(ButteraugliDistance(io.frames, io2.frames, ButteraugliParams(),
                                     GetJxlCms(),
                                     /*distmap=*/nullptr),
                 IsSlightlyBelow(1.6));
@@ -665,7 +665,7 @@ TEST(JxlTest, RoundtripGrayscale) {
     EXPECT_TRUE(io2.Main().IsGray());
 
     EXPECT_LE(compressed.size(), 1300u);
-    EXPECT_THAT(ButteraugliDistance(io.frames, io2.frames, cparams.ba_params,
+    EXPECT_THAT(ButteraugliDistance(io.frames, io2.frames, ButteraugliParams(),
                                     GetJxlCms(),
                                     /*distmap=*/nullptr),
                 IsSlightlyBelow(6.0));
@@ -687,7 +687,7 @@ TEST(JxlTest, RoundtripGrayscale) {
     EXPECT_FALSE(io2.Main().IsGray());
 
     EXPECT_LE(compressed.size(), 7000u);
-    EXPECT_THAT(ButteraugliDistance(io.frames, io2.frames, cparams.ba_params,
+    EXPECT_THAT(ButteraugliDistance(io.frames, io2.frames, ButteraugliParams(),
                                     GetJxlCms(),
                                     /*distmap=*/nullptr),
                 IsSlightlyBelow(1.6));
@@ -728,8 +728,8 @@ TEST(JxlTest, RoundtripAlpha) {
       dparams.unpremultiply_alpha = unpremul_alpha;
       EXPECT_TRUE(
           test::DecodeFile(dparams, Span<const uint8_t>(compressed), &io2));
-      EXPECT_THAT(ButteraugliDistance(io.frames, io2.frames, cparams.ba_params,
-                                      GetJxlCms(),
+      EXPECT_THAT(ButteraugliDistance(io.frames, io2.frames,
+                                      ButteraugliParams(), GetJxlCms(),
                                       /*distmap=*/nullptr),
                   IsSlightlyBelow(1.15));
     }
@@ -843,14 +843,14 @@ TEST(JxlTest, RoundtripAlphaPremultiplied) {
         EXPECT_EQ(unpremul_alpha, !io2.Main().AlphaIsPremultiplied());
         if (!unpremul_alpha) {
           EXPECT_THAT(ButteraugliDistance(io.frames, io2.frames,
-                                          cparams.ba_params, GetJxlCms(),
+                                          ButteraugliParams(), GetJxlCms(),
                                           /*distmap=*/nullptr),
                       IsSlightlyBelow(1.2));
           EXPECT_TRUE(UnpremultiplyAlpha(io2));
           EXPECT_FALSE(io2.Main().AlphaIsPremultiplied());
         }
         EXPECT_THAT(ButteraugliDistance(io_nopremul.frames, io2.frames,
-                                        cparams.ba_params, GetJxlCms(),
+                                        ButteraugliParams(), GetJxlCms(),
                                         /*distmap=*/nullptr),
                     IsSlightlyBelow(1.47));
       }

--- a/lib/jxl/modular/encoding/enc_encoding.cc
+++ b/lib/jxl/modular/encoding/enc_encoding.cc
@@ -39,8 +39,8 @@ namespace jxl {
 
 namespace {
 // Plot tree (if enabled) and predictor usage map.
-constexpr bool kWantDebug = false;
-constexpr bool kPrintTree = false;
+constexpr bool kWantDebug = true;
+// constexpr bool kPrintTree = false;
 
 inline std::array<uint8_t, 3> PredictorColor(Predictor p) {
   switch (p) {
@@ -367,11 +367,14 @@ Status EncodeModularChannelMAANS(const Image &image, pixel_type chan,
       }
     }
   }
-  if (kWantDebug && WantDebugOutput(aux_out)) {
-    aux_out->DumpImage(
+  /* TODO(szabadka): Add cparams to the call stack here.
+  if (kWantDebug && WantDebugOutput(cparams)) {
+    DumpImage(
+        cparams,
         ("pred_" + ToString(group_id) + "_" + ToString(chan)).c_str(),
         predictor_img);
   }
+  */
   *tokenpp = tokenp;
   return true;
 }
@@ -467,9 +470,11 @@ Status ModularEncode(const Image &image, const ModularOptions &options,
     JXL_ASSERT(tree->size() == decoded_tree.size());
     tree_storage = std::move(decoded_tree);
 
+    /* TODO(szabadka) Add text output callback
     if (kWantDebug && kPrintTree && WantDebugOutput(aux_out)) {
       PrintTree(*tree, aux_out->debug_prefix + "/tree_" + ToString(group_id));
-    }
+    } */
+
     // Write tree
     BuildAndEncodeHistograms(HistogramParams(), kNumTreeContexts, tree_tokens,
                              &code, &context_map, writer, kLayerModularTree,

--- a/lib/jxl/modular_test.cc
+++ b/lib/jxl/modular_test.cc
@@ -112,8 +112,7 @@ TEST(ModularTest, RoundtripLossyDeltaPalette) {
   size_t compressed_size;
   JXL_EXPECT_OK(Roundtrip(&io, cparams, {}, &io_out, _, &compressed_size));
   EXPECT_LE(compressed_size, 6800u);
-  cparams.ba_params.intensity_target = 80.0f;
-  EXPECT_THAT(ButteraugliDistance(io.frames, io_out.frames, cparams.ba_params,
+  EXPECT_THAT(ButteraugliDistance(io.frames, io_out.frames, ButteraugliParams(),
                                   GetJxlCms(),
                                   /*distmap=*/nullptr),
               IsSlightlyBelow(1.5));
@@ -136,8 +135,7 @@ TEST(ModularTest, RoundtripLossyDeltaPaletteWP) {
   size_t compressed_size;
   JXL_EXPECT_OK(Roundtrip(&io, cparams, {}, &io_out, _, &compressed_size));
   EXPECT_LE(compressed_size, 7000u);
-  cparams.ba_params.intensity_target = 80.0f;
-  EXPECT_THAT(ButteraugliDistance(io.frames, io_out.frames, cparams.ba_params,
+  EXPECT_THAT(ButteraugliDistance(io.frames, io_out.frames, ButteraugliParams(),
                                   GetJxlCms(),
                                   /*distmap=*/nullptr),
               IsSlightlyBelow(10.1));
@@ -158,8 +156,7 @@ TEST(ModularTest, RoundtripLossy) {
   size_t compressed_size;
   JXL_EXPECT_OK(Roundtrip(&io, cparams, {}, &io_out, _, &compressed_size));
   EXPECT_LE(compressed_size, 30000u);
-  cparams.ba_params.intensity_target = 80.0f;
-  EXPECT_THAT(ButteraugliDistance(io.frames, io_out.frames, cparams.ba_params,
+  EXPECT_THAT(ButteraugliDistance(io.frames, io_out.frames, ButteraugliParams(),
                                   GetJxlCms(),
                                   /*distmap=*/nullptr),
               IsSlightlyBelow(2.3));
@@ -184,8 +181,7 @@ TEST(ModularTest, RoundtripLossy16) {
   size_t compressed_size;
   JXL_EXPECT_OK(Roundtrip(&io, cparams, {}, &io_out, _, &compressed_size));
   EXPECT_LE(compressed_size, 300u);
-  cparams.ba_params.intensity_target = 80.0f;
-  EXPECT_THAT(ButteraugliDistance(io.frames, io_out.frames, cparams.ba_params,
+  EXPECT_THAT(ButteraugliDistance(io.frames, io_out.frames, ButteraugliParams(),
                                   GetJxlCms(),
                                   /*distmap=*/nullptr),
               IsSlightlyBelow(1.6));

--- a/lib/jxl/passes_test.cc
+++ b/lib/jxl/passes_test.cc
@@ -47,10 +47,10 @@ TEST(PassesTest, RoundtripSmallPasses) {
 
   CodecInOut io2;
   JXL_EXPECT_OK(Roundtrip(&io, cparams, {}, &io2, _));
-  EXPECT_THAT(
-      ButteraugliDistance(io.frames, io2.frames, cparams.ba_params, GetJxlCms(),
-                          /*distmap=*/nullptr),
-      IsSlightlyBelow(1.1));
+  EXPECT_THAT(ButteraugliDistance(io.frames, io2.frames, ButteraugliParams(),
+                                  GetJxlCms(),
+                                  /*distmap=*/nullptr),
+              IsSlightlyBelow(1.1));
 }
 
 TEST(PassesTest, RoundtripUnalignedPasses) {
@@ -66,10 +66,10 @@ TEST(PassesTest, RoundtripUnalignedPasses) {
 
   CodecInOut io2;
   JXL_EXPECT_OK(Roundtrip(&io, cparams, {}, &io2, _));
-  EXPECT_THAT(
-      ButteraugliDistance(io.frames, io2.frames, cparams.ba_params, GetJxlCms(),
-                          /*distmap=*/nullptr),
-      IsSlightlyBelow(1.72));
+  EXPECT_THAT(ButteraugliDistance(io.frames, io2.frames, ButteraugliParams(),
+                                  GetJxlCms(),
+                                  /*distmap=*/nullptr),
+              IsSlightlyBelow(1.72));
 }
 
 TEST(PassesTest, RoundtripMultiGroupPasses) {
@@ -89,7 +89,7 @@ TEST(PassesTest, RoundtripMultiGroupPasses) {
     CodecInOut io2;
     JXL_EXPECT_OK(Roundtrip(&io, cparams, {}, &io2, _,
                             /* compressed_size */ nullptr, &pool));
-    EXPECT_THAT(ButteraugliDistance(io.frames, io2.frames, cparams.ba_params,
+    EXPECT_THAT(ButteraugliDistance(io.frames, io2.frames, ButteraugliParams(),
                                     GetJxlCms(),
                                     /*distmap=*/nullptr, &pool),
                 IsSlightlyBelow(target_distance + threshold));
@@ -145,10 +145,10 @@ TEST(PassesTest, RoundtripProgressiveConsistent) {
 
     // Exact same distance.
     const float dist2 = ButteraugliDistance(io.frames, io2.frames,
-                                            cparams.ba_params, GetJxlCms(),
+                                            ButteraugliParams(), GetJxlCms(),
                                             /*distmap=*/nullptr, &pool);
     const float dist3 = ButteraugliDistance(io.frames, io3.frames,
-                                            cparams.ba_params, GetJxlCms(),
+                                            ButteraugliParams(), GetJxlCms(),
                                             /*distmap=*/nullptr, &pool);
     EXPECT_EQ(dist2, dist3);
   }
@@ -193,7 +193,7 @@ TEST(PassesTest, AllDownsampleFeasible) {
         test::DecodeFile(dparams, Span<const uint8_t>(compressed), &output));
     EXPECT_EQ(output.xsize(), io.xsize()) << "downsampling = " << downsampling;
     EXPECT_EQ(output.ysize(), io.ysize()) << "downsampling = " << downsampling;
-    EXPECT_LE(ButteraugliDistance(io.frames, output.frames, cparams.ba_params,
+    EXPECT_LE(ButteraugliDistance(io.frames, output.frames, ButteraugliParams(),
                                   GetJxlCms(),
                                   /*distmap=*/nullptr, nullptr),
               target_butteraugli[downsampling])
@@ -242,7 +242,7 @@ TEST(PassesTest, AllDownsampleFeasibleQProgressive) {
         test::DecodeFile(dparams, Span<const uint8_t>(compressed), &output));
     EXPECT_EQ(output.xsize(), io.xsize()) << "downsampling = " << downsampling;
     EXPECT_EQ(output.ysize(), io.ysize()) << "downsampling = " << downsampling;
-    EXPECT_LE(ButteraugliDistance(io.frames, output.frames, cparams.ba_params,
+    EXPECT_LE(ButteraugliDistance(io.frames, output.frames, ButteraugliParams(),
                                   GetJxlCms(),
                                   /*distmap=*/nullptr),
               target_butteraugli[downsampling])
@@ -295,7 +295,7 @@ TEST(PassesTest, ProgressiveDownsample2DegradesCorrectlyGrayscale) {
 
   // 0 if reading all the passes, ~15 if skipping the 8x pass.
   float butteraugli_distance_down2_full = ButteraugliDistance(
-      output.frames, output_d2.frames, cparams.ba_params, GetJxlCms(),
+      output.frames, output_d2.frames, ButteraugliParams(), GetJxlCms(),
       /*distmap=*/nullptr);
 
   EXPECT_LE(butteraugli_distance_down2_full, 3.2f);
@@ -343,7 +343,7 @@ TEST(PassesTest, ProgressiveDownsample2DegradesCorrectly) {
 
   // 0 if reading all the passes, ~15 if skipping the 8x pass.
   float butteraugli_distance_down2_full = ButteraugliDistance(
-      output.frames, output_d2.frames, cparams.ba_params, GetJxlCms(),
+      output.frames, output_d2.frames, ButteraugliParams(), GetJxlCms(),
       /*distmap=*/nullptr);
 
   EXPECT_LE(butteraugli_distance_down2_full, 3.0f);
@@ -392,10 +392,10 @@ TEST(PassesTest, RoundtripSmallNoGaborishPasses) {
 
   CodecInOut io2;
   JXL_EXPECT_OK(Roundtrip(&io, cparams, {}, &io2, _));
-  EXPECT_THAT(
-      ButteraugliDistance(io.frames, io2.frames, cparams.ba_params, GetJxlCms(),
-                          /*distmap=*/nullptr),
-      IsSlightlyBelow(1.2));
+  EXPECT_THAT(ButteraugliDistance(io.frames, io2.frames, ButteraugliParams(),
+                                  GetJxlCms(),
+                                  /*distmap=*/nullptr),
+              IsSlightlyBelow(1.2));
 }
 
 }  // namespace

--- a/lib/jxl/patch_dictionary_test.cc
+++ b/lib/jxl/patch_dictionary_test.cc
@@ -48,10 +48,10 @@ TEST(PatchDictionaryTest, GrayscaleVarDCT) {
   JXL_EXPECT_OK(Roundtrip(&io, cparams, {}, &io2, _, &compressed_size));
   EXPECT_LE(compressed_size, 14000u);
   // Without patches: ~1.2
-  EXPECT_LE(
-      ButteraugliDistance(io.frames, io2.frames, cparams.ba_params, GetJxlCms(),
-                          /*distmap=*/nullptr),
-      1.1);
+  EXPECT_LE(ButteraugliDistance(io.frames, io2.frames, ButteraugliParams(),
+                                GetJxlCms(),
+                                /*distmap=*/nullptr),
+            1.1);
 }
 
 }  // namespace

--- a/lib/jxl/preview_test.cc
+++ b/lib/jxl/preview_test.cc
@@ -55,13 +55,13 @@ TEST(PreviewTest, RoundtripGivenPreview) {
   EXPECT_EQ(preview_ysize, io2.preview_frame.ysize());
 
   EXPECT_LE(ButteraugliDistance(io.preview_frame, io2.preview_frame,
-                                cparams.ba_params, GetJxlCms(),
+                                ButteraugliParams(), GetJxlCms(),
                                 /*distmap=*/nullptr),
             2.5);
-  EXPECT_LE(
-      ButteraugliDistance(io.Main(), io2.Main(), cparams.ba_params, GetJxlCms(),
-                          /*distmap=*/nullptr),
-      2.5);
+  EXPECT_LE(ButteraugliDistance(io.Main(), io2.Main(), ButteraugliParams(),
+                                GetJxlCms(),
+                                /*distmap=*/nullptr),
+            2.5);
 }
 
 }  // namespace

--- a/lib/jxl/speed_tier_test.cc
+++ b/lib/jxl/speed_tier_test.cc
@@ -99,10 +99,10 @@ TEST_P(SpeedTierTest, Roundtrip) {
   JXL_EXPECT_OK(test::Roundtrip(&io, cparams, {}, &io2, _));
 
   // Can be 2.2 in non-hare mode.
-  EXPECT_LE(
-      ButteraugliDistance(io.frames, io2.frames, cparams.ba_params, GetJxlCms(),
-                          /*distmap=*/nullptr, /*pool=*/nullptr),
-      2.8);
+  EXPECT_LE(ButteraugliDistance(io.frames, io2.frames, ButteraugliParams(),
+                                GetJxlCms(),
+                                /*distmap=*/nullptr, /*pool=*/nullptr),
+            2.8);
 }
 }  // namespace
 }  // namespace jxl

--- a/lib/jxl_lists.bzl
+++ b/lib/jxl_lists.bzl
@@ -327,6 +327,8 @@ libjxl_enc_sources = [
     "jxl/enc_comparator.h",
     "jxl/enc_context_map.cc",
     "jxl/enc_context_map.h",
+    "jxl/enc_debug_image.cc",
+    "jxl/enc_debug_image.h",
     "jxl/enc_detect_dots.cc",
     "jxl/enc_detect_dots.h",
     "jxl/enc_dot_dictionary.cc",
@@ -551,6 +553,7 @@ libjxl_public_headers = [
     "include/jxl/encode_cxx.h",
     "include/jxl/memory_manager.h",
     "include/jxl/parallel_runner.h",
+    "include/jxl/stats.h",
     "include/jxl/types.h",
 ]
 

--- a/lib/jxl_lists.cmake
+++ b/lib/jxl_lists.cmake
@@ -327,6 +327,8 @@ set(JPEGXL_INTERNAL_ENC_SOURCES
   jxl/enc_comparator.h
   jxl/enc_context_map.cc
   jxl/enc_context_map.h
+  jxl/enc_debug_image.cc
+  jxl/enc_debug_image.h
   jxl/enc_detect_dots.cc
   jxl/enc_detect_dots.h
   jxl/enc_dot_dictionary.cc
@@ -543,6 +545,7 @@ set(JPEGXL_INTERNAL_PUBLIC_HEADERS
   include/jxl/encode_cxx.h
   include/jxl/memory_manager.h
   include/jxl/parallel_runner.h
+  include/jxl/stats.h
   include/jxl/types.h
 )
 

--- a/tools/benchmark/benchmark_codec_jxl.cc
+++ b/tools/benchmark/benchmark_codec_jxl.cc
@@ -4,6 +4,7 @@
 // license that can be found in the LICENSE file.
 #include "tools/benchmark/benchmark_codec_jxl.h"
 
+#include <jxl/stats.h>
 #include <jxl/thread_parallel_runner_cxx.h>
 
 #include <cstdint>
@@ -16,23 +17,16 @@
 
 #include "lib/extras/codec.h"
 #include "lib/extras/dec/jxl.h"
+#include "lib/extras/enc/apng.h"
 #include "lib/extras/enc/encode.h"
 #include "lib/extras/enc/jpg.h"
+#include "lib/extras/enc/jxl.h"
 #include "lib/extras/packed_image_convert.h"
 #include "lib/extras/time.h"
 #include "lib/jxl/base/data_parallel.h"
 #include "lib/jxl/base/override.h"
-#include "lib/jxl/base/padded_bytes.h"
 #include "lib/jxl/base/span.h"
 #include "lib/jxl/codec_in_out.h"
-#include "lib/jxl/enc_cache.h"
-#include "lib/jxl/enc_color_management.h"
-#include "lib/jxl/enc_external_image.h"
-#include "lib/jxl/enc_file.h"
-#include "lib/jxl/enc_params.h"
-#include "lib/jxl/image_bundle.h"
-#include "lib/jxl/image_metadata.h"
-#include "lib/jxl/modular/encoding/encoding.h"
 #include "tools/benchmark/benchmark_file_io.h"
 #include "tools/benchmark/benchmark_stats.h"
 #include "tools/cmdline.h"
@@ -40,32 +34,15 @@
 namespace jpegxl {
 namespace tools {
 
-using ::jxl::AuxOut;
-using ::jxl::ColorTransform;
-using ::jxl::CompressParams;
 using ::jxl::Image3F;
-using ::jxl::PaddedBytes;
-using ::jxl::PassesEncoderState;
-using ::jxl::Predictor;
-using ::jxl::SpeedTier;
 using ::jxl::extras::EncodedImage;
 using ::jxl::extras::Encoder;
+using ::jxl::extras::JXLCompressParams;
 using ::jxl::extras::JXLDecompressParams;
+using ::jxl::extras::PackedFrame;
 using ::jxl::extras::PackedPixelFile;
 
-// Output function for EncodeBrunsli.
-size_t OutputToBytes(void* data, const uint8_t* buf, size_t count) {
-  PaddedBytes* output = reinterpret_cast<PaddedBytes*>(data);
-  output->append(buf, buf + count);
-  return count;
-}
-
 struct JxlArgs {
-  double hf_asymmetry;
-  double xmul;
-  double quant_bias;
-
-  bool use_ac_strategy;
   bool qprogressive;  // progressive with shift-quantization.
   bool progressive;
   int progressive_dc;
@@ -80,18 +57,6 @@ struct JxlArgs {
 static JxlArgs* const jxlargs = new JxlArgs;
 
 Status AddCommandLineOptionsJxlCodec(BenchmarkArgs* args) {
-  args->AddDouble(&jxlargs->hf_asymmetry, "hf_asymmetry",
-                  "Multiplier for weighting HF artefacts more than features "
-                  "being smoothed out. 1.0 means no HF asymmetry. 0.3 is "
-                  "a good value to start exploring for asymmetry.",
-                  1.0);
-  args->AddDouble(&jxlargs->xmul, "xmul",
-                  "Multiplier for the difference in X channel in Butteraugli.",
-                  1.0);
-  args->AddDouble(&jxlargs->quant_bias, "quant_bias",
-                  "Bias border pixels during quantization by this ratio.", 0.0);
-  args->AddFlag(&jxlargs->use_ac_strategy, "use_ac_strategy",
-                "If true, AC strategy will be used.", false);
   args->AddFlag(&jxlargs->qprogressive, "qprogressive",
                 "Enable quantized progressive mode for AC.", false);
   args->AddFlag(&jxlargs->progressive, "progressive",
@@ -116,42 +81,41 @@ Status AddCommandLineOptionsJxlCodec(BenchmarkArgs* args) {
 
 Status ValidateArgsJxlCodec(BenchmarkArgs* args) { return true; }
 
-inline bool ParseSpeedTier(const std::string& s, SpeedTier* out) {
+inline bool ParseEffort(const std::string& s, int* out) {
   if (s == "lightning") {
-    *out = SpeedTier::kLightning;
+    *out = 1;
     return true;
   } else if (s == "thunder") {
-    *out = SpeedTier::kThunder;
+    *out = 2;
     return true;
   } else if (s == "falcon") {
-    *out = SpeedTier::kFalcon;
+    *out = 3;
     return true;
   } else if (s == "cheetah") {
-    *out = SpeedTier::kCheetah;
+    *out = 4;
     return true;
   } else if (s == "hare") {
-    *out = SpeedTier::kHare;
+    *out = 5;
     return true;
   } else if (s == "fast" || s == "wombat") {
-    *out = SpeedTier::kWombat;
+    *out = 6;
     return true;
   } else if (s == "squirrel") {
-    *out = SpeedTier::kSquirrel;
+    *out = 7;
     return true;
   } else if (s == "kitten") {
-    *out = SpeedTier::kKitten;
+    *out = 8;
     return true;
   } else if (s == "guetzli" || s == "tortoise") {
-    *out = SpeedTier::kTortoise;
+    *out = 9;
     return true;
   } else if (s == "glacier") {
-    *out = SpeedTier::kGlacier;
+    *out = 10;
     return true;
   }
-  size_t st = 10 - static_cast<size_t>(strtoull(s.c_str(), nullptr, 0));
-  if (st <= static_cast<size_t>(SpeedTier::kLightning) &&
-      st >= static_cast<size_t>(SpeedTier::kTortoise)) {
-    *out = SpeedTier(st);
+  size_t st = static_cast<size_t>(strtoull(s.c_str(), nullptr, 0));
+  if (st <= 10 && st >= 1) {
+    *out = st;
     return true;
   }
   return false;
@@ -159,37 +123,34 @@ inline bool ParseSpeedTier(const std::string& s, SpeedTier* out) {
 
 class JxlCodec : public ImageCodec {
  public:
-  explicit JxlCodec(const BenchmarkArgs& args) : ImageCodec(args) {}
+  explicit JxlCodec(const BenchmarkArgs& args)
+      : ImageCodec(args), stats_(nullptr, JxlEncoderStatsDestroy) {}
 
   Status ParseParam(const std::string& param) override {
     const std::string kMaxPassesPrefix = "max_passes=";
     const std::string kDownsamplingPrefix = "downsampling=";
     const std::string kResamplingPrefix = "resampling=";
     const std::string kEcResamplingPrefix = "ec_resampling=";
-
+    int val;
+    float fval;
     if (param.substr(0, kResamplingPrefix.size()) == kResamplingPrefix) {
       std::istringstream parser(param.substr(kResamplingPrefix.size()));
-      parser >> cparams_.resampling;
+      int resampling;
+      parser >> resampling;
+      cparams_.AddOption(JXL_ENC_FRAME_SETTING_RESAMPLING, resampling);
     } else if (param.substr(0, kEcResamplingPrefix.size()) ==
                kEcResamplingPrefix) {
       std::istringstream parser(param.substr(kEcResamplingPrefix.size()));
-      parser >> cparams_.ec_resampling;
+      int ec_resampling;
+      parser >> ec_resampling;
+      cparams_.AddOption(JXL_ENC_FRAME_SETTING_EXTRA_CHANNEL_RESAMPLING,
+                         ec_resampling);
     } else if (ImageCodec::ParseParam(param)) {
-      if (param[0] == 'd' && butteraugli_target_ == 0.0) {
-        cparams_.SetLossless();
-      }
+      // Nothing to do.
     } else if (param == "uint8") {
       uint8_ = true;
-    } else if (param[0] == 'u') {
-      char* end;
-      cparams_.uniform_quant = strtof(param.c_str() + 1, &end);
-      if (end == param.c_str() + 1 || *end != '\0') {
-        return JXL_FAILURE("failed to parse uniform quant parameter %s",
-                           param.c_str());
-      }
     } else if (param[0] == 'D') {
-      cparams_.ec_distance.clear();
-      cparams_.ec_distance.push_back(strtof(param.substr(1).c_str(), nullptr));
+      cparams_.alpha_distance = strtof(param.substr(1).c_str(), nullptr);
     } else if (param.substr(0, kMaxPassesPrefix.size()) == kMaxPassesPrefix) {
       std::istringstream parser(param.substr(kMaxPassesPrefix.size()));
       parser >> dparams_.max_passes;
@@ -197,71 +158,81 @@ class JxlCodec : public ImageCodec {
                kDownsamplingPrefix) {
       std::istringstream parser(param.substr(kDownsamplingPrefix.size()));
       parser >> dparams_.max_downsampling;
-    } else if (ParseSpeedTier(param, &cparams_.speed_tier)) {
-      // Nothing to do.
+    } else if (ParseEffort(param, &val)) {
+      cparams_.AddOption(JXL_ENC_FRAME_SETTING_EFFORT, val);
     } else if (param[0] == 'X') {
-      cparams_.channel_colors_pre_transform_percent =
-          strtol(param.substr(1).c_str(), nullptr, 10);
+      fval = strtof(param.substr(1).c_str(), nullptr);
+      cparams_.AddFloatOption(
+          JXL_ENC_FRAME_SETTING_CHANNEL_COLORS_GLOBAL_PERCENT, fval);
     } else if (param[0] == 'Y') {
-      cparams_.channel_colors_percent =
-          strtol(param.substr(1).c_str(), nullptr, 10);
+      fval = strtof(param.substr(1).c_str(), nullptr);
+      cparams_.AddFloatOption(
+          JXL_ENC_FRAME_SETTING_CHANNEL_COLORS_GROUP_PERCENT, fval);
     } else if (param[0] == 'p') {
-      cparams_.palette_colors = strtol(param.substr(1).c_str(), nullptr, 10);
+      val = strtol(param.substr(1).c_str(), nullptr, 10);
+      cparams_.AddOption(JXL_ENC_FRAME_SETTING_PALETTE_COLORS, val);
     } else if (param == "lp") {
-      cparams_.lossy_palette = true;
+      cparams_.AddOption(JXL_ENC_FRAME_SETTING_LOSSY_PALETTE, 1);
     } else if (param[0] == 'C') {
-      cparams_.colorspace = strtol(param.substr(1).c_str(), nullptr, 10);
+      val = strtol(param.substr(1).c_str(), nullptr, 10);
+      cparams_.AddOption(JXL_ENC_FRAME_SETTING_MODULAR_COLOR_SPACE, val);
     } else if (param[0] == 'c') {
-      cparams_.color_transform =
-          (jxl::ColorTransform)strtol(param.substr(1).c_str(), nullptr, 10);
+      val = strtol(param.substr(1).c_str(), nullptr, 10);
+      cparams_.AddOption(JXL_ENC_FRAME_SETTING_COLOR_TRANSFORM, val);
       has_ctransform_ = true;
     } else if (param[0] == 'I') {
-      cparams_.options.nb_repeats = strtof(param.substr(1).c_str(), nullptr);
+      fval = strtof(param.substr(1).c_str(), nullptr);
+      cparams_.AddFloatOption(
+          JXL_ENC_FRAME_SETTING_MODULAR_MA_TREE_LEARNING_PERCENT, fval * 100.0);
     } else if (param[0] == 'E') {
-      cparams_.options.max_properties =
-          strtof(param.substr(1).c_str(), nullptr);
+      val = strtol(param.substr(1).c_str(), nullptr, 10);
+      cparams_.AddOption(JXL_ENC_FRAME_SETTING_MODULAR_NB_PREV_CHANNELS, val);
     } else if (param[0] == 'P') {
-      cparams_.options.predictor =
-          static_cast<Predictor>(strtof(param.substr(1).c_str(), nullptr));
+      val = strtol(param.substr(1).c_str(), nullptr, 10);
+      cparams_.AddOption(JXL_ENC_FRAME_SETTING_MODULAR_PREDICTOR, val);
     } else if (param == "slow") {
-      cparams_.options.nb_repeats = 2;
+      cparams_.AddFloatOption(
+          JXL_ENC_FRAME_SETTING_MODULAR_MA_TREE_LEARNING_PERCENT, 50.0);
     } else if (param == "R") {
-      cparams_.responsive = 1;
+      cparams_.AddOption(JXL_ENC_FRAME_SETTING_RESPONSIVE, 1);
     } else if (param[0] == 'R') {
-      cparams_.responsive = strtol(param.substr(1).c_str(), nullptr, 10);
+      val = strtol(param.substr(1).c_str(), nullptr, 10);
+      cparams_.AddOption(JXL_ENC_FRAME_SETTING_RESPONSIVE, val);
     } else if (param == "m") {
-      cparams_.modular_mode = true;
-      cparams_.color_transform = jxl::ColorTransform::kNone;
+      cparams_.AddOption(JXL_ENC_FRAME_SETTING_MODULAR, 1);
+      cparams_.AddOption(JXL_ENC_FRAME_SETTING_COLOR_TRANSFORM, 1);  // kNone
+      modular_mode_ = true;
     } else if (param.substr(0, 3) == "gab") {
-      long gab = strtol(param.substr(3).c_str(), nullptr, 10);
-      if (gab != 0 && gab != 1) {
+      val = strtol(param.substr(3).c_str(), nullptr, 10);
+      if (val != 0 && val != 1) {
         return JXL_FAILURE("Invalid gab value");
       }
-      cparams_.gaborish = static_cast<Override>(gab);
+      cparams_.AddOption(JXL_ENC_FRAME_SETTING_GABORISH, val);
     } else if (param[0] == 'g') {
-      long gsize = strtol(param.substr(1).c_str(), nullptr, 10);
-      if (gsize < 0 || gsize > 3) {
+      val = strtol(param.substr(1).c_str(), nullptr, 10);
+      if (val < 0 || val > 3) {
         return JXL_FAILURE("Invalid group size shift value");
       }
-      cparams_.modular_group_size_shift = gsize;
+      cparams_.AddOption(JXL_ENC_FRAME_SETTING_MODULAR_GROUP_SIZE, val);
     } else if (param == "plt") {
-      cparams_.options.max_properties = 0;
-      cparams_.options.nb_repeats = 0;
-      cparams_.options.predictor = Predictor::Zero;
-      cparams_.responsive = 0;
-      cparams_.colorspace = 0;
-      cparams_.channel_colors_pre_transform_percent = 0;
-      cparams_.channel_colors_percent = 0;
+      cparams_.AddOption(JXL_ENC_FRAME_SETTING_MODULAR_NB_PREV_CHANNELS, 0);
+      cparams_.AddFloatOption(
+          JXL_ENC_FRAME_SETTING_MODULAR_MA_TREE_LEARNING_PERCENT, 0.0f);
+      cparams_.AddOption(JXL_ENC_FRAME_SETTING_MODULAR_PREDICTOR, 0);
+      cparams_.AddOption(JXL_ENC_FRAME_SETTING_RESPONSIVE, 0);
+      cparams_.AddOption(JXL_ENC_FRAME_SETTING_MODULAR_COLOR_SPACE, 0);
+      cparams_.AddOption(JXL_ENC_FRAME_SETTING_CHANNEL_COLORS_GLOBAL_PERCENT,
+                         0);
+      cparams_.AddOption(JXL_ENC_FRAME_SETTING_CHANNEL_COLORS_GROUP_PERCENT, 0);
     } else if (param.substr(0, 3) == "epf") {
-      cparams_.epf = strtol(param.substr(3).c_str(), nullptr, 10);
-      if (cparams_.epf > 3) {
+      val = strtol(param.substr(3).c_str(), nullptr, 10);
+      if (val > 3) {
         return JXL_FAILURE("Invalid epf value");
       }
-    } else if (param.substr(0, 2) == "nr") {
-      normalize_bitrate_ = true;
+      cparams_.AddOption(JXL_ENC_FRAME_SETTING_EPF, val);
     } else if (param.substr(0, 16) == "faster_decoding=") {
-      cparams_.decoding_speed_tier =
-          strtol(param.substr(16).c_str(), nullptr, 10);
+      val = strtol(param.substr(16).c_str(), nullptr, 10);
+      cparams_.AddOption(JXL_ENC_FRAME_SETTING_DECODING_SPEED, val);
     } else {
       return JXL_FAILURE("Unrecognized param");
     }
@@ -271,72 +242,36 @@ class JxlCodec : public ImageCodec {
   Status Compress(const std::string& filename, const CodecInOut* io,
                   ThreadPool* pool, std::vector<uint8_t>* compressed,
                   jpegxl::tools::SpeedStats* speed_stats) override {
-    if (!jxlargs->debug_image_dir.empty()) {
-      cinfo_.dump_image = [](Image3F&& image,
-                             const ColorEncoding& color_encoding,
-                             const std::string& path) -> Status {
-        CodecInOut io;
-        // Always save to 16-bit png.
-        io.metadata.m.SetUintSamples(16);
-        io.metadata.m.color_encoding = color_encoding;
-        io.SetFromImage(std::move(image), io.metadata.m.color_encoding);
-        std::vector<uint8_t> encoded;
-        return Encode(io, path, &encoded) && WriteFile(path, encoded);
-      };
-      cinfo_.debug_prefix =
-          JoinPath(jxlargs->debug_image_dir, FileBaseName(filename)) +
-          ".jxl:" + params_ + ".dbg/";
-      JXL_RETURN_IF_ERROR(MakeDir(cinfo_.debug_prefix));
+    PackedPixelFile ppf;
+    JxlPixelFormat format{0, JXL_TYPE_FLOAT, JXL_NATIVE_ENDIAN, 0};
+    JXL_RETURN_IF_ERROR(ConvertCodecInOutToPackedPixelFile(
+        *io, format, io->Main().c_current(), pool, &ppf));
+    cparams_.runner = pool->runner();
+    cparams_.runner_opaque = pool->runner_opaque();
+    cparams_.distance = butteraugli_target_;
+    cparams_.AddOption(JXL_ENC_FRAME_SETTING_NOISE, (int)jxlargs->noise);
+    cparams_.AddOption(JXL_ENC_FRAME_SETTING_DOTS, (int)jxlargs->dots);
+    cparams_.AddOption(JXL_ENC_FRAME_SETTING_PATCHES, (int)jxlargs->patches);
+    cparams_.AddOption(JXL_ENC_FRAME_SETTING_PROGRESSIVE_AC,
+                       jxlargs->progressive);
+    cparams_.AddOption(JXL_ENC_FRAME_SETTING_QPROGRESSIVE_AC,
+                       jxlargs->qprogressive);
+    cparams_.AddOption(JXL_ENC_FRAME_SETTING_PROGRESSIVE_DC,
+                       jxlargs->progressive_dc);
+    if (butteraugli_target_ > 0.f && modular_mode_ && !has_ctransform_) {
+      // Reset color transform to default XYB for lossy modular.
+      cparams_.AddOption(JXL_ENC_FRAME_SETTING_COLOR_TRANSFORM, -1);
     }
-    cparams_.butteraugli_distance = butteraugli_target_;
-    cparams_.target_bitrate = bitrate_target_;
-
-    cparams_.dots = jxlargs->dots;
-    cparams_.patches = jxlargs->patches;
-
-    cparams_.progressive_mode = jxlargs->progressive;
-    cparams_.qprogressive_mode = jxlargs->qprogressive;
-    cparams_.progressive_dc = jxlargs->progressive_dc;
-
-    cparams_.noise = jxlargs->noise;
-
-    cparams_.ba_params.hf_asymmetry = static_cast<float>(jxlargs->hf_asymmetry);
-    cparams_.ba_params.xmul = static_cast<float>(jxlargs->xmul);
-
-    if (cparams_.butteraugli_distance > 0.f &&
-        cparams_.color_transform == ColorTransform::kNone &&
-        cparams_.modular_mode && !has_ctransform_) {
-      cparams_.color_transform = ColorTransform::kXYB;
+    std::string debug_prefix;
+    SetDebugImageCallback(filename, &debug_prefix, &cparams_);
+    if (args_.print_more_stats) {
+      stats_.reset(JxlEncoderStatsCreate());
+      cparams_.stats = stats_.get();
     }
-
-    if (normalize_bitrate_ && cparams_.butteraugli_distance > 0.0f) {
-      PackedPixelFile ppf;
-      JxlPixelFormat format = {0, JXL_TYPE_UINT8, JXL_BIG_ENDIAN, 0};
-      JXL_RETURN_IF_ERROR(ConvertCodecInOutToPackedPixelFile(
-          *io, format, io->metadata.m.color_encoding, pool, &ppf));
-      EncodedImage encoded;
-      std::unique_ptr<Encoder> encoder = jxl::extras::GetJPEGEncoder();
-      if (!encoder.get()) {
-        fprintf(stderr, "libjpeg codec is not supported\n");
-        return false;
-      }
-      encoder->SetOption("q", "95");
-      JXL_RETURN_IF_ERROR(encoder->Encode(ppf, &encoded, pool));
-      float jpeg_bits = encoded.bitstreams.back().size() * jxl::kBitsPerByte;
-      float jpeg_bitrate = jpeg_bits / (io->xsize() * io->ysize());
-      // Formula fitted on jyrki31 corpus for distances between 1.0 and 8.0.
-      cparams_.target_bitrate = (jpeg_bitrate * 0.36f /
-                                 (0.6f * cparams_.butteraugli_distance + 0.4f));
-    }
-
     const double start = jxl::Now();
-    PassesEncoderState passes_encoder_state;
-    PaddedBytes compressed_padded;
-    JXL_RETURN_IF_ERROR(jxl::EncodeFile(cparams_, io, &passes_encoder_state,
-                                        &compressed_padded, jxl::GetJxlCms(),
-                                        &cinfo_, pool));
+    JXL_RETURN_IF_ERROR(jxl::extras::EncodeImageJXL(
+        cparams_, ppf, /*jpeg_bytes=*/nullptr, compressed));
     const double end = jxl::Now();
-    compressed->assign(compressed_padded.begin(), compressed_padded.end());
     speed_stats->NotifyElapsed(end - start);
     return true;
   }
@@ -368,19 +303,50 @@ class JxlCodec : public ImageCodec {
   }
 
   void GetMoreStats(BenchmarkStats* stats) override {
-    JxlStats jxl_stats;
-    jxl_stats.num_inputs = 1;
-    jxl_stats.aux_out = cinfo_;
-    stats->jxl_stats.Assimilate(jxl_stats);
+    stats->jxl_stats.num_inputs += 1;
+    JxlEncoderStatsMerge(stats->jxl_stats.stats.get(), stats_.get());
   }
 
  protected:
-  AuxOut cinfo_;
-  CompressParams cparams_;
+  JXLCompressParams cparams_;
   bool has_ctransform_ = false;
+  bool modular_mode_ = false;
   JXLDecompressParams dparams_;
   bool uint8_ = false;
-  bool normalize_bitrate_ = false;
+  std::unique_ptr<JxlEncoderStats, decltype(JxlEncoderStatsDestroy)*> stats_;
+
+ private:
+  void SetDebugImageCallback(const std::string& filename,
+                             std::string* debug_prefix,
+                             JXLCompressParams* cparams) {
+    if (jxlargs->debug_image_dir.empty()) return;
+    *debug_prefix = JoinPath(jxlargs->debug_image_dir, FileBaseName(filename)) +
+                    ".jxl:" + params_ + ".dbg/";
+    JXL_CHECK(MakeDir(*debug_prefix));
+    cparams->debug_image_opaque = debug_prefix;
+    cparams->debug_image = [](void* opaque, const char* label, size_t xsize,
+                              size_t ysize, const JxlColorEncoding* color,
+                              const uint16_t* pixels) {
+      auto encoder = jxl::extras::GetAPNGEncoder();
+      JXL_CHECK(encoder);
+      PackedPixelFile debug_ppf;
+      JxlPixelFormat format{3, JXL_TYPE_UINT16, JXL_BIG_ENDIAN, 0};
+      PackedFrame frame(xsize, ysize, format);
+      memcpy(frame.color.pixels(), pixels, 6 * xsize * ysize);
+      debug_ppf.frames.emplace_back(std::move(frame));
+      debug_ppf.info.xsize = xsize;
+      debug_ppf.info.ysize = ysize;
+      debug_ppf.info.num_color_channels = 3;
+      debug_ppf.info.bits_per_sample = 16;
+      debug_ppf.color_encoding = *color;
+      EncodedImage encoded;
+      JXL_CHECK(encoder->Encode(debug_ppf, &encoded));
+      JXL_CHECK(!encoded.bitstreams.empty());
+      std::string* debug_prefix = reinterpret_cast<std::string*>(opaque);
+      std::string fn = *debug_prefix + std::string(label) + ".png";
+      WriteFile(fn, encoded.bitstreams[0]);
+    };
+  }
 };
 
 ImageCodec* CreateNewJxlCodec(const BenchmarkArgs& args) {

--- a/tools/benchmark/benchmark_stats.cc
+++ b/tools/benchmark/benchmark_stats.cc
@@ -19,6 +19,53 @@
 
 namespace jpegxl {
 namespace tools {
+
+#define ADD_NAME(val, name) \
+  case JXL_ENC_STAT_##val:  \
+    return name
+const char* JxlStatsName(JxlEncoderStatsKey key) {
+  switch (key) {
+    ADD_NAME(HEADER_BITS, "Header bits");
+    ADD_NAME(TOC_BITS, "TOC bits");
+    ADD_NAME(DICTIONARY_BITS, "Patch dictionary bits");
+    ADD_NAME(SPLINES_BITS, "Splines bits");
+    ADD_NAME(NOISE_BITS, "Noise bits");
+    ADD_NAME(QUANT_BITS, "Quantizer bits");
+    ADD_NAME(MODULAR_TREE_BITS, "Modular tree bits");
+    ADD_NAME(MODULAR_GLOBAL_BITS, "Modular global bits");
+    ADD_NAME(DC_BITS, "DC bits");
+    ADD_NAME(MODULAR_DC_GROUP_BITS, "Modular DC group bits");
+    ADD_NAME(CONTROL_FIELDS_BITS, "Control field bits");
+    ADD_NAME(COEF_ORDER_BITS, "Coeff order bits");
+    ADD_NAME(AC_HISTOGRAM_BITS, "AC histogram bits");
+    ADD_NAME(AC_BITS, "AC token bits");
+    ADD_NAME(MODULAR_AC_GROUP_BITS, "Modular AC group bits");
+    ADD_NAME(NUM_SMALL_BLOCKS, "Number of small blocks");
+    ADD_NAME(NUM_DCT4X8_BLOCKS, "Number of 4x8 blocks");
+    ADD_NAME(NUM_AFV_BLOCKS, "Number of AFV blocks");
+    ADD_NAME(NUM_DCT8_BLOCKS, "Number of 8x8 blocks");
+    ADD_NAME(NUM_DCT8X32_BLOCKS, "Number of 8x32 blocks");
+    ADD_NAME(NUM_DCT16_BLOCKS, "Number of 16x16 blocks");
+    ADD_NAME(NUM_DCT16X32_BLOCKS, "Number of 16x32 blocks");
+    ADD_NAME(NUM_DCT32_BLOCKS, "Number of 32x32 blocks");
+    ADD_NAME(NUM_DCT32X64_BLOCKS, "Number of 32x64 blocks");
+    ADD_NAME(NUM_DCT64_BLOCKS, "Number of 64x64 blocks");
+    ADD_NAME(NUM_BUTTERAUGLI_ITERS, "Butteraugli iters");
+    default:
+      return "";
+  };
+  return "";
+}
+#undef ADD_NAME
+
+void JxlStats::Print() const {
+  for (int i = 0; i < JXL_ENC_NUM_STATS; ++i) {
+    JxlEncoderStatsKey key = static_cast<JxlEncoderStatsKey>(i);
+    size_t value = JxlEncoderStatsGet(stats.get(), key);
+    if (value) printf("%-25s  %10" PRIuS "\n", JxlStatsName(key), value);
+  }
+}
+
 namespace {
 
 // Computes longest codec name from Args()->codec, for table alignment.
@@ -83,21 +130,10 @@ std::vector<ColumnDescriptor> GetColumnDescriptors(size_t num_extra_metrics) {
       {{"D MP/s"},          8,  3, TYPE_POSITIVE_FLOAT, false},
       {{"Max norm"},       13,  8, TYPE_POSITIVE_FLOAT, false},
       {{"SSIMULACRA2"},    13,  8, TYPE_POSITIVE_FLOAT, false},
+      {{"PSNR"},            7,  2, TYPE_POSITIVE_FLOAT, false},
       {{"pnorm"},          13,  8, TYPE_POSITIVE_FLOAT, false},
-      {{"PSNR"},            7,  2, TYPE_POSITIVE_FLOAT, true},
-      {{"QABPP"},           8,  3, TYPE_POSITIVE_FLOAT, true},
-      {{"SmallB"},          8,  4, TYPE_POSITIVE_FLOAT, true},
-      {{"DCT4x8"},          8,  4, TYPE_POSITIVE_FLOAT, true},
-      {{"AFV"},             8,  4, TYPE_POSITIVE_FLOAT, true},
-      {{"DCT8x8"},          8,  4, TYPE_POSITIVE_FLOAT, true},
-      {{"8x16"},            8,  4, TYPE_POSITIVE_FLOAT, true},
-      {{"8x32"},            8,  4, TYPE_POSITIVE_FLOAT, true},
-      {{"16"},              8,  4, TYPE_POSITIVE_FLOAT, true},
-      {{"16x32"},           8,  4, TYPE_POSITIVE_FLOAT, true},
-      {{"32"},              8,  4, TYPE_POSITIVE_FLOAT, true},
-      {{"32x64"},           8,  4, TYPE_POSITIVE_FLOAT, true},
-      {{"64"},              8,  4, TYPE_POSITIVE_FLOAT, true},
       {{"BPP*pnorm"},      16, 12, TYPE_POSITIVE_FLOAT, false},
+      {{"QABPP"},           8,  3, TYPE_POSITIVE_FLOAT, false},
       {{"Bugs"},            7,  5, TYPE_COUNT, false},
   };
   // clang-format on
@@ -169,13 +205,6 @@ void BenchmarkStats::Assimilate(const BenchmarkStats& victim) {
 void BenchmarkStats::PrintMoreStats() const {
   if (Args()->print_more_stats) {
     jxl_stats.Print();
-    size_t total_bits = jxl_stats.aux_out.TotalBits();
-    size_t compressed_bits = total_compressed_size * jxl::kBitsPerByte;
-    if (total_bits != compressed_bits) {
-      printf("Total layer bits: %" PRIuS " vs total compressed bits: %" PRIuS
-             "  (%.2f%% accounted for)\n",
-             total_bits, compressed_bits, total_bits * 100.0 / compressed_bits);
-    }
   }
   if (Args()->print_distance_percentiles) {
     std::vector<float> sorted = distances;
@@ -216,39 +245,13 @@ std::vector<ColumnValue> BenchmarkStats::ComputeColumns(
   values[5].f = decompression_speed;
   values[6].f = static_cast<double>(max_distance_avg);
   values[7].f = ssimulacra2_avg;
-  values[8].f = p_norm_avg;
-  values[9].f = psnr_avg;
-  values[10].f = adj_comp_bpp;
-  // The DCT2, DCT4, AFV and DCT4X8 are applied to an 8x8 block by having 4x4
-  // DCT2X2s, 2x2 DCT4x4s/AFVs, or 2x1 DCT4X8s, filling the whole 8x8 blocks.
-  // Thus we need to multiply the block count by 8.0 * 8.0 pixels for these
-  // transforms.
-  values[11].f = 100.f * jxl_stats.aux_out.num_small_blocks * 8.0 * 8.0 /
-                 total_input_pixels;
-  values[12].f = 100.f * jxl_stats.aux_out.num_dct4x8_blocks * 8.0 * 8.0 /
-                 total_input_pixels;
-  values[13].f =
-      100.f * jxl_stats.aux_out.num_afv_blocks * 8.0 * 8.0 / total_input_pixels;
-  values[14].f = 100.f * jxl_stats.aux_out.num_dct8_blocks * 8.0 * 8.0 /
-                 total_input_pixels;
-  values[15].f = 100.f * jxl_stats.aux_out.num_dct8x16_blocks * 8.0 * 16.0 /
-                 total_input_pixels;
-  values[16].f = 100.f * jxl_stats.aux_out.num_dct8x32_blocks * 8.0 * 32.0 /
-                 total_input_pixels;
-  values[17].f = 100.f * jxl_stats.aux_out.num_dct16_blocks * 16.0 * 16.0 /
-                 total_input_pixels;
-  values[18].f = 100.f * jxl_stats.aux_out.num_dct16x32_blocks * 16.0 * 32.0 /
-                 total_input_pixels;
-  values[19].f = 100.f * jxl_stats.aux_out.num_dct32_blocks * 32.0 * 32.0 /
-                 total_input_pixels;
-  values[20].f = 100.f * jxl_stats.aux_out.num_dct32x64_blocks * 32.0 * 64.0 /
-                 total_input_pixels;
-  values[21].f = 100.f * jxl_stats.aux_out.num_dct64_blocks * 64.0 * 64.0 /
-                 total_input_pixels;
-  values[22].f = bpp_p_norm;
-  values[23].i = total_errors;
+  values[8].f = psnr_avg;
+  values[9].f = p_norm_avg;
+  values[10].f = bpp_p_norm;
+  values[11].f = adj_comp_bpp;
+  values[12].i = total_errors;
   for (size_t i = 0; i < extra_metrics.size(); i++) {
-    values[24 + i].f = extra_metrics[i] / total_input_files;
+    values[13 + i].f = extra_metrics[i] / total_input_files;
   }
   return values;
 }

--- a/tools/benchmark/benchmark_stats.h
+++ b/tools/benchmark/benchmark_stats.h
@@ -6,34 +6,30 @@
 #ifndef TOOLS_BENCHMARK_BENCHMARK_STATS_H_
 #define TOOLS_BENCHMARK_BENCHMARK_STATS_H_
 
+#include <jxl/stats.h>
 #include <stddef.h>
 #include <stdint.h>
 
+#include <memory>
 #include <string>
 #include <vector>
-
-#include "lib/jxl/enc_aux_out.h"
 
 namespace jpegxl {
 namespace tools {
 
-using ::jxl::AuxOut;
-
 std::string StringPrintf(const char* format, ...);
 
 struct JxlStats {
-  JxlStats() {
-    num_inputs = 0;
-    aux_out = AuxOut();
-  }
+  JxlStats()
+      : num_inputs(0), stats(JxlEncoderStatsCreate(), JxlEncoderStatsDestroy) {}
   void Assimilate(const JxlStats& victim) {
     num_inputs += victim.num_inputs;
-    aux_out.Assimilate(victim.aux_out);
+    JxlEncoderStatsMerge(stats.get(), victim.stats.get());
   }
-  void Print() const { aux_out.Print(num_inputs); }
+  void Print() const;
 
   size_t num_inputs;
-  AuxOut aux_out;
+  std::unique_ptr<JxlEncoderStats, decltype(JxlEncoderStatsDestroy)*> stats;
 };
 
 // The value of an entry in the table. Depending on the ColumnType, the string,

--- a/tools/icc_codec_fuzzer.cc
+++ b/tools/icc_codec_fuzzer.cc
@@ -12,7 +12,6 @@ namespace tools {
 using ::jxl::PaddedBytes;
 
 #ifdef JXL_ICC_FUZZER_SLOW_TEST
-using ::jxl::AuxOut;
 using ::jxl::BitReader;
 using ::jxl::Span;
 #endif
@@ -45,10 +44,9 @@ int TestOneInput(const uint8_t* data, size_t size) {
     PaddedBytes icc;
     icc.assign(data, data + size);
     BitWriter writer;
-    AuxOut aux;
     // Writing should support any random bytestream so must succeed, make
     // fuzzer fail if not.
-    JXL_ASSERT(jxl::WriteICC(icc, &writer, 0, &aux));
+    JXL_ASSERT(jxl::WriteICC(icc, &writer, 0, nullptr));
   }
 #else  // JXL_ICC_FUZZER_SLOW_TEST
   if (read) {


### PR DESCRIPTION
The functionality regarding debug images and stats is almost the same, for the rest I added TODOs.

Removed the unused or publicly not exposed fields from the CompressParams struct.