### PR TITLE
tweak lossless e4+

### DIFF
--- a/lib/jxl/enc_modular.cc
+++ b/lib/jxl/enc_modular.cc
@@ -362,7 +362,9 @@ ModularFrameEncoder::ModularFrameEncoder(const FrameHeader& frame_header,
       // Same, but for the non-Squeeze case.
       prop_order = {0, 1, 15, 9, 10, 11, 12, 13, 14, 2, 3, 4, 5, 6, 7, 8};
       // if few groups, don't use group as a property
-      if (num_streams < 30) prop_order.erase(prop_order.begin() + 1);
+      if (num_streams < 30 && cparams_.speed_tier > SpeedTier::kTortoise) {
+        prop_order.erase(prop_order.begin() + 1);
+      }
     }
     switch (cparams_.speed_tier) {
       case SpeedTier::kHare:

--- a/lib/jxl/enc_modular.cc
+++ b/lib/jxl/enc_modular.cc
@@ -348,11 +348,9 @@ ModularFrameEncoder::ModularFrameEncoder(const FrameHeader& frame_header,
     }
   }
 
-  if (cparams_.speed_tier > SpeedTier::kWombat) {
-    cparams_.options.splitting_heuristics_node_threshold = 192;
-  } else {
-    cparams_.options.splitting_heuristics_node_threshold = 96;
-  }
+  cparams_.options.splitting_heuristics_node_threshold =
+      82 + 14 * static_cast<int>(cparams_.speed_tier);
+
   {
     // Set properties.
     std::vector<uint32_t> prop_order;
@@ -363,17 +361,29 @@ ModularFrameEncoder::ModularFrameEncoder(const FrameHeader& frame_header,
     } else {
       // Same, but for the non-Squeeze case.
       prop_order = {0, 1, 15, 9, 10, 11, 12, 13, 14, 2, 3, 4, 5, 6, 7, 8};
+      // if few groups, don't use group as a property
+      if (num_streams < 30) prop_order.erase(prop_order.begin() + 1);
     }
     switch (cparams_.speed_tier) {
+      case SpeedTier::kHare:
+        cparams_.options.splitting_heuristics_properties.assign(
+            prop_order.begin(), prop_order.begin() + 4);
+        cparams_.options.max_property_values = 24;
+        break;
+      case SpeedTier::kWombat:
+        cparams_.options.splitting_heuristics_properties.assign(
+            prop_order.begin(), prop_order.begin() + 5);
+        cparams_.options.max_property_values = 32;
+        break;
       case SpeedTier::kSquirrel:
         cparams_.options.splitting_heuristics_properties.assign(
-            prop_order.begin(), prop_order.begin() + 8);
-        cparams_.options.max_property_values = 32;
+            prop_order.begin(), prop_order.begin() + 7);
+        cparams_.options.max_property_values = 48;
         break;
       case SpeedTier::kKitten:
         cparams_.options.splitting_heuristics_properties.assign(
             prop_order.begin(), prop_order.begin() + 10);
-        cparams_.options.max_property_values = 64;
+        cparams_.options.max_property_values = 96;
         break;
       case SpeedTier::kTortoise:
         cparams_.options.splitting_heuristics_properties = prop_order;
@@ -381,7 +391,7 @@ ModularFrameEncoder::ModularFrameEncoder(const FrameHeader& frame_header,
         break;
       default:
         cparams_.options.splitting_heuristics_properties.assign(
-            prop_order.begin(), prop_order.begin() + 6);
+            prop_order.begin(), prop_order.begin() + 3);
         cparams_.options.max_property_values = 16;
         break;
     }

--- a/lib/jxl/jxl_test.cc
+++ b/lib/jxl/jxl_test.cc
@@ -1104,7 +1104,7 @@ TEST(JxlTest, RoundtripLossless16AlphaNotMisdetectedAs8Bit) {
   dparams.accepted_formats.push_back(t.ppf().frames[0].color.format);
 
   PackedPixelFile ppf_out;
-  EXPECT_NEAR(Roundtrip(t.ppf(), cparams, dparams, pool, &ppf_out), 543, 75);
+  EXPECT_NEAR(Roundtrip(t.ppf(), cparams, dparams, pool, &ppf_out), 591, 50);
   EXPECT_EQ(ComputeDistance2(t.ppf(), ppf_out), 0.0);
   EXPECT_EQ(ppf_out.info.bits_per_sample, 16);
   EXPECT_EQ(ppf_out.info.alpha_bits, 16);

--- a/lib/jxl/jxl_test.cc
+++ b/lib/jxl/jxl_test.cc
@@ -966,7 +966,7 @@ TEST(JxlTest, JXL_SLOW_TEST(RoundtripLossless8)) {
   JXLCompressParams cparams = CompressParamsForLossless();
 
   PackedPixelFile ppf_out;
-  EXPECT_EQ(Roundtrip(t.ppf(), cparams, {}, &pool, &ppf_out), 222167);
+  EXPECT_EQ(Roundtrip(t.ppf(), cparams, {}, &pool, &ppf_out), 223151);
   EXPECT_EQ(ComputeDistance2(t.ppf(), ppf_out), 0.0);
 }
 
@@ -1033,7 +1033,7 @@ TEST(JxlTest, RoundtripLossless8Alpha) {
   dparams.accepted_formats.push_back(t.ppf().frames[0].color.format);
 
   PackedPixelFile ppf_out;
-  EXPECT_EQ(Roundtrip(t.ppf(), cparams, dparams, pool, &ppf_out), 248817);
+  EXPECT_EQ(Roundtrip(t.ppf(), cparams, dparams, pool, &ppf_out), 251291);
   EXPECT_EQ(ComputeDistance2(t.ppf(), ppf_out), 0.0);
   EXPECT_EQ(ppf_out.info.alpha_bits, 8);
   EXPECT_TRUE(test::SameAlpha(t.ppf(), ppf_out));
@@ -1167,7 +1167,7 @@ TEST(JxlTest, RoundtripLossless8Gray) {
   dparams.accepted_formats.push_back(t.ppf().frames[0].color.format);
 
   PackedPixelFile ppf_out;
-  EXPECT_EQ(Roundtrip(t.ppf(), cparams, dparams, pool, &ppf_out), 92766);
+  EXPECT_EQ(Roundtrip(t.ppf(), cparams, dparams, pool, &ppf_out), 92140);
   EXPECT_EQ(ComputeDistance2(t.ppf(), ppf_out), 0.0);
   EXPECT_EQ(ppf_out.color_encoding.color_space, JXL_COLOR_SPACE_GRAY);
   EXPECT_EQ(ppf_out.info.bits_per_sample, 8);

--- a/lib/jxl/modular/encoding/context_predict.h
+++ b/lib/jxl/modular/encoding/context_predict.h
@@ -589,6 +589,18 @@ inline PredictionResult PredictTreeWP(Properties *p, size_t w,
       p, w, pp, onerow, x, y, Predictor::Zero, &tree_lookup, &references,
       wp_state, /*predictions=*/nullptr);
 }
+inline PredictionResult PredictTreeWPNEC(Properties *p, size_t w,
+                                         const pixel_type *JXL_RESTRICT pp,
+                                         const intptr_t onerow, const int x,
+                                         const int y,
+                                         const MATreeLookup &tree_lookup,
+                                         const Channel &references,
+                                         weighted::State *wp_state) {
+  return detail::Predict<detail::kUseTree | detail::kUseWP |
+                         detail::kNoEdgeCases>(
+      p, w, pp, onerow, x, y, Predictor::Zero, &tree_lookup, &references,
+      wp_state, /*predictions=*/nullptr);
+}
 
 inline PredictionResult PredictLearn(Properties *p, size_t w,
                                      const pixel_type *JXL_RESTRICT pp,
@@ -609,6 +621,29 @@ inline void PredictLearnAll(Properties *p, size_t w,
                             pixel_type_w *predictions) {
   detail::Predict<detail::kForceComputeProperties | detail::kUseWP |
                   detail::kAllPredictions>(
+      p, w, pp, onerow, x, y, Predictor::Zero,
+      /*lookup=*/nullptr, &references, wp_state, predictions);
+}
+inline PredictionResult PredictLearnNEC(Properties *p, size_t w,
+                                        const pixel_type *JXL_RESTRICT pp,
+                                        const intptr_t onerow, const int x,
+                                        const int y, Predictor predictor,
+                                        const Channel &references,
+                                        weighted::State *wp_state) {
+  return detail::Predict<detail::kForceComputeProperties | detail::kUseWP |
+                         detail::kNoEdgeCases>(
+      p, w, pp, onerow, x, y, predictor, /*lookup=*/nullptr, &references,
+      wp_state, /*predictions=*/nullptr);
+}
+
+inline void PredictLearnAllNEC(Properties *p, size_t w,
+                               const pixel_type *JXL_RESTRICT pp,
+                               const intptr_t onerow, const int x, const int y,
+                               const Channel &references,
+                               weighted::State *wp_state,
+                               pixel_type_w *predictions) {
+  detail::Predict<detail::kForceComputeProperties | detail::kUseWP |
+                  detail::kAllPredictions | detail::kNoEdgeCases>(
       p, w, pp, onerow, x, y, Predictor::Zero,
       /*lookup=*/nullptr, &references, wp_state, predictions);
 }

--- a/lib/jxl/modular/encoding/enc_encoding.cc
+++ b/lib/jxl/modular/encoding/enc_encoding.cc
@@ -107,29 +107,62 @@ void GatherTreeData(const Image &image, pixel_type chan, size_t group_id,
   Channel references(properties.size() - kNumNonrefProperties, channel.w);
   weighted::State wp_state(wp_header, channel.w, channel.h);
   tree_samples.PrepareForSamples(pixel_fraction * channel.h * channel.w + 64);
+  const bool multiple_predictors = tree_samples.NumPredictors() != 1;
+  auto compute_sample = [&](const pixel_type *p, size_t x, size_t y) {
+    pixel_type_w pred[kNumModularPredictors];
+    if (multiple_predictors) {
+      PredictLearnAll(&properties, channel.w, p + x, onerow, x, y, references,
+                      &wp_state, pred);
+    } else {
+      pred[static_cast<int>(tree_samples.PredictorFromIndex(0))] =
+          PredictLearn(&properties, channel.w, p + x, onerow, x, y,
+                       tree_samples.PredictorFromIndex(0), references,
+                       &wp_state)
+              .guess;
+    }
+    (*total_pixels)++;
+    if (use_sample()) {
+      tree_samples.AddSample(p[x], properties, pred);
+    }
+    wp_state.UpdateErrors(p[x], x, y, channel.w);
+  };
+
   for (size_t y = 0; y < channel.h; y++) {
     const pixel_type *JXL_RESTRICT p = channel.Row(y);
     PrecomputeReferences(channel, y, image, chan, &references);
     InitPropsRow(&properties, static_props, y);
+
     // TODO(veluca): avoid computing WP if we don't use its property or
     // predictions.
-    for (size_t x = 0; x < channel.w; x++) {
-      pixel_type_w pred[kNumModularPredictors];
-      if (tree_samples.NumPredictors() != 1) {
-        PredictLearnAll(&properties, channel.w, p + x, onerow, x, y, references,
-                        &wp_state, pred);
-      } else {
-        pred[static_cast<int>(tree_samples.PredictorFromIndex(0))] =
-            PredictLearn(&properties, channel.w, p + x, onerow, x, y,
-                         tree_samples.PredictorFromIndex(0), references,
-                         &wp_state)
-                .guess;
+    if (y > 1 && channel.w > 8 && references.w == 0) {
+      for (size_t x = 0; x < 2; x++) {
+        compute_sample(p, x, y);
       }
-      (*total_pixels)++;
-      if (use_sample()) {
-        tree_samples.AddSample(p[x], properties, pred);
+      for (size_t x = 2; x < channel.w - 2; x++) {
+        pixel_type_w pred[kNumModularPredictors];
+        if (multiple_predictors) {
+          PredictLearnAllNEC(&properties, channel.w, p + x, onerow, x, y,
+                             references, &wp_state, pred);
+        } else {
+          pred[static_cast<int>(tree_samples.PredictorFromIndex(0))] =
+              PredictLearnNEC(&properties, channel.w, p + x, onerow, x, y,
+                              tree_samples.PredictorFromIndex(0), references,
+                              &wp_state)
+                  .guess;
+        }
+        (*total_pixels)++;
+        if (use_sample()) {
+          tree_samples.AddSample(p[x], properties, pred);
+        }
+        wp_state.UpdateErrors(p[x], x, y, channel.w);
       }
-      wp_state.UpdateErrors(p[x], x, y, channel.w);
+      for (size_t x = channel.w - 2; x < channel.w; x++) {
+        compute_sample(p, x, y);
+      }
+    } else {
+      for (size_t x = 0; x < channel.w; x++) {
+        compute_sample(p, x, y);
+      }
     }
   }
 }
@@ -333,7 +366,7 @@ Status EncodeModularChannelMAANS(const Image &image, pixel_type chan,
           }
         }
         pixel_type_w residual = p[x] - res.guess;
-        JXL_ASSERT(residual % res.multiplier == 0);
+        JXL_DASSERT(residual % res.multiplier == 0);
         *tokenp++ = Token(res.context, PackSigned(residual / res.multiplier));
       }
     }
@@ -361,7 +394,7 @@ Status EncodeModularChannelMAANS(const Image &image, pixel_type chan,
           }
         }
         pixel_type_w residual = p[x] - res.guess;
-        JXL_ASSERT(residual % res.multiplier == 0);
+        JXL_DASSERT(residual % res.multiplier == 0);
         *tokenp++ = Token(res.context, PackSigned(residual / res.multiplier));
         wp_state.UpdateErrors(p[x], x, y, channel.w);
       }

--- a/lib/jxl/modular/encoding/enc_ma.cc
+++ b/lib/jxl/modular/encoding/enc_ma.cc
@@ -733,9 +733,9 @@ std::vector<int32_t> QuantizeHistogram(const std::vector<uint32_t> &histogram,
   // TODO(veluca): selecting distinct quantiles is likely not the best
   // way to go about this.
   std::vector<int32_t> thresholds;
-  size_t sum = std::accumulate(histogram.begin(), histogram.end(), 0LU);
-  size_t cumsum = 0;
-  size_t threshold = 1;
+  uint64_t sum = std::accumulate(histogram.begin(), histogram.end(), 0LU);
+  uint64_t cumsum = 0;
+  uint64_t threshold = 1;
   for (size_t i = 0; i + 1 < histogram.size(); i++) {
     cumsum += histogram[i];
     if (cumsum >= threshold * sum / num_chunks) {

--- a/lib/jxl/modular/encoding/enc_ma.cc
+++ b/lib/jxl/modular/encoding/enc_ma.cc
@@ -735,12 +735,12 @@ std::vector<int32_t> QuantizeHistogram(const std::vector<uint32_t> &histogram,
   std::vector<int32_t> thresholds;
   size_t sum = std::accumulate(histogram.begin(), histogram.end(), 0LU);
   size_t cumsum = 0;
-  size_t threshold = 0;
+  size_t threshold = 1;
   for (size_t i = 0; i + 1 < histogram.size(); i++) {
     cumsum += histogram[i];
-    if (cumsum > (threshold + 1) * sum / num_chunks) {
+    if (cumsum >= threshold * sum / num_chunks) {
       thresholds.push_back(i);
-      while (cumsum >= (threshold + 1) * sum / num_chunks) threshold++;
+      while (cumsum > threshold * sum / num_chunks) threshold++;
     }
   }
   return thresholds;

--- a/lib/jxl/modular_test.cc
+++ b/lib/jxl/modular_test.cc
@@ -90,7 +90,7 @@ TEST(ModularTest, RoundtripLosslessCustomWP_PermuteRCT) {
 
   size_t compressed_size;
   JXL_EXPECT_OK(Roundtrip(&io, cparams, {}, &io_out, _, &compressed_size));
-  EXPECT_LE(compressed_size, 10150u);
+  EXPECT_LE(compressed_size, 10169u);
   JXL_EXPECT_OK(SamePixels(*io.Main().color(), *io_out.Main().color(), _));
 }
 


### PR DESCRIPTION
The way things currently are, there's a big gap between lossless e3 and e4, where e4 is a _lot_ slower than e3. This makes the gap smaller, making e4 about twice as fast at the cost of some compression density.

All the lossless e4-e7 settings get faster, e8+ has roughly the same speed as before. Efforts 1-3 are not modified. Density of e4-e6 gets worse (but speed improves), density of e7+ is about the same or maybe slightly better. The new e5 is faster than the old e4 and also better; the new e4 does a better job at filling the gap between e3 and e5.
Decode speed also improves.

Obviously results are image-dependent and your mileage may vary.

Overview of the changes:

- Make the MA tree splitting heuristic threshold get lower gradually as effort goes up, instead of a big step
- Don't use the group number as a property if the number of groups is small (less than 9)
- Use fewer properties (faster for both encode and decode) but pre-quantize them a bit less (slower but better encode)
- Swap `>` and `>=` in the pre-quantization (seems slightly better)
- Specialize GatherTreeData a bit to avoid branching due to edge cases (eventually we should solve this by doing fast-lossless style padding, at least for the encoder)


Summary table: (for speed, "+" means faster/better; for density "-" means smaller/better)
| Effort | Photo speed | Photo density | Non-photo speed | Non-photo density |
| --- | --- | --- | --- | --- | 
| e4 | +126% | + 0.50% | + 107% | + 3.5% |
| e5 | +44% |  + 0.16% | +29% | + 2.3%
| e6 | +8% |  + 0.17% | +4% | + 0.62%
| e7 | + 10% |  + 0.04% | +10% | - 0.25%
| e8 |  + 1% | - 0.05% | +0.5% | - 0.58%
| e9 | = | +0.15% | = | -0.005%

(raw benchmark results below)

Photographic images (jyrki31):

Before:
```
Encoding      kPixels    Bytes          BPP  E MP/s  D MP/s     Max norm  SSIMULACRA2        pnorm       BPP*pnorm   Bugs
-------------------------------------------------------------------------------------------------------------------------
jxl:d0:2        13270 18711689   11.2802146  13.012  17.842         -nan 100.00000000   0.00000000  0.000000000000      0
jxl:d0:3        13270 17219213   10.3804855   6.039   7.010         -nan 100.00000000   0.00000000  0.000000000000      0
jxl:d0:4        13270 17075845   10.2940571   0.721   4.169         -nan 100.00000000   0.00000000  0.000000000000      0
jxl:d0:5        13270 16937952   10.2109293   0.628   4.237         -nan 100.00000000   0.00000000  0.000000000000      0
jxl:d0:6        13270 16872040   10.1711947   0.572   3.953         -nan 100.00000000   0.00000000  0.000000000000      0
jxl:d0:7        13270 16705950   10.0710684   0.398   3.891         -nan 100.00000000   0.00000000  0.000000000000      0
jxl:d0:8        13270 16625956   10.0228446   0.154   3.886         -nan 100.00000000   0.00000000  0.000000000000      0
jxl:d0:9        13270 16447283    9.9151328   0.031   3.846         -nan 100.00000000   0.00000000  0.000000000000      0
Aggregate:      13270 17062243   10.2858572   0.666   5.167   0.00000000 100.00000000   0.00000000  0.000000000000      0
```

After:
```
Encoding      kPixels    Bytes          BPP  E MP/s  D MP/s     Max norm  SSIMULACRA2        pnorm       BPP*pnorm   Bugs
-------------------------------------------------------------------------------------------------------------------------
jxl:d0:2        13270 18711689   11.2802146  13.107  17.900         -nan 100.00000000   0.00000000  0.000000000000      0
jxl:d0:3        13270 17219213   10.3804855   6.004   7.038         -nan 100.00000000   0.00000000  0.000000000000      0
jxl:d0:4        13270 17162131   10.3460740   1.635   5.744         -nan 100.00000000   0.00000000  0.000000000000      0
jxl:d0:5        13270 16965129   10.2273127   0.903   4.511         -nan 100.00000000   0.00000000  0.000000000000      0
jxl:d0:6        13270 16901229   10.1887910   0.620   4.155         -nan 100.00000000   0.00000000  0.000000000000      0
jxl:d0:7        13270 16711883   10.0746451   0.440   3.946         -nan 100.00000000   0.00000000  0.000000000000      0
jxl:d0:8        13270 16617202   10.0175673   0.156   3.874         -nan 100.00000000   0.00000000  0.000000000000      0
jxl:d0:9        13270 16471757    9.9298868   0.031   3.731         -nan 100.00000000   0.00000000  0.000000000000      0
Aggregate:      13270 17082917   10.2983202   0.791   5.446   0.00000000 100.00000000   0.00000000  0.000000000000      0
```

Some non-photographic images (manga):

Before:
```
Encoding      kPixels    Bytes          BPP  E MP/s  D MP/s     Max norm  SSIMULACRA2        pnorm       BPP*pnorm   Bugs
-------------------------------------------------------------------------------------------------------------------------
jxl:d0:2        14727 12846550    6.9783291  11.226  16.894         -nan 100.00000000   0.00000000  0.000000000000      0
jxl:d0:3        14727 10968310    5.9580570   5.825   7.025         -nan 100.00000000   0.00000000  0.000000000000      0
jxl:d0:4        14727 10500700    5.7040482   0.838   4.031         -nan 100.00000000   0.00000000  0.000000000000      0
jxl:d0:5        14727  9810711    5.3292417   0.680   4.148         -nan 100.00000000   0.00000000  0.000000000000      0
jxl:d0:6        14727  9782955    5.3141645   0.646   4.074         -nan 100.00000000   0.00000000  0.000000000000      0
jxl:d0:7        14727  9481982    5.1506740   0.448   3.933         -nan 100.00000000   0.00000000  0.000000000000      0
jxl:d0:8        14727  9340793    5.0739792   0.199   3.915         -nan 100.00000000   0.00000000  0.000000000000      0
jxl:d0:9        14727  8651293    4.6994384   0.038   3.729         -nan 100.00000000   0.00000000  0.000000000000      0
Aggregate:      14727 10106130    5.4897150   0.731   5.109   0.00000000 100.00000000   0.00000000  0.000000000000      0
```

After:
```
Encoding      kPixels    Bytes          BPP  E MP/s  D MP/s     Max norm  SSIMULACRA2        pnorm       BPP*pnorm   Bugs
-------------------------------------------------------------------------------------------------------------------------
jxl:d0:2        14727 12846550    6.9783291  11.368  16.932         -nan 100.00000000   0.00000000  0.000000000000      0
jxl:d0:3        14727 10968310    5.9580570   5.842   7.002         -nan 100.00000000   0.00000000  0.000000000000      0
jxl:d0:4        14727 10868840    5.9040242   1.731   5.523         -nan 100.00000000   0.00000000  0.000000000000      0
jxl:d0:5        14727 10037654    5.4525186   0.874   4.502         -nan 100.00000000   0.00000000  0.000000000000      0
jxl:d0:6        14727  9843434    5.3470171   0.671   4.222         -nan 100.00000000   0.00000000  0.000000000000      0
jxl:d0:7        14727  9458372    5.1378489   0.493   3.978         -nan 100.00000000   0.00000000  0.000000000000      0
jxl:d0:8        14727  9287075    5.0447993   0.200   3.922         -nan 100.00000000   0.00000000  0.000000000000      0
jxl:d0:9        14727  8650805    4.6991733   0.038   3.752         -nan 100.00000000   0.00000000  0.000000000000      0
Aggregate:      14727 10176068    5.5277062   0.842   5.405   0.00000000 100.00000000   0.00000000  0.000000000000      0
```
