### PR TITLE
Support more types of PNG input in extras jpeg(li) wrappers.

### DIFF
--- a/lib/extras/enc/jpg.cc
+++ b/lib/extras/enc/jpg.cc
@@ -316,13 +316,39 @@ Status EncodeWithLibJpeg(const PackedImage& image, const JxlBasicInfo& info,
   if (cinfo.input_components > 3 || cinfo.input_components < 0)
     return JXL_FAILURE("invalid numbers of components");
 
-  std::vector<uint8_t> raw_bytes(image.pixels_size);
-  memcpy(&raw_bytes[0], reinterpret_cast<const uint8_t*>(image.pixels()),
-         image.pixels_size);
-  for (size_t y = 0; y < info.ysize; ++y) {
-    JSAMPROW row[] = {raw_bytes.data() + y * image.stride};
-
-    jpeg_write_scanlines(&cinfo, row, 1);
+  std::vector<uint8_t> row_bytes(image.stride);
+  const uint8_t* pixels = reinterpret_cast<const uint8_t*>(image.pixels());
+  if (cinfo.num_components == (int)image.format.num_channels &&
+      image.format.data_type == JXL_TYPE_UINT8) {
+    for (size_t y = 0; y < info.ysize; ++y) {
+      memcpy(&row_bytes[0], pixels + y * image.stride, image.stride);
+      JSAMPROW row[] = {row_bytes.data()};
+      jpeg_write_scanlines(&cinfo, row, 1);
+    }
+  } else if (image.format.data_type == JXL_TYPE_UINT8) {
+    for (size_t y = 0; y < info.ysize; ++y) {
+      const uint8_t* image_row = pixels + y * image.stride;
+      for (size_t x = 0; x < info.xsize; ++x) {
+        const uint8_t* image_pixel = image_row + x * image.pixel_stride();
+        memcpy(&row_bytes[x * cinfo.num_components], image_pixel,
+               cinfo.num_components);
+      }
+      JSAMPROW row[] = {row_bytes.data()};
+      jpeg_write_scanlines(&cinfo, row, 1);
+    }
+  } else {
+    for (size_t y = 0; y < info.ysize; ++y) {
+      const uint8_t* image_row = pixels + y * image.stride;
+      for (size_t x = 0; x < info.xsize; ++x) {
+        const uint8_t* image_pixel = image_row + x * image.pixel_stride();
+        for (int c = 0; c < cinfo.num_components; ++c) {
+          uint32_t val16 = (image_pixel[2 * c] << 8) + image_pixel[2 * c + 1];
+          row_bytes[x * cinfo.num_components + c] = (val16 + 128) / 257;
+        }
+      }
+      JSAMPROW row[] = {row_bytes.data()};
+      jpeg_write_scanlines(&cinfo, row, 1);
+    }
   }
   jpeg_finish_compress(&cinfo);
   jpeg_destroy_compress(&cinfo);
@@ -415,6 +441,12 @@ Status EncodeWithSJpeg(const PackedImage& image, const JxlBasicInfo& info,
 #if !JPEGXL_ENABLE_SJPEG
   return JXL_FAILURE("JPEG XL was built without sjpeg support");
 #else
+  if (image.format.data_type != JXL_TYPE_UINT8) {
+    return JXL_FAILURE("Unsupported pixel data type");
+  }
+  if (info.alpha_bits > 0) {
+    return JXL_FAILURE("alpha is not supported");
+  }
   sjpeg::EncoderParam param(params.quality);
   if (!icc.empty()) {
     param.iccp.assign(icc.begin(), icc.end());
@@ -477,12 +509,6 @@ Status EncodeImageJPG(const PackedImage& image, const JxlBasicInfo& info,
                       std::vector<uint8_t> exif, JpegEncoder encoder,
                       const JpegParams& params, ThreadPool* pool,
                       std::vector<uint8_t>* bytes) {
-  if (image.format.data_type != JXL_TYPE_UINT8) {
-    return JXL_FAILURE("Unsupported pixel data type");
-  }
-  if (info.alpha_bits > 0) {
-    return JXL_FAILURE("alpha is not supported");
-  }
   if (params.quality > 100) {
     return JXL_FAILURE("please specify a 0-100 JPEG quality");
   }
@@ -506,13 +532,17 @@ Status EncodeImageJPG(const PackedImage& image, const JxlBasicInfo& info,
 class JPEGEncoder : public Encoder {
   std::vector<JxlPixelFormat> AcceptedFormats() const override {
     std::vector<JxlPixelFormat> formats;
-    for (const uint32_t num_channels : {1, 3}) {
+    for (const uint32_t num_channels : {1, 2, 3, 4}) {
       for (JxlEndianness endianness : {JXL_BIG_ENDIAN, JXL_LITTLE_ENDIAN}) {
         formats.push_back(JxlPixelFormat{/*num_channels=*/num_channels,
                                          /*data_type=*/JXL_TYPE_UINT8,
                                          /*endianness=*/endianness,
                                          /*align=*/0});
       }
+      formats.push_back(JxlPixelFormat{/*num_channels=*/num_channels,
+                                       /*data_type=*/JXL_TYPE_UINT16,
+                                       /*endianness=*/JXL_BIG_ENDIAN,
+                                       /*align=*/0});
     }
     return formats;
   }

--- a/lib/jxl/enc_butteraugli_comparator.cc
+++ b/lib/jxl/enc_butteraugli_comparator.cc
@@ -75,9 +75,10 @@ float JxlButteraugliComparator::BadQualityScore() const {
 float ButteraugliDistance(const ImageBundle& rgb0, const ImageBundle& rgb1,
                           const ButteraugliParams& params,
                           const JxlCmsInterface& cms, ImageF* distmap,
-                          ThreadPool* pool) {
+                          ThreadPool* pool, bool ignore_alpha) {
   JxlButteraugliComparator comparator(params, cms);
-  return ComputeScore(rgb0, rgb1, &comparator, cms, distmap, pool);
+  return ComputeScore(rgb0, rgb1, &comparator, cms, distmap, pool,
+                      ignore_alpha);
 }
 
 float ButteraugliDistance(const std::vector<ImageBundle>& frames0,

--- a/lib/jxl/enc_butteraugli_comparator.h
+++ b/lib/jxl/enc_butteraugli_comparator.h
@@ -46,7 +46,8 @@ class JxlButteraugliComparator : public Comparator {
 float ButteraugliDistance(const ImageBundle& rgb0, const ImageBundle& rgb1,
                           const ButteraugliParams& params,
                           const JxlCmsInterface& cms, ImageF* distmap = nullptr,
-                          ThreadPool* pool = nullptr);
+                          ThreadPool* pool = nullptr,
+                          bool ignore_alpha = false);
 
 float ButteraugliDistance(const std::vector<ImageBundle>& frames0,
                           const std::vector<ImageBundle>& frames1,

--- a/lib/jxl/enc_comparator.cc
+++ b/lib/jxl/enc_comparator.cc
@@ -69,7 +69,7 @@ float ComputeScoreImpl(const ImageBundle& rgb0, const ImageBundle& rgb1,
 
 float ComputeScore(const ImageBundle& rgb0, const ImageBundle& rgb1,
                    Comparator* comparator, const JxlCmsInterface& cms,
-                   ImageF* diffmap, ThreadPool* pool) {
+                   ImageF* diffmap, ThreadPool* pool, bool ignore_alpha) {
   // Convert to linear sRGB (unless already in that space)
   ImageMetadata metadata0 = *rgb0.metadata();
   ImageBundle store0(&metadata0);
@@ -83,7 +83,7 @@ float ComputeScore(const ImageBundle& rgb0, const ImageBundle& rgb1,
                               cms, pool, &store1, &linear_srgb1));
 
   // No alpha: skip blending, only need a single call to Butteraugli.
-  if (!rgb0.HasAlpha() && !rgb1.HasAlpha()) {
+  if (ignore_alpha || (!rgb0.HasAlpha() && !rgb1.HasAlpha())) {
     return ComputeScoreImpl(*linear_srgb0, *linear_srgb1, comparator, diffmap);
   }
 

--- a/lib/jxl/enc_comparator.h
+++ b/lib/jxl/enc_comparator.h
@@ -45,7 +45,8 @@ class Comparator {
 // alpha channel.
 float ComputeScore(const ImageBundle& rgb0, const ImageBundle& rgb1,
                    Comparator* comparator, const JxlCmsInterface& cms,
-                   ImageF* diffmap = nullptr, ThreadPool* pool = nullptr);
+                   ImageF* diffmap = nullptr, ThreadPool* pool = nullptr,
+                   bool ignore_alpha = false);
 
 }  // namespace jxl
 

--- a/tools/benchmark/benchmark_codec.h
+++ b/tools/benchmark/benchmark_codec.h
@@ -61,6 +61,8 @@ class ImageCodec {
 
   virtual void GetMoreStats(BenchmarkStats* stats) {}
 
+  virtual bool IgnoreAlpha() const { return false; }
+
   virtual Status CanRecompressJpeg() const { return false; }
   virtual Status RecompressJpeg(const std::string& filename,
                                 const std::vector<uint8_t>& data,

--- a/tools/benchmark/benchmark_xl.cc
+++ b/tools/benchmark/benchmark_xl.cc
@@ -241,8 +241,9 @@ void DoCompress(const std::string& filename, const CodecInOut& io,
         if (fabs(params.intensity_target - 255.0f) < 1e-3) {
           params.intensity_target = 80.0;
         }
-        distance = ButteraugliDistance(ib1, ib2, params, jxl::GetJxlCms(),
-                                       &distmap, inner_pool);
+        distance =
+            ButteraugliDistance(ib1, ib2, params, jxl::GetJxlCms(), &distmap,
+                                inner_pool, codec->IgnoreAlpha());
       } else {
         // TODO(veluca): re-upsample and compute proper distance.
         distance = 1e+4f;


### PR DESCRIPTION
If input has alpha we simply drop it (this is the same behavior as in ImageMagick) and if input is 16-bit, then we convert it to 8-bit for libjpeg (for jpegli we handle 16-bit directly as before).