### PR TITLE
simplify EstimateBits a bit

### DIFF
--- a/lib/jxl/jxl_test.cc
+++ b/lib/jxl/jxl_test.cc
@@ -966,7 +966,7 @@ TEST(JxlTest, JXL_SLOW_TEST(RoundtripLossless8)) {
   JXLCompressParams cparams = CompressParamsForLossless();
 
   PackedPixelFile ppf_out;
-  EXPECT_EQ(Roundtrip(t.ppf(), cparams, {}, &pool, &ppf_out), 223151);
+  EXPECT_EQ(Roundtrip(t.ppf(), cparams, {}, &pool, &ppf_out), 223058);
   EXPECT_EQ(ComputeDistance2(t.ppf(), ppf_out), 0.0);
 }
 
@@ -1033,7 +1033,7 @@ TEST(JxlTest, RoundtripLossless8Alpha) {
   dparams.accepted_formats.push_back(t.ppf().frames[0].color.format);
 
   PackedPixelFile ppf_out;
-  EXPECT_EQ(Roundtrip(t.ppf(), cparams, dparams, pool, &ppf_out), 251291);
+  EXPECT_EQ(Roundtrip(t.ppf(), cparams, dparams, pool, &ppf_out), 251470);
   EXPECT_EQ(ComputeDistance2(t.ppf(), ppf_out), 0.0);
   EXPECT_EQ(ppf_out.info.alpha_bits, 8);
   EXPECT_TRUE(test::SameAlpha(t.ppf(), ppf_out));
@@ -1167,7 +1167,7 @@ TEST(JxlTest, RoundtripLossless8Gray) {
   dparams.accepted_formats.push_back(t.ppf().frames[0].color.format);
 
   PackedPixelFile ppf_out;
-  EXPECT_EQ(Roundtrip(t.ppf(), cparams, dparams, pool, &ppf_out), 92140);
+  EXPECT_EQ(Roundtrip(t.ppf(), cparams, dparams, pool, &ppf_out), 92185);
   EXPECT_EQ(ComputeDistance2(t.ppf(), ppf_out), 0.0);
   EXPECT_EQ(ppf_out.color_encoding.color_space, JXL_COLOR_SPACE_GRAY);
   EXPECT_EQ(ppf_out.info.bits_per_sample, 8);

--- a/lib/jxl/jxl_test.cc
+++ b/lib/jxl/jxl_test.cc
@@ -1068,7 +1068,7 @@ TEST(JxlTest, RoundtripLossless16Alpha) {
 
   PackedPixelFile ppf_out;
   // TODO(szabadka) Investigate big size difference on i686
-  EXPECT_NEAR(Roundtrip(t.ppf(), cparams, dparams, pool, &ppf_out), 4849, 100);
+  EXPECT_NEAR(Roundtrip(t.ppf(), cparams, dparams, pool, &ppf_out), 4884, 100);
   EXPECT_EQ(ComputeDistance2(t.ppf(), ppf_out), 0.0);
   EXPECT_EQ(ppf_out.info.alpha_bits, 16);
   EXPECT_TRUE(test::SameAlpha(t.ppf(), ppf_out));

--- a/lib/jxl/modular/encoding/enc_ma.cc
+++ b/lib/jxl/modular/encoding/enc_ma.cc
@@ -37,33 +37,23 @@ const HWY_FULL(float) df;
 const HWY_FULL(int32_t) di;
 size_t Padded(size_t x) { return RoundUpTo(x, Lanes(df)); }
 
-float EstimateBits(const int32_t *counts, int32_t *rounded_counts,
-                   size_t num_symbols) {
-  // Try to approximate the effect of rounding up nonzero probabilities.
+// Compute entropy of the histogram, taking into account the minimum probability
+// for symbols with non-zero counts.
+float EstimateBits(const int32_t *counts, size_t num_symbols) {
   int32_t total = std::accumulate(counts, counts + num_symbols, 0);
-  const auto min = Set(di, (total + ANS_TAB_SIZE - 1) >> ANS_LOG_TAB_SIZE);
-  const auto zero_i = Zero(di);
-  for (size_t i = 0; i < num_symbols; i += Lanes(df)) {
-    auto counts_v = LoadU(di, &counts[i]);
-    counts_v = IfThenElse(Eq(counts_v, zero_i), zero_i,
-                          IfThenElse(Lt(counts_v, min), min, counts_v));
-    StoreU(counts_v, di, &rounded_counts[i]);
-  }
-  // Compute entropy of the "rounded" probabilities.
   const auto zero = Zero(df);
-  const size_t total_scalar =
-      std::accumulate(rounded_counts, rounded_counts + num_symbols, 0);
-  const auto inv_total = Set(df, 1.0f / total_scalar);
+  const auto minprob = Set(df, 1.0f / ANS_TAB_SIZE);
+  const auto inv_total = Set(df, 1.0f / total);
   auto bits_lanes = Zero(df);
-  auto total_v = Set(di, total_scalar);
+  auto total_v = Set(di, total);
   for (size_t i = 0; i < num_symbols; i += Lanes(df)) {
-    const auto counts_v = ConvertTo(df, LoadU(di, &counts[i]));
-    const auto round_counts_v = LoadU(di, &rounded_counts[i]);
-    const auto probs = Mul(ConvertTo(df, round_counts_v), inv_total);
-    const auto nbps = IfThenElse(Eq(round_counts_v, total_v), BitCast(di, zero),
-                                 BitCast(di, FastLog2f(df, probs)));
-    bits_lanes = Sub(bits_lanes, IfThenElse(Eq(counts_v, zero), zero,
-                                            Mul(counts_v, BitCast(df, nbps))));
+    const auto counts_iv = LoadU(di, &counts[i]);
+    const auto counts_fv = ConvertTo(df, counts_iv);
+    const auto probs = Mul(counts_fv, inv_total);
+    const auto mprobs = Max(probs, minprob);
+    const auto nbps = IfThenElse(Eq(counts_iv, total_v), BitCast(di, zero),
+                                 BitCast(di, FastLog2f(df, mprobs)));
+    bits_lanes = Sub(bits_lanes, Mul(counts_fv, BitCast(df, nbps)));
   }
   return GetLane(SumOfLanes(df, bits_lanes));
 }
@@ -225,7 +215,6 @@ void FindBestSplit(TreeSamples &tree_samples, float threshold,
       }
     }
     max_symbols = Padded(max_symbols);
-    std::vector<int32_t> rounded_counts(max_symbols);
     std::vector<int32_t> counts(max_symbols * num_predictors);
     std::vector<uint32_t> tot_extra_bits(num_predictors);
     for (size_t pred = 0; pred < num_predictors; pred++) {
@@ -240,9 +229,9 @@ void FindBestSplit(TreeSamples &tree_samples, float threshold,
     float base_bits;
     {
       size_t pred = tree_samples.PredictorIndex((*tree)[pos].predictor);
-      base_bits = EstimateBits(counts.data() + pred * max_symbols,
-                               rounded_counts.data(), max_symbols) +
-                  tot_extra_bits[pred];
+      base_bits =
+          EstimateBits(counts.data() + pred * max_symbols, max_symbols) +
+          tot_extra_bits[pred];
     }
 
     SplitInfo *best = &best_split_nonstatic;
@@ -353,11 +342,9 @@ void FindBestSplit(TreeSamples &tree_samples, float threshold,
               counts_below[sym] += count_increase[i * max_symbols + sym];
               count_increase[i * max_symbols + sym] = 0;
             }
-            float rcost = EstimateBits(counts_above.data(),
-                                       rounded_counts.data(), max_symbols) +
+            float rcost = EstimateBits(counts_above.data(), max_symbols) +
                           tot_extra_bits[pred] - extra_bits_below;
-            float lcost = EstimateBits(counts_below.data(),
-                                       rounded_counts.data(), max_symbols) +
+            float lcost = EstimateBits(counts_below.data(), max_symbols) +
                           extra_bits_below;
             JXL_DASSERT(extra_bits_below <= tot_extra_bits[pred]);
             float penalty = 0;

--- a/lib/jxl/modular/encoding/enc_ma.cc
+++ b/lib/jxl/modular/encoding/enc_ma.cc
@@ -32,6 +32,7 @@ namespace HWY_NAMESPACE {
 using hwy::HWY_NAMESPACE::Eq;
 using hwy::HWY_NAMESPACE::IfThenElse;
 using hwy::HWY_NAMESPACE::Lt;
+using hwy::HWY_NAMESPACE::Max;
 
 const HWY_FULL(float) df;
 const HWY_FULL(int32_t) di;


### PR DESCRIPTION
Simplify the function EstimateBits a little bit: instead of first rounding up the non-zero counts that would otherwise end up getting a probability below 1/4096, just make all probabilities at least 1/4096 — that's wrong if the count was zero but it doesn't matter since we'll then multiply the number by zero anyway.

This gives a small (~2% or so) speedup at most of the lossless effort settings, but a ~20% speedup at e9.

Both ways of doing the estimate are not quite exact, and this approximation is slightly different from the previous one. The effect of this change on density is small but this way of doing it also seems slightly better for compression (but it's image-dependent and mostly just some fluctuation).

Before (jyrki31):
```
Encoding      kPixels    Bytes          BPP  E MP/s  D MP/s     Max norm  SSIMULACRA2        pnorm       BPP*pnorm   Bugs
-------------------------------------------------------------------------------------------------------------------------
jxl:d0:2        13270 18711689   11.2802146  13.107  17.900         -nan 100.00000000   0.00000000  0.000000000000      0
jxl:d0:3        13270 17219213   10.3804855   6.004   7.038         -nan 100.00000000   0.00000000  0.000000000000      0
jxl:d0:4        13270 17162131   10.3460740   1.635   5.744         -nan 100.00000000   0.00000000  0.000000000000      0
jxl:d0:5        13270 16965129   10.2273127   0.903   4.511         -nan 100.00000000   0.00000000  0.000000000000      0
jxl:d0:6        13270 16901229   10.1887910   0.620   4.155         -nan 100.00000000   0.00000000  0.000000000000      0
jxl:d0:7        13270 16711883   10.0746451   0.440   3.946         -nan 100.00000000   0.00000000  0.000000000000      0
jxl:d0:8        13270 16617202   10.0175673   0.156   3.874         -nan 100.00000000   0.00000000  0.000000000000      0
jxl:d0:9        13270 16447585    9.9153148   0.030   3.836         -nan 100.00000000   0.00000000  0.000000000000      0
```

After:
```
Encoding      kPixels    Bytes          BPP  E MP/s  D MP/s     Max norm  SSIMULACRA2        pnorm       BPP*pnorm   Bugs
-------------------------------------------------------------------------------------------------------------------------
jxl:d0:2        13270 18711689   11.2802146  12.668  18.936         -nan 100.00000000   0.00000000  0.000000000000      0
jxl:d0:3        13270 17219213   10.3804855   5.918   7.102         -nan 100.00000000   0.00000000  0.000000000000      0
jxl:d0:4        13270 17161706   10.3458178   1.646   5.761         -nan 100.00000000   0.00000000  0.000000000000      0
jxl:d0:5        13270 16963847   10.2265399   0.921   4.488         -nan 100.00000000   0.00000000  0.000000000000      0
jxl:d0:6        13270 16898265   10.1870042   0.648   4.136         -nan 100.00000000   0.00000000  0.000000000000      0
jxl:d0:7        13270 16708943   10.0728727   0.463   3.913         -nan 100.00000000   0.00000000  0.000000000000      0
jxl:d0:8        13270 16611499   10.0141293   0.160   3.843         -nan 100.00000000   0.00000000  0.000000000000      0
jxl:d0:9        13270 16447225    9.9150978   0.038   3.807         -nan 100.00000000   0.00000000  0.000000000000      0
```

Before: (nonphoto)
```
Encoding      kPixels    Bytes          BPP  E MP/s  D MP/s     Max norm  SSIMULACRA2        pnorm       BPP*pnorm   Bugs
-------------------------------------------------------------------------------------------------------------------------
jxl:d0:2        14727 12846550    6.9783291  11.368  16.932         -nan 100.00000000   0.00000000  0.000000000000      0
jxl:d0:3        14727 10968310    5.9580570   5.842   7.002         -nan 100.00000000   0.00000000  0.000000000000      0
jxl:d0:4        14727 10868840    5.9040242   1.731   5.523         -nan 100.00000000   0.00000000  0.000000000000      0
jxl:d0:5        14727 10037654    5.4525186   0.874   4.502         -nan 100.00000000   0.00000000  0.000000000000      0
jxl:d0:6        14727  9843434    5.3470171   0.671   4.222         -nan 100.00000000   0.00000000  0.000000000000      0
jxl:d0:7        14727  9458372    5.1378489   0.493   3.978         -nan 100.00000000   0.00000000  0.000000000000      0
jxl:d0:8        14727  9287075    5.0447993   0.200   3.922         -nan 100.00000000   0.00000000  0.000000000000      0
jxl:d0:9        14727  8650805    4.6991733   0.038   3.761         -nan 100.00000000   0.00000000  0.000000000000      0
```

After:
```
Encoding      kPixels    Bytes          BPP  E MP/s  D MP/s     Max norm  SSIMULACRA2        pnorm       BPP*pnorm   Bugs
-------------------------------------------------------------------------------------------------------------------------
jxl:d0:2        14727 12846550    6.9783291  11.236  18.020         -nan 100.00000000   0.00000000  0.000000000000      0
jxl:d0:3        14727 10968310    5.9580570   5.788   7.173         -nan 100.00000000   0.00000000  0.000000000000      0
jxl:d0:4        14727 10871521    5.9054806   1.729   5.513         -nan 100.00000000   0.00000000  0.000000000000      0
jxl:d0:5        14727 10037599    5.4524888   0.888   4.513         -nan 100.00000000   0.00000000  0.000000000000      0
jxl:d0:6        14727  9842695    5.3466156   0.683   4.239         -nan 100.00000000   0.00000000  0.000000000000      0
jxl:d0:7        14727  9456181    5.1366587   0.503   3.983         -nan 100.00000000   0.00000000  0.000000000000      0
jxl:d0:8        14727  9272555    5.0369119   0.205   3.878         -nan 100.00000000   0.00000000  0.000000000000      0
jxl:d0:9        14727  8654170    4.7010012   0.045   3.725         -nan 100.00000000   0.00000000  0.000000000000      0
```
