### PR TITLE
Fix sjpeg build flag.

### DIFF
--- a/lib/jxl_extras.cmake
+++ b/lib/jxl_extras.cmake
@@ -58,6 +58,14 @@ if(JPEG_FOUND)
   endif()  # JPEGXL_DEP_LICENSE_DIR
 endif()
 
+if (JPEGXL_ENABLE_SJPEG)
+  target_compile_definitions(jxl_extras_core-obj PRIVATE
+    -DJPEGXL_ENABLE_SJPEG=1)
+  target_include_directories(jxl_extras_core-obj PRIVATE
+    ../third_party/sjpeg/src)
+  list(APPEND JXL_EXTRAS_CODEC_INTERNAL_LIBRARIES sjpeg)
+endif()
+
 if(JPEGXL_ENABLE_JPEGLI)
   add_library(jxl_extras_jpegli-obj OBJECT
     "${JPEGXL_INTERNAL_CODEC_JPEGLI_SOURCES}"
@@ -139,10 +147,6 @@ target_link_libraries(jxl_extras-static PUBLIC
   jxl-static
   jxl_threads-static
 )
-if (JPEGXL_ENABLE_SJPEG)
-  target_compile_definitions(jxl_extras-static PUBLIC -DJPEGXL_ENABLE_SJPEG=1)
-  target_link_libraries(jxl_extras-static PRIVATE sjpeg)
-endif ()
 if(JPEGXL_ENABLE_JPEGLI)
   target_compile_definitions(jxl_extras-static PUBLIC -DJPEGXL_ENABLE_JPEGLI=1)
   target_link_libraries(jxl_extras-static PRIVATE jpegli-static)

--- a/tools/djxl_main.cc
+++ b/tools/djxl_main.cc
@@ -147,11 +147,9 @@ struct DecompressArgs {
                            "No output file will be written (for benchmarking)",
                            &disable_output, &SetBooleanTrue, 2);
 
-#if JPEGXL_ENABLE_SJPEG
     cmdline->AddOptionFlag('\0', "use_sjpeg",
                            "Use sjpeg instead of libjpeg for JPEG output.",
                            &use_sjpeg, &SetBooleanTrue, 2);
-#endif
 
     cmdline->AddOptionFlag('\0', "norender_spotcolors",
                            "Disables rendering of spot colors.",
@@ -481,11 +479,9 @@ int main(int argc, const char* argv[]) {
       os << args.jpeg_quality;
       encoder->SetOption("q", os.str());
     }
-#if JPEGXL_ENABLE_SJPEG
     if (encoder && args.use_sjpeg) {
       encoder->SetOption("jpeg_encoder", "sjpeg");
     }
-#endif
     jxl::extras::EncodedImage encoded_image;
     if (encoder) {
       if (!args.quiet) cmdline.VerbosePrintf(2, "Encoding decoded image\n");


### PR DESCRIPTION
The -DJPEGXL_ENABLE_SJPEG=1 flag has to be added to the object library that contains lib/extras/enc/jpg.cc otherwise it has no effect.

The build flag from djxl_main.cc is removed because it is not possible to know when building the tool what the extras library has compiled in.