### PR TITLE
inline and specialize the symbol reading

### DIFF
--- a/lib/jxl/dec_ans.h
+++ b/lib/jxl/dec_ans.h
@@ -276,9 +276,10 @@ class ANSSymbolReader {
   }
 
   // Takes a *clustered* idx. Can only use if HuffRleOnly() is true.
-  void ReadHybridUintClusteredHuffRleOnly(size_t ctx,
-                                          BitReader* JXL_RESTRICT br,
-                                          uint32_t* value, uint32_t* run) {
+  JXL_INLINE void ReadHybridUintClusteredHuffRleOnly(size_t ctx,
+                                                     BitReader* JXL_RESTRICT br,
+                                                     uint32_t* value,
+                                                     uint32_t* run) {
     JXL_DASSERT(HuffRleOnly());
     br->Refill();  // covers ReadSymbolWithoutRefill + PeekBits
     size_t token = ReadSymbolHuffWithoutRefill(ctx, br);
@@ -302,53 +303,62 @@ class ANSSymbolReader {
   }
 
   // Takes a *clustered* idx.
-  size_t ReadHybridUintClustered(size_t ctx, BitReader* JXL_RESTRICT br) {
-    if (JXL_UNLIKELY(num_to_copy_ > 0)) {
-      size_t ret = lz77_window_[(copy_pos_++) & kWindowMask];
-      num_to_copy_--;
-      lz77_window_[(num_decoded_++) & kWindowMask] = ret;
-      return ret;
+  template <bool uses_lz77>
+  JXL_INLINE size_t ReadHybridUintClustered(size_t ctx,
+                                            BitReader* JXL_RESTRICT br) {
+    if (uses_lz77) {
+      if (JXL_UNLIKELY(num_to_copy_ > 0)) {
+        size_t ret = lz77_window_[(copy_pos_++) & kWindowMask];
+        num_to_copy_--;
+        lz77_window_[(num_decoded_++) & kWindowMask] = ret;
+        return ret;
+      }
     }
+
     br->Refill();  // covers ReadSymbolWithoutRefill + PeekBits
     size_t token = ReadSymbolWithoutRefill(ctx, br);
-    if (JXL_UNLIKELY(token >= lz77_threshold_)) {
-      num_to_copy_ =
-          ReadHybridUintConfig(lz77_length_uint_, token - lz77_threshold_, br) +
-          lz77_min_length_;
-      br->Refill();  // covers ReadSymbolWithoutRefill + PeekBits
-      // Distance code.
-      size_t token = ReadSymbolWithoutRefill(lz77_ctx_, br);
-      size_t distance = ReadHybridUintConfig(configs[lz77_ctx_], token, br);
-      if (JXL_LIKELY(distance < num_special_distances_)) {
-        distance = special_distances_[distance];
-      } else {
-        distance = distance + 1 - num_special_distances_;
+    if (uses_lz77) {
+      if (JXL_UNLIKELY(token >= lz77_threshold_)) {
+        num_to_copy_ = ReadHybridUintConfig(lz77_length_uint_,
+                                            token - lz77_threshold_, br) +
+                       lz77_min_length_;
+        br->Refill();  // covers ReadSymbolWithoutRefill + PeekBits
+        // Distance code.
+        size_t token = ReadSymbolWithoutRefill(lz77_ctx_, br);
+        size_t distance = ReadHybridUintConfig(configs[lz77_ctx_], token, br);
+        if (JXL_LIKELY(distance < num_special_distances_)) {
+          distance = special_distances_[distance];
+        } else {
+          distance = distance + 1 - num_special_distances_;
+        }
+        if (JXL_UNLIKELY(distance > num_decoded_)) {
+          distance = num_decoded_;
+        }
+        if (JXL_UNLIKELY(distance > kWindowSize)) {
+          distance = kWindowSize;
+        }
+        copy_pos_ = num_decoded_ - distance;
+        if (JXL_UNLIKELY(distance == 0)) {
+          JXL_DASSERT(lz77_window_ != nullptr);
+          // distance 0 -> num_decoded_ == copy_pos_ == 0
+          size_t to_fill = std::min<size_t>(num_to_copy_, kWindowSize);
+          memset(lz77_window_, 0, to_fill * sizeof(lz77_window_[0]));
+        }
+        // TODO(eustas): overflow; mark BitReader as unhealthy
+        if (num_to_copy_ < lz77_min_length_) return 0;
+        return ReadHybridUintClustered<uses_lz77>(ctx,
+                                                  br);  // will trigger a copy.
       }
-      if (JXL_UNLIKELY(distance > num_decoded_)) {
-        distance = num_decoded_;
-      }
-      if (JXL_UNLIKELY(distance > kWindowSize)) {
-        distance = kWindowSize;
-      }
-      copy_pos_ = num_decoded_ - distance;
-      if (JXL_UNLIKELY(distance == 0)) {
-        JXL_DASSERT(lz77_window_ != nullptr);
-        // distance 0 -> num_decoded_ == copy_pos_ == 0
-        size_t to_fill = std::min<size_t>(num_to_copy_, kWindowSize);
-        memset(lz77_window_, 0, to_fill * sizeof(lz77_window_[0]));
-      }
-      // TODO(eustas): overflow; mark BitReader as unhealthy
-      if (num_to_copy_ < lz77_min_length_) return 0;
-      return ReadHybridUintClustered(ctx, br);  // will trigger a copy.
     }
     size_t ret = ReadHybridUintConfig(configs[ctx], token, br);
-    if (lz77_window_) lz77_window_[(num_decoded_++) & kWindowMask] = ret;
+    if (uses_lz77 && lz77_window_)
+      lz77_window_[(num_decoded_++) & kWindowMask] = ret;
     return ret;
   }
 
   JXL_INLINE size_t ReadHybridUint(size_t ctx, BitReader* JXL_RESTRICT br,
                                    const std::vector<uint8_t>& context_map) {
-    return ReadHybridUintClustered(context_map[ctx], br);
+    return ReadHybridUintClustered<true>(context_map[ctx], br);
   }
 
   // ctx is a *clustered* context!

--- a/lib/jxl/dec_ans.h
+++ b/lib/jxl/dec_ans.h
@@ -301,8 +301,9 @@ class ANSSymbolReader {
     if (configs[lz77_ctx_].split_token > 1) return false;
     return true;
   }
+  bool UsesLZ77() { return lz77_window_ != nullptr; }
 
-  // Takes a *clustered* idx.
+  // Takes a *clustered* idx. Inlined, for use in hot paths.
   template <bool uses_lz77>
   JXL_INLINE size_t ReadHybridUintClustered(size_t ctx,
                                             BitReader* JXL_RESTRICT br) {
@@ -362,8 +363,9 @@ class ANSSymbolReader {
     return ret;
   }
 
-  JXL_INLINE size_t ReadHybridUint(size_t ctx, BitReader* JXL_RESTRICT br,
-                                   const std::vector<uint8_t>& context_map) {
+  // not inlined, for use in non-hot paths
+  size_t ReadHybridUint(size_t ctx, BitReader* JXL_RESTRICT br,
+                        const std::vector<uint8_t>& context_map) {
     return ReadHybridUintClustered<true>(context_map[ctx], br);
   }
 

--- a/lib/jxl/dec_ans.h
+++ b/lib/jxl/dec_ans.h
@@ -346,8 +346,14 @@ class ANSSymbolReader {
         }
         // TODO(eustas): overflow; mark BitReader as unhealthy
         if (num_to_copy_ < lz77_min_length_) return 0;
-        return ReadHybridUintClustered<uses_lz77>(ctx,
-                                                  br);  // will trigger a copy.
+        // the code below is the same as doing this:
+        //        return ReadHybridUintClustered<uses_lz77>(ctx, br);
+        // but gcc doesn't like recursive inlining
+
+        size_t ret = lz77_window_[(copy_pos_++) & kWindowMask];
+        num_to_copy_--;
+        lz77_window_[(num_decoded_++) & kWindowMask] = ret;
+        return ret;
       }
     }
     size_t ret = ReadHybridUintConfig(configs[ctx], token, br);

--- a/lib/jxl/dec_ans.h
+++ b/lib/jxl/dec_ans.h
@@ -363,10 +363,18 @@ class ANSSymbolReader {
     return ret;
   }
 
+  // inlined, for use in hot paths
+  template <bool uses_lz77>
+  JXL_INLINE size_t
+  ReadHybridUintInlined(size_t ctx, BitReader* JXL_RESTRICT br,
+                        const std::vector<uint8_t>& context_map) {
+    return ReadHybridUintClustered<uses_lz77>(context_map[ctx], br);
+  }
+
   // not inlined, for use in non-hot paths
   size_t ReadHybridUint(size_t ctx, BitReader* JXL_RESTRICT br,
                         const std::vector<uint8_t>& context_map) {
-    return ReadHybridUintClustered<true>(context_map[ctx], br);
+    return ReadHybridUintClustered</*uses_lz77=*/true>(context_map[ctx], br);
   }
 
   // ctx is a *clustered* context!

--- a/lib/jxl/dec_context_map.cc
+++ b/lib/jxl/dec_context_map.cc
@@ -66,7 +66,8 @@ Status DecodeContextMap(std::vector<uint8_t>* context_map, size_t* num_htrees,
     size_t i = 0;
     uint32_t maxsym = 0;
     while (i < context_map->size()) {
-      uint32_t sym = reader.ReadHybridUintClustered<1>(dummy_ctx_map[0], input);
+      uint32_t sym = reader.ReadHybridUintInlined</*uses_lz77=*/true>(
+          0, input, dummy_ctx_map);
       maxsym = sym > maxsym ? sym : maxsym;
       (*context_map)[i] = sym;
       i++;

--- a/lib/jxl/dec_context_map.cc
+++ b/lib/jxl/dec_context_map.cc
@@ -64,13 +64,15 @@ Status DecodeContextMap(std::vector<uint8_t>* context_map, size_t* num_htrees,
                          /*disallow_lz77=*/context_map->size() <= 2));
     ANSSymbolReader reader(&code, input);
     size_t i = 0;
+    uint32_t maxsym = 0;
     while (i < context_map->size()) {
-      uint32_t sym = reader.ReadHybridUint(0, input, dummy_ctx_map);
-      if (sym >= kMaxClusters) {
-        return JXL_FAILURE("Invalid cluster ID");
-      }
+      uint32_t sym = reader.ReadHybridUintClustered<1>(dummy_ctx_map[0], input);
+      maxsym = sym > maxsym ? sym : maxsym;
       (*context_map)[i] = sym;
       i++;
+    }
+    if (maxsym >= kMaxClusters) {
+      return JXL_FAILURE("Invalid cluster ID");
     }
     if (!reader.CheckANSFinalState()) {
       return JXL_FAILURE("Invalid context map");

--- a/lib/jxl/dec_group.cc
+++ b/lib/jxl/dec_group.cc
@@ -459,7 +459,7 @@ Status DecodeACVarBlock(size_t ctx_offset, size_t log2_covered_blocks,
       block_ctx_map.NonZeroContext(predicted_nzeros, block_ctx) + ctx_offset;
 
   size_t nzeros =
-      decoder->ReadHybridUintClustered<uses_lz77>(context_map[nzero_ctx], br);
+      decoder->ReadHybridUintInlined<uses_lz77>(nzero_ctx, br, context_map);
   if (nzeros + covered_blocks > size) {
     return JXL_FAILURE("Invalid AC: nzeros too large");
   }
@@ -479,7 +479,7 @@ Status DecodeACVarBlock(size_t ctx_offset, size_t log2_covered_blocks,
         histo_offset + ZeroDensityContext(nzeros, k, covered_blocks,
                                           log2_covered_blocks, prev);
     const size_t u_coeff =
-        decoder->ReadHybridUintClustered<uses_lz77>(context_map[ctx], br);
+        decoder->ReadHybridUintInlined<uses_lz77>(ctx, br, context_map);
     // Hand-rolled version of UnpackSigned, shifting before the conversion to
     // signed integer to avoid undefined behavior of shifting negative numbers.
     const size_t magnitude = u_coeff >> 1;

--- a/lib/jxl/dec_group.cc
+++ b/lib/jxl/dec_group.cc
@@ -431,7 +431,7 @@ namespace jxl {
 namespace {
 // Decode quantized AC coefficients of DCT blocks.
 // LLF components in the output block will not be modified.
-template <ACType ac_type>
+template <ACType ac_type, bool uses_lz77>
 Status DecodeACVarBlock(size_t ctx_offset, size_t log2_covered_blocks,
                         int32_t* JXL_RESTRICT row_nzeros,
                         const int32_t* JXL_RESTRICT row_nzeros_top,
@@ -458,7 +458,8 @@ Status DecodeACVarBlock(size_t ctx_offset, size_t log2_covered_blocks,
   const int32_t nzero_ctx =
       block_ctx_map.NonZeroContext(predicted_nzeros, block_ctx) + ctx_offset;
 
-  size_t nzeros = decoder->ReadHybridUint(nzero_ctx, br, context_map);
+  size_t nzeros =
+      decoder->ReadHybridUintClustered<uses_lz77>(context_map[nzero_ctx], br);
   if (nzeros + covered_blocks > size) {
     return JXL_FAILURE("Invalid AC: nzeros too large");
   }
@@ -477,7 +478,8 @@ Status DecodeACVarBlock(size_t ctx_offset, size_t log2_covered_blocks,
     const size_t ctx =
         histo_offset + ZeroDensityContext(nzeros, k, covered_blocks,
                                           log2_covered_blocks, prev);
-    const size_t u_coeff = decoder->ReadHybridUint(ctx, br, context_map);
+    const size_t u_coeff =
+        decoder->ReadHybridUintClustered<uses_lz77>(context_map[ctx], br);
     // Hand-rolled version of UnpackSigned, shifting before the conversion to
     // signed integer to avoid undefined behavior of shifting negative numbers.
     const size_t magnitude = u_coeff >> 1;
@@ -525,9 +527,7 @@ struct GetBlockFromBitstream : public GetBlock {
   Status LoadBlock(size_t bx, size_t by, const AcStrategy& acs, size_t size,
                    size_t log2_covered_blocks, ACPtr block[3],
                    ACType ac_type) override {
-    auto decode_ac_varblock = ac_type == ACType::k16
-                                  ? DecodeACVarBlock<ACType::k16>
-                                  : DecodeACVarBlock<ACType::k32>;
+    ;
     for (size_t c : {1, 0, 2}) {
       size_t sbx = bx >> hshift[c];
       size_t sby = by >> vshift[c];
@@ -536,6 +536,12 @@ struct GetBlockFromBitstream : public GetBlock {
       }
 
       for (size_t pass = 0; JXL_UNLIKELY(pass < num_passes); pass++) {
+        auto decode_ac_varblock =
+            decoders[pass].UsesLZ77()
+                ? (ac_type == ACType::k16 ? DecodeACVarBlock<ACType::k16, 1>
+                                          : DecodeACVarBlock<ACType::k32, 1>)
+                : (ac_type == ACType::k16 ? DecodeACVarBlock<ACType::k16, 0>
+                                          : DecodeACVarBlock<ACType::k32, 0>);
         JXL_RETURN_IF_ERROR(decode_ac_varblock(
             ctx_offset[pass], log2_covered_blocks, row_nzeros[pass][c],
             row_nzeros_top[pass][c], nzeros_stride, c, sbx, sby, bx, acs,

--- a/lib/jxl/modular/encoding/encoding.cc
+++ b/lib/jxl/modular/encoding/encoding.cc
@@ -561,11 +561,11 @@ Status ModularDecode(BitReader *br, Image &image, GroupHeader &header,
       break;
     }
     if (reader.UsesLZ77()) {
-      JXL_RETURN_IF_ERROR(DecodeModularChannelMAANS<1>(
+      JXL_RETURN_IF_ERROR(DecodeModularChannelMAANS</*uses_lz77=*/true>(
           br, &reader, *context_map, *tree, header.wp_header, next_channel,
           group_id, &image));
     } else {
-      JXL_RETURN_IF_ERROR(DecodeModularChannelMAANS<0>(
+      JXL_RETURN_IF_ERROR(DecodeModularChannelMAANS</*uses_lz77=*/false>(
           br, &reader, *context_map, *tree, header.wp_header, next_channel,
           group_id, &image));
     }

--- a/lib/jxl/modular/encoding/encoding.cc
+++ b/lib/jxl/modular/encoding/encoding.cc
@@ -125,6 +125,7 @@ FlatTree FilterTree(const Tree &global_tree,
   return output;
 }
 
+template <bool uses_lz77>
 Status DecodeModularChannelMAANS(BitReader *br, ANSSymbolReader *reader,
                                  const std::vector<uint8_t> &context_map,
                                  const Tree &global_tree,
@@ -192,7 +193,8 @@ Status DecodeModularChannelMAANS(BitReader *br, ANSSymbolReader *reader,
           for (size_t y = 0; y < channel.h; y++) {
             pixel_type *JXL_RESTRICT r = channel.Row(y);
             for (size_t x = 0; x < channel.w; x++) {
-              uint32_t v = reader->ReadHybridUintClustered(ctx_id, br);
+              uint32_t v =
+                  reader->ReadHybridUintClustered<uses_lz77>(ctx_id, br);
               r[x] = UnpackSigned(v);
             }
           }
@@ -200,13 +202,14 @@ Status DecodeModularChannelMAANS(BitReader *br, ANSSymbolReader *reader,
           for (size_t y = 0; y < channel.h; y++) {
             pixel_type *JXL_RESTRICT r = channel.Row(y);
             for (size_t x = 0; x < channel.w; x++) {
-              uint32_t v = reader->ReadHybridUintClustered(ctx_id, br);
+              uint32_t v =
+                  reader->ReadHybridUintClustered<uses_lz77>(ctx_id, br);
               r[x] = make_pixel(v, multiplier, offset);
             }
           }
         }
       }
-    } else if (predictor == Predictor::Gradient && offset == 0 &&
+    } else if (uses_lz77 && predictor == Predictor::Gradient && offset == 0 &&
                multiplier == 1 && reader->HuffRleOnly()) {
       JXL_DEBUG_V(8, "Gradient RLE (fjxl) very fast track.");
       uint32_t run = 0;
@@ -250,7 +253,7 @@ Status DecodeModularChannelMAANS(BitReader *br, ANSSymbolReader *reader,
           pixel_type top = (y ? *(r + x - onerow) : left);
           pixel_type topleft = (x && y ? *(r + x - 1 - onerow) : left);
           pixel_type guess = ClampedGradient(top, left, topleft);
-          uint64_t v = reader->ReadHybridUintClustered(ctx_id, br);
+          uint64_t v = reader->ReadHybridUintClustered<uses_lz77>(ctx_id, br);
           r[x] = make_pixel(v, 1, guess);
         }
       }
@@ -264,7 +267,7 @@ Status DecodeModularChannelMAANS(BitReader *br, ANSSymbolReader *reader,
           PredictionResult pred =
               PredictNoTreeNoWP(channel.w, r + x, onerow, x, y, predictor);
           pixel_type_w g = pred.guess + offset;
-          uint64_t v = reader->ReadHybridUintClustered(ctx_id, br);
+          uint64_t v = reader->ReadHybridUintClustered<uses_lz77>(ctx_id, br);
           // NOTE: pred.multiplier is unset.
           r[x] = make_pixel(v, multiplier, g);
         }
@@ -280,7 +283,7 @@ Status DecodeModularChannelMAANS(BitReader *br, ANSSymbolReader *reader,
                                            predictor, &wp_state)
                                .guess +
                            offset;
-          uint64_t v = reader->ReadHybridUintClustered(ctx_id, br);
+          uint64_t v = reader->ReadHybridUintClustered<uses_lz77>(ctx_id, br);
           r[x] = make_pixel(v, multiplier, g);
           wp_state.UpdateErrors(r[x], x, y, channel.w);
         }
@@ -319,7 +322,7 @@ Status DecodeModularChannelMAANS(BitReader *br, ANSSymbolReader *reader,
                 std::max<pixel_type_w>(-kPropRangeFast, top + left - topleft),
                 kPropRangeFast - 1);
         uint32_t ctx_id = context_lookup[pos];
-        uint64_t v = reader->ReadHybridUintClustered(ctx_id, br);
+        uint64_t v = reader->ReadHybridUintClustered<uses_lz77>(ctx_id, br);
         r[x] = make_pixel(v, multipliers[pos],
                           static_cast<pixel_type_w>(offsets[pos]) + guess);
       }
@@ -346,7 +349,7 @@ Status DecodeModularChannelMAANS(BitReader *br, ANSSymbolReader *reader,
             kPropRangeFast + std::min(std::max(-kPropRangeFast, properties[0]),
                                       kPropRangeFast - 1);
         uint32_t ctx_id = context_lookup[pos];
-        uint64_t v = reader->ReadHybridUintClustered(ctx_id, br);
+        uint64_t v = reader->ReadHybridUintClustered<uses_lz77>(ctx_id, br);
         r[x] = make_pixel(v, multipliers[pos],
                           static_cast<pixel_type_w>(offsets[pos]) + guess);
         wp_state.UpdateErrors(r[x], x, y, channel.w);
@@ -369,21 +372,24 @@ Status DecodeModularChannelMAANS(BitReader *br, ANSSymbolReader *reader,
           PredictionResult res =
               PredictTreeNoWP(&properties, channel.w, p + x, onerow, x, y,
                               tree_lookup, references);
-          uint64_t v = reader->ReadHybridUintClustered(res.context, br);
+          uint64_t v =
+              reader->ReadHybridUintClustered<uses_lz77>(res.context, br);
           p[x] = make_pixel(v, res.multiplier, res.guess);
         }
         for (size_t x = 2; x < channel.w - 2; x++) {
           PredictionResult res =
               PredictTreeNoWPNEC(&properties, channel.w, p + x, onerow, x, y,
                                  tree_lookup, references);
-          uint64_t v = reader->ReadHybridUintClustered(res.context, br);
+          uint64_t v =
+              reader->ReadHybridUintClustered<uses_lz77>(res.context, br);
           p[x] = make_pixel(v, res.multiplier, res.guess);
         }
         for (size_t x = channel.w - 2; x < channel.w; x++) {
           PredictionResult res =
               PredictTreeNoWP(&properties, channel.w, p + x, onerow, x, y,
                               tree_lookup, references);
-          uint64_t v = reader->ReadHybridUintClustered(res.context, br);
+          uint64_t v =
+              reader->ReadHybridUintClustered<uses_lz77>(res.context, br);
           p[x] = make_pixel(v, res.multiplier, res.guess);
         }
       } else {
@@ -391,7 +397,8 @@ Status DecodeModularChannelMAANS(BitReader *br, ANSSymbolReader *reader,
           PredictionResult res =
               PredictTreeNoWP(&properties, channel.w, p + x, onerow, x, y,
                               tree_lookup, references);
-          uint64_t v = reader->ReadHybridUintClustered(res.context, br);
+          uint64_t v =
+              reader->ReadHybridUintClustered<uses_lz77>(res.context, br);
           p[x] = make_pixel(v, res.multiplier, res.guess);
         }
       }
@@ -412,7 +419,8 @@ Status DecodeModularChannelMAANS(BitReader *br, ANSSymbolReader *reader,
           PredictionResult res =
               PredictTreeWP(&properties, channel.w, p + x, onerow, x, y,
                             tree_lookup, references, &wp_state);
-          uint64_t v = reader->ReadHybridUintClustered(res.context, br);
+          uint64_t v =
+              reader->ReadHybridUintClustered<uses_lz77>(res.context, br);
           p[x] = make_pixel(v, res.multiplier, res.guess);
           wp_state.UpdateErrors(p[x], x, y, channel.w);
         }
@@ -420,7 +428,8 @@ Status DecodeModularChannelMAANS(BitReader *br, ANSSymbolReader *reader,
           PredictionResult res =
               PredictTreeWPNEC(&properties, channel.w, p + x, onerow, x, y,
                                tree_lookup, references, &wp_state);
-          uint64_t v = reader->ReadHybridUintClustered(res.context, br);
+          uint64_t v =
+              reader->ReadHybridUintClustered<uses_lz77>(res.context, br);
           p[x] = make_pixel(v, res.multiplier, res.guess);
           wp_state.UpdateErrors(p[x], x, y, channel.w);
         }
@@ -428,7 +437,8 @@ Status DecodeModularChannelMAANS(BitReader *br, ANSSymbolReader *reader,
           PredictionResult res =
               PredictTreeWP(&properties, channel.w, p + x, onerow, x, y,
                             tree_lookup, references, &wp_state);
-          uint64_t v = reader->ReadHybridUintClustered(res.context, br);
+          uint64_t v =
+              reader->ReadHybridUintClustered<uses_lz77>(res.context, br);
           p[x] = make_pixel(v, res.multiplier, res.guess);
           wp_state.UpdateErrors(p[x], x, y, channel.w);
         }
@@ -437,7 +447,8 @@ Status DecodeModularChannelMAANS(BitReader *br, ANSSymbolReader *reader,
           PredictionResult res =
               PredictTreeWP(&properties, channel.w, p + x, onerow, x, y,
                             tree_lookup, references, &wp_state);
-          uint64_t v = reader->ReadHybridUintClustered(res.context, br);
+          uint64_t v =
+              reader->ReadHybridUintClustered<uses_lz77>(res.context, br);
           p[x] = make_pixel(v, res.multiplier, res.guess);
           wp_state.UpdateErrors(p[x], x, y, channel.w);
         }
@@ -578,9 +589,16 @@ Status ModularDecode(BitReader *br, Image &image, GroupHeader &header,
          channel.h > options->max_chan_size)) {
       break;
     }
-    JXL_RETURN_IF_ERROR(DecodeModularChannelMAANS(
-        br, &reader, *context_map, *tree, header.wp_header, next_channel,
-        group_id, &image));
+    if (code->lz77.enabled) {
+      JXL_RETURN_IF_ERROR(DecodeModularChannelMAANS<true>(
+          br, &reader, *context_map, *tree, header.wp_header, next_channel,
+          group_id, &image));
+    } else {
+      JXL_RETURN_IF_ERROR(DecodeModularChannelMAANS<false>(
+          br, &reader, *context_map, *tree, header.wp_header, next_channel,
+          group_id, &image));
+    }
+
     // Truncated group.
     if (!br->AllReadsWithinBounds()) {
       if (!allow_truncated_group) return JXL_FAILURE("Truncated input");


### PR DESCRIPTION
Some more decoding speedup by avoiding a function call in the hot loops, and by having a specialization in modular decoding for the no-lz77 case (which is quite common since only e1 and e8/e9 use lz77 at the moment).

Binary size goes up a bit because of this (by 100kb or so on x86), so we may want to be a bit more selective with the inlining and templating, but I think it's ok for now.

Modular decode speedup is 5-10%, also VarDCT decode gets some speedup (3% or so).

Before: (30 decode reps, single-core)
```
station.png
Encoding      kPixels    Bytes          BPP  E MP/s  D MP/s     Max norm  SSIMULACRA2   PSNR        pnorm       BPP*pnorm   QABPP   Bugs
----------------------------------------------------------------------------------------------------------------------------------------
jxl:d0:2          987  1487163   12.0458779   9.070  18.741         -nan 100.00000000  99.99   0.00000000  0.000000000000  12.046      0
jxl:d0:3          987  1416083   11.4701367   5.467   7.072         -nan 100.00000000  99.99   0.00000000  0.000000000000  11.470      0
jxl:d0:4          987  1401819   11.3545996   1.430   5.559         -nan 100.00000000  99.99   0.00000000  0.000000000000  11.355      0
jxl:d0:5          987  1390068   11.2594177   0.791   5.241         -nan 100.00000000  99.99   0.00000000  0.000000000000  11.259      0
jxl:d0:6          987  1381828   11.1926744   0.525   4.762         -nan 100.00000000  99.99   0.00000000  0.000000000000  11.193      0
jxl:d0:7          987  1370796   11.1033163   0.372   4.456         -nan 100.00000000  99.99   0.00000000  0.000000000000  11.103      0
jxl:d1            987   268868    2.1778050   2.738  32.124   1.36113428  84.78277345  40.43   0.58483733  1.273661684303   2.964      0
jxl:d2            987   165244    1.3384606   2.971  35.156   2.41245678  75.53099932  36.49   0.99354436  1.329819958131   3.229      0
jxl:d3            987   121301    0.9825265   2.838  36.348   3.68713610  66.98580653  34.43   1.34944885  1.325869234777   3.623      0
Aggregate:        987   702916    5.6935529   1.849  11.443   2.29623621  91.02428861  71.81   0.92213164  1.309531274247   7.511      0
```

After:
```
station.png
Encoding      kPixels    Bytes          BPP  E MP/s  D MP/s     Max norm  SSIMULACRA2   PSNR        pnorm       BPP*pnorm   QABPP   Bugs
----------------------------------------------------------------------------------------------------------------------------------------
jxl:d0:2          987  1487163   12.0458779   9.257  20.856         -nan 100.00000000  99.99   0.00000000  0.000000000000  12.046      0
jxl:d0:3          987  1416083   11.4701367   5.500   7.735         -nan 100.00000000  99.99   0.00000000  0.000000000000  11.470      0
jxl:d0:4          987  1401819   11.3545996   1.404   5.880         -nan 100.00000000  99.99   0.00000000  0.000000000000  11.355      0
jxl:d0:5          987  1390068   11.2594177   0.793   5.513         -nan 100.00000000  99.99   0.00000000  0.000000000000  11.259      0
jxl:d0:6          987  1381828   11.1926744   0.539   4.986         -nan 100.00000000  99.99   0.00000000  0.000000000000  11.193      0
jxl:d0:7          987  1370796   11.1033163   0.381   4.665         -nan 100.00000000  99.99   0.00000000  0.000000000000  11.103      0
jxl:d1            987   268868    2.1778050   2.729  33.065   1.36113428  84.78277345  40.43   0.58483733  1.273661684303   2.964      0
jxl:d2            987   165244    1.3384606   2.886  35.833   2.41245678  75.53099932  36.49   0.99354436  1.329819958131   3.229      0
jxl:d3            987   121301    0.9825265   2.821  37.419   3.68713610  66.98580653  34.43   1.34944885  1.325869234777   3.623      0
Aggregate:        987   702916    5.6935529   1.854  12.059   2.29623621  91.02428861  71.81   0.92213164  1.309531274247   7.511      0
```