### PR TITLE
0.22 % improvement in BPP*pnorm

### DIFF
--- a/lib/jxl/enc_group.cc
+++ b/lib/jxl/enc_group.cc
@@ -47,11 +47,11 @@ void QuantizeBlockAC(const Quantizer& quantizer, const bool error_diffusion,
   const float* JXL_RESTRICT qm = quantizer.InvDequantMatrix(quant_kind, c);
   float qac = quantizer.Scale() * (*quant);
   // Not SIMD-ified for now.
-  if (c != 1 && (xsize > 1 || ysize > 1)) {
+  if (c != 1 && xsize * ysize >= 4) {
     for (int i = 0; i < 4; ++i) {
-      thresholds[i] -= Clamp1(0.003f * xsize * ysize, 0.f, 0.08f);
-      if (thresholds[i] < 0.54) {
-        thresholds[i] = 0.54;
+      thresholds[i] -= 0.00744f * xsize * ysize;
+      if (thresholds[i] < 0.5) {
+        thresholds[i] = 0.5;
       }
     }
   }


### PR DESCRIPTION
slight change in color quantization for larger dct blocks (16x16 and larger).

```
Before:

Encoding      kPixels    Bytes          BPP  E MP/s  D MP/s     Max norm  SSIMULACRA2   PSNR        pnorm       BPP*pnorm   QABPP   Bugs
----------------------------------------------------------------------------------------------------------------------------------------
jxl:d0.1        19988 16281427    6.5164491   1.225  10.449   0.35786679  95.44384877  55.33   0.11870980  0.773566372007   6.516      0
jxl:d0.5        19988  6335293    2.5356263   1.648  16.656   0.79260558  91.38443700  46.40   0.34883491  0.884514964955   2.563      0
jxl:d0.8        19988  4696969    1.8799064   1.824  17.665   1.10381763  88.63176086  43.83   0.48257228  0.907190733968   2.182      0
jxl:d1          19988  4062645    1.6260257   1.870  18.257   1.30617895  86.93918486  42.65   0.56561700  0.919707793053   2.199      0
jxl:d1.1        19988  3830920    1.5332805   1.920  18.502   1.41216809  86.11943272  42.16   0.60584798  0.928934916036   2.255      0
jxl:d1.2        19988  3617332    1.4477945   1.718  17.732   1.49669713  85.34635256  41.71   0.64141652  0.928639274698   2.237      0
jxl:d1.3        19988  3444670    1.3786885   1.904  18.013   1.58055969  84.62342884  41.35   0.67668470  0.932937436060   2.275      0
jxl:d1.4        19988  3279984    1.3127749   1.689  18.467   1.67048473  83.89419880  40.99   0.71527008  0.938988608571   2.299      0
jxl:d1.5        19988  3126171    1.2512131   1.823  17.139   1.76132915  83.11748380  40.67   0.74847145  0.936497257259   2.297      0
jxl:d1.6        19988  2993847    1.1982519   1.722  17.441   1.83769402  82.40822539  40.35   0.78435423  0.939853972280   2.298      0
jxl:d1.7        19988  2873506    1.1500869   1.922  16.320   1.94437554  81.68838091  40.06   0.81892006  0.941829212961   2.323      0
jxl:d1.8        19988  2765490    1.1068547   1.830  16.757   1.99587952  80.99349495  39.78   0.84977904  0.940581964841   2.316      0
jxl:d1.9        19988  2665040    1.0666508   1.820  16.843   2.11523144  80.28016515  39.53   0.88426294  0.943199783169   2.352      0
jxl:d2.0        19988  2570282    1.0287250   1.731  16.842   2.21120438  79.58919899  39.29   0.91806167  0.944433032773   2.377      0
jxl:d2.1        19988  2482752    0.9936922   1.784  17.636   2.32608086  78.87450129  39.06   0.95118190  0.945182029999   2.417      0
jxl:d2.2        19988  2402385    0.9615263   1.883  17.264   2.39269591  78.18619947  38.83   0.98274840  0.944938383620   2.398      0
jxl:d2.3        19988  2328524    0.9319643   1.908  15.969   2.47905358  77.49024441  38.62   1.01731198  0.948098404883   2.409      0
jxl:d2.4        19988  2255756    0.9028397   1.769  18.325   2.53043833  76.86378733  38.41   1.04950367  0.947533601363   2.380      0
jxl:d2.5        19988  2193031    0.8777348   1.926  18.128   2.60849359  76.27774695  38.22   1.08128756  0.949083700659   2.385      0
jxl:d2.6        19988  2132515    0.8535140   1.864  16.920   2.71693298  75.66713289  38.04   1.11022123  0.947589330934   2.445      0
jxl:d2.7        19988  2073685    0.8299680   1.903  16.589   2.76070704  75.00914744  37.86   1.14352901  0.949092435442   2.411      0
jxl:d2.8        19988  2019671    0.8083495   1.673  17.481   2.81157652  74.40304374  37.68   1.17233663  0.947657717250   2.380      0
jxl:d2.9        19988  1970389    0.7886250   2.004  18.015   2.89888610  73.79663148  37.52   1.19902350  0.945579850001   2.395      0
jxl:d3          19988  1922123    0.7693071   1.835  16.979   2.96751876  73.16765631  37.38   1.22873423  0.945273909548   2.390      0
jxl:d5          19988  1314968    0.5263004   1.794  10.374   4.49220937  61.95837085  35.19   1.75539161  0.923863355824   2.476      0
jxl:d7          19988  1023284    0.4095573   1.659  10.277   5.66080658  52.63088222  33.78   2.21759419  0.908231994376   2.406      0
jxl:d15         19988   581535    0.2327525   1.855   9.640  10.00913279  23.81943588  30.94   3.76036819  0.875235181985   2.370      0
jxl:d24         19988   418550    0.1675197   0.311  18.052  16.83273335   4.60019202  29.37   5.83881466  0.978116475742   2.700      0
Aggregate:      19988  2486686    0.9952666   1.681  16.119   2.27160413  68.30752240  39.20   0.93280398  0.928388602857   2.453      0

After:

Encoding      kPixels    Bytes          BPP  E MP/s  D MP/s     Max norm  SSIMULACRA2   PSNR        pnorm       BPP*pnorm   QABPP   Bugs
----------------------------------------------------------------------------------------------------------------------------------------
jxl:d0.1        19988 16285960    6.5182633   1.291  10.229   0.35751487  95.44402571  55.33   0.11858650  0.772978009094   6.518      0
jxl:d0.5        19988  6339424    2.5372797   1.624  14.694   0.79035681  91.38825397  46.40   0.34845275  0.884122066221   2.555      0
jxl:d0.8        19988  4701461    1.8817043   1.701  17.075   1.09826621  88.63624132  43.82   0.48126914  0.905606213630   2.170      0
jxl:d1          19988  4066796    1.6276871   1.784  16.776   1.29830298  86.94908843  42.65   0.56324061  0.916779489707   2.185      0
jxl:d1.1        19988  3834985    1.5349075   1.793  16.524   1.40209202  86.12912665  42.15   0.60383247  0.926826994495   2.226      0
jxl:d1.2        19988  3621465    1.4494486   1.817  17.414   1.49289339  85.35873340  41.70   0.63955578  0.927003254419   2.230      0
jxl:d1.3        19988  3448449    1.3802010   1.668  17.234   1.57583157  84.63618920  41.35   0.67527268  0.932012044925   2.269      0
jxl:d1.4        19988  3284236    1.3144767   1.853  16.641   1.66047920  83.90826531  40.98   0.71212263  0.936068612924   2.278      0
jxl:d1.5        19988  3129599    1.2525851   1.724  16.425   1.75564795  83.12646053  40.67   0.74590365  0.934307779815   2.289      0
jxl:d1.6        19988  2997417    1.1996808   1.798  15.657   1.83073897  82.40931306  40.34   0.78004083  0.935799996141   2.293      0
jxl:d1.7        19988  2876815    1.1514113   1.693  16.307   1.93884508  81.70825258  40.05   0.81556908  0.939055429113   2.320      0
jxl:d1.8        19988  2769009    1.1082632   1.798  16.875   1.99102893  81.02600542  39.78   0.84673271  0.938402691399   2.318      0
jxl:d1.9        19988  2668067    1.0678623   1.795  17.297   2.10990198  80.32178201  39.53   0.88138065  0.941193197111   2.348      0
jxl:d2.0        19988  2573082    1.0298457   1.838  16.195   2.20576200  79.61327630  39.28   0.91623638  0.943582110681   2.372      0
jxl:d2.1        19988  2486051    0.9950126   1.746  18.218   2.32109719  78.90663159  39.05   0.94839361  0.943663575733   2.414      0
jxl:d2.2        19988  2405306    0.9626953   1.772  17.239   2.39137476  78.24816534  38.82   0.98056199  0.943982470104   2.407      0
jxl:d2.3        19988  2331373    0.9331045   1.840  16.630   2.47462624  77.53665843  38.62   1.01454988  0.946681096426   2.411      0
jxl:d2.4        19988  2258867    0.9040849   1.829  16.545   2.51686303  76.89487151  38.40   1.04239733  0.942415648734   2.381      0
jxl:d2.5        19988  2196134    0.8789767   1.713  16.577   2.60048243  76.29271876  38.22   1.07625916  0.946006748263   2.384      0
jxl:d2.6        19988  2135335    0.8546426   1.940  15.711   2.69720074  75.69466592  38.03   1.10331624  0.942941103357   2.416      0
jxl:d2.7        19988  2076592    0.8311314   1.831  15.213   2.73398836  75.03732080  37.85   1.13498402  0.943320911304   2.380      0
jxl:d2.8        19988  2022493    0.8094790   2.001  17.560   2.79854035  74.43480341  37.67   1.16672158  0.944436569116   2.367      0
jxl:d2.9        19988  1972736    0.7895643   1.755  17.954   2.89414623  73.83591201  37.51   1.19433777  0.943006473603   2.394      0
jxl:d3          19988  1924950    0.7704385   1.762  16.892   2.96724285  73.19510771  37.37   1.22665501  0.945062276366   2.389      0
jxl:d5          19988  1317018    0.5271209   1.789  10.026   4.48213719  61.97760944  35.18   1.75117830  0.923082711057   2.474      0
jxl:d7          19988  1024640    0.4101001   1.786   9.693   5.67068376  52.64901238  33.78   2.21083339  0.906662929486   2.423      0
jxl:d15         19988   582163    0.2330039   1.671   9.396   9.99172708  23.83331659  30.94   3.75675171  0.875337694702   2.371      0
jxl:d24         19988   419010    0.1677038   0.295  18.776  16.77332106   4.63090106  29.37   5.83275744  0.978175639780   2.688      0
Aggregate:      19988  2489603    0.9964343   1.650  15.517   2.26406973  68.34347554  39.20   0.92965684  0.926341941080   2.446      0
```