### PR TITLE
improve on chess board images substantially

### DIFF
--- a/lib/jxl/jxl_test.cc
+++ b/lib/jxl/jxl_test.cc
@@ -149,7 +149,7 @@ TEST(JxlTest, RoundtripResample2) {
   cparams.AddOption(JXL_ENC_FRAME_SETTING_EFFORT, 3);  // kFalcon
 
   PackedPixelFile ppf_out;
-  EXPECT_NEAR(Roundtrip(t.ppf(), cparams, {}, pool, &ppf_out), 18772, 200);
+  EXPECT_NEAR(Roundtrip(t.ppf(), cparams, {}, pool, &ppf_out), 18500, 200);
   EXPECT_THAT(ComputeDistance2(t.ppf(), ppf_out), IsSlightlyBelow(90));
 }
 
@@ -166,7 +166,7 @@ TEST(JxlTest, RoundtripResample2Slow) {
   cparams.distance = 10.0;
 
   PackedPixelFile ppf_out;
-  EXPECT_NEAR(Roundtrip(t.ppf(), cparams, {}, pool, &ppf_out), 4088, 200);
+  EXPECT_NEAR(Roundtrip(t.ppf(), cparams, {}, pool, &ppf_out), 3888, 200);
   EXPECT_THAT(ComputeDistance2(t.ppf(), ppf_out), IsSlightlyBelow(250));
 }
 

--- a/tools/optimizer/simplex_fork.py
+++ b/tools/optimizer/simplex_fork.py
@@ -123,7 +123,7 @@ def Eval(vec, binary_name, cached=True):
     sys.stdout.flush()
     if line[0:3] == b'jxl':
       bpp = line.split()[3]
-      dist_pnorm = line.split()[8]
+      dist_pnorm = line.split()[7]
       dist_max = line.split()[6]
       vec[0] *= float(dist_pnorm) * float(bpp) / 16.0
       #vec[0] *= (float(dist_max) * float(bpp) / 16.0) ** 0.01


### PR DESCRIPTION
small degradation on metrics (except psnr)

improves chessboard patterns a lot at all distances

reduces the quality of a complex pixel graphic pattern

```
Before:

Encoding      kPixels    Bytes          BPP  E MP/s  D MP/s     Max norm  SSIMULACRA2   PSNR        pnorm       BPP*pnorm   QABPP   Bugs
----------------------------------------------------------------------------------------------------------------------------------------
jxl:d0.1        19988 16285960    6.5182633   1.211  11.091   0.35751487  95.44402571  55.33   0.11858650  0.772978009094   6.518      0
jxl:d0.5        19988  6339424    2.5372797   1.616  16.782   0.79035681  91.38825397  46.40   0.34845275  0.884122066221   2.555      0
jxl:d0.8        19988  4701461    1.8817043   1.698  16.455   1.09826621  88.63624132  43.82   0.48126914  0.905606213630   2.170      0
jxl:d1          19988  4066796    1.6276871   1.784  17.946   1.29830298  86.94908843  42.65   0.56324061  0.916779489707   2.185      0
jxl:d1.1        19988  3834985    1.5349075   1.796  18.206   1.40209202  86.12912665  42.15   0.60383247  0.926826994495   2.226      0
jxl:d1.2        19988  3621465    1.4494486   1.803  18.289   1.49289339  85.35873340  41.70   0.63955578  0.927003254419   2.230      0
jxl:d1.3        19988  3448449    1.3802010   1.903  18.380   1.57583157  84.63618920  41.35   0.67527268  0.932012044925   2.269      0
jxl:d1.4        19988  3284236    1.3144767   1.725  18.511   1.66047920  83.90826531  40.98   0.71212263  0.936068612924   2.278      0
jxl:d1.5        19988  3129599    1.2525851   1.909  17.647   1.75564795  83.12646053  40.67   0.74590365  0.934307779815   2.289      0
jxl:d1.6        19988  2997417    1.1996808   1.735  16.823   1.83073897  82.40931306  40.34   0.78004083  0.935799996141   2.293      0
jxl:d1.7        19988  2876815    1.1514113   1.839  17.681   1.93884508  81.70825258  40.05   0.81556908  0.939055429113   2.320      0
jxl:d1.8        19988  2769009    1.1082632   1.938  18.221   1.99102893  81.02600542  39.78   0.84673271  0.938402691399   2.318      0
jxl:d1.9        19988  2668067    1.0678623   1.861  17.090   2.10990198  80.32178201  39.53   0.88138065  0.941193197111   2.348      0
jxl:d2.0        19988  2573082    1.0298457   1.773  18.641   2.20576200  79.61327630  39.28   0.91623638  0.943582110681   2.372      0
jxl:d2.1        19988  2486051    0.9950126   1.793  18.080   2.32109719  78.90663159  39.05   0.94839361  0.943663575733   2.414      0
jxl:d2.2        19988  2405306    0.9626953   1.886  18.171   2.39137476  78.24816534  38.82   0.98056199  0.943982470104   2.407      0
jxl:d2.3        19988  2331373    0.9331045   1.873  17.332   2.47462624  77.53665843  38.62   1.01454988  0.946681096426   2.411      0
jxl:d2.4        19988  2258867    0.9040849   1.686  16.296   2.51686303  76.89487151  38.40   1.04239733  0.942415648734   2.381      0
jxl:d2.5        19988  2196134    0.8789767   1.839  18.604   2.60048243  76.29271876  38.22   1.07625916  0.946006748263   2.384      0
jxl:d2.6        19988  2135335    0.8546426   1.903  18.795   2.69720074  75.69466592  38.03   1.10331624  0.942941103357   2.416      0
jxl:d2.7        19988  2076592    0.8311314   1.985  17.341   2.73398836  75.03732080  37.85   1.13498402  0.943320911304   2.380      0
jxl:d2.8        19988  2022493    0.8094790   1.682  17.431   2.79854035  74.43480341  37.67   1.16672158  0.944436569116   2.367      0
jxl:d2.9        19988  1972736    0.7895643   1.924  18.142   2.89414623  73.83591201  37.51   1.19433777  0.943006473603   2.394      0
jxl:d3          19988  1924950    0.7704385   1.790  17.040   2.96724285  73.19510771  37.37   1.22665501  0.945062276366   2.389      0
jxl:d5          19988  1317018    0.5271209   1.813  10.135   4.48213719  61.97760944  35.18   1.75117830  0.923082711057   2.474      0
jxl:d7          19988  1024640    0.4101001   1.742  10.258   5.67068376  52.64901238  33.78   2.21083339  0.906662929486   2.423      0
jxl:d15         19988   582163    0.2330039   1.829   9.180   9.99172708  23.83331659  30.94   3.75675171  0.875337694702   2.371      0
jxl:d24         19988   419010    0.1677038   0.306  15.602  16.77332106   4.63090106  29.37   5.83275744  0.978175639780   2.688      0
Aggregate:      19988  2489603    0.9964343   1.675  16.289   2.26406973  68.34347554  39.20   0.92965684  0.926341941080   2.446      0

After:

Encoding      kPixels    Bytes          BPP  E MP/s  D MP/s     Max norm  SSIMULACRA2   PSNR        pnorm       BPP*pnorm   QABPP   Bugs
----------------------------------------------------------------------------------------------------------------------------------------
jxl:d0.1        19988 16248290    6.5031864   1.296  11.329   0.36367235  95.40348953  55.31   0.12028512  0.782236544141   6.503      0
jxl:d0.5        19988  6352958    2.5426965   1.653  16.402   0.79687579  91.35179185  46.51   0.34868202  0.886592546922   2.605      0
jxl:d0.8        19988  4707656    1.8841838   1.857  14.768   1.10919731  88.57292056  43.96   0.48342015  0.910852406120   2.194      0
jxl:d1          19988  4078500    1.6323715   1.821  17.774   1.30898709  86.90706394  42.78   0.56445029  0.921392573816   2.221      0
jxl:d1.1        19988  3845641    1.5391724   1.925  18.801   1.41488396  86.11047555  42.29   0.60373050  0.929245340838   2.270      0
jxl:d1.2        19988  3631977    1.4536559   1.726  17.812   1.51117344  85.35813865  41.84   0.64090110  0.931649690291   2.278      0
jxl:d1.3        19988  3459534    1.3846377   1.936  18.989   1.59434154  84.63468801  41.49   0.67596061  0.935960521270   2.312      0
jxl:d1.4        19988  3294711    1.3186692   1.750  18.538   1.67239921  83.87441738  41.11   0.71270738  0.939825279772   2.303      0
jxl:d1.5        19988  3138556    1.2561700   1.846  17.348   1.76853932  83.11326497  40.78   0.74656270  0.937809677352   2.327      0
jxl:d1.6        19988  3004237    1.2024104   1.752  17.092   1.84912348  82.37974117  40.46   0.78174179  0.939974469782   2.334      0
jxl:d1.7        19988  2882460    1.1536706   1.930  18.378   1.95514891  81.66370992  40.17   0.81651697  0.941991633329   2.354      0
jxl:d1.8        19988  2773116    1.1099070   1.937  17.557   2.00495856  80.99931267  39.88   0.84778884  0.940966740536   2.340      0
jxl:d1.9        19988  2671335    1.0691703   1.904  18.090   2.12723872  80.27963340  39.62   0.88395400  0.945097373071   2.375      0
jxl:d2.0        19988  2574588    1.0304485   1.771  17.544   2.22323638  79.59105702  39.37   0.91856374  0.946532606538   2.393      0
jxl:d2.1        19988  2486959    0.9953760   1.791  17.478   2.34122361  78.90420373  39.13   0.95006767  0.945674552420   2.437      0
jxl:d2.2        19988  2405370    0.9627210   1.916  18.529   2.41381282  78.23821492  38.90   0.98168178  0.945085630061   2.429      0
jxl:d2.3        19988  2331303    0.9330765   1.888  16.948   2.49056859  77.53981770  38.69   1.01331063  0.945496359160   2.429      0
jxl:d2.4        19988  2257459    0.9035213   1.850  18.639   2.53670376  76.86602531  38.48   1.04364831  0.942958508656   2.405      0
jxl:d2.5        19988  2194456    0.8783051   1.921  17.441   2.62107556  76.26099884  38.29   1.07467957  0.943896568431   2.416      0
jxl:d2.6        19988  2131495    0.8531057   1.894  17.347   2.73241900  75.63391919  38.09   1.10744484  0.944767532160   2.456      0
jxl:d2.7        19988  2072521    0.8295021   1.980  17.041   2.74464111  75.00803091  37.91   1.13588846  0.942221841020   2.384      0
jxl:d2.8        19988  2018583    0.8079140   1.678  18.201   2.81098999  74.40579484  37.73   1.16626193  0.942239372083   2.384      0
jxl:d2.9        19988  1969701    0.7883496   1.917  18.450   2.90759246  73.79936405  37.57   1.19733338  0.943917277608   2.412      0
jxl:d3          19988  1922735    0.7695520   1.794  17.118   2.97272859  73.17126098  37.44   1.22586709  0.943368469938   2.401      0
jxl:d5          19988  1313990    0.5259090   1.828  10.660   4.49523143  61.88030612  35.21   1.75770288  0.924391752650   2.481      0
jxl:d7          19988  1017516    0.4072488   1.688   9.818   5.68191825  52.51951153  33.80   2.21213918  0.900890967950   2.397      0
jxl:d15         19988   572839    0.2292721   1.820   9.642  10.01007107  23.69896998  30.93   3.76417030  0.863019046324   2.339      0
jxl:d24         19988   409829    0.1640292   0.295  18.592  16.77811816   4.45547099  29.36   5.84265893  0.958366799342   2.620      0
Aggregate:      19988  2486889    0.9953481   1.698  16.375   2.28088070  68.20575369  39.28   0.93137065  0.927038045639   2.466      0
```