### PR TITLE
tweak modular decode speed vs binary size

### DIFF
--- a/lib/jxl/modular/encoding/encoding.cc
+++ b/lib/jxl/modular/encoding/encoding.cc
@@ -194,7 +194,7 @@ Status DecodeModularChannelMAANS(BitReader *br, ANSSymbolReader *reader,
             pixel_type *JXL_RESTRICT r = channel.Row(y);
             for (size_t x = 0; x < channel.w; x++) {
               uint32_t v =
-                  reader->ReadHybridUintClustered<uses_lz77>(ctx_id, br);
+                  reader->ReadHybridUintClusteredInlined<uses_lz77>(ctx_id, br);
               r[x] = UnpackSigned(v);
             }
           }
@@ -203,7 +203,8 @@ Status DecodeModularChannelMAANS(BitReader *br, ANSSymbolReader *reader,
             pixel_type *JXL_RESTRICT r = channel.Row(y);
             for (size_t x = 0; x < channel.w; x++) {
               uint32_t v =
-                  reader->ReadHybridUintClustered<uses_lz77>(ctx_id, br);
+                  reader->ReadHybridUintClusteredMaybeInlined<uses_lz77>(ctx_id,
+                                                                         br);
               r[x] = make_pixel(v, multiplier, offset);
             }
           }
@@ -255,7 +256,8 @@ Status DecodeModularChannelMAANS(BitReader *br, ANSSymbolReader *reader,
           pixel_type top = (y ? *(r + x - onerow) : left);
           pixel_type topleft = (x && y ? *(r + x - 1 - onerow) : left);
           pixel_type guess = ClampedGradient(top, left, topleft);
-          uint64_t v = reader->ReadHybridUintClustered<uses_lz77>(ctx_id, br);
+          uint64_t v = reader->ReadHybridUintClusteredMaybeInlined<uses_lz77>(
+              ctx_id, br);
           r[x] = make_pixel(v, 1, guess);
         }
       }
@@ -293,34 +295,69 @@ Status DecodeModularChannelMAANS(BitReader *br, ANSSymbolReader *reader,
                 std::max<pixel_type_w>(-kPropRangeFast, top + left - topleft),
                 kPropRangeFast - 1);
         uint32_t ctx_id = context_lookup[pos];
-        uint64_t v = reader->ReadHybridUintClustered<uses_lz77>(ctx_id, br);
+        uint64_t v =
+            reader->ReadHybridUintClusteredMaybeInlined<uses_lz77>(ctx_id, br);
         r[x] = make_pixel(v, multipliers[pos],
                           static_cast<pixel_type_w>(offsets[pos]) + guess);
       }
     }
-  } else if (!uses_lz77 && is_wp_only) {
+  } else if (!uses_lz77 && is_wp_only && channel.w > 8) {
     JXL_DEBUG_V(8, "WP fast track.");
-    const intptr_t onerow = channel.plane.PixelsPerRow();
     weighted::State wp_state(wp_header, channel.w, channel.h);
     Properties properties(1);
     for (size_t y = 0; y < channel.h; y++) {
       pixel_type *JXL_RESTRICT r = channel.Row(y);
-      for (size_t x = 0; x < channel.w; x++) {
+      const pixel_type *JXL_RESTRICT rtop = (y ? channel.Row(y - 1) : r - 1);
+      const pixel_type *JXL_RESTRICT rtoptop =
+          (y > 1 ? channel.Row(y - 2) : rtop);
+      const pixel_type *JXL_RESTRICT rtopleft =
+          (y ? channel.Row(y - 1) - 1 : r - 1);
+      const pixel_type *JXL_RESTRICT rtopright =
+          (y ? channel.Row(y - 1) + 1 : r - 1);
+      size_t x = 0;
+      {
         size_t offset = 0;
-        pixel_type_w left = (x ? r[x - 1] : y ? *(r + x - onerow) : 0);
-        pixel_type_w top = (y ? *(r + x - onerow) : left);
-        pixel_type_w topleft = (x && y ? *(r + x - 1 - onerow) : left);
-        pixel_type_w topright =
-            (x + 1 < channel.w && y ? *(r + x + 1 - onerow) : top);
-        pixel_type_w toptop = (y > 1 ? *(r + x - onerow - onerow) : top);
+        pixel_type_w left = y ? rtop[x] : 0;
+        pixel_type_w topright = (x + 1 < channel.w && y ? rtop[x + 1] : left);
         int32_t guess = wp_state.Predict</*compute_properties=*/true>(
-            x, y, channel.w, top, left, topright, topleft, toptop, &properties,
-            offset);
+            x, y, channel.w, left, left, topright, left, rtoptop[x],
+            &properties, offset);
         uint32_t pos =
             kPropRangeFast + std::min(std::max(-kPropRangeFast, properties[0]),
                                       kPropRangeFast - 1);
         uint32_t ctx_id = context_lookup[pos];
-        uint64_t v = reader->ReadHybridUintClustered<uses_lz77>(ctx_id, br);
+        uint64_t v =
+            reader->ReadHybridUintClusteredInlined<uses_lz77>(ctx_id, br);
+        r[x] = make_pixel(v, multipliers[pos],
+                          static_cast<pixel_type_w>(offsets[pos]) + guess);
+        wp_state.UpdateErrors(r[x], x, y, channel.w);
+      }
+      for (x = 1; x + 1 < channel.w; x++) {
+        size_t offset = 0;
+        int32_t guess = wp_state.Predict</*compute_properties=*/true>(
+            x, y, channel.w, rtop[x], r[x - 1], rtopright[x], rtopleft[x],
+            rtoptop[x], &properties, offset);
+        uint32_t pos =
+            kPropRangeFast + std::min(std::max(-kPropRangeFast, properties[0]),
+                                      kPropRangeFast - 1);
+        uint32_t ctx_id = context_lookup[pos];
+        uint64_t v =
+            reader->ReadHybridUintClusteredInlined<uses_lz77>(ctx_id, br);
+        r[x] = make_pixel(v, multipliers[pos],
+                          static_cast<pixel_type_w>(offsets[pos]) + guess);
+        wp_state.UpdateErrors(r[x], x, y, channel.w);
+      }
+      {
+        size_t offset = 0;
+        int32_t guess = wp_state.Predict</*compute_properties=*/true>(
+            x, y, channel.w, rtop[x], r[x - 1], rtop[x], rtopleft[x],
+            rtoptop[x], &properties, offset);
+        uint32_t pos =
+            kPropRangeFast + std::min(std::max(-kPropRangeFast, properties[0]),
+                                      kPropRangeFast - 1);
+        uint32_t ctx_id = context_lookup[pos];
+        uint64_t v =
+            reader->ReadHybridUintClusteredInlined<uses_lz77>(ctx_id, br);
         r[x] = make_pixel(v, multipliers[pos],
                           static_cast<pixel_type_w>(offsets[pos]) + guess);
         wp_state.UpdateErrors(r[x], x, y, channel.w);
@@ -351,8 +388,8 @@ Status DecodeModularChannelMAANS(BitReader *br, ANSSymbolReader *reader,
           PredictionResult res =
               PredictTreeNoWPNEC(&properties, channel.w, p + x, onerow, x, y,
                                  tree_lookup, references);
-          uint64_t v =
-              reader->ReadHybridUintClustered<uses_lz77>(res.context, br);
+          uint64_t v = reader->ReadHybridUintClusteredInlined<uses_lz77>(
+              res.context, br);
           p[x] = make_pixel(v, res.multiplier, res.guess);
         }
         for (size_t x = channel.w - 2; x < channel.w; x++) {
@@ -368,8 +405,8 @@ Status DecodeModularChannelMAANS(BitReader *br, ANSSymbolReader *reader,
           PredictionResult res =
               PredictTreeNoWP(&properties, channel.w, p + x, onerow, x, y,
                               tree_lookup, references);
-          uint64_t v =
-              reader->ReadHybridUintClustered<uses_lz77>(res.context, br);
+          uint64_t v = reader->ReadHybridUintClusteredMaybeInlined<uses_lz77>(
+              res.context, br);
           p[x] = make_pixel(v, res.multiplier, res.guess);
         }
       }
@@ -399,8 +436,8 @@ Status DecodeModularChannelMAANS(BitReader *br, ANSSymbolReader *reader,
           PredictionResult res =
               PredictTreeWPNEC(&properties, channel.w, p + x, onerow, x, y,
                                tree_lookup, references, &wp_state);
-          uint64_t v =
-              reader->ReadHybridUintClustered<uses_lz77>(res.context, br);
+          uint64_t v = reader->ReadHybridUintClusteredInlined<uses_lz77>(
+              res.context, br);
           p[x] = make_pixel(v, res.multiplier, res.guess);
           wp_state.UpdateErrors(p[x], x, y, channel.w);
         }


### PR DESCRIPTION
Minor tweaks to improve the modular decode speed and binary size.

Before: (single-core, only decode speed is measured accurately)
```
station.png
Encoding      kPixels    Bytes          BPP  E MP/s  D MP/s     Max norm  SSIMULACRA2   PSNR        pnorm       BPP*pnorm   QABPP   Bugs
----------------------------------------------------------------------------------------------------------------------------------------
jxl:d0:2          987  1487163   12.0458779   9.497  21.502         -nan 100.00000000  99.99   0.00000000  0.000000000000  12.046      0
jxl:d0:3          987  1416083   11.4701367   5.772   8.072         -nan 100.00000000  99.99   0.00000000  0.000000000000  11.470      0
jxl:d0:4          987  1401819   11.3545996   1.489   6.190         -nan 100.00000000  99.99   0.00000000  0.000000000000  11.355      0
jxl:d0:5          987  1390068   11.2594177   0.814   5.827         -nan 100.00000000  99.99   0.00000000  0.000000000000  11.259      0
jxl:d0:6          987  1381828   11.1926744   0.537   5.269         -nan 100.00000000  99.99   0.00000000  0.000000000000  11.193      0
jxl:d0:7          987  1370796   11.1033163   0.376   4.903         -nan 100.00000000  99.99   0.00000000  0.000000000000  11.103      0
jxl:d0:8          987  1354026   10.9674809   0.156   4.872         -nan 100.00000000  99.99   0.00000000  0.000000000000  10.967      0
jxl:d0:9          987  1345638   10.8995389   0.031   4.594         -nan 100.00000000  99.99   0.00000000  0.000000000000  10.900      0
Aggregate:        987  1392819   11.2817001   0.711   6.604   0.00000000 100.00000000  99.99   0.00000000  0.000000000000  11.282      0
```

libjxl.so is 2726792 bytes (stripped release build, x64, clang 14)


After:
```
station.png
Encoding      kPixels    Bytes          BPP  E MP/s  D MP/s     Max norm  SSIMULACRA2   PSNR        pnorm       BPP*pnorm   QABPP   Bugs
----------------------------------------------------------------------------------------------------------------------------------------
jxl:d0:2          987  1487163   12.0458779   9.769  22.046         -nan 100.00000000  99.99   0.00000000  0.000000000000  12.046      0
jxl:d0:3          987  1416083   11.4701367   5.820   8.228         -nan 100.00000000  99.99   0.00000000  0.000000000000  11.470      0
jxl:d0:4          987  1401819   11.3545996   1.475   6.276         -nan 100.00000000  99.99   0.00000000  0.000000000000  11.355      0
jxl:d0:5          987  1390068   11.2594177   0.799   5.890         -nan 100.00000000  99.99   0.00000000  0.000000000000  11.259      0
jxl:d0:6          987  1381828   11.1926744   0.545   5.366         -nan 100.00000000  99.99   0.00000000  0.000000000000  11.193      0
jxl:d0:7          987  1370796   11.1033163   0.384   5.023         -nan 100.00000000  99.99   0.00000000  0.000000000000  11.103      0
jxl:d0:8          987  1354026   10.9674809   0.153   4.935         -nan 100.00000000  99.99   0.00000000  0.000000000000  10.967      0
jxl:d0:9          987  1345638   10.8995389   0.032   4.692         -nan 100.00000000  99.99   0.00000000  0.000000000000  10.900      0
Aggregate:        987  1392819   11.2817001   0.715   6.725   0.00000000 100.00000000  99.99   0.00000000  0.000000000000  11.282      0
```

libjxl.so is 2710408 bytes


So it's a small speedup (1-2% faster modular decoding) and a small binary size reduction (-16kb).