### PR TITLE
improve metadata handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `JxlEncoderChunkedImageFrameStart`,
   - `JxlEncoderChunkedImageFrameAddPart` and new
   - `JXL_ENC_FRAME_SETTING_BUFFERING` enum value.
+ - encoder API: new options for more fine-grained control over metadata
+   preservation when using `JxlEncoderAddJPEGFrame`:
+  - `JXL_ENC_FRAME_SETTING_JPEG_KEEP_EXIF`
+  - `JXL_ENC_FRAME_SETTING_JPEG_KEEP_XMP`
+  - `JXL_ENC_FRAME_SETTING_JPEG_KEEP_JUMBF`
+ - cjxl can now be used to explicitly add/update/strip Exif/XMP/JUMBF metadata using
+   the decoder-hints syntax, e.g. `cjxl input.ppm -x exif=input.exif output.jxl`
+ - djxl can now be used to extract Exif/XMP/JUMBF metadata
+
 ### Removed
  - API: the Butteraugli API (`jxl/butteraugli.h`) was removed.
  - encoder and decoder API: all deprecated functions were removed:

--- a/lib/extras/dec/color_hints.cc
+++ b/lib/extras/dec/color_hints.cc
@@ -15,19 +15,15 @@ namespace extras {
 Status ApplyColorHints(const ColorHints& color_hints,
                        const bool color_already_set, const bool is_gray,
                        PackedPixelFile* ppf) {
-  if (color_already_set) {
-    return color_hints.Foreach(
-        [](const std::string& key, const std::string& /*value*/) {
-          JXL_WARNING("Decoder ignoring %s hint", key.c_str());
-          return true;
-        });
-  }
-
-  bool got_color_space = false;
+  bool got_color_space = color_already_set;
 
   JXL_RETURN_IF_ERROR(color_hints.Foreach(
-      [is_gray, ppf, &got_color_space](const std::string& key,
-                                       const std::string& value) -> Status {
+      [color_already_set, is_gray, ppf, &got_color_space](
+          const std::string& key, const std::string& value) -> Status {
+        if (color_already_set && (key == "color_space" || key == "icc")) {
+          JXL_WARNING("Decoder ignoring %s hint", key.c_str());
+          return true;
+        }
         if (key == "color_space") {
           JxlColorEncoding c_original_external;
           if (!ParseDescription(value, &c_original_external)) {
@@ -46,6 +42,18 @@ Status ApplyColorHints(const ColorHints& color_hints,
           std::vector<uint8_t> icc(data, data + value.size());
           ppf->icc.swap(icc);
           got_color_space = true;
+        } else if (key == "exif") {
+          const uint8_t* data = reinterpret_cast<const uint8_t*>(value.data());
+          std::vector<uint8_t> blob(data, data + value.size());
+          ppf->metadata.exif.swap(blob);
+        } else if (key == "xmp") {
+          const uint8_t* data = reinterpret_cast<const uint8_t*>(value.data());
+          std::vector<uint8_t> blob(data, data + value.size());
+          ppf->metadata.xmp.swap(blob);
+        } else if (key == "jumbf") {
+          const uint8_t* data = reinterpret_cast<const uint8_t*>(value.data());
+          std::vector<uint8_t> blob(data, data + value.size());
+          ppf->metadata.jumbf.swap(blob);
         } else {
           JXL_WARNING("Ignoring %s hint", key.c_str());
         }

--- a/lib/extras/dec/color_hints.h
+++ b/lib/extras/dec/color_hints.h
@@ -10,6 +10,8 @@
 // information into the file, and those that support it may not have it.
 // To allow attaching color information to those file formats the caller can
 // define these color hints.
+// Besides color space information, 'ColorHints' may also include other
+// additional information such as Exif, XMP and JUMBF metadata.
 
 #include <stddef.h>
 #include <stdint.h>

--- a/lib/extras/dec/decode.cc
+++ b/lib/extras/dec/decode.cc
@@ -122,7 +122,9 @@ Status DecodeBytes(const Span<const uint8_t> bytes,
     JXLDecompressParams dparams = {};
     size_t decoded_bytes;
     if (DecodeImageJXL(bytes.data(), bytes.size(), dparams, &decoded_bytes,
-                       ppf)) {
+                       ppf) &&
+        ApplyColorHints(color_hints, true, ppf->info.num_color_channels == 1,
+                        ppf)) {
       return Codec::kJXL;
     }
     if (DecodeImageGIF(bytes, color_hints, ppf, constraints)) {

--- a/lib/extras/dec/jxl.cc
+++ b/lib/extras/dec/jxl.cc
@@ -125,12 +125,7 @@ bool DecodeImageJXL(const uint8_t* bytes, size_t bytes_size,
 
   JxlPixelFormat format;
   std::vector<JxlPixelFormat> accepted_formats = dparams.accepted_formats;
-  if (accepted_formats.empty()) {
-    for (const uint32_t num_channels : {1, 2, 3, 4}) {
-      accepted_formats.push_back(
-          {num_channels, JXL_TYPE_FLOAT, JXL_LITTLE_ENDIAN, /*align=*/0});
-    }
-  }
+
   JxlColorEncoding color_encoding;
   size_t num_color_channels = 0;
   if (!dparams.color_space.empty()) {
@@ -169,6 +164,10 @@ bool DecodeImageJXL(const uint8_t* bytes, size_t bytes_size,
   } else {
     events |= (JXL_DEC_COLOR_ENCODING | JXL_DEC_FRAME | JXL_DEC_PREVIEW_IMAGE |
                JXL_DEC_BOX);
+    if (accepted_formats.empty()) {
+      // decoding just the metadata, not the pixel data
+      events ^= JXL_DEC_FULL_IMAGE;
+    }
   }
   if (JXL_DEC_SUCCESS != JxlDecoderSubscribeEvents(dec, events)) {
     fprintf(stderr, "JxlDecoderSubscribeEvents failed\n");
@@ -206,7 +205,7 @@ bool DecodeImageJXL(const uint8_t* bytes, size_t bytes_size,
     return false;
   }
   uint32_t progression_index = 0;
-  bool codestream_done = false;
+  bool codestream_done = accepted_formats.empty();
   BoxProcessor boxes(dec);
   for (;;) {
     JxlDecoderStatus status = JxlDecoderProcessInput(dec);
@@ -285,6 +284,7 @@ bool DecodeImageJXL(const uint8_t* bytes, size_t bytes_size,
         fprintf(stderr, "JxlDecoderGetBasicInfo failed\n");
         return false;
       }
+      if (accepted_formats.empty()) continue;
       if (num_color_channels != 0) {
         // Mark the change in number of color channels due to the requested
         // color space.

--- a/lib/extras/enc/encode.h
+++ b/lib/extras/enc/encode.h
@@ -43,6 +43,8 @@ class Encoder {
 
   virtual ~Encoder() = default;
 
+  // Set of pixel formats that this encoder takes as input.
+  // If empty, the 'encoder' does not need any pixels (it's metadata-only).
   virtual std::vector<JxlPixelFormat> AcceptedFormats() const = 0;
 
   // Any existing data in encoded_image is discarded.

--- a/lib/extras/enc/jxl.cc
+++ b/lib/extras/enc/jxl.cc
@@ -87,6 +87,18 @@ bool EncodeImageJXL(const JXLCompressParams& params, const PackedPixelFile& ppf,
       fprintf(stderr, "Storing JPEG metadata failed.\n");
       return false;
     }
+    if (!params.jpeg_store_metadata && params.jpeg_strip_exif) {
+      JxlEncoderFrameSettingsSetOption(settings,
+                                       JXL_ENC_FRAME_SETTING_JPEG_KEEP_EXIF, 0);
+    }
+    if (!params.jpeg_store_metadata && params.jpeg_strip_xmp) {
+      JxlEncoderFrameSettingsSetOption(settings,
+                                       JXL_ENC_FRAME_SETTING_JPEG_KEEP_XMP, 0);
+    }
+    if (params.jpeg_strip_jumbf) {
+      JxlEncoderFrameSettingsSetOption(
+          settings, JXL_ENC_FRAME_SETTING_JPEG_KEEP_JUMBF, 0);
+    }
     if (JXL_ENC_SUCCESS != JxlEncoderAddJPEGFrame(settings, jpeg_bytes->data(),
                                                   jpeg_bytes->size())) {
       fprintf(stderr, "JxlEncoderAddJPEGFrame() failed.\n");

--- a/lib/extras/enc/jxl.h
+++ b/lib/extras/enc/jxl.h
@@ -43,6 +43,9 @@ struct JXLCompressParams {
   bool use_container = false;
   // Whether to enable/disable byte-exact jpeg reconstruction for jpeg inputs.
   bool jpeg_store_metadata = true;
+  bool jpeg_strip_exif = false;
+  bool jpeg_strip_xmp = false;
+  bool jpeg_strip_jumbf = false;
   // Whether to create brob boxes.
   bool compress_boxes = true;
   // Upper bound on the intensity level present in the image in nits (zero means

--- a/lib/include/jxl/encode.h
+++ b/lib/include/jxl/encode.h
@@ -349,6 +349,30 @@ typedef enum {
    */
   JXL_ENC_FRAME_SETTING_BUFFERING = 34,
 
+  /** Keep or discard Exif metadata boxes derived from a JPEG frame when using
+   * JxlEncoderAddJPEGFrame. This has no effect on boxes added using
+   * JxlEncoderAddBox. When JxlEncoderStoreJPEGMetadata is set to 1, this option
+   * cannot be set to 0. Even when Exif metadata is discarded, the orientation
+   * will still be applied. 0 = discard Exif metadata, 1 = keep Exif metadata
+   * (default).
+   */
+  JXL_ENC_FRAME_SETTING_JPEG_KEEP_EXIF = 35,
+
+  /** Keep or discard XMP metadata boxes derived from a JPEG frame when using
+   * JxlEncoderAddJPEGFrame. This has no effect on boxes added using
+   * JxlEncoderAddBox. When JxlEncoderStoreJPEGMetadata is set to 1, this option
+   * cannot be set to 0. 0 = discard XMP metadata, 1 = keep XMP metadata
+   * (default).
+   */
+  JXL_ENC_FRAME_SETTING_JPEG_KEEP_XMP = 36,
+
+  /** Keep or discard JUMBF metadata boxes derived from a JPEG frame when using
+   * JxlEncoderAddJPEGFrame. This has no effect on boxes added using
+   * JxlEncoderAddBox. 0 = discard JUMBF metadata, 1 = keep JUMBF metadata
+   * (default).
+   */
+  JXL_ENC_FRAME_SETTING_JPEG_KEEP_JUMBF = 37,
+
   /** Enum value not to be used as an option. This value is added to force the
    * C compiler to have the enum to take a known size.
    */

--- a/lib/jxl/enc_params.h
+++ b/lib/jxl/enc_params.h
@@ -122,6 +122,11 @@ struct CompressParams {
   // Use brotli compression for any boxes derived from a JPEG frame.
   bool jpeg_compress_boxes = true;
 
+  // Preserve this metadata when doing JPEG recompression.
+  bool jpeg_keep_exif = true;
+  bool jpeg_keep_xmp = true;
+  bool jpeg_keep_jumbf = true;
+
   // Set the noise to what it would approximately be if shooting at the nominal
   // exposure for a given ISO setting on a 35mm camera.
   float photon_noise_iso = 0;

--- a/lib/jxl/encode_test.cc
+++ b/lib/jxl/encode_test.cc
@@ -842,6 +842,7 @@ TEST(EncodeTest, JXL_TRANSCODE_JPEG_TEST(JPEGReconstructionTest)) {
   EXPECT_EQ(JXL_ENC_SUCCESS, process_result);
 
   jxl::extras::JXLDecompressParams dparams;
+  jxl::test::DefaultAcceptedFormats(dparams);
   std::vector<uint8_t> decoded_jpeg_bytes;
   jxl::extras::PackedPixelFile ppf;
   EXPECT_TRUE(DecodeImageJXL(compressed.data(), compressed.size(), dparams,
@@ -883,6 +884,7 @@ TEST(EncodeTest, JXL_TRANSCODE_JPEG_TEST(ProgressiveJPEGReconstructionTest)) {
   EXPECT_EQ(JXL_ENC_SUCCESS, process_result);
 
   jxl::extras::JXLDecompressParams dparams;
+  jxl::test::DefaultAcceptedFormats(dparams);
   std::vector<uint8_t> decoded_jpeg_bytes;
   jxl::extras::PackedPixelFile ppf;
   EXPECT_TRUE(DecodeImageJXL(compressed.data(), compressed.size(), dparams,

--- a/lib/jxl/jxl_test.cc
+++ b/lib/jxl/jxl_test.cc
@@ -1262,6 +1262,7 @@ size_t RoundtripJpeg(const PaddedBytes& jpeg_in, ThreadPool* pool) {
                                      &compressed));
 
   jxl::JXLDecompressParams dparams;
+  test::DefaultAcceptedFormats(dparams);
   test::SetThreadParallelRunner(dparams, pool);
   std::vector<uint8_t> out;
   jxl::PackedPixelFile ppf;
@@ -1290,6 +1291,7 @@ void RoundtripJpegToPixels(const PaddedBytes& jpeg_in,
   EXPECT_TRUE(extras::EncodeImageJXL({}, extras::PackedPixelFile(), &jpeg_bytes,
                                      &compressed));
 
+  test::DefaultAcceptedFormats(dparams);
   test::SetThreadParallelRunner(dparams, pool);
   EXPECT_TRUE(DecodeImageJXL(compressed.data(), compressed.size(), dparams,
                              nullptr, ppf_out, nullptr));

--- a/lib/jxl/test_utils.cc
+++ b/lib/jxl/test_utils.cc
@@ -56,9 +56,19 @@ PaddedBytes ReadTestData(const std::string& filename) {
   return result;
 }
 
+void DefaultAcceptedFormats(extras::JXLDecompressParams& dparams) {
+  if (dparams.accepted_formats.empty()) {
+    for (const uint32_t num_channels : {1, 2, 3, 4}) {
+      dparams.accepted_formats.push_back(
+          {num_channels, JXL_TYPE_FLOAT, JXL_LITTLE_ENDIAN, /*align=*/0});
+    }
+  }
+}
+
 Status DecodeFile(extras::JXLDecompressParams dparams,
                   const Span<const uint8_t> file, CodecInOut* JXL_RESTRICT io,
                   ThreadPool* pool) {
+  DefaultAcceptedFormats(dparams);
   SetThreadParallelRunner(dparams, pool);
   extras::PackedPixelFile ppf;
   JXL_RETURN_IF_ERROR(DecodeImageJXL(file.data(), file.size(), dparams,
@@ -139,6 +149,7 @@ bool Roundtrip(const CodecInOut* io, const CompressParams& cparams,
                extras::JXLDecompressParams dparams,
                CodecInOut* JXL_RESTRICT io2, std::stringstream& failures,
                size_t* compressed_size, ThreadPool* pool, AuxOut* aux_out) {
+  DefaultAcceptedFormats(dparams);
   if (compressed_size) {
     *compressed_size = static_cast<size_t>(-1);
   }
@@ -203,6 +214,7 @@ size_t Roundtrip(const extras::PackedPixelFile& ppf_in,
                  extras::JXLCompressParams cparams,
                  extras::JXLDecompressParams dparams, ThreadPool* pool,
                  extras::PackedPixelFile* ppf_out) {
+  DefaultAcceptedFormats(dparams);
   SetThreadParallelRunner(cparams, pool);
   SetThreadParallelRunner(dparams, pool);
   std::vector<uint8_t> compressed;

--- a/lib/jxl/test_utils.h
+++ b/lib/jxl/test_utils.h
@@ -50,6 +50,8 @@ PaddedBytes ReadTestData(const std::string& filename);
 void JxlBasicInfoSetFromPixelFormat(JxlBasicInfo* basic_info,
                                     const JxlPixelFormat* pixel_format);
 
+void DefaultAcceptedFormats(extras::JXLDecompressParams& dparams);
+
 template <typename Params>
 void SetThreadParallelRunner(Params params, ThreadPool* pool) {
   if (pool && !params.runner_opaque) {

--- a/tools/args.h
+++ b/tools/args.h
@@ -82,6 +82,13 @@ struct ColorHintsProxy {
       JXL_RETURN_IF_ERROR(ReadFile(value, &icc));
       const char* data = reinterpret_cast<const char*>(icc.data());
       target.Add("icc", std::string(data, data + icc.size()));
+    } else if (key == "exif" || key == "xmp" || key == "jumbf") {
+      std::vector<uint8_t> metadata;
+      JXL_RETURN_IF_ERROR(ReadFile(value, &metadata));
+      const char* data = reinterpret_cast<const char*>(metadata.data());
+      target.Add(key, std::string(data, data + metadata.size()));
+    } else if (key == "strip") {
+      target.Add(value, "");
     } else {
       target.Add(key, value);
     }

--- a/tools/djxl_main.cc
+++ b/tools/djxl_main.cc
@@ -43,7 +43,7 @@ struct DecompressArgs {
   DecompressArgs() = default;
 
   void AddCommandLineOptions(CommandLineParser* cmdline) {
-    std::string output_help("The output can be ");
+    std::string output_help("The output format can be ");
     if (jxl::extras::GetAPNGEncoder()) {
       output_help.append("PNG, APNG, ");
     }
@@ -56,9 +56,11 @@ struct DecompressArgs {
       output_help.append("EXR, ");
     }
     output_help.append(
-        "PPM, PFM, or PAM. Use '-' for output to stdout.\n"
-        "    The output format is selected based on the extension or a prefix "
-        "(e.g. 'png:-')");
+        "PPM, PFM, or PAM.\n"
+        "    To extract metadata, use output format EXIF, XMP, or JUMBF.\n"
+        "    The format is selected based on extension ('filename.png') or "
+        "prefix ('png:filename').\n"
+        "    Use '-' for output to stdout (e.g. 'ppm:-')");
     cmdline->AddPositionalOption(
         "INPUT", /* required = */ true,
         "The compressed input file (JXL). Use '-' for input from stdin.",


### PR DESCRIPTION
This adds some functionality to improve metadata handling.

In djxl, 'metadata-only output formats' are added (`.exif`, `.xmp`, `.jumbf`) which can be used to extract the metadata embedded in a jxl file.

In cjxl, a new `--dec-hints` (`-x`) syntax is added so you can add a sidecar exif/xmp/jumbf file to the input file (e.g. `cjxl -x exif=input.exif`); this allows adding metadata to input formats like PPM, and it also allows overriding the metadata of the input file with something else. Specific metadata can also be stripped from the input file using the syntax `-x strip=exif`.

To make metadata stripping also work when losslessly recompressing JPEG images (assuming it is not needed to reconstruct the original JPEG file), some encode options were added to the API:
  - `JXL_ENC_FRAME_SETTING_JPEG_KEEP_EXIF`
  - `JXL_ENC_FRAME_SETTING_JPEG_KEEP_XMP`
  - `JXL_ENC_FRAME_SETTING_JPEG_KEEP_JUMBF`
 
(this was needed because current behavior is to always preserve this metadata when doing JxlEncoderAddJPEGFrame).


Known remaining limitations:
- only one metadata blob per type is supported in cjxl/djxl, while in principle the spec allows having _multiple_ Exif / XMP / JUMBF boxes. In particular for JUMBF it could be useful to also parse the content type of the JUMBF box and have ways to get/set more than one JUMBF box.
- brotli compression (and the brotli effort) is configured globally in cjxl, while it could make sense to have e.g. Exif uncompressed and XMP compressed.