### PR TITLE
reduces ringing near borders

### DIFF
--- a/lib/jxl/decode_test.cc
+++ b/lib/jxl/decode_test.cc
@@ -1928,9 +1928,9 @@ TEST(DecodeTest, PixelTestOpaqueSrgbLossy) {
         ButteraugliDistance(io0.frames, io1.frames, ba, jxl::GetJxlCms(),
                             /*distmap=*/nullptr, nullptr),
 #if JXL_HIGH_PRECISION
-        IsSlightlyBelow(0.74f));
+        IsSlightlyBelow(0.93f));
 #else
-        IsSlightlyBelow(0.75f));
+        IsSlightlyBelow(0.93f));
 #endif
 
     JxlDecoderDestroy(dec);

--- a/lib/jxl/enc_ac_strategy.h
+++ b/lib/jxl/enc_ac_strategy.h
@@ -37,12 +37,7 @@ struct ACSConfig {
   size_t masking_field_stride;
   const float* JXL_RESTRICT src_rows[3];
   size_t src_stride;
-  // Cost for 1 (-1), 2 (-2) explicitly, cost for others computed with cost1 +
-  // cost2 + sqrt(q) * cost_delta.
-  float cost1;
-  float cost2;
   float cost_delta;
-  float base_entropy;
   float zeros_mul;
   const float& Pixel(size_t c, size_t x, size_t y) const {
     return src_rows[c][y * src_stride + x];

--- a/lib/jxl/enc_adaptive_quantization.cc
+++ b/lib/jxl/enc_adaptive_quantization.cc
@@ -736,7 +736,7 @@ ImageF TileDistMap(const ImageF& distmap, int tile_size, int margin,
 
 static const float kDcQuantPow = 0.83;
 static const float kDcQuant = 1.095924047623553f;
-static const float kAcQuant = 0.7784;
+static const float kAcQuant = 0.774;
 
 // Computes the decoded image for a given set of compression parameters.
 ImageBundle RoundtripImage(const Image3F& opsin, PassesEncoderState* enc_state,

--- a/lib/jxl/encode_test.cc
+++ b/lib/jxl/encode_test.cc
@@ -523,7 +523,7 @@ TEST(EncodeTest, LossyEncoderUseOriginalProfileTest) {
     ASSERT_EQ(JXL_ENC_SUCCESS,
               JxlEncoderFrameSettingsSetOption(
                   frame_settings, JXL_ENC_FRAME_SETTING_EFFORT, 8));
-    VerifyFrameEncoding(63, 129, enc.get(), frame_settings, 7173, true);
+    VerifyFrameEncoding(63, 129, enc.get(), frame_settings, 7228, true);
   }
 }
 

--- a/lib/jxl/jxl_test.cc
+++ b/lib/jxl/jxl_test.cc
@@ -123,7 +123,7 @@ TEST(JxlTest, RoundtripSmallD1) {
   {
     PackedPixelFile ppf_out;
     EXPECT_NEAR(Roundtrip(t.ppf(), {}, {}, pool, &ppf_out), 766, 40);
-    EXPECT_THAT(ButteraugliDistance(t.ppf(), ppf_out), IsSlightlyBelow(1.2));
+    EXPECT_THAT(ButteraugliDistance(t.ppf(), ppf_out), IsSlightlyBelow(0.888));
   }
 
   // With a lower intensity target than the default, the bitrate should be
@@ -223,7 +223,7 @@ TEST(JxlTest, RoundtripOutOfOrderProcessingBorder) {
   cparams.AddOption(JXL_ENC_FRAME_SETTING_RESAMPLING, 2);
 
   PackedPixelFile ppf_out;
-  EXPECT_NEAR(Roundtrip(t.ppf(), cparams, {}, &pool, &ppf_out), 10907, 200);
+  EXPECT_NEAR(Roundtrip(t.ppf(), cparams, {}, &pool, &ppf_out), 10516, 200);
   EXPECT_LE(ButteraugliDistance(t.ppf(), ppf_out), 2.9);
 }
 
@@ -296,7 +296,7 @@ TEST(JxlTest, RoundtripMultiGroup) {
   };
 
   auto run_kitten = std::async(std::launch::async, test, SpeedTier::kKitten,
-                               1.0f, 56570u, 11.7);
+                               1.0f, 55602u, 11.7);
   auto run_wombat = std::async(std::launch::async, test, SpeedTier::kWombat,
                                2.0f, 35274u, 20.0);
 }
@@ -470,7 +470,7 @@ TEST(JxlTest, RoundtripNoGaborishNoAR) {
   cparams.AddOption(JXL_ENC_FRAME_SETTING_GABORISH, 0);
 
   PackedPixelFile ppf_out;
-  EXPECT_NEAR(Roundtrip(t.ppf(), cparams, {}, pool, &ppf_out), 38009, 200);
+  EXPECT_NEAR(Roundtrip(t.ppf(), cparams, {}, pool, &ppf_out), 38900, 200);
   EXPECT_THAT(ButteraugliDistance(t.ppf(), ppf_out), IsSlightlyBelow(1.8));
 }
 
@@ -515,7 +515,7 @@ TEST(JxlTest, RoundtripSmallPatchesAlpha) {
 
   PackedPixelFile ppf_out;
   EXPECT_NEAR(Roundtrip(t.ppf(), cparams, {}, pool, &ppf_out), 597, 100);
-  EXPECT_THAT(ButteraugliDistance(t.ppf(), ppf_out), IsSlightlyBelow(0.015f));
+  EXPECT_THAT(ButteraugliDistance(t.ppf(), ppf_out), IsSlightlyBelow(0.018f));
 }
 
 TEST(JxlTest, RoundtripSmallPatches) {
@@ -540,7 +540,7 @@ TEST(JxlTest, RoundtripSmallPatches) {
 
   PackedPixelFile ppf_out;
   EXPECT_NEAR(Roundtrip(t.ppf(), cparams, {}, pool, &ppf_out), 486, 100);
-  EXPECT_THAT(ButteraugliDistance(t.ppf(), ppf_out), IsSlightlyBelow(0.015f));
+  EXPECT_THAT(ButteraugliDistance(t.ppf(), ppf_out), IsSlightlyBelow(0.018f));
 }
 
 // TODO(szabadka) Add encoder and decoder API functions that accept frame
@@ -846,7 +846,7 @@ TEST(JxlTest, RoundtripAlphaPremultiplied) {
           EXPECT_THAT(ButteraugliDistance(io.frames, io2.frames,
                                           ButteraugliParams(), GetJxlCms(),
                                           /*distmap=*/nullptr),
-                      IsSlightlyBelow(1.2));
+                      IsSlightlyBelow(1.111));
           EXPECT_TRUE(UnpremultiplyAlpha(io2));
           EXPECT_FALSE(io2.Main().AlphaIsPremultiplied());
         }
@@ -874,7 +874,7 @@ TEST(JxlTest, RoundtripAlphaResampling) {
   cparams.AddOption(JXL_ENC_FRAME_SETTING_EXTRA_CHANNEL_RESAMPLING, 2);
 
   PackedPixelFile ppf_out;
-  EXPECT_NEAR(Roundtrip(t.ppf(), cparams, {}, pool, &ppf_out), 12745, 130);
+  EXPECT_NEAR(Roundtrip(t.ppf(), cparams, {}, pool, &ppf_out), 13155, 130);
   EXPECT_THAT(ButteraugliDistance(t.ppf(), ppf_out), IsSlightlyBelow(5.2));
 }
 
@@ -1149,7 +1149,7 @@ TEST(JxlTest, RoundtripNoise) {
   cparams.AddOption(JXL_ENC_FRAME_SETTING_NOISE, 1);
 
   PackedPixelFile ppf_out;
-  EXPECT_NEAR(Roundtrip(t.ppf(), cparams, {}, pool, &ppf_out), 38244, 750);
+  EXPECT_NEAR(Roundtrip(t.ppf(), cparams, {}, pool, &ppf_out), 39261, 750);
   EXPECT_THAT(ButteraugliDistance(t.ppf(), ppf_out), IsSlightlyBelow(1.3));
 }
 
@@ -1490,7 +1490,7 @@ TEST(JxlTest, RoundtripProgressiveLevel2Slow) {
   cparams.AddOption(JXL_ENC_FRAME_SETTING_RESPONSIVE, 1);
 
   PackedPixelFile ppf_out;
-  EXPECT_NEAR(Roundtrip(t.ppf(), cparams, {}, &pool, &ppf_out), 74621, 1000);
+  EXPECT_NEAR(Roundtrip(t.ppf(), cparams, {}, &pool, &ppf_out), 72059, 1000);
   EXPECT_THAT(ButteraugliDistance(t.ppf(), ppf_out), IsSlightlyBelow(1.17));
 }
 

--- a/lib/jxl/render_pipeline/render_pipeline_test.cc
+++ b/lib/jxl/render_pipeline/render_pipeline_test.cc
@@ -232,7 +232,7 @@ TEST_P(RenderPipelineTestParam, PipelineTest) {
 #if JXL_HIGH_PRECISION
     constexpr float kMaxError = 1e-5;
 #else
-    constexpr float kMaxError = 1e-4;
+    constexpr float kMaxError = 5e-4;
 #endif
     Image3F def = std::move(*io_default.frames[i].color());
     Image3F pip = std::move(*io_slow_pipeline.frames[i].color());

--- a/tools/optimizer/simplex_fork.py
+++ b/tools/optimizer/simplex_fork.py
@@ -123,7 +123,7 @@ def Eval(vec, binary_name, cached=True):
     sys.stdout.flush()
     if line[0:3] == b'jxl':
       bpp = line.split()[3]
-      dist_pnorm = line.split()[7]
+      dist_pnorm = line.split()[9]
       dist_max = line.split()[6]
       vec[0] *= float(dist_pnorm) * float(bpp) / 16.0
       #vec[0] *= (float(dist_max) * float(bpp) / 16.0) ** 0.01


### PR DESCRIPTION
this PR reduces ringing at distance 3 and below

at high distances it is less clear if this is an improvement, more likely not

this simplifies the logic in entropy/information loss calculation and might make future improvements easier

all metrics show a degradation -- careful viewing shows an improvement however

```
Before:

Encoding      kPixels    Bytes          BPP  E MP/s  D MP/s     Max norm  SSIMULACRA2   PSNR        pnorm       BPP*pnorm   QABPP   Bugs
----------------------------------------------------------------------------------------------------------------------------------------
jxl:d0.1        19988 16248290    6.5031864   1.207  10.666   0.36367235  95.40348953  55.31   0.12028512  0.782236544141   6.503      0
jxl:d0.5        19988  6352958    2.5426965   1.594  14.169   0.79687579  91.35179185  46.51   0.34868202  0.886592546922   2.605      0
jxl:d0.8        19988  4707656    1.8841838   1.595  15.437   1.10919731  88.57292056  43.96   0.48342015  0.910852406120   2.194      0
jxl:d1          19988  4078500    1.6323715   1.722  15.545   1.30898709  86.90706394  42.78   0.56445029  0.921392573816   2.221      0
jxl:d1.1        19988  3845641    1.5391724   1.713  17.135   1.41488396  86.11047555  42.29   0.60373050  0.929245340838   2.270      0
jxl:d1.2        19988  3631977    1.4536559   1.674  16.685   1.51117344  85.35813865  41.84   0.64090110  0.931649690291   2.278      0
jxl:d1.3        19988  3459534    1.3846377   1.689  17.017   1.59434154  84.63468801  41.49   0.67596061  0.935960521270   2.312      0
jxl:d1.4        19988  3294711    1.3186692   1.761  16.587   1.67239921  83.87441738  41.11   0.71270738  0.939825279772   2.303      0
jxl:d1.5        19988  3138556    1.2561700   1.701  16.253   1.76853932  83.11326497  40.78   0.74656270  0.937809677352   2.327      0
jxl:d1.6        19988  3004237    1.2024104   1.613  16.956   1.84912348  82.37974117  40.46   0.78174179  0.939974469782   2.334      0
jxl:d1.7        19988  2882460    1.1536706   1.748  16.297   1.95514891  81.66370992  40.17   0.81651697  0.941991633329   2.354      0
jxl:d1.8        19988  2773116    1.1099070   1.694  17.190   2.00495856  80.99931267  39.88   0.84778884  0.940966740536   2.340      0
jxl:d1.9        19988  2671335    1.0691703   1.735  15.817   2.12723872  80.27963340  39.62   0.88395400  0.945097373071   2.375      0
jxl:d2.0        19988  2574588    1.0304485   1.746  17.996   2.22323638  79.59105702  39.37   0.91856374  0.946532606538   2.393      0
jxl:d2.1        19988  2486959    0.9953760   1.741  17.175   2.34122361  78.90420373  39.13   0.95006767  0.945674552420   2.437      0
jxl:d2.2        19988  2405370    0.9627210   1.827  17.542   2.41381282  78.23821492  38.90   0.98168178  0.945085630061   2.429      0
jxl:d2.3        19988  2331303    0.9330765   1.786  17.429   2.49056859  77.53981770  38.69   1.01331063  0.945496359160   2.429      0
jxl:d2.4        19988  2257459    0.9035213   1.746  17.166   2.53670376  76.86602531  38.48   1.04364831  0.942958508656   2.405      0
jxl:d2.5        19988  2194456    0.8783051   1.750  16.457   2.62107556  76.26099884  38.29   1.07467957  0.943896568431   2.416      0
jxl:d2.6        19988  2131495    0.8531057   1.835  17.471   2.73241900  75.63391919  38.09   1.10744484  0.944767532160   2.456      0
jxl:d2.7        19988  2072521    0.8295021   1.804  15.138   2.74464111  75.00803091  37.91   1.13588846  0.942221841020   2.384      0
jxl:d2.8        19988  2018583    0.8079140   1.780  16.879   2.81098999  74.40579484  37.73   1.16626193  0.942239372083   2.384      0
jxl:d2.9        19988  1969701    0.7883496   1.793  16.835   2.90759246  73.79936405  37.57   1.19733338  0.943917277608   2.412      0
jxl:d3          19988  1922735    0.7695520   1.687  15.564   2.97272859  73.17126098  37.44   1.22586709  0.943368469938   2.401      0
jxl:d5          19988  1313990    0.5259090   1.659   9.398   4.49523143  61.88030612  35.21   1.75770288  0.924391752650   2.481      0
jxl:d7          19988  1017516    0.4072488   1.652   9.522   5.68191825  52.51951153  33.80   2.21213918  0.900890967950   2.397      0
jxl:d15         19988   572839    0.2292721   1.736   8.671  10.01007107  23.69896998  30.93   3.76417030  0.863019046324   2.339      0
Aggregate:      19988  2658633    1.0640867   1.699  15.236   2.11838439  75.45833393  39.70   0.87013363  0.925897598942   2.461      0

After:

Encoding      kPixels    Bytes          BPP  E MP/s  D MP/s     Max norm  SSIMULACRA2   PSNR        pnorm       BPP*pnorm   QABPP   Bugs
----------------------------------------------------------------------------------------------------------------------------------------
jxl:d0.1        19988 16693665    6.6814425   1.135  10.277   0.35456480  95.44155680  55.47   0.11593286  0.774598729101   6.681      0
jxl:d0.5        19988  6429657    2.5733944   1.589  16.265   0.78151145  91.36043638  46.57   0.34635956  0.891319724555   2.626      0
jxl:d0.8        19988  4743361    1.8984743   1.603  15.330   1.11258089  88.59181145  44.01   0.48485962  0.920493515133   2.221      0
jxl:d1          19988  4105683    1.6432512   1.697  15.257   1.30049006  86.88464920  42.82   0.56566775  0.929534192516   2.220      0
jxl:d1.1        19988  3866462    1.5475058   1.725  16.534   1.41677074  86.08552499  42.33   0.60397301  0.934651732378   2.273      0
jxl:d1.2        19988  3650397    1.4610283   1.736  17.146   1.50091628  85.26902145  41.87   0.64266973  0.938958683637   2.286      0
jxl:d1.3        19988  3478653    1.3922898   1.686  15.161   1.59054497  84.58146002  41.52   0.67836480  0.944480410562   2.317      0
jxl:d1.4        19988  3307782    1.3239007   1.760  17.797   1.69266701  83.79923293  41.14   0.71480551  0.946331524080   2.327      0
jxl:d1.5        19988  3150945    1.2611286   1.798  16.059   1.76684521  83.06017331  40.80   0.74949748  0.945212673282   2.320      0
jxl:d1.6        19988  3017795    1.2078368   1.589  14.782   1.86603035  82.31697268  40.47   0.78410708  0.947073415181   2.354      0
jxl:d1.7        19988  2892633    1.1577422   1.807  14.069   1.95966623  81.59095020  40.17   0.81885983  0.948028605322   2.362      0
jxl:d1.8        19988  2777685    1.1117356   1.723  17.236   2.04710340  80.92193492  39.89   0.85174237  0.946912360532   2.381      0
jxl:d1.9        19988  2671822    1.0693652   1.799  15.305   2.15944082  80.16986694  39.61   0.88671321  0.948220277982   2.400      0
jxl:d2.0        19988  2574226    1.0303036   1.735  16.195   2.24435480  79.45978313  39.34   0.92208365  0.950026090895   2.421      0
jxl:d2.1        19988  2484608    0.9944350   1.752  15.852   2.34070990  78.71849054  39.10   0.95461898  0.949306564043   2.430      0
jxl:d2.2        19988  2401921    0.9613405   1.826  17.161   2.43922784  78.07159625  38.87   0.98953786  0.951282858284   2.456      0
jxl:d2.3        19988  2325286    0.9306683   1.804  17.485   2.51825723  77.40529505  38.66   1.01942111  0.948742899007   2.451      0
jxl:d2.4        19988  2253939    0.9021125   1.742  16.700   2.55026675  76.74190256  38.46   1.05046656  0.947639008178   2.412      0
jxl:d2.5        19988  2185141    0.8745769   1.718  15.652   2.67876114  76.08511041  38.26   1.08272336  0.946924848661   2.466      0
jxl:d2.6        19988  2127879    0.8516585   1.801  16.621   2.76707317  75.42451416  38.07   1.11468130  0.949327765130   2.483      0
jxl:d2.7        19988  2069028    0.8281040   1.704  16.757   2.86921275  74.81162646  37.88   1.14514681  0.948300707366   2.507      0
jxl:d2.8        19988  2011874    0.8052288   1.799  17.973   2.92775913  74.23741731  37.70   1.17593567  0.946897306136   2.490      0
jxl:d2.9        19988  1961112    0.7849119   1.685  17.490   3.02160920  73.57472435  37.54   1.20654448  0.947031171695   2.512      0
jxl:d3          19988  1913814    0.7659815   1.698  16.224   3.04174953  72.96737170  37.39   1.23358604  0.944904054756   2.465      0
jxl:d5          19988  1298834    0.5198430   1.752  10.282   4.52413129  61.65147360  35.15   1.77030405  0.920280142026   2.462      0
jxl:d7          19988  1005172    0.4023082   1.691   9.439   5.77718198  52.30848822  33.73   2.22140005  0.893687530217   2.396      0
jxl:d15         19988   561952    0.2249147   1.603   8.386  10.18460959  22.89953808  30.84   3.80496397  0.855792169507   2.328      0
Aggregate:      19988  2660339    1.0647693   1.696  15.043   2.13883941  75.25076520  39.69   0.87285478  0.929388936929   2.490      0
```