### PR TITLE
fix overflow in corrupt exif offset

### DIFF
--- a/lib/extras/exif.cc
+++ b/lib/extras/exif.cc
@@ -23,7 +23,7 @@ void ResetExifOrientation(std::vector<uint8_t>& exif) {
     return;  // not a valid tiff header
   }
   t += 4;
-  uint32_t offset = (bigendian ? LoadBE32(t) : LoadLE32(t));
+  uint64_t offset = (bigendian ? LoadBE32(t) : LoadLE32(t));
   if (exif.size() < 12 + offset + 2 || offset < 8) return;
   t += offset - 4;
   uint16_t nb_tags = (bigendian ? LoadBE16(t) : LoadLE16(t));


### PR DESCRIPTION
I think this fixes the djxl fuzzerbug in https://github.com/libjxl/libjxl/issues/2661 (though the asan trace suggests the issue is elsewhere). In any case this fixes _something_ in that example.

Since `offset` was uint32_t, the test `exif.size() < 12 + offset + 2` was not quite robust: in that fuzzer example, `offset` has the value 4294967287, so the right hand side evaluates to something that overflows (so the result is not 4294967301 but that number mod 2^32, which is 5). Doing the arithmetic in uint64_t avoids that problem.

We didn't catch this overflow before because this code is not called by libjxl (or djxl_fuzzer) but only by the `extras` encoders used by djxl.