### PR TITLE
small heuristics tuning for adaptive quant

### DIFF
--- a/lib/jxl/decode_test.cc
+++ b/lib/jxl/decode_test.cc
@@ -1666,9 +1666,9 @@ TEST(DecodeTest, PixelTestWithICCProfileLossy) {
   EXPECT_THAT(ButteraugliDistance(io0.frames, io1.frames, ba, jxl::GetJxlCms(),
                                   /*distmap=*/nullptr, nullptr),
 #if JXL_HIGH_PRECISION
-              IsSlightlyBelow(0.70f));
+              IsSlightlyBelow(0.9f));
 #else
-              IsSlightlyBelow(0.78f));
+              IsSlightlyBelow(0.98f));
 #endif
 
   JxlDecoderDestroy(dec);

--- a/lib/jxl/enc_adaptive_quantization.cc
+++ b/lib/jxl/enc_adaptive_quantization.cc
@@ -736,7 +736,7 @@ ImageF TileDistMap(const ImageF& distmap, int tile_size, int margin,
 
 static const float kDcQuantPow = 0.83;
 static const float kDcQuant = 1.095924047623553f;
-static const float kAcQuant = 0.774;
+static const float kAcQuant = 0.7635;
 
 // Computes the decoded image for a given set of compression parameters.
 ImageBundle RoundtripImage(const Image3F& opsin, PassesEncoderState* enc_state,

--- a/lib/jxl/enc_group.cc
+++ b/lib/jxl/enc_group.cc
@@ -209,39 +209,39 @@ void AdjustQuantBlockAC(const Quantizer& quantizer, size_t c,
   {
     static const double kMul1[3][3] = {
         {
-            0.30628347689416235,
-            0.19096514988140451,
-            0.10092267072278764,
+            0.13289977307244785,
+            0.13991489841351781,
+            0.083900681804010419,
         },
         {
-            0.68175730483344243,
-            0.19038660767376803,
-            0.14069887255219371,
+            0.69938583107168562,
+            0.19612117586770869,
+            0.15307492924107463,
         },
         {
-            0.74599469660659012,
-            0.10465705596003883,
-            0.075491104183520744,
+            0.099160801461836312,
+            0.16684944507307059,
+            0.16608517854968413,
         },
     };
     static const double kMul2[3][3] = {
         {
-            0.022707896753424779,
-            0.84465309720205983,
-            5.2275313293658812,
+            0.24773711435293466,
+            0.65189637683223112,
+            1.0,
         },
         {
-            0.17545973555482378,
-            0.97395015736868384,
-            1.9659234163151995,
+            0.46465181913392556,
+            0.3142440606068525,
+            0.30128806880068809,
         },
         {
-            0.75243833661051895,
-            1.7774383804879366,
-            0.3793181712352986,
+            0.45203398366713637,
+            0.15063329382779103,
+            0.067846407329923752,
         },
     };
-    const float kQuantNormalizer = 2.9037220690527175;
+    const float kQuantNormalizer = 2.8261379721245263;
     sum_of_error *= kQuantNormalizer;
     sum_of_vals *= kQuantNormalizer;
     if (quant_kind >= AcStrategy::Type::DCT16X16) {
@@ -252,9 +252,15 @@ void AdjustQuantBlockAC(const Quantizer& quantizer, size_t c,
       } else if (quant_kind == AcStrategy::Type::DCT16X16) {
         ix = 0;
       }
-      if (sum_of_error > kMul1[ix][c] * xsize * ysize * kBlockDim * kBlockDim &&
-          sum_of_error > kMul2[ix][c] * sum_of_vals) {
-        *quant += 1;
+      int step =
+          sum_of_error / (kMul1[ix][c] * xsize * ysize * kBlockDim * kBlockDim +
+                          kMul2[ix][c] * sum_of_vals);
+      if (step >= 2) {
+        step = 2;
+      }
+      if (sum_of_error > kMul1[ix][c] * xsize * ysize * kBlockDim * kBlockDim +
+                             kMul2[ix][c] * sum_of_vals) {
+        *quant += step;
         if (*quant >= Quantizer::kQuantMax) {
           *quant = Quantizer::kQuantMax - 1;
         }

--- a/lib/jxl/jxl_test.cc
+++ b/lib/jxl/jxl_test.cc
@@ -122,7 +122,7 @@ TEST(JxlTest, RoundtripSmallD1) {
 
   {
     PackedPixelFile ppf_out;
-    EXPECT_NEAR(Roundtrip(t.ppf(), {}, {}, pool, &ppf_out), 766, 40);
+    EXPECT_NEAR(Roundtrip(t.ppf(), {}, {}, pool, &ppf_out), 816, 40);
     EXPECT_THAT(ButteraugliDistance(t.ppf(), ppf_out), IsSlightlyBelow(0.888));
   }
 
@@ -203,7 +203,7 @@ TEST(JxlTest, RoundtripOutOfOrderProcessing) {
   cparams.AddOption(JXL_ENC_FRAME_SETTING_EPF, 3);
 
   PackedPixelFile ppf_out;
-  EXPECT_NEAR(Roundtrip(t.ppf(), cparams, {}, &pool, &ppf_out), 23553, 400);
+  EXPECT_NEAR(Roundtrip(t.ppf(), cparams, {}, &pool, &ppf_out), 22999, 400);
   EXPECT_LE(ButteraugliDistance(t.ppf(), ppf_out), 1.35);
 }
 
@@ -223,7 +223,7 @@ TEST(JxlTest, RoundtripOutOfOrderProcessingBorder) {
   cparams.AddOption(JXL_ENC_FRAME_SETTING_RESAMPLING, 2);
 
   PackedPixelFile ppf_out;
-  EXPECT_NEAR(Roundtrip(t.ppf(), cparams, {}, &pool, &ppf_out), 10516, 200);
+  EXPECT_NEAR(Roundtrip(t.ppf(), cparams, {}, &pool, &ppf_out), 11015, 200);
   EXPECT_LE(ButteraugliDistance(t.ppf(), ppf_out), 2.9);
 }
 
@@ -298,7 +298,7 @@ TEST(JxlTest, RoundtripMultiGroup) {
   auto run_kitten = std::async(std::launch::async, test, SpeedTier::kKitten,
                                1.0f, 55602u, 11.7);
   auto run_wombat = std::async(std::launch::async, test, SpeedTier::kWombat,
-                               2.0f, 35274u, 20.0);
+                               2.0f, 33624u, 20.0);
 }
 
 TEST(JxlTest, RoundtripRGBToGrayscale) {
@@ -357,7 +357,7 @@ TEST(JxlTest, RoundtripLargeFast) {
   cparams.AddOption(JXL_ENC_FRAME_SETTING_EFFORT, 7);  // kSquirrel
 
   PackedPixelFile ppf_out;
-  EXPECT_NEAR(Roundtrip(t.ppf(), cparams, {}, &pool, &ppf_out), 453713, 5000);
+  EXPECT_NEAR(Roundtrip(t.ppf(), cparams, {}, &pool, &ppf_out), 445555, 5000);
   EXPECT_THAT(ComputeDistance2(t.ppf(), ppf_out), IsSlightlyBelow(100));
 }
 
@@ -374,7 +374,7 @@ TEST(JxlTest, RoundtripDotsForceEpf) {
   cparams.AddOption(JXL_ENC_FRAME_SETTING_DOTS, 1);
 
   PackedPixelFile ppf_out;
-  EXPECT_NEAR(Roundtrip(t.ppf(), cparams, {}, &pool, &ppf_out), 41087, 300);
+  EXPECT_NEAR(Roundtrip(t.ppf(), cparams, {}, &pool, &ppf_out), 41777, 300);
   EXPECT_THAT(ComputeDistance2(t.ppf(), ppf_out), IsSlightlyBelow(18));
 }
 
@@ -454,7 +454,7 @@ TEST(JxlTest, RoundtripSmallNL) {
   t.SetDimensions(xsize, ysize);
 
   PackedPixelFile ppf_out;
-  EXPECT_NEAR(Roundtrip(t.ppf(), {}, {}, pool, &ppf_out), 753, 45);
+  EXPECT_NEAR(Roundtrip(t.ppf(), {}, {}, pool, &ppf_out), 801, 45);
   EXPECT_THAT(ButteraugliDistance(t.ppf(), ppf_out), IsSlightlyBelow(1.1));
 }
 
@@ -853,7 +853,7 @@ TEST(JxlTest, RoundtripAlphaPremultiplied) {
         EXPECT_THAT(ButteraugliDistance(io_nopremul.frames, io2.frames,
                                         ButteraugliParams(), GetJxlCms(),
                                         /*distmap=*/nullptr),
-                    IsSlightlyBelow(1.47));
+                    IsSlightlyBelow(1.55));
       }
     }
   }
@@ -1129,7 +1129,7 @@ TEST(JxlTest, RoundtripDots) {
   cparams.distance = 0.04;
 
   PackedPixelFile ppf_out;
-  EXPECT_NEAR(Roundtrip(t.ppf(), cparams, {}, pool, &ppf_out), 277976, 4000);
+  EXPECT_NEAR(Roundtrip(t.ppf(), cparams, {}, pool, &ppf_out), 273333, 4000);
   EXPECT_THAT(ButteraugliDistance(t.ppf(), ppf_out), IsSlightlyBelow(0.35));
 }
 
@@ -1150,7 +1150,7 @@ TEST(JxlTest, RoundtripNoise) {
 
   PackedPixelFile ppf_out;
   EXPECT_NEAR(Roundtrip(t.ppf(), cparams, {}, pool, &ppf_out), 39261, 750);
-  EXPECT_THAT(ButteraugliDistance(t.ppf(), ppf_out), IsSlightlyBelow(1.3));
+  EXPECT_THAT(ButteraugliDistance(t.ppf(), ppf_out), IsSlightlyBelow(1.35));
 }
 
 TEST(JxlTest, RoundtripLossless8Gray) {
@@ -1473,7 +1473,7 @@ TEST(JxlTest, RoundtripProgressive) {
   cparams.AddOption(JXL_ENC_FRAME_SETTING_RESPONSIVE, 1);
 
   PackedPixelFile ppf_out;
-  EXPECT_NEAR(Roundtrip(t.ppf(), cparams, {}, &pool, &ppf_out), 63570, 750);
+  EXPECT_NEAR(Roundtrip(t.ppf(), cparams, {}, &pool, &ppf_out), 62160, 750);
   EXPECT_THAT(ButteraugliDistance(t.ppf(), ppf_out), IsSlightlyBelow(1.4));
 }
 
@@ -1490,7 +1490,7 @@ TEST(JxlTest, RoundtripProgressiveLevel2Slow) {
   cparams.AddOption(JXL_ENC_FRAME_SETTING_RESPONSIVE, 1);
 
   PackedPixelFile ppf_out;
-  EXPECT_NEAR(Roundtrip(t.ppf(), cparams, {}, &pool, &ppf_out), 72059, 1000);
+  EXPECT_NEAR(Roundtrip(t.ppf(), cparams, {}, &pool, &ppf_out), 71111, 1000);
   EXPECT_THAT(ButteraugliDistance(t.ppf(), ppf_out), IsSlightlyBelow(1.17));
 }
 


### PR DESCRIPTION
make large (16x16 and above) blocks with high error but not a lot of signal get higher adaptive quant

```
Before:

Encoding      kPixels    Bytes          BPP  E MP/s  D MP/s     Max norm  SSIMULACRA2   PSNR        pnorm       BPP*pnorm   QABPP   Bugs
----------------------------------------------------------------------------------------------------------------------------------------
jxl:d0.1        19988 16856164    6.7464808   1.149   8.660   0.35450427  95.45846516  55.53   0.11510705  0.776567470265   6.746      0
jxl:d0.5        19988  6518150    2.6088126   1.638  15.463   0.78029452  91.40099532  46.62   0.34410685  0.897710301801   2.661      0
jxl:d0.8        19988  4794309    1.9188656   1.703  15.062   1.11216959  88.61554644  44.05   0.48290552  0.926630798371   2.241      0
jxl:d1          19988  4145276    1.6590978   1.709  15.453   1.29413140  86.91656063  42.86   0.56380751  0.935411810793   2.230      0
jxl:d1.1        19988  3901539    1.5615450   1.790  16.778   1.41344101  86.11986409  42.36   0.60219554  0.940355403128   2.291      0
jxl:d1.2        19988  3682756    1.4739796   1.809  17.366   1.49755032  85.31887851  41.90   0.64089713  0.944669324882   2.302      0
jxl:d1.3        19988  3508866    1.4043822   1.706  17.891   1.57883604  84.62678639  41.55   0.67656565  0.950156762552   2.314      0
jxl:d1.4        19988  3336145    1.3352527   1.711  17.613   1.69128911  83.84194535  41.17   0.71333945  0.952488410053   2.347      0
jxl:d1.5        19988  3179160    1.2724213   1.762  16.430   1.77711609  83.10351850  40.84   0.74796786  0.951730225714   2.359      0
jxl:d1.6        19988  3041845    1.2174626   1.720  17.335   1.86588021  82.38323758  40.51   0.78268371  0.952888118034   2.373      0
jxl:d1.7        19988  2916169    1.1671622   1.772  16.871   1.95498776  81.61357504  40.20   0.81752615  0.954185650713   2.375      0
jxl:d1.8        19988  2799878    1.1206181   1.650  16.767   2.04212529  80.93174118  39.92   0.85059758  0.953195077039   2.396      0
jxl:d1.9        19988  2692739    1.0777370   1.737  16.985   2.14851030  80.22186360  39.63   0.88526346  0.954081203902   2.409      0
jxl:d2.0        19988  2592942    1.0377944   1.835  17.022   2.23279275  79.49539583  39.37   0.92073790  0.955536673874   2.424      0
jxl:d2.1        19988  2503855    1.0021384   1.716  15.217   2.33285370  78.79949286  39.13   0.95312450  0.955162687470   2.447      0
jxl:d2.2        19988  2420131    0.9686289   1.793  16.181   2.43593205  78.14247294  38.90   0.98814165  0.957142534831   2.468      0
jxl:d2.3        19988  2342013    0.9373631   1.803  14.673   2.51318905  77.45633785  38.69   1.01826457  0.954483608876   2.465      0
jxl:d2.4        19988  2270996    0.9089394   1.718  16.342   2.55398531  76.79891321  38.49   1.04991586  0.954309848281   2.435      0
jxl:d2.5        19988  2202371    0.8814730   1.644  15.825   2.67489507  76.14951553  38.29   1.08155085  0.953357878435   2.482      0
jxl:d2.6        19988  2142699    0.8575900   1.636  13.012   2.76568397  75.49964280  38.09   1.11391630  0.955283476947   2.498      0
jxl:d2.7        19988  2084986    0.8344910   1.742  16.621   2.86750314  74.88579104  37.91   1.14423196  0.954851323319   2.528      0
jxl:d2.8        19988  2026175    0.8109526   1.733  16.708   2.92594080  74.29197719  37.73   1.17555138  0.953316494387   2.506      0
jxl:d2.9        19988  1974316    0.7901967   1.811  16.334   3.02129452  73.61043980  37.56   1.20573020  0.952764005982   2.523      0
jxl:d3          19988  1926804    0.7711806   1.585  15.682   3.04209658  73.06138726  37.42   1.23212810  0.950193246719   2.482      0
jxl:d5          19988  1305239    0.5224065   1.766   9.749   4.52704525  61.67583240  35.17   1.77044988  0.924894544288   2.471      0
jxl:d7          19988  1009201    0.4039208   1.657   9.937   5.71969113  52.32657799  33.74   2.21925398  0.896402826561   2.384      0
jxl:d15         19988   562527    0.2251448   1.604   8.655  10.19399162  22.88296398  30.84   3.80825976  0.857409863308   2.331      0
Aggregate:      19988  2681070    1.0730668   1.694  14.910   2.13519760  75.29202703  39.73   0.87121515  0.934872074538   2.505      0

After:

Encoding      kPixels    Bytes          BPP  E MP/s  D MP/s     Max norm  SSIMULACRA2   PSNR        pnorm       BPP*pnorm   QABPP   Bugs
----------------------------------------------------------------------------------------------------------------------------------------
jxl:d0.1        19988 16784603    6.7178393   1.196   9.987   0.35344780  95.45324324  55.50   0.11530948  0.774630533555   6.718      0
jxl:d0.5        19988  6564798    2.6274829   1.456  15.801   0.76515284  91.48522002  46.67   0.33909698  0.890971520619   2.681      0
jxl:d0.8        19988  4816983    1.9279406   1.601  15.255   1.07876817  88.73800428  44.08   0.47856808  0.922650844172   2.176      0
jxl:d1          19988  4160357    1.6651338   1.541  17.014   1.28954376  87.02324297  42.87   0.56010405  0.932648188022   2.227      0
jxl:d1.1        19988  3914695    1.5668105   1.553  17.417   1.38863664  86.17735062  42.38   0.59957476  0.939420016245   2.243      0
jxl:d1.2        19988  3695255    1.4789822   1.613  14.943   1.47642226  85.36374829  41.92   0.63747480  0.942813893499   2.272      0
jxl:d1.3        19988  3518731    1.4083306   1.634  15.557   1.53628343  84.72616204  41.57   0.67229551  0.946814321919   2.251      0
jxl:d1.4        19988  3347270    1.3397053   1.645  15.156   1.63701807  83.94189946  41.19   0.70888385  0.949695467942   2.289      0
jxl:d1.5        19988  3187752    1.2758601   1.636  15.607   1.77071639  83.19201182  40.85   0.74537564  0.950995055446   2.378      0
jxl:d1.6        19988  3048788    1.2202414   1.502  14.019   1.83550813  82.47573878  40.51   0.78104422  0.953062519399   2.339      0
jxl:d1.7        19988  2921948    1.1694752   1.688  16.658   1.92264107  81.73695394  40.21   0.81490679  0.953013287231   2.358      0
jxl:d1.8        19988  2804560    1.1224921   1.554  15.637   2.02563746  81.00494310  39.91   0.84983933  0.953937891222   2.385      0
jxl:d1.9        19988  2696535    1.0792563   1.537  13.847   2.13772487  80.24769535  39.62   0.88647454  0.956733249822   2.412      0
jxl:d2.0        19988  2596371    1.0391669   1.652  15.615   2.20290422  79.55527157  39.37   0.91917514  0.955176345767   2.399      0
jxl:d2.1        19988  2506145    1.0030550   1.638  16.675   2.26809558  78.85198308  39.12   0.95197865  0.954886914752   2.383      0
jxl:d2.2        19988  2422389    0.9695326   1.671  14.967   2.37877265  78.18243352  38.90   0.98568565  0.955654383498   2.412      0
jxl:d2.3        19988  2345953    0.9389400   1.681  16.765   2.46838019  77.50793619  38.69   1.01631011  0.954254220433   2.438      0
jxl:d2.4        19988  2270281    0.9086532   1.633  15.003   2.57858429  76.82840874  38.48   1.04982257  0.953924623134   2.474      0
jxl:d2.5        19988  2203939    0.8821006   1.581  15.450   2.64270452  76.14526713  38.27   1.08086508  0.953431717179   2.456      0
jxl:d2.6        19988  2141991    0.8573066   1.607  15.085   2.75839054  75.45030932  38.08   1.11430010  0.955296857926   2.498      0
jxl:d2.7        19988  2082799    0.8336157   1.835  16.487   2.82997046  74.85439161  37.89   1.14432014  0.953923263294   2.490      0
jxl:d2.8        19988  2027798    0.8116022   1.767  17.336   2.92739657  74.18981395  37.71   1.17625210  0.954648823361   2.499      0
jxl:d2.9        19988  1972466    0.7894562   1.809  15.247   2.99048090  73.57066277  37.55   1.20492815  0.951238050750   2.485      0
jxl:d3          19988  1924563    0.7702836   1.608  14.653   3.04169920  72.97862310  37.41   1.23402542  0.950549584433   2.469      0
jxl:d5          19988  1299793    0.5202268   1.644   9.605   4.53565544  61.44188416  35.14   1.77481068  0.923304105266   2.465      0
jxl:d7          19988  1003246    0.4015374   1.595   9.038   5.73887022  51.96098885  33.71   2.23185416  0.896172862019   2.383      0
jxl:d15         19988   552553    0.2211528   1.596   9.053  10.21322735  21.77281081  30.75   3.86999565  0.855860447688   2.290      0
Aggregate:      19988  2681938    1.0734139   1.606  14.500   2.11138788  75.15332194  39.72   0.86989067  0.933752758559   2.481      0
```