### PR TITLE
improve API documentation structure

### DIFF
--- a/doc/api.txt
+++ b/doc/api.txt
@@ -14,13 +14,17 @@
 @addtogroup libjxl
 @{
 
-@defgroup libjxl_decoder JPEG XL Decoder
+@defgroup libjxl_decoder JPEG XL Decoder API
 
-@defgroup libjxl_encoder JPEG XL Encoder
+@defgroup libjxl_encoder JPEG XL Encoder API
 
-@defgroup libjxl_common JPEG XL common definitions
+@defgroup libjxl_common Common API concepts
 
-@defgroup libjxl_butteraugli Butteraugli metric
+@defgroup libjxl_metadata Image and frame metadata
+
+@defgroup libjxl_color Color encoding and conversion
+
+@defgroup libjxl_cpp C++ helpers
 
 @}
 

--- a/doc/sphinx/api.rst
+++ b/doc/sphinx/api.rst
@@ -1,5 +1,5 @@
-API reference
-=============
+libjxl API reference
+====================
 
 ``libjxl`` exposes a C API for encoding and decoding JPEG XL files with some
 C++ header-only helpers for C++ users.
@@ -11,5 +11,7 @@ C++ header-only helpers for C++ users.
    api_decoder
    api_encoder
    api_common
-   api_butteraugli
+   api_metadata
+   api_color
    api_threads
+   api_cpp

--- a/doc/sphinx/api_butteraugli.rst
+++ b/doc/sphinx/api_butteraugli.rst
@@ -1,6 +1,0 @@
-Butteraugli API - ``jxl/butteraugli.h``
-=======================================
-
-.. doxygengroup:: libjxl_butteraugli
-   :members:
-   :private-members:

--- a/doc/sphinx/api_color.rst
+++ b/doc/sphinx/api_color.rst
@@ -1,0 +1,6 @@
+Color encoding and conversion
+=============================
+
+.. doxygengroup:: libjxl_color
+   :members:
+   :private-members:

--- a/doc/sphinx/api_cpp.rst
+++ b/doc/sphinx/api_cpp.rst
@@ -1,0 +1,6 @@
+C++ helpers
+===========
+
+.. doxygengroup:: libjxl_cpp
+   :members:
+   :private-members:

--- a/doc/sphinx/api_metadata.rst
+++ b/doc/sphinx/api_metadata.rst
@@ -1,0 +1,6 @@
+Image and frame metadata
+========================
+
+.. doxygengroup:: libjxl_metadata
+   :members:
+   :private-members:

--- a/lib/include/jxl/cms_interface.h
+++ b/lib/include/jxl/cms_interface.h
@@ -4,7 +4,7 @@
  * license that can be found in the LICENSE file.
  */
 
-/** @addtogroup libjxl_common
+/** @addtogroup libjxl_color
  * @{
  * @file cms_interface.h
  * @brief Interface to allow the injection of different color management systems

--- a/lib/include/jxl/codestream_header.h
+++ b/lib/include/jxl/codestream_header.h
@@ -4,7 +4,7 @@
  * license that can be found in the LICENSE file.
  */
 
-/** @addtogroup libjxl_common
+/** @addtogroup libjxl_metadata
  * @{
  * @file codestream_header.h
  * @brief Definitions of structs and enums for the metadata from the JPEG XL

--- a/lib/include/jxl/color_encoding.h
+++ b/lib/include/jxl/color_encoding.h
@@ -4,7 +4,7 @@
  * license that can be found in the LICENSE file.
  */
 
-/** @addtogroup libjxl_common
+/** @addtogroup libjxl_color
  * @{
  * @file color_encoding.h
  * @brief Color Encoding definitions used by JPEG XL.

--- a/lib/include/jxl/decode.h
+++ b/lib/include/jxl/decode.h
@@ -320,6 +320,33 @@ typedef enum {
   JXL_DEC_FRAME_PROGRESSION = 0x8000,
 } JxlDecoderStatus;
 
+/** Types of progressive detail.
+ * Setting a progressive detail with value N implies all progressive details
+ * with smaller or equal value. Currently only the following level of
+ * progressive detail is implemented:
+ *  - kDC (which implies kFrames)
+ *  - kLastPasses (which implies kDC and kFrames)
+ *  - kPasses (which implies kLastPasses, kDC and kFrames)
+ */
+typedef enum {
+  // after completed kRegularFrames
+  kFrames = 0,
+  // after completed DC (1:8)
+  kDC = 1,
+  // after completed AC passes that are the last pass for their resolution
+  // target.
+  kLastPasses = 2,
+  // after completed AC passes that are not the last pass for their resolution
+  // target.
+  kPasses = 3,
+  // during DC frame when lower resolution are completed (1:32, 1:16)
+  kDCProgressive = 4,
+  // after completed groups
+  kDCGroups = 5,
+  // after completed groups
+  kGroups = 6,
+} JxlProgressiveDetail;
+
 /** Rewinds decoder to the beginning. The same input must be given again from
  * the beginning of the file and the decoder will emit events from the beginning
  * again. When rewinding (as opposed to @ref JxlDecoderReset), the decoder can

--- a/lib/include/jxl/decode_cxx.h
+++ b/lib/include/jxl/decode_cxx.h
@@ -3,7 +3,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-/// @addtogroup libjxl_decoder
+/// @addtogroup libjxl_cpp
 /// @{
 ///
 /// @file decode_cxx.h

--- a/lib/include/jxl/encode_cxx.h
+++ b/lib/include/jxl/encode_cxx.h
@@ -3,7 +3,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-/// @addtogroup libjxl_encoder
+/// @addtogroup libjxl_cpp
 ///@{
 ///
 /// @file encode_cxx.h

--- a/lib/include/jxl/parallel_runner.h
+++ b/lib/include/jxl/parallel_runner.h
@@ -4,7 +4,7 @@
  * license that can be found in the LICENSE file.
  */
 
-/** @addtogroup libjxl_common
+/** @addtogroup libjxl_threads
  *  @{
  */
 /**

--- a/lib/include/jxl/resizable_parallel_runner_cxx.h
+++ b/lib/include/jxl/resizable_parallel_runner_cxx.h
@@ -3,7 +3,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-/// @addtogroup libjxl_threads
+/// @addtogroup libjxl_cpp
 /// @{
 ///
 /// @file resizable_parallel_runner_cxx.h

--- a/lib/include/jxl/thread_parallel_runner_cxx.h
+++ b/lib/include/jxl/thread_parallel_runner_cxx.h
@@ -3,7 +3,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-/// @addtogroup libjxl_threads
+/// @addtogroup libjxl_cpp
 /// @{
 ///
 /// @file thread_parallel_runner_cxx.h

--- a/lib/include/jxl/types.h
+++ b/lib/include/jxl/types.h
@@ -143,33 +143,6 @@ typedef struct {
  */
 typedef char JxlBoxType[4];
 
-/** Types of progressive detail.
- * Setting a progressive detail with value N implies all progressive details
- * with smaller or equal value. Currently only the following level of
- * progressive detail is implemented:
- *  - kDC (which implies kFrames)
- *  - kLastPasses (which implies kDC and kFrames)
- *  - kPasses (which implies kLastPasses, kDC and kFrames)
- */
-typedef enum {
-  // after completed kRegularFrames
-  kFrames = 0,
-  // after completed DC (1:8)
-  kDC = 1,
-  // after completed AC passes that are the last pass for their resolution
-  // target.
-  kLastPasses = 2,
-  // after completed AC passes that are not the last pass for their resolution
-  // target.
-  kPasses = 3,
-  // during DC frame when lower resolution are completed (1:32, 1:16)
-  kDCProgressive = 4,
-  // after completed groups
-  kDCGroups = 5,
-  // after completed groups
-  kGroups = 6,
-} JxlProgressiveDetail;
-
 #if defined(__cplusplus) || defined(c_plusplus)
 }
 #endif


### PR DESCRIPTION
Cluster things a bit more by topic, so the API documentation will end up being a bit better organized.

Also move `JxlProgressiveDetail` from types.h to decode.h since it's not a common type (used in both encoder and decoder) but only relevant for the decoder.

For convenience: this is what the API documentation looks like after this PR:
https://libjxl--2706.org.readthedocs.build/en/2706/