### PR TITLE
Fix using uninitialized value

### DIFF
--- a/lib/extras/dec/decode.cc
+++ b/lib/extras/dec/decode.cc
@@ -120,6 +120,10 @@ Status DecodeBytes(const Span<const uint8_t> bytes,
       return Codec::kPNM;
     }
     JXLDecompressParams dparams = {};
+    for (const uint32_t num_channels : {1, 2, 3, 4}) {
+      dparams.accepted_formats.push_back(
+          {num_channels, JXL_TYPE_FLOAT, JXL_LITTLE_ENDIAN, /*align=*/0});
+    }
     size_t decoded_bytes;
     if (DecodeImageJXL(bytes.data(), bytes.size(), dparams, &decoded_bytes,
                        ppf) &&

--- a/lib/extras/dec/jxl.cc
+++ b/lib/extras/dec/jxl.cc
@@ -166,7 +166,7 @@ bool DecodeImageJXL(const uint8_t* bytes, size_t bytes_size,
                JXL_DEC_BOX);
     if (accepted_formats.empty()) {
       // decoding just the metadata, not the pixel data
-      events ^= JXL_DEC_FULL_IMAGE;
+      events ^= (JXL_DEC_FULL_IMAGE | JXL_DEC_PREVIEW_IMAGE);
     }
   }
   if (JXL_DEC_SUCCESS != JxlDecoderSubscribeEvents(dec, events)) {


### PR DESCRIPTION
Folow-up: fix exrtas-jxl-codec-decode to decode just metadata