### PR TITLE
[dec_group] Optimizing with SIMD in dec_group

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -37,6 +37,7 @@ Fred Brennan <copypaste@kittens.ph>
 gi-man
 Gilles Devillers (GilDev) <gildev@gmail.com>
 Heiko Becker <heirecka@exherbo.org>
+Ho Cheung <uioptt24@gmail.com>
 Jim Robinson <jimbo2150@gmail.com>
 Jon Sneyers <jon@cloudinary.com>
 Jonathan Brown (Jonnyawsom3) <jonathanbr30@gmail.com>


### PR DESCRIPTION
Introduce `emmintrin.h` in dec_group to optimize `Transpose8x8InPlace` and `Status LoadBlock` using SIMD.

At present, only the x86 architecture and the situation that does not support SIMD are processed, and the situation of non-X86 architecture has not been processed for the time being.