### PR TITLE
remove paths-ignore

### DIFF
--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -13,9 +13,6 @@ on:
       - v*.*.x
   pull_request:
     types: [opened, reopened, labeled, synchronize]
-    paths-ignore:
-      - '**.md'
-      - 'AUTHORS'
 
 permissions:
   contents: read

--- a/.github/workflows/build_test_cross.yml
+++ b/.github/workflows/build_test_cross.yml
@@ -13,9 +13,6 @@ on:
       - v*.*.x
   pull_request:
     types: [opened, reopened, labeled, synchronize]
-    paths-ignore:
-      - '**.md'
-      - 'AUTHORS'
 
 permissions:
   contents: read

--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -13,9 +13,6 @@ on:
       - v*.*.x
   pull_request:
     types: [opened, reopened, labeled, synchronize]
-    paths-ignore:
-      - '**.md'
-      - 'AUTHORS'
 
 permissions:
   contents: read


### PR DESCRIPTION
This removes the paths-ignores for ichange to .md and AUTHORS. This allows us to have required workflows. The ci is faster now and also we don't have many such pull requests.