### PR TITLE
Fix subtle logic error in djxl_fuzzer

### DIFF
--- a/lib/jxl/decode.cc
+++ b/lib/jxl/decode.cc
@@ -1964,9 +1964,9 @@ static JxlDecoderStatus HandleBoxes(JxlDecoder* dec) {
         dec->box_stage = BoxStage::kHeader;
         // If successful JPEG reconstruction, return the success if the user
         // cares about it, otherwise continue.
-        if (dec->events_wanted & recon_result) {
-          dec->events_wanted &= ~recon_result;
-          return recon_result;
+        if (dec->events_wanted & JXL_DEC_JPEG_RECONSTRUCTION) {
+          dec->events_wanted &= ~JXL_DEC_JPEG_RECONSTRUCTION;
+          return JXL_DEC_JPEG_RECONSTRUCTION;
         }
       } else {
         // If anything else, return the result.

--- a/tools/djxl_fuzzer.cc
+++ b/tools/djxl_fuzzer.cc
@@ -211,6 +211,7 @@ bool DecodeJpegXl(const uint8_t* jxl, size_t size, size_t max_pixels,
         return false;
       }
     } else if (status == JXL_DEC_JPEG_NEED_MORE_OUTPUT) {
+      if (want_preview) abort();  // expected preview before frame
       if (spec.jpeg_to_pixels) abort();
       if (!seen_jpeg_reconstruction) abort();
       seen_jpeg_need_more_output = true;
@@ -395,7 +396,10 @@ bool DecodeJpegXl(const uint8_t* jxl, size_t size, size_t max_pixels,
         }
       }
     } else if (status == JXL_DEC_JPEG_RECONSTRUCTION) {
-      if (want_preview) abort();  // expected preview before frame
+      // Do not check preview precedence here, since this event only declares
+      // that JPEG is going to be decoded; though, when first byte of JPEG
+      // arrives (JXL_DEC_JPEG_NEED_MORE_OUTPUT) it is certain that preview
+      // should have been produced already.
       if (seen_jpeg_reconstruction) abort();
       seen_jpeg_reconstruction = true;
       if (!spec.jpeg_to_pixels) {


### PR DESCRIPTION
Preview have to be emitted before JPEG stream, but when decoder reports it will produce JPEG stream it is still not too late to spit a preview.