### PR TITLE
Fix edge case in JPEG serialization

### DIFF
--- a/lib/jxl/jpeg/dec_jpeg_data_writer.cc
+++ b/lib/jxl/jpeg/dec_jpeg_data_writer.cc
@@ -483,6 +483,7 @@ bool EncodeDCTBlockSequential(const coeff_t* coeffs, HuffmanCodeTable* dc_huff,
                               coeff_t* last_dc_coeff, JpegBitWriter* bw) {
   coeff_t temp2;
   coeff_t temp;
+  coeff_t litmus = 0;
   temp2 = coeffs[0];
   temp = temp2 - *last_dc_coeff;
   *last_dc_coeff = temp2;
@@ -523,7 +524,9 @@ bool EncodeDCTBlockSequential(const coeff_t* coeffs, HuffmanCodeTable* dc_huff,
           r -= 16;
         }
       }
-      int ac_nbits = FloorLog2Nonzero<uint32_t>(temp2) + 1;
+      litmus |= temp2;
+      int ac_nbits =
+          FloorLog2Nonzero<uint32_t>(static_cast<uint16_t>(temp2)) + 1;
       int symbol = (r << 4u) + ac_nbits;
       WriteSymbolBits(symbol, ac_huff, bw, ac_nbits,
                       temp & ((1 << ac_nbits) - 1));
@@ -538,7 +541,7 @@ bool EncodeDCTBlockSequential(const coeff_t* coeffs, HuffmanCodeTable* dc_huff,
   if (r > 0) {
     WriteSymbol(0, ac_huff, bw);
   }
-  return true;
+  return (litmus >= 0);
 }
 
 bool EncodeDCTBlockProgressive(const coeff_t* coeffs, HuffmanCodeTable* dc_huff,


### PR DESCRIPTION
When AC coeff is -32768 the logic of "de-signization" does not work. Healthy JPEGs does not contain such values.