### PR TITLE
Correct link to Pale Moon release notes in doc/sofware-support.md

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -53,6 +53,7 @@ Martin Strunz
 Mathieu Malaterre <mathieu.malaterre@gmail.com>
 Mikk Leini <mikk.leini@krakul.eu>
 Misaki Kasumi <misakikasumi@outlook.com>
+Moonchild Straver <moonchild@palemoon.org>
 Nicholas Hayes <0xC0000054@users.noreply.github.com>
 Nigel Tao <nigeltao@golang.org>
 Petr Diblík

--- a/doc/software_support.md
+++ b/doc/software_support.md
@@ -18,7 +18,7 @@ Please add missing software to this list.
 - Edge: behind a flag since version 91, start with `.\msedge.exe --enable-features=JXL`
 - Opera: behind a flag since version 77.
 - Basilisk: supported since version v2023.01.07, [release notes](https://www.basilisk-browser.org/releasenotes.shtml)
-- Pale Moon: supported since version 31.4.0, [release notes](https://www.palemoon.org/releasenotes.shtml)
+- Pale Moon: supported since version 31.4.0, [release notes](https://www.palemoon.org/releasenotes-archived.shtml#v31.4.0)
 - Waterfox: [enabled by default](https://github.com/WaterfoxCo/Waterfox/pull/2936)
 
 For all browsers and to track browsers progress see [Can I Use](https://caniuse.com/jpegxl).


### PR DESCRIPTION
Older release notes are regularly moved to "archived release notes" in the Pale Moon project. Since this change was made in November 2022, it's no longer relevant for the main release notes page. The correct/permanent link at this point in time is https://www.palemoon.org/releasenotes-archived.shtml#v31.4.0 -- jumping directly to the related version.