### PR TITLE
Fix WASM build

### DIFF
--- a/lib/extras/metrics.cc
+++ b/lib/extras/metrics.cc
@@ -42,7 +42,7 @@ double ComputeDistanceP(const ImageF& distmap, const ButteraugliParams& params,
     using T = float;
 #endif
     const HWY_FULL(T) d;
-    constexpr size_t N = MaxLanes(HWY_FULL(T)());
+    constexpr size_t N = MaxLanes(d);
     // Manually aligned storage to avoid asan crash on clang-7 due to
     // unaligned spill.
     HWY_ALIGN T sum_totals0[N] = {0};

--- a/lib/jxl/enc_color_management.cc
+++ b/lib/jxl/enc_color_management.cc
@@ -192,8 +192,7 @@ Status AfterTransform(JxlCms* t, float* JXL_RESTRICT buf_dst, size_t buf_size) {
       HWY_FULL(float) df;
       for (size_t i = 0; i < buf_size; i += Lanes(df)) {
         const auto val = Load(df, buf_dst + i);
-        const auto result =
-            TF_SRGB().EncodedFromDisplay(HWY_FULL(float)(), val);
+        const auto result = TF_SRGB().EncodedFromDisplay(df, val);
         Store(result, df, buf_dst + i);
       }
 #if JXL_CMS_VERBOSE >= 2

--- a/lib/jxl/gauss_blur.cc
+++ b/lib/jxl/gauss_blur.cc
@@ -216,7 +216,8 @@ struct OutputStore {
   void operator()(const V& out, float* JXL_RESTRICT pos,
                   ptrdiff_t offset) const {
     // Stream helps for large images but is slower for images that fit in cache.
-    Store(out, HWY_FULL(float)(), pos + offset);
+    const HWY_FULL(float) df;
+    Store(out, df, pos + offset);
   }
 };
 
@@ -226,7 +227,8 @@ class SingleInput {
  public:
   explicit SingleInput(const float* pos) : pos_(pos) {}
   Vec<HWY_FULL(float)> operator()(const size_t offset) const {
-    return Load(HWY_FULL(float)(), pos_ + offset);
+    const HWY_FULL(float) df;
+    return Load(df, pos_ + offset);
   }
   const float* pos_;
 };
@@ -237,8 +239,9 @@ class TwoInputs {
  public:
   TwoInputs(const float* pos1, const float* pos2) : pos1_(pos1), pos2_(pos2) {}
   Vec<HWY_FULL(float)> operator()(const size_t offset) const {
-    const auto in1 = Load(HWY_FULL(float)(), pos1_ + offset);
-    const auto in2 = Load(HWY_FULL(float)(), pos2_ + offset);
+    const HWY_FULL(float) df;
+    const auto in1 = Load(df, pos1_ + offset);
+    const auto in2 = Load(df, pos2_ + offset);
     return Add(in1, in2);
   }
 
@@ -378,8 +381,9 @@ void FastGaussianVertical(const hwy::AlignedUniquePtr<RecursiveGaussian>& rg,
                           ImageF* JXL_RESTRICT out) {
   JXL_CHECK(SameSize(in, *out));
 
+  const HWY_FULL(float) df;
   constexpr size_t kCacheLineLanes = 64 / sizeof(float);
-  constexpr size_t kVN = MaxLanes(HWY_FULL(float)());
+  constexpr size_t kVN = MaxLanes(df);
   constexpr size_t kCacheLineVectors =
       (kVN < kCacheLineLanes) ? (kCacheLineLanes / kVN) : 4;
   constexpr size_t kFastPace = kCacheLineVectors * kVN;

--- a/tools/wasm_demo/jxl_decoder.cc
+++ b/tools/wasm_demo/jxl_decoder.cc
@@ -9,6 +9,7 @@
 #include <jxl/decode_cxx.h>
 #include <jxl/thread_parallel_runner_cxx.h>
 
+#include <cstdio>
 #include <cstring>
 #include <memory>
 #include <vector>


### PR DESCRIPTION
Drive-by: avoid nameless HWY_FULL(T) instantiations