### PR TITLE
don't special case intensity target for pq

### DIFF
--- a/lib/jxl/color_management.cc
+++ b/lib/jxl/color_management.cc
@@ -52,8 +52,9 @@ Status ToneMapPixel(const ColorEncoding& c, const float in[3],
   float linear[3];
   HWY_CAPPED(float, 1) d;
   if (c.tf.IsPQ()) {
+    TF_PQ tf_pq(/*display_intensity_target=*/10000.0);
     for (size_t i = 0; i < 3; ++i) {
-      linear[i] = TF_PQ().DisplayFromEncoded(in[i]);
+      linear[i] = tf_pq.DisplayFromEncoded(in[i]);
     }
   } else {
     for (size_t i = 0; i < 3; ++i) {
@@ -126,12 +127,13 @@ std::vector<uint16_t> CreateTableCurve(uint32_t N, const ExtraTF tf,
                                    {0, kDefaultIntensityTarget}, kLuminances);
   // No point using float - LCMS converts to 16-bit for A2B/MFT.
   std::vector<uint16_t> table(N);
+  TF_PQ tf_pq(/*display_intensity_target=*/10000.0);
   for (uint32_t i = 0; i < N; ++i) {
     const float x = static_cast<float>(i) / (N - 1);  // 1.0 at index N - 1.
     const double dx = static_cast<double>(x);
     // LCMS requires EOTF (e.g. 2.4 exponent).
     double y = (tf == ExtraTF::kHLG) ? TF_HLG().DisplayFromEncoded(dx)
-                                     : TF_PQ().DisplayFromEncoded(dx);
+                                     : tf_pq.DisplayFromEncoded(dx);
     if (tone_map && tf == ExtraTF::kPQ &&
         kPQIntensityTarget > kDefaultIntensityTarget) {
       D df;

--- a/lib/jxl/dec_tone_mapping-inl.h
+++ b/lib/jxl/dec_tone_mapping-inl.h
@@ -107,6 +107,8 @@ class Rec2408ToneMapper {
   const float green_Y_;
   const float blue_Y_;
 
+  const TF_PQ tf_pq_ = TF_PQ(/*display_intensity_target=*/1.0);
+
   const float pq_mastering_min_ = InvEOTF(source_range_.first);
   const float pq_mastering_max_ = InvEOTF(source_range_.second);
   const float pq_mastering_range_ = pq_mastering_max_ - pq_mastering_min_;
@@ -123,8 +125,6 @@ class Rec2408ToneMapper {
 
   const float normalizer_ = source_range_.second / target_range_.second;
   const float inv_target_peak_ = 1.f / target_range_.second;
-
-  const TF_PQ tf_pq_ = TF_PQ(/*display_intensity_target=*/1.0);
 };
 
 class HlgOOTF {

--- a/lib/jxl/dec_tone_mapping-inl.h
+++ b/lib/jxl/dec_tone_mapping-inl.h
@@ -61,8 +61,7 @@ class Rec2408ToneMapper {
     const V e4 = MulAdd(e3, pq_mastering_range, pq_mastering_min);
     const V new_luminance =
         Min(Set(df_, target_range_.second),
-            ZeroIfNegative(
-                Mul(Set(df_, 10000), TF_PQ().DisplayFromEncoded(df_, e4))));
+            ZeroIfNegative(tf_pq_.DisplayFromEncoded(df_, e4)));
     const V min_luminance = Set(df_, 1e-6f);
     const auto use_cap = Le(luminance, min_luminance);
     const V ratio = Div(new_luminance, Max(luminance, min_luminance));
@@ -76,11 +75,10 @@ class Rec2408ToneMapper {
 
  private:
   V InvEOTF(const V luminance) const {
-    return TF_PQ().EncodedFromDisplay(df_,
-                                      Mul(luminance, Set(df_, 1. / 10000)));
+    return tf_pq_.EncodedFromDisplay(df_, luminance);
   }
   float InvEOTF(const float luminance) const {
-    return TF_PQ().EncodedFromDisplay(luminance / 10000.0f);
+    return tf_pq_.EncodedFromDisplay(luminance);
   }
   V T(const V a) const {
     const V ks = Set(df_, ks_);
@@ -125,6 +123,8 @@ class Rec2408ToneMapper {
 
   const float normalizer_ = source_range_.second / target_range_.second;
   const float inv_target_peak_ = 1.f / target_range_.second;
+
+  const TF_PQ tf_pq_ = TF_PQ(/*display_intensity_target=*/1.0);
 };
 
 class HlgOOTF {

--- a/lib/jxl/dec_xyb.cc
+++ b/lib/jxl/dec_xyb.cc
@@ -303,14 +303,11 @@ Status OutputEncodingInfo::SetColorEncoding(const ColorEncoding& c_desired) {
 
   // The internal XYB color space uses absolute luminance, so we scale back the
   // opsin inverse matrix to relative luminance where 1.0 corresponds to the
-  // original intensity target, or to absolute luminance for PQ, where 1.0
-  // corresponds to 10000 nits.
+  // original intensity target.
   if (xyb_encoded) {
-    float intensity_target =
-        (c_desired.tf.IsPQ() ? 10000 : orig_intensity_target);
     InitSIMDInverseMatrix(inverse_matrix, opsin_params.inverse_opsin_matrix,
-                          intensity_target);
-    all_default_opsin = (std::abs(intensity_target - 255.0) <= 0.1f &&
+                          orig_intensity_target);
+    all_default_opsin = (std::abs(orig_intensity_target - 255.0) <= 0.1f &&
                          inverse_matrix_is_default);
   }
 

--- a/lib/jxl/enc_color_management.cc
+++ b/lib/jxl/enc_color_management.cc
@@ -98,16 +98,11 @@ Status BeforeTransform(JxlCms* t, const float* buf_src, float* xform_src,
       break;
 
     case ExtraTF::kPQ: {
-      // By default, PQ content has an intensity target of 10000, stored
-      // exactly.
       HWY_FULL(float) df;
-      const auto multiplier = Set(df, t->intensity_target == 10000.f
-                                          ? 1.0f
-                                          : 10000.f / t->intensity_target);
+      TF_PQ tf_pq(t->intensity_target);
       for (size_t i = 0; i < buf_size; i += Lanes(df)) {
         const auto val = Load(df, buf_src + i);
-        const auto result =
-            Mul(multiplier, TF_PQ().DisplayFromEncoded(df, val));
+        const auto result = tf_pq.DisplayFromEncoded(df, val);
         Store(result, df, xform_src + i);
       }
 #if JXL_CMS_VERBOSE >= 2
@@ -159,13 +154,10 @@ Status AfterTransform(JxlCms* t, float* JXL_RESTRICT buf_dst, size_t buf_size) {
       break;
     case ExtraTF::kPQ: {
       HWY_FULL(float) df;
-      const auto multiplier =
-          Set(df, t->intensity_target == 10000.f ? 1.0f
-                                                 : t->intensity_target * 1e-4f);
+      TF_PQ tf_pq(t->intensity_target);
       for (size_t i = 0; i < buf_size; i += Lanes(df)) {
         const auto val = Load(df, buf_dst + i);
-        const auto result =
-            TF_PQ().EncodedFromDisplay(df, Mul(multiplier, val));
+        const auto result = tf_pq.EncodedFromDisplay(df, val);
         Store(result, df, buf_dst + i);
       }
 #if JXL_CMS_VERBOSE >= 2

--- a/lib/jxl/fast_math_test.cc
+++ b/lib/jxl/fast_math_test.cc
@@ -143,10 +143,11 @@ HWY_NOINLINE void TestFastPQEFD() {
   Rng rng(1);
   float max_abs_err = 0;
   HWY_FULL(float) d;
+  TF_PQ tf_pq(/*display_intensity_target=*/11111.0);
   for (size_t i = 0; i < kNumTrials; i++) {
     const float f = rng.UniformF(0.0f, 1.0f);
-    const float actual = GetLane(TF_PQ().EncodedFromDisplay(d, Set(d, f)));
-    const float expected = TF_PQ().EncodedFromDisplay(f);
+    const float actual = GetLane(tf_pq.EncodedFromDisplay(d, Set(d, f)));
+    const float expected = tf_pq.EncodedFromDisplay(f);
     const float abs_err = std::abs(expected - actual);
     EXPECT_LT(abs_err, 7e-7) << "f = " << f;
     max_abs_err = std::max(max_abs_err, abs_err);
@@ -191,10 +192,11 @@ HWY_NOINLINE void TestFastPQDFE() {
   Rng rng(1);
   float max_abs_err = 0;
   HWY_FULL(float) d;
+  TF_PQ tf_pq(/*display_intensity_target=*/11111.0);
   for (size_t i = 0; i < kNumTrials; i++) {
     const float f = rng.UniformF(0.0f, 1.0f);
-    const float actual = GetLane(TF_PQ().DisplayFromEncoded(d, Set(d, f)));
-    const float expected = TF_PQ().DisplayFromEncoded(f);
+    const float actual = GetLane(tf_pq.DisplayFromEncoded(d, Set(d, f)));
+    const float expected = tf_pq.DisplayFromEncoded(f);
     const float abs_err = std::abs(expected - actual);
     EXPECT_LT(abs_err, 3E-6) << "f = " << f;
     max_abs_err = std::max(max_abs_err, abs_err);

--- a/lib/jxl/rational_polynomial-inl.h
+++ b/lib/jxl/rational_polynomial-inl.h
@@ -87,6 +87,9 @@ HWY_INLINE HWY_MAYBE_UNUSED V EvalRationalPolynomial(const D d, const V x,
   if (kDegP >= 7) yp = MulAdd(yp, x, LoadDup128(d, p + ((kDegP - 7) * 4)));
   if (kDegQ >= 7) yq = MulAdd(yq, x, LoadDup128(d, q + ((kDegQ - 7) * 4)));
 
+  static_assert(kDegP < 8, "Polynomial degree is too high");
+  static_assert(kDegQ < 8, "Polynomial degree is too high");
+
   return FastDivision<T, V>()(yp, yq);
 }
 

--- a/lib/jxl/render_pipeline/stage_from_linear.cc
+++ b/lib/jxl/render_pipeline/stage_from_linear.cc
@@ -58,10 +58,12 @@ struct OpRgb {
 };
 
 struct OpPq {
+  explicit OpPq(const float intensity_target) : tf_pq_(intensity_target) {}
   template <typename D, typename T>
   T Transform(D d, const T& linear) const {
-    return TF_PQ().EncodedFromDisplay(d, linear);
+    return tf_pq_.EncodedFromDisplay(d, linear);
   }
+  TF_PQ tf_pq_;
 };
 
 struct OpHlg {
@@ -153,7 +155,8 @@ std::unique_ptr<RenderPipelineStage> GetFromLinearStage(
   } else if (output_encoding_info.color_encoding.tf.IsSRGB()) {
     return MakeFromLinearStage(MakePerChannelOp(OpRgb()));
   } else if (output_encoding_info.color_encoding.tf.IsPQ()) {
-    return MakeFromLinearStage(MakePerChannelOp(OpPq()));
+    return MakeFromLinearStage(
+        MakePerChannelOp(OpPq(output_encoding_info.orig_intensity_target)));
   } else if (output_encoding_info.color_encoding.tf.IsHLG()) {
     return MakeFromLinearStage(
         OpHlg(output_encoding_info.luminances,

--- a/lib/jxl/render_pipeline/stage_to_linear.cc
+++ b/lib/jxl/render_pipeline/stage_to_linear.cc
@@ -54,10 +54,12 @@ struct OpRgb {
 };
 
 struct OpPq {
+  explicit OpPq(const float intensity_target) : tf_pq_(intensity_target) {}
   template <typename D, typename T>
   T Transform(D d, const T& encoded) const {
-    return TF_PQ().DisplayFromEncoded(d, encoded);
+    return tf_pq_.DisplayFromEncoded(d, encoded);
   }
+  TF_PQ tf_pq_;
 };
 
 struct OpHlg {
@@ -165,7 +167,8 @@ std::unique_ptr<RenderPipelineStage> GetToLinearStage(
   } else if (output_encoding_info.color_encoding.tf.IsSRGB()) {
     return MakeToLinearStage(MakePerChannelOp(OpRgb()));
   } else if (output_encoding_info.color_encoding.tf.IsPQ()) {
-    return MakeToLinearStage(MakePerChannelOp(OpPq()));
+    return MakeToLinearStage(
+        MakePerChannelOp(OpPq(output_encoding_info.orig_intensity_target)));
   } else if (output_encoding_info.color_encoding.tf.IsHLG()) {
     return MakeToLinearStage(OpHlg(output_encoding_info.luminances,
                                    output_encoding_info.orig_intensity_target));

--- a/lib/jxl/tf_gbench.cc
+++ b/lib/jxl/tf_gbench.cc
@@ -74,19 +74,23 @@ HWY_NOINLINE void BM_TFSRGB(benchmark::State& state) {
 }
 
 HWY_NOINLINE void BM_PQDFE(benchmark::State& state) {
-  RUN_BENCHMARK(TF_PQ().DisplayFromEncoded);
+  TF_PQ tf_pq(10000.0);
+  RUN_BENCHMARK(tf_pq.DisplayFromEncoded);
 }
 
 HWY_NOINLINE void BM_PQEFD(benchmark::State& state) {
-  RUN_BENCHMARK(TF_PQ().EncodedFromDisplay);
+  TF_PQ tf_pq(10000.0);
+  RUN_BENCHMARK(tf_pq.EncodedFromDisplay);
 }
 
 HWY_NOINLINE void BM_PQSlowDFE(benchmark::State& state) {
-  RUN_BENCHMARK_SCALAR(TF_PQ().DisplayFromEncoded);
+  TF_PQ tf_pq(10000.0);
+  RUN_BENCHMARK_SCALAR(tf_pq.DisplayFromEncoded);
 }
 
 HWY_NOINLINE void BM_PQSlowEFD(benchmark::State& state) {
-  RUN_BENCHMARK_SCALAR(TF_PQ().EncodedFromDisplay);
+  TF_PQ tf_pq(10000.0);
+  RUN_BENCHMARK_SCALAR(tf_pq.EncodedFromDisplay);
 }
 }  // namespace
 // NOLINTNEXTLINE(google-readability-namespace-comments)

--- a/lib/jxl/transfer_functions-inl.h
+++ b/lib/jxl/transfer_functions-inl.h
@@ -165,12 +165,11 @@ class TF_709 {
 // Perceptual Quantization
 class TF_PQ {
  public:
-  explicit TF_PQ(float display_intensity_target) {
-    display_scaling_factor_to_10000_nits_ =
-        display_intensity_target * (1.0f / 10000.0f);
-    display_scaling_factor_from_10000_nits_ =
-        1.0f / display_scaling_factor_to_10000_nits_;
-  }
+  explicit TF_PQ(float display_intensity_target)
+      : display_scaling_factor_to_10000_nits_(display_intensity_target *
+                                              (1.0f / 10000.0f)),
+        display_scaling_factor_from_10000_nits_(
+            1.0f / display_scaling_factor_to_10000_nits_) {}
 
   // EOTF (defines the PQ approach). e = encoded.
   JXL_INLINE double DisplayFromEncoded(double e) const {

--- a/lib/jxl/transfer_functions-inl.h
+++ b/lib/jxl/transfer_functions-inl.h
@@ -165,7 +165,7 @@ class TF_709 {
 // Perceptual Quantization
 class TF_PQ {
  public:
-  explicit TF_PQ(float display_intensity_target = 255.0)
+  explicit TF_PQ(float display_intensity_target)
       : display_scaling_factor_to_10000_nits_(display_intensity_target *
                                               (1.0f / 10000.0f)),
         display_scaling_factor_from_10000_nits_(10000.0f /
@@ -274,8 +274,8 @@ class TF_PQ {
   static constexpr double kC2 = (2413.0 / 4096) * 32;
   static constexpr double kC3 = (2392.0 / 4096) * 32;
 
-  const float display_scaling_factor_to_10000_nits_;
-  const float display_scaling_factor_from_10000_nits_;
+  const float display_scaling_factor_to_10000_nits_ = 0.0;
+  const float display_scaling_factor_from_10000_nits_ = 0.0;
 };
 
 // sRGB

--- a/lib/jxl/transfer_functions-inl.h
+++ b/lib/jxl/transfer_functions-inl.h
@@ -165,7 +165,7 @@ class TF_709 {
 // Perceptual Quantization
 class TF_PQ {
  public:
-  explicit TF_PQ(float display_intensity_target)
+  explicit TF_PQ(float display_intensity_target = 255.0)
       : display_scaling_factor_to_10000_nits_(display_intensity_target *
                                               (1.0f / 10000.0f)),
         display_scaling_factor_from_10000_nits_(10000.0f /

--- a/lib/jxl/transfer_functions-inl.h
+++ b/lib/jxl/transfer_functions-inl.h
@@ -165,9 +165,7 @@ class TF_709 {
 // Perceptual Quantization
 class TF_PQ {
  public:
-  TF_PQ() = delete;
-
-  explicit TF_PQ(float display_intensity_target)
+  explicit TF_PQ(float display_intensity_target = kDefaultIntensityTarget)
       : display_scaling_factor_to_10000_nits_(display_intensity_target *
                                               (1.0f / 10000.0f)),
         display_scaling_factor_from_10000_nits_(10000.0f /

--- a/lib/jxl/transfer_functions-inl.h
+++ b/lib/jxl/transfer_functions-inl.h
@@ -274,8 +274,8 @@ class TF_PQ {
   static constexpr double kC2 = (2413.0 / 4096) * 32;
   static constexpr double kC3 = (2392.0 / 4096) * 32;
 
-  float display_scaling_factor_to_10000_nits_ = 0.0;
-  float display_scaling_factor_from_10000_nits_ = 0.0;
+  const float display_scaling_factor_to_10000_nits_;
+  const float display_scaling_factor_from_10000_nits_;
 };
 
 // sRGB

--- a/lib/jxl/transfer_functions-inl.h
+++ b/lib/jxl/transfer_functions-inl.h
@@ -168,8 +168,8 @@ class TF_PQ {
   explicit TF_PQ(float display_intensity_target)
       : display_scaling_factor_to_10000_nits_(display_intensity_target *
                                               (1.0f / 10000.0f)),
-        display_scaling_factor_from_10000_nits_(
-            1.0f / display_scaling_factor_to_10000_nits_) {}
+        display_scaling_factor_from_10000_nits_(10000.0f /
+                                                display_intensity_target) {}
 
   // EOTF (defines the PQ approach). e = encoded.
   JXL_INLINE double DisplayFromEncoded(double e) const {

--- a/lib/jxl/transfer_functions-inl.h
+++ b/lib/jxl/transfer_functions-inl.h
@@ -274,8 +274,8 @@ class TF_PQ {
   static constexpr double kC2 = (2413.0 / 4096) * 32;
   static constexpr double kC3 = (2392.0 / 4096) * 32;
 
-  float display_scaling_factor_to_10000_nits_;
-  float display_scaling_factor_from_10000_nits_;
+  float display_scaling_factor_to_10000_nits_ = 0.0;
+  float display_scaling_factor_from_10000_nits_ = 0.0;
 };
 
 // sRGB

--- a/lib/jxl/transfer_functions-inl.h
+++ b/lib/jxl/transfer_functions-inl.h
@@ -165,6 +165,13 @@ class TF_709 {
 // Perceptual Quantization
 class TF_PQ {
  public:
+  explicit TF_PQ(float display_intensity_target) {
+    display_scaling_factor_to_10000_nits_ =
+        display_intensity_target * (1.0f / 10000.0f);
+    display_scaling_factor_from_10000_nits_ =
+        1.0f / display_scaling_factor_to_10000_nits_;
+  }
+
   // EOTF (defines the PQ approach). e = encoded.
   JXL_INLINE double DisplayFromEncoded(double e) const {
     if (e == 0.0) return 0.0;
@@ -177,7 +184,8 @@ class TF_PQ {
     JXL_DASSERT(den != 0.0);
     const double d = std::pow(num / den, 1.0 / kM1);
     JXL_DASSERT(d >= 0.0);  // Equal for e ~= 1E-9
-    return copysignf(d, original_sign);
+    return copysignf(d * display_scaling_factor_from_10000_nits_,
+                     original_sign);
   }
 
   // Maximum error 3e-6
@@ -201,7 +209,10 @@ class TF_PQ {
         HWY_REP4(2.67718770e+00f),
     };
     auto magnitude = EvalRationalPolynomial(d, xpxx, p, q);
-    return Or(AndNot(kSign, magnitude), original_sign);
+    return Or(
+        AndNot(kSign,
+               Mul(magnitude, Set(d, display_scaling_factor_from_10000_nits_))),
+        original_sign);
   }
 
   // Inverse EOTF. d = display.
@@ -210,7 +221,7 @@ class TF_PQ {
     const double original_sign = d;
     d = std::abs(d);
 
-    const double xp = std::pow(d, kM1);
+    const double xp = std::pow(d * display_scaling_factor_to_10000_nits_, kM1);
     const double num = kC1 + xp * kC2;
     const double den = 1.0 + xp * kC3;
     const double e = std::pow(num / den, kM2);
@@ -227,7 +238,8 @@ class TF_PQ {
     x = AndNot(kSign, x);  // abs
     // 4-over-4-degree rational polynomial approximation on x**0.25, with two
     // different polynomials above and below 1e-4.
-    auto xto025 = Sqrt(Sqrt(x));
+    auto xto025 =
+        Sqrt(Sqrt(Mul(x, Set(d, display_scaling_factor_to_10000_nits_))));
     HWY_ALIGN constexpr float p[(4 + 1) * 4] = {
         HWY_REP4(1.351392e-02f), HWY_REP4(-1.095778e+00f),
         HWY_REP4(5.522776e+01f), HWY_REP4(1.492516e+02f),
@@ -262,6 +274,9 @@ class TF_PQ {
   static constexpr double kC1 = 3424.0 / 4096;
   static constexpr double kC2 = (2413.0 / 4096) * 32;
   static constexpr double kC3 = (2392.0 / 4096) * 32;
+
+  float display_scaling_factor_to_10000_nits_;
+  float display_scaling_factor_from_10000_nits_;
 };
 
 // sRGB

--- a/lib/jxl/transfer_functions-inl.h
+++ b/lib/jxl/transfer_functions-inl.h
@@ -165,6 +165,8 @@ class TF_709 {
 // Perceptual Quantization
 class TF_PQ {
  public:
+  TF_PQ() = delete;
+
   explicit TF_PQ(float display_intensity_target)
       : display_scaling_factor_to_10000_nits_(display_intensity_target *
                                               (1.0f / 10000.0f)),
@@ -274,8 +276,8 @@ class TF_PQ {
   static constexpr double kC2 = (2413.0 / 4096) * 32;
   static constexpr double kC3 = (2392.0 / 4096) * 32;
 
-  const float display_scaling_factor_to_10000_nits_ = 0.0;
-  const float display_scaling_factor_from_10000_nits_ = 0.0;
+  const float display_scaling_factor_to_10000_nits_;
+  const float display_scaling_factor_from_10000_nits_;
 };
 
 // sRGB


### PR DESCRIPTION
Benchmarking with
```
build/lib/jxl_gbench --benchmark_filter=".*PQ.*"
```
showed that TF_PQ() was not made significantly slower by this change.

Drive-by: add `static_assert` when evaluating polynomials