### PR TITLE
lib/include/jxl: use void for strict C prototypes

### DIFF
--- a/lib/include/jxl/stats.h
+++ b/lib/include/jxl/stats.h
@@ -33,7 +33,7 @@ typedef struct JxlEncoderStatsStruct JxlEncoderStats;
  *
  * @return pointer to initialized JxlEncoderStats instance
  */
-JXL_EXPORT JxlEncoderStats* JxlEncoderStatsCreate();
+JXL_EXPORT JxlEncoderStats* JxlEncoderStatsCreate(void);
 
 /**
  * Deinitializes and frees JxlEncoderStats instance.

--- a/lib/include/jxl/thread_parallel_runner.h
+++ b/lib/include/jxl/thread_parallel_runner.h
@@ -60,7 +60,7 @@ JXL_THREADS_EXPORT void JxlThreadParallelRunnerDestroy(void* runner_opaque);
 /** Returns a default num_worker_threads value for
  * JxlThreadParallelRunnerCreate.
  */
-JXL_THREADS_EXPORT size_t JxlThreadParallelRunnerDefaultNumWorkerThreads();
+JXL_THREADS_EXPORT size_t JxlThreadParallelRunnerDefaultNumWorkerThreads(void);
 
 #if defined(__cplusplus) || defined(c_plusplus)
 }


### PR DESCRIPTION
Declaring a function as foo(); is fine in C++ but produces a warning in C. Since these are C headers, we should declare them as foo(void). This has been the case since C89.

See: -Wstrict-prototypes
