### PR TITLE
Add low memory version of butteraugli.

### DIFF
--- a/lib/jxl/butteraugli/butteraugli.cc
+++ b/lib/jxl/butteraugli/butteraugli.cc
@@ -49,6 +49,24 @@
 
 namespace jxl {
 
+static const double wMfMalta = 37.0819870399;
+static const double norm1Mf = 130262059.556;
+static const double wMfMaltaX = 8246.75321353;
+static const double norm1MfX = 1009002.70582;
+static const double wHfMalta = 18.7237414387;
+static const double norm1Hf = 4498534.45232;
+static const double wHfMaltaX = 6923.99476109;
+static const double norm1HfX = 8051.15833247;
+static const double wUhfMalta = 1.10039032555;
+static const double norm1Uhf = 71.7800275169;
+static const double wUhfMaltaX = 173.5;
+static const double norm1UhfX = 5.0;
+static const double wmul[9] = {
+    400.0,         1.50815703118,  0,
+    2150.0,        10.6195433239,  16.2176043152,
+    29.2353797994, 0.844626970982, 0.703646627719,
+};
+
 std::vector<float> ComputeKernel(float sigma) {
   const float m = 2.25;  // Accuracy increases when m is increased.
   const double scaler = -1.0 / (2.0 * sigma * sigma);
@@ -310,80 +328,104 @@ HWY_INLINE void XybLowFreqToVals(const D d, const V& x, const V& y,
   *valy = Mul(y, ymul);
 }
 
-void SuppressXByY(const ImageF& in_x, const ImageF& in_y, const double yw,
-                  ImageF* HWY_RESTRICT out) {
-  JXL_DASSERT(SameSize(in_x, in_y) && SameSize(in_x, *out));
-  const size_t xsize = in_x.xsize();
-  const size_t ysize = in_x.ysize();
-
+void XybLowFreqToVals(Image3F* xyb_lf) {
+  // Modify range around zero code only concerns the high frequency
+  // planes and only the X and Y channels.
+  // Convert low freq xyb to vals space so that we can do a simple squared sum
+  // diff on the low frequencies later.
   const HWY_FULL(float) d;
+  for (size_t y = 0; y < xyb_lf->ysize(); ++y) {
+    float* BUTTERAUGLI_RESTRICT row_x = xyb_lf->PlaneRow(0, y);
+    float* BUTTERAUGLI_RESTRICT row_y = xyb_lf->PlaneRow(1, y);
+    float* BUTTERAUGLI_RESTRICT row_b = xyb_lf->PlaneRow(2, y);
+    for (size_t x = 0; x < xyb_lf->xsize(); x += Lanes(d)) {
+      auto valx = Undefined(d);
+      auto valy = Undefined(d);
+      auto valb = Undefined(d);
+      XybLowFreqToVals(d, Load(d, row_x + x), Load(d, row_y + x),
+                       Load(d, row_b + x), &valx, &valy, &valb);
+      Store(valx, d, row_x + x);
+      Store(valy, d, row_y + x);
+      Store(valb, d, row_b + x);
+    }
+  }
+}
+
+void SuppressXByY(const ImageF& in_y, ImageF* HWY_RESTRICT inout_x) {
+  JXL_DASSERT(SameSize(*inout_x, in_y));
+  const size_t xsize = in_y.xsize();
+  const size_t ysize = in_y.ysize();
+  const HWY_FULL(float) d;
+  static const double suppress = 46.0;
   static const double s = 0.653020556257;
   const auto sv = Set(d, s);
   const auto one_minus_s = Set(d, 1.0 - s);
-  const auto ywv = Set(d, yw);
+  const auto ywv = Set(d, suppress);
 
   for (size_t y = 0; y < ysize; ++y) {
-    const float* HWY_RESTRICT row_x = in_x.ConstRow(y);
     const float* HWY_RESTRICT row_y = in_y.ConstRow(y);
-    float* HWY_RESTRICT row_out = out->Row(y);
-
+    float* HWY_RESTRICT row_x = inout_x->Row(y);
     for (size_t x = 0; x < xsize; x += Lanes(d)) {
       const auto vx = Load(d, row_x + x);
       const auto vy = Load(d, row_y + x);
       const auto scaler =
           MulAdd(Div(ywv, MulAdd(vy, vy, ywv)), one_minus_s, sv);
-      Store(Mul(scaler, vx), d, row_out + x);
+      Store(Mul(scaler, vx), d, row_x + x);
     }
   }
 }
 
-static void SeparateFrequencies(size_t xsize, size_t ysize,
-                                const ButteraugliParams& params,
-                                BlurTemp* blur_temp, const Image3F& xyb,
-                                PsychoImage& ps) {
+void Subtract(const ImageF& a, const ImageF& b, ImageF* c) {
   const HWY_FULL(float) d;
-
-  // Extract lf ...
-  static const double kSigmaLf = 7.15593339443;
-  static const double kSigmaHf = 3.22489901262;
-  static const double kSigmaUhf = 1.56416327805;
-  ps.mf = Image3F(xsize, ysize);
-  ps.hf[0] = ImageF(xsize, ysize);
-  ps.hf[1] = ImageF(xsize, ysize);
-  ps.lf = Image3F(xyb.xsize(), xyb.ysize());
-  ps.mf = Image3F(xyb.xsize(), xyb.ysize());
-  for (int i = 0; i < 3; ++i) {
-    Blur(xyb.Plane(i), kSigmaLf, params, blur_temp, &ps.lf.Plane(i));
-
-    // ... and keep everything else in mf.
-    for (size_t y = 0; y < ysize; ++y) {
-      const float* BUTTERAUGLI_RESTRICT row_xyb = xyb.PlaneRow(i, y);
-      const float* BUTTERAUGLI_RESTRICT row_lf = ps.lf.ConstPlaneRow(i, y);
-      float* BUTTERAUGLI_RESTRICT row_mf = ps.mf.PlaneRow(i, y);
-      for (size_t x = 0; x < xsize; x += Lanes(d)) {
-        const auto mf = Sub(Load(d, row_xyb + x), Load(d, row_lf + x));
-        Store(mf, d, row_mf + x);
-      }
+  for (size_t y = 0; y < a.ysize(); ++y) {
+    const float* row_a = a.ConstRow(y);
+    const float* row_b = b.ConstRow(y);
+    float* row_c = c->Row(y);
+    for (size_t x = 0; x < a.xsize(); x += Lanes(d)) {
+      Store(Sub(Load(d, row_a + x), Load(d, row_b + x)), d, row_c + x);
     }
+  }
+}
+
+void SeparateLFAndMF(const ButteraugliParams& params, const Image3F& xyb,
+                     Image3F* lf, Image3F* mf, BlurTemp* blur_temp) {
+  static const double kSigmaLf = 7.15593339443;
+  for (int i = 0; i < 3; ++i) {
+    // Extract lf ...
+    Blur(xyb.Plane(i), kSigmaLf, params, blur_temp, &lf->Plane(i));
+    // ... and keep everything else in mf.
+    Subtract(xyb.Plane(i), lf->Plane(i), &mf->Plane(i));
+  }
+  XybLowFreqToVals(lf);
+}
+
+void SeparateMFAndHF(const ButteraugliParams& params, Image3F* mf, ImageF* hf,
+                     BlurTemp* blur_temp) {
+  const HWY_FULL(float) d;
+  static const double kSigmaHf = 3.22489901262;
+  const size_t xsize = mf->xsize();
+  const size_t ysize = mf->ysize();
+  hf[0] = ImageF(xsize, ysize);
+  hf[1] = ImageF(xsize, ysize);
+  for (int i = 0; i < 3; ++i) {
     if (i == 2) {
-      Blur(ps.mf.Plane(i), kSigmaHf, params, blur_temp, &ps.mf.Plane(i));
+      Blur(mf->Plane(i), kSigmaHf, params, blur_temp, &mf->Plane(i));
       break;
     }
-    // Divide mf into mf and hf.
     for (size_t y = 0; y < ysize; ++y) {
-      float* BUTTERAUGLI_RESTRICT row_mf = ps.mf.PlaneRow(i, y);
-      float* BUTTERAUGLI_RESTRICT row_hf = ps.hf[i].Row(y);
+      float* BUTTERAUGLI_RESTRICT row_mf = mf->PlaneRow(i, y);
+      float* BUTTERAUGLI_RESTRICT row_hf = hf[i].Row(y);
       for (size_t x = 0; x < xsize; x += Lanes(d)) {
         Store(Load(d, row_mf + x), d, row_hf + x);
       }
     }
-    Blur(ps.mf.Plane(i), kSigmaHf, params, blur_temp, &ps.mf.Plane(i));
+    Blur(mf->Plane(i), kSigmaHf, params, blur_temp, &mf->Plane(i));
     static const double kRemoveMfRange = 0.29;
     static const double kAddMfRange = 0.1;
     if (i == 0) {
       for (size_t y = 0; y < ysize; ++y) {
-        float* BUTTERAUGLI_RESTRICT row_mf = ps.mf.PlaneRow(0, y);
-        float* BUTTERAUGLI_RESTRICT row_hf = ps.hf[0].Row(y);
+        float* BUTTERAUGLI_RESTRICT row_mf = mf->PlaneRow(0, y);
+        float* BUTTERAUGLI_RESTRICT row_hf = hf[0].Row(y);
         for (size_t x = 0; x < xsize; x += Lanes(d)) {
           auto mf = Load(d, row_mf + x);
           auto hf = Sub(Load(d, row_hf + x), mf);
@@ -394,8 +436,8 @@ static void SeparateFrequencies(size_t xsize, size_t ysize,
       }
     } else {
       for (size_t y = 0; y < ysize; ++y) {
-        float* BUTTERAUGLI_RESTRICT row_mf = ps.mf.PlaneRow(1, y);
-        float* BUTTERAUGLI_RESTRICT row_hf = ps.hf[1].Row(y);
+        float* BUTTERAUGLI_RESTRICT row_mf = mf->PlaneRow(1, y);
+        float* BUTTERAUGLI_RESTRICT row_hf = hf[1].Row(y);
         for (size_t x = 0; x < xsize; x += Lanes(d)) {
           auto mf = Load(d, row_mf + x);
           auto hf = Sub(Load(d, row_hf + x), mf);
@@ -407,27 +449,28 @@ static void SeparateFrequencies(size_t xsize, size_t ysize,
       }
     }
   }
-
-  // Temporarily used as output of SuppressXByY
-  ps.uhf[0] = ImageF(xsize, ysize);
-  ps.uhf[1] = ImageF(xsize, ysize);
-
   // Suppress red-green by intensity change in the high freq channels.
-  static const double suppress = 46.0;
-  SuppressXByY(ps.hf[0], ps.hf[1], suppress, &ps.uhf[0]);
-  // hf is the SuppressXByY output, uhf will be written below.
-  ps.hf[0].Swap(ps.uhf[0]);
+  SuppressXByY(hf[1], &hf[0]);
+}
 
+void SeparateHFAndUHF(const ButteraugliParams& params, ImageF* hf, ImageF* uhf,
+                      BlurTemp* blur_temp) {
+  const HWY_FULL(float) d;
+  const size_t xsize = hf[0].xsize();
+  const size_t ysize = hf[0].ysize();
+  static const double kSigmaUhf = 1.56416327805;
+  uhf[0] = ImageF(xsize, ysize);
+  uhf[1] = ImageF(xsize, ysize);
   for (int i = 0; i < 2; ++i) {
     // Divide hf into hf and uhf.
     for (size_t y = 0; y < ysize; ++y) {
-      float* BUTTERAUGLI_RESTRICT row_uhf = ps.uhf[i].Row(y);
-      float* BUTTERAUGLI_RESTRICT row_hf = ps.hf[i].Row(y);
+      float* BUTTERAUGLI_RESTRICT row_uhf = uhf[i].Row(y);
+      float* BUTTERAUGLI_RESTRICT row_hf = hf[i].Row(y);
       for (size_t x = 0; x < xsize; ++x) {
         row_uhf[x] = row_hf[x];
       }
     }
-    Blur(ps.hf[i], kSigmaUhf, params, blur_temp, &ps.hf[i]);
+    Blur(hf[i], kSigmaUhf, params, blur_temp, &hf[i]);
     static const double kRemoveHfRange = 1.5;
     static const double kAddHfRange = 0.132;
     static const double kRemoveUhfRange = 0.04;
@@ -437,8 +480,8 @@ static void SeparateFrequencies(size_t xsize, size_t ysize,
     static double kMulYUhf = 2.69313763794;
     if (i == 0) {
       for (size_t y = 0; y < ysize; ++y) {
-        float* BUTTERAUGLI_RESTRICT row_uhf = ps.uhf[0].Row(y);
-        float* BUTTERAUGLI_RESTRICT row_hf = ps.hf[0].Row(y);
+        float* BUTTERAUGLI_RESTRICT row_uhf = uhf[0].Row(y);
+        float* BUTTERAUGLI_RESTRICT row_hf = hf[0].Row(y);
         for (size_t x = 0; x < xsize; x += Lanes(d)) {
           auto hf = Load(d, row_hf + x);
           auto uhf = Sub(Load(d, row_uhf + x), hf);
@@ -450,8 +493,8 @@ static void SeparateFrequencies(size_t xsize, size_t ysize,
       }
     } else {
       for (size_t y = 0; y < ysize; ++y) {
-        float* BUTTERAUGLI_RESTRICT row_uhf = ps.uhf[1].Row(y);
-        float* BUTTERAUGLI_RESTRICT row_hf = ps.hf[1].Row(y);
+        float* BUTTERAUGLI_RESTRICT row_uhf = uhf[1].Row(y);
+        float* BUTTERAUGLI_RESTRICT row_hf = hf[1].Row(y);
         for (size_t x = 0; x < xsize; x += Lanes(d)) {
           auto hf = Load(d, row_hf + x);
           hf = MaximumClamp(d, hf, kMaxclampHf);
@@ -468,25 +511,24 @@ static void SeparateFrequencies(size_t xsize, size_t ysize,
       }
     }
   }
-  // Modify range around zero code only concerns the high frequency
-  // planes and only the X and Y channels.
-  // Convert low freq xyb to vals space so that we can do a simple squared sum
-  // diff on the low frequencies later.
-  for (size_t y = 0; y < ysize; ++y) {
-    float* BUTTERAUGLI_RESTRICT row_x = ps.lf.PlaneRow(0, y);
-    float* BUTTERAUGLI_RESTRICT row_y = ps.lf.PlaneRow(1, y);
-    float* BUTTERAUGLI_RESTRICT row_b = ps.lf.PlaneRow(2, y);
-    for (size_t x = 0; x < xsize; x += Lanes(d)) {
-      auto valx = Undefined(d);
-      auto valy = Undefined(d);
-      auto valb = Undefined(d);
-      XybLowFreqToVals(d, Load(d, row_x + x), Load(d, row_y + x),
-                       Load(d, row_b + x), &valx, &valy, &valb);
-      Store(valx, d, row_x + x);
-      Store(valy, d, row_y + x);
-      Store(valb, d, row_b + x);
-    }
+}
+
+void DeallocateHFAndUHF(ImageF* hf, ImageF* uhf) {
+  for (int i = 0; i < 2; ++i) {
+    hf[i] = ImageF();
+    uhf[i] = ImageF();
   }
+}
+
+static void SeparateFrequencies(size_t xsize, size_t ysize,
+                                const ButteraugliParams& params,
+                                BlurTemp* blur_temp, const Image3F& xyb,
+                                PsychoImage& ps) {
+  ps.lf = Image3F(xyb.xsize(), xyb.ysize());
+  ps.mf = Image3F(xyb.xsize(), xyb.ysize());
+  SeparateLFAndMF(params, xyb, &ps.lf, &ps.mf, blur_temp);
+  SeparateMFAndHF(params, &ps.mf, &ps.hf[0], blur_temp);
+  SeparateHFAndUHF(params, &ps.hf[0], &ps.uhf[0], blur_temp);
 }
 
 namespace {
@@ -921,7 +963,7 @@ static void MaltaDiffMapT(const Tag tag, const ImageF& lum0, const ImageF& lum1,
                           const double w_0gt1, const double w_0lt1,
                           const double norm1, const double len,
                           const double mulli, ImageF* HWY_RESTRICT diffs,
-                          Image3F* HWY_RESTRICT block_diff_ac, size_t c) {
+                          ImageF* HWY_RESTRICT block_diff_ac) {
   JXL_DASSERT(SameSize(lum0, lum1) && SameSize(lum0, *diffs));
   const size_t xsize_ = lum0.xsize();
   const size_t ysize_ = lum0.ysize();
@@ -976,7 +1018,7 @@ static void MaltaDiffMapT(const Tag tag, const ImageF& lum0, const ImageF& lum1,
   size_t y0 = 0;
   // Top
   for (; y0 < 4; ++y0) {
-    float* BUTTERAUGLI_RESTRICT row_diff = block_diff_ac->PlaneRow(c, y0);
+    float* BUTTERAUGLI_RESTRICT row_diff = block_diff_ac->Row(y0);
     for (size_t x0 = 0; x0 < xsize_; ++x0) {
       row_diff[x0] += PaddedMaltaUnit<Tag>(*diffs, x0, y0);
     }
@@ -989,7 +1031,7 @@ static void MaltaDiffMapT(const Tag tag, const ImageF& lum0, const ImageF& lum1,
   // Middle
   for (; y0 < ysize_ - 4; ++y0) {
     const float* BUTTERAUGLI_RESTRICT row_in = diffs->ConstRow(y0);
-    float* BUTTERAUGLI_RESTRICT row_diff = block_diff_ac->PlaneRow(c, y0);
+    float* BUTTERAUGLI_RESTRICT row_diff = block_diff_ac->Row(y0);
     size_t x0 = 0;
     for (; x0 < aligned_x; ++x0) {
       row_diff[x0] += PaddedMaltaUnit<Tag>(*diffs, x0, y0);
@@ -1007,7 +1049,7 @@ static void MaltaDiffMapT(const Tag tag, const ImageF& lum0, const ImageF& lum1,
 
   // Bottom
   for (; y0 < ysize_; ++y0) {
-    float* BUTTERAUGLI_RESTRICT row_diff = block_diff_ac->PlaneRow(c, y0);
+    float* BUTTERAUGLI_RESTRICT row_diff = block_diff_ac->Row(y0);
     for (size_t x0 = 0; x0 < xsize_; ++x0) {
       row_diff[x0] += PaddedMaltaUnit<Tag>(*diffs, x0, y0);
     }
@@ -1016,19 +1058,49 @@ static void MaltaDiffMapT(const Tag tag, const ImageF& lum0, const ImageF& lum1,
 
 // Need non-template wrapper functions for HWY_EXPORT.
 void MaltaDiffMap(const ImageF& lum0, const ImageF& lum1, const double w_0gt1,
-                  const double w_0lt1, const double norm1, const double len,
-                  const double mulli, ImageF* HWY_RESTRICT diffs,
-                  Image3F* HWY_RESTRICT block_diff_ac, size_t c) {
+                  const double w_0lt1, const double norm1,
+                  ImageF* HWY_RESTRICT diffs,
+                  ImageF* HWY_RESTRICT block_diff_ac) {
+  const double len = 3.75;
+  static const double mulli = 0.39905817637;
   MaltaDiffMapT(MaltaTag(), lum0, lum1, w_0gt1, w_0lt1, norm1, len, mulli,
-                diffs, block_diff_ac, c);
+                diffs, block_diff_ac);
 }
 
 void MaltaDiffMapLF(const ImageF& lum0, const ImageF& lum1, const double w_0gt1,
-                    const double w_0lt1, const double norm1, const double len,
-                    const double mulli, ImageF* HWY_RESTRICT diffs,
-                    Image3F* HWY_RESTRICT block_diff_ac, size_t c) {
+                    const double w_0lt1, const double norm1,
+                    ImageF* HWY_RESTRICT diffs,
+                    ImageF* HWY_RESTRICT block_diff_ac) {
+  const double len = 3.75;
+  static const double mulli = 0.611612573796;
   MaltaDiffMapT(MaltaTagLF(), lum0, lum1, w_0gt1, w_0lt1, norm1, len, mulli,
-                diffs, block_diff_ac, c);
+                diffs, block_diff_ac);
+}
+
+void CombineChannelsForMasking(const ImageF* hf, const ImageF* uhf,
+                               ImageF* out) {
+  // Only X and Y components are involved in masking. B's influence
+  // is considered less important in the high frequency area, and we
+  // don't model masking from lower frequency signals.
+  static const float muls[3] = {
+      2.5f,
+      0.4f,
+      0.4f,
+  };
+  // Silly and unoptimized approach here. TODO(jyrki): rework this.
+  for (size_t y = 0; y < hf[0].ysize(); ++y) {
+    const float* BUTTERAUGLI_RESTRICT row_y_hf = hf[1].Row(y);
+    const float* BUTTERAUGLI_RESTRICT row_y_uhf = uhf[1].Row(y);
+    const float* BUTTERAUGLI_RESTRICT row_x_hf = hf[0].Row(y);
+    const float* BUTTERAUGLI_RESTRICT row_x_uhf = uhf[0].Row(y);
+    float* BUTTERAUGLI_RESTRICT row = out->Row(y);
+    for (size_t x = 0; x < hf[0].xsize(); ++x) {
+      float xdiff = (row_x_uhf[x] + row_x_hf[x]) * muls[0];
+      float ydiff = row_y_uhf[x] * muls[1] + row_y_hf[x] * muls[2];
+      row[x] = xdiff * xdiff + ydiff * ydiff;
+      row[x] = sqrt(row[x]);
+    }
+  }
 }
 
 void DiffPrecompute(const ImageF& xyb, float mul, float bias_arg, ImageF* out) {
@@ -1121,9 +1193,6 @@ void Mask(const ImageF& mask0, const ImageF& mask1,
           const ButteraugliParams& params, BlurTemp* blur_temp,
           ImageF* BUTTERAUGLI_RESTRICT mask,
           ImageF* BUTTERAUGLI_RESTRICT diff_ac) {
-  // Only X and Y components are involved in masking. B's influence
-  // is considered less important in the high frequency area, and we
-  // don't model masking from lower frequency signals.
   const size_t xsize = mask0.xsize();
   const size_t ysize = mask0.ysize();
   *mask = ImageF(xsize, ysize);
@@ -1139,7 +1208,6 @@ void Mask(const ImageF& mask0, const ImageF& mask1,
   Blur(diff0, kRadius, params, blur_temp, &blurred0);
   FuzzyErosion(blurred0, &diff0);
   Blur(diff1, kRadius, params, blur_temp, &blurred1);
-  FuzzyErosion(blurred1, &diff1);
   for (size_t y = 0; y < ysize; ++y) {
     for (size_t x = 0; x < xsize; ++x) {
       mask->Row(y)[x] = diff0.Row(y)[x];
@@ -1155,39 +1223,13 @@ void Mask(const ImageF& mask0, const ImageF& mask1,
 // `diff_ac` may be null.
 void MaskPsychoImage(const PsychoImage& pi0, const PsychoImage& pi1,
                      const size_t xsize, const size_t ysize,
-                     const ButteraugliParams& params, Image3F* temp,
-                     BlurTemp* blur_temp, ImageF* BUTTERAUGLI_RESTRICT mask,
+                     const ButteraugliParams& params, BlurTemp* blur_temp,
+                     ImageF* BUTTERAUGLI_RESTRICT mask,
                      ImageF* BUTTERAUGLI_RESTRICT diff_ac) {
   ImageF mask0(xsize, ysize);
   ImageF mask1(xsize, ysize);
-  static const float muls[3] = {
-      2.5f,
-      0.4f,
-      0.4f,
-  };
-  // Silly and unoptimized approach here. TODO(jyrki): rework this.
-  for (size_t y = 0; y < ysize; ++y) {
-    const float* BUTTERAUGLI_RESTRICT row_y_hf0 = pi0.hf[1].Row(y);
-    const float* BUTTERAUGLI_RESTRICT row_y_hf1 = pi1.hf[1].Row(y);
-    const float* BUTTERAUGLI_RESTRICT row_y_uhf0 = pi0.uhf[1].Row(y);
-    const float* BUTTERAUGLI_RESTRICT row_y_uhf1 = pi1.uhf[1].Row(y);
-    const float* BUTTERAUGLI_RESTRICT row_x_hf0 = pi0.hf[0].Row(y);
-    const float* BUTTERAUGLI_RESTRICT row_x_hf1 = pi1.hf[0].Row(y);
-    const float* BUTTERAUGLI_RESTRICT row_x_uhf0 = pi0.uhf[0].Row(y);
-    const float* BUTTERAUGLI_RESTRICT row_x_uhf1 = pi1.uhf[0].Row(y);
-    float* BUTTERAUGLI_RESTRICT row0 = mask0.Row(y);
-    float* BUTTERAUGLI_RESTRICT row1 = mask1.Row(y);
-    for (size_t x = 0; x < xsize; ++x) {
-      float xdiff0 = (row_x_uhf0[x] + row_x_hf0[x]) * muls[0];
-      float xdiff1 = (row_x_uhf1[x] + row_x_hf1[x]) * muls[0];
-      float ydiff0 = row_y_uhf0[x] * muls[1] + row_y_hf0[x] * muls[2];
-      float ydiff1 = row_y_uhf1[x] * muls[1] + row_y_hf1[x] * muls[2];
-      row0[x] = xdiff0 * xdiff0 + ydiff0 * ydiff0;
-      row0[x] = sqrt(row0[x]);
-      row1[x] = xdiff1 * xdiff1 + ydiff1 * ydiff1;
-      row1[x] = sqrt(row1[x]);
-    }
-  }
+  CombineChannelsForMasking(&pi0.hf[0], &pi0.uhf[0], &mask0);
+  CombineChannelsForMasking(&pi1.hf[0], &pi1.uhf[0], &mask1);
   Mask(mask0, mask1, params, blur_temp, mask, diff_ac);
 }
 
@@ -1242,7 +1284,7 @@ void CombineChannelsToDiffmap(const ImageF& mask, const Image3F& block_diff_dc,
 
 // Adds weighted L2 difference between i0 and i1 to diffmap.
 static void L2Diff(const ImageF& i0, const ImageF& i1, const float w,
-                   Image3F* BUTTERAUGLI_RESTRICT diffmap, size_t c) {
+                   ImageF* BUTTERAUGLI_RESTRICT diffmap) {
   if (w == 0) return;
 
   const HWY_FULL(float) d;
@@ -1251,7 +1293,7 @@ static void L2Diff(const ImageF& i0, const ImageF& i1, const float w,
   for (size_t y = 0; y < i0.ysize(); ++y) {
     const float* BUTTERAUGLI_RESTRICT row0 = i0.ConstRow(y);
     const float* BUTTERAUGLI_RESTRICT row1 = i1.ConstRow(y);
-    float* BUTTERAUGLI_RESTRICT row_diff = diffmap->PlaneRow(c, y);
+    float* BUTTERAUGLI_RESTRICT row_diff = diffmap->Row(y);
 
     for (size_t x = 0; x < i0.xsize(); x += Lanes(d)) {
       const auto diff = Sub(Load(d, row0 + x), Load(d, row1 + x));
@@ -1264,7 +1306,7 @@ static void L2Diff(const ImageF& i0, const ImageF& i1, const float w,
 
 // Initializes diffmap to the weighted L2 difference between i0 and i1.
 static void SetL2Diff(const ImageF& i0, const ImageF& i1, const float w,
-                      Image3F* BUTTERAUGLI_RESTRICT diffmap, size_t c) {
+                      ImageF* BUTTERAUGLI_RESTRICT diffmap) {
   if (w == 0) return;
 
   const HWY_FULL(float) d;
@@ -1273,7 +1315,7 @@ static void SetL2Diff(const ImageF& i0, const ImageF& i1, const float w,
   for (size_t y = 0; y < i0.ysize(); ++y) {
     const float* BUTTERAUGLI_RESTRICT row0 = i0.ConstRow(y);
     const float* BUTTERAUGLI_RESTRICT row1 = i1.ConstRow(y);
-    float* BUTTERAUGLI_RESTRICT row_diff = diffmap->PlaneRow(c, y);
+    float* BUTTERAUGLI_RESTRICT row_diff = diffmap->Row(y);
 
     for (size_t x = 0; x < i0.xsize(); x += Lanes(d)) {
       const auto diff = Sub(Load(d, row0 + x), Load(d, row1 + x));
@@ -1287,7 +1329,7 @@ static void SetL2Diff(const ImageF& i0, const ImageF& i1, const float w,
 // i1 is the deformed copy.
 static void L2DiffAsymmetric(const ImageF& i0, const ImageF& i1, float w_0gt1,
                              float w_0lt1,
-                             Image3F* BUTTERAUGLI_RESTRICT diffmap, size_t c) {
+                             ImageF* BUTTERAUGLI_RESTRICT diffmap) {
   if (w_0gt1 == 0 && w_0lt1 == 0) {
     return;
   }
@@ -1299,7 +1341,7 @@ static void L2DiffAsymmetric(const ImageF& i0, const ImageF& i1, float w_0gt1,
   for (size_t y = 0; y < i0.ysize(); ++y) {
     const float* BUTTERAUGLI_RESTRICT row0 = i0.Row(y);
     const float* BUTTERAUGLI_RESTRICT row1 = i1.Row(y);
-    float* BUTTERAUGLI_RESTRICT row_diff = diffmap->PlaneRow(c, y);
+    float* BUTTERAUGLI_RESTRICT row_diff = diffmap->Row(y);
 
     for (size_t x = 0; x < i0.xsize(); x += Lanes(d)) {
       const auto val0 = Load(d, row0 + x);
@@ -1389,9 +1431,8 @@ BUTTERAUGLI_INLINE void OpsinAbsorbance(const DF df, const V& in0, const V& in1,
 }
 
 // `blurred` is a temporary image used inside this function and not returned.
-Image3F OpsinDynamicsImage(const Image3F& rgb, const ButteraugliParams& params,
-                           Image3F* blurred, BlurTemp* blur_temp) {
-  Image3F xyb(rgb.xsize(), rgb.ysize());
+void OpsinDynamicsImage(const Image3F& rgb, const ButteraugliParams& params,
+                        Image3F* blurred, BlurTemp* blur_temp, Image3F* xyb) {
   const double kSigma = 1.2;
   Blur(rgb.Plane(0), kSigma, params, blur_temp, &blurred->Plane(0));
   Blur(rgb.Plane(1), kSigma, params, blur_temp, &blurred->Plane(1));
@@ -1399,18 +1440,15 @@ Image3F OpsinDynamicsImage(const Image3F& rgb, const ButteraugliParams& params,
   const HWY_FULL(float) df;
   const auto intensity_target_multiplier = Set(df, params.intensity_target);
   for (size_t y = 0; y < rgb.ysize(); ++y) {
-    const float* BUTTERAUGLI_RESTRICT row_r = rgb.ConstPlaneRow(0, y);
-    const float* BUTTERAUGLI_RESTRICT row_g = rgb.ConstPlaneRow(1, y);
-    const float* BUTTERAUGLI_RESTRICT row_b = rgb.ConstPlaneRow(2, y);
-    const float* BUTTERAUGLI_RESTRICT row_blurred_r =
-        blurred->ConstPlaneRow(0, y);
-    const float* BUTTERAUGLI_RESTRICT row_blurred_g =
-        blurred->ConstPlaneRow(1, y);
-    const float* BUTTERAUGLI_RESTRICT row_blurred_b =
-        blurred->ConstPlaneRow(2, y);
-    float* BUTTERAUGLI_RESTRICT row_out_x = xyb.PlaneRow(0, y);
-    float* BUTTERAUGLI_RESTRICT row_out_y = xyb.PlaneRow(1, y);
-    float* BUTTERAUGLI_RESTRICT row_out_b = xyb.PlaneRow(2, y);
+    const float* row_r = rgb.ConstPlaneRow(0, y);
+    const float* row_g = rgb.ConstPlaneRow(1, y);
+    const float* row_b = rgb.ConstPlaneRow(2, y);
+    const float* row_blurred_r = blurred->ConstPlaneRow(0, y);
+    const float* row_blurred_g = blurred->ConstPlaneRow(1, y);
+    const float* row_blurred_b = blurred->ConstPlaneRow(2, y);
+    float* row_out_x = xyb->PlaneRow(0, y);
+    float* row_out_y = xyb->PlaneRow(1, y);
+    float* row_out_b = xyb->PlaneRow(2, y);
     const auto min = Set(df, 1e-4f);
     for (size_t x = 0; x < rgb.xsize(); x += Lanes(df)) {
       auto sensitivity0 = Undefined(df);
@@ -1460,7 +1498,108 @@ Image3F OpsinDynamicsImage(const Image3F& rgb, const ButteraugliParams& params,
       Store(cur_mixed2, df, row_out_b + x);
     }
   }
-  return xyb;
+}
+
+void ButteraugliDiffmapInPlace(Image3F& image0, Image3F& image1,
+                               const ButteraugliParams& params,
+                               ImageF& diffmap) {
+  // image0 and image1 are in linear sRGB color space
+  const size_t xsize = image0.xsize();
+  const size_t ysize = image0.ysize();
+  BlurTemp blur_temp;
+  {
+    // Convert image0 and image1 to XYB in-place
+    Image3F temp(xsize, ysize);
+    OpsinDynamicsImage(image0, params, &temp, &blur_temp, &image0);
+    OpsinDynamicsImage(image1, params, &temp, &blur_temp, &image1);
+  }
+  // image0 and image1 are in XYB color space
+  ImageF block_diff_dc(xsize, ysize);
+  ZeroFillImage(&block_diff_dc);
+  {
+    // separate out LF components from image0 and image1 and compute the dc
+    // diff image from them
+    Image3F lf0 = Image3F(xsize, ysize);
+    Image3F lf1 = Image3F(xsize, ysize);
+    SeparateLFAndMF(params, image0, &lf0, &image0, &blur_temp);
+    SeparateLFAndMF(params, image1, &lf1, &image1, &blur_temp);
+    for (size_t c = 0; c < 3; ++c) {
+      L2Diff(lf0.Plane(c), lf1.Plane(c), wmul[6 + c], &block_diff_dc);
+    }
+  }
+  // image0 and image1 are MF residuals (before blurring) in XYB color space
+  ImageF hf0[2];
+  ImageF hf1[2];
+  SeparateMFAndHF(params, &image0, &hf0[0], &blur_temp);
+  SeparateMFAndHF(params, &image1, &hf1[0], &blur_temp);
+  // image0 and image1 are MF-images in XYB color space
+
+  ImageF block_diff_ac(xsize, ysize);
+  ZeroFillImage(&block_diff_ac);
+  // start accumulating ac diff image from MF images
+  {
+    ImageF diffs(xsize, ysize);
+    MaltaDiffMapLF(image0.Plane(1), image1.Plane(1), wMfMalta, wMfMalta,
+                   norm1Mf, &diffs, &block_diff_ac);
+    MaltaDiffMapLF(image0.Plane(0), image1.Plane(0), wMfMaltaX, wMfMaltaX,
+                   norm1MfX, &diffs, &block_diff_ac);
+  }
+  for (size_t c = 0; c < 3; ++c) {
+    L2Diff(image0.Plane(c), image1.Plane(c), wmul[3 + c], &block_diff_ac);
+  }
+  // we will not need the MF-images and more, so we deallocate them to reduce
+  // peak memory usage
+  image0 = Image3F();
+  image1 = Image3F();
+
+  ImageF uhf0[2];
+  ImageF uhf1[2];
+  SeparateHFAndUHF(params, &hf0[0], &uhf0[0], &blur_temp);
+  SeparateHFAndUHF(params, &hf1[0], &uhf1[0], &blur_temp);
+
+  // continue accumulating ac diff image from HF and UHF images
+  const float hf_asymmetry = params.hf_asymmetry;
+  {
+    ImageF diffs(xsize, ysize);
+    MaltaDiffMap(uhf0[1], uhf1[1], wUhfMalta * hf_asymmetry,
+                 wUhfMalta / hf_asymmetry, norm1Uhf, &diffs, &block_diff_ac);
+    MaltaDiffMap(uhf0[0], uhf1[0], wUhfMaltaX * hf_asymmetry,
+                 wUhfMaltaX / hf_asymmetry, norm1UhfX, &diffs, &block_diff_ac);
+    MaltaDiffMapLF(hf0[1], hf1[1], wHfMalta * std::sqrt(hf_asymmetry),
+                   wHfMalta / std::sqrt(hf_asymmetry), norm1Hf, &diffs,
+                   &block_diff_ac);
+    MaltaDiffMapLF(hf0[0], hf1[0], wHfMaltaX * std::sqrt(hf_asymmetry),
+                   wHfMaltaX / std::sqrt(hf_asymmetry), norm1HfX, &diffs,
+                   &block_diff_ac);
+  }
+  for (size_t c = 0; c < 2; ++c) {
+    L2DiffAsymmetric(hf0[c], hf1[c], wmul[c] * hf_asymmetry,
+                     wmul[c] / hf_asymmetry, &block_diff_ac);
+  }
+
+  // compute mask image from HF and UHF X and Y images
+  ImageF mask(xsize, ysize);
+  {
+    ImageF mask0(xsize, ysize);
+    ImageF mask1(xsize, ysize);
+    CombineChannelsForMasking(&hf0[0], &uhf0[0], &mask0);
+    CombineChannelsForMasking(&hf1[0], &uhf1[0], &mask1);
+    DeallocateHFAndUHF(&hf1[0], &uhf1[0]);
+    DeallocateHFAndUHF(&hf0[0], &uhf0[0]);
+    Mask(mask0, mask1, params, &blur_temp, &mask, &block_diff_ac);
+  }
+
+  // compute final diffmap from mask image and ac and dc diff images
+  diffmap = ImageF(xsize, ysize);
+  for (size_t y = 0; y < ysize; ++y) {
+    const float* row_dc = block_diff_dc.Row(y);
+    const float* row_ac = block_diff_ac.Row(y);
+    float* row_out = diffmap.Row(y);
+    for (size_t x = 0; x < xsize; ++x) {
+      const float val = mask.Row(y)[x];
+      row_out[x] = sqrt(row_dc[x] * MaskDcY(val) + row_ac[x] * MaskY(val));
+    }
+  }
 }
 
 // NOLINTNEXTLINE(google-readability-namespace-comments)
@@ -1480,6 +1619,7 @@ HWY_EXPORT(CombineChannelsToDiffmap);  // Local function.
 HWY_EXPORT(MaltaDiffMap);              // Local function.
 HWY_EXPORT(MaltaDiffMapLF);            // Local function.
 HWY_EXPORT(OpsinDynamicsImage);        // Local function.
+HWY_EXPORT(ButteraugliDiffmapInPlace);  // Local function.
 
 #if BUTTERAUGLI_ENABLE_CHECKS
 
@@ -1595,8 +1735,9 @@ ButteraugliComparator::ButteraugliComparator(const Image3F& rgb0,
     return;
   }
 
-  Image3F xyb0 = HWY_DYNAMIC_DISPATCH(OpsinDynamicsImage)(rgb0, params, Temp(),
-                                                          &blur_temp_);
+  Image3F xyb0(xsize_, ysize_);
+  HWY_DYNAMIC_DISPATCH(OpsinDynamicsImage)
+  (rgb0, params, Temp(), &blur_temp_, &xyb0);
   ReleaseTemp();
   HWY_DYNAMIC_DISPATCH(SeparateFrequencies)
   (xsize_, ysize_, params_, &blur_temp_, xyb0, pi0_);
@@ -1609,8 +1750,7 @@ ButteraugliComparator::ButteraugliComparator(const Image3F& rgb0,
 
 void ButteraugliComparator::Mask(ImageF* BUTTERAUGLI_RESTRICT mask) const {
   HWY_DYNAMIC_DISPATCH(MaskPsychoImage)
-  (pi0_, pi0_, xsize_, ysize_, params_, Temp(), &blur_temp_, mask, nullptr);
-  ReleaseTemp();
+  (pi0_, pi0_, xsize_, ysize_, params_, &blur_temp_, mask, nullptr);
 }
 
 void ButteraugliComparator::Diffmap(const Image3F& rgb1, ImageF& result) const {
@@ -1618,16 +1758,18 @@ void ButteraugliComparator::Diffmap(const Image3F& rgb1, ImageF& result) const {
     ZeroFillImage(&result);
     return;
   }
-  const Image3F xyb1 = HWY_DYNAMIC_DISPATCH(OpsinDynamicsImage)(
-      rgb1, params_, Temp(), &blur_temp_);
+  Image3F xyb1(xsize_, ysize_);
+  HWY_DYNAMIC_DISPATCH(OpsinDynamicsImage)
+  (rgb1, params_, Temp(), &blur_temp_, &xyb1);
   ReleaseTemp();
   DiffmapOpsinDynamicsImage(xyb1, result);
   if (sub_) {
     if (sub_->xsize_ < 8 || sub_->ysize_ < 8) {
       return;
     }
-    const Image3F sub_xyb = HWY_DYNAMIC_DISPATCH(OpsinDynamicsImage)(
-        SubSample2x(rgb1), params_, sub_->Temp(), &sub_->blur_temp_);
+    Image3F sub_xyb(sub_->xsize_, sub_->ysize_);
+    HWY_DYNAMIC_DISPATCH(OpsinDynamicsImage)
+    (SubSample2x(rgb1), params_, sub_->Temp(), &sub_->blur_temp_, &sub_xyb);
     sub_->ReleaseTemp();
     ImageF subresult;
     sub_->DiffmapOpsinDynamicsImage(sub_xyb, subresult);
@@ -1654,20 +1796,16 @@ void MaltaDiffMap(const ImageF& lum0, const ImageF& lum1, const double w_0gt1,
                   const double w_0lt1, const double norm1,
                   ImageF* HWY_RESTRICT diffs,
                   Image3F* HWY_RESTRICT block_diff_ac, size_t c) {
-  const double len = 3.75;
-  static const double mulli = 0.39905817637;
   HWY_DYNAMIC_DISPATCH(MaltaDiffMap)
-  (lum0, lum1, w_0gt1, w_0lt1, norm1, len, mulli, diffs, block_diff_ac, c);
+  (lum0, lum1, w_0gt1, w_0lt1, norm1, diffs, &block_diff_ac->Plane(c));
 }
 
 void MaltaDiffMapLF(const ImageF& lum0, const ImageF& lum1, const double w_0gt1,
                     const double w_0lt1, const double norm1,
                     ImageF* HWY_RESTRICT diffs,
                     Image3F* HWY_RESTRICT block_diff_ac, size_t c) {
-  const double len = 3.75;
-  static const double mulli = 0.611612573796;
   HWY_DYNAMIC_DISPATCH(MaltaDiffMapLF)
-  (lum0, lum1, w_0gt1, w_0lt1, norm1, len, mulli, diffs, block_diff_ac, c);
+  (lum0, lum1, w_0gt1, w_0lt1, norm1, diffs, &block_diff_ac->Plane(c));
 }
 
 }  // namespace
@@ -1685,62 +1823,39 @@ void ButteraugliComparator::DiffmapPsychoImage(const PsychoImage& pi1,
   ImageF diffs(xsize_, ysize_);
   Image3F block_diff_ac(xsize_, ysize_);
   ZeroFillImage(&block_diff_ac);
-  static const double wUhfMalta = 1.10039032555;
-  static const double norm1Uhf = 71.7800275169;
   MaltaDiffMap(pi0_.uhf[1], pi1.uhf[1], wUhfMalta * hf_asymmetry_,
                wUhfMalta / hf_asymmetry_, norm1Uhf, &diffs, &block_diff_ac, 1);
-
-  static const double wUhfMaltaX = 173.5;
-  static const double norm1UhfX = 5.0;
   MaltaDiffMap(pi0_.uhf[0], pi1.uhf[0], wUhfMaltaX * hf_asymmetry_,
                wUhfMaltaX / hf_asymmetry_, norm1UhfX, &diffs, &block_diff_ac,
                0);
-
-  static const double wHfMalta = 18.7237414387;
-  static const double norm1Hf = 4498534.45232;
   MaltaDiffMapLF(pi0_.hf[1], pi1.hf[1], wHfMalta * std::sqrt(hf_asymmetry_),
                  wHfMalta / std::sqrt(hf_asymmetry_), norm1Hf, &diffs,
                  &block_diff_ac, 1);
-
-  static const double wHfMaltaX = 6923.99476109;
-  static const double norm1HfX = 8051.15833247;
   MaltaDiffMapLF(pi0_.hf[0], pi1.hf[0], wHfMaltaX * std::sqrt(hf_asymmetry_),
                  wHfMaltaX / std::sqrt(hf_asymmetry_), norm1HfX, &diffs,
                  &block_diff_ac, 0);
-
-  static const double wMfMalta = 37.0819870399;
-  static const double norm1Mf = 130262059.556;
   MaltaDiffMapLF(pi0_.mf.Plane(1), pi1.mf.Plane(1), wMfMalta, wMfMalta, norm1Mf,
                  &diffs, &block_diff_ac, 1);
-
-  static const double wMfMaltaX = 8246.75321353;
-  static const double norm1MfX = 1009002.70582;
   MaltaDiffMapLF(pi0_.mf.Plane(0), pi1.mf.Plane(0), wMfMaltaX, wMfMaltaX,
                  norm1MfX, &diffs, &block_diff_ac, 0);
 
-  static const double wmul[9] = {
-      400.0,         1.50815703118,  0,
-      2150.0,        10.6195433239,  16.2176043152,
-      29.2353797994, 0.844626970982, 0.703646627719,
-  };
   Image3F block_diff_dc(xsize_, ysize_);
   for (size_t c = 0; c < 3; ++c) {
     if (c < 2) {  // No blue channel error accumulated at HF.
       HWY_DYNAMIC_DISPATCH(L2DiffAsymmetric)
       (pi0_.hf[c], pi1.hf[c], wmul[c] * hf_asymmetry_, wmul[c] / hf_asymmetry_,
-       &block_diff_ac, c);
+       &block_diff_ac.Plane(c));
     }
     HWY_DYNAMIC_DISPATCH(L2Diff)
-    (pi0_.mf.Plane(c), pi1.mf.Plane(c), wmul[3 + c], &block_diff_ac, c);
+    (pi0_.mf.Plane(c), pi1.mf.Plane(c), wmul[3 + c], &block_diff_ac.Plane(c));
     HWY_DYNAMIC_DISPATCH(SetL2Diff)
-    (pi0_.lf.Plane(c), pi1.lf.Plane(c), wmul[6 + c], &block_diff_dc, c);
+    (pi0_.lf.Plane(c), pi1.lf.Plane(c), wmul[6 + c], &block_diff_dc.Plane(c));
   }
 
   ImageF mask;
   HWY_DYNAMIC_DISPATCH(MaskPsychoImage)
-  (pi0_, pi1, xsize_, ysize_, params_, Temp(), &blur_temp_, &mask,
+  (pi0_, pi1, xsize_, ysize_, params_, &blur_temp_, &mask,
    &block_diff_ac.Plane(1));
-  ReleaseTemp();
 
   HWY_DYNAMIC_DISPATCH(CombineChannelsToDiffmap)
   (mask, block_diff_dc, block_diff_ac, xmul_, &diffmap);
@@ -1766,6 +1881,42 @@ bool ButteraugliDiffmap(const Image3F& rgb0, const Image3F& rgb1,
   return ButteraugliDiffmap(rgb0, rgb1, params, diffmap);
 }
 
+template <size_t kMax>
+bool ButteraugliDiffmapSmall(const Image3F& rgb0, const Image3F& rgb1,
+                             const ButteraugliParams& params, ImageF& diffmap) {
+  const size_t xsize = rgb0.xsize();
+  const size_t ysize = rgb0.ysize();
+  // Butteraugli values for small (where xsize or ysize is smaller
+  // than 8 pixels) images are non-sensical, but most likely it is
+  // less disruptive to try to compute something than just give up.
+  // Temporarily extend the borders of the image to fit 8 x 8 size.
+  size_t xborder = xsize < kMax ? (kMax - xsize) / 2 : 0;
+  size_t yborder = ysize < kMax ? (kMax - ysize) / 2 : 0;
+  size_t xscaled = std::max<size_t>(kMax, xsize);
+  size_t yscaled = std::max<size_t>(kMax, ysize);
+  Image3F scaled0(xscaled, yscaled);
+  Image3F scaled1(xscaled, yscaled);
+  for (int i = 0; i < 3; ++i) {
+    for (size_t y = 0; y < yscaled; ++y) {
+      for (size_t x = 0; x < xscaled; ++x) {
+        size_t x2 = std::min<size_t>(xsize - 1, x > xborder ? x - xborder : 0);
+        size_t y2 = std::min<size_t>(ysize - 1, y > yborder ? y - yborder : 0);
+        scaled0.PlaneRow(i, y)[x] = rgb0.PlaneRow(i, y2)[x2];
+        scaled1.PlaneRow(i, y)[x] = rgb1.PlaneRow(i, y2)[x2];
+      }
+    }
+  }
+  ImageF diffmap_scaled;
+  const bool ok = ButteraugliDiffmap(scaled0, scaled1, params, diffmap_scaled);
+  diffmap = ImageF(xsize, ysize);
+  for (size_t y = 0; y < ysize; ++y) {
+    for (size_t x = 0; x < xsize; ++x) {
+      diffmap.Row(y)[x] = diffmap_scaled.Row(y + yborder)[x + xborder];
+    }
+  }
+  return ok;
+}
+
 bool ButteraugliDiffmap(const Image3F& rgb0, const Image3F& rgb1,
                         const ButteraugliParams& params, ImageF& diffmap) {
   const size_t xsize = rgb0.xsize();
@@ -1778,38 +1929,7 @@ bool ButteraugliDiffmap(const Image3F& rgb0, const Image3F& rgb1,
   }
   static const int kMax = 8;
   if (xsize < kMax || ysize < kMax) {
-    // Butteraugli values for small (where xsize or ysize is smaller
-    // than 8 pixels) images are non-sensical, but most likely it is
-    // less disruptive to try to compute something than just give up.
-    // Temporarily extend the borders of the image to fit 8 x 8 size.
-    size_t xborder = xsize < kMax ? (kMax - xsize) / 2 : 0;
-    size_t yborder = ysize < kMax ? (kMax - ysize) / 2 : 0;
-    size_t xscaled = std::max<size_t>(kMax, xsize);
-    size_t yscaled = std::max<size_t>(kMax, ysize);
-    Image3F scaled0(xscaled, yscaled);
-    Image3F scaled1(xscaled, yscaled);
-    for (int i = 0; i < 3; ++i) {
-      for (size_t y = 0; y < yscaled; ++y) {
-        for (size_t x = 0; x < xscaled; ++x) {
-          size_t x2 =
-              std::min<size_t>(xsize - 1, x > xborder ? x - xborder : 0);
-          size_t y2 =
-              std::min<size_t>(ysize - 1, y > yborder ? y - yborder : 0);
-          scaled0.PlaneRow(i, y)[x] = rgb0.PlaneRow(i, y2)[x2];
-          scaled1.PlaneRow(i, y)[x] = rgb1.PlaneRow(i, y2)[x2];
-        }
-      }
-    }
-    ImageF diffmap_scaled;
-    const bool ok =
-        ButteraugliDiffmap(scaled0, scaled1, params, diffmap_scaled);
-    diffmap = ImageF(xsize, ysize);
-    for (size_t y = 0; y < ysize; ++y) {
-      for (size_t x = 0; x < xsize; ++x) {
-        diffmap.Row(y)[x] = diffmap_scaled.Row(y + yborder)[x + xborder];
-      }
-    }
-    return ok;
+    return ButteraugliDiffmapSmall<kMax>(rgb0, rgb1, params, diffmap);
   }
   ButteraugliComparator butteraugli(rgb0, params);
   butteraugli.Diffmap(rgb1, diffmap);
@@ -1830,6 +1950,38 @@ bool ButteraugliInterface(const Image3F& rgb0, const Image3F& rgb1,
                           double& diffvalue) {
   if (!ButteraugliDiffmap(rgb0, rgb1, params, diffmap)) {
     return false;
+  }
+  diffvalue = ButteraugliScoreFromDiffmap(diffmap, &params);
+  return true;
+}
+
+bool ButteraugliInterfaceInPlace(Image3F&& rgb0, Image3F&& rgb1,
+                                 const ButteraugliParams& params,
+                                 ImageF& diffmap, double& diffvalue) {
+  const size_t xsize = rgb0.xsize();
+  const size_t ysize = rgb0.ysize();
+  if (xsize < 1 || ysize < 1) {
+    return JXL_FAILURE("Zero-sized image");
+  }
+  if (!SameSize(rgb0, rgb1)) {
+    return JXL_FAILURE("Size mismatch");
+  }
+  static const int kMax = 8;
+  if (xsize < kMax || ysize < kMax) {
+    bool ok = ButteraugliDiffmapSmall<kMax>(rgb0, rgb1, params, diffmap);
+    diffvalue = ButteraugliScoreFromDiffmap(diffmap, &params);
+    return ok;
+  }
+  ImageF subdiffmap;
+  if (xsize >= 15 && ysize >= 15) {
+    Image3F rgb0_sub = SubSample2x(rgb0);
+    Image3F rgb1_sub = SubSample2x(rgb1);
+    HWY_DYNAMIC_DISPATCH(ButteraugliDiffmapInPlace)
+    (rgb0_sub, rgb1_sub, params, subdiffmap);
+  }
+  HWY_DYNAMIC_DISPATCH(ButteraugliDiffmapInPlace)(rgb0, rgb1, params, diffmap);
+  if (xsize >= 15 && ysize >= 15) {
+    AddSupersampled2x(subdiffmap, 0.5, diffmap);
   }
   diffvalue = ButteraugliScoreFromDiffmap(diffmap, &params);
   return true;

--- a/lib/jxl/butteraugli/butteraugli.h
+++ b/lib/jxl/butteraugli/butteraugli.h
@@ -85,6 +85,13 @@ bool ButteraugliInterface(const Image3F &rgb0, const Image3F &rgb1,
                           float hf_asymmetry, float xmul, ImageF &diffmap,
                           double &diffvalue);
 
+// Same as ButteraugliInterface, but reuses rgb0 and rgb1 for other purposes
+// inside the function after they are not needed any more, and it ignores
+// params.xmul.
+bool ButteraugliInterfaceInPlace(Image3F &&rgb0, Image3F &&rgb1,
+                                 const ButteraugliParams &params,
+                                 ImageF &diffmap, double &diffvalue);
+
 // Converts the butteraugli score into fuzzy class values that are continuous
 // at the class boundary. The class boundary location is based on human
 // raters, but the slope is arbitrary. Particularly, it does not reflect

--- a/lib/jxl/butteraugli/butteraugli_test.cc
+++ b/lib/jxl/butteraugli/butteraugli_test.cc
@@ -1,0 +1,107 @@
+// Copyright (c) the JPEG XL Project Authors. All rights reserved.
+//
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+#include "lib/jxl/butteraugli/butteraugli.h"
+
+#include "lib/extras/metrics.h"
+#include "lib/jxl/base/random.h"
+#include "lib/jxl/enc_external_image.h"
+#include "lib/jxl/test_image.h"
+#include "lib/jxl/testing.h"
+
+namespace jxl {
+namespace {
+
+using extras::PackedImage;
+using extras::PackedPixelFile;
+using test::TestImage;
+
+Image3F SinglePixelImage(float red, float green, float blue) {
+  Image3F img(1, 1);
+  img.PlaneRow(0, 0)[0] = red;
+  img.PlaneRow(1, 0)[0] = green;
+  img.PlaneRow(2, 0)[0] = blue;
+  return img;
+}
+
+Image3F GetColorImage(const PackedPixelFile& ppf) {
+  JXL_CHECK(!ppf.frames.empty());
+  const PackedImage& image = ppf.frames[0].color;
+  const JxlPixelFormat& format = image.format;
+  const uint8_t* pixels = reinterpret_cast<const uint8_t*>(image.pixels());
+  Image3F color(image.xsize, image.ysize);
+  for (size_t c = 0; c < format.num_channels; ++c) {
+    JXL_CHECK(
+        ConvertFromExternal(Span<const uint8_t>(pixels, image.pixels_size),
+                            image.xsize, image.ysize, ppf.info.bits_per_sample,
+                            format, c, nullptr, &color.Plane(c)));
+  }
+  return color;
+}
+
+void AddUniformNoise(Image3F* img, float d, size_t seed) {
+  Rng generator(seed);
+  for (size_t y = 0; y < img->ysize(); ++y) {
+    for (int c = 0; c < 3; ++c) {
+      for (size_t x = 0; x < img->xsize(); ++x) {
+        img->PlaneRow(c, y)[x] += generator.UniformF(-d, d);
+      }
+    }
+  }
+}
+
+void AddEdge(Image3F* img, float d, size_t x0, size_t y0) {
+  const size_t h = std::min<size_t>(img->ysize() - y0, 100);
+  const size_t w = std::min<size_t>(img->xsize() - x0, 5);
+  for (size_t dy = 0; dy < h; ++dy) {
+    for (size_t dx = 0; dx < w; ++dx) {
+      img->PlaneRow(1, y0 + dy)[x0 + dx] += d;
+    }
+  }
+}
+
+TEST(ButteraugliInPlaceTest, SinglePixel) {
+  Image3F rgb0 = SinglePixelImage(0.5f, 0.5f, 0.5f);
+  Image3F rgb1 = SinglePixelImage(0.5f, 0.49f, 0.5f);
+  ButteraugliParams ba;
+  ImageF diffmap;
+  double diffval;
+  EXPECT_TRUE(ButteraugliInterface(rgb0, rgb1, ba, diffmap, diffval));
+  EXPECT_NEAR(diffval, 2.5, 0.5);
+  ImageF diffmap2;
+  double diffval2;
+  EXPECT_TRUE(ButteraugliInterfaceInPlace(std::move(rgb0), std::move(rgb1), ba,
+                                          diffmap2, diffval2));
+  EXPECT_NEAR(diffval, diffval2, 1e-10);
+}
+
+TEST(ButteraugliInPlaceTest, LargeImage) {
+  const size_t xsize = 1024;
+  const size_t ysize = 1024;
+  TestImage img;
+  img.SetDimensions(xsize, ysize).AddFrame().RandomFill(777);
+  Image3F rgb0 = GetColorImage(img.ppf());
+  Image3F rgb1(xsize, ysize);
+  CopyImageTo(rgb0, &rgb1);
+  AddUniformNoise(&rgb1, 0.02f, 7777);
+  AddEdge(&rgb1, 0.1f, xsize / 2, xsize / 2);
+  ButteraugliParams ba;
+  ImageF diffmap;
+  double diffval;
+  EXPECT_TRUE(ButteraugliInterface(rgb0, rgb1, ba, diffmap, diffval));
+  double distp = ComputeDistanceP(diffmap, ba, 3.0);
+  EXPECT_NEAR(diffval, 4.0, 0.5);
+  EXPECT_NEAR(distp, 1.5, 0.5);
+  ImageF diffmap2;
+  double diffval2;
+  EXPECT_TRUE(ButteraugliInterfaceInPlace(std::move(rgb0), std::move(rgb1), ba,
+                                          diffmap2, diffval2));
+  double distp2 = ComputeDistanceP(diffmap2, ba, 3.0);
+  EXPECT_NEAR(diffval, diffval2, 1e-10);
+  EXPECT_NEAR(distp, distp2, 1e-8);
+}
+
+}  // namespace
+}  // namespace jxl

--- a/lib/jxl_lists.bzl
+++ b/lib/jxl_lists.bzl
@@ -584,6 +584,7 @@ libjxl_tests = [
     "jxl/bit_reader_test.cc",
     "jxl/bits_test.cc",
     "jxl/blending_test.cc",
+    "jxl/butteraugli/butteraugli_test.cc",
     "jxl/byte_order_test.cc",
     "jxl/coeff_order_test.cc",
     "jxl/color_encoding_internal_test.cc",

--- a/lib/jxl_lists.cmake
+++ b/lib/jxl_lists.cmake
@@ -576,6 +576,7 @@ set(JPEGXL_INTERNAL_TESTS
   jxl/bit_reader_test.cc
   jxl/bits_test.cc
   jxl/blending_test.cc
+  jxl/butteraugli/butteraugli_test.cc
   jxl/byte_order_test.cc
   jxl/coeff_order_test.cc
   jxl/color_encoding_internal_test.cc


### PR DESCRIPTION
The new in-place version can be used when the input images are not needed after the comparison and thus can be deallocated or reused within the butteraugli computation.

This version uses less than 1/3 of peak memory than the comparator-based one.
