### PR TITLE
add PAT for branch protection check

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -52,7 +52,7 @@ jobs:
           # you want to enable the Branch-Protection check on a *public* repository
           # To create the PAT, follow the steps in
           # https://github.com/ossf/scorecard-action#authentication-with-fine-grained-pat-optional
-          # repo_token: ${{ secrets.SCORECARD_TOKEN }}
+          repo_token: ${{ secrets.SCORECARD_TOKEN }}
 
           # - Publish results to OpenSSF REST API for easy access by consumers
           # - Allows the repository to include the Scorecard badge.


### PR DESCRIPTION
Added a fine-grained PAT so the scorecard action can check the branch protection settings.