### PR TITLE
fix e8+ VarDCT with noise enabled

### DIFF
--- a/lib/jxl/dec_cache.cc
+++ b/lib/jxl/dec_cache.cc
@@ -28,7 +28,7 @@ Status PassesDecoderState::PreparePipeline(ImageBundle* decoded,
                                            PipelineOptions options) {
   const FrameHeader& frame_header = shared->frame_header;
   size_t num_c = 3 + frame_header.nonserialized_metadata->m.num_extra_channels;
-  if ((frame_header.flags & FrameHeader::kNoise) != 0) {
+  if (options.render_noise && (frame_header.flags & FrameHeader::kNoise) != 0) {
     num_c += 3;
   }
 
@@ -110,8 +110,7 @@ Status PassesDecoderState::PreparePipeline(ImageBundle* decoded,
           CeilLog2Nonzero(frame_header.upsampling)));
     }
   }
-
-  if ((frame_header.flags & FrameHeader::kNoise) != 0) {
+  if (options.render_noise && (frame_header.flags & FrameHeader::kNoise) != 0) {
     builder.AddStage(GetConvolveNoiseStage(num_c - 3));
     builder.AddStage(GetAddNoiseStage(shared->image_features.noise_params,
                                       shared->cmap, num_c - 3));

--- a/lib/jxl/dec_cache.h
+++ b/lib/jxl/dec_cache.h
@@ -127,6 +127,7 @@ struct PassesDecoderState {
     bool use_slow_render_pipeline;
     bool coalescing;
     bool render_spotcolors;
+    bool render_noise;
   };
 
   Status PreparePipeline(ImageBundle* decoded, PipelineOptions options);

--- a/lib/jxl/dec_frame.cc
+++ b/lib/jxl/dec_frame.cc
@@ -645,6 +645,7 @@ Status FrameDecoder::ProcessSections(const SectionInfo* sections, size_t num,
     pipeline_options.use_slow_render_pipeline = use_slow_rendering_pipeline_;
     pipeline_options.coalescing = coalescing_;
     pipeline_options.render_spotcolors = render_spotcolors_;
+    pipeline_options.render_noise = true;
     JXL_RETURN_IF_ERROR(
         dec_state_->PreparePipeline(decoded_, pipeline_options));
     FinalizeDC();

--- a/lib/jxl/enc_adaptive_quantization.cc
+++ b/lib/jxl/enc_adaptive_quantization.cc
@@ -770,6 +770,7 @@ ImageBundle RoundtripImage(const Image3F& opsin, PassesEncoderState* enc_state,
   options.use_slow_render_pipeline = false;
   options.coalescing = false;
   options.render_spotcolors = false;
+  options.render_noise = false;
 
   // Same as dec_state->shared->frame_header.nonserialized_metadata->m
   const ImageMetadata& metadata = *decoded.metadata();


### PR DESCRIPTION
At effort >= 8 in VarDCT mode, i.e. when adaptive quantization iterations are being done, if noise is enabled then this causes trouble:

- noise generation is not properly initialized or something in this code path (decoding-while-encoding), causing nondeterministic results (!) and probably also wildly wrong noise (haven't checked but this is what I would expect)
- BA scores will be lower because of the noise (possibly wildly lower if the noise is wildly wrong), causing adaptive quantization to bump up the quality a lot (so the file size will be a lot larger with --noise=1 than with --noise=0)

This simply disables noise rendering when doing decoding-while-encoding, which makes the resulting main image data identical whether noise is enabled or not, the only difference being the signaling of noise or not — just like it is at lower effort settings too.