### PR TITLE
add some hardening compiler flags

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -369,6 +369,10 @@ else ()
 
     # Global warning settings.
     -Wall
+
+    # Hardening options
+    -D_FORTIFY_SOURCE=2
+    -fstack-protector-strong
   )
 
   if (JPEGXL_WARNINGS_AS_ERRORS)


### PR DESCRIPTION
Adds some compiler flags (as described on https://wiki.debian.org/Hardening) that are supposed to improve security without hurting performance.