### PR TITLE
back-and-forth dcts for ac strategy

### DIFF
--- a/lib/jxl/decode_test.cc
+++ b/lib/jxl/decode_test.cc
@@ -1668,11 +1668,7 @@ TEST(DecodeTest, PixelTestWithICCProfileLossy) {
   EXPECT_THAT(
       ButteraugliDistance(io0.frames, io1.frames, ba, *JxlGetDefaultCms(),
                           /*distmap=*/nullptr, nullptr),
-#if JXL_HIGH_PRECISION
-      IsSlightlyBelow(0.9f));
-#else
-      IsSlightlyBelow(0.98f));
-#endif
+      IsSlightlyBelow(0.55f));
 
   JxlDecoderDestroy(dec);
 }
@@ -1930,11 +1926,7 @@ TEST(DecodeTest, PixelTestOpaqueSrgbLossy) {
     EXPECT_THAT(
         ButteraugliDistance(io0.frames, io1.frames, ba, *JxlGetDefaultCms(),
                             /*distmap=*/nullptr, nullptr),
-#if JXL_HIGH_PRECISION
-        IsSlightlyBelow(0.93f));
-#else
-        IsSlightlyBelow(0.94f));
-#endif
+        IsSlightlyBelow(0.65f));
 
     JxlDecoderDestroy(dec);
   }
@@ -1985,7 +1977,7 @@ TEST(DecodeTest, PixelTestOpaqueSrgbLossyNoise) {
     EXPECT_THAT(
         ButteraugliDistance(io0.frames, io1.frames, ba, *JxlGetDefaultCms(),
                             /*distmap=*/nullptr, nullptr),
-        IsSlightlyBelow(2.04444f));
+        IsSlightlyBelow(1.2222f));
 
     JxlDecoderDestroy(dec);
   }

--- a/lib/jxl/enc_ac_strategy.cc
+++ b/lib/jxl/enc_ac_strategy.cc
@@ -26,6 +26,7 @@
 #include "lib/jxl/coeff_order_fwd.h"
 #include "lib/jxl/convolve.h"
 #include "lib/jxl/dct_scales.h"
+#include "lib/jxl/dec_transforms-inl.h"
 #include "lib/jxl/enc_aux_out.h"
 #include "lib/jxl/enc_debug_image.h"
 #include "lib/jxl/enc_params.h"
@@ -349,73 +350,8 @@ bool MultiBlockTransformCrossesVerticalBoundary(
   return false;
 }
 
-static const float kChromaErrorWeight[AcStrategy::kNumValidStrategies] = {
-    0.95f,  // DCT = 0,
-    1.0f,   // IDENTITY = 1,
-    0.5f,   // DCT2X2 = 2,
-    1.0f,   // DCT4X4 = 3,
-    2.0f,   // DCT16X16 = 4,
-    2.0f,   // DCT32X32 = 5,
-    1.4f,   // DCT16X8 = 6,
-    1.4f,   // DCT8X16 = 7,
-    2.0f,   // DCT32X8 = 8,
-    2.0f,   // DCT8X32 = 9,
-    2.0f,   // DCT32X16 = 10,
-    2.0f,   // DCT16X32 = 11,
-    2.0f,   // DCT4X8 = 12,
-    2.0f,   // DCT8X4 = 13,
-    1.7f,   // AFV0 = 14,
-    1.7f,   // AFV1 = 15,
-    1.7f,   // AFV2 = 16,
-    1.7f,   // AFV3 = 17,
-    2.0f,   // DCT64X64 = 18,
-    2.0f,   // DCT64X32 = 19,
-    2.0f,   // DCT32X64 = 20,
-    2.0f,   // DCT128X128 = 21,
-    2.0f,   // DCT128X64 = 22,
-    2.0f,   // DCT64X128 = 23,
-    2.0f,   // DCT256X256 = 24,
-    2.0f,   // DCT256X128 = 25,
-    2.0f,   // DCT128X256 = 26,
-};
-
-// For DCT the maximum error is roughly a sum of the values.
-// For some transforms, especially IDENTITY and DCT2X2, not all
-// the coefficients affect the maximum error. Probably would
-// be better to do transforms back and forth and look at the pixels
-// but that would significantly slow down the computation.
-static const float kMixLossTable[AcStrategy::kNumValidStrategies] = {
-    1.0f,   // DCT = 0,
-    0.45f,  // IDENTITY = 1,
-    0.45f,  // DCT2X2 = 2,
-    0.7f,   // DCT4X4 = 3,
-    1.0f,   // DCT16X16 = 4,
-    1.0f,   // DCT32X32 = 5,
-    1.0f,   // DCT16X8 = 6,
-    1.0f,   // DCT8X16 = 7,
-    1.0f,   // DCT32X8 = 8,
-    1.0f,   // DCT8X32 = 9,
-    1.0f,   // DCT32X16 = 10,
-    1.0f,   // DCT16X32 = 11,
-    0.96f,  // DCT4X8 = 12,
-    0.96f,  // DCT8X4 = 13,
-    0.94f,  // AFV0 = 14,
-    0.94f,  // AFV1 = 15,
-    0.94f,  // AFV2 = 16,
-    0.94f,  // AFV3 = 17,
-    1.0f,   // DCT64X64 = 18,
-    1.0f,   // DCT64X32 = 19,
-    1.0f,   // DCT32X64 = 20,
-    1.0f,   // DCT128X128 = 21,
-    1.0f,   // DCT128X64 = 22,
-    1.0f,   // DCT64X128 = 23,
-    1.0f,   // DCT256X256 = 24,
-    1.0f,   // DCT256X128 = 25,
-    1.0f,   // DCT128X256 = 26,
-};
-
-float EstimateEntropy(const AcStrategy& acs, size_t x, size_t y,
-                      const ACSConfig& config,
+float EstimateEntropy(const AcStrategy& acs, float entropy_mul, size_t x,
+                      size_t y, const ACSConfig& config,
                       const float* JXL_RESTRICT cmap_factors, float* block,
                       float* scratch_space, uint32_t* quantized) {
   const size_t size = (1 << acs.log2_covered_blocks()) * kDCTBlockSize;
@@ -430,36 +366,22 @@ float EstimateEntropy(const AcStrategy& acs, size_t x, size_t y,
 
   const size_t num_blocks = acs.covered_blocks_x() * acs.covered_blocks_y();
   // avoid large blocks when there is a lot going on in red-green.
-  float cmul[3] = {kChromaErrorWeight[acs.RawStrategy()], 1.0f, 1.0f};
-  float quant_norm8 = 0;
-  float masking = 0;
+  float quant_norm16 = 0;
   if (num_blocks == 1) {
     // When it is only one 8x8, we don't need aggregation of values.
-    quant_norm8 = config.Quant(x / 8, y / 8);
-    masking = config.Masking(x / 8, y / 8);
-    // Make DCT2X2 more favored when area is exposed.
-    float kExposedMasking = 0.118f;
-    if (acs.RawStrategy() == 2 && masking >= kExposedMasking) {
-      masking = kExposedMasking + 0.56 * (masking - kExposedMasking);
-    }
+    quant_norm16 = config.Quant(x / 8, y / 8);
   } else if (num_blocks == 2) {
     // Taking max instead of 8th norm seems to work
     // better for smallest blocks up to 16x8. Jyrki couldn't get
     // improvements in trying the same for 16x16 blocks.
     if (acs.covered_blocks_y() == 2) {
-      quant_norm8 =
+      quant_norm16 =
           std::max(config.Quant(x / 8, y / 8), config.Quant(x / 8, y / 8 + 1));
-      masking = std::max(config.Masking(x / 8, y / 8),
-                         config.Masking(x / 8, y / 8 + 1));
     } else {
-      quant_norm8 =
+      quant_norm16 =
           std::max(config.Quant(x / 8, y / 8), config.Quant(x / 8 + 1, y / 8));
-      masking = std::max(config.Masking(x / 8, y / 8),
-                         config.Masking(x / 8 + 1, y / 8));
     }
   } else {
-    float masking_norm2 = 0;
-    float masking_max = 0;
     // Load QF value, calculate empirical heuristic on masking field
     // for weighting the information loss. Information loss manifests
     // itself as ringing, and masking could hide it.
@@ -468,27 +390,25 @@ float EstimateEntropy(const AcStrategy& acs, size_t x, size_t y,
         float qval = config.Quant(x / 8 + ix, y / 8 + iy);
         qval *= qval;
         qval *= qval;
-        quant_norm8 += qval * qval;
-        float maskval = config.Masking(x / 8 + ix, y / 8 + iy);
-        masking_max = std::max<float>(masking_max, maskval);
-        masking_norm2 += maskval * maskval;
+        qval *= qval;
+        quant_norm16 += qval * qval;
       }
     }
-    quant_norm8 /= num_blocks;
-    quant_norm8 = FastPowf(quant_norm8, 1.0f / 8.0f);
-    masking_norm2 = sqrt(masking_norm2 / num_blocks);
-    // This is a highly empirical formula.
-    masking = 0.5 * (masking_norm2 + masking_max);
+    quant_norm16 /= num_blocks;
+    quant_norm16 = FastPowf(quant_norm16, 1.0f / 16.0f);
   }
-  const auto q = Set(df, quant_norm8);
+  const auto quant = Set(df, quant_norm16);
 
   // Compute entropy.
   float entropy = 0.0f;
-  auto info_loss = Zero(df);
-  auto info_loss2 = Zero(df);
+  const HWY_CAPPED(float, 8) df8;
 
+  auto mem_alloc = hwy::AllocateAligned<float>(AcStrategy::kMaxCoeffArea);
+  float* mem = mem_alloc.get();
+  auto loss = Zero(df8);
   for (size_t c = 0; c < 3; c++) {
     const float* inv_matrix = config.dequant->InvMatrix(acs.RawStrategy(), c);
+    const float* matrix = config.dequant->Matrix(acs.RawStrategy(), c);
     const auto cmap_factor = Set(df, cmap_factors[c]);
 
     auto entropy_v = Zero(df);
@@ -497,11 +417,11 @@ float EstimateEntropy(const AcStrategy& acs, size_t x, size_t y,
       const auto in = Load(df, block + c * size + i);
       const auto in_y = Mul(Load(df, block + size + i), cmap_factor);
       const auto im = Load(df, inv_matrix + i);
-      const auto val = Mul(Sub(in, in_y), Mul(im, q));
+      const auto val = Mul(Sub(in, in_y), Mul(im, quant));
       const auto rval = Round(val);
-      const auto diff = AbsDiff(val, rval);
-      info_loss = Add(info_loss, diff);
-      info_loss2 = MulAdd(diff, diff, info_loss2);
+      const auto diff = Sub(val, rval);
+      const auto m = Load(df, matrix + i);
+      Store(Mul(m, diff), df, &mem[i]);
       const auto q = Abs(rval);
       const auto q_is_zero = Eq(q, Zero(df));
       // We used to have q * C here, but that cost model seems to
@@ -510,7 +430,40 @@ float EstimateEntropy(const AcStrategy& acs, size_t x, size_t y,
       entropy_v = Add(Sqrt(q), entropy_v);
       nzeros_v = Add(nzeros_v, IfThenZeroElse(q_is_zero, Set(df, 1.0f)));
     }
-    entropy += config.cost_delta * cmul[c] * GetLane(SumOfLanes(df, entropy_v));
+
+    {
+      auto lossc = Zero(df8);
+      TransformToPixels(acs.Strategy(), &mem[0], block,
+                        acs.covered_blocks_x() * 8, scratch_space);
+
+      for (size_t iy = 0; iy < acs.covered_blocks_y(); iy++) {
+        for (size_t ix = 0; ix < acs.covered_blocks_x(); ix++) {
+          for (size_t dy = 0; dy < kBlockDim; ++dy) {
+            for (size_t dx = 0; dx < kBlockDim; dx += Lanes(df8)) {
+              auto in = Load(df8, block +
+                                      (iy * kBlockDim + dy) *
+                                          (acs.covered_blocks_x() * kBlockDim) +
+                                      ix * kBlockDim + dx);
+              auto masku = Abs(Load(
+                  df8, config.MaskingPtr1x1(x + ix * 8 + dx, y + iy * 8 + dy)));
+              in = Mul(masku, in);
+              in = Mul(in, in);
+              in = Mul(in, in);
+              in = Mul(in, in);
+              lossc = Add(lossc, in);
+            }
+          }
+        }
+      }
+      static const double kChannelMul[3] = {
+          10.2,
+          1.0,
+          1.03,
+      };
+      lossc = Mul(Set(df8, pow(kChannelMul[c], 8.0)), lossc);
+      loss = Add(loss, lossc);
+    }
+    entropy += config.cost_delta * GetLane(SumOfLanes(df, entropy_v));
     size_t num_nzeros = GetLane(SumOfLanes(df, nzeros_v));
     // Add #bit of num_nonzeros, as an estimate of the cost for encoding the
     // number of non-zeros of the block.
@@ -519,20 +472,17 @@ float EstimateEntropy(const AcStrategy& acs, size_t x, size_t y,
     // bias.
     entropy += config.zeros_mul * (CeilLog2Nonzero(nbits + 17) + nbits);
   }
-  const float kMixLoss = kMixLossTable[acs.RawStrategy()];
-  const float loss1 = GetLane(SumOfLanes(df, info_loss));
-  const float loss2 =
-      sqrt(GetLane(SumOfLanes(df, info_loss2)) * (num_blocks * 64));
-  const float loss = kMixLoss * (config.info_loss_multiplier * loss1) +
-                     (1.0 - kMixLoss) * (config.info_loss_multiplier2 * loss2);
-  const float kRegulateSurface = 11.5f;
-  float large_surface_error_mul =
-      (kRegulateSurface + sqrt(num_blocks)) * (1.0f / (kRegulateSurface + 1));
-  return entropy + large_surface_error_mul * masking * loss;
+  float loss_scalar =
+      pow(GetLane(SumOfLanes(df8, loss)) / (num_blocks * kDCTBlockSize),
+          1.0 / 8.0) *
+      (num_blocks * kDCTBlockSize) / quant_norm16;
+  float ret = entropy * entropy_mul;
+  ret += config.info_loss_multiplier * loss_scalar;
+  return ret;
 }
 
 uint8_t FindBest8x8Transform(size_t x, size_t y, int encoding_speed_tier,
-                             const ACSConfig& config,
+                             float butteraugli_target, const ACSConfig& config,
                              const float* JXL_RESTRICT cmap_factors,
                              AcStrategyImage* JXL_RESTRICT ac_strategy,
                              float* block, float* scratch_space,
@@ -540,69 +490,58 @@ uint8_t FindBest8x8Transform(size_t x, size_t y, int encoding_speed_tier,
   struct TransformTry8x8 {
     AcStrategy::Type type;
     int encoding_speed_tier_max_limit;
-    float entropy_add;
-    float entropy_mul;
+    double entropy_mul;
   };
   static const TransformTry8x8 kTransforms8x8[] = {
       {
           AcStrategy::Type::DCT,
           9,
-          3.0f,
-          0.785f,
+          0.8,
       },
       {
           AcStrategy::Type::DCT4X4,
           5,
-          4.0f,
-          0.7f,
+          1.08,
       },
       {
           AcStrategy::Type::DCT2X2,
           5,
-          0.0f,
-          0.685f,
+          0.95,
       },
       {
           AcStrategy::Type::DCT4X8,
           4,
-          3.0f,
-          0.745f,
+          0.85931637428340035,
       },
       {
           AcStrategy::Type::DCT8X4,
           4,
-          3.0f,
-          0.745f,
+          0.85931637428340035,
       },
       {
           AcStrategy::Type::IDENTITY,
           5,
-          8.0f,
-          0.81217614513585534f,
+          1.0427542510634957,
       },
       {
           AcStrategy::Type::AFV0,
           4,
-          3.0f,
-          0.70086131125719425f,
+          0.81779489591359944,
       },
       {
           AcStrategy::Type::AFV1,
           4,
-          3.0f,
-          0.70086131125719425f,
+          0.81779489591359944,
       },
       {
           AcStrategy::Type::AFV2,
           4,
-          3.0f,
-          0.70086131125719425f,
+          0.81779489591359944,
       },
       {
           AcStrategy::Type::AFV3,
           4,
-          3.0f,
-          0.70086131125719425f,
+          0.81779489591359944,
       },
   };
   double best = 1e30;
@@ -612,9 +551,28 @@ uint8_t FindBest8x8Transform(size_t x, size_t y, int encoding_speed_tier,
       continue;
     }
     AcStrategy acs = AcStrategy::FromRawStrategy(tx.type);
-    float entropy = EstimateEntropy(acs, x, y, config, cmap_factors, block,
-                                    scratch_space, quantized);
-    entropy = tx.entropy_add + tx.entropy_mul * entropy;
+    float entropy_mul = tx.entropy_mul / kTransforms8x8[0].entropy_mul;
+    if ((tx.type == AcStrategy::Type::DCT2X2 ||
+         tx.type == AcStrategy::Type::IDENTITY) &&
+        butteraugli_target < 5.0) {
+      static const float kFavor2X2AtHighQuality = 0.4;
+      float weight = pow((5.0f - butteraugli_target) / 5.0f, 2.0);
+      entropy_mul -= kFavor2X2AtHighQuality * weight;
+    }
+    if ((tx.type != AcStrategy::Type::DCT &&
+         tx.type != AcStrategy::Type::DCT2X2 &&
+         tx.type != AcStrategy::Type::IDENTITY) &&
+        butteraugli_target > 4.0) {
+      static const float kAvoidEntropyOfTransforms = 0.5;
+      float mul = 1.0;
+      if (butteraugli_target < 12.0) {
+        mul *= (12.0 - 4.0) / (butteraugli_target - 4.0);
+      }
+      entropy_mul += kAvoidEntropyOfTransforms * mul;
+    }
+    float entropy =
+        EstimateEntropy(acs, entropy_mul, x, y, config, cmap_factors, block,
+                        scratch_space, quantized);
     if (entropy < best) {
       best_tx = tx.type;
       best = entropy;
@@ -648,9 +606,8 @@ void TryMergeAcs(AcStrategy::Type acs_raw, size_t bx, size_t by, size_t cx,
     }
   }
   float entropy_candidate =
-      entropy_mul * EstimateEntropy(acs, (bx + cx) * 8, (by + cy) * 8, config,
-                                    cmap_factors, block, scratch_space,
-                                    quantized);
+      EstimateEntropy(acs, entropy_mul, (bx + cx) * 8, (by + cy) * 8, config,
+                      cmap_factors, block, scratch_space, quantized);
   if (entropy_candidate >= entropy_current) return;
   // Accept the candidate.
   for (size_t iy = 0; iy < acs.covered_blocks_y(); iy++) {
@@ -766,42 +723,37 @@ void FindBestFirstLevelDivisionForSquare(
   float entropy_JXJ = std::numeric_limits<float>::max();
   if (allow_JXK) {
     if (row0[bx + cx + 0].RawStrategy() != acs_rawJXK) {
-      entropy_JXK_left =
-          entropy_mul_JXK *
-          EstimateEntropy(acsJXK, (bx + cx + 0) * 8, (by + cy + 0) * 8, config,
-                          cmap_factors, block, scratch_space, quantized);
+      entropy_JXK_left = EstimateEntropy(
+          acsJXK, entropy_mul_JXK, (bx + cx + 0) * 8, (by + cy + 0) * 8, config,
+          cmap_factors, block, scratch_space, quantized);
     }
     if (row0[bx + cx + blocks_half].RawStrategy() != acs_rawJXK) {
       entropy_JXK_right =
-          entropy_mul_JXK * EstimateEntropy(acsJXK, (bx + cx + blocks_half) * 8,
-                                            (by + cy + 0) * 8, config,
-                                            cmap_factors, block, scratch_space,
-                                            quantized);
+          EstimateEntropy(acsJXK, entropy_mul_JXK, (bx + cx + blocks_half) * 8,
+                          (by + cy + 0) * 8, config, cmap_factors, block,
+                          scratch_space, quantized);
     }
   }
   if (allow_KXJ) {
     if (row0[bx + cx].RawStrategy() != acs_rawKXJ) {
-      entropy_KXJ_top =
-          entropy_mul_JXK *
-          EstimateEntropy(acsKXJ, (bx + cx + 0) * 8, (by + cy + 0) * 8, config,
-                          cmap_factors, block, scratch_space, quantized);
+      entropy_KXJ_top = EstimateEntropy(
+          acsKXJ, entropy_mul_JXK, (bx + cx + 0) * 8, (by + cy + 0) * 8, config,
+          cmap_factors, block, scratch_space, quantized);
     }
     if (row1[bx + cx].RawStrategy() != acs_rawKXJ) {
       entropy_KXJ_bottom =
-          entropy_mul_JXK * EstimateEntropy(acsKXJ, (bx + cx + 0) * 8,
-                                            (by + cy + blocks_half) * 8, config,
-                                            cmap_factors, block, scratch_space,
-                                            quantized);
+          EstimateEntropy(acsKXJ, entropy_mul_JXK, (bx + cx + 0) * 8,
+                          (by + cy + blocks_half) * 8, config, cmap_factors,
+                          block, scratch_space, quantized);
     }
   }
   if (allow_square_transform) {
     // We control the exploration of the square transform separately so that
     // we can turn it off at high decoding speeds for 32x32, but still allow
     // exploring 16x32 and 32x16.
-    entropy_JXJ = entropy_mul_JXJ * EstimateEntropy(acsJXJ, (bx + cx + 0) * 8,
-                                                    (by + cy + 0) * 8, config,
-                                                    cmap_factors, block,
-                                                    scratch_space, quantized);
+    entropy_JXJ = EstimateEntropy(acsJXJ, entropy_mul_JXJ, (bx + cx + 0) * 8,
+                                  (by + cy + 0) * 8, config, cmap_factors,
+                                  block, scratch_space, quantized);
   }
 
   // Test if this block should have JXK or KXJ transforms,
@@ -883,7 +835,7 @@ void ProcessRectACS(PassesEncoderState* JXL_RESTRICT enc_state,
   float entropy_estimate[64] = {};
   // Favor all 8x8 transforms (against 16x8 and larger transforms)) at
   // low butteraugli_target distances.
-  static const float k8x8mul1 = -0.55;
+  static const float k8x8mul1 = -0.4;
   static const float k8x8mul2 = 1.0;
   static const float k8x8base = 1.4;
   const float mul8x8 = k8x8mul2 + k8x8mul1 / (butteraugli_target + k8x8base);
@@ -892,8 +844,8 @@ void ProcessRectACS(PassesEncoderState* JXL_RESTRICT enc_state,
       float entropy = 0.0;
       const uint8_t best_of_8x8s = FindBest8x8Transform(
           8 * (bx + ix), 8 * (by + iy), static_cast<int>(cparams.speed_tier),
-          config, cmap_factors, ac_strategy, block, scratch_space, quantized,
-          &entropy);
+          butteraugli_target, config, cmap_factors, ac_strategy, block,
+          scratch_space, quantized, &entropy);
       ac_strategy->Set(bx + ix, by + iy,
                        static_cast<AcStrategy::Type>(best_of_8x8s));
       entropy_estimate[iy * 8 + ix] = entropy * mul8x8;
@@ -908,28 +860,16 @@ void ProcessRectACS(PassesEncoderState* JXL_RESTRICT enc_state,
     uint8_t encoding_speed_tier_max_limit;
     float entropy_mul;
   };
-  static const float k8X16mul1 = -0.55;
-  static const float k8X16mul2 = 0.885;
-  static const float k8X16base = 1.6;
-  const float entropy_mul16X8 =
-      k8X16mul2 + k8X16mul1 / (butteraugli_target + k8X16base);
-  //  const float entropy_mul16X8 = mul8X16 * 0.91195782912371126f;
-
-  static const float k16X16mul1 = -0.35;
-  static const float k16X16mul2 = 0.808;
-  static const float k16X16base = 2.0;
-  const float entropy_mul16X16 =
-      k16X16mul2 + k16X16mul1 / (butteraugli_target + k16X16base);
-  //  const float entropy_mul16X16 = mul16X16 * 0.83183417727960129f;
-
-  static const float k32X16mul1 = -0.1;
-  static const float k32X16mul2 = 0.854;
-  static const float k32X16base = 2.5;
-  const float entropy_mul16X32 =
-      k32X16mul2 + k32X16mul1 / (butteraugli_target + k32X16base);
-
-  const float entropy_mul32X32 = 0.93;
-  const float entropy_mul64X64 = 1.52f;
+  // These numbers need to be figured out manually and looking at
+  // ringing next to sky etc. Optimization will find larger numbers
+  // and produce more ringing than is ideal. Larger numbers will
+  // help stop ringing.
+  const float entropy_mul16X8 = 1.25;
+  const float entropy_mul16X16 = 1.35;
+  const float entropy_mul16X32 = 1.5;
+  const float entropy_mul32X32 = 1.5;
+  const float entropy_mul64X32 = 2.26;
+  const float entropy_mul64X64 = 2.26;
   // TODO(jyrki): Consider this feedback in further changes:
   // Also effectively when the multipliers for smaller blocks are
   // below 1, this raises the bar for the bigger blocks even higher
@@ -949,8 +889,8 @@ void ProcessRectACS(PassesEncoderState* JXL_RESTRICT enc_state,
       // FindBestFirstLevelDivisionForSquare looks for DCT32X32 and its
       // subdivisions. {AcStrategy::Type::DCT32X32, 5, 1, 5,
       // 0.9822994906548809f},
-      {AcStrategy::Type::DCT64X32, 6, 1, 3, 1.29f},
-      {AcStrategy::Type::DCT32X64, 6, 1, 3, 1.29f},
+      {AcStrategy::Type::DCT64X32, 6, 1, 3, entropy_mul64X32},
+      {AcStrategy::Type::DCT32X64, 6, 1, 3, entropy_mul64X32},
       // {AcStrategy::Type::DCT64X64, 8, 1, 3, 2.0846542128012948f},
   };
   /*
@@ -1121,9 +1061,14 @@ void AcStrategyHeuristics::Init(const Image3F& src,
   config.quant_field_row = enc_state->initial_quant_field.Row(0);
   config.quant_field_stride = enc_state->initial_quant_field.PixelsPerRow();
   auto& mask = enc_state->initial_quant_masking;
+  auto& mask1x1 = enc_state->initial_quant_masking1x1;
   if (mask.xsize() > 0 && mask.ysize() > 0) {
     config.masking_field_row = mask.Row(0);
     config.masking_field_stride = mask.PixelsPerRow();
+  }
+  if (mask1x1.xsize() > 0 && mask1x1.ysize() > 0) {
+    config.masking1x1_field_row = mask1x1.Row(0);
+    config.masking1x1_field_stride = mask1x1.PixelsPerRow();
   }
 
   config.src_rows[0] = src.ConstPlaneRow(0, 0);
@@ -1135,10 +1080,19 @@ void AcStrategyHeuristics::Init(const Image3F& src,
   //  - estimate of the number of bits that will be used by the block
   //  - information loss due to quantization
   // The following constant controls the relative weights of these components.
-  config.info_loss_multiplier = 58.67516723857484f;
-  config.info_loss_multiplier2 = 43.0f;
-  config.zeros_mul = 2.55f;
-  config.cost_delta = 4.9425062806007478f;
+  config.info_loss_multiplier = 1.2;
+  config.zeros_mul = 9.3089059022677905;
+  config.cost_delta = 10.833273317067883;
+
+  static const float kBias = 0.13731742964354549;
+  const float ratio = (cparams.butteraugli_distance + kBias) / (1.0f + kBias);
+
+  static const float kPow1 = 0.33677806662454718;
+  static const float kPow2 = 0.50990926717963703;
+  static const float kPow3 = 0.36702940662370243;
+  config.info_loss_multiplier *= pow(ratio, kPow1);
+  config.zeros_mul *= pow(ratio, kPow2);
+  config.cost_delta *= pow(ratio, kPow3);
   JXL_ASSERT(enc_state->shared.ac_strategy.xsize() ==
              enc_state->shared.frame_dim.xsize_blocks);
   JXL_ASSERT(enc_state->shared.ac_strategy.ysize() ==

--- a/lib/jxl/enc_ac_strategy.h
+++ b/lib/jxl/enc_ac_strategy.h
@@ -28,14 +28,15 @@ struct AuxOut;
 
 struct ACSConfig {
   const DequantMatrices* JXL_RESTRICT dequant;
-  float info_loss_multiplier;
-  float info_loss_multiplier2;
   float* JXL_RESTRICT quant_field_row;
   size_t quant_field_stride;
   float* JXL_RESTRICT masking_field_row;
   size_t masking_field_stride;
+  float* JXL_RESTRICT masking1x1_field_row;
+  size_t masking1x1_field_stride;
   const float* JXL_RESTRICT src_rows[3];
   size_t src_stride;
+  float info_loss_multiplier;
   float cost_delta;
   float zeros_mul;
   const float& Pixel(size_t c, size_t x, size_t y) const {
@@ -44,6 +45,10 @@ struct ACSConfig {
   float Masking(size_t bx, size_t by) const {
     JXL_DASSERT(masking_field_row[by * masking_field_stride + bx] > 0);
     return masking_field_row[by * masking_field_stride + bx];
+  }
+  float* MaskingPtr1x1(size_t bx, size_t by) const {
+    JXL_DASSERT(masking1x1_field_row[by * masking1x1_field_stride + bx] > 0);
+    return &masking1x1_field_row[by * masking1x1_field_stride + bx];
   }
   float Quant(size_t bx, size_t by) const {
     JXL_DASSERT(quant_field_row[by * quant_field_stride + bx] > 0);

--- a/lib/jxl/enc_adaptive_quantization.cc
+++ b/lib/jxl/enc_adaptive_quantization.cc
@@ -79,12 +79,12 @@ float ComputeMaskForAcStrategyUse(const float out_val) {
 
 template <class D, class V>
 V ComputeMask(const D d, const V out_val) {
-  const auto kBase = Set(d, -0.76471879237038032f);
-  const auto kMul4 = Set(d, 4.4585596705216615f);
-  const auto kMul2 = Set(d, 17.282053892620215f);
-  const auto kOffset2 = Set(d, 302.36961315317848f);
-  const auto kMul3 = Set(d, 7.0561261998705858f);
-  const auto kOffset3 = Set(d, 2.3179635626140773f);
+  const auto kBase = Set(d, -0.7647f);
+  const auto kMul4 = Set(d, 9.4708735624378946f);
+  const auto kMul2 = Set(d, 17.35036561631863f);
+  const auto kOffset2 = Set(d, 302.59587815579727f);
+  const auto kMul3 = Set(d, 6.7943250517376494f);
+  const auto kOffset3 = Set(d, 3.7179635626140772f);
   const auto kOffset4 = Mul(Set(d, 0.25f), kOffset3);
   const auto kMul0 = Set(d, 0.80061762862741759f);
   const auto k1 = Set(d, 1.0f);
@@ -193,76 +193,9 @@ V GammaModulation(const D d, const size_t x, const size_t y,
   // ideally -1.0, but likely optimal correction adds some entropy, so slightly
   // less than that.
   // ln(2) constant folded in because we want std::log but have FastLog2f.
-  const auto kGam = Set(d, -0.15526878023684174f * 0.693147180559945f);
+  static const float v = 0.14507933746197058f;
+  const auto kGam = Set(d, v * 0.693147180559945f);
   return MulAdd(kGam, FastLog2f(d, overall_ratio), out_val);
-}
-
-template <class D, class V>
-V ColorModulation(const D d, const size_t x, const size_t y,
-                  const ImageF& xyb_x, const ImageF& xyb_y, const ImageF& xyb_b,
-                  const double butteraugli_target, V out_val) {
-  static const float kStrengthMul = 4.2456542701250122f;
-  static const float kRedRampStart = 0.18748564245760829f;
-  static const float kRedRampLength = 0.16701783842516479f;
-  static const float kBlueRampLength = 0.16117602661852037f;
-  static const float kBlueRampStart = 0.47897504338287333f;
-  const float strength = kStrengthMul * (1.0f - 0.15f * butteraugli_target);
-  if (strength < 0) {
-    return out_val;
-  }
-  // x values are smaller than y and b values, need to take the difference into
-  // account.
-  const float red_strength = strength * 6.0f;
-  const float blue_strength = strength;
-  {
-    // Reduce some bits from areas not blue or red.
-    const float offset = strength * -0.007;  // 9174542291185913f;
-    out_val = Add(out_val, Set(d, offset));
-  }
-  // Calculate how much of the 8x8 block is covered with blue or red.
-  auto blue_coverage = Zero(d);
-  auto red_coverage = Zero(d);
-  auto bias_y = Set(d, 0.2f);
-  auto bias_y_add = Set(d, 0.1f);
-  for (size_t dy = 0; dy < 8; ++dy) {
-    const float* const JXL_RESTRICT row_in_x = xyb_x.Row(y + dy);
-    const float* const JXL_RESTRICT row_in_y = xyb_y.Row(y + dy);
-    const float* const JXL_RESTRICT row_in_b = xyb_b.Row(y + dy);
-    for (size_t dx = 0; dx < 8; dx += Lanes(d)) {
-      const auto pixel_y = Load(d, row_in_y + x + dx);
-      // Estimate redness-greeness relative to the intensity.
-      const auto pixel_xpy = Div(Abs(Load(d, row_in_x + x + dx)),
-                                 Max(Add(bias_y_add, pixel_y), bias_y));
-      const auto pixel_x =
-          Max(Set(d, 0.0f), Sub(pixel_xpy, Set(d, kRedRampStart)));
-      const auto pixel_b =
-          Max(Set(d, 0.0f), Sub(Load(d, row_in_b + x + dx),
-                                Add(pixel_y, Set(d, kBlueRampStart))));
-      const auto blue_slope = Min(pixel_b, Set(d, kBlueRampLength));
-      const auto red_slope = Min(pixel_x, Set(d, kRedRampLength));
-      red_coverage = Add(red_coverage, red_slope);
-      blue_coverage = Add(blue_coverage, blue_slope);
-    }
-  }
-
-  // Saturate when the high red or high blue coverage is above a level.
-  // The idea here is that if a certain fraction of the block is red or
-  // blue we consider as if it was fully red or blue.
-  static const float ratio = 28.0f;  // out of 64 pixels.
-
-  auto overall_red_coverage = SumOfLanes(d, red_coverage);
-  overall_red_coverage =
-      Min(overall_red_coverage, Set(d, ratio * kRedRampLength));
-  overall_red_coverage =
-      Mul(overall_red_coverage, Set(d, red_strength / ratio));
-
-  auto overall_blue_coverage = SumOfLanes(d, blue_coverage);
-  overall_blue_coverage =
-      Min(overall_blue_coverage, Set(d, ratio * kBlueRampLength));
-  overall_blue_coverage =
-      Mul(overall_blue_coverage, Set(d, blue_strength / ratio));
-
-  return Add(overall_red_coverage, Add(overall_blue_coverage, out_val));
 }
 
 // Change precision in 8x8 blocks that have high frequency content.
@@ -276,7 +209,7 @@ V HfModulation(const D d, const size_t x, const size_t y, const ImageF& xyb,
 
   auto sum = Zero(d);  // sum of absolute differences with right and below
 
-  static const float valmin = 0.52489909479039587f;
+  static const float valmin = 0.020602694503245016f;
   auto valminv = Set(d, valmin);
   for (size_t dy = 0; dy < 8; ++dy) {
     const float* JXL_RESTRICT row_in = xyb.Row(y + dy) + x;
@@ -308,15 +241,10 @@ V HfModulation(const D d, const size_t x, const size_t y, const ImageF& xyb,
 #endif
   }
   // more negative value gives more bpp
-  static const float kOffset = -2.6545897672771526;
-  static const float kMul = -0.049868161744916512;
-
+  static const float kOffset = -1.110929106987477;
+  static const float kMul = -0.38078920620238305;
   sum = SumOfLanes(d, sum);
   float scalar_sum = GetLane(sum);
-  static const float maxsum = 7.9076877647025947f;
-  static const float minsum = 0.53640540945659809f;
-  scalar_sum = std::min(maxsum, scalar_sum);
-  scalar_sum = std::max(minsum, scalar_sum);
   scalar_sum += kOffset;
   scalar_sum *= kMul;
   return Add(Set(d, scalar_sum), out_val);
@@ -351,8 +279,6 @@ void PerBlockModulations(const float butteraugli_target, const ImageF& xyb_x,
       auto out_val = Set(df, row_out[ix]);
       out_val = ComputeMask(df, out_val);
       out_val = HfModulation(df, x, y, xyb_y, out_val);
-      out_val = ColorModulation(df, x, y, xyb_x, xyb_y, xyb_b,
-                                butteraugli_target, out_val);
       out_val = GammaModulation(df, x, y, xyb_x, xyb_y, out_val);
       // We want multiplicative quantization field, so everything
       // until this point has been modulating the exponent.
@@ -400,14 +326,38 @@ void StoreMin4(const float v, float& min0, float& min1, float& min2,
 // Look for smooth areas near the area of degradation.
 // If the areas are generally smooth, don't do masking.
 // Output is downsampled 2x.
-void FuzzyErosion(const Rect& from_rect, const ImageF& from,
-                  const Rect& to_rect, ImageF* to) {
+void FuzzyErosion(const float butteraugli_target, const Rect& from_rect,
+                  const ImageF& from, const Rect& to_rect, ImageF* to) {
   const size_t xsize = from.xsize();
   const size_t ysize = from.ysize();
   constexpr int kStep = 1;
   static_assert(kStep == 1, "Step must be 1");
   JXL_ASSERT(to_rect.xsize() * 2 == from_rect.xsize());
   JXL_ASSERT(to_rect.ysize() * 2 == from_rect.ysize());
+  static const float kMulBase0 = 0.125;
+  static const float kMulBase1 = 0.10;
+  static const float kMulBase2 = 0.09;
+  static const float kMulBase3 = 0.06;
+  static const float kMulAdd0 = 0.0;
+  static const float kMulAdd1 = -0.10;
+  static const float kMulAdd2 = -0.09;
+  static const float kMulAdd3 = -0.06;
+
+  float mul = 0.0;
+  if (butteraugli_target < 2.0f) {
+    mul = (2.0f - butteraugli_target) * (1.0f / 2.0f);
+  }
+  float kMul0 = kMulBase0 + mul * kMulAdd0;
+  float kMul1 = kMulBase1 + mul * kMulAdd1;
+  float kMul2 = kMulBase2 + mul * kMulAdd2;
+  float kMul3 = kMulBase3 + mul * kMulAdd3;
+  static const float kTotal = 0.29959705784054957;
+  float norm = kTotal / (kMul0 + kMul1 + kMul2 + kMul3);
+  kMul0 *= norm;
+  kMul1 *= norm;
+  kMul2 *= norm;
+  kMul3 *= norm;
+
   for (size_t fy = 0; fy < from_rect.ysize(); ++fy) {
     size_t y = fy + from_rect.y0();
     size_t ym1 = y >= kStep ? y - kStep : y;
@@ -437,10 +387,7 @@ void FuzzyErosion(const Rect& from_rect, const ImageF& from,
       StoreMin4(rowb[xm1], min0, min1, min2, min3);
       StoreMin4(rowb[x], min0, min1, min2, min3);
       StoreMin4(rowb[xp1], min0, min1, min2, min3);
-      static const float kMul0 = 0.125f;
-      static const float kMul1 = 0.075f;
-      static const float kMul2 = 0.06f;
-      static const float kMul3 = 0.05f;
+
       float v = kMul0 * min0 + kMul1 * min1 + kMul2 * min2 + kMul3 * min3;
       if (fx % 2 == 0 && fy % 2 == 0) {
         row_out[fx / 2] = v;
@@ -468,7 +415,8 @@ struct AdaptiveQuantizationImpl {
   }
 
   void ComputeTile(float butteraugli_target, float scale, const Image3F& xyb,
-                   const Rect& rect, const int thread, ImageF* mask) {
+                   const Rect& rect, const int thread, ImageF* mask,
+                   ImageF* mask1x1) {
     const size_t xsize = xyb.xsize();
     const size_t ysize = xyb.ysize();
 
@@ -492,9 +440,36 @@ struct AdaptiveQuantizationImpl {
     if (y_end != xyb.ysize()) y_end += 4;
     pre_erosion[thread].ShrinkTo((x1 - x0) / 4, (y_end - y_start) / 4);
 
-    static const float limit = 0.2f;
     // Computes image (padded to multiple of 8x8) of local pixel differences.
     // Subsample both directions by 4.
+    // 1x1 Laplacian of intensity.
+    for (size_t y = y_start; y < y_end; ++y) {
+      const size_t y2 = y + 1 < ysize ? y + 1 : y;
+      const size_t y1 = y > 0 ? y - 1 : y;
+      const float* row_in = xyb.PlaneRow(1, y);
+      const float* row_in1 = xyb.PlaneRow(1, y1);
+      const float* row_in2 = xyb.PlaneRow(1, y2);
+      float* mask1x1_out = mask1x1->Row(y);
+      auto scalar_pixel1x1 = [&](size_t x) {
+        const size_t x2 = x + 1 < xsize ? x + 1 : x;
+        const size_t x1 = x > 0 ? x - 1 : x;
+        const float base =
+            0.25f * (row_in2[x] + row_in1[x] + row_in[x1] + row_in[x2]);
+        const float gammac = RatioOfDerivativesOfCubicRootToSimpleGamma(
+            row_in[x] + match_gamma_offset);
+        float diff = fabs(gammac * (row_in[x] - base));
+        static const double kScaler = 1.0;
+        diff *= kScaler;
+        diff = log1p(diff);
+        static const float kMul = 1.0;
+        static const float kOffset = 0.01;
+        mask1x1_out[x] = kMul / (diff + kOffset);
+      };
+      for (size_t x = x0; x < x1; ++x) {
+        scalar_pixel1x1(x);
+      }
+    }
+    static const float limit = 0.2f;
     for (size_t y = y_start; y < y_end; ++y) {
       size_t y2 = y + 1 < ysize ? y + 1 : y;
       size_t y1 = y > 0 ? y - 1 : y;
@@ -567,7 +542,8 @@ struct AdaptiveQuantizationImpl {
     }
     Rect from_rect(x0 % 8 == 0 ? 0 : 1, y_start % 8 == 0 ? 0 : 1,
                    rect.xsize() * 2, rect.ysize() * 2);
-    FuzzyErosion(from_rect, pre_erosion[thread], rect, &aq_map);
+    FuzzyErosion(butteraugli_target, from_rect, pre_erosion[thread], rect,
+                 &aq_map);
     for (size_t y = 0; y < rect.ysize(); ++y) {
       const float* aq_map_row = rect.ConstRow(aq_map, y);
       float* mask_row = rect.Row(mask, y);
@@ -583,13 +559,48 @@ struct AdaptiveQuantizationImpl {
   ImageF diff_buffer;
 };
 
+static void Blur1x1Masking(const FrameDimensions& frame_dim, ThreadPool* pool,
+                           ImageF* mask1x1) {
+  // Blur the mask1x1 to obtain the masking image.
+  // Before blurring it contains an image of absolute value of the
+  // Laplacian of the intensity channel.
+  static const float kFilterMask1x1[5] = {
+      static_cast<float>(0.25647067633737227),
+      static_cast<float>(0.2050056912354399075),
+      static_cast<float>(0.154082048668497307),
+      static_cast<float>(0.08149576591362004441),
+      static_cast<float>(0.0512750104812308467),
+  };
+  double sum =
+      1.0 + 4 * (kFilterMask1x1[0] + kFilterMask1x1[1] + kFilterMask1x1[2] +
+                 kFilterMask1x1[4] + 2 * kFilterMask1x1[3]);
+  if (sum < 1e-5) {
+    sum = 1e-5;
+  }
+  const float normalize = static_cast<float>(1.0 / sum);
+  const float normalize_mul = normalize;
+  WeightsSymmetric5 weights =
+      WeightsSymmetric5{{HWY_REP4(normalize)},
+                        {HWY_REP4(normalize_mul * kFilterMask1x1[0])},
+                        {HWY_REP4(normalize_mul * kFilterMask1x1[2])},
+                        {HWY_REP4(normalize_mul * kFilterMask1x1[1])},
+                        {HWY_REP4(normalize_mul * kFilterMask1x1[4])},
+                        {HWY_REP4(normalize_mul * kFilterMask1x1[3])}};
+  Rect from_rect(0, 0, 8 * frame_dim.xsize_blocks, 8 * frame_dim.ysize_blocks);
+  ImageF temp(mask1x1->xsize(), mask1x1->ysize());
+  Symmetric5(*mask1x1, from_rect, weights, pool, &temp);
+  CopyImageTo(temp, mask1x1);  // TODO: make it a swap
+}
+
 ImageF AdaptiveQuantizationMap(const float butteraugli_target,
                                const Image3F& xyb,
                                const FrameDimensions& frame_dim, float scale,
-                               ThreadPool* pool, ImageF* mask) {
+                               ThreadPool* pool, ImageF* mask,
+                               ImageF* mask1x1) {
   AdaptiveQuantizationImpl impl;
   impl.Init(xyb);
   *mask = ImageF(frame_dim.xsize_blocks, frame_dim.ysize_blocks);
+  *mask1x1 = ImageF(8 * frame_dim.xsize_blocks, 8 * frame_dim.ysize_blocks);
   JXL_CHECK(RunOnPool(
       pool, 0,
       DivCeil(frame_dim.xsize_blocks, kEncTileDimInBlocks) *
@@ -610,10 +621,12 @@ ImageF AdaptiveQuantizationMap(const float butteraugli_target,
         size_t bx1 =
             std::min((tx + 1) * kEncTileDimInBlocks, frame_dim.xsize_blocks);
         Rect r(bx0, by0, bx1 - bx0, by1 - by0);
-        impl.ComputeTile(butteraugli_target, scale, xyb, r, thread, mask);
+        impl.ComputeTile(butteraugli_target, scale, xyb, r, thread, mask,
+                         mask1x1);
       },
       "AQ DiffPrecompute"));
 
+  Blur1x1Masking(frame_dim, pool, mask1x1);
   return std::move(impl).aq_map;
 }
 
@@ -733,9 +746,9 @@ ImageF TileDistMap(const ImageF& distmap, int tile_size, int margin,
   return tile_distmap;
 }
 
-static const float kDcQuantPow = 0.83;
+static const float kDcQuantPow = 0.83f;
 static const float kDcQuant = 1.095924047623553f;
-static const float kAcQuant = 0.7635;
+static const float kAcQuant = 0.7381485255235064f;
 
 // Computes the decoded image for a given set of compression parameters.
 ImageBundle RoundtripImage(const Image3F& opsin, PassesEncoderState* enc_state,
@@ -1147,10 +1160,11 @@ float InitialQuantDC(float butteraugli_target) {
 
 ImageF InitialQuantField(const float butteraugli_target, const Image3F& opsin,
                          const FrameDimensions& frame_dim, ThreadPool* pool,
-                         float rescale, ImageF* mask) {
+                         float rescale, ImageF* mask, ImageF* mask1x1) {
   const float quant_ac = kAcQuant / butteraugli_target;
   return HWY_DYNAMIC_DISPATCH(AdaptiveQuantizationMap)(
-      butteraugli_target, opsin, frame_dim, quant_ac * rescale, pool, mask);
+      butteraugli_target, opsin, frame_dim, quant_ac * rescale, pool, mask,
+      mask1x1);
 }
 
 void FindBestQuantizer(const ImageBundle* linear, const Image3F& opsin,

--- a/lib/jxl/enc_adaptive_quantization.h
+++ b/lib/jxl/enc_adaptive_quantization.h
@@ -38,7 +38,8 @@ struct AuxOut;
 // can later be used to make better decisions about ac strategy.
 ImageF InitialQuantField(float butteraugli_target, const Image3F& opsin,
                          const FrameDimensions& frame_dim, ThreadPool* pool,
-                         float rescale, ImageF* initial_quant_mask);
+                         float rescale, ImageF* initial_quant_mask,
+                         ImageF* initial_quant_mask1x1);
 
 float InitialQuantDC(float butteraugli_target);
 

--- a/lib/jxl/enc_cache.h
+++ b/lib/jxl/enc_cache.h
@@ -37,6 +37,7 @@ struct PassesEncoderState {
 
   ImageF initial_quant_field;    // Invalid in Falcon mode.
   ImageF initial_quant_masking;  // Invalid in Falcon mode.
+  ImageF initial_quant_masking1x1;  // Invalid in Falcon mode.
 
   // Per-pass DCT coefficients for the image. One row per group.
   std::vector<std::unique_ptr<ACImage>> coeffs;

--- a/lib/jxl/enc_chroma_from_luma.cc
+++ b/lib/jxl/enc_chroma_from_luma.cc
@@ -160,7 +160,10 @@ int32_t FindBestMultiplier(const float* values_m, const float* values_s,
   }
   // CFL seems to be tricky for larger transforms for HF components
   // close to zero. This heuristic brings the solutions closer to zero
-  // and reduces red-green oscillations.
+  // and reduces red-green oscillations. A better approach would
+  // look into variance of the multiplier within seperate (e.g. 8x8)
+  // areas and only apply this heuristic where there is a high variance.
+  // This would give about 1 % more compression density.
   float towards_zero = 2.6;
   if (x >= towards_zero) {
     x -= towards_zero;

--- a/lib/jxl/enc_group.cc
+++ b/lib/jxl/enc_group.cc
@@ -150,7 +150,7 @@ void AdjustQuantBlockAC(const Quantizer& quantizer, size_t c,
       }
     }
   }
-  if (c == 1 && sum_of_vals < std::max(xsize, ysize)) {
+  if (c == 1 && sum_of_vals * 8 < xsize * ysize) {
     static const double kLimit[4] = {
         0.46,
         0.46,
@@ -208,56 +208,71 @@ void AdjustQuantBlockAC(const Quantizer& quantizer, size_t c,
     }
   }
   {
-    static const double kMul1[3][3] = {
+    static const double kMul1[4][3] = {
         {
-            0.13289977307244785,
-            0.13991489841351781,
-            0.083900681804010419,
+            0.22080615753848404,
+            0.45797479824262011,
+            0.29859235095977965,
         },
         {
-            0.69938583107168562,
-            0.19612117586770869,
-            0.15307492924107463,
+            0.70109486510286834,
+            0.16185281305512639,
+            0.14387691730035473,
         },
         {
-            0.099160801461836312,
-            0.16684944507307059,
-            0.16608517854968413,
-        },
-    };
-    static const double kMul2[3][3] = {
-        {
-            0.24773711435293466,
-            0.65189637683223112,
-            1.0,
+            0.114985964456218638,
+            0.44656840441027695,
+            0.10587658215149048,
         },
         {
-            0.46465181913392556,
-            0.3142440606068525,
-            0.30128806880068809,
-        },
-        {
-            0.45203398366713637,
-            0.15063329382779103,
-            0.067846407329923752,
+            0.46849665264409396,
+            0.41239077937781954,
+            0.088667407767185444,
         },
     };
-    const float kQuantNormalizer = 2.8261379721245263;
+    static const double kMul2[4][3] = {
+        {
+            0.27450281941822197,
+            1.1255766549984996,
+            0.98950459134128388,
+        },
+        {
+            0.4652168675598285,
+            0.40945807983455818,
+            0.36581899811751367,
+        },
+        {
+            0.28034972424715715,
+            0.9182653201929738,
+            1.5581531543057416,
+        },
+        {
+            0.26873118114033728,
+            0.68863712390392484,
+            1.2082185408666786,
+        },
+    };
+    static const double kQuantNormalizer = 2.2942708343284721;
     sum_of_error *= kQuantNormalizer;
     sum_of_vals *= kQuantNormalizer;
     if (quant_kind >= AcStrategy::Type::DCT16X16) {
-      int ix = 2;
+      int ix = 3;
       if (quant_kind == AcStrategy::Type::DCT32X16 ||
           quant_kind == AcStrategy::Type::DCT16X32) {
         ix = 1;
       } else if (quant_kind == AcStrategy::Type::DCT16X16) {
         ix = 0;
+      } else if (quant_kind == AcStrategy::Type::DCT32X32) {
+        ix = 2;
       }
       int step =
           sum_of_error / (kMul1[ix][c] * xsize * ysize * kBlockDim * kBlockDim +
                           kMul2[ix][c] * sum_of_vals);
       if (step >= 2) {
         step = 2;
+      }
+      if (step < 0) {
+        step = 0;
       }
       if (sum_of_error > kMul1[ix][c] * xsize * ysize * kBlockDim * kBlockDim +
                              kMul2[ix][c] * sum_of_vals) {
@@ -270,7 +285,7 @@ void AdjustQuantBlockAC(const Quantizer& quantizer, size_t c,
   }
   {
     // Reduce quant in highly active areas.
-    int32_t div = (xsize + ysize) / 2;
+    int32_t div = (xsize * ysize);
     int32_t activity = (hfNonZeros[0] + div / 2) / div;
     int32_t orig_qp_limit = std::max(4, *quant / 2);
     for (int i = 1; i < 4; ++i) {

--- a/lib/jxl/enc_heuristics.cc
+++ b/lib/jxl/enc_heuristics.cc
@@ -844,7 +844,8 @@ Status DefaultEncoderHeuristics::LossyFrameHeuristics(
     }
     enc_state->initial_quant_field = InitialQuantField(
         butteraugli_distance_for_iqf, *opsin, shared.frame_dim, pool, 1.0f,
-        &enc_state->initial_quant_masking);
+        &enc_state->initial_quant_masking,
+        &enc_state->initial_quant_masking1x1);
     quantizer.SetQuantField(quant_dc, enc_state->initial_quant_field, nullptr);
   }
 

--- a/lib/jxl/jxl_test.cc
+++ b/lib/jxl/jxl_test.cc
@@ -121,7 +121,7 @@ TEST(JxlTest, RoundtripSmallD1) {
 
   {
     PackedPixelFile ppf_out;
-    EXPECT_NEAR(Roundtrip(t.ppf(), {}, {}, pool, &ppf_out), 816, 40);
+    EXPECT_NEAR(Roundtrip(t.ppf(), {}, {}, pool, &ppf_out), 1027, 40);
     EXPECT_THAT(ButteraugliDistance(t.ppf(), ppf_out), IsSlightlyBelow(0.888));
   }
 
@@ -131,7 +131,7 @@ TEST(JxlTest, RoundtripSmallD1) {
 
   {
     PackedPixelFile ppf_out;
-    EXPECT_NEAR(Roundtrip(t.ppf(), {}, {}, pool, &ppf_out), 659, 20);
+    EXPECT_NEAR(Roundtrip(t.ppf(), {}, {}, pool, &ppf_out), 745, 20);
     EXPECT_THAT(ButteraugliDistance(t.ppf(), ppf_out), IsSlightlyBelow(1.3));
     EXPECT_EQ(ppf_out.info.intensity_target, t.ppf().info.intensity_target);
   }
@@ -202,7 +202,7 @@ TEST(JxlTest, RoundtripOutOfOrderProcessing) {
   cparams.AddOption(JXL_ENC_FRAME_SETTING_EPF, 3);
 
   PackedPixelFile ppf_out;
-  EXPECT_NEAR(Roundtrip(t.ppf(), cparams, {}, &pool, &ppf_out), 22999, 400);
+  EXPECT_NEAR(Roundtrip(t.ppf(), cparams, {}, &pool, &ppf_out), 27444, 400);
   EXPECT_LE(ButteraugliDistance(t.ppf(), ppf_out), 1.35);
 }
 
@@ -222,7 +222,7 @@ TEST(JxlTest, RoundtripOutOfOrderProcessingBorder) {
   cparams.AddOption(JXL_ENC_FRAME_SETTING_RESAMPLING, 2);
 
   PackedPixelFile ppf_out;
-  EXPECT_NEAR(Roundtrip(t.ppf(), cparams, {}, &pool, &ppf_out), 11015, 200);
+  EXPECT_NEAR(Roundtrip(t.ppf(), cparams, {}, &pool, &ppf_out), 10065, 200);
   EXPECT_LE(ButteraugliDistance(t.ppf(), ppf_out), 2.9);
 }
 
@@ -295,9 +295,9 @@ TEST(JxlTest, RoundtripMultiGroup) {
   };
 
   auto run_kitten = std::async(std::launch::async, test, SpeedTier::kKitten,
-                               1.0f, 55602u, 11.7);
+                               1.0f, 63624u, 8.5);
   auto run_wombat = std::async(std::launch::async, test, SpeedTier::kWombat,
-                               2.0f, 33624u, 20.0);
+                               2.0f, 39620u, 15.5);
 }
 
 TEST(JxlTest, RoundtripRGBToGrayscale) {
@@ -356,8 +356,8 @@ TEST(JxlTest, RoundtripLargeFast) {
   cparams.AddOption(JXL_ENC_FRAME_SETTING_EFFORT, 7);  // kSquirrel
 
   PackedPixelFile ppf_out;
-  EXPECT_NEAR(Roundtrip(t.ppf(), cparams, {}, &pool, &ppf_out), 445555, 5000);
-  EXPECT_THAT(ComputeDistance2(t.ppf(), ppf_out), IsSlightlyBelow(100));
+  EXPECT_NEAR(Roundtrip(t.ppf(), cparams, {}, &pool, &ppf_out), 505555, 5000);
+  EXPECT_THAT(ComputeDistance2(t.ppf(), ppf_out), IsSlightlyBelow(75));
 }
 
 TEST(JxlTest, RoundtripDotsForceEpf) {
@@ -373,7 +373,7 @@ TEST(JxlTest, RoundtripDotsForceEpf) {
   cparams.AddOption(JXL_ENC_FRAME_SETTING_DOTS, 1);
 
   PackedPixelFile ppf_out;
-  EXPECT_NEAR(Roundtrip(t.ppf(), cparams, {}, &pool, &ppf_out), 41777, 300);
+  EXPECT_NEAR(Roundtrip(t.ppf(), cparams, {}, &pool, &ppf_out), 40777, 300);
   EXPECT_THAT(ComputeDistance2(t.ppf(), ppf_out), IsSlightlyBelow(18));
 }
 
@@ -453,8 +453,8 @@ TEST(JxlTest, RoundtripSmallNL) {
   t.SetDimensions(xsize, ysize);
 
   PackedPixelFile ppf_out;
-  EXPECT_NEAR(Roundtrip(t.ppf(), {}, {}, pool, &ppf_out), 801, 45);
-  EXPECT_THAT(ButteraugliDistance(t.ppf(), ppf_out), IsSlightlyBelow(1.1));
+  EXPECT_NEAR(Roundtrip(t.ppf(), {}, {}, pool, &ppf_out), 1027, 45);
+  EXPECT_THAT(ButteraugliDistance(t.ppf(), ppf_out), IsSlightlyBelow(0.82));
 }
 
 TEST(JxlTest, RoundtripNoGaborishNoAR) {
@@ -469,7 +469,7 @@ TEST(JxlTest, RoundtripNoGaborishNoAR) {
   cparams.AddOption(JXL_ENC_FRAME_SETTING_GABORISH, 0);
 
   PackedPixelFile ppf_out;
-  EXPECT_NEAR(Roundtrip(t.ppf(), cparams, {}, pool, &ppf_out), 38900, 200);
+  EXPECT_NEAR(Roundtrip(t.ppf(), cparams, {}, pool, &ppf_out), 41769, 400);
   EXPECT_THAT(ButteraugliDistance(t.ppf(), ppf_out), IsSlightlyBelow(1.8));
 }
 
@@ -487,7 +487,7 @@ TEST(JxlTest, RoundtripSmallNoGaborish) {
   cparams.AddOption(JXL_ENC_FRAME_SETTING_GABORISH, 0);
 
   PackedPixelFile ppf_out;
-  EXPECT_NEAR(Roundtrip(t.ppf(), cparams, {}, pool, &ppf_out), 811, 20);
+  EXPECT_NEAR(Roundtrip(t.ppf(), cparams, {}, pool, &ppf_out), 1032, 20);
   EXPECT_THAT(ButteraugliDistance(t.ppf(), ppf_out), IsSlightlyBelow(1.1));
 }
 
@@ -667,7 +667,7 @@ TEST(JxlTest, RoundtripGrayscale) {
     EXPECT_THAT(ButteraugliDistance(io.frames, io2.frames, ButteraugliParams(),
                                     *JxlGetDefaultCms(),
                                     /*distmap=*/nullptr),
-                IsSlightlyBelow(6.0));
+                IsSlightlyBelow(6.7));
   }
 
   {
@@ -875,7 +875,7 @@ TEST(JxlTest, RoundtripAlphaResampling) {
   cparams.AddOption(JXL_ENC_FRAME_SETTING_EXTRA_CHANNEL_RESAMPLING, 2);
 
   PackedPixelFile ppf_out;
-  EXPECT_NEAR(Roundtrip(t.ppf(), cparams, {}, pool, &ppf_out), 13155, 130);
+  EXPECT_NEAR(Roundtrip(t.ppf(), cparams, {}, pool, &ppf_out), 13655, 130);
   EXPECT_THAT(ButteraugliDistance(t.ppf(), ppf_out), IsSlightlyBelow(5.2));
 }
 
@@ -943,7 +943,7 @@ TEST(JxlTest, RoundtripAlpha16) {
   PackedPixelFile ppf_out;
   // TODO(szabadka) Investigate big size difference on i686
   // This still keeps happening (2023-04-18).
-  EXPECT_NEAR(Roundtrip(t.ppf(), cparams, {}, &pool, &ppf_out), 3466, 120);
+  EXPECT_NEAR(Roundtrip(t.ppf(), cparams, {}, &pool, &ppf_out), 3666, 120);
   EXPECT_THAT(ButteraugliDistance(t.ppf(), ppf_out), IsSlightlyBelow(0.65));
 }
 
@@ -1130,7 +1130,7 @@ TEST(JxlTest, RoundtripDots) {
   cparams.distance = 0.04;
 
   PackedPixelFile ppf_out;
-  EXPECT_NEAR(Roundtrip(t.ppf(), cparams, {}, pool, &ppf_out), 273333, 4000);
+  EXPECT_NEAR(Roundtrip(t.ppf(), cparams, {}, pool, &ppf_out), 280333, 4000);
   EXPECT_THAT(ButteraugliDistance(t.ppf(), ppf_out), IsSlightlyBelow(0.35));
 }
 
@@ -1150,7 +1150,7 @@ TEST(JxlTest, RoundtripNoise) {
   cparams.AddOption(JXL_ENC_FRAME_SETTING_NOISE, 1);
 
   PackedPixelFile ppf_out;
-  EXPECT_NEAR(Roundtrip(t.ppf(), cparams, {}, pool, &ppf_out), 39261, 750);
+  EXPECT_NEAR(Roundtrip(t.ppf(), cparams, {}, pool, &ppf_out), 42345, 750);
   EXPECT_THAT(ButteraugliDistance(t.ppf(), ppf_out), IsSlightlyBelow(1.35));
 }
 
@@ -1191,7 +1191,7 @@ TEST(JxlTest, RoundtripAnimation) {
 
   PackedPixelFile ppf_out;
   EXPECT_THAT(Roundtrip(t.ppf(), {}, dparams, pool, &ppf_out),
-              IsSlightlyBelow(2600));
+              IsSlightlyBelow(2888));
 
   t.CoalesceGIFAnimationWithAlpha();
   ASSERT_EQ(ppf_out.frames.size(), t.ppf().frames.size());
@@ -1249,10 +1249,10 @@ TEST(JxlTest, RoundtripAnimationPatches) {
   PackedPixelFile ppf_out;
   // 40k with no patches, 27k with patch frames encoded multiple times.
   EXPECT_THAT(Roundtrip(t.ppf(), cparams, dparams, pool, &ppf_out),
-              IsSlightlyBelow(16789));
+              IsSlightlyBelow(19222));
   EXPECT_EQ(ppf_out.frames.size(), t.ppf().frames.size());
   // >10 with broken patches
-  EXPECT_THAT(ButteraugliDistance(t.ppf(), ppf_out), IsSlightlyBelow(1.0999));
+  EXPECT_THAT(ButteraugliDistance(t.ppf(), ppf_out), IsSlightlyBelow(0.8999));
 }
 
 size_t RoundtripJpeg(const PaddedBytes& jpeg_in, ThreadPool* pool) {
@@ -1476,7 +1476,7 @@ TEST(JxlTest, RoundtripProgressive) {
   cparams.AddOption(JXL_ENC_FRAME_SETTING_RESPONSIVE, 1);
 
   PackedPixelFile ppf_out;
-  EXPECT_NEAR(Roundtrip(t.ppf(), cparams, {}, &pool, &ppf_out), 62160, 750);
+  EXPECT_NEAR(Roundtrip(t.ppf(), cparams, {}, &pool, &ppf_out), 71444, 750);
   EXPECT_THAT(ButteraugliDistance(t.ppf(), ppf_out), IsSlightlyBelow(1.4));
 }
 
@@ -1493,7 +1493,7 @@ TEST(JxlTest, RoundtripProgressiveLevel2Slow) {
   cparams.AddOption(JXL_ENC_FRAME_SETTING_RESPONSIVE, 1);
 
   PackedPixelFile ppf_out;
-  EXPECT_NEAR(Roundtrip(t.ppf(), cparams, {}, &pool, &ppf_out), 71111, 1000);
+  EXPECT_NEAR(Roundtrip(t.ppf(), cparams, {}, &pool, &ppf_out), 76666, 1000);
   EXPECT_THAT(ButteraugliDistance(t.ppf(), ppf_out), IsSlightlyBelow(1.17));
 }
 

--- a/lib/jxl/passes_test.cc
+++ b/lib/jxl/passes_test.cc
@@ -50,7 +50,7 @@ TEST(PassesTest, RoundtripSmallPasses) {
   EXPECT_THAT(ButteraugliDistance(io.frames, io2.frames, ButteraugliParams(),
                                   *JxlGetDefaultCms(),
                                   /*distmap=*/nullptr),
-              IsSlightlyBelow(1.1));
+              IsSlightlyBelow(0.8222));
 }
 
 TEST(PassesTest, RoundtripUnalignedPasses) {
@@ -97,7 +97,7 @@ TEST(PassesTest, RoundtripMultiGroupPasses) {
                 IsSlightlyBelow(target_distance + threshold));
   };
 
-  auto run1 = std::async(std::launch::async, test, 1.0f, 0.5f);
+  auto run1 = std::async(std::launch::async, test, 1.0f, 0.15f);
   auto run2 = std::async(std::launch::async, test, 2.0f, 0.0f);
 }
 

--- a/tools/optimizer/simplex_fork.py
+++ b/tools/optimizer/simplex_fork.py
@@ -61,10 +61,10 @@ def EvalCacheForget():
 
 def RandomizedJxlCodecs():
   retval = []
-  minval = 0.5
-  maxval = 8.3
+  minval = 0.2
+  maxval = 9.3
   rangeval = maxval/minval
-  steps = 17
+  steps = 13
   for i in range(steps):
     mul = minval * rangeval**(float(i)/(steps - 1))
     mul *= 0.99 + 0.05 * random.random()
@@ -103,7 +103,7 @@ def Eval(vec, binary_name, cached=True):
       (binary_name,
        '--input',
        '/usr/local/google/home/jyrki/newcorpus/split/*.png',
-       '--error_pnorm=4',
+       '--error_pnorm=3.0',
        '--more_columns',
        '--codec', g_codecs),
       stdout=subprocess.PIPE,
@@ -130,8 +130,8 @@ def Eval(vec, binary_name, cached=True):
       n += 1
       found_score = True
       distance = float(line.split()[0].split(b'd')[-1])
-      #faultybpp = 1.0 + 0.43 * ((float(bpp) * distance ** 0.69) - 1.595) ** 2
-      #vec[0] *= faultybpp
+      faultybpp = 1.0 + 0.43 * ((float(bpp) * distance ** 0.69) - 1.64) ** 2
+      vec[0] *= faultybpp
 
   print("eval: ", vec)
   if (vec[0] <= 0.0):


### PR DESCRIPTION
measure the quality of an integral transform in the pixel space rather than dct coefficient base (as done before this PR)

some more ringing, better texture/subtle material fitting, some more details right, better performance on difficult images, cleaner architecture for further quality improvements, slower

```
Before:

Encoding      kPixels    Bytes          BPP  E MP/s  D MP/s     Max norm  SSIMULACRA2   PSNR        pnorm       BPP*pnorm   QABPP   Bugs
----------------------------------------------------------------------------------------------------------------------------------------
jxl:d0.1        20315 17381585    6.8445662   2.475  20.374   0.35752780  95.38110842  55.31   0.11907606  0.815023950090   6.845      0
jxl:d0.5        20315  6840469    2.6936578   3.043  30.431   0.81159277  91.28096152  46.43   0.35275973  0.950214025947   2.869      0
jxl:d0.8        20315  5026234    1.9792436   3.150  30.813   1.13390198  88.47341146  43.85   0.49912046  0.987880993221   2.364      0
jxl:d1          20315  4350486    1.7131458   3.204  32.057   1.34645549  86.76725072  42.66   0.58255077  0.997994400876   2.425      0
jxl:d1.5        20315  3367818    1.3261882   3.301  31.213   1.81159865  82.90450127  40.65   0.76549843  1.015194998864   2.587      0
jxl:d2.0        20315  2756702    1.0855414   3.351  31.893   2.25382353  79.17774155  39.19   0.94089680  1.021382378837   2.644      0
jxl:d2.5        20315  2341183    0.9219172   3.387  31.992   2.69914340  75.65279876  38.09   1.10692818  1.020496116869   2.695      0
jxl:d3          20315  2044812    0.8052114   3.169  31.749   3.11376459  72.28282385  37.21   1.26722218  1.020381792024   2.717      0
jxl:d5          20315  1363710    0.5370053   3.203  19.568   4.61445302  60.43067032  34.95   1.81935734  0.977004538421   2.621      0
jxl:d10         20315   803918    0.3165689   3.242  18.816   7.48235611  38.43593542  32.15   2.90685959  0.920221460214   2.439      0
Aggregate:      20315  3237961    1.2750529   3.142  27.277   1.87071131  74.92120226  40.60   0.76113960  0.970493289476   2.855      0

After

Encoding      kPixels    Bytes          BPP  E MP/s  D MP/s     Max norm  SSIMULACRA2   PSNR        pnorm       BPP*pnorm   QABPP   Bugs
----------------------------------------------------------------------------------------------------------------------------------------
jxl:d0.1        20315 17738232    6.9850076   1.837  20.854   0.36042851  95.39565073  55.62   0.11757951  0.821293744281   6.985      0
jxl:d0.5        20315  7083423    2.7893289   2.151  30.164   0.78012465  91.40832941  46.83   0.33259288  0.927710947397   2.885      0
jxl:d0.8        20315  5236376    2.0619939   2.235  30.836   1.12970444  88.63541402  44.21   0.47622603  0.981975169666   2.484      0
jxl:d1          20315  4502264    1.7729133   2.283  31.480   1.33640281  86.84913794  43.02   0.56322339  0.998546267198   2.511      0
jxl:d1.5        20315  3425292    1.3488205   2.347  30.762   1.87159566  82.76248986  40.94   0.77005819  1.038670260263   2.683      0
jxl:d2.0        20315  2780424    1.0948827   2.389  31.405   2.39023632  78.71547418  39.43   0.96306921  1.054447784649   2.773      0
jxl:d2.5        20315  2349487    0.9251872   2.434  31.658   2.84069056  75.09626979  38.26   1.13209238  1.047397331748   2.797      0
jxl:d3          20315  2029235    0.7990775   2.332  31.496   3.24060299  71.45589318  37.33   1.29583167  1.035469909914   2.738      0
jxl:d5          20315  1365069    0.5375405   2.358  19.596   4.49634149  59.74897514  35.13   1.81036984  0.973147025987   2.547      0
jxl:d10         20315   806188    0.3174628   2.352  18.654   7.78598920  36.65342191  32.20   2.97087931  0.943143743937   2.491      0
Aggregate:      20315  3288759    1.2950561   2.265  27.117   1.89966100  74.31700863  40.84   0.75648483  0.979690273899   2.922      0
```

<!-- Thank you for considering a contribution to `libjxl`! -->

### Description

<!-- Please provide a brief description of the changes in this PR and any additional context (e.g., why these changes were made, related issues, etc.). -->

### Pull Request Checklist

- [x] **CLA Signed**: Have you signed the [Contributor License Agreement](https://code.google.com/legal/individual-cla-v1.0.html) (individual or corporate, as appropriate)? Only contributions from signed contributors can be accepted.
- [x] **Authors**: If this is your first contribution, have you added your name to the [AUTHORS](AUTHORS) file?
- [x] **Code Style**: Have you ensured your code adheres to the project's coding style guidelines? You can use `./ci.sh lint` for automatic code formatting.


Please review the full [contributing guidelines](https://github.com/libjxl/libjxl/blob/main/CONTRIBUTING.md) for more details.
