### PR TITLE
Test `cjxl -e 1 -d 0` for images with few colors

### DIFF
--- a/lib/jxl/jxl_test.cc
+++ b/lib/jxl/jxl_test.cc
@@ -1566,5 +1566,21 @@ TEST(JxlTest, LosslessPNMRoundtrip) {
   }
 }
 
+TEST(JxlTest, LosslessSmallFewColors) {
+  ThreadPoolForTests pool(8);
+  const PaddedBytes orig =
+      jxl::test::ReadTestData("jxl/blending/cropped_traffic_light_frame-0.png");
+  TestImage t;
+  t.DecodeFromBytes(orig).ClearMetadata();
+
+  JXLCompressParams cparams;
+  cparams.distance = 0;
+  cparams.AddOption(JXL_ENC_FRAME_SETTING_EFFORT, 1);
+
+  PackedPixelFile ppf_out;
+  EXPECT_EQ(Roundtrip(t.ppf(), cparams, {}, &pool, &ppf_out), 576);
+  EXPECT_EQ(ComputeDistance2(t.ppf(), ppf_out), 0.0);
+}
+
 }  // namespace
 }  // namespace jxl


### PR DESCRIPTION
This tests for a problem that was fixed in https://github.com/libjxl/libjxl/pull/2842.