### PR TITLE
Added jpegview and antidupl.net to software_support.md

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -39,6 +39,7 @@ Fred Brennan <copypaste@kittens.ph>
 gi-man
 Gilles Devillers (GilDev) <gildev@gmail.com>
 Heiko Becker <heirecka@exherbo.org>
+Ivan Kokorev
 Jim Robinson <jimbo2150@gmail.com>
 Jon Sneyers <jon@cloudinary.com>
 Jonathan Brown (Jonnyawsom3) <jonathanbr30@gmail.com>

--- a/doc/software_support.md
+++ b/doc/software_support.md
@@ -57,15 +57,20 @@ For all browsers and to track browsers progress see [Can I Use](https://caniuse.
 
 ## Image viewers
 
-- [XnView](https://www.xnview.com/en/)
 - [ImageGlass](https://imageglass.org/)
 - [IrfanView](https://www.irfanview.com/); supported since 4.59 - requires a [plugin](https://www.irfanview.com/plugins.htm) to be downloaded and enabled.
+- [jpegview](https://github.com/sylikc/jpegview/releases)
+- [Swayimg](https://github.com/artemsen/swayimg)
 - [Tachiyomi](https://github.com/tachiyomiorg/tachiyomi/releases/tag/v0.12.1)
+- [XnView](https://www.xnview.com/en/)
 - Any viewer based on Qt, KDE, GDK-pixbuf, EFL, ImageMagick, libvips or imlib2 (see above)
   - Qt viewers: gwenview, digiKam, KolourPaint, KPhotoAlbum, LXImage-Qt, qimgv, qView, nomacs, VookiImageViewer, PhotoQt
   - GTK viewers: Eye of Gnome (eog), gThumb, Geeqie
   - EFL viewers: entice, ephoto
-- [Swayimg](https://github.com/artemsen/swayimg)
+ 
+## Duplicate image finders
+
+- [AntiDupl.NET](https://github.com/ermig1979/AntiDupl/releases)
 
 ## Online tools
 


### PR DESCRIPTION
### Description

Added 2 programs for Windows now supporting jxl: 
- the best (imho) picture viewer - jpegview
- duplicate image finder able to find similar images with different resolution, rotation, flipping - AntiDupl.NET
Also sorted image viewers alphabetically