### PR TITLE
Pick-up fix from Brunsli upstream

### DIFF
--- a/lib/jxl/jpeg/dec_jpeg_data_writer.cc
+++ b/lib/jxl/jpeg/dec_jpeg_data_writer.cc
@@ -8,6 +8,8 @@
 #include <stdlib.h>
 #include <string.h> /* for memset, memcpy */
 
+#include <cstddef>
+#include <cstdint>
 #include <deque>
 #include <string>
 #include <vector>
@@ -36,9 +38,6 @@ const int kJpegPrecision = 8;
 
 // JpegBitWriter: buffer size
 const size_t kJpegBitWriterChunkSize = 16384;
-
-// DCTCodingState: maximum number of correction bits to buffer
-const int kJPEGMaxCorrectionBits = 1u << 16;
 
 // Returns non-zero if and only if x has a zero byte, i.e. one of
 // x & 0xff, x & 0xff00, ..., x & 0xff00000000000000 is zero.
@@ -184,7 +183,7 @@ void DCTCodingStateInit(DCTCodingState* s) {
   s->eob_run_ = 0;
   s->cur_ac_huff_ = nullptr;
   s->refinement_bits_.clear();
-  s->refinement_bits_.reserve(kJPEGMaxCorrectionBits);
+  s->refinement_bits_.reserve(64);
 }
 
 static JXL_INLINE void WriteSymbol(int symbol, HuffmanCodeTable* table,
@@ -211,28 +210,56 @@ static JXL_INLINE void Flush(DCTCodingState* s, JpegBitWriter* bw) {
     }
     s->eob_run_ = 0;
   }
-  for (size_t i = 0; i < s->refinement_bits_.size(); ++i) {
-    WriteBits(bw, 1, s->refinement_bits_[i]);
+  size_t num_words = s->refinement_bits_count_ >> 4;
+  for (size_t i = 0; i < num_words; ++i) {
+    WriteBits(bw, 16, s->refinement_bits_[i]);
+  }
+  size_t tail = s->refinement_bits_count_ & 0xF;
+  if (tail) {
+    WriteBits(bw, tail, s->refinement_bits_.back());
   }
   s->refinement_bits_.clear();
+  s->refinement_bits_count_ = 0;
 }
 
 // Buffer some more data at the end-of-band (the last non-zero or newly
 // non-zero coefficient within the [Ss, Se] spectral band).
 static JXL_INLINE void BufferEndOfBand(DCTCodingState* s,
                                        HuffmanCodeTable* ac_huff,
-                                       const std::vector<int>* new_bits,
+                                       const int* new_bits_array,
+                                       size_t new_bits_count,
                                        JpegBitWriter* bw) {
   if (s->eob_run_ == 0) {
     s->cur_ac_huff_ = ac_huff;
   }
   ++s->eob_run_;
-  if (new_bits) {
-    s->refinement_bits_.insert(s->refinement_bits_.end(), new_bits->begin(),
-                               new_bits->end());
+  if (new_bits_count) {
+    uint64_t new_bits = 0;
+    for (size_t i = 0; i < new_bits_count; ++i) {
+      new_bits = (new_bits << 1) | new_bits_array[i];
+    }
+    size_t tail = s->refinement_bits_count_ & 0xF;
+    if (tail) {  // First stuff the tail item
+      size_t stuff_bits_count = std::min(16 - tail, new_bits_count);
+      uint16_t stuff_bits = new_bits >> (new_bits_count - stuff_bits_count);
+      stuff_bits &= ((1u << stuff_bits_count) - 1);
+      s->refinement_bits_.back() =
+          (s->refinement_bits_.back() << stuff_bits_count) | stuff_bits;
+      new_bits_count -= stuff_bits_count;
+      s->refinement_bits_count_ += stuff_bits_count;
+    }
+    while (new_bits_count >= 16) {
+      s->refinement_bits_.push_back(new_bits >> (new_bits_count - 16));
+      new_bits_count -= 16;
+      s->refinement_bits_count_ += 16;
+    }
+    if (new_bits_count) {
+      s->refinement_bits_.push_back(new_bits & ((1u << new_bits_count) - 1));
+      s->refinement_bits_count_ += new_bits_count;
+    }
   }
-  if (s->eob_run_ == 0x7FFF ||
-      s->refinement_bits_.size() > kJPEGMaxCorrectionBits - kDCTBlockSize + 1) {
+
+  if (s->eob_run_ == 0x7FFF) {
     Flush(s, bw);
   }
 }
@@ -611,7 +638,7 @@ bool EncodeDCTBlockProgressive(const coeff_t* coeffs, HuffmanCodeTable* dc_huff,
     }
   }
   if (r > 0) {
-    BufferEndOfBand(coding_state, ac_huff, nullptr, bw);
+    BufferEndOfBand(coding_state, ac_huff, nullptr, 0, bw);
     if (!eob_run_allowed) {
       Flush(coding_state, bw);
     }
@@ -641,8 +668,8 @@ bool EncodeRefinementBits(const coeff_t* coeffs, HuffmanCodeTable* ac_huff,
     }
   }
   int r = 0;
-  std::vector<int> refinement_bits;
-  refinement_bits.reserve(kDCTBlockSize);
+  int refinement_bits[kDCTBlockSize];
+  size_t refinement_bits_count = 0;
   for (int k = Ss; k <= Se; k++) {
     if (abs_values[k] == 0) {
       r++;
@@ -652,13 +679,13 @@ bool EncodeRefinementBits(const coeff_t* coeffs, HuffmanCodeTable* ac_huff,
       Flush(coding_state, bw);
       WriteSymbol(0xf0, ac_huff, bw);
       r -= 16;
-      for (int bit : refinement_bits) {
-        WriteBits(bw, 1, bit);
+      for (size_t i = 0; i < refinement_bits_count; ++i) {
+        WriteBits(bw, 1, refinement_bits[i]);
       }
-      refinement_bits.clear();
+      refinement_bits_count = 0;
     }
     if (abs_values[k] > 1) {
-      refinement_bits.push_back(abs_values[k] & 1u);
+      refinement_bits[refinement_bits_count++] = abs_values[k] & 1u;
       continue;
     }
     Flush(coding_state, bw);
@@ -666,14 +693,15 @@ bool EncodeRefinementBits(const coeff_t* coeffs, HuffmanCodeTable* ac_huff,
     int new_non_zero_bit = (coeffs[kJPEGNaturalOrder[k]] < 0) ? 0 : 1;
     WriteSymbol(symbol, ac_huff, bw);
     WriteBits(bw, 1, new_non_zero_bit);
-    for (int bit : refinement_bits) {
-      WriteBits(bw, 1, bit);
+    for (size_t i = 0; i < refinement_bits_count; ++i) {
+      WriteBits(bw, 1, refinement_bits[i]);
     }
-    refinement_bits.clear();
+    refinement_bits_count = 0;
     r = 0;
   }
-  if (r > 0 || !refinement_bits.empty()) {
-    BufferEndOfBand(coding_state, ac_huff, &refinement_bits, bw);
+  if (r > 0 || refinement_bits_count) {
+    BufferEndOfBand(coding_state, ac_huff, refinement_bits,
+                    refinement_bits_count, bw);
     if (!eob_run_allowed) {
       Flush(coding_state, bw);
     }

--- a/lib/jxl/jpeg/dec_jpeg_serialization_state.h
+++ b/lib/jxl/jpeg/dec_jpeg_serialization_state.h
@@ -44,7 +44,8 @@ struct DCTCodingState {
   HuffmanCodeTable* cur_ac_huff_;
   // The sequence of currently buffered refinement bits for a successive
   // approximation scan (one where Ah > 0).
-  std::vector<int> refinement_bits_;
+  std::vector<uint16_t> refinement_bits_;
+  size_t refinement_bits_count_ = 0;
 };
 
 struct EncodeScanState {


### PR DESCRIPTION
Some JPEGs failed to decode, others produced not the same bytes (but, likely represented original image data)

Also this makes decoding faster and saves memory.
