### PR TITLE
allow non-XYB encoding with default colorspace

### DIFF
--- a/lib/jxl/encode.cc
+++ b/lib/jxl/encode.cc
@@ -2187,12 +2187,8 @@ static bool CanDoFastLossless(const JxlEncoderFrameSettings* frame_settings,
 JxlEncoderStatus JxlEncoderAddImageFrame(
     const JxlEncoderFrameSettings* frame_settings,
     const JxlPixelFormat* pixel_format, const void* buffer, size_t size) {
-  if (!frame_settings->enc->basic_info_set ||
-      (!frame_settings->enc->color_encoding_set &&
-       !frame_settings->enc->metadata.m.xyb_encoded)) {
-    // Basic Info must be set, and color encoding must be set directly,
-    // or set to XYB via JxlBasicInfo.uses_original_profile = JXL_FALSE
-    // Otherwise, this is an API misuse.
+  if (!frame_settings->enc->basic_info_set) {
+    // Basic Info must be set. Otherwise, this is an API misuse.
     return JXL_API_ERROR(frame_settings->enc, JXL_ENC_ERR_API_USAGE,
                          "Basic info or color encoding not set yet");
   }

--- a/lib/jxl/encode_test.cc
+++ b/lib/jxl/encode_test.cc
@@ -82,32 +82,6 @@ TEST(EncodeTest, AddJPEGAfterCloseTest) {
             JxlEncoderAddJPEGFrame(frame_settings, orig.data(), orig.size()));
 }
 
-TEST(EncodeTest, AddFrameBeforeColorEncodingTest) {
-  JxlEncoderPtr enc = JxlEncoderMake(nullptr);
-  EXPECT_NE(nullptr, enc.get());
-
-  size_t xsize = 64;
-  size_t ysize = 64;
-  JxlPixelFormat pixel_format = {4, JXL_TYPE_UINT16, JXL_BIG_ENDIAN, 0};
-  std::vector<uint8_t> pixels = jxl::test::GetSomeTestImage(xsize, ysize, 4, 0);
-
-  jxl::CodecInOut input_io =
-      jxl::test::SomeTestImageToCodecInOut(pixels, 4, xsize, ysize);
-
-  JxlBasicInfo basic_info;
-  jxl::test::JxlBasicInfoSetFromPixelFormat(&basic_info, &pixel_format);
-  basic_info.xsize = xsize;
-  basic_info.ysize = ysize;
-  basic_info.uses_original_profile = true;
-  EXPECT_EQ(JXL_ENC_SUCCESS, JxlEncoderSetCodestreamLevel(enc.get(), 10));
-  EXPECT_EQ(JXL_ENC_SUCCESS, JxlEncoderSetBasicInfo(enc.get(), &basic_info));
-  JxlEncoderFrameSettings* frame_settings =
-      JxlEncoderFrameSettingsCreate(enc.get(), NULL);
-  EXPECT_EQ(JXL_ENC_ERROR,
-            JxlEncoderAddImageFrame(frame_settings, &pixel_format,
-                                    pixels.data(), pixels.size()));
-}
-
 TEST(EncodeTest, AddFrameBeforeBasicInfoTest) {
   JxlEncoderPtr enc = JxlEncoderMake(nullptr);
   EXPECT_NE(nullptr, enc.get());


### PR DESCRIPTION
Fixes https://github.com/libjxl/libjxl/issues/2870

In case of non-XYB (e.g. lossless), we currently force applications to explicitly set a colorspace with `JxlEncoderSetColorEncoding` or `JxlEncoderSetICCProfile`, while in our documentation (https://github.com/libjxl/libjxl/blob/main/lib/include/jxl/encode.h#L645) we say that if it is not explicitly set, it has a default (which is sRGB, either linear or nonlinear depending on the pixel format).

This fixes the discrepancy by also allowing to use the default colorspace in the non-XYB case.