### PR TITLE
Fix fast-lossless on images with a palette larger than 256 colors.

### DIFF
--- a/lib/jxl/enc_fast_lossless.cc
+++ b/lib/jxl/enc_fast_lossless.cc
@@ -2497,10 +2497,10 @@ struct UpTo8Bits {
     GenericEncodeChunk(residuals, n, skip, code, output);
   }
 
-  size_t NumSymbols(bool doing_ycocg) const {
+  size_t NumSymbols(bool doing_ycocg_or_large_palette) const {
     // values gain 1 bit for YCoCg, 1 bit for prediction.
     // Maximum symbol is 1 + effective bit depth of residuals.
-    if (doing_ycocg) {
+    if (doing_ycocg_or_large_palette) {
       return bitdepth + 3;
     } else {
       return bitdepth + 2;
@@ -2560,10 +2560,10 @@ struct From9To13Bits {
     GenericEncodeChunk(residuals, n, skip, code, output);
   }
 
-  size_t NumSymbols(bool doing_ycocg) const {
+  size_t NumSymbols(bool doing_ycocg_or_large_palette) const {
     // values gain 1 bit for YCoCg, 1 bit for prediction.
     // Maximum symbol is 1 + effective bit depth of residuals.
-    if (doing_ycocg) {
+    if (doing_ycocg_or_large_palette) {
       return bitdepth + 3;
     } else {
       return bitdepth + 2;
@@ -3623,7 +3623,9 @@ JxlFastLosslessFrameState* LLEnc(const unsigned char* rgba, size_t width,
       5,    1,   1,    1,    1,    1,   1,   1,   1};
 
   bool doing_ycocg = nb_chans > 2 && collided;
-  for (size_t i = bitdepth.NumSymbols(doing_ycocg); i < kNumRawSymbols; i++) {
+  bool large_palette = !collided || pcolors >= 256;
+  for (size_t i = bitdepth.NumSymbols(doing_ycocg || large_palette);
+       i < kNumRawSymbols; i++) {
     base_raw_counts[i] = 0;
   }
 


### PR DESCRIPTION
Fixes #2841 (the new failing image).