### PR TITLE
Reduce use of PaddedBytes outside of encoder/decoder libs

### DIFF
--- a/lib/extras/codec.cc
+++ b/lib/extras/codec.cc
@@ -16,7 +16,6 @@
 #include "lib/extras/enc/pnm.h"
 #include "lib/extras/packed_image.h"
 #include "lib/extras/packed_image_convert.h"
-#include "lib/jxl/base/padded_bytes.h"
 #include "lib/jxl/base/status.h"
 #include "lib/jxl/image_bundle.h"
 

--- a/lib/extras/codec.h
+++ b/lib/extras/codec.h
@@ -17,7 +17,6 @@
 #include "lib/extras/dec/decode.h"
 #include "lib/jxl/base/compiler_specific.h"
 #include "lib/jxl/base/data_parallel.h"
-#include "lib/jxl/base/padded_bytes.h"
 #include "lib/jxl/base/span.h"
 #include "lib/jxl/base/status.h"
 #include "lib/jxl/codec_in_out.h"

--- a/lib/extras/codec_test.cc
+++ b/lib/extras/codec_test.cc
@@ -8,6 +8,7 @@
 #include <stddef.h>
 
 #include <algorithm>
+#include <cstdint>
 #include <sstream>
 #include <string>
 #include <utility>
@@ -265,8 +266,7 @@ void TestRoundTrip(const TestImageParams& params, ThreadPool* pool) {
     color_hints.Add("color_space",
                     params.is_gray ? "Gra_D65_Rel_SRG" : "RGB_D65_SRG_Rel_SRG");
   }
-  ASSERT_TRUE(DecodeBytes(Span<const uint8_t>(encoded.bitstreams[0]),
-                          color_hints, &ppf_out));
+  ASSERT_TRUE(DecodeBytes(Bytes(encoded.bitstreams[0]), color_hints, &ppf_out));
   if (params.codec == Codec::kPNG && ppf_out.icc.empty()) {
     // Decoding a PNG may drop the ICC profile if there's a valid cICP chunk.
     // Rendering intent is not preserved in this case.
@@ -348,14 +348,14 @@ TEST(CodecTest, LosslessPNMRoundtrip) {
       std::string filename = "jxl/flower/flower_small." +
                              std::string(kChannels[channels]) + ".depth" +
                              std::to_string(bit_depth) + extension;
-      const PaddedBytes orig = jxl::test::ReadTestData(filename);
+      const std::vector<uint8_t> orig = jxl::test::ReadTestData(filename);
 
       PackedPixelFile ppf;
       ColorHints color_hints;
       color_hints.Add("color_space",
                       channels < 3 ? "Gra_D65_Rel_SRG" : "RGB_D65_SRG_Rel_SRG");
-      ASSERT_TRUE(DecodeBytes(Span<const uint8_t>(orig.data(), orig.size()),
-                              color_hints, &ppf));
+      ASSERT_TRUE(
+          DecodeBytes(Bytes(orig.data(), orig.size()), color_hints, &ppf));
 
       EncodedImage encoded;
       auto encoder = Encoder::FromExtension(extension);
@@ -415,11 +415,10 @@ TEST(CodecTest, EncodeToPNG) {
     return;
   }
 
-  const PaddedBytes original_png = jxl::test::ReadTestData(
+  const std::vector<uint8_t> original_png = jxl::test::ReadTestData(
       "external/wesaturate/500px/tmshre_riaphotographs_srgb8.png");
   PackedPixelFile ppf;
-  ASSERT_TRUE(extras::DecodeBytes(Span<const uint8_t>(original_png),
-                                  ColorHints(), &ppf));
+  ASSERT_TRUE(extras::DecodeBytes(Bytes(original_png), ColorHints(), &ppf));
 
   const JxlPixelFormat& format = ppf.frames.front().color.format;
   ASSERT_THAT(
@@ -433,9 +432,8 @@ TEST(CodecTest, EncodeToPNG) {
   ASSERT_THAT(encoded_png.bitstreams, SizeIs(1));
 
   PackedPixelFile decoded_ppf;
-  ASSERT_TRUE(
-      extras::DecodeBytes(Span<const uint8_t>(encoded_png.bitstreams.front()),
-                          ColorHints(), &decoded_ppf));
+  ASSERT_TRUE(extras::DecodeBytes(Bytes(encoded_png.bitstreams.front()),
+                                  ColorHints(), &decoded_ppf));
 
   ASSERT_EQ(decoded_ppf.info.bits_per_sample, ppf.info.bits_per_sample);
   ASSERT_EQ(decoded_ppf.frames.size(), 1);

--- a/lib/extras/dec/apng.h
+++ b/lib/extras/dec/apng.h
@@ -13,7 +13,6 @@
 #include "lib/extras/dec/color_hints.h"
 #include "lib/extras/packed_image.h"
 #include "lib/jxl/base/data_parallel.h"
-#include "lib/jxl/base/padded_bytes.h"
 #include "lib/jxl/base/span.h"
 #include "lib/jxl/base/status.h"
 

--- a/lib/extras/dec/exr.h
+++ b/lib/extras/dec/exr.h
@@ -11,7 +11,6 @@
 #include "lib/extras/dec/color_hints.h"
 #include "lib/extras/packed_image.h"
 #include "lib/jxl/base/data_parallel.h"
-#include "lib/jxl/base/padded_bytes.h"
 #include "lib/jxl/base/span.h"
 #include "lib/jxl/base/status.h"
 

--- a/lib/extras/dec/jpg.h
+++ b/lib/extras/dec/jpg.h
@@ -13,7 +13,6 @@
 #include "lib/extras/codec.h"
 #include "lib/extras/dec/color_hints.h"
 #include "lib/jxl/base/data_parallel.h"
-#include "lib/jxl/base/padded_bytes.h"
 #include "lib/jxl/base/span.h"
 #include "lib/jxl/base/status.h"
 

--- a/lib/extras/dec/pgx.h
+++ b/lib/extras/dec/pgx.h
@@ -14,7 +14,6 @@
 #include "lib/extras/dec/color_hints.h"
 #include "lib/extras/packed_image.h"
 #include "lib/jxl/base/data_parallel.h"
-#include "lib/jxl/base/padded_bytes.h"
 #include "lib/jxl/base/span.h"
 #include "lib/jxl/base/status.h"
 

--- a/lib/extras/dec/pgx_test.cc
+++ b/lib/extras/dec/pgx_test.cc
@@ -14,8 +14,7 @@ namespace extras {
 namespace {
 
 Span<const uint8_t> MakeSpan(const char* str) {
-  return Span<const uint8_t>(reinterpret_cast<const uint8_t*>(str),
-                             strlen(str));
+  return Bytes(reinterpret_cast<const uint8_t*>(str), strlen(str));
 }
 
 TEST(CodecPGXTest, Test8bits) {

--- a/lib/extras/dec/pnm.cc
+++ b/lib/extras/dec/pnm.cc
@@ -320,8 +320,7 @@ class Parser {
 };
 
 Span<const uint8_t> MakeSpan(const char* str) {
-  return Span<const uint8_t>(reinterpret_cast<const uint8_t*>(str),
-                             strlen(str));
+  return Bytes(reinterpret_cast<const uint8_t*>(str), strlen(str));
 }
 
 }  // namespace

--- a/lib/extras/dec/pnm.h
+++ b/lib/extras/dec/pnm.h
@@ -17,7 +17,6 @@
 #include "lib/extras/dec/color_hints.h"
 #include "lib/extras/packed_image.h"
 #include "lib/jxl/base/data_parallel.h"
-#include "lib/jxl/base/padded_bytes.h"
 #include "lib/jxl/base/span.h"
 #include "lib/jxl/base/status.h"
 

--- a/lib/extras/jpegli_test.cc
+++ b/lib/extras/jpegli_test.cc
@@ -10,8 +10,10 @@
 #include <jxl/color_encoding.h>
 #include <stdint.h>
 
+#include <cstdint>
 #include <memory>
 #include <string>
+#include <vector>
 
 #include "lib/extras/dec/color_hints.h"
 #include "lib/extras/dec/decode.h"
@@ -36,14 +38,14 @@ using test::ButteraugliDistance;
 using test::TestImage;
 
 Status ReadTestImage(const std::string& pathname, PackedPixelFile* ppf) {
-  const PaddedBytes encoded = jxl::test::ReadTestData(pathname);
+  const std::vector<uint8_t> encoded = jxl::test::ReadTestData(pathname);
   ColorHints color_hints;
   if (pathname.find(".ppm") != std::string::npos) {
     color_hints.Add("color_space", "RGB_D65_SRG_Rel_SRG");
   } else if (pathname.find(".pgm") != std::string::npos) {
     color_hints.Add("color_space", "Gra_D65_Rel_SRG");
   }
-  return DecodeBytes(Span<const uint8_t>(encoded), color_hints, ppf);
+  return DecodeBytes(Bytes(encoded), color_hints, ppf);
 }
 
 std::vector<uint8_t> GetAppData(const std::vector<uint8_t>& compressed) {
@@ -67,7 +69,7 @@ std::vector<uint8_t> GetAppData(const std::vector<uint8_t>& compressed) {
 Status DecodeWithLibjpeg(const std::vector<uint8_t>& compressed,
                          PackedPixelFile* ppf,
                          const JPGDecompressParams* dparams = nullptr) {
-  return DecodeImageJPG(Span<const uint8_t>(compressed), ColorHints(), ppf,
+  return DecodeImageJPG(Bytes(compressed), ColorHints(), ppf,
                         /*constraints=*/nullptr, dparams);
 }
 

--- a/lib/jpegli/decode_api_test.cc
+++ b/lib/jpegli/decode_api_test.cc
@@ -4,6 +4,7 @@
 // license that can be found in the LICENSE file.
 
 #include <cmath>
+#include <cstdint>
 #include <vector>
 
 #include "lib/jpegli/decode.h"

--- a/lib/jpegli/input_suspension_test.cc
+++ b/lib/jpegli/input_suspension_test.cc
@@ -4,6 +4,7 @@
 // license that can be found in the LICENSE file.
 
 #include <cmath>
+#include <cstdint>
 #include <vector>
 
 #include "lib/jpegli/decode.h"

--- a/lib/jpegli/source_manager_test.cc
+++ b/lib/jpegli/source_manager_test.cc
@@ -4,6 +4,7 @@
 // license that can be found in the LICENSE file.
 
 #include <cmath>
+#include <cstdint>
 #include <vector>
 
 #include "lib/jpegli/decode.h"

--- a/lib/jpegli/test_utils.cc
+++ b/lib/jpegli/test_utils.cc
@@ -6,6 +6,7 @@
 #include "lib/jpegli/test_utils.h"
 
 #include <cmath>
+#include <cstdint>
 #include <fstream>
 
 #include "lib/jpegli/decode.h"

--- a/lib/jxl/base/span.h
+++ b/lib/jxl/base/span.h
@@ -64,7 +64,7 @@ class Span {
 
   // NCT == non-const-T; compiler will complain if NCT is not compatible with T.
   template <typename NCT>
-  void AppendTo(std::vector<NCT>* dst) {
+  void AppendTo(std::vector<NCT>* dst) const {
     dst->insert(dst->end(), begin(), end());
   }
 
@@ -72,6 +72,8 @@ class Span {
   T* ptr_;
   size_t len_;
 };
+
+typedef Span<const uint8_t> Bytes;
 
 }  // namespace jxl
 

--- a/lib/jxl/bit_reader_test.cc
+++ b/lib/jxl/bit_reader_test.cc
@@ -27,7 +27,7 @@ TEST(BitReaderTest, ExtendsWithZeroes) {
     std::vector<uint8_t> data(size, 0xff);
 
     for (size_t n_bytes = 0; n_bytes < size; n_bytes++) {
-      BitReader br(Span<const uint8_t>(data.data(), n_bytes));
+      BitReader br(Bytes(data.data(), n_bytes));
       // Read all the bits
       for (size_t i = 0; i < n_bytes * kBitsPerByte; i++) {
         ASSERT_EQ(br.ReadBits(1), 1u) << "n_bytes=" << n_bytes << " i=" << i;
@@ -214,7 +214,7 @@ TEST(BitReaderTest, TestOrder) {
 
 TEST(BitReaderTest, TotalCountersTest) {
   uint8_t buf[8] = {1, 2, 3, 4};
-  BitReader reader(Span<const uint8_t>(buf, sizeof(buf)));
+  BitReader reader(Bytes(buf, sizeof(buf)));
 
   EXPECT_EQ(sizeof(buf), reader.TotalBytes());
   EXPECT_EQ(0u, reader.TotalBitsConsumed());
@@ -240,7 +240,7 @@ TEST(BitReaderTest, MoveTest) {
   uint8_t buf[8] = {1, 2, 3, 4};
   BitReader reader2;
   {
-    BitReader reader1(Span<const uint8_t>(buf, sizeof(buf)));
+    BitReader reader1(Bytes(buf, sizeof(buf)));
 
     EXPECT_EQ(0u, reader1.TotalBitsConsumed());
     reader1.ReadFixedBits<16>();

--- a/lib/jxl/blending_test.cc
+++ b/lib/jxl/blending_test.cc
@@ -3,6 +3,9 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
+#include <cstdint>
+#include <vector>
+
 #include "lib/extras/codec.h"
 #include "lib/jxl/image_test_utils.h"
 #include "lib/jxl/test_utils.h"
@@ -14,20 +17,20 @@ namespace {
 using ::testing::SizeIs;
 
 TEST(BlendingTest, Crops) {
-  const PaddedBytes compressed =
+  const std::vector<uint8_t> compressed =
       jxl::test::ReadTestData("jxl/blending/cropped_traffic_light.jxl");
   CodecInOut decoded;
-  ASSERT_TRUE(test::DecodeFile({}, Span<const uint8_t>(compressed), &decoded));
+  ASSERT_TRUE(test::DecodeFile({}, Bytes(compressed), &decoded));
   ASSERT_THAT(decoded.frames, SizeIs(4));
 
   int i = 0;
   for (const ImageBundle& ib : decoded.frames) {
     std::ostringstream filename;
     filename << "jxl/blending/cropped_traffic_light_frame-" << i << ".png";
-    const PaddedBytes compressed_frame =
+    const std::vector<uint8_t> compressed_frame =
         jxl::test::ReadTestData(filename.str());
     CodecInOut frame;
-    ASSERT_TRUE(SetFromBytes(Span<const uint8_t>(compressed_frame), &frame));
+    ASSERT_TRUE(SetFromBytes(Bytes(compressed_frame), &frame));
     JXL_EXPECT_OK(SamePixels(ib.color(), *frame.Main().color(), _));
     ++i;
   }

--- a/lib/jxl/butteraugli/butteraugli_test.cc
+++ b/lib/jxl/butteraugli/butteraugli_test.cc
@@ -44,10 +44,9 @@ Image3F GetColorImage(const PackedPixelFile& ppf) {
   const uint8_t* pixels = reinterpret_cast<const uint8_t*>(image.pixels());
   Image3F color(image.xsize, image.ysize);
   for (size_t c = 0; c < format.num_channels; ++c) {
-    JXL_CHECK(
-        ConvertFromExternal(Span<const uint8_t>(pixels, image.pixels_size),
-                            image.xsize, image.ysize, ppf.info.bits_per_sample,
-                            format, c, nullptr, &color.Plane(c)));
+    JXL_CHECK(ConvertFromExternal(Bytes(pixels, image.pixels_size), image.xsize,
+                                  image.ysize, ppf.info.bits_per_sample, format,
+                                  c, nullptr, &color.Plane(c)));
   }
   return color;
 }

--- a/lib/jxl/cms/color_management.cc
+++ b/lib/jxl/cms/color_management.cc
@@ -1056,8 +1056,8 @@ Status MaybeCreateProfile(const JxlColorEncoding& c,
   WriteICCUint32(header.size() + tagtable.size() + tags.size(), 0, &header);
 
   *icc = header;
-  Span<const uint8_t>(tagtable).AppendTo(icc);
-  Span<const uint8_t>(tags).AppendTo(icc);
+  Bytes(tagtable).AppendTo(icc);
+  Bytes(tags).AppendTo(icc);
 
   // The MD5 checksum must be computed on the profile with profile flags,
   // rendering intent, and region of the checksum itself, set to 0.

--- a/lib/jxl/cms/jxl_cms.cc
+++ b/lib/jxl/cms/jxl_cms.cc
@@ -576,8 +576,7 @@ Status ProfileEquivalentToICC(const cmsContext context, const Profile& profile1,
   const uint32_t type_src = Type64(c);
 
   Profile profile2;
-  JXL_RETURN_IF_ERROR(
-      DecodeProfile(context, Span<const uint8_t>(icc), &profile2));
+  JXL_RETURN_IF_ERROR(DecodeProfile(context, Bytes(icc), &profile2));
 
   Profile profile_xyz;
   JXL_RETURN_IF_ERROR(CreateProfileXYZ(context, &profile_xyz));
@@ -1002,8 +1001,8 @@ JXL_BOOL JxlCmsSetFieldsFromICC(void* user_data, const uint8_t* icc_data,
   const cmsContext context = GetContext();
 
   Profile profile;
-  JXL_RETURN_IF_ERROR(DecodeProfile(
-      context, Span<const uint8_t>(icc_data, icc_size), &profile));
+  JXL_RETURN_IF_ERROR(
+      DecodeProfile(context, Bytes(icc_data, icc_size), &profile));
 
   const cmsUInt32Number rendering_intent32 =
       cmsGetHeaderRenderingIntent(profile.get());
@@ -1119,11 +1118,11 @@ void* JxlCmsInit(void* init_data, size_t num_threads, size_t xsize,
 #else   // JPEGXL_ENABLE_SKCMS
   const cmsContext context = GetContext();
   Profile profile_src, profile_dst;
-  if (!DecodeProfile(context, Span<const uint8_t>(c_src.icc), &profile_src)) {
+  if (!DecodeProfile(context, Bytes(c_src.icc), &profile_src)) {
     JXL_NOTIFY_ERROR("JxlCmsInit: lcms failed to parse input ICC");
     return nullptr;
   }
-  if (!DecodeProfile(context, Span<const uint8_t>(c_dst.icc), &profile_dst)) {
+  if (!DecodeProfile(context, Bytes(c_dst.icc), &profile_dst)) {
     JXL_NOTIFY_ERROR("JxlCmsInit: lcms failed to parse output ICC");
     return nullptr;
   }
@@ -1169,7 +1168,7 @@ void* JxlCmsInit(void* init_data, size_t num_threads, size_t xsize,
 #if JPEGXL_ENABLE_SKCMS
         DecodeProfile(icc_src.data(), icc_src.size(), &new_src)) {
 #else   // JPEGXL_ENABLE_SKCMS
-        DecodeProfile(context, Span<const uint8_t>(icc_src), &new_src)) {
+        DecodeProfile(context, Bytes(icc_src), &new_src)) {
 #endif  // JPEGXL_ENABLE_SKCMS
 #if JXL_CMS_VERBOSE
       printf("Special HLG/PQ/sRGB -> linear\n");
@@ -1210,7 +1209,7 @@ void* JxlCmsInit(void* init_data, size_t num_threads, size_t xsize,
 #if JPEGXL_ENABLE_SKCMS
         DecodeProfile(icc_dst.data(), icc_dst.size(), &new_dst)) {
 #else   // JPEGXL_ENABLE_SKCMS
-        DecodeProfile(context, Span<const uint8_t>(icc_dst), &new_dst)) {
+        DecodeProfile(context, Bytes(icc_dst), &new_dst)) {
 #endif  // JPEGXL_ENABLE_SKCMS
 #if JXL_CMS_VERBOSE
       printf("Special linear -> HLG/PQ/sRGB\n");

--- a/lib/jxl/coeff_order.cc
+++ b/lib/jxl/coeff_order.cc
@@ -11,7 +11,6 @@
 #include <vector>
 
 #include "lib/jxl/ans_params.h"
-#include "lib/jxl/base/padded_bytes.h"
 #include "lib/jxl/base/span.h"
 #include "lib/jxl/coeff_order_fwd.h"
 #include "lib/jxl/dec_ans.h"

--- a/lib/jxl/color_management_test.cc
+++ b/lib/jxl/color_management_test.cc
@@ -7,6 +7,7 @@
 #include <stdint.h>
 
 #include <algorithm>
+#include <cstdint>
 #include <new>
 #include <string>
 #include <utility>
@@ -14,7 +15,6 @@
 #include "lib/jxl/base/common.h"
 #include "lib/jxl/base/compiler_specific.h"
 #include "lib/jxl/base/data_parallel.h"
-#include "lib/jxl/base/padded_bytes.h"
 #include "lib/jxl/base/random.h"
 #include "lib/jxl/base/span.h"
 #include "lib/jxl/cms/color_encoding_cms.h"
@@ -232,10 +232,10 @@ TEST_F(ColorManagementTest, sRGBChromaticity) {
 }
 
 TEST_F(ColorManagementTest, D2700Chromaticity) {
-  PaddedBytes icc_data =
+  std::vector<uint8_t> icc_data =
       jxl::test::ReadTestData("jxl/color_management/sRGB-D2700.icc");
   IccBytes icc;
-  Span<const uint8_t>(icc_data).AppendTo(&icc);
+  Bytes(icc_data).AppendTo(&icc);
   ColorEncoding sRGB_D2700;
   ASSERT_TRUE(sRGB_D2700.SetICC(std::move(icc), JxlGetDefaultCms()));
 
@@ -249,10 +249,10 @@ TEST_F(ColorManagementTest, D2700Chromaticity) {
 }
 
 TEST_F(ColorManagementTest, D2700ToSRGB) {
-  PaddedBytes icc_data =
+  std::vector<uint8_t> icc_data =
       jxl::test::ReadTestData("jxl/color_management/sRGB-D2700.icc");
   IccBytes icc;
-  Span<const uint8_t>(icc_data).AppendTo(&icc);
+  Bytes(icc_data).AppendTo(&icc);
   ColorEncoding sRGB_D2700;
   ASSERT_TRUE(sRGB_D2700.SetICC(std::move(icc), JxlGetDefaultCms()));
 

--- a/lib/jxl/compressed_dc.cc
+++ b/lib/jxl/compressed_dc.cc
@@ -26,7 +26,6 @@
 #include "lib/jxl/base/bits.h"
 #include "lib/jxl/base/compiler_specific.h"
 #include "lib/jxl/base/data_parallel.h"
-#include "lib/jxl/base/padded_bytes.h"
 #include "lib/jxl/base/status.h"
 #include "lib/jxl/chroma_from_luma.h"
 #include "lib/jxl/dec_ans.h"

--- a/lib/jxl/dec_bit_reader.h
+++ b/lib/jxl/dec_bit_reader.h
@@ -227,7 +227,7 @@ class BitReader {
     JXL_ASSERT(TotalBitsConsumed() % kBitsPerByte == 0);
     const size_t offset = TotalBitsConsumed() / kBitsPerByte;  // no remainder
     JXL_ASSERT(offset <= TotalBytes());
-    return Span<const uint8_t>(first_byte_ + offset, TotalBytes() - offset);
+    return Bytes(first_byte_ + offset, TotalBytes() - offset);
   }
 
   // Returns whether all the bits read so far have been within the input bounds.

--- a/lib/jxl/dec_frame.cc
+++ b/lib/jxl/dec_frame.cc
@@ -82,7 +82,7 @@ Status DecodeFrame(PassesDecoderState* dec_state, ThreadPool* JXL_RESTRICT pool,
   FrameDecoder frame_decoder(dec_state, metadata, pool,
                              use_slow_rendering_pipeline);
 
-  BitReader reader(Span<const uint8_t>(next_in, avail_in));
+  BitReader reader(Bytes(next_in, avail_in));
   JXL_RETURN_IF_ERROR(frame_decoder.InitFrame(&reader, decoded,
                                               /*is_preview=*/false));
   JXL_RETURN_IF_ERROR(frame_decoder.InitFrameOutput());
@@ -102,8 +102,7 @@ Status DecodeFrame(PassesDecoderState* dec_state, ThreadPool* JXL_RESTRICT pool,
     size_t index = 0;
     for (auto toc_entry : frame_decoder.Toc()) {
       JXL_RETURN_IF_ERROR(pos + toc_entry.size <= avail_in);
-      auto br = make_unique<BitReader>(
-          Span<const uint8_t>(next_in + pos, toc_entry.size));
+      auto br = make_unique<BitReader>(Bytes(next_in + pos, toc_entry.size));
       section_info.emplace_back(
           FrameDecoder::SectionInfo{br.get(), toc_entry.id, index++});
       section_closers.emplace_back(

--- a/lib/jxl/decode_test.cc
+++ b/lib/jxl/decode_test.cc
@@ -8,9 +8,9 @@
 #include <jxl/resizable_parallel_runner_cxx.h>
 #include <jxl/thread_parallel_runner_cxx.h>
 #include <jxl/types.h>
-#include <stdint.h>
-#include <stdlib.h>
 
+#include <cstdint>
+#include <cstdlib>
 #include <sstream>
 #include <string>
 #include <utility>
@@ -278,7 +278,7 @@ PaddedBytes CreateTestJXLCodestream(Span<const uint8_t> pixels, size_t xsize,
       params.jpeg_codestream->append(jpeg_bytes.data(),
                                      jpeg_bytes.data() + jpeg_bytes.size());
       EXPECT_TRUE(jxl::jpeg::DecodeImageJPG(
-          jxl::Span<const uint8_t>(jpeg_bytes.data(), jpeg_bytes.size()), &io));
+          jxl::Bytes(jpeg_bytes.data(), jpeg_bytes.size()), &io));
       EXPECT_TRUE(
           EncodeJPEGData(*io.Main().jpeg_data, &jpeg_data, params.cparams));
       io.metadata.m.xyb_encoded = false;
@@ -1288,8 +1288,8 @@ TEST_P(DecodeTestParam, PixelTest) {
   params.preview_mode = config.preview_mode;
   params.add_intrinsic_size = config.add_intrinsic_size;
   jxl::PaddedBytes compressed = jxl::CreateTestJXLCodestream(
-      jxl::Span<const uint8_t>(pixels.data(), pixels.size()), config.xsize,
-      config.ysize, orig_channels, params);
+      jxl::Bytes(pixels.data(), pixels.size()), config.xsize, config.ysize,
+      orig_channels, params);
 
   JxlPixelFormat format = {config.output_channels, config.data_type,
                            config.endianness, 0};
@@ -1298,11 +1298,11 @@ TEST_P(DecodeTestParam, PixelTest) {
   size_t xsize = swap_xy ? config.ysize : config.xsize;
   size_t ysize = swap_xy ? config.xsize : config.ysize;
 
-  std::vector<uint8_t> pixels2 = jxl::DecodeWithAPI(
-      dec, jxl::Span<const uint8_t>(compressed.data(), compressed.size()),
-      format, config.use_callback, config.set_buffer_early,
-      config.use_resizable_runner, /*require_boxes=*/false,
-      /*expect_success=*/true);
+  std::vector<uint8_t> pixels2 =
+      jxl::DecodeWithAPI(dec, jxl::Bytes(compressed.data(), compressed.size()),
+                         format, config.use_callback, config.set_buffer_early,
+                         config.use_resizable_runner, /*require_boxes=*/false,
+                         /*expect_success=*/true);
   JxlDecoderReset(dec);
   EXPECT_EQ(num_pixels * config.output_channels *
                 jxl::test::GetDataBits(config.data_type) / jxl::kBitsPerByte,
@@ -1562,16 +1562,15 @@ TEST(DecodeTest, PixelTestWithICCProfileLossless) {
   // For variation: some have container and no preview, others have preview
   // and no container.
   jxl::PaddedBytes compressed = jxl::CreateTestJXLCodestream(
-      jxl::Span<const uint8_t>(pixels.data(), pixels.size()), xsize, ysize, 4,
-      params);
+      jxl::Bytes(pixels.data(), pixels.size()), xsize, ysize, 4, params);
 
   for (uint32_t channels = 3; channels <= 4; ++channels) {
     {
       JxlPixelFormat format = {channels, JXL_TYPE_UINT8, JXL_LITTLE_ENDIAN, 0};
 
       std::vector<uint8_t> pixels2 = jxl::DecodeWithAPI(
-          dec, jxl::Span<const uint8_t>(compressed.data(), compressed.size()),
-          format, /*use_callback=*/false, /*set_buffer_early=*/false,
+          dec, jxl::Bytes(compressed.data(), compressed.size()), format,
+          /*use_callback=*/false, /*set_buffer_early=*/false,
           /*use_resizable_runner=*/false, /*require_boxes=*/false,
           /*expect_success=*/true);
       JxlDecoderReset(dec);
@@ -1585,8 +1584,8 @@ TEST(DecodeTest, PixelTestWithICCProfileLossless) {
 
       // Test with the container for one of the pixel formats.
       std::vector<uint8_t> pixels2 = jxl::DecodeWithAPI(
-          dec, jxl::Span<const uint8_t>(compressed.data(), compressed.size()),
-          format, /*use_callback=*/true, /*set_buffer_early=*/true,
+          dec, jxl::Bytes(compressed.data(), compressed.size()), format,
+          /*use_callback=*/true, /*set_buffer_early=*/true,
           /*use_resizable_runner=*/false, /*require_boxes=*/false,
           /*expect_success=*/true);
       JxlDecoderReset(dec);
@@ -1600,8 +1599,8 @@ TEST(DecodeTest, PixelTestWithICCProfileLossless) {
       JxlPixelFormat format = {channels, JXL_TYPE_FLOAT, JXL_LITTLE_ENDIAN, 0};
 
       std::vector<uint8_t> pixels2 = jxl::DecodeWithAPI(
-          dec, jxl::Span<const uint8_t>(compressed.data(), compressed.size()),
-          format, /*use_callback=*/false, /*set_buffer_early=*/false,
+          dec, jxl::Bytes(compressed.data(), compressed.size()), format,
+          /*use_callback=*/false, /*set_buffer_early=*/false,
           /*use_resizable_runner=*/false, /*require_boxes=*/false,
           /*expect_success=*/true);
       JxlDecoderReset(dec);
@@ -1625,16 +1624,15 @@ TEST(DecodeTest, PixelTestWithICCProfileLossy) {
   jxl::TestCodestreamParams params;
   params.add_icc_profile = true;
   jxl::PaddedBytes compressed = jxl::CreateTestJXLCodestream(
-      jxl::Span<const uint8_t>(pixels.data(), pixels.size()), xsize, ysize, 3,
-      params);
+      jxl::Bytes(pixels.data(), pixels.size()), xsize, ysize, 3, params);
   uint32_t channels = 3;
 
   JxlPixelFormat format = {channels, JXL_TYPE_FLOAT, JXL_LITTLE_ENDIAN, 0};
 
   jxl::PaddedBytes icc_data;
   std::vector<uint8_t> pixels2 = jxl::DecodeWithAPI(
-      dec, jxl::Span<const uint8_t>(compressed.data(), compressed.size()),
-      format, /*use_callback=*/false, /*set_buffer_early=*/true,
+      dec, jxl::Bytes(compressed.data(), compressed.size()), format,
+      /*use_callback=*/false, /*set_buffer_early=*/true,
       /*use_resizable_runner=*/false, /*require_boxes=*/false,
       /*expect_success=*/true, /*icc=*/&icc_data);
   JxlDecoderReset(dec);
@@ -1653,7 +1651,7 @@ TEST(DecodeTest, PixelTestWithICCProfileLossy) {
 
   jxl::ColorEncoding color_encoding1;
   jxl::IccBytes icc;
-  jxl::Span<const uint8_t>(icc_data).AppendTo(&icc);
+  jxl::Bytes(icc_data).AppendTo(&icc);
   EXPECT_TRUE(color_encoding1.SetICC(std::move(icc), JxlGetDefaultCms()));
   jxl::Span<const uint8_t> span1(pixels2.data(), pixels2.size());
   jxl::CodecInOut io1;
@@ -1706,8 +1704,7 @@ double ButteraugliDistance(size_t xsize, size_t ysize,
   JxlPixelFormat format_in = {static_cast<uint32_t>(color_in.Channels()),
                               JXL_TYPE_UINT16, JXL_BIG_ENDIAN, 0};
   EXPECT_TRUE(jxl::ConvertFromExternal(
-      jxl::Span<const uint8_t>(pixels_in.data(), pixels_in.size()), xsize,
-      ysize, color_in,
+      jxl::Bytes(pixels_in.data(), pixels_in.size()), xsize, ysize, color_in,
       /*bits_per_sample=*/16, format_in,
       /*pool=*/nullptr, &in.Main()));
   jxl::CodecInOut out;
@@ -1716,8 +1713,7 @@ double ButteraugliDistance(size_t xsize, size_t ysize,
   JxlPixelFormat format_out = {static_cast<uint32_t>(color_out.Channels()),
                                JXL_TYPE_UINT16, JXL_BIG_ENDIAN, 0};
   EXPECT_TRUE(jxl::ConvertFromExternal(
-      jxl::Span<const uint8_t>(pixels_out.data(), pixels_out.size()), xsize,
-      ysize, color_out,
+      jxl::Bytes(pixels_out.data(), pixels_out.size()), xsize, ysize, color_out,
       /*bits_per_sample=*/16, format_out,
       /*pool=*/nullptr, &out.Main()));
   return ButteraugliDistance(in.frames, out.frames, jxl::ButteraugliParams(),
@@ -1744,8 +1740,7 @@ TEST_P(DecodeAllEncodingsTest, PreserveOriginalProfileTest) {
   params.color_space = color_space_in;
   params.intensity_target = intensity_in;
   jxl::PaddedBytes data = jxl::CreateTestJXLCodestream(
-      jxl::Span<const uint8_t>(pixels.data(), pixels.size()), xsize, ysize, 3,
-      params);
+      jxl::Bytes(pixels.data(), pixels.size()), xsize, ysize, 3, params);
   JxlDecoder* dec = JxlDecoderCreate(nullptr);
   EXPECT_EQ(JXL_DEC_SUCCESS, JxlDecoderSubscribeEvents(dec, events));
   EXPECT_EQ(JXL_DEC_SUCCESS, JxlDecoderSetInput(dec, data.data(), data.size()));
@@ -1787,9 +1782,9 @@ void SetPreferredColorProfileTest(
   jxl::TestCodestreamParams params;
   params.color_space = color_space_in;
   params.intensity_target = intensity_in;
-  jxl::PaddedBytes data = jxl::CreateTestJXLCodestream(
-      jxl::Span<const uint8_t>(pixels.data(), pixels.size()), xsize, ysize,
-      num_channels, params);
+  jxl::PaddedBytes data =
+      jxl::CreateTestJXLCodestream(jxl::Bytes(pixels.data(), pixels.size()),
+                                   xsize, ysize, num_channels, params);
   auto all_encodings = jxl::test::AllEncodings();
   all_encodings.push_back(
       {jxl::ColorSpace::kXYB, jxl::WhitePoint::kD65, jxl::Primaries::kCustom,
@@ -1893,14 +1888,14 @@ TEST(DecodeTest, PixelTestOpaqueSrgbLossy) {
         jxl::test::GetSomeTestImage(xsize, ysize, 3, 0);
     JxlPixelFormat format_orig = {3, JXL_TYPE_UINT16, JXL_BIG_ENDIAN, 0};
     jxl::PaddedBytes compressed = jxl::CreateTestJXLCodestream(
-        jxl::Span<const uint8_t>(pixels.data(), pixels.size()), xsize, ysize, 3,
+        jxl::Bytes(pixels.data(), pixels.size()), xsize, ysize, 3,
         jxl::TestCodestreamParams());
 
     JxlPixelFormat format = {channels, JXL_TYPE_UINT8, JXL_LITTLE_ENDIAN, 0};
 
     std::vector<uint8_t> pixels2 = jxl::DecodeWithAPI(
-        dec, jxl::Span<const uint8_t>(compressed.data(), compressed.size()),
-        format, /*use_callback=*/true, /*set_buffer_early=*/false,
+        dec, jxl::Bytes(compressed.data(), compressed.size()), format,
+        /*use_callback=*/true, /*set_buffer_early=*/false,
         /*use_resizable_runner=*/false, /*require_boxes=*/false,
         /*expect_success*/ true);
     JxlDecoderReset(dec);
@@ -1944,14 +1939,13 @@ TEST(DecodeTest, PixelTestOpaqueSrgbLossyNoise) {
     jxl::TestCodestreamParams params;
     params.cparams.noise = jxl::Override::kOn;
     jxl::PaddedBytes compressed = jxl::CreateTestJXLCodestream(
-        jxl::Span<const uint8_t>(pixels.data(), pixels.size()), xsize, ysize, 3,
-        params);
+        jxl::Bytes(pixels.data(), pixels.size()), xsize, ysize, 3, params);
 
     JxlPixelFormat format = {channels, JXL_TYPE_UINT8, JXL_LITTLE_ENDIAN, 0};
 
     std::vector<uint8_t> pixels2 = jxl::DecodeWithAPI(
-        dec, jxl::Span<const uint8_t>(compressed.data(), compressed.size()),
-        format, /*use_callback=*/false, /*set_buffer_early=*/true,
+        dec, jxl::Bytes(compressed.data(), compressed.size()), format,
+        /*use_callback=*/false, /*set_buffer_early=*/true,
         /*use_resizable_runner=*/false, /*require_boxes=*/false,
         /*expect_success=*/true);
     JxlDecoderReset(dec);
@@ -1994,8 +1988,7 @@ TEST(DecodeTest, ProcessEmptyInputWithBoxes) {
     params.box_format = (CodeStreamBoxFormat)i;
     printf("Testing empty input with box format %d\n", (int)params.box_format);
     jxl::PaddedBytes compressed = jxl::CreateTestJXLCodestream(
-        jxl::Span<const uint8_t>(pixels.data(), pixels.size()), xsize, ysize, 3,
-        params);
+        jxl::Bytes(pixels.data(), pixels.size()), xsize, ysize, 3, params);
     const int events =
         JXL_DEC_BASIC_INFO | JXL_DEC_FULL_IMAGE | JXL_DEC_COLOR_ENCODING;
     EXPECT_EQ(JXL_DEC_SUCCESS, JxlDecoderSubscribeEvents(dec, events));
@@ -2038,8 +2031,7 @@ TEST(DecodeTest, ExtraBytesAfterCompressedStream) {
     jxl::TestCodestreamParams params;
     params.box_format = box_format;
     jxl::PaddedBytes compressed = jxl::CreateTestJXLCodestream(
-        jxl::Span<const uint8_t>(pixels.data(), pixels.size()), xsize, ysize, 3,
-        params);
+        jxl::Bytes(pixels.data(), pixels.size()), xsize, ysize, 3, params);
     // Add some more bytes after compressed data.
     compressed.push_back(0);
     compressed.push_back(1);
@@ -2048,8 +2040,8 @@ TEST(DecodeTest, ExtraBytesAfterCompressedStream) {
     uint32_t channels = 3;
     JxlPixelFormat format = {channels, JXL_TYPE_FLOAT, JXL_LITTLE_ENDIAN, 0};
     std::vector<uint8_t> pixels2 = jxl::DecodeWithAPI(
-        dec, jxl::Span<const uint8_t>(compressed.data(), compressed.size()),
-        format, /*use_callback=*/false, /*set_buffer_early=*/true,
+        dec, jxl::Bytes(compressed.data(), compressed.size()), format,
+        /*use_callback=*/false, /*set_buffer_early=*/true,
         /*use_resizable_runner=*/false, /*require_boxes=*/false,
         /*expect_success=*/true);
     size_t unconsumed_bytes = JxlDecoderReleaseInput(dec);
@@ -2074,8 +2066,7 @@ TEST(DecodeTest, ExtraBytesAfterCompressedStreamRequireBoxes) {
     jxl::TestCodestreamParams params;
     params.box_format = box_format;
     jxl::PaddedBytes compressed = jxl::CreateTestJXLCodestream(
-        jxl::Span<const uint8_t>(pixels.data(), pixels.size()), xsize, ysize, 3,
-        params);
+        jxl::Bytes(pixels.data(), pixels.size()), xsize, ysize, 3, params);
     // Add some more bytes after compressed data.
     compressed.push_back(0);
     compressed.push_back(1);
@@ -2084,8 +2075,8 @@ TEST(DecodeTest, ExtraBytesAfterCompressedStreamRequireBoxes) {
     uint32_t channels = 3;
     JxlPixelFormat format = {channels, JXL_TYPE_FLOAT, JXL_LITTLE_ENDIAN, 0};
     std::vector<uint8_t> pixels2 = jxl::DecodeWithAPI(
-        dec, jxl::Span<const uint8_t>(compressed.data(), compressed.size()),
-        format, /*use_callback=*/false, /*set_buffer_early=*/true,
+        dec, jxl::Bytes(compressed.data(), compressed.size()), format,
+        /*use_callback=*/false, /*set_buffer_early=*/true,
         /*use_resizable_runner=*/false, /*require_boxes=*/true, expect_success);
     size_t unconsumed_bytes = JxlDecoderReleaseInput(dec);
     EXPECT_EQ(3, unconsumed_bytes);
@@ -2105,8 +2096,7 @@ TEST(DecodeTest, ConcatenatedCompressedStreams) {
     jxl::TestCodestreamParams params1;
     params1.box_format = first_box_format;
     jxl::PaddedBytes compressed1 = jxl::CreateTestJXLCodestream(
-        jxl::Span<const uint8_t>(pixels.data(), pixels.size()), xsize, ysize, 3,
-        params1);
+        jxl::Bytes(pixels.data(), pixels.size()), xsize, ysize, 3, params1);
     for (int j = 0; j < kCSBF_NUM_ENTRIES; ++j) {
       CodeStreamBoxFormat second_box_format = (CodeStreamBoxFormat)j;
       if (second_box_format == kCSBF_Multi_Other_Zero_Terminated) continue;
@@ -2115,8 +2105,7 @@ TEST(DecodeTest, ConcatenatedCompressedStreams) {
       jxl::TestCodestreamParams params2;
       params2.box_format = second_box_format;
       jxl::PaddedBytes compressed2 = jxl::CreateTestJXLCodestream(
-          jxl::Span<const uint8_t>(pixels.data(), pixels.size()), xsize, ysize,
-          3, params2);
+          jxl::Bytes(pixels.data(), pixels.size()), xsize, ysize, 3, params2);
       jxl::PaddedBytes concat;
       concat.append(compressed1);
       concat.append(compressed2);
@@ -2132,8 +2121,8 @@ TEST(DecodeTest, ConcatenatedCompressedStreams) {
              second_box_format == kCSBF_Single_Zero_Terminated ||
              second_box_format == kCSBF_Multi_Zero_Terminated);
         std::vector<uint8_t> pixels2 = jxl::DecodeWithAPI(
-            dec, jxl::Span<const uint8_t>(concat.data() + pos, remaining),
-            format, /*use_callback=*/false, /*set_buffer_early=*/true,
+            dec, jxl::Bytes(concat.data() + pos, remaining), format,
+            /*use_callback=*/false, /*set_buffer_early=*/true,
             /*use_resizable_runner=*/false, /*require_boxes=*/true,
             expect_success);
         EXPECT_EQ(num_pixels * channels * 4, pixels2.size());
@@ -2175,9 +2164,9 @@ void TestPartialStream(bool reconstructible_jpeg) {
     if (reconstructible_jpeg) {
       params.jpeg_codestream = &jpeg_codestreams[i];
     }
-    codestreams[i] = jxl::CreateTestJXLCodestream(
-        jxl::Span<const uint8_t>(pixels.data(), pixels.size()), xsize, ysize,
-        channels, params);
+    codestreams[i] =
+        jxl::CreateTestJXLCodestream(jxl::Bytes(pixels.data(), pixels.size()),
+                                     xsize, ysize, channels, params);
   }
 
   // Test multiple step sizes, to test different combinations of the streaming
@@ -2341,8 +2330,7 @@ TEST(DecodeTest, PreviewTest) {
     params.preview_mode = mode;
 
     jxl::PaddedBytes compressed = jxl::CreateTestJXLCodestream(
-        jxl::Span<const uint8_t>(pixels.data(), pixels.size()), xsize, ysize, 3,
-        params);
+        jxl::Bytes(pixels.data(), pixels.size()), xsize, ysize, 3, params);
 
     JxlPixelFormat format = {3, JXL_TYPE_UINT8, JXL_LITTLE_ENDIAN, 0};
 
@@ -2365,9 +2353,8 @@ TEST(DecodeTest, PreviewTest) {
     jxl::ColorEncoding c_srgb = jxl::ColorEncoding::SRGB(false);
     jxl::CodecInOut io0;
     EXPECT_TRUE(jxl::ConvertFromExternal(
-        jxl::Span<const uint8_t>(pixels.data(), pixels.size()), xsize, ysize,
-        c_srgb, /*bits_per_sample=*/16, format_orig, /*pool=*/nullptr,
-        &io0.Main()));
+        jxl::Bytes(pixels.data(), pixels.size()), xsize, ysize, c_srgb,
+        /*bits_per_sample=*/16, format_orig, /*pool=*/nullptr, &io0.Main()));
     GeneratePreview(params.preview_mode, &io0.Main());
 
     size_t xsize_preview = io0.Main().xsize();
@@ -2386,11 +2373,11 @@ TEST(DecodeTest, PreviewTest) {
     EXPECT_EQ(JXL_DEC_PREVIEW_IMAGE, JxlDecoderProcessInput(dec));
 
     jxl::CodecInOut io1;
-    EXPECT_TRUE(jxl::ConvertFromExternal(
-        jxl::Span<const uint8_t>(preview.data(), preview.size()), xsize_preview,
-        ysize_preview, c_srgb,
-        /*bits_per_sample=*/8, format,
-        /*pool=*/nullptr, &io1.Main()));
+    EXPECT_TRUE(
+        jxl::ConvertFromExternal(jxl::Bytes(preview.data(), preview.size()),
+                                 xsize_preview, ysize_preview, c_srgb,
+                                 /*bits_per_sample=*/8, format,
+                                 /*pool=*/nullptr, &io1.Main()));
 
     jxl::ButteraugliParams ba;
     // TODO(lode): this ButteraugliDistance silently returns 0 (dangerous for
@@ -2418,8 +2405,7 @@ TEST(DecodeTest, AlignTest) {
   params.cparams.SetLossless();
   params.cparams.speed_tier = jxl::SpeedTier::kThunder;
   jxl::PaddedBytes compressed = jxl::CreateTestJXLCodestream(
-      jxl::Span<const uint8_t>(pixels.data(), pixels.size()), xsize, ysize, 4,
-      params);
+      jxl::Bytes(pixels.data(), pixels.size()), xsize, ysize, 4, params);
 
   size_t align = 17;
   JxlPixelFormat format = {3, JXL_TYPE_UINT8, JXL_LITTLE_ENDIAN, align};
@@ -2428,8 +2414,8 @@ TEST(DecodeTest, AlignTest) {
 
   for (int use_callback = 0; use_callback <= 1; ++use_callback) {
     std::vector<uint8_t> pixels2 = jxl::DecodeWithAPI(
-        jxl::Span<const uint8_t>(compressed.data(), compressed.size()), format,
-        use_callback, /*set_buffer_early=*/false,
+        jxl::Bytes(compressed.data(), compressed.size()), format, use_callback,
+        /*set_buffer_early=*/false,
         /*use_resizable_runner=*/false, /*require_boxes=*/false,
         /*expect_success=*/true);
     EXPECT_EQ(expected_line_bytes * ysize, pixels2.size());
@@ -2464,8 +2450,8 @@ TEST(DecodeTest, AnimationTest) {
     jxl::ImageBundle bundle(&io.metadata.m);
 
     EXPECT_TRUE(ConvertFromExternal(
-        jxl::Span<const uint8_t>(frames[i].data(), frames[i].size()), xsize,
-        ysize, jxl::ColorEncoding::SRGB(/*is_gray=*/false),
+        jxl::Bytes(frames[i].data(), frames[i].size()), xsize, ysize,
+        jxl::ColorEncoding::SRGB(/*is_gray=*/false),
         /*bits_per_sample=*/16, format,
         /*pool=*/nullptr, &bundle));
     bundle.duration = frame_durations[i];
@@ -2567,8 +2553,8 @@ TEST(DecodeTest, AnimationTestStreaming) {
     jxl::ImageBundle bundle(&io.metadata.m);
 
     EXPECT_TRUE(ConvertFromExternal(
-        jxl::Span<const uint8_t>(frames[i].data(), frames[i].size()), xsize,
-        ysize, jxl::ColorEncoding::SRGB(/*is_gray=*/false),
+        jxl::Bytes(frames[i].data(), frames[i].size()), xsize, ysize,
+        jxl::ColorEncoding::SRGB(/*is_gray=*/false),
         /*bits_per_sample=*/16, format,
         /*pool=*/nullptr, &bundle));
     bundle.duration = frame_durations[i];
@@ -2686,8 +2672,7 @@ TEST(DecodeTest, ExtraChannelTest) {
   params.cparams.SetLossless();
   params.cparams.speed_tier = jxl::SpeedTier::kThunder;
   jxl::PaddedBytes compressed = jxl::CreateTestJXLCodestream(
-      jxl::Span<const uint8_t>(pixels.data(), pixels.size()), xsize, ysize, 4,
-      params);
+      jxl::Bytes(pixels.data(), pixels.size()), xsize, ysize, 4, params);
 
   size_t align = 17;
   JxlPixelFormat format = {3, JXL_TYPE_UINT8, JXL_LITTLE_ENDIAN, align};
@@ -2785,8 +2770,8 @@ TEST(DecodeTest, SkipCurrentFrameTest) {
     }
 
     EXPECT_TRUE(ConvertFromExternal(
-        jxl::Span<const uint8_t>(frames[i].data(), frames[i].size()), xsize,
-        ysize, jxl::ColorEncoding::SRGB(/*is_gray=*/false),
+        jxl::Bytes(frames[i].data(), frames[i].size()), xsize, ysize,
+        jxl::ColorEncoding::SRGB(/*is_gray=*/false),
         /*bits_per_sample=*/16, format,
         /*pool=*/nullptr, &bundle));
     bundle.duration = frame_durations[i];
@@ -2899,8 +2884,8 @@ TEST(DecodeTest, SkipFrameTest) {
     }
 
     EXPECT_TRUE(ConvertFromExternal(
-        jxl::Span<const uint8_t>(frames[i].data(), frames[i].size()), xsize,
-        ysize, jxl::ColorEncoding::SRGB(/*is_gray=*/false),
+        jxl::Bytes(frames[i].data(), frames[i].size()), xsize, ysize,
+        jxl::ColorEncoding::SRGB(/*is_gray=*/false),
         /*bits_per_sample=*/16, format,
         /*pool=*/nullptr, &bundle));
     bundle.duration = frame_durations[i];
@@ -3033,9 +3018,8 @@ TEST(DecodeTest, SkipFrameWithBlendingTest) {
       // rendered frames depend
       jxl::ImageBundle bundle_internal(&io.metadata.m);
       EXPECT_TRUE(ConvertFromExternal(
-          jxl::Span<const uint8_t>(frame_internal.data(),
-                                   frame_internal.size()),
-          xsize, ysize, jxl::ColorEncoding::SRGB(/*is_gray=*/false),
+          jxl::Bytes(frame_internal.data(), frame_internal.size()), xsize,
+          ysize, jxl::ColorEncoding::SRGB(/*is_gray=*/false),
           /*bits_per_sample=*/16, format,
           /*pool=*/nullptr, &bundle_internal));
       bundle_internal.duration = 0;
@@ -3048,11 +3032,11 @@ TEST(DecodeTest, SkipFrameWithBlendingTest) {
     // Actual rendered frame
     frame_durations[i] = 5 + i;
     jxl::ImageBundle bundle(&io.metadata.m);
-    EXPECT_TRUE(ConvertFromExternal(
-        jxl::Span<const uint8_t>(frame.data(), frame.size()), xsize, ysize,
-        jxl::ColorEncoding::SRGB(/*is_gray=*/false),
-        /*bits_per_sample=*/16, format,
-        /*pool=*/nullptr, &bundle));
+    EXPECT_TRUE(ConvertFromExternal(jxl::Bytes(frame.data(), frame.size()),
+                                    xsize, ysize,
+                                    jxl::ColorEncoding::SRGB(/*is_gray=*/false),
+                                    /*bits_per_sample=*/16, format,
+                                    /*pool=*/nullptr, &bundle));
     bundle.duration = frame_durations[i];
     // Create some variation in which frames depend on which.
     if (i != 3 && i != 9 && i != 10) {
@@ -3257,9 +3241,8 @@ TEST(DecodeTest, SkipFrameWithAlphaBlendingTest) {
       // which the rendered frames depend
       jxl::ImageBundle bundle_internal(&io.metadata.m);
       EXPECT_TRUE(ConvertFromExternal(
-          jxl::Span<const uint8_t>(frame_internal.data(),
-                                   frame_internal.size()),
-          xsize / 2, ysize / 2, jxl::ColorEncoding::SRGB(/*is_gray=*/false),
+          jxl::Bytes(frame_internal.data(), frame_internal.size()), xsize / 2,
+          ysize / 2, jxl::ColorEncoding::SRGB(/*is_gray=*/false),
           /*bits_per_sample=*/16, format,
           /*pool=*/nullptr, &bundle_internal));
       bundle_internal.duration = 0;
@@ -3277,11 +3260,11 @@ TEST(DecodeTest, SkipFrameWithAlphaBlendingTest) {
         jxl::test::GetSomeTestImage(cropxsize, cropysize, 4, i * 2);
     // Actual rendered frame
     jxl::ImageBundle bundle(&io.metadata.m);
-    EXPECT_TRUE(ConvertFromExternal(
-        jxl::Span<const uint8_t>(frame.data(), frame.size()), cropxsize,
-        cropysize, jxl::ColorEncoding::SRGB(/*is_gray=*/false),
-        /*bits_per_sample=*/16, format,
-        /*pool=*/nullptr, &bundle));
+    EXPECT_TRUE(ConvertFromExternal(jxl::Bytes(frame.data(), frame.size()),
+                                    cropxsize, cropysize,
+                                    jxl::ColorEncoding::SRGB(/*is_gray=*/false),
+                                    /*bits_per_sample=*/16, format,
+                                    /*pool=*/nullptr, &bundle));
     bundle.duration = 5 + i;
     frame_durations_nc.push_back(5 + i);
     frame_durations_c.push_back(5 + i);
@@ -3540,8 +3523,8 @@ TEST(DecodeTest, OrientedCroppedFrameTest) {
           jxl::test::GetSomeTestImage(cropxsize, cropysize, 4, i * 2);
       jxl::ImageBundle bundle(&io.metadata.m);
       EXPECT_TRUE(ConvertFromExternal(
-          jxl::Span<const uint8_t>(frame.data(), frame.size()), cropxsize,
-          cropysize, jxl::ColorEncoding::SRGB(/*is_gray=*/false),
+          jxl::Bytes(frame.data(), frame.size()), cropxsize, cropysize,
+          jxl::ColorEncoding::SRGB(/*is_gray=*/false),
           /*bits_per_sample=*/16, format,
           /*pool=*/nullptr, &bundle));
       bundle.origin = {cropx0, cropy0};
@@ -3725,8 +3708,7 @@ void AnalyzeCodestream(const jxl::PaddedBytes& data,
     return pos + offset;
   };
   // Analyze the unboxed codestream.
-  jxl::BitReader br(
-      jxl::Span<const uint8_t>(codestream.data(), codestream.size()));
+  jxl::BitReader br(jxl::Bytes(codestream.data(), codestream.size()));
   ASSERT_EQ(br.ReadFixedBits<16>(), 0x0AFF);
   jxl::CodecMetadata metadata;
   ASSERT_TRUE(ReadSizeHeader(&br, &metadata.size));
@@ -3736,10 +3718,8 @@ void AnalyzeCodestream(const jxl::PaddedBytes& data,
   metadata.transform_data.nonserialized_xyb_encoded = metadata.m.xyb_encoded;
   ASSERT_TRUE(jxl::Bundle::Read(&br, &metadata.transform_data));
   if (metadata.m.color_encoding.WantICC()) {
-    jxl::PaddedBytes icc_data;
-    ASSERT_TRUE(jxl::ReadICC(&br, &icc_data));
-    jxl::IccBytes icc;
-    jxl::Span<const uint8_t>(icc_data).AppendTo(&icc);
+    std::vector<uint8_t> icc;
+    ASSERT_TRUE(jxl::test::ReadICC(&br, &icc));
     ASSERT_TRUE(!icc.empty());
     metadata.m.color_encoding.SetICCRaw(std::move(icc));
   }
@@ -3868,9 +3848,9 @@ TEST(DecodeTest, ProgressionTest) {
   jxl::TestCodestreamParams params;
   params.cparams.progressive_dc = 1;
   params.preview_mode = jxl::kSmallPreview;
-  jxl::PaddedBytes data = jxl::CreateTestJXLCodestream(
-      jxl::Span<const uint8_t>(pixels.data(), pixels.size()), xsize, ysize,
-      num_channels, params);
+  jxl::PaddedBytes data =
+      jxl::CreateTestJXLCodestream(jxl::Bytes(pixels.data(), pixels.size()),
+                                   xsize, ysize, num_channels, params);
   StreamPositions streampos;
   AnalyzeCodestream(data, &streampos);
   const std::vector<FramePositions>& fp = streampos.frames;
@@ -3904,9 +3884,9 @@ TEST(DecodeTest, ProgressionTestLosslessAlpha) {
   params.cparams.SetLossless();
   params.cparams.speed_tier = jxl::SpeedTier::kThunder;
   params.cparams.responsive = 1;
-  jxl::PaddedBytes data = jxl::CreateTestJXLCodestream(
-      jxl::Span<const uint8_t>(pixels.data(), pixels.size()), xsize, ysize,
-      num_channels, params);
+  jxl::PaddedBytes data =
+      jxl::CreateTestJXLCodestream(jxl::Bytes(pixels.data(), pixels.size()),
+                                   xsize, ysize, num_channels, params);
   StreamPositions streampos;
   AnalyzeCodestream(data, &streampos);
   const std::vector<FramePositions>& fp = streampos.frames;
@@ -3949,9 +3929,9 @@ TEST(DecodeTest, InputHandlingTestOneShot) {
     params.cparams.progressive_dc = 1;
     params.preview_mode = jxl::kSmallPreview;
     params.box_format = (CodeStreamBoxFormat)i;
-    jxl::PaddedBytes data = jxl::CreateTestJXLCodestream(
-        jxl::Span<const uint8_t>(pixels.data(), pixels.size()), xsize, ysize,
-        num_channels, params);
+    jxl::PaddedBytes data =
+        jxl::CreateTestJXLCodestream(jxl::Bytes(pixels.data(), pixels.size()),
+                                     xsize, ysize, num_channels, params);
     JxlPixelFormat format = {num_channels, JXL_TYPE_UINT16, JXL_BIG_ENDIAN, 0};
     StreamPositions streampos;
     AnalyzeCodestream(data, &streampos);
@@ -4044,9 +4024,9 @@ TEST(DecodeTest, JXL_TRANSCODE_JPEG_TEST(InputHandlingTestJPEGOneshot)) {
     params.jpeg_codestream = &jpeg_codestream;
     params.preview_mode = jxl::kSmallPreview;
     params.box_format = (CodeStreamBoxFormat)i;
-    jxl::PaddedBytes data = jxl::CreateTestJXLCodestream(
-        jxl::Span<const uint8_t>(pixels.data(), pixels.size()), xsize, ysize,
-        channels, params);
+    jxl::PaddedBytes data =
+        jxl::CreateTestJXLCodestream(jxl::Bytes(pixels.data(), pixels.size()),
+                                     xsize, ysize, channels, params);
     JxlPixelFormat format = {3, JXL_TYPE_UINT16, JXL_BIG_ENDIAN, 0};
     StreamPositions streampos;
     AnalyzeCodestream(data, &streampos);
@@ -4133,9 +4113,9 @@ TEST(DecodeTest, InputHandlingTestStreaming) {
     params.cparams.progressive_dc = 1;
     params.box_format = (CodeStreamBoxFormat)i;
     params.preview_mode = jxl::kSmallPreview;
-    jxl::PaddedBytes data = jxl::CreateTestJXLCodestream(
-        jxl::Span<const uint8_t>(pixels.data(), pixels.size()), xsize, ysize,
-        num_channels, params);
+    jxl::PaddedBytes data =
+        jxl::CreateTestJXLCodestream(jxl::Bytes(pixels.data(), pixels.size()),
+                                     xsize, ysize, num_channels, params);
     JxlPixelFormat format = {num_channels, JXL_TYPE_UINT16, JXL_BIG_ENDIAN, 0};
     StreamPositions streampos;
     AnalyzeCodestream(data, &streampos);
@@ -4228,9 +4208,9 @@ TEST(DecodeTest, FlushTest) {
       jxl::test::GetSomeTestImage(xsize, ysize, num_channels, 0);
   jxl::TestCodestreamParams params;
   params.preview_mode = jxl::kSmallPreview;
-  jxl::PaddedBytes data = jxl::CreateTestJXLCodestream(
-      jxl::Span<const uint8_t>(pixels.data(), pixels.size()), xsize, ysize,
-      num_channels, params);
+  jxl::PaddedBytes data =
+      jxl::CreateTestJXLCodestream(jxl::Bytes(pixels.data(), pixels.size()),
+                                   xsize, ysize, num_channels, params);
   JxlPixelFormat format = {num_channels, JXL_TYPE_UINT16, JXL_BIG_ENDIAN, 0};
 
   std::vector<uint8_t> pixels2;
@@ -4303,9 +4283,9 @@ TEST(DecodeTest, FlushTestImageOutCallback) {
       jxl::test::GetSomeTestImage(xsize, ysize, num_channels, 0);
   jxl::TestCodestreamParams params;
   params.preview_mode = jxl::kSmallPreview;
-  jxl::PaddedBytes data = jxl::CreateTestJXLCodestream(
-      jxl::Span<const uint8_t>(pixels.data(), pixels.size()), xsize, ysize,
-      num_channels, params);
+  jxl::PaddedBytes data =
+      jxl::CreateTestJXLCodestream(jxl::Bytes(pixels.data(), pixels.size()),
+                                   xsize, ysize, num_channels, params);
   JxlPixelFormat format = {num_channels, JXL_TYPE_UINT16, JXL_BIG_ENDIAN, 0};
 
   std::vector<uint8_t> pixels2;
@@ -4389,9 +4369,9 @@ TEST(DecodeTest, FlushTestLossyProgressiveAlpha) {
       jxl::test::GetSomeTestImage(xsize, ysize, num_channels, 0);
   jxl::TestCodestreamParams params;
   params.preview_mode = jxl::kSmallPreview;
-  jxl::PaddedBytes data = jxl::CreateTestJXLCodestream(
-      jxl::Span<const uint8_t>(pixels.data(), pixels.size()), xsize, ysize,
-      num_channels, params);
+  jxl::PaddedBytes data =
+      jxl::CreateTestJXLCodestream(jxl::Bytes(pixels.data(), pixels.size()),
+                                   xsize, ysize, num_channels, params);
   JxlPixelFormat format = {num_channels, JXL_TYPE_UINT16, JXL_BIG_ENDIAN, 0};
 
   std::vector<uint8_t> pixels2;
@@ -4461,9 +4441,9 @@ TEST(DecodeTest, FlushTestLossyProgressiveAlphaUpsampling) {
   params.cparams.resampling = 2;
   params.cparams.ec_resampling = 4;
   params.preview_mode = jxl::kSmallPreview;
-  jxl::PaddedBytes data = jxl::CreateTestJXLCodestream(
-      jxl::Span<const uint8_t>(pixels.data(), pixels.size()), xsize, ysize,
-      num_channels, params);
+  jxl::PaddedBytes data =
+      jxl::CreateTestJXLCodestream(jxl::Bytes(pixels.data(), pixels.size()),
+                                   xsize, ysize, num_channels, params);
   JxlPixelFormat format = {num_channels, JXL_TYPE_UINT16, JXL_BIG_ENDIAN, 0};
 
   std::vector<uint8_t> pixels2;
@@ -4537,9 +4517,9 @@ TEST(DecodeTest, FlushTestLosslessProgressiveAlpha) {
   params.cparams.responsive = 1;
   params.cparams.modular_group_size_shift = 1;
   params.preview_mode = jxl::kSmallPreview;
-  jxl::PaddedBytes data = jxl::CreateTestJXLCodestream(
-      jxl::Span<const uint8_t>(pixels.data(), pixels.size()), xsize, ysize,
-      num_channels, params);
+  jxl::PaddedBytes data =
+      jxl::CreateTestJXLCodestream(jxl::Bytes(pixels.data(), pixels.size()),
+                                   xsize, ysize, num_channels, params);
   JxlPixelFormat format = {num_channels, JXL_TYPE_UINT16, JXL_BIG_ENDIAN, 0};
 
   std::vector<uint8_t> pixels2;
@@ -4632,8 +4612,7 @@ TEST_P(DecodeProgressiveTest, ProgressiveEventTest) {
     jxl::ColorEncoding color_encoding = jxl::ColorEncoding::SRGB(false);
     jxl::CodecInOut io;
     EXPECT_TRUE(jxl::ConvertFromExternal(
-        jxl::Span<const uint8_t>(pixels.data(), pixels.size()), xsize, ysize,
-        color_encoding,
+        jxl::Bytes(pixels.data(), pixels.size()), xsize, ysize, color_encoding,
         /*bits_per_sample=*/16, format,
         /*pool=*/nullptr, &io.Main()));
     jxl::TestCodestreamParams params;
@@ -4647,9 +4626,9 @@ TEST_P(DecodeProgressiveTest, ProgressiveEventTest) {
     const int kNumPasses = 5;
     jxl::ProgressiveMode progressive_mode{passes};
     params.progressive_mode = &progressive_mode;
-    jxl::PaddedBytes data = jxl::CreateTestJXLCodestream(
-        jxl::Span<const uint8_t>(pixels.data(), pixels.size()), xsize, ysize,
-        num_channels, params);
+    jxl::PaddedBytes data =
+        jxl::CreateTestJXLCodestream(jxl::Bytes(pixels.data(), pixels.size()),
+                                     xsize, ysize, num_channels, params);
 
     for (size_t increment : {(size_t)1, data.size()}) {
       printf(
@@ -4749,8 +4728,8 @@ TEST_P(DecodeProgressiveTest, ProgressiveEventTest) {
       for (int p = 0;; p = next_pass(p)) {
         jxl::CodecInOut io1;
         EXPECT_TRUE(jxl::ConvertFromExternal(
-            jxl::Span<const uint8_t>(passes[p].data(), passes[p].size()), xsize,
-            ysize, color_encoding,
+            jxl::Bytes(passes[p].data(), passes[p].size()), xsize, ysize,
+            color_encoding,
             /*bits_per_sample=*/16, format,
             /*pool=*/nullptr, &io1.Main()));
         distances[p] = ButteraugliDistance(
@@ -4773,8 +4752,8 @@ TEST_P(DecodeProgressiveTest, ProgressiveEventTest) {
   }
 }
 
-void VerifyJPEGReconstruction(const jxl::PaddedBytes& container,
-                              const jxl::PaddedBytes& jpeg_bytes) {
+void VerifyJPEGReconstruction(jxl::Span<const uint8_t> container,
+                              jxl::Span<const uint8_t> jpeg_bytes) {
   JxlDecoderPtr dec = JxlDecoderMake(nullptr);
   EXPECT_EQ(JXL_DEC_SUCCESS,
             JxlDecoderSubscribeEvents(
@@ -4816,17 +4795,15 @@ TEST(DecodeTest, JXL_TRANSCODE_JPEG_TEST(JPEGReconstructTestCodestream)) {
   params.jpeg_codestream = &jpeg_codestream;
   params.preview_mode = jxl::kSmallPreview;
   jxl::PaddedBytes compressed = jxl::CreateTestJXLCodestream(
-      jxl::Span<const uint8_t>(pixels.data(), pixels.size()), xsize, ysize,
-      channels, params);
-  VerifyJPEGReconstruction(compressed, jpeg_codestream);
+      jxl::Bytes(pixels.data(), pixels.size()), xsize, ysize, channels, params);
+  VerifyJPEGReconstruction(jxl::Bytes(compressed), jxl::Bytes(jpeg_codestream));
 }
 
 TEST(DecodeTest, JXL_TRANSCODE_JPEG_TEST(JPEGReconstructionTest)) {
   const std::string jpeg_path = "jxl/flower/flower.png.im_q85_420.jpg";
-  const jxl::PaddedBytes orig = jxl::test::ReadTestData(jpeg_path);
+  const std::vector<uint8_t> orig = jxl::test::ReadTestData(jpeg_path);
   jxl::CodecInOut orig_io;
-  ASSERT_TRUE(
-      jxl::jpeg::DecodeImageJPG(jxl::Span<const uint8_t>(orig), &orig_io));
+  ASSERT_TRUE(jxl::jpeg::DecodeImageJPG(jxl::Bytes(orig), &orig_io));
   orig_io.metadata.m.xyb_encoded = false;
   jxl::BitWriter writer;
   ASSERT_TRUE(WriteCodestreamHeaders(&orig_io.metadata, &writer, nullptr));
@@ -4850,15 +4827,15 @@ TEST(DecodeTest, JXL_TRANSCODE_JPEG_TEST(JPEGReconstructionTest)) {
   jxl::AppendBoxHeader(jxl::MakeBoxType("jxlc"), 0, true, &container);
   jxl::PaddedBytes codestream = std::move(writer).TakeBytes();
   container.append(codestream.data(), codestream.data() + codestream.size());
-  VerifyJPEGReconstruction(container, orig);
+  VerifyJPEGReconstruction(jxl::Bytes(container), jxl::Bytes(orig));
 }
 
 TEST(DecodeTest, JXL_TRANSCODE_JPEG_TEST(JPEGReconstructionMetadataTest)) {
   const std::string jpeg_path = "jxl/jpeg_reconstruction/1x1_exif_xmp.jpg";
   const std::string jxl_path = "jxl/jpeg_reconstruction/1x1_exif_xmp.jxl";
-  const jxl::PaddedBytes jpeg = jxl::test::ReadTestData(jpeg_path);
-  const jxl::PaddedBytes jxl = jxl::test::ReadTestData(jxl_path);
-  VerifyJPEGReconstruction(jxl, jpeg);
+  const std::vector<uint8_t> jpeg = jxl::test::ReadTestData(jpeg_path);
+  const std::vector<uint8_t> jxl = jxl::test::ReadTestData(jxl_path);
+  VerifyJPEGReconstruction(jxl::Bytes(jxl), jxl::Bytes(jpeg));
 }
 
 TEST(DecodeTest, ContinueFinalNonEssentialBoxTest) {
@@ -4868,8 +4845,7 @@ TEST(DecodeTest, ContinueFinalNonEssentialBoxTest) {
   params.box_format = kCSBF_Multi_Other_Terminated;
   params.add_icc_profile = true;
   jxl::PaddedBytes compressed = jxl::CreateTestJXLCodestream(
-      jxl::Span<const uint8_t>(pixels.data(), pixels.size()), xsize, ysize, 4,
-      params);
+      jxl::Bytes(pixels.data(), pixels.size()), xsize, ysize, 4, params);
   StreamPositions streampos;
   AnalyzeCodestream(compressed, &streampos);
 
@@ -4928,7 +4904,7 @@ bool BoxTypeEquals(const std::string& type_string, JxlBoxType type) {
 
 TEST(DecodeTest, ExtentedBoxSizeTest) {
   const std::string jxl_path = "jxl/boxes/square-extended-size-container.jxl";
-  const jxl::PaddedBytes orig = jxl::test::ReadTestData(jxl_path);
+  const std::vector<uint8_t> orig = jxl::test::ReadTestData(jxl_path);
   JxlDecoder* dec = JxlDecoderCreate(nullptr);
 
   EXPECT_EQ(JXL_DEC_SUCCESS, JxlDecoderSubscribeEvents(dec, JXL_DEC_BOX));
@@ -4962,8 +4938,7 @@ TEST(DecodeTest, JXL_BOXES_TEST(BoxTest)) {
   params.box_format = kCSBF_Multi_Other_Terminated;
   params.add_icc_profile = true;
   jxl::PaddedBytes compressed = jxl::CreateTestJXLCodestream(
-      jxl::Span<const uint8_t>(pixels.data(), pixels.size()), xsize, ysize, 4,
-      params);
+      jxl::Bytes(pixels.data(), pixels.size()), xsize, ysize, 4, params);
 
   JxlDecoder* dec = JxlDecoderCreate(nullptr);
 
@@ -5037,8 +5012,7 @@ TEST(DecodeTest, JXL_BOXES_TEST(ExifBrobBoxTest)) {
   params.box_format = kCSBF_Brob_Exif;
   params.add_icc_profile = true;
   jxl::PaddedBytes compressed = jxl::CreateTestJXLCodestream(
-      jxl::Span<const uint8_t>(pixels.data(), pixels.size()), xsize, ysize, 4,
-      params);
+      jxl::Bytes(pixels.data(), pixels.size()), xsize, ysize, 4, params);
 
   // Test raw brob box, not brotli-decompressing
   for (int streaming = 0; streaming < 2; ++streaming) {
@@ -5221,8 +5195,7 @@ TEST(DecodeTest, JXL_BOXES_TEST(PartialCodestreamBoxTest)) {
   params.box_format = kCSBF_Multi;
   params.add_icc_profile = true;
   jxl::PaddedBytes compressed = jxl::CreateTestJXLCodestream(
-      jxl::Span<const uint8_t>(pixels.data(), pixels.size()), xsize, ysize, 4,
-      params);
+      jxl::Bytes(pixels.data(), pixels.size()), xsize, ysize, 4, params);
 
   std::vector<uint8_t> extracted_codestream;
 

--- a/lib/jxl/decode_to_jpeg.cc
+++ b/lib/jxl/decode_to_jpeg.cc
@@ -21,14 +21,14 @@ JxlDecoderStatus JxlToJpegDecoder::Process(const uint8_t** next_in,
   Span<const uint8_t> to_decode;
   if (box_until_eof_) {
     // Until EOF means consume all data.
-    to_decode = Span<const uint8_t>(*next_in, *avail_in);
+    to_decode = Bytes(*next_in, *avail_in);
     *next_in += *avail_in;
     *avail_in = 0;
   } else {
     // Defined size means consume min(available, needed).
     size_t avail_recon_in =
         std::min<size_t>(*avail_in, box_size_ - buffer_.size());
-    to_decode = Span<const uint8_t>(*next_in, avail_recon_in);
+    to_decode = Bytes(*next_in, avail_recon_in);
     *next_in += avail_recon_in;
     *avail_in -= avail_recon_in;
   }
@@ -37,7 +37,7 @@ JxlDecoderStatus JxlToJpegDecoder::Process(const uint8_t** next_in,
     // Append incoming data to buffer if we already had data in the buffer.
     buffer_.insert(buffer_.end(), to_decode.data(),
                    to_decode.data() + to_decode.size());
-    to_decode = Span<const uint8_t>(buffer_.data(), buffer_.size());
+    to_decode = Bytes(buffer_.data(), buffer_.size());
   }
   if (!box_until_eof_ && to_decode.size() > box_size_) {
     JXL_UNREACHABLE("JPEG reconstruction data to decode larger than expected");

--- a/lib/jxl/enc_bit_writer.h
+++ b/lib/jxl/enc_bit_writer.h
@@ -45,7 +45,7 @@ struct BitWriter {
   Span<const uint8_t> GetSpan() const {
     // Callers must ensure byte alignment to avoid uninitialized bits.
     JXL_ASSERT(bits_written_ % kBitsPerByte == 0);
-    return Span<const uint8_t>(storage_.data(), bits_written_ / kBitsPerByte);
+    return Bytes(storage_.data(), bits_written_ / kBitsPerByte);
   }
 
   // Example usage: bytes = std::move(writer).TakeBytes(); Useful for the

--- a/lib/jxl/enc_cache.cc
+++ b/lib/jxl/enc_cache.cc
@@ -13,7 +13,6 @@
 #include "lib/jxl/ac_strategy.h"
 #include "lib/jxl/base/common.h"
 #include "lib/jxl/base/compiler_specific.h"
-#include "lib/jxl/base/padded_bytes.h"
 #include "lib/jxl/base/span.h"
 #include "lib/jxl/color_encoding_internal.h"
 #include "lib/jxl/compressed_dc.h"

--- a/lib/jxl/enc_chroma_from_luma.cc
+++ b/lib/jxl/enc_chroma_from_luma.cc
@@ -20,7 +20,6 @@
 
 #include "lib/jxl/base/bits.h"
 #include "lib/jxl/base/common.h"
-#include "lib/jxl/base/padded_bytes.h"
 #include "lib/jxl/base/span.h"
 #include "lib/jxl/base/status.h"
 #include "lib/jxl/cms/opsin_params.h"

--- a/lib/jxl/enc_coeff_order.cc
+++ b/lib/jxl/enc_coeff_order.cc
@@ -10,7 +10,6 @@
 #include <vector>
 
 #include "lib/jxl/ans_params.h"
-#include "lib/jxl/base/padded_bytes.h"
 #include "lib/jxl/base/span.h"
 #include "lib/jxl/coeff_order.h"
 #include "lib/jxl/coeff_order_fwd.h"

--- a/lib/jxl/enc_external_image.cc
+++ b/lib/jxl/enc_external_image.cc
@@ -158,8 +158,8 @@ Status BufferToImageF(const JxlPixelFormat& pixel_format, size_t xsize,
                       ThreadPool* pool, ImageF* channel) {
   size_t bitdepth = JxlDataTypeBytes(pixel_format.data_type) * kBitsPerByte;
   return ConvertFromExternal(
-      jxl::Span<const uint8_t>(static_cast<const uint8_t*>(buffer), size),
-      xsize, ysize, bitdepth, pixel_format, 0, pool, channel);
+      jxl::Bytes(static_cast<const uint8_t*>(buffer), size), xsize, ysize,
+      bitdepth, pixel_format, 0, pool, channel);
 }
 
 Status BufferToImageBundle(const JxlPixelFormat& pixel_format, uint32_t xsize,
@@ -169,8 +169,8 @@ Status BufferToImageBundle(const JxlPixelFormat& pixel_format, uint32_t xsize,
                            jxl::ImageBundle* ib) {
   size_t bitdepth = JxlDataTypeBytes(pixel_format.data_type) * kBitsPerByte;
   JXL_RETURN_IF_ERROR(ConvertFromExternal(
-      jxl::Span<const uint8_t>(static_cast<const uint8_t*>(buffer), size),
-      xsize, ysize, c_current, bitdepth, pixel_format, pool, ib));
+      jxl::Bytes(static_cast<const uint8_t*>(buffer), size), xsize, ysize,
+      c_current, bitdepth, pixel_format, pool, ib));
   ib->VerifyMetadata();
 
   return true;

--- a/lib/jxl/enc_external_image.h
+++ b/lib/jxl/enc_external_image.h
@@ -13,7 +13,6 @@
 #include <stdint.h>
 
 #include "lib/jxl/base/data_parallel.h"
-#include "lib/jxl/base/padded_bytes.h"
 #include "lib/jxl/base/status.h"
 #include "lib/jxl/color_encoding_internal.h"
 #include "lib/jxl/image.h"

--- a/lib/jxl/enc_external_image_gbench.cc
+++ b/lib/jxl/enc_external_image_gbench.cc
@@ -25,8 +25,7 @@ void BM_EncExternalImage_ConvertImageRGBA(benchmark::State& state) {
   for (auto _ : state) {
     for (size_t i = 0; i < kNumIter; ++i) {
       JXL_CHECK(ConvertFromExternal(
-          Span<const uint8_t>(interleaved.data(), interleaved.size()), xsize,
-          ysize,
+          Bytes(interleaved.data(), interleaved.size()), xsize, ysize,
           /*c_current=*/ColorEncoding::SRGB(),
           /*bits_per_sample=*/8, format,
           /*pool=*/nullptr, &ib));

--- a/lib/jxl/enc_external_image_test.cc
+++ b/lib/jxl/enc_external_image_test.cc
@@ -26,16 +26,16 @@ TEST(ExternalImageTest, InvalidSize) {
 
   JxlPixelFormat format = {4, JXL_TYPE_UINT16, JXL_BIG_ENDIAN, 0};
   const uint8_t buf[10 * 100 * 8] = {};
+  EXPECT_FALSE(ConvertFromExternal(Bytes(buf, 10), /*xsize=*/10, /*ysize=*/100,
+                                   /*c_current=*/ColorEncoding::SRGB(),
+                                   /*bits_per_sample=*/16, format, nullptr,
+                                   &ib));
   EXPECT_FALSE(ConvertFromExternal(
-      Span<const uint8_t>(buf, 10), /*xsize=*/10, /*ysize=*/100,
-      /*c_current=*/ColorEncoding::SRGB(),
-      /*bits_per_sample=*/16, format, nullptr, &ib));
-  EXPECT_FALSE(ConvertFromExternal(
-      Span<const uint8_t>(buf, sizeof(buf) - 1), /*xsize=*/10, /*ysize=*/100,
+      Bytes(buf, sizeof(buf) - 1), /*xsize=*/10, /*ysize=*/100,
       /*c_current=*/ColorEncoding::SRGB(),
       /*bits_per_sample=*/16, format, nullptr, &ib));
   EXPECT_TRUE(
-      ConvertFromExternal(Span<const uint8_t>(buf, sizeof(buf)), /*xsize=*/10,
+      ConvertFromExternal(Bytes(buf, sizeof(buf)), /*xsize=*/10,
                           /*ysize=*/100, /*c_current=*/ColorEncoding::SRGB(),
                           /*bits_per_sample=*/16, format, nullptr, &ib));
 }
@@ -53,8 +53,7 @@ TEST(ExternalImageTest, AlphaMissing) {
   JxlPixelFormat format = {4, JXL_TYPE_UINT8, JXL_BIG_ENDIAN, 0};
   // has_alpha is true but the ImageBundle has no alpha. Alpha channel should
   // be ignored.
-  EXPECT_TRUE(ConvertFromExternal(Span<const uint8_t>(buf, sizeof(buf)), xsize,
-                                  ysize,
+  EXPECT_TRUE(ConvertFromExternal(Bytes(buf, sizeof(buf)), xsize, ysize,
                                   /*c_current=*/ColorEncoding::SRGB(),
                                   /*bits_per_sample=*/8, format, nullptr, &ib));
   EXPECT_FALSE(ib.HasAlpha());

--- a/lib/jxl/enc_file.h
+++ b/lib/jxl/enc_file.h
@@ -9,7 +9,6 @@
 // Facade for JXL encoding.
 
 #include "lib/jxl/base/data_parallel.h"
-#include "lib/jxl/base/padded_bytes.h"
 #include "lib/jxl/base/status.h"
 #include "lib/jxl/enc_cache.h"
 #include "lib/jxl/enc_params.h"
@@ -18,6 +17,7 @@ namespace jxl {
 
 struct AuxOut;
 class CodecInOut;
+class PaddedBytes;
 
 // Compresses pixels from `io` (given in any ColorEncoding).
 // `io->metadata.m.original` must be set.

--- a/lib/jxl/enc_frame.cc
+++ b/lib/jxl/enc_frame.cc
@@ -24,7 +24,6 @@
 #include "lib/jxl/base/compiler_specific.h"
 #include "lib/jxl/base/data_parallel.h"
 #include "lib/jxl/base/override.h"
-#include "lib/jxl/base/padded_bytes.h"
 #include "lib/jxl/base/status.h"
 #include "lib/jxl/chroma_from_luma.h"
 #include "lib/jxl/coeff_order.h"

--- a/lib/jxl/enc_icc_codec.cc
+++ b/lib/jxl/enc_icc_codec.cc
@@ -12,6 +12,7 @@
 #include <vector>
 
 #include "lib/jxl/base/byte_order.h"
+#include "lib/jxl/base/padded_bytes.h"
 #include "lib/jxl/enc_ans.h"
 #include "lib/jxl/enc_aux_out.h"
 #include "lib/jxl/fields.h"
@@ -105,7 +106,8 @@ Status PredictICC(const uint8_t* icc, size_t size, PaddedBytes* result) {
   EncodeVarInt(size, result);
 
   // Header
-  PaddedBytes header = ICCInitialHeaderPrediction();
+  PaddedBytes header;
+  header.append(ICCInitialHeaderPrediction());
   EncodeUint32(0, size, &header);
   for (size_t i = 0; i < kICCHeaderSize && i < size; i++) {
     ICCPredictHeader(icc, size, header.data(), i);

--- a/lib/jxl/enc_icc_codec.h
+++ b/lib/jxl/enc_icc_codec.h
@@ -14,7 +14,6 @@
 #include <vector>
 
 #include "lib/jxl/base/compiler_specific.h"
-#include "lib/jxl/base/padded_bytes.h"
 #include "lib/jxl/base/status.h"
 #include "lib/jxl/dec_bit_reader.h"
 #include "lib/jxl/enc_bit_writer.h"
@@ -22,6 +21,7 @@
 namespace jxl {
 
 struct AuxOut;
+class PaddedBytes;
 
 // Should still be called if `icc.empty()` - if so, writes only 1 bit.
 Status WriteICC(const std::vector<uint8_t>& icc, BitWriter* JXL_RESTRICT writer,

--- a/lib/jxl/enc_image_bundle.cc
+++ b/lib/jxl/enc_image_bundle.cc
@@ -13,7 +13,6 @@
 
 #include "lib/jxl/alpha.h"
 #include "lib/jxl/base/byte_order.h"
-#include "lib/jxl/base/padded_bytes.h"
 #include "lib/jxl/color_encoding_internal.h"
 #include "lib/jxl/fields.h"
 #include "lib/jxl/image_bundle.h"

--- a/lib/jxl/enc_modular.cc
+++ b/lib/jxl/enc_modular.cc
@@ -16,7 +16,6 @@
 #include <vector>
 
 #include "lib/jxl/base/compiler_specific.h"
-#include "lib/jxl/base/padded_bytes.h"
 #include "lib/jxl/base/printf_macros.h"
 #include "lib/jxl/base/status.h"
 #include "lib/jxl/compressed_dc.h"

--- a/lib/jxl/encode.cc
+++ b/lib/jxl/encode.cc
@@ -1015,9 +1015,8 @@ jxl::Status JxlEncoderStruct::ProcessOneEnqueuedInput() {
     if (last_frame && frame_index_box.StoreFrameIndexBox()) {
       std::vector<uint8_t> index_box_content;
       EncodeFrameIndexBox(frame_index_box, index_box_content);
-      JXL_RETURN_IF_ERROR(
-          AppendBoxWithContents(jxl::MakeBoxType("jxli"),
-                                jxl::Span<const uint8_t>(index_box_content)));
+      JXL_RETURN_IF_ERROR(AppendBoxWithContents(jxl::MakeBoxType("jxli"),
+                                                jxl::Bytes(index_box_content)));
     }
   } else {
     // Not a frame, so is a box instead
@@ -2005,7 +2004,7 @@ JxlEncoderStatus JxlEncoderAddJPEGFrame(
   }
 
   jxl::CodecInOut io;
-  if (!jxl::jpeg::DecodeImageJPG(jxl::Span<const uint8_t>(buffer, size), &io)) {
+  if (!jxl::jpeg::DecodeImageJPG(jxl::Bytes(buffer, size), &io)) {
     return JXL_API_ERROR(frame_settings->enc, JXL_ENC_ERR_BAD_INPUT,
                          "Error during decode of input JPEG");
   }
@@ -2331,10 +2330,10 @@ JxlEncoderStatus JxlEncoderAddImageFrame(
       GetBitDepth(frame_settings->values.image_bit_depth,
                   frame_settings->enc->metadata.m, *pixel_format);
   const uint8_t* uint8_buffer = reinterpret_cast<const uint8_t*>(buffer);
-  if (!jxl::ConvertFromExternal(
-          jxl::Span<const uint8_t>(uint8_buffer, size), xsize, ysize, c_current,
-          bits_per_sample, *pixel_format,
-          frame_settings->enc->thread_pool.get(), &(queued_frame->frame))) {
+  if (!jxl::ConvertFromExternal(jxl::Bytes(uint8_buffer, size), xsize, ysize,
+                                c_current, bits_per_sample, *pixel_format,
+                                frame_settings->enc->thread_pool.get(),
+                                &(queued_frame->frame))) {
     return JXL_API_ERROR(frame_settings->enc, JXL_ENC_ERR_API_USAGE,
                          "Invalid input buffer");
   }
@@ -2521,8 +2520,8 @@ JXL_EXPORT JxlEncoderStatus JxlEncoderSetExtraChannelBuffer(
       frame_settings->enc->metadata.m.extra_channel_info[index], ec_format);
   const uint8_t* uint8_buffer = reinterpret_cast<const uint8_t*>(buffer);
   auto queued_frame = frame_settings->enc->input_queue.back().frame.get();
-  if (!jxl::ConvertFromExternal(jxl::Span<const uint8_t>(uint8_buffer, size),
-                                xsize, ysize, bits_per_sample, ec_format, 0,
+  if (!jxl::ConvertFromExternal(jxl::Bytes(uint8_buffer, size), xsize, ysize,
+                                bits_per_sample, ec_format, 0,
                                 frame_settings->enc->thread_pool.get(),
                                 &queued_frame->frame.extra_channels()[index])) {
     return JXL_API_ERROR(frame_settings->enc, JXL_ENC_ERR_API_USAGE,

--- a/lib/jxl/exif.h
+++ b/lib/jxl/exif.h
@@ -11,7 +11,6 @@
 
 #include <jxl/codestream_header.h>
 
-#include "lib/jxl/base/padded_bytes.h"
 #include "lib/jxl/image_metadata.h"
 
 namespace jxl {

--- a/lib/jxl/frame_header.h
+++ b/lib/jxl/frame_header.h
@@ -17,7 +17,6 @@
 
 #include "lib/jxl/base/compiler_specific.h"
 #include "lib/jxl/base/override.h"
-#include "lib/jxl/base/padded_bytes.h"
 #include "lib/jxl/base/status.h"
 #include "lib/jxl/coeff_order_fwd.h"
 #include "lib/jxl/common.h"  // kMaxNumPasses

--- a/lib/jxl/gradient_test.cc
+++ b/lib/jxl/gradient_test.cc
@@ -164,8 +164,7 @@ void TestGradient(ThreadPool* pool, uint32_t color0, uint32_t color1,
   PassesEncoderState enc_state;
   EXPECT_TRUE(EncodeFile(cparams, &io, &enc_state, &compressed,
                          *JxlGetDefaultCms(), aux_out, pool));
-  EXPECT_TRUE(
-      test::DecodeFile({}, Span<const uint8_t>(compressed), &io2, pool));
+  EXPECT_TRUE(test::DecodeFile({}, Bytes(compressed), &io2, pool));
   EXPECT_TRUE(io2.Main().TransformTo(io2.metadata.m.color_encoding,
                                      *JxlGetDefaultCms(), pool));
 

--- a/lib/jxl/icc_codec.cc
+++ b/lib/jxl/icc_codec.cc
@@ -12,6 +12,7 @@
 #include <vector>
 
 #include "lib/jxl/base/byte_order.h"
+#include "lib/jxl/base/padded_bytes.h"
 #include "lib/jxl/dec_ans.h"
 #include "lib/jxl/fields.h"
 #include "lib/jxl/icc_codec_common.h"
@@ -108,7 +109,8 @@ Status UnpredictICC(const uint8_t* enc, size_t size, PaddedBytes* result) {
   pos = commands_end;  // pos in data stream
 
   // Header
-  PaddedBytes header = ICCInitialHeaderPrediction();
+  PaddedBytes header;
+  header.append(ICCInitialHeaderPrediction());
   EncodeUint32(0, osize, &header);
   for (size_t i = 0; i <= kICCHeaderSize; i++) {
     if (result->size() == osize) {
@@ -388,14 +390,6 @@ Status ICCReader::CheckEOI(BitReader* reader) {
   if (reader->AllReadsWithinBounds()) return true;
   return JXL_STATUS(StatusCode::kNotEnoughBytes,
                     "Not enough bytes for reading ICC profile");
-}
-
-Status ReadICC(BitReader* JXL_RESTRICT reader, PaddedBytes* JXL_RESTRICT icc,
-               size_t output_limit) {
-  ICCReader icc_reader;
-  JXL_RETURN_IF_ERROR(icc_reader.Init(reader, output_limit));
-  JXL_RETURN_IF_ERROR(icc_reader.Process(reader, icc));
-  return true;
 }
 
 }  // namespace jxl

--- a/lib/jxl/icc_codec.h
+++ b/lib/jxl/icc_codec.h
@@ -39,13 +39,6 @@ struct ICCReader {
   PaddedBytes decompressed_;
 };
 
-// `icc` may be empty afterwards - if so, call CreateProfile. Does not append,
-// clears any original data that was in icc.
-// If `output_limit` is not 0, then returns error if resulting profile would be
-// longer than `output_limit`
-Status ReadICC(BitReader* JXL_RESTRICT reader, PaddedBytes* JXL_RESTRICT icc,
-               size_t output_limit = 0);
-
 // Exposed only for testing
 Status PredictICC(const uint8_t* icc, size_t size, PaddedBytes* result);
 

--- a/lib/jxl/icc_codec_common.cc
+++ b/lib/jxl/icc_codec_common.cc
@@ -12,6 +12,7 @@
 #include <vector>
 
 #include "lib/jxl/base/byte_order.h"
+#include "lib/jxl/base/padded_bytes.h"
 #include "lib/jxl/fields.h"
 
 namespace jxl {
@@ -93,29 +94,19 @@ Status CheckIs32Bit(uint64_t v) {
   return true;
 }
 
-PaddedBytes ICCInitialHeaderPrediction() {
-  PaddedBytes result(kICCHeaderSize);
-  for (size_t i = 0; i < kICCHeaderSize; i++) {
-    result[i] = 0;
-  }
-  result[8] = 4;
-  EncodeKeyword(kMntrTag, result.data(), result.size(), 12);
-  EncodeKeyword(kRgb_Tag, result.data(), result.size(), 16);
-  EncodeKeyword(kXyz_Tag, result.data(), result.size(), 20);
-  EncodeKeyword(kAcspTag, result.data(), result.size(), 36);
-  result[68] = 0;
-  result[69] = 0;
-  result[70] = 246;
-  result[71] = 214;
-  result[72] = 0;
-  result[73] = 1;
-  result[74] = 0;
-  result[75] = 0;
-  result[76] = 0;
-  result[77] = 0;
-  result[78] = 211;
-  result[79] = 45;
-  return result;
+const uint8_t kIccInitialHeaderPrediction[kICCHeaderSize] = {
+    0,   0,   0,   0,   0,   0,   0,   0,   4, 0, 0, 0, 'm', 'n', 't', 'r',
+    'R', 'G', 'B', ' ', 'X', 'Y', 'Z', ' ', 0, 0, 0, 0, 0,   0,   0,   0,
+    0,   0,   0,   0,   'a', 'c', 's', 'p', 0, 0, 0, 0, 0,   0,   0,   0,
+    0,   0,   0,   0,   0,   0,   0,   0,   0, 0, 0, 0, 0,   0,   0,   0,
+    0,   0,   0,   0,   0,   0,   246, 214, 0, 1, 0, 0, 0,   0,   211, 45,
+    0,   0,   0,   0,   0,   0,   0,   0,   0, 0, 0, 0, 0,   0,   0,   0,
+    0,   0,   0,   0,   0,   0,   0,   0,   0, 0, 0, 0, 0,   0,   0,   0,
+    0,   0,   0,   0,   0,   0,   0,   0,   0, 0, 0, 0, 0,   0,   0,   0,
+};
+
+const Span<const uint8_t> ICCInitialHeaderPrediction() {
+  return Bytes(kIccInitialHeaderPrediction);
 }
 
 void ICCPredictHeader(const uint8_t* icc, size_t size, uint8_t* header,

--- a/lib/jxl/icc_codec_common.h
+++ b/lib/jxl/icc_codec_common.h
@@ -8,15 +8,16 @@
 
 // Compressed representation of ICC profiles.
 
-#include <stddef.h>
-#include <stdint.h>
-
 #include <array>
+#include <cstddef>
+#include <cstdint>
 
-#include "lib/jxl/base/padded_bytes.h"
+#include "lib/jxl/base/span.h"
 #include "lib/jxl/base/status.h"
 
 namespace jxl {
+
+class PaddedBytes;
 
 static constexpr size_t kICCHeaderSize = 128;
 
@@ -94,7 +95,7 @@ void AppendKeyword(const Tag& keyword, PaddedBytes* data);
 Status CheckOutOfBounds(size_t a, size_t b, size_t size);
 Status CheckIs32Bit(uint64_t v);
 
-PaddedBytes ICCInitialHeaderPrediction();
+const Span<const uint8_t> ICCInitialHeaderPrediction();
 void ICCPredictHeader(const uint8_t* icc, size_t size, uint8_t* header,
                       size_t pos);
 uint8_t LinearPredictICCValue(const uint8_t* data, size_t start, size_t i,

--- a/lib/jxl/icc_codec_test.cc
+++ b/lib/jxl/icc_codec_test.cc
@@ -11,6 +11,7 @@
 #include "lib/jxl/base/span.h"
 #include "lib/jxl/color_encoding_internal.h"
 #include "lib/jxl/enc_icc_codec.h"
+#include "lib/jxl/test_utils.h"
 #include "lib/jxl/testing.h"
 
 namespace jxl {
@@ -20,9 +21,9 @@ void TestProfile(const IccBytes& icc) {
   BitWriter writer;
   ASSERT_TRUE(WriteICC(icc, &writer, 0, nullptr));
   writer.ZeroPadToByte();
-  PaddedBytes dec;
+  std::vector<uint8_t> dec;
   BitReader reader(writer.GetSpan());
-  ASSERT_TRUE(ReadICC(&reader, &dec));
+  ASSERT_TRUE(test::ReadICC(&reader, &dec));
   ASSERT_TRUE(reader.Close());
   EXPECT_EQ(icc.size(), dec.size());
   if (icc.size() == dec.size()) {
@@ -35,7 +36,7 @@ void TestProfile(const IccBytes& icc) {
 
 void TestProfile(const std::string& icc) {
   IccBytes data;
-  Span<const uint8_t>(icc).AppendTo(&data);
+  Bytes(icc).AppendTo(&data);
   TestProfile(data);
 }
 
@@ -137,7 +138,7 @@ TEST(IccCodecTest, Icc) {
 
   {
     IccBytes profile;
-    Span<const uint8_t>(kTestProfile, sizeof(kTestProfile)).AppendTo(&profile);
+    Bytes(kTestProfile, sizeof(kTestProfile)).AppendTo(&profile);
     TestProfile(profile);
   }
 
@@ -190,10 +191,10 @@ static const unsigned char kEncodedTestProfile[] = {
 
 // Tests that the decoded kEncodedTestProfile matches kTestProfile.
 TEST(IccCodecTest, EncodedIccProfile) {
-  jxl::BitReader reader(jxl::Span<const uint8_t>(kEncodedTestProfile,
-                                                 sizeof(kEncodedTestProfile)));
-  jxl::PaddedBytes dec;
-  ASSERT_TRUE(ReadICC(&reader, &dec));
+  jxl::BitReader reader(
+      jxl::Bytes(kEncodedTestProfile, sizeof(kEncodedTestProfile)));
+  std::vector<uint8_t> dec;
+  ASSERT_TRUE(test::ReadICC(&reader, &dec));
   ASSERT_TRUE(reader.Close());
   EXPECT_EQ(sizeof(kTestProfile), dec.size());
   if (sizeof(kTestProfile) == dec.size()) {

--- a/lib/jxl/image_bundle.cc
+++ b/lib/jxl/image_bundle.cc
@@ -9,7 +9,6 @@
 #include <utility>
 
 #include "lib/jxl/base/byte_order.h"
-#include "lib/jxl/base/padded_bytes.h"
 #include "lib/jxl/base/printf_macros.h"
 #include "lib/jxl/fields.h"
 

--- a/lib/jxl/image_metadata.cc
+++ b/lib/jxl/image_metadata.cc
@@ -10,7 +10,6 @@
 
 #include "lib/jxl/alpha.h"
 #include "lib/jxl/base/byte_order.h"
-#include "lib/jxl/base/padded_bytes.h"
 #include "lib/jxl/cms/opsin_params.h"
 #include "lib/jxl/fields.h"
 #include "lib/jxl/frame_header.h"

--- a/lib/jxl/jpeg/enc_jpeg_data.cc
+++ b/lib/jxl/jpeg/enc_jpeg_data.cc
@@ -7,6 +7,7 @@
 
 #include <brotli/encode.h>
 
+#include "lib/jxl/codec_in_out.h"
 #include "lib/jxl/enc_fields.h"
 #include "lib/jxl/image_bundle.h"
 #include "lib/jxl/jpeg/enc_jpeg_data_reader.h"

--- a/lib/jxl/jpeg/enc_jpeg_data.h
+++ b/lib/jxl/jpeg/enc_jpeg_data.h
@@ -6,13 +6,15 @@
 #ifndef LIB_JXL_JPEG_ENC_JPEG_DATA_H_
 #define LIB_JXL_JPEG_ENC_JPEG_DATA_H_
 
-#include "lib/jxl/base/padded_bytes.h"
-#include "lib/jxl/codec_in_out.h"
 #include "lib/jxl/color_encoding_internal.h"
 #include "lib/jxl/enc_params.h"
 #include "lib/jxl/jpeg/jpeg_data.h"
 
 namespace jxl {
+
+class CodecInOut;
+class PaddedBytes;
+
 namespace jpeg {
 Status EncodeJPEGData(JPEGData& jpeg_data, PaddedBytes* bytes,
                       const CompressParams& cparams);

--- a/lib/jxl/jxl_test.cc
+++ b/lib/jxl/jxl_test.cc
@@ -8,6 +8,7 @@
 #include <stdint.h>
 
 #include <array>
+#include <cstdint>
 #include <future>
 #include <string>
 #include <tuple>
@@ -56,6 +57,7 @@ using extras::JXLDecompressParams;
 using extras::PackedPixelFile;
 using test::ButteraugliDistance;
 using test::ComputeDistance2;
+using test::ReadTestData;
 using test::Roundtrip;
 using test::TestImage;
 using test::ThreadPoolForTests;
@@ -96,8 +98,8 @@ TEST(JxlTest, RoundtripMarker) {
 
 TEST(JxlTest, RoundtripTinyFast) {
   ThreadPool* pool = nullptr;
-  const PaddedBytes orig = jxl::test::ReadTestData(
-      "external/wesaturate/500px/u76c0g_bliznaca_srgb8.png");
+  const std::vector<uint8_t> orig =
+      ReadTestData("external/wesaturate/500px/u76c0g_bliznaca_srgb8.png");
   TestImage t;
   t.DecodeFromBytes(orig).ClearMetadata().SetDimensions(32, 32);
 
@@ -111,8 +113,8 @@ TEST(JxlTest, RoundtripTinyFast) {
 
 TEST(JxlTest, RoundtripSmallD1) {
   ThreadPool* pool = nullptr;
-  const PaddedBytes orig = jxl::test::ReadTestData(
-      "external/wesaturate/500px/u76c0g_bliznaca_srgb8.png");
+  const std::vector<uint8_t> orig =
+      ReadTestData("external/wesaturate/500px/u76c0g_bliznaca_srgb8.png");
   TestImage t;
   t.DecodeFromBytes(orig).ClearMetadata();
   size_t xsize = t.ppf().info.xsize / 8;
@@ -138,8 +140,8 @@ TEST(JxlTest, RoundtripSmallD1) {
 }
 TEST(JxlTest, RoundtripResample2) {
   ThreadPool* pool = nullptr;
-  const PaddedBytes orig = jxl::test::ReadTestData(
-      "external/wesaturate/500px/u76c0g_bliznaca_srgb8.png");
+  const std::vector<uint8_t> orig =
+      ReadTestData("external/wesaturate/500px/u76c0g_bliznaca_srgb8.png");
   TestImage t;
   t.DecodeFromBytes(orig).ClearMetadata();
 
@@ -154,8 +156,8 @@ TEST(JxlTest, RoundtripResample2) {
 
 TEST(JxlTest, RoundtripResample2Slow) {
   ThreadPool* pool = nullptr;
-  const PaddedBytes orig = jxl::test::ReadTestData(
-      "external/wesaturate/500px/u76c0g_bliznaca_srgb8.png");
+  const std::vector<uint8_t> orig =
+      ReadTestData("external/wesaturate/500px/u76c0g_bliznaca_srgb8.png");
   TestImage t;
   t.DecodeFromBytes(orig).ClearMetadata();
 
@@ -171,7 +173,7 @@ TEST(JxlTest, RoundtripResample2Slow) {
 
 TEST(JxlTest, RoundtripResample2MT) {
   ThreadPoolForTests pool(4);
-  const PaddedBytes orig = jxl::test::ReadTestData("jxl/flower/flower.png");
+  const std::vector<uint8_t> orig = ReadTestData("jxl/flower/flower.png");
   // image has to be large enough to have multiple groups after downsampling
   TestImage t;
   t.DecodeFromBytes(orig).ClearMetadata();
@@ -190,7 +192,7 @@ TEST(JxlTest, RoundtripResample2MT) {
 TEST(JxlTest, RoundtripOutOfOrderProcessing) {
   FakeParallelRunner fake_pool(/*order_seed=*/123, /*num_threads=*/8);
   ThreadPool pool(&JxlFakeParallelRunner, &fake_pool);
-  const PaddedBytes orig = jxl::test::ReadTestData("jxl/flower/flower.png");
+  const std::vector<uint8_t> orig = ReadTestData("jxl/flower/flower.png");
   TestImage t;
   t.DecodeFromBytes(orig).ClearMetadata();
   // Image size is selected so that the block border needed is larger than the
@@ -209,7 +211,7 @@ TEST(JxlTest, RoundtripOutOfOrderProcessing) {
 TEST(JxlTest, RoundtripOutOfOrderProcessingBorder) {
   FakeParallelRunner fake_pool(/*order_seed=*/47, /*num_threads=*/8);
   ThreadPool pool(&JxlFakeParallelRunner, &fake_pool);
-  const PaddedBytes orig = jxl::test::ReadTestData("jxl/flower/flower.png");
+  const std::vector<uint8_t> orig = ReadTestData("jxl/flower/flower.png");
   TestImage t;
   t.DecodeFromBytes(orig).ClearMetadata();
   // Image size is selected so that the block border needed is larger than the
@@ -228,8 +230,8 @@ TEST(JxlTest, RoundtripOutOfOrderProcessingBorder) {
 
 TEST(JxlTest, RoundtripResample4) {
   ThreadPool* pool = nullptr;
-  const PaddedBytes orig = jxl::test::ReadTestData(
-      "external/wesaturate/500px/u76c0g_bliznaca_srgb8.png");
+  const std::vector<uint8_t> orig =
+      ReadTestData("external/wesaturate/500px/u76c0g_bliznaca_srgb8.png");
   TestImage t;
   t.DecodeFromBytes(orig).ClearMetadata();
 
@@ -243,8 +245,8 @@ TEST(JxlTest, RoundtripResample4) {
 
 TEST(JxlTest, RoundtripResample8) {
   ThreadPool* pool = nullptr;
-  const PaddedBytes orig = jxl::test::ReadTestData(
-      "external/wesaturate/500px/u76c0g_bliznaca_srgb8.png");
+  const std::vector<uint8_t> orig =
+      ReadTestData("external/wesaturate/500px/u76c0g_bliznaca_srgb8.png");
   TestImage t;
   t.DecodeFromBytes(orig).ClearMetadata();
 
@@ -258,8 +260,8 @@ TEST(JxlTest, RoundtripResample8) {
 
 TEST(JxlTest, RoundtripUnalignedD2) {
   ThreadPool* pool = nullptr;
-  const PaddedBytes orig = jxl::test::ReadTestData(
-      "external/wesaturate/500px/u76c0g_bliznaca_srgb8.png");
+  const std::vector<uint8_t> orig =
+      ReadTestData("external/wesaturate/500px/u76c0g_bliznaca_srgb8.png");
   TestImage t;
   t.DecodeFromBytes(orig).ClearMetadata();
   size_t xsize = t.ppf().info.xsize / 12;
@@ -275,7 +277,7 @@ TEST(JxlTest, RoundtripUnalignedD2) {
 }
 
 TEST(JxlTest, RoundtripMultiGroup) {
-  const PaddedBytes orig = jxl::test::ReadTestData("jxl/flower/flower.png");
+  const std::vector<uint8_t> orig = ReadTestData("jxl/flower/flower.png");
   TestImage t;
   t.DecodeFromBytes(orig).ClearMetadata().SetDimensions(600, 1024);
 
@@ -302,9 +304,9 @@ TEST(JxlTest, RoundtripMultiGroup) {
 
 TEST(JxlTest, RoundtripRGBToGrayscale) {
   ThreadPoolForTests pool(4);
-  const PaddedBytes orig = jxl::test::ReadTestData("jxl/flower/flower.png");
+  const std::vector<uint8_t> orig = ReadTestData("jxl/flower/flower.png");
   CodecInOut io;
-  ASSERT_TRUE(SetFromBytes(Span<const uint8_t>(orig), &io, &pool));
+  ASSERT_TRUE(SetFromBytes(Bytes(orig), &io, &pool));
   io.ShrinkTo(600, 1024);
 
   CompressParams cparams;
@@ -348,7 +350,7 @@ TEST(JxlTest, RoundtripRGBToGrayscale) {
 
 TEST(JxlTest, RoundtripLargeFast) {
   ThreadPoolForTests pool(8);
-  const PaddedBytes orig = jxl::test::ReadTestData("jxl/flower/flower.png");
+  const std::vector<uint8_t> orig = ReadTestData("jxl/flower/flower.png");
   TestImage t;
   t.DecodeFromBytes(orig).ClearMetadata();
 
@@ -362,8 +364,8 @@ TEST(JxlTest, RoundtripLargeFast) {
 
 TEST(JxlTest, RoundtripDotsForceEpf) {
   ThreadPoolForTests pool(8);
-  const PaddedBytes orig = jxl::test::ReadTestData(
-      "external/wesaturate/500px/cvo9xd_keong_macan_srgb8.png");
+  const std::vector<uint8_t> orig =
+      ReadTestData("external/wesaturate/500px/cvo9xd_keong_macan_srgb8.png");
   TestImage t;
   t.DecodeFromBytes(orig).ClearMetadata();
 
@@ -382,7 +384,7 @@ TEST(JxlTest, RoundtripDotsForceEpf) {
 // Failing this may be a sign of race conditions or invalid memory accesses.
 TEST(JxlTest, RoundtripD2Consistent) {
   ThreadPoolForTests pool(8);
-  const PaddedBytes orig = jxl::test::ReadTestData("jxl/flower/flower.png");
+  const std::vector<uint8_t> orig = ReadTestData("jxl/flower/flower.png");
   TestImage t;
   t.DecodeFromBytes(orig).ClearMetadata();
 
@@ -412,7 +414,7 @@ TEST(JxlTest, RoundtripD2Consistent) {
 
 // Same as above, but for full image, testing multiple groups.
 TEST(JxlTest, RoundtripLargeConsistent) {
-  const PaddedBytes orig = jxl::test::ReadTestData("jxl/flower/flower.png");
+  const std::vector<uint8_t> orig = ReadTestData("jxl/flower/flower.png");
   TestImage t;
   t.DecodeFromBytes(orig).ClearMetadata();
 
@@ -444,8 +446,8 @@ TEST(JxlTest, RoundtripLargeConsistent) {
 
 TEST(JxlTest, RoundtripSmallNL) {
   ThreadPool* pool = nullptr;
-  const PaddedBytes orig = jxl::test::ReadTestData(
-      "external/wesaturate/500px/u76c0g_bliznaca_srgb8.png");
+  const std::vector<uint8_t> orig =
+      ReadTestData("external/wesaturate/500px/u76c0g_bliznaca_srgb8.png");
   TestImage t;
   t.DecodeFromBytes(orig).ClearMetadata();
   size_t xsize = t.ppf().info.xsize / 8;
@@ -459,8 +461,8 @@ TEST(JxlTest, RoundtripSmallNL) {
 
 TEST(JxlTest, RoundtripNoGaborishNoAR) {
   ThreadPool* pool = nullptr;
-  const PaddedBytes orig = jxl::test::ReadTestData(
-      "external/wesaturate/500px/u76c0g_bliznaca_srgb8.png");
+  const std::vector<uint8_t> orig =
+      ReadTestData("external/wesaturate/500px/u76c0g_bliznaca_srgb8.png");
   TestImage t;
   t.DecodeFromBytes(orig).ClearMetadata();
 
@@ -475,8 +477,8 @@ TEST(JxlTest, RoundtripNoGaborishNoAR) {
 
 TEST(JxlTest, RoundtripSmallNoGaborish) {
   ThreadPool* pool = nullptr;
-  const PaddedBytes orig = jxl::test::ReadTestData(
-      "external/wesaturate/500px/u76c0g_bliznaca_srgb8.png");
+  const std::vector<uint8_t> orig =
+      ReadTestData("external/wesaturate/500px/u76c0g_bliznaca_srgb8.png");
   TestImage t;
   t.DecodeFromBytes(orig).ClearMetadata();
   size_t xsize = t.ppf().info.xsize / 8;
@@ -617,10 +619,10 @@ TEST(JxlTest, RoundtripImageBundleOriginalBits) {
 #endif
 
 TEST(JxlTest, RoundtripGrayscale) {
-  const PaddedBytes orig = jxl::test::ReadTestData(
+  const std::vector<uint8_t> orig = ReadTestData(
       "external/wesaturate/500px/cvo9xd_keong_macan_grayscale.png");
   CodecInOut io;
-  ASSERT_TRUE(SetFromBytes(Span<const uint8_t>(orig), &io));
+  ASSERT_TRUE(SetFromBytes(Bytes(orig), &io));
   ASSERT_NE(io.xsize(), 0u);
   io.ShrinkTo(128, 128);
   EXPECT_TRUE(io.Main().IsGray());
@@ -640,7 +642,7 @@ TEST(JxlTest, RoundtripGrayscale) {
     EXPECT_TRUE(EncodeFile(cparams, &io, &enc_state, &compressed,
                            *JxlGetDefaultCms(), aux_out));
     CodecInOut io2;
-    EXPECT_TRUE(test::DecodeFile({}, Span<const uint8_t>(compressed), &io2));
+    EXPECT_TRUE(test::DecodeFile({}, Bytes(compressed), &io2));
     EXPECT_TRUE(io2.Main().IsGray());
 
     EXPECT_LE(compressed.size(), 7000u);
@@ -660,7 +662,7 @@ TEST(JxlTest, RoundtripGrayscale) {
     EXPECT_TRUE(EncodeFile(cparams, &io, &enc_state, &compressed,
                            *JxlGetDefaultCms(), aux_out));
     CodecInOut io2;
-    EXPECT_TRUE(test::DecodeFile({}, Span<const uint8_t>(compressed), &io2));
+    EXPECT_TRUE(test::DecodeFile({}, Bytes(compressed), &io2));
     EXPECT_TRUE(io2.Main().IsGray());
 
     EXPECT_LE(compressed.size(), 1300u);
@@ -681,8 +683,7 @@ TEST(JxlTest, RoundtripGrayscale) {
     CodecInOut io2;
     JXLDecompressParams dparams;
     dparams.color_space = "RGB_D65_SRG_Rel_SRG";
-    EXPECT_TRUE(
-        test::DecodeFile(dparams, Span<const uint8_t>(compressed), &io2));
+    EXPECT_TRUE(test::DecodeFile(dparams, Bytes(compressed), &io2));
     EXPECT_FALSE(io2.Main().IsGray());
 
     EXPECT_LE(compressed.size(), 7000u);
@@ -694,10 +695,10 @@ TEST(JxlTest, RoundtripGrayscale) {
 }
 
 TEST(JxlTest, RoundtripAlpha) {
-  const PaddedBytes orig = jxl::test::ReadTestData(
-      "external/wesaturate/500px/tmshre_riaphotographs_alpha.png");
+  const std::vector<uint8_t> orig =
+      ReadTestData("external/wesaturate/500px/tmshre_riaphotographs_alpha.png");
   CodecInOut io;
-  ASSERT_TRUE(SetFromBytes(Span<const uint8_t>(orig), &io));
+  ASSERT_TRUE(SetFromBytes(Bytes(orig), &io));
 
   ASSERT_NE(io.xsize(), 0u);
   ASSERT_TRUE(io.metadata.m.HasAlpha());
@@ -725,8 +726,7 @@ TEST(JxlTest, RoundtripAlpha) {
       JXLDecompressParams dparams;
       dparams.use_image_callback = use_image_callback;
       dparams.unpremultiply_alpha = unpremul_alpha;
-      EXPECT_TRUE(
-          test::DecodeFile(dparams, Span<const uint8_t>(compressed), &io2));
+      EXPECT_TRUE(test::DecodeFile(dparams, Bytes(compressed), &io2));
       EXPECT_THAT(ButteraugliDistance(io.frames, io2.frames,
                                       ButteraugliParams(), *JxlGetDefaultCms(),
                                       /*distmap=*/nullptr),
@@ -791,11 +791,11 @@ bool UnpremultiplyAlpha(CodecInOut& io) {
 }  // namespace
 
 TEST(JxlTest, RoundtripAlphaPremultiplied) {
-  const PaddedBytes orig = jxl::test::ReadTestData(
-      "external/wesaturate/500px/tmshre_riaphotographs_alpha.png");
+  const std::vector<uint8_t> orig =
+      ReadTestData("external/wesaturate/500px/tmshre_riaphotographs_alpha.png");
   CodecInOut io, io_nopremul;
-  ASSERT_TRUE(SetFromBytes(Span<const uint8_t>(orig), &io));
-  ASSERT_TRUE(SetFromBytes(Span<const uint8_t>(orig), &io_nopremul));
+  ASSERT_TRUE(SetFromBytes(Bytes(orig), &io));
+  ASSERT_TRUE(SetFromBytes(Bytes(orig), &io_nopremul));
 
   ASSERT_NE(io.xsize(), 0u);
   ASSERT_TRUE(io.metadata.m.HasAlpha());
@@ -837,8 +837,7 @@ TEST(JxlTest, RoundtripAlphaPremultiplied) {
           dparams.accepted_formats = {
               {4, JXL_TYPE_UINT8, JXL_LITTLE_ENDIAN, 0}};
         }
-        EXPECT_TRUE(
-            test::DecodeFile(dparams, Span<const uint8_t>(compressed), &io2));
+        EXPECT_TRUE(test::DecodeFile(dparams, Bytes(compressed), &io2));
 
         EXPECT_EQ(unpremul_alpha, !io2.Main().AlphaIsPremultiplied());
         if (!unpremul_alpha) {
@@ -862,8 +861,8 @@ TEST(JxlTest, RoundtripAlphaPremultiplied) {
 
 TEST(JxlTest, RoundtripAlphaResampling) {
   ThreadPool* pool = nullptr;
-  const PaddedBytes orig = jxl::test::ReadTestData(
-      "external/wesaturate/500px/tmshre_riaphotographs_alpha.png");
+  const std::vector<uint8_t> orig =
+      ReadTestData("external/wesaturate/500px/tmshre_riaphotographs_alpha.png");
   TestImage t;
   t.DecodeFromBytes(orig).ClearMetadata();
   ASSERT_NE(t.ppf().info.xsize, 0);
@@ -881,8 +880,8 @@ TEST(JxlTest, RoundtripAlphaResampling) {
 
 TEST(JxlTest, RoundtripAlphaResamplingOnlyAlpha) {
   ThreadPool* pool = nullptr;
-  const PaddedBytes orig = jxl::test::ReadTestData(
-      "external/wesaturate/500px/tmshre_riaphotographs_alpha.png");
+  const std::vector<uint8_t> orig =
+      ReadTestData("external/wesaturate/500px/tmshre_riaphotographs_alpha.png");
   TestImage t;
   t.DecodeFromBytes(orig).ClearMetadata();
   ASSERT_NE(t.ppf().info.xsize, 0);
@@ -899,8 +898,8 @@ TEST(JxlTest, RoundtripAlphaResamplingOnlyAlpha) {
 
 TEST(JxlTest, RoundtripAlphaNonMultipleOf8) {
   ThreadPool* pool = nullptr;
-  const PaddedBytes orig = jxl::test::ReadTestData(
-      "external/wesaturate/500px/tmshre_riaphotographs_alpha.png");
+  const std::vector<uint8_t> orig =
+      ReadTestData("external/wesaturate/500px/tmshre_riaphotographs_alpha.png");
   TestImage t;
   t.DecodeFromBytes(orig).ClearMetadata().SetDimensions(12, 12);
   ASSERT_NE(t.ppf().info.xsize, 0);
@@ -960,8 +959,8 @@ JXLCompressParams CompressParamsForLossless() {
 
 TEST(JxlTest, JXL_SLOW_TEST(RoundtripLossless8)) {
   ThreadPoolForTests pool(8);
-  const PaddedBytes orig = jxl::test::ReadTestData(
-      "external/wesaturate/500px/tmshre_riaphotographs_srgb8.png");
+  const std::vector<uint8_t> orig =
+      ReadTestData("external/wesaturate/500px/tmshre_riaphotographs_srgb8.png");
   TestImage t;
   t.DecodeFromBytes(orig).ClearMetadata();
 
@@ -974,8 +973,8 @@ TEST(JxlTest, JXL_SLOW_TEST(RoundtripLossless8)) {
 
 TEST(JxlTest, JXL_SLOW_TEST(RoundtripLossless8ThunderGradient)) {
   ThreadPoolForTests pool(8);
-  const PaddedBytes orig = jxl::test::ReadTestData(
-      "external/wesaturate/500px/tmshre_riaphotographs_srgb8.png");
+  const std::vector<uint8_t> orig =
+      ReadTestData("external/wesaturate/500px/tmshre_riaphotographs_srgb8.png");
   TestImage t;
   t.DecodeFromBytes(orig).ClearMetadata();
 
@@ -990,8 +989,8 @@ TEST(JxlTest, JXL_SLOW_TEST(RoundtripLossless8ThunderGradient)) {
 
 TEST(JxlTest, JXL_SLOW_TEST(RoundtripLossless8LightningGradient)) {
   ThreadPoolForTests pool(8);
-  const PaddedBytes orig = jxl::test::ReadTestData(
-      "external/wesaturate/500px/tmshre_riaphotographs_srgb8.png");
+  const std::vector<uint8_t> orig =
+      ReadTestData("external/wesaturate/500px/tmshre_riaphotographs_srgb8.png");
   TestImage t;
   t.DecodeFromBytes(orig).ClearMetadata();
 
@@ -1007,8 +1006,8 @@ TEST(JxlTest, JXL_SLOW_TEST(RoundtripLossless8LightningGradient)) {
 
 TEST(JxlTest, JXL_SLOW_TEST(RoundtripLossless8Falcon)) {
   ThreadPoolForTests pool(8);
-  const PaddedBytes orig = jxl::test::ReadTestData(
-      "external/wesaturate/500px/tmshre_riaphotographs_srgb8.png");
+  const std::vector<uint8_t> orig =
+      ReadTestData("external/wesaturate/500px/tmshre_riaphotographs_srgb8.png");
   TestImage t;
   t.DecodeFromBytes(orig).ClearMetadata();
 
@@ -1022,8 +1021,8 @@ TEST(JxlTest, JXL_SLOW_TEST(RoundtripLossless8Falcon)) {
 
 TEST(JxlTest, RoundtripLossless8Alpha) {
   ThreadPool* pool = nullptr;
-  const PaddedBytes orig = jxl::test::ReadTestData(
-      "external/wesaturate/500px/tmshre_riaphotographs_alpha.png");
+  const std::vector<uint8_t> orig =
+      ReadTestData("external/wesaturate/500px/tmshre_riaphotographs_alpha.png");
   TestImage t;
   t.DecodeFromBytes(orig).ClearMetadata();
   ASSERT_EQ(t.ppf().info.alpha_bits, 8);
@@ -1115,8 +1114,8 @@ TEST(JxlTest, RoundtripLossless16AlphaNotMisdetectedAs8Bit) {
 
 TEST(JxlTest, RoundtripDots) {
   ThreadPool* pool = nullptr;
-  const PaddedBytes orig = jxl::test::ReadTestData(
-      "external/wesaturate/500px/cvo9xd_keong_macan_srgb8.png");
+  const std::vector<uint8_t> orig =
+      ReadTestData("external/wesaturate/500px/cvo9xd_keong_macan_srgb8.png");
   TestImage t;
   t.DecodeFromBytes(orig).ClearMetadata();
   ASSERT_NE(t.ppf().info.xsize, 0);
@@ -1136,8 +1135,8 @@ TEST(JxlTest, RoundtripDots) {
 
 TEST(JxlTest, RoundtripNoise) {
   ThreadPool* pool = nullptr;
-  const PaddedBytes orig = jxl::test::ReadTestData(
-      "external/wesaturate/500px/u76c0g_bliznaca_srgb8.png");
+  const std::vector<uint8_t> orig =
+      ReadTestData("external/wesaturate/500px/u76c0g_bliznaca_srgb8.png");
   TestImage t;
   t.DecodeFromBytes(orig).ClearMetadata();
   ASSERT_NE(t.ppf().info.xsize, 0);
@@ -1156,7 +1155,7 @@ TEST(JxlTest, RoundtripNoise) {
 
 TEST(JxlTest, RoundtripLossless8Gray) {
   ThreadPool* pool = nullptr;
-  const PaddedBytes orig = jxl::test::ReadTestData(
+  const std::vector<uint8_t> orig = ReadTestData(
       "external/wesaturate/500px/cvo9xd_keong_macan_grayscale.png");
   TestImage t;
   t.SetColorEncoding("Gra_D65_Rel_SRG").DecodeFromBytes(orig).ClearMetadata();
@@ -1181,7 +1180,7 @@ TEST(JxlTest, RoundtripAnimation) {
     return;
   }
   ThreadPool* pool = nullptr;
-  const PaddedBytes orig = jxl::test::ReadTestData("jxl/traffic_light.gif");
+  const std::vector<uint8_t> orig = ReadTestData("jxl/traffic_light.gif");
   TestImage t;
   t.DecodeFromBytes(orig).ClearMetadata();
   EXPECT_EQ(4, t.ppf().frames.size());
@@ -1209,7 +1208,7 @@ TEST(JxlTest, RoundtripLosslessAnimation) {
     return;
   }
   ThreadPool* pool = nullptr;
-  const PaddedBytes orig = jxl::test::ReadTestData("jxl/traffic_light.gif");
+  const std::vector<uint8_t> orig = ReadTestData("jxl/traffic_light.gif");
   TestImage t;
   t.DecodeFromBytes(orig).ClearMetadata();
   EXPECT_EQ(4, t.ppf().frames.size());
@@ -1234,7 +1233,7 @@ TEST(JxlTest, RoundtripAnimationPatches) {
     return;
   }
   ThreadPool* pool = nullptr;
-  const PaddedBytes orig = jxl::test::ReadTestData("jxl/animation_patches.gif");
+  const std::vector<uint8_t> orig = ReadTestData("jxl/animation_patches.gif");
 
   TestImage t;
   t.DecodeFromBytes(orig).ClearMetadata();
@@ -1255,11 +1254,9 @@ TEST(JxlTest, RoundtripAnimationPatches) {
   EXPECT_THAT(ButteraugliDistance(t.ppf(), ppf_out), IsSlightlyBelow(0.8999));
 }
 
-size_t RoundtripJpeg(const PaddedBytes& jpeg_in, ThreadPool* pool) {
-  std::vector<uint8_t> jpeg_bytes(jpeg_in.data(),
-                                  jpeg_in.data() + jpeg_in.size());
+size_t RoundtripJpeg(const std::vector<uint8_t>& jpeg_in, ThreadPool* pool) {
   std::vector<uint8_t> compressed;
-  EXPECT_TRUE(extras::EncodeImageJXL({}, extras::PackedPixelFile(), &jpeg_bytes,
+  EXPECT_TRUE(extras::EncodeImageJXL({}, extras::PackedPixelFile(), &jpeg_in,
                                      &compressed));
 
   jxl::JXLDecompressParams dparams;
@@ -1283,7 +1280,7 @@ size_t RoundtripJpeg(const PaddedBytes& jpeg_in, ThreadPool* pool) {
   return compressed.size();
 }
 
-void RoundtripJpegToPixels(const PaddedBytes& jpeg_in,
+void RoundtripJpegToPixels(const std::vector<uint8_t>& jpeg_in,
                            JXLDecompressParams dparams, ThreadPool* pool,
                            PackedPixelFile* ppf_out) {
   std::vector<uint8_t> jpeg_bytes(jpeg_in.data(),
@@ -1300,8 +1297,8 @@ void RoundtripJpegToPixels(const PaddedBytes& jpeg_in,
 
 TEST(JxlTest, JXL_TRANSCODE_JPEG_TEST(RoundtripJpegRecompression444)) {
   ThreadPoolForTests pool(8);
-  const PaddedBytes orig =
-      jxl::test::ReadTestData("jxl/flower/flower.png.im_q85_444.jpg");
+  const std::vector<uint8_t> orig =
+      ReadTestData("jxl/flower/flower.png.im_q85_444.jpg");
   // JPEG size is 696,659 bytes.
   EXPECT_NEAR(RoundtripJpeg(orig, &pool), 568940u, 10);
 }
@@ -1309,8 +1306,8 @@ TEST(JxlTest, JXL_TRANSCODE_JPEG_TEST(RoundtripJpegRecompression444)) {
 TEST(JxlTest, JXL_TRANSCODE_JPEG_TEST(RoundtripJpegRecompressionToPixels)) {
   TEST_LIBJPEG_SUPPORT();
   ThreadPoolForTests pool(8);
-  const PaddedBytes orig =
-      jxl::test::ReadTestData("jxl/flower/flower.png.im_q85_444.jpg");
+  const std::vector<uint8_t> orig =
+      ReadTestData("jxl/flower/flower.png.im_q85_444.jpg");
   TestImage t;
   t.DecodeFromBytes(orig);
 
@@ -1322,8 +1319,8 @@ TEST(JxlTest, JXL_TRANSCODE_JPEG_TEST(RoundtripJpegRecompressionToPixels)) {
 TEST(JxlTest, JXL_TRANSCODE_JPEG_TEST(RoundtripJpegRecompressionToPixels420)) {
   TEST_LIBJPEG_SUPPORT();
   ThreadPoolForTests pool(8);
-  const PaddedBytes orig =
-      jxl::test::ReadTestData("jxl/flower/flower.png.im_q85_420.jpg");
+  const std::vector<uint8_t> orig =
+      ReadTestData("jxl/flower/flower.png.im_q85_420.jpg");
   TestImage t;
   t.DecodeFromBytes(orig);
 
@@ -1336,8 +1333,8 @@ TEST(JxlTest,
      JXL_TRANSCODE_JPEG_TEST(RoundtripJpegRecompressionToPixels420EarlyFlush)) {
   TEST_LIBJPEG_SUPPORT();
   ThreadPoolForTests pool(8);
-  const PaddedBytes orig =
-      jxl::test::ReadTestData("jxl/flower/flower.png.im_q85_420.jpg");
+  const std::vector<uint8_t> orig =
+      ReadTestData("jxl/flower/flower.png.im_q85_420.jpg");
   TestImage t;
   t.DecodeFromBytes(orig);
 
@@ -1353,8 +1350,8 @@ TEST(JxlTest,
      JXL_TRANSCODE_JPEG_TEST(RoundtripJpegRecompressionToPixels420Mul16)) {
   TEST_LIBJPEG_SUPPORT();
   ThreadPoolForTests pool(8);
-  const PaddedBytes orig =
-      jxl::test::ReadTestData("jxl/flower/flower_cropped.jpg");
+  const std::vector<uint8_t> orig =
+      ReadTestData("jxl/flower/flower_cropped.jpg");
   TestImage t;
   t.DecodeFromBytes(orig);
 
@@ -1367,8 +1364,8 @@ TEST(JxlTest,
      JXL_TRANSCODE_JPEG_TEST(RoundtripJpegRecompressionToPixels_asymmetric)) {
   TEST_LIBJPEG_SUPPORT();
   ThreadPoolForTests pool(8);
-  const PaddedBytes orig =
-      jxl::test::ReadTestData("jxl/flower/flower.png.im_q85_asymmetric.jpg");
+  const std::vector<uint8_t> orig =
+      ReadTestData("jxl/flower/flower.png.im_q85_asymmetric.jpg");
   TestImage t;
   t.DecodeFromBytes(orig);
 
@@ -1379,16 +1376,16 @@ TEST(JxlTest,
 
 TEST(JxlTest, JXL_TRANSCODE_JPEG_TEST(RoundtripJpegRecompressionGray)) {
   ThreadPoolForTests pool(8);
-  const PaddedBytes orig =
-      jxl::test::ReadTestData("jxl/flower/flower.png.im_q85_gray.jpg");
+  const std::vector<uint8_t> orig =
+      ReadTestData("jxl/flower/flower.png.im_q85_gray.jpg");
   // JPEG size is 456,528 bytes.
   EXPECT_NEAR(RoundtripJpeg(orig, &pool), 387496u, 200);
 }
 
 TEST(JxlTest, JXL_TRANSCODE_JPEG_TEST(RoundtripJpegRecompression420)) {
   ThreadPoolForTests pool(8);
-  const PaddedBytes orig =
-      jxl::test::ReadTestData("jxl/flower/flower.png.im_q85_420.jpg");
+  const std::vector<uint8_t> orig =
+      ReadTestData("jxl/flower/flower.png.im_q85_420.jpg");
   // JPEG size is 546,797 bytes.
   EXPECT_NEAR(RoundtripJpeg(orig, &pool), 455560u, 10);
 }
@@ -1396,8 +1393,8 @@ TEST(JxlTest, JXL_TRANSCODE_JPEG_TEST(RoundtripJpegRecompression420)) {
 TEST(JxlTest,
      JXL_TRANSCODE_JPEG_TEST(RoundtripJpegRecompression_luma_subsample)) {
   ThreadPoolForTests pool(8);
-  const PaddedBytes orig = jxl::test::ReadTestData(
-      "jxl/flower/flower.png.im_q85_luma_subsample.jpg");
+  const std::vector<uint8_t> orig =
+      ReadTestData("jxl/flower/flower.png.im_q85_luma_subsample.jpg");
   // JPEG size is 400,724 bytes.
   EXPECT_NEAR(RoundtripJpeg(orig, &pool), 325354u, 10);
 }
@@ -1405,24 +1402,24 @@ TEST(JxlTest,
 TEST(JxlTest, JXL_TRANSCODE_JPEG_TEST(RoundtripJpegRecompression444_12)) {
   // 444 JPEG that has an interesting sampling-factor (1x2, 1x2, 1x2).
   ThreadPoolForTests pool(8);
-  const PaddedBytes orig =
-      jxl::test::ReadTestData("jxl/flower/flower.png.im_q85_444_1x2.jpg");
+  const std::vector<uint8_t> orig =
+      ReadTestData("jxl/flower/flower.png.im_q85_444_1x2.jpg");
   // JPEG size is 703,874 bytes.
   EXPECT_NEAR(RoundtripJpeg(orig, &pool), 569679u, 10);
 }
 
 TEST(JxlTest, JXL_TRANSCODE_JPEG_TEST(RoundtripJpegRecompression422)) {
   ThreadPoolForTests pool(8);
-  const PaddedBytes orig =
-      jxl::test::ReadTestData("jxl/flower/flower.png.im_q85_422.jpg");
+  const std::vector<uint8_t> orig =
+      ReadTestData("jxl/flower/flower.png.im_q85_422.jpg");
   // JPEG size is 522,057 bytes.
   EXPECT_NEAR(RoundtripJpeg(orig, &pool), 499282u, 10);
 }
 
 TEST(JxlTest, JXL_TRANSCODE_JPEG_TEST(RoundtripJpegRecompression440)) {
   ThreadPoolForTests pool(8);
-  const PaddedBytes orig =
-      jxl::test::ReadTestData("jxl/flower/flower.png.im_q85_440.jpg");
+  const std::vector<uint8_t> orig =
+      ReadTestData("jxl/flower/flower.png.im_q85_440.jpg");
   // JPEG size is 603,623 bytes.
   EXPECT_NEAR(RoundtripJpeg(orig, &pool), 501151u, 10);
 }
@@ -1431,32 +1428,32 @@ TEST(JxlTest, JXL_TRANSCODE_JPEG_TEST(RoundtripJpegRecompression_asymmetric)) {
   // 2x vertical downsample of one chroma channel, 2x horizontal downsample of
   // the other.
   ThreadPoolForTests pool(8);
-  const PaddedBytes orig =
-      jxl::test::ReadTestData("jxl/flower/flower.png.im_q85_asymmetric.jpg");
+  const std::vector<uint8_t> orig =
+      ReadTestData("jxl/flower/flower.png.im_q85_asymmetric.jpg");
   // JPEG size is 604,601 bytes.
   EXPECT_NEAR(RoundtripJpeg(orig, &pool), 500602u, 10);
 }
 
 TEST(JxlTest, JXL_TRANSCODE_JPEG_TEST(RoundtripJpegRecompression420Progr)) {
   ThreadPoolForTests pool(8);
-  const PaddedBytes orig =
-      jxl::test::ReadTestData("jxl/flower/flower.png.im_q85_420_progr.jpg");
+  const std::vector<uint8_t> orig =
+      ReadTestData("jxl/flower/flower.png.im_q85_420_progr.jpg");
   // JPEG size is 522,057 bytes.
   EXPECT_NEAR(RoundtripJpeg(orig, &pool), 455499u, 10);
 }
 
 TEST(JxlTest, JXL_TRANSCODE_JPEG_TEST(RoundtripJpegRecompressionMetadata)) {
   ThreadPoolForTests pool(8);
-  const PaddedBytes orig =
-      jxl::test::ReadTestData("jxl/jpeg_reconstruction/1x1_exif_xmp.jpg");
+  const std::vector<uint8_t> orig =
+      ReadTestData("jxl/jpeg_reconstruction/1x1_exif_xmp.jpg");
   // JPEG size is 4290 bytes
   EXPECT_NEAR(RoundtripJpeg(orig, &pool), 1400u, 30);
 }
 
 TEST(JxlTest, JXL_TRANSCODE_JPEG_TEST(RoundtripJpegRecompressionRestarts)) {
   ThreadPoolForTests pool(8);
-  const PaddedBytes orig =
-      jxl::test::ReadTestData("jxl/jpeg_reconstruction/bicycles_restarts.jpg");
+  const std::vector<uint8_t> orig =
+      ReadTestData("jxl/jpeg_reconstruction/bicycles_restarts.jpg");
   // JPEG size is 87478 bytes
   EXPECT_NEAR(RoundtripJpeg(orig, &pool), 76125u, 30);
 }
@@ -1464,8 +1461,8 @@ TEST(JxlTest, JXL_TRANSCODE_JPEG_TEST(RoundtripJpegRecompressionRestarts)) {
 TEST(JxlTest,
      JXL_TRANSCODE_JPEG_TEST(RoundtripJpegRecompressionOrientationICC)) {
   ThreadPoolForTests pool(8);
-  const PaddedBytes orig =
-      jxl::test::ReadTestData("jxl/jpeg_reconstruction/sideways_bench.jpg");
+  const std::vector<uint8_t> orig =
+      ReadTestData("jxl/jpeg_reconstruction/sideways_bench.jpg");
   // JPEG size is 15252 bytes
   EXPECT_NEAR(RoundtripJpeg(orig, &pool), 12000u, 470);
   // TODO(jon): investigate why 'Cross-compiling i686-linux-gnu' produces a
@@ -1474,7 +1471,7 @@ TEST(JxlTest,
 
 TEST(JxlTest, RoundtripProgressive) {
   ThreadPoolForTests pool(4);
-  const PaddedBytes orig = jxl::test::ReadTestData("jxl/flower/flower.png");
+  const std::vector<uint8_t> orig = ReadTestData("jxl/flower/flower.png");
   TestImage t;
   t.DecodeFromBytes(orig).ClearMetadata().SetDimensions(600, 1024);
 
@@ -1490,7 +1487,7 @@ TEST(JxlTest, RoundtripProgressive) {
 
 TEST(JxlTest, RoundtripProgressiveLevel2Slow) {
   ThreadPoolForTests pool(8);
-  const PaddedBytes orig = jxl::test::ReadTestData("jxl/flower/flower.png");
+  const std::vector<uint8_t> orig = ReadTestData("jxl/flower/flower.png");
   TestImage t;
   t.DecodeFromBytes(orig).ClearMetadata().SetDimensions(600, 1024);
 
@@ -1546,7 +1543,7 @@ TEST(JxlTest, LosslessPNMRoundtrip) {
       std::string filename = "jxl/flower/flower_small." +
                              std::string(kChannels[channels]) + ".depth" +
                              std::to_string(bit_depth) + extension;
-      const PaddedBytes orig = jxl::test::ReadTestData(filename);
+      const std::vector<uint8_t> orig = ReadTestData(filename);
       test::TestImage t;
       if (channels < 3) t.SetColorEncoding("Gra_D65_Rel_SRG");
       t.DecodeFromBytes(orig);
@@ -1578,7 +1575,7 @@ class JxlTest : public ::testing::TestWithParam<const char*> {};
 
 TEST_P(JxlTest, LosslessSmallFewColors) {
   ThreadPoolForTests pool(8);
-  const PaddedBytes orig = jxl::test::ReadTestData(GetParam());
+  const std::vector<uint8_t> orig = ReadTestData(GetParam());
   TestImage t;
   t.DecodeFromBytes(orig).ClearMetadata();
 

--- a/lib/jxl/modular_test.cc
+++ b/lib/jxl/modular_test.cc
@@ -3,9 +3,8 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-#include <stdint.h>
-
 #include <array>
+#include <cstdint>
 #include <string>
 #include <utility>
 #include <vector>
@@ -39,10 +38,12 @@
 
 namespace jxl {
 namespace {
+
+using test::ReadTestData;
 using test::Roundtrip;
 
 void TestLosslessGroups(size_t group_size_shift) {
-  const PaddedBytes orig = jxl::test::ReadTestData("jxl/flower/flower.png");
+  const std::vector<uint8_t> orig = ReadTestData("jxl/flower/flower.png");
   CompressParams cparams;
   cparams.SetLossless();
   cparams.modular_group_size_shift = group_size_shift;
@@ -50,7 +51,7 @@ void TestLosslessGroups(size_t group_size_shift) {
   CodecInOut io_out;
 
   CodecInOut io;
-  ASSERT_TRUE(SetFromBytes(Span<const uint8_t>(orig), &io));
+  ASSERT_TRUE(SetFromBytes(Bytes(orig), &io));
   io.ShrinkTo(io.xsize() / 4, io.ysize() / 4);
 
   size_t compressed_size;
@@ -70,8 +71,8 @@ TEST(ModularTest, JXL_TSAN_SLOW_TEST(RoundtripLosslessGroups1024)) {
 }
 
 TEST(ModularTest, RoundtripLosslessCustomWP_PermuteRCT) {
-  const PaddedBytes orig = jxl::test::ReadTestData(
-      "external/wesaturate/500px/u76c0g_bliznaca_srgb8.png");
+  const std::vector<uint8_t> orig =
+      ReadTestData("external/wesaturate/500px/u76c0g_bliznaca_srgb8.png");
   CompressParams cparams;
   cparams.SetLossless();
   // 9 = permute to GBR, to test the special case of permutation-only
@@ -83,7 +84,7 @@ TEST(ModularTest, RoundtripLosslessCustomWP_PermuteRCT) {
   CodecInOut io_out;
 
   CodecInOut io;
-  ASSERT_TRUE(SetFromBytes(Span<const uint8_t>(orig), &io));
+  ASSERT_TRUE(SetFromBytes(Bytes(orig), &io));
   io.ShrinkTo(100, 100);
 
   size_t compressed_size;
@@ -93,8 +94,8 @@ TEST(ModularTest, RoundtripLosslessCustomWP_PermuteRCT) {
 }
 
 TEST(ModularTest, RoundtripLossyDeltaPalette) {
-  const PaddedBytes orig = jxl::test::ReadTestData(
-      "external/wesaturate/500px/u76c0g_bliznaca_srgb8.png");
+  const std::vector<uint8_t> orig =
+      ReadTestData("external/wesaturate/500px/u76c0g_bliznaca_srgb8.png");
   CompressParams cparams;
   cparams.modular_mode = true;
   cparams.color_transform = jxl::ColorTransform::kNone;
@@ -104,7 +105,7 @@ TEST(ModularTest, RoundtripLossyDeltaPalette) {
   CodecInOut io_out;
 
   CodecInOut io;
-  ASSERT_TRUE(SetFromBytes(Span<const uint8_t>(orig), &io));
+  ASSERT_TRUE(SetFromBytes(Bytes(orig), &io));
   io.ShrinkTo(300, 100);
 
   size_t compressed_size;
@@ -116,8 +117,8 @@ TEST(ModularTest, RoundtripLossyDeltaPalette) {
               IsSlightlyBelow(1.5));
 }
 TEST(ModularTest, RoundtripLossyDeltaPaletteWP) {
-  const PaddedBytes orig = jxl::test::ReadTestData(
-      "external/wesaturate/500px/u76c0g_bliznaca_srgb8.png");
+  const std::vector<uint8_t> orig =
+      ReadTestData("external/wesaturate/500px/u76c0g_bliznaca_srgb8.png");
   CompressParams cparams;
   cparams.SetLossless();
   cparams.lossy_palette = true;
@@ -127,7 +128,7 @@ TEST(ModularTest, RoundtripLossyDeltaPaletteWP) {
   CodecInOut io_out;
 
   CodecInOut io;
-  ASSERT_TRUE(SetFromBytes(Span<const uint8_t>(orig), &io));
+  ASSERT_TRUE(SetFromBytes(Bytes(orig), &io));
   io.ShrinkTo(300, 100);
 
   size_t compressed_size;
@@ -140,8 +141,8 @@ TEST(ModularTest, RoundtripLossyDeltaPaletteWP) {
 }
 
 TEST(ModularTest, RoundtripLossy) {
-  const PaddedBytes orig = jxl::test::ReadTestData(
-      "external/wesaturate/500px/u76c0g_bliznaca_srgb8.png");
+  const std::vector<uint8_t> orig =
+      ReadTestData("external/wesaturate/500px/u76c0g_bliznaca_srgb8.png");
   CompressParams cparams;
   cparams.modular_mode = true;
   cparams.butteraugli_distance = 2.f;
@@ -150,7 +151,7 @@ TEST(ModularTest, RoundtripLossy) {
   CodecInOut io_out;
 
   CodecInOut io;
-  ASSERT_TRUE(SetFromBytes(Span<const uint8_t>(orig), &io));
+  ASSERT_TRUE(SetFromBytes(Bytes(orig), &io));
 
   size_t compressed_size;
   JXL_EXPECT_OK(Roundtrip(&io, cparams, {}, &io_out, _, &compressed_size));
@@ -162,8 +163,8 @@ TEST(ModularTest, RoundtripLossy) {
 }
 
 TEST(ModularTest, RoundtripLossy16) {
-  const PaddedBytes orig = jxl::test::ReadTestData(
-      "external/raw.pixls/DJI-FC6310-16bit_709_v4_krita.png");
+  const std::vector<uint8_t> orig =
+      ReadTestData("external/raw.pixls/DJI-FC6310-16bit_709_v4_krita.png");
   CompressParams cparams;
   cparams.modular_mode = true;
   cparams.butteraugli_distance = 2.f;
@@ -171,7 +172,7 @@ TEST(ModularTest, RoundtripLossy16) {
   CodecInOut io_out;
 
   CodecInOut io;
-  ASSERT_TRUE(SetFromBytes(Span<const uint8_t>(orig), &io));
+  ASSERT_TRUE(SetFromBytes(Bytes(orig), &io));
   JXL_CHECK(!io.metadata.m.have_preview);
   JXL_CHECK(io.frames.size() == 1);
   JXL_CHECK(
@@ -230,10 +231,10 @@ TEST(ModularTest, RoundtripExtraProperties) {
 }
 
 TEST(ModularTest, RoundtripLosslessCustomSqueeze) {
-  const PaddedBytes orig = jxl::test::ReadTestData(
-      "external/wesaturate/500px/tmshre_riaphotographs_srgb8.png");
+  const std::vector<uint8_t> orig =
+      ReadTestData("external/wesaturate/500px/tmshre_riaphotographs_srgb8.png");
   CodecInOut io;
-  ASSERT_TRUE(SetFromBytes(Span<const uint8_t>(orig), &io));
+  ASSERT_TRUE(SetFromBytes(Bytes(orig), &io));
 
   CompressParams cparams;
   cparams.modular_mode = true;
@@ -297,10 +298,10 @@ TEST_P(ModularTestParam, RoundtripLossless) {
 
   ThreadPool* pool = nullptr;
   Rng generator(123);
-  const PaddedBytes orig = jxl::test::ReadTestData(
-      "external/wesaturate/500px/u76c0g_bliznaca_srgb8.png");
+  const std::vector<uint8_t> orig =
+      ReadTestData("external/wesaturate/500px/u76c0g_bliznaca_srgb8.png");
   CodecInOut io1;
-  ASSERT_TRUE(SetFromBytes(Span<const uint8_t>(orig), &io1, pool));
+  ASSERT_TRUE(SetFromBytes(Bytes(orig), &io1, pool));
 
   // vary the dimensions a bit, in case of bugs related to
   // even vs odd width or height.

--- a/lib/jxl/passes_test.cc
+++ b/lib/jxl/passes_test.cc
@@ -28,16 +28,17 @@
 
 namespace jxl {
 
+using test::ReadTestData;
 using test::Roundtrip;
 using test::ThreadPoolForTests;
 
 namespace {
 
 TEST(PassesTest, RoundtripSmallPasses) {
-  const PaddedBytes orig = jxl::test::ReadTestData(
-      "external/wesaturate/500px/u76c0g_bliznaca_srgb8.png");
+  const std::vector<uint8_t> orig =
+      ReadTestData("external/wesaturate/500px/u76c0g_bliznaca_srgb8.png");
   CodecInOut io;
-  ASSERT_TRUE(SetFromBytes(Span<const uint8_t>(orig), &io));
+  ASSERT_TRUE(SetFromBytes(Bytes(orig), &io));
   io.ShrinkTo(io.xsize() / 8, io.ysize() / 8);
 
   CompressParams cparams;
@@ -54,10 +55,10 @@ TEST(PassesTest, RoundtripSmallPasses) {
 }
 
 TEST(PassesTest, RoundtripUnalignedPasses) {
-  const PaddedBytes orig = jxl::test::ReadTestData(
-      "external/wesaturate/500px/u76c0g_bliznaca_srgb8.png");
+  const std::vector<uint8_t> orig =
+      ReadTestData("external/wesaturate/500px/u76c0g_bliznaca_srgb8.png");
   CodecInOut io;
-  ASSERT_TRUE(SetFromBytes(Span<const uint8_t>(orig), &io));
+  ASSERT_TRUE(SetFromBytes(Bytes(orig), &io));
   io.ShrinkTo(io.xsize() / 12, io.ysize() / 7);
 
   CompressParams cparams;
@@ -74,11 +75,11 @@ TEST(PassesTest, RoundtripUnalignedPasses) {
 }
 
 TEST(PassesTest, RoundtripMultiGroupPasses) {
-  const PaddedBytes orig = jxl::test::ReadTestData("jxl/flower/flower.png");
+  const std::vector<uint8_t> orig = ReadTestData("jxl/flower/flower.png");
   CodecInOut io;
   {
     ThreadPoolForTests pool(4);
-    ASSERT_TRUE(SetFromBytes(Span<const uint8_t>(orig), &io, &pool));
+    ASSERT_TRUE(SetFromBytes(Bytes(orig), &io, &pool));
   }
   io.ShrinkTo(600, 1024);  // partial X, full Y group
 
@@ -103,9 +104,9 @@ TEST(PassesTest, RoundtripMultiGroupPasses) {
 
 TEST(PassesTest, RoundtripLargeFastPasses) {
   ThreadPoolForTests pool(8);
-  const PaddedBytes orig = jxl::test::ReadTestData("jxl/flower/flower.png");
+  const std::vector<uint8_t> orig = ReadTestData("jxl/flower/flower.png");
   CodecInOut io;
-  ASSERT_TRUE(SetFromBytes(Span<const uint8_t>(orig), &io, &pool));
+  ASSERT_TRUE(SetFromBytes(Bytes(orig), &io, &pool));
 
   CompressParams cparams;
   cparams.speed_tier = SpeedTier::kSquirrel;
@@ -122,9 +123,9 @@ TEST(PassesTest, RoundtripLargeFastPasses) {
 // Failing this may be a sign of race conditions or invalid memory accesses.
 TEST(PassesTest, RoundtripProgressiveConsistent) {
   ThreadPoolForTests pool(8);
-  const PaddedBytes orig = jxl::test::ReadTestData("jxl/flower/flower.png");
+  const std::vector<uint8_t> orig = ReadTestData("jxl/flower/flower.png");
   CodecInOut io;
-  ASSERT_TRUE(SetFromBytes(Span<const uint8_t>(orig), &io, &pool));
+  ASSERT_TRUE(SetFromBytes(Bytes(orig), &io, &pool));
 
   CompressParams cparams;
   cparams.speed_tier = SpeedTier::kSquirrel;
@@ -160,10 +161,10 @@ TEST(PassesTest, RoundtripProgressiveConsistent) {
 
 TEST(PassesTest, AllDownsampleFeasible) {
   ThreadPoolForTests pool(8);
-  const PaddedBytes orig = jxl::test::ReadTestData(
-      "external/wesaturate/500px/u76c0g_bliznaca_srgb8.png");
+  const std::vector<uint8_t> orig =
+      ReadTestData("external/wesaturate/500px/u76c0g_bliznaca_srgb8.png");
   CodecInOut io;
-  ASSERT_TRUE(SetFromBytes(Span<const uint8_t>(orig), &io, &pool));
+  ASSERT_TRUE(SetFromBytes(Bytes(orig), &io, &pool));
 
   PaddedBytes compressed;
   AuxOut aux;
@@ -193,8 +194,7 @@ TEST(PassesTest, AllDownsampleFeasible) {
     extras::JXLDecompressParams dparams;
     dparams.max_downsampling = downsampling;
     CodecInOut output;
-    ASSERT_TRUE(
-        test::DecodeFile(dparams, Span<const uint8_t>(compressed), &output));
+    ASSERT_TRUE(test::DecodeFile(dparams, Bytes(compressed), &output));
     EXPECT_EQ(output.xsize(), io.xsize()) << "downsampling = " << downsampling;
     EXPECT_EQ(output.ysize(), io.ysize()) << "downsampling = " << downsampling;
     EXPECT_LE(ButteraugliDistance(io.frames, output.frames, ButteraugliParams(),
@@ -209,10 +209,10 @@ TEST(PassesTest, AllDownsampleFeasible) {
 
 TEST(PassesTest, AllDownsampleFeasibleQProgressive) {
   ThreadPoolForTests pool(8);
-  const PaddedBytes orig = jxl::test::ReadTestData(
-      "external/wesaturate/500px/u76c0g_bliznaca_srgb8.png");
+  const std::vector<uint8_t> orig =
+      ReadTestData("external/wesaturate/500px/u76c0g_bliznaca_srgb8.png");
   CodecInOut io;
-  ASSERT_TRUE(SetFromBytes(Span<const uint8_t>(orig), &io, &pool));
+  ASSERT_TRUE(SetFromBytes(Bytes(orig), &io, &pool));
 
   PaddedBytes compressed;
   AuxOut aux;
@@ -242,8 +242,7 @@ TEST(PassesTest, AllDownsampleFeasibleQProgressive) {
     extras::JXLDecompressParams dparams;
     dparams.max_downsampling = downsampling;
     CodecInOut output;
-    ASSERT_TRUE(
-        test::DecodeFile(dparams, Span<const uint8_t>(compressed), &output));
+    ASSERT_TRUE(test::DecodeFile(dparams, Bytes(compressed), &output));
     EXPECT_EQ(output.xsize(), io.xsize()) << "downsampling = " << downsampling;
     EXPECT_EQ(output.ysize(), io.ysize()) << "downsampling = " << downsampling;
     EXPECT_LE(ButteraugliDistance(io.frames, output.frames, ButteraugliParams(),
@@ -258,10 +257,10 @@ TEST(PassesTest, AllDownsampleFeasibleQProgressive) {
 
 TEST(PassesTest, ProgressiveDownsample2DegradesCorrectlyGrayscale) {
   ThreadPoolForTests pool(8);
-  const PaddedBytes orig = jxl::test::ReadTestData(
+  const std::vector<uint8_t> orig = ReadTestData(
       "external/wesaturate/500px/cvo9xd_keong_macan_grayscale.png");
   CodecInOut io_orig;
-  ASSERT_TRUE(SetFromBytes(Span<const uint8_t>(orig), &io_orig, &pool));
+  ASSERT_TRUE(SetFromBytes(Bytes(orig), &io_orig, &pool));
   Rect rect(0, 0, io_orig.xsize(), 128);
   // need 2 DC groups for the DC frame to actually be progressive.
   Image3F large(4242, rect.ysize());
@@ -289,13 +288,11 @@ TEST(PassesTest, ProgressiveDownsample2DegradesCorrectlyGrayscale) {
   extras::JXLDecompressParams dparams;
   dparams.max_downsampling = 1;
   CodecInOut output;
-  ASSERT_TRUE(
-      test::DecodeFile(dparams, Span<const uint8_t>(compressed), &output));
+  ASSERT_TRUE(test::DecodeFile(dparams, Bytes(compressed), &output));
 
   dparams.max_downsampling = 2;
   CodecInOut output_d2;
-  ASSERT_TRUE(
-      test::DecodeFile(dparams, Span<const uint8_t>(compressed), &output_d2));
+  ASSERT_TRUE(test::DecodeFile(dparams, Bytes(compressed), &output_d2));
 
   // 0 if reading all the passes, ~15 if skipping the 8x pass.
   float butteraugli_distance_down2_full = ButteraugliDistance(
@@ -308,9 +305,9 @@ TEST(PassesTest, ProgressiveDownsample2DegradesCorrectlyGrayscale) {
 
 TEST(PassesTest, ProgressiveDownsample2DegradesCorrectly) {
   ThreadPoolForTests pool(8);
-  const PaddedBytes orig = jxl::test::ReadTestData("jxl/flower/flower.png");
+  const std::vector<uint8_t> orig = ReadTestData("jxl/flower/flower.png");
   CodecInOut io_orig;
-  ASSERT_TRUE(SetFromBytes(Span<const uint8_t>(orig), &io_orig, &pool));
+  ASSERT_TRUE(SetFromBytes(Bytes(orig), &io_orig, &pool));
   Rect rect(0, 0, io_orig.xsize(), 128);
   // need 2 DC groups for the DC frame to actually be progressive.
   Image3F large(4242, rect.ysize());
@@ -337,13 +334,11 @@ TEST(PassesTest, ProgressiveDownsample2DegradesCorrectly) {
   extras::JXLDecompressParams dparams;
   dparams.max_downsampling = 1;
   CodecInOut output;
-  ASSERT_TRUE(
-      test::DecodeFile(dparams, Span<const uint8_t>(compressed), &output));
+  ASSERT_TRUE(test::DecodeFile(dparams, Bytes(compressed), &output));
 
   dparams.max_downsampling = 2;
   CodecInOut output_d2;
-  ASSERT_TRUE(
-      test::DecodeFile(dparams, Span<const uint8_t>(compressed), &output_d2));
+  ASSERT_TRUE(test::DecodeFile(dparams, Bytes(compressed), &output_d2));
 
   // 0 if reading all the passes, ~15 if skipping the 8x pass.
   float butteraugli_distance_down2_full = ButteraugliDistance(
@@ -356,9 +351,9 @@ TEST(PassesTest, ProgressiveDownsample2DegradesCorrectly) {
 
 TEST(PassesTest, NonProgressiveDCImage) {
   ThreadPoolForTests pool(8);
-  const PaddedBytes orig = jxl::test::ReadTestData("jxl/flower/flower.png");
+  const std::vector<uint8_t> orig = ReadTestData("jxl/flower/flower.png");
   CodecInOut io;
-  ASSERT_TRUE(SetFromBytes(Span<const uint8_t>(orig), &io, &pool));
+  ASSERT_TRUE(SetFromBytes(Bytes(orig), &io, &pool));
 
   PaddedBytes compressed;
   AuxOut aux;
@@ -376,17 +371,16 @@ TEST(PassesTest, NonProgressiveDCImage) {
   extras::JXLDecompressParams dparams;
   dparams.max_downsampling = 100;
   CodecInOut output;
-  ASSERT_TRUE(test::DecodeFile(dparams, Span<const uint8_t>(compressed),
-                               &output, &pool));
+  ASSERT_TRUE(test::DecodeFile(dparams, Bytes(compressed), &output, &pool));
   EXPECT_EQ(output.xsize(), io.xsize());
   EXPECT_EQ(output.ysize(), io.ysize());
 }
 
 TEST(PassesTest, RoundtripSmallNoGaborishPasses) {
-  const PaddedBytes orig = jxl::test::ReadTestData(
-      "external/wesaturate/500px/u76c0g_bliznaca_srgb8.png");
+  const std::vector<uint8_t> orig =
+      ReadTestData("external/wesaturate/500px/u76c0g_bliznaca_srgb8.png");
   CodecInOut io;
-  ASSERT_TRUE(SetFromBytes(Span<const uint8_t>(orig), &io));
+  ASSERT_TRUE(SetFromBytes(Bytes(orig), &io));
   io.ShrinkTo(io.xsize() / 8, io.ysize() / 8);
 
   CompressParams cparams;

--- a/lib/jxl/patch_dictionary_test.cc
+++ b/lib/jxl/patch_dictionary_test.cc
@@ -3,6 +3,9 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
+#include <cstdint>
+#include <vector>
+
 #include "lib/extras/codec.h"
 #include "lib/jxl/cms/jxl_cms.h"
 #include "lib/jxl/enc_butteraugli_comparator.h"
@@ -14,12 +17,13 @@
 namespace jxl {
 namespace {
 
-using ::jxl::test::Roundtrip;
+using test::ReadTestData;
+using test::Roundtrip;
 
 TEST(PatchDictionaryTest, GrayscaleModular) {
-  const PaddedBytes orig = jxl::test::ReadTestData("jxl/grayscale_patches.png");
+  const std::vector<uint8_t> orig = ReadTestData("jxl/grayscale_patches.png");
   CodecInOut io;
-  ASSERT_TRUE(SetFromBytes(Span<const uint8_t>(orig), &io));
+  ASSERT_TRUE(SetFromBytes(Bytes(orig), &io));
 
   CompressParams cparams;
   cparams.SetLossless();
@@ -35,9 +39,9 @@ TEST(PatchDictionaryTest, GrayscaleModular) {
 }
 
 TEST(PatchDictionaryTest, GrayscaleVarDCT) {
-  const PaddedBytes orig = jxl::test::ReadTestData("jxl/grayscale_patches.png");
+  const std::vector<uint8_t> orig = ReadTestData("jxl/grayscale_patches.png");
   CodecInOut io;
-  ASSERT_TRUE(SetFromBytes(Span<const uint8_t>(orig), &io));
+  ASSERT_TRUE(SetFromBytes(Bytes(orig), &io));
 
   CompressParams cparams;
   cparams.patches = jxl::Override::kOn;

--- a/lib/jxl/preview_test.cc
+++ b/lib/jxl/preview_test.cc
@@ -11,7 +11,6 @@
 #include "lib/jxl/base/compiler_specific.h"
 #include "lib/jxl/base/data_parallel.h"
 #include "lib/jxl/base/override.h"
-#include "lib/jxl/base/padded_bytes.h"
 #include "lib/jxl/cms/jxl_cms.h"
 #include "lib/jxl/codec_in_out.h"
 #include "lib/jxl/color_encoding_internal.h"
@@ -26,13 +25,14 @@
 
 namespace jxl {
 namespace {
+using test::ReadTestData;
 using test::Roundtrip;
 
 TEST(PreviewTest, RoundtripGivenPreview) {
-  const PaddedBytes orig = jxl::test::ReadTestData(
-      "external/wesaturate/500px/u76c0g_bliznaca_srgb8.png");
+  const std::vector<uint8_t> orig =
+      ReadTestData("external/wesaturate/500px/u76c0g_bliznaca_srgb8.png");
   CodecInOut io;
-  ASSERT_TRUE(SetFromBytes(Span<const uint8_t>(orig), &io));
+  ASSERT_TRUE(SetFromBytes(Bytes(orig), &io));
   io.ShrinkTo(io.xsize() / 8, io.ysize() / 8);
   // Same as main image
   io.preview_frame = io.Main().Copy();

--- a/lib/jxl/roundtrip_test.cc
+++ b/lib/jxl/roundtrip_test.cc
@@ -37,7 +37,7 @@ namespace {
 jxl::CodecInOut ConvertTestImage(const std::vector<uint8_t>& buf,
                                  const size_t xsize, const size_t ysize,
                                  const JxlPixelFormat& pixel_format,
-                                 const jxl::PaddedBytes& icc_profile) {
+                                 const jxl::Bytes& icc_profile) {
   jxl::CodecInOut io;
   io.SetSize(xsize, ysize);
 
@@ -88,7 +88,7 @@ jxl::CodecInOut ConvertTestImage(const std::vector<uint8_t>& buf,
   jxl::ColorEncoding color_encoding;
   if (!icc_profile.empty()) {
     jxl::IccBytes icc_profile_copy;
-    jxl::Span<const uint8_t>(icc_profile).AppendTo(&icc_profile_copy);
+    icc_profile.AppendTo(&icc_profile_copy);
     EXPECT_TRUE(
         color_encoding.SetICC(std::move(icc_profile_copy), JxlGetDefaultCms()));
   } else if (pixel_format.data_type == JXL_TYPE_FLOAT) {
@@ -96,11 +96,10 @@ jxl::CodecInOut ConvertTestImage(const std::vector<uint8_t>& buf,
   } else {
     color_encoding = jxl::ColorEncoding::SRGB(is_gray);
   }
-  EXPECT_TRUE(
-      ConvertFromExternal(jxl::Span<const uint8_t>(buf.data(), buf.size()),
-                          xsize, ysize, color_encoding,
-                          /*bits_per_sample=*/bitdepth, pixel_format,
-                          /*pool=*/nullptr, &io.Main()));
+  EXPECT_TRUE(ConvertFromExternal(jxl::Bytes(buf.data(), buf.size()), xsize,
+                                  ysize, color_encoding,
+                                  /*bits_per_sample=*/bitdepth, pixel_format,
+                                  /*pool=*/nullptr, &io.Main()));
   return io;
 }
 
@@ -231,8 +230,7 @@ void VerifyRoundtripCompression(
   if (alpha_in_extra_channels_vector && !has_interleaved_alpha) {
     jxl::ImageF alpha_channel(xsize, ysize);
     EXPECT_TRUE(jxl::ConvertFromExternal(
-        jxl::Span<const uint8_t>(extra_channel_bytes.data(),
-                                 extra_channel_bytes.size()),
+        jxl::Bytes(extra_channel_bytes.data(), extra_channel_bytes.size()),
         xsize, ysize, basic_info.bits_per_sample, extra_channel_pixel_format, 0,
         /*pool=*/nullptr, &alpha_channel));
 
@@ -356,7 +354,7 @@ void VerifyRoundtripCompression(
   EXPECT_EQ(JXL_DEC_SUCCESS,
             JxlDecoderGetICCProfileSize(dec, JXL_COLOR_PROFILE_TARGET_DATA,
                                         &icc_profile_size));
-  jxl::PaddedBytes icc_profile(icc_profile_size);
+  std::vector<uint8_t> icc_profile(icc_profile_size);
   EXPECT_EQ(JXL_DEC_SUCCESS, JxlDecoderGetColorAsICCProfile(
                                  dec, JXL_COLOR_PROFILE_TARGET_DATA,
                                  icc_profile.data(), icc_profile.size()));
@@ -413,7 +411,7 @@ void VerifyRoundtripCompression(
 
   jxl::CodecInOut decoded_io = ConvertTestImage(
       decoded_bytes, xsize, ysize, output_pixel_format_with_extra_channel_alpha,
-      icc_profile);
+      jxl::Bytes(icc_profile));
 
   if (already_downsampled) {
     jxl::Image3F* color = decoded_io.Main().color();
@@ -650,7 +648,7 @@ TEST(RoundtripTest, ExtraBoxesTest) {
   EXPECT_EQ(JXL_DEC_SUCCESS,
             JxlDecoderGetICCProfileSize(dec, JXL_COLOR_PROFILE_TARGET_DATA,
                                         &icc_profile_size));
-  jxl::PaddedBytes icc_profile(icc_profile_size);
+  std::vector<uint8_t> icc_profile(icc_profile_size);
   EXPECT_EQ(JXL_DEC_SUCCESS, JxlDecoderGetColorAsICCProfile(
                                  dec, JXL_COLOR_PROFILE_TARGET_DATA,
                                  icc_profile.data(), icc_profile.size()));
@@ -667,8 +665,8 @@ TEST(RoundtripTest, ExtraBoxesTest) {
 
   JxlDecoderDestroy(dec);
 
-  jxl::CodecInOut decoded_io =
-      ConvertTestImage(decoded_bytes, xsize, ysize, pixel_format, icc_profile);
+  jxl::CodecInOut decoded_io = ConvertTestImage(
+      decoded_bytes, xsize, ysize, pixel_format, jxl::Bytes(icc_profile));
 
   jxl::ButteraugliParams ba;
   float butteraugli_score = ButteraugliDistance(
@@ -785,7 +783,7 @@ TEST(RoundtripTest, MultiFrameTest) {
     EXPECT_EQ(JXL_DEC_SUCCESS,
               JxlDecoderGetICCProfileSize(dec, JXL_COLOR_PROFILE_TARGET_DATA,
                                           &icc_profile_size));
-    jxl::PaddedBytes icc_profile(icc_profile_size);
+    std::vector<uint8_t> icc_profile(icc_profile_size);
     EXPECT_EQ(JXL_DEC_SUCCESS, JxlDecoderGetColorAsICCProfile(
                                    dec, JXL_COLOR_PROFILE_TARGET_DATA,
                                    icc_profile.data(), icc_profile.size()));
@@ -803,8 +801,9 @@ TEST(RoundtripTest, MultiFrameTest) {
       EXPECT_EQ(JXL_DEC_FULL_IMAGE, JxlDecoderProcessInput(dec));
     }
     JxlDecoderDestroy(dec);
-    jxl::CodecInOut decoded_io = ConvertTestImage(
-        decoded_bytes, xsize, ysize * nb_frames, pixel_format, icc_profile);
+    jxl::CodecInOut decoded_io =
+        ConvertTestImage(decoded_bytes, xsize, ysize * nb_frames, pixel_format,
+                         jxl::Bytes(icc_profile));
 
     jxl::ButteraugliParams ba;
     float butteraugli_score = ButteraugliDistance(
@@ -853,10 +852,10 @@ static const unsigned char kEncodedTestProfile[] = {
 TEST(RoundtripTest, TestICCProfile) {
   // JxlEncoderSetICCProfile parses the ICC profile, so a valid profile is
   // needed. The profile should be passed correctly through the roundtrip.
-  jxl::BitReader reader(jxl::Span<const uint8_t>(kEncodedTestProfile,
-                                                 sizeof(kEncodedTestProfile)));
-  jxl::PaddedBytes icc;
-  ASSERT_TRUE(ReadICC(&reader, &icc));
+  jxl::BitReader reader(
+      jxl::Bytes(kEncodedTestProfile, sizeof(kEncodedTestProfile)));
+  std::vector<uint8_t> icc;
+  ASSERT_TRUE(jxl::test::ReadICC(&reader, &icc));
   ASSERT_TRUE(reader.Close());
 
   JxlPixelFormat format =
@@ -921,7 +920,7 @@ TEST(RoundtripTest, TestICCProfile) {
             JxlDecoderGetICCProfileSize(dec, JXL_COLOR_PROFILE_TARGET_ORIGINAL,
                                         &dec_icc_size));
   EXPECT_EQ(icc.size(), dec_icc_size);
-  jxl::PaddedBytes dec_icc(dec_icc_size);
+  std::vector<uint8_t> dec_icc(dec_icc_size);
   EXPECT_EQ(JXL_DEC_SUCCESS, JxlDecoderGetColorAsICCProfile(
                                  dec, JXL_COLOR_PROFILE_TARGET_ORIGINAL,
                                  dec_icc.data(), dec_icc.size()));
@@ -944,10 +943,9 @@ TEST(RoundtripTest, TestICCProfile) {
 TEST(RoundtripTest, JXL_TRANSCODE_JPEG_TEST(TestJPEGReconstruction)) {
   TEST_LIBJPEG_SUPPORT();
   const std::string jpeg_path = "jxl/flower/flower.png.im_q85_420.jpg";
-  const jxl::PaddedBytes orig = jxl::test::ReadTestData(jpeg_path);
+  const std::vector<uint8_t> orig = jxl::test::ReadTestData(jpeg_path);
   jxl::CodecInOut orig_io;
-  ASSERT_TRUE(
-      SetFromBytes(jxl::Span<const uint8_t>(orig), &orig_io, /*pool=*/nullptr));
+  ASSERT_TRUE(SetFromBytes(jxl::Bytes(orig), &orig_io, /*pool=*/nullptr));
 
   JxlEncoderPtr enc = JxlEncoderMake(nullptr);
   JxlEncoderFrameSettings* frame_settings =

--- a/lib/jxl/speed_tier_test.cc
+++ b/lib/jxl/speed_tier_test.cc
@@ -7,7 +7,6 @@
 
 #include "lib/extras/codec.h"
 #include "lib/jxl/base/data_parallel.h"
-#include "lib/jxl/base/padded_bytes.h"
 #include "lib/jxl/cms/jxl_cms.h"
 #include "lib/jxl/codec_in_out.h"
 #include "lib/jxl/enc_butteraugli_comparator.h"
@@ -80,11 +79,11 @@ JXL_GTEST_INSTANTIATE_TEST_SUITE_P(
                                         /*shrink8=*/true}));
 
 TEST_P(SpeedTierTest, Roundtrip) {
-  const PaddedBytes orig = jxl::test::ReadTestData(
+  const std::vector<uint8_t> orig = jxl::test::ReadTestData(
       "external/wesaturate/500px/u76c0g_bliznaca_srgb8.png");
   CodecInOut io;
   test::ThreadPoolForTests pool(8);
-  ASSERT_TRUE(SetFromBytes(Span<const uint8_t>(orig), &io, &pool));
+  ASSERT_TRUE(SetFromBytes(Bytes(orig), &io, &pool));
 
   const SpeedTierTestParams& params = GetParam();
 

--- a/lib/jxl/splines_test.cc
+++ b/lib/jxl/splines_test.cc
@@ -28,6 +28,7 @@ std::ostream& operator<<(std::ostream& os, const Spline& spline) {
 
 namespace {
 
+using test::ReadTestData;
 using ::testing::AllOf;
 using ::testing::Field;
 using ::testing::FloatNear;
@@ -277,8 +278,8 @@ TEST(SplinesTest, DuplicatePoints) {
 
 TEST(SplinesTest, Drawing) {
   CodecInOut io_expected;
-  const PaddedBytes orig = jxl::test::ReadTestData("jxl/splines.pfm");
-  ASSERT_TRUE(SetFromBytes(Span<const uint8_t>(orig), &io_expected,
+  const std::vector<uint8_t> orig = ReadTestData("jxl/splines.pfm");
+  ASSERT_TRUE(SetFromBytes(Bytes(orig), &io_expected,
                            /*pool=*/nullptr));
 
   std::vector<Spline::Point> control_points{{9, 54},  {118, 159}, {97, 3},
@@ -323,15 +324,14 @@ TEST(SplinesTest, Drawing) {
 
 TEST(SplinesTest, ClearedEveryFrame) {
   CodecInOut io_expected;
-  const PaddedBytes bytes_expected =
-      jxl::test::ReadTestData("jxl/spline_on_first_frame.png");
-  ASSERT_TRUE(SetFromBytes(Span<const uint8_t>(bytes_expected), &io_expected,
+  const std::vector<uint8_t> bytes_expected =
+      ReadTestData("jxl/spline_on_first_frame.png");
+  ASSERT_TRUE(SetFromBytes(Bytes(bytes_expected), &io_expected,
                            /*pool=*/nullptr));
   CodecInOut io_actual;
-  const PaddedBytes bytes_actual =
-      jxl::test::ReadTestData("jxl/spline_on_first_frame.jxl");
-  ASSERT_TRUE(
-      test::DecodeFile({}, Span<const uint8_t>(bytes_actual), &io_actual));
+  const std::vector<uint8_t> bytes_actual =
+      ReadTestData("jxl/spline_on_first_frame.jxl");
+  ASSERT_TRUE(test::DecodeFile({}, Bytes(bytes_actual), &io_actual));
 
   ASSERT_TRUE(io_actual.frames[0].TransformTo(ColorEncoding::SRGB(),
                                               *JxlGetDefaultCms()));

--- a/lib/jxl/test_image.cc
+++ b/lib/jxl/test_image.cc
@@ -219,13 +219,12 @@ TestImage::TestImage() {
   SetColorEncoding("RGB_D65_SRG_Rel_SRG");
 }
 
-TestImage& TestImage::DecodeFromBytes(const PaddedBytes& bytes) {
+TestImage& TestImage::DecodeFromBytes(const std::vector<uint8_t>& bytes) {
   ColorEncoding c_enc;
   JXL_CHECK(c_enc.FromExternal(ppf_.color_encoding));
   extras::ColorHints color_hints;
   color_hints.Add("color_space", Description(c_enc));
-  JXL_CHECK(
-      extras::DecodeBytes(Span<const uint8_t>(bytes), color_hints, &ppf_));
+  JXL_CHECK(extras::DecodeBytes(Bytes(bytes), color_hints, &ppf_));
   return *this;
 }
 

--- a/lib/jxl/test_image.h
+++ b/lib/jxl/test_image.h
@@ -9,13 +9,13 @@
 #include <jxl/codestream_header.h>
 #include <jxl/types.h>
 #include <stddef.h>
-#include <stdint.h>
 
+#include <cstdint>
 #include <string>
 #include <vector>
 
 #include "lib/extras/packed_image.h"
-#include "lib/jxl/base/padded_bytes.h"
+#include "lib/jxl/base/span.h"
 
 namespace jxl {
 namespace test {
@@ -32,7 +32,7 @@ class TestImage {
 
   extras::PackedPixelFile& ppf() { return ppf_; }
 
-  TestImage& DecodeFromBytes(const PaddedBytes& bytes);
+  TestImage& DecodeFromBytes(const std::vector<uint8_t>& bytes);
 
   TestImage& ClearMetadata();
 

--- a/lib/jxl/test_utils.h
+++ b/lib/jxl/test_utils.h
@@ -12,9 +12,9 @@
 
 #include <jxl/codestream_header.h>
 #include <jxl/thread_parallel_runner_cxx.h>
-#include <stddef.h>
-#include <stdint.h>
 
+#include <cstddef>
+#include <cstdint>
 #include <ostream>
 #include <vector>
 
@@ -23,7 +23,6 @@
 #include "lib/extras/enc/jxl.h"
 #include "lib/extras/packed_image.h"
 #include "lib/jxl/base/data_parallel.h"
-#include "lib/jxl/base/padded_bytes.h"
 #include "lib/jxl/base/span.h"
 #include "lib/jxl/base/status.h"
 #include "lib/jxl/codec_in_out.h"
@@ -45,7 +44,7 @@ struct AuxOut;
 namespace test {
 
 std::string GetTestDataPath(const std::string& filename);
-PaddedBytes ReadTestData(const std::string& filename);
+std::vector<uint8_t> ReadTestData(const std::string& filename);
 
 void JxlBasicInfoSetFromPixelFormat(JxlBasicInfo* basic_info,
                                     const JxlPixelFormat* pixel_format);
@@ -171,12 +170,19 @@ class ThreadPoolForTests {
   std::unique_ptr<ThreadPool> pool_;
 };
 
+// `icc` may be empty afterwards - if so, call CreateProfile. Does not append,
+// clears any original data that was in icc.
+// If `output_limit` is not 0, then returns error if resulting profile would be
+// longer than `output_limit`
+Status ReadICC(BitReader* JXL_RESTRICT reader,
+               std::vector<uint8_t>* JXL_RESTRICT icc, size_t output_limit = 0);
+
 }  // namespace test
 
-bool operator==(const jxl::PaddedBytes& a, const jxl::PaddedBytes& b);
+bool operator==(const jxl::Bytes& a, const jxl::Bytes& b);
 
-// Allow using EXPECT_EQ on jxl::PaddedBytes
-bool operator!=(const jxl::PaddedBytes& a, const jxl::PaddedBytes& b);
+// Allow using EXPECT_EQ on jxl::Bytes
+bool operator!=(const jxl::Bytes& a, const jxl::Bytes& b);
 
 }  // namespace jxl
 

--- a/tools/benchmark/benchmark_codec.cc
+++ b/tools/benchmark/benchmark_codec.cc
@@ -15,7 +15,6 @@
 
 #include "lib/extras/time.h"
 #include "lib/jxl/base/data_parallel.h"
-#include "lib/jxl/base/padded_bytes.h"
 #include "lib/jxl/base/span.h"
 #include "lib/jxl/base/status.h"
 #include "lib/jxl/codec_in_out.h"

--- a/tools/benchmark/benchmark_codec.h
+++ b/tools/benchmark/benchmark_codec.h
@@ -13,7 +13,6 @@
 #include <vector>
 
 #include "lib/jxl/base/data_parallel.h"
-#include "lib/jxl/base/padded_bytes.h"
 #include "lib/jxl/base/span.h"
 #include "lib/jxl/base/status.h"
 #include "lib/jxl/butteraugli/butteraugli.h"

--- a/tools/benchmark/benchmark_codec_avif.cc
+++ b/tools/benchmark/benchmark_codec_avif.cc
@@ -27,6 +27,7 @@
 namespace jpegxl {
 namespace tools {
 
+using ::jxl::Bytes;
 using ::jxl::CodecInOut;
 using ::jxl::IccBytes;
 using ::jxl::ImageBundle;
@@ -346,8 +347,7 @@ class AvifCodec : public ImageCodec {
               JXL_NATIVE_ENDIAN, 0};
           ImageBundle ib(&io->metadata.m);
           JXL_RETURN_IF_ERROR(ConvertFromExternal(
-              Span<const uint8_t>(rgb_image.pixels,
-                                  rgb_image.height * rgb_image.rowBytes),
+              Bytes(rgb_image.pixels, rgb_image.height * rgb_image.rowBytes),
               rgb_image.width, rgb_image.height, color, rgb_image.depth, format,
               pool, &ib));
           io->frames.push_back(std::move(ib));

--- a/tools/benchmark/benchmark_codec_custom.cc
+++ b/tools/benchmark/benchmark_codec_custom.cc
@@ -178,7 +178,7 @@ class CustomCodec : public ImageCodec {
     std::vector<uint8_t> encoded;
     JXL_RETURN_IF_ERROR(ReadFile(out_filename, &encoded));
     JXL_RETURN_IF_ERROR(
-        jxl::SetFromBytes(jxl::Span<const uint8_t>(encoded), hints, io, pool));
+        jxl::SetFromBytes(jxl::Bytes(encoded), hints, io, pool));
     io->metadata.m.SetIntensityTarget(saved_intensity_target_);
     return true;
   }

--- a/tools/benchmark/benchmark_codec_jpeg.cc
+++ b/tools/benchmark/benchmark_codec_jpeg.cc
@@ -24,7 +24,6 @@
 #include "lib/extras/packed_image.h"
 #include "lib/extras/packed_image_convert.h"
 #include "lib/extras/time.h"
-#include "lib/jxl/base/padded_bytes.h"
 #include "lib/jxl/base/span.h"
 #include "lib/jxl/codec_in_out.h"
 #include "lib/jxl/image_bundle.h"

--- a/tools/benchmark/benchmark_codec_png.cc
+++ b/tools/benchmark/benchmark_codec_png.cc
@@ -16,7 +16,6 @@
 #include "lib/extras/packed_image.h"
 #include "lib/extras/packed_image_convert.h"
 #include "lib/extras/time.h"
-#include "lib/jxl/base/padded_bytes.h"
 #include "lib/jxl/base/span.h"
 #include "lib/jxl/codec_in_out.h"
 #include "lib/jxl/image_bundle.h"

--- a/tools/benchmark/benchmark_codec_webp.cc
+++ b/tools/benchmark/benchmark_codec_webp.cc
@@ -15,7 +15,6 @@
 #include "lib/extras/time.h"
 #include "lib/jxl/base/compiler_specific.h"
 #include "lib/jxl/base/data_parallel.h"
-#include "lib/jxl/base/padded_bytes.h"
 #include "lib/jxl/base/span.h"
 #include "lib/jxl/base/status.h"
 #include "lib/jxl/cms/jxl_cms.h"

--- a/tools/box/box_list_main.cc
+++ b/tools/box/box_list_main.cc
@@ -7,12 +7,11 @@
 // JPEG 2000, MP4, ...).
 // This exists as a test for manual verification, rather than an actual tool.
 
-#include <stddef.h>
-#include <stdint.h>
-#include <stdio.h>
-#include <string.h>
+#include <cstddef>
+#include <cstdint>
+#include <cstdio>
+#include <cstring>  // memcmp
 
-#include "lib/jxl/base/padded_bytes.h"
 #include "lib/jxl/base/printf_macros.h"
 #include "tools/box/box.h"
 #include "tools/file_io.h"
@@ -26,7 +25,7 @@ int RunMain(int argc, const char* argv[]) {
     return 1;
   }
 
-  jxl::PaddedBytes compressed;
+  std::vector<uint8_t> compressed;
   if (!ReadFile(argv[1], &compressed)) return 1;
   fprintf(stderr, "Read %" PRIuS " compressed bytes\n", compressed.size());
 

--- a/tools/butteraugli_main.cc
+++ b/tools/butteraugli_main.cc
@@ -13,7 +13,6 @@
 #include "lib/extras/dec/color_hints.h"
 #include "lib/extras/metrics.h"
 #include "lib/jxl/base/data_parallel.h"
-#include "lib/jxl/base/padded_bytes.h"
 #include "lib/jxl/base/printf_macros.h"
 #include "lib/jxl/base/span.h"
 #include "lib/jxl/base/status.h"
@@ -69,8 +68,7 @@ Status RunButteraugli(const char* pathname1, const char* pathname2,
       fprintf(stderr, "Failed to read image from %s\n", pathname[i]);
       return false;
     }
-    if (!jxl::SetFromBytes(jxl::Span<const uint8_t>(encoded), color_hints,
-                           &io[i], &pool)) {
+    if (!jxl::SetFromBytes(jxl::Bytes(encoded), color_hints, &io[i], &pool)) {
       fprintf(stderr, "Failed to decode image from %s\n", pathname[i]);
       return false;
     }

--- a/tools/cjpegli.cc
+++ b/tools/cjpegli.cc
@@ -207,7 +207,7 @@ int CJpegliMain(int argc, const char* argv[]) {
   }
 
   jxl::extras::PackedPixelFile ppf;
-  if (!jxl::extras::DecodeBytes(jxl::Span<const uint8_t>(input_bytes),
+  if (!jxl::extras::DecodeBytes(jxl::Bytes(input_bytes),
                                 args.color_hints_proxy.target, &ppf)) {
     fprintf(stderr, "Failed to decode input image %s\n", args.file_in);
     return EXIT_FAILURE;

--- a/tools/cjxl_main.cc
+++ b/tools/cjxl_main.cc
@@ -988,9 +988,9 @@ int main(int argc, char** argv) {
   ProcessFlags(codec, ppf, jpeg_bytes, &cmdline, &args, &params);
   if (!args.lossless_jpeg) {
     const double t0 = jxl::Now();
-    jxl::Status status = jxl::extras::DecodeBytes(
-        jxl::Span<const uint8_t>(image_data), args.color_hints_proxy.target,
-        &ppf, nullptr, &codec);
+    jxl::Status status = jxl::extras::DecodeBytes(jxl::Bytes(image_data),
+                                                  args.color_hints_proxy.target,
+                                                  &ppf, nullptr, &codec);
 
     if (!status) {
       std::cerr << "Getting pixel data failed." << std::endl;

--- a/tools/comparison_viewer/codec_comparison_window.h
+++ b/tools/comparison_viewer/codec_comparison_window.h
@@ -13,7 +13,6 @@
 #include <QString>
 
 #include "lib/jxl/base/common.h"
-#include "lib/jxl/base/padded_bytes.h"
 #include "tools/comparison_viewer/ui_codec_comparison_window.h"
 
 namespace jpegxl {

--- a/tools/comparison_viewer/image_loading.cc
+++ b/tools/comparison_viewer/image_loading.cc
@@ -7,6 +7,8 @@
 
 #include <QRgb>
 #include <QThread>
+#include <cstdint>
+#include <vector>
 
 #include "lib/extras/codec.h"
 #include "lib/extras/dec/color_hints.h"
@@ -25,7 +27,6 @@ using jxl::ColorEncoding;
 using jxl::IccBytes;
 using jxl::Image3F;
 using jxl::ImageBundle;
-using jxl::PaddedBytes;
 using jxl::Rect;
 using jxl::Span;
 using jxl::Status;
@@ -36,7 +37,7 @@ namespace {
 
 Status loadFromFile(const QString& filename, const ColorHints& color_hints,
                     CodecInOut* const decoded, ThreadPool* const pool) {
-  PaddedBytes compressed;
+  std::vector<uint8_t> compressed;
   JXL_RETURN_IF_ERROR(
       jpegxl::tools::ReadFile(filename.toStdString(), &compressed));
   const Span<const uint8_t> compressed_span(compressed);

--- a/tools/decode_and_encode.cc
+++ b/tools/decode_and_encode.cc
@@ -37,8 +37,7 @@ int Convert(int argc, char** argv) {
   jxl::extras::ColorHints color_hints;
   jpegxl::tools::ThreadPoolInternal pool(4);
   color_hints.Add("color_space", desc);
-  if (!jxl::SetFromBytes(jxl::Span<const uint8_t>(encoded_in), color_hints, &io,
-                         &pool)) {
+  if (!jxl::SetFromBytes(jxl::Bytes(encoded_in), color_hints, &io, &pool)) {
     fprintf(stderr, "Failed to decode %s\n", pathname_in.c_str());
     return 1;
   }

--- a/tools/djxl_fuzzer_corpus.cc
+++ b/tools/djxl_fuzzer_corpus.cc
@@ -235,7 +235,7 @@ bool GenerateFile(const char* output_dir, const ImageSpec& spec,
                                           /*bits_per_sample=*/8, &jpeg_bytes,
                                           /*pool=*/nullptr));
     JXL_RETURN_IF_ERROR(jxl::jpeg::DecodeImageJPG(
-        jxl::Span<const uint8_t>(jpeg_bytes.data(), jpeg_bytes.size()), &io));
+        jxl::Bytes(jpeg_bytes.data(), jpeg_bytes.size()), &io));
     jxl::PaddedBytes jpeg_data;
     JXL_RETURN_IF_ERROR(
         EncodeJPEGData(*io.Main().jpeg_data, &jpeg_data, params));

--- a/tools/djxl_fuzzer_test.cc
+++ b/tools/djxl_fuzzer_test.cc
@@ -6,6 +6,7 @@
 #include <jxl/thread_parallel_runner.h>
 #include <jxl/thread_parallel_runner_cxx.h>
 
+#include <cstdint>
 #include <sstream>
 #include <string>
 #include <vector>
@@ -39,6 +40,6 @@ TEST_P(DjxlFuzzerTest, TestOne) {
   std::ostringstream os;
   os << "oss-fuzz/clusterfuzz-testcase-minimized-djxl_fuzzer-" << id;
   printf("Testing %s\n", os.str().c_str());
-  const jxl::PaddedBytes input = jxl::test::ReadTestData(os.str());
+  const std::vector<uint8_t> input = jxl::test::ReadTestData(os.str());
   LLVMFuzzerTestOneInput(input.data(), input.size());
 }

--- a/tools/fields_fuzzer.cc
+++ b/tools/fields_fuzzer.cc
@@ -20,11 +20,11 @@ namespace jpegxl {
 namespace tools {
 
 using ::jxl::BitReader;
+using ::jxl::Bytes;
 using ::jxl::CodecMetadata;
 using ::jxl::CustomTransformData;
 using ::jxl::ImageMetadata;
 using ::jxl::SizeHeader;
-using ::jxl::Span;
 
 int TestOneInput(const uint8_t* data, size_t size) {
   // Global parameters used by some headers.
@@ -32,7 +32,7 @@ int TestOneInput(const uint8_t* data, size_t size) {
 
   // First byte controls which header to parse.
   if (size == 0) return 0;
-  BitReader reader(Span<const uint8_t>(data + 1, size - 1));
+  BitReader reader(Bytes(data + 1, size - 1));
 #define FUZZER_CASE_HEADER(number, classname, ...) \
   case number: {                                   \
     ::jxl::classname header{__VA_ARGS__};          \

--- a/tools/hdr/display_to_hlg.cc
+++ b/tools/hdr/display_to_hlg.cc
@@ -69,8 +69,8 @@ int main(int argc, const char** argv) {
   std::vector<uint8_t> encoded;
   JXL_CHECK(jpegxl::tools::ReadFile(input_filename, &encoded));
   jxl::CodecInOut image;
-  JXL_CHECK(jxl::SetFromBytes(jxl::Span<const uint8_t>(encoded),
-                              jxl::extras::ColorHints(), &image, &pool));
+  JXL_CHECK(jxl::SetFromBytes(jxl::Bytes(encoded), jxl::extras::ColorHints(),
+                              &image, &pool));
   image.metadata.m.SetIntensityTarget(max_nits);
   JXL_CHECK(jxl::HlgInverseOOTF(
       &image.Main(), jxl::GetHlgGamma(max_nits, surround_nits), &pool));

--- a/tools/hdr/exr_to_pq.cc
+++ b/tools/hdr/exr_to_pq.cc
@@ -79,7 +79,7 @@ int main(int argc, const char** argv) {
   jxl::extras::PackedPixelFile ppf;
   std::vector<uint8_t> input_bytes;
   JXL_CHECK(jpegxl::tools::ReadFile(input_filename, &input_bytes));
-  JXL_CHECK(jxl::extras::DecodeBytes(jxl::Span<const uint8_t>(input_bytes),
+  JXL_CHECK(jxl::extras::DecodeBytes(jxl::Bytes(input_bytes),
                                      jxl::extras::ColorHints(), &ppf));
 
   jxl::CodecInOut image;

--- a/tools/hdr/local_tone_map.cc
+++ b/tools/hdr/local_tone_map.cc
@@ -489,8 +489,7 @@ int main(int argc, const char** argv) {
   color_hints.Add("color_space", "RGB_D65_202_Rel_PeQ");
   std::vector<uint8_t> encoded;
   JXL_CHECK(jpegxl::tools::ReadFile(input_filename, &encoded));
-  JXL_CHECK(jxl::SetFromBytes(jxl::Span<const uint8_t>(encoded), color_hints,
-                              &image, &pool));
+  JXL_CHECK(jxl::SetFromBytes(jxl::Bytes(encoded), color_hints, &image, &pool));
 
   if (max_nits > 0) {
     image.metadata.m.SetIntensityTarget(max_nits);

--- a/tools/hdr/pq_to_hlg.cc
+++ b/tools/hdr/pq_to_hlg.cc
@@ -58,8 +58,7 @@ int main(int argc, const char** argv) {
   color_hints.Add("color_space", "RGB_D65_202_Rel_PeQ");
   std::vector<uint8_t> encoded;
   JXL_CHECK(jpegxl::tools::ReadFile(input_filename, &encoded));
-  JXL_CHECK(jxl::SetFromBytes(jxl::Span<const uint8_t>(encoded), color_hints,
-                              &image, &pool));
+  JXL_CHECK(jxl::SetFromBytes(jxl::Bytes(encoded), color_hints, &image, &pool));
   if (max_nits > 0) {
     image.metadata.m.SetIntensityTarget(max_nits);
   }

--- a/tools/hdr/render_hlg.cc
+++ b/tools/hdr/render_hlg.cc
@@ -73,8 +73,7 @@ int main(int argc, const char** argv) {
   color_hints.Add("color_space", "RGB_D65_202_Rel_HLG");
   std::vector<uint8_t> encoded;
   JXL_CHECK(jpegxl::tools::ReadFile(input_filename, &encoded));
-  JXL_CHECK(jxl::SetFromBytes(jxl::Span<const uint8_t>(encoded), color_hints,
-                              &image, &pool));
+  JXL_CHECK(jxl::SetFromBytes(jxl::Bytes(encoded), color_hints, &image, &pool));
   // Ensures that conversions to linear by JxlCms will not apply the OOTF as we
   // apply it ourselves to control the subsequent gamut mapping.
   image.metadata.m.SetIntensityTarget(301);

--- a/tools/hdr/texture_to_cube.cc
+++ b/tools/hdr/texture_to_cube.cc
@@ -45,8 +45,8 @@ int main(int argc, const char** argv) {
   jxl::CodecInOut image;
   std::vector<uint8_t> encoded;
   JXL_CHECK(jpegxl::tools::ReadFile(input_filename, &encoded));
-  JXL_CHECK(jxl::SetFromBytes(jxl::Span<const uint8_t>(encoded),
-                              jxl::extras::ColorHints(), &image, &pool));
+  JXL_CHECK(jxl::SetFromBytes(jxl::Bytes(encoded), jxl::extras::ColorHints(),
+                              &image, &pool));
 
   JXL_CHECK(image.xsize() == image.ysize() * image.ysize());
   const unsigned N = image.ysize();

--- a/tools/hdr/tone_map.cc
+++ b/tools/hdr/tone_map.cc
@@ -72,8 +72,7 @@ int main(int argc, const char** argv) {
   color_hints.Add("color_space", "RGB_D65_202_Rel_PeQ");
   std::vector<uint8_t> encoded;
   JXL_CHECK(jpegxl::tools::ReadFile(input_filename, &encoded));
-  JXL_CHECK(jxl::SetFromBytes(jxl::Span<const uint8_t>(encoded), color_hints,
-                              &image, &pool));
+  JXL_CHECK(jxl::SetFromBytes(jxl::Bytes(encoded), color_hints, &image, &pool));
   if (max_nits > 0) {
     image.metadata.m.SetIntensityTarget(max_nits);
   }

--- a/tools/icc_codec_fuzzer.cc
+++ b/tools/icc_codec_fuzzer.cc
@@ -35,9 +35,9 @@ int TestOneInput(const uint8_t* data, size_t size) {
   // the ICC parsing.
   if (read) {
     // Reading parses the compressed format.
-    BitReader br(Span<const uint8_t>(data, size));
-    PaddedBytes result;
-    (void)jxl::ReadICC(&br, &result);
+    BitReader br(Bytes(data, size));
+    std::vector<uint8_t> result;
+    (void)jxl::test::ReadICC(&br, &result);
     (void)br.Close();
   } else {
     // Writing parses the original ICC profile.

--- a/tools/rans_fuzzer.cc
+++ b/tools/rans_fuzzer.cc
@@ -13,7 +13,7 @@ using ::jxl::ANSCode;
 using ::jxl::ANSSymbolReader;
 using ::jxl::BitReader;
 using ::jxl::BitReaderScopedCloser;
-using ::jxl::Span;
+using ::jxl::Bytes;
 using ::jxl::Status;
 
 int TestOneInput(const uint8_t* data, size_t size) {
@@ -25,7 +25,7 @@ int TestOneInput(const uint8_t* data, size_t size) {
   std::vector<uint8_t> context_map;
   Status ret = true;
   {
-    BitReader br(Span<const uint8_t>(data, size));
+    BitReader br(Bytes(data, size));
     BitReaderScopedCloser br_closer(&br, &ret);
     ANSCode code;
     JXL_RETURN_IF_ERROR(

--- a/tools/set_from_bytes_fuzzer.cc
+++ b/tools/set_from_bytes_fuzzer.cc
@@ -23,8 +23,7 @@ int TestOneInput(const uint8_t* data, size_t size) {
   constraints.dec_max_pixels = 1u << 22;
   jpegxl::tools::ThreadPoolInternal pool(0);
 
-  (void)jxl::SetFromBytes(jxl::Span<const uint8_t>(data, size), &io, &pool,
-                          &constraints);
+  (void)jxl::SetFromBytes(jxl::Bytes(data, size), &io, &pool, &constraints);
 
   return 0;
 }

--- a/tools/ssimulacra2_main.cc
+++ b/tools/ssimulacra2_main.cc
@@ -50,8 +50,8 @@ int main(int argc, char** argv) {
       fprintf(stderr, "Could not load %s image: %s\n", purpose[i], argv[1 + i]);
       return 1;
     }
-    if (!jxl::SetFromBytes(jxl::Span<const uint8_t>(encoded),
-                           jxl::extras::ColorHints(), &io[i])) {
+    if (!jxl::SetFromBytes(jxl::Bytes(encoded), jxl::extras::ColorHints(),
+                           &io[i])) {
       fprintf(stderr, "Could not decode %s image: %s\n", purpose[i],
               argv[1 + i]);
       return 1;

--- a/tools/ssimulacra_main.cc
+++ b/tools/ssimulacra_main.cc
@@ -40,8 +40,8 @@ int Run(int argc, char** argv) {
   for (size_t i = 0; i < 2; ++i) {
     std::vector<uint8_t> encoded;
     JXL_CHECK(jpegxl::tools::ReadFile(argv[input_arg + i], &encoded));
-    JXL_CHECK(jxl::SetFromBytes(jxl::Span<const uint8_t>(encoded),
-                                jxl::extras::ColorHints(), &io[i]));
+    JXL_CHECK(jxl::SetFromBytes(jxl::Bytes(encoded), jxl::extras::ColorHints(),
+                                &io[i]));
   }
   jxl::ImageBundle& ib1 = io[0].Main();
   jxl::ImageBundle& ib2 = io[1].Main();

--- a/tools/transforms_fuzzer.cc
+++ b/tools/transforms_fuzzer.cc
@@ -15,13 +15,13 @@ namespace tools {
 
 using ::jxl::BitReader;
 using ::jxl::BitReaderScopedCloser;
+using ::jxl::Bytes;
 using ::jxl::Channel;
 using ::jxl::GroupHeader;
 using ::jxl::Image;
 using ::jxl::ModularOptions;
 using ::jxl::pixel_type;
 using ::jxl::Rng;
-using ::jxl::Span;
 using ::jxl::Status;
 using ::jxl::Transform;
 using ::jxl::weighted::Header;
@@ -46,7 +46,7 @@ void AssertEq(T a, T b) {
 
 int TestOneInput(const uint8_t* data, size_t size) {
   static Status nevermind = true;
-  BitReader reader(Span<const uint8_t>(data, size));
+  BitReader reader(Bytes(data, size));
   BitReaderScopedCloser reader_closer(&reader, &nevermind);
 
   Rng rng(reader.ReadFixedBits<56>());


### PR DESCRIPTION
Likely PaddedBytes will move out of base/
