### PR TITLE
Set PKGCONFIG_TARGET_LIBS/INCLUDES for libjxl_cms.pc

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -69,6 +69,7 @@ Stephan T. Lavavej <stl@nuwen.net>
 StepSecurity Bot <bot@stepsecurity.io>
 Sylvestre Ledru <sylvestre@debian.org>
 Thomas Bonfort <thomas.bonfort@airbus.com>
+Timo Rothenpieler <timo@rothenpieler.org>
 tmkk <tmkkmac@gmail.com>
 Vincent Torri <vincent.torri@gmail.com>
 xiota

--- a/lib/jxl_cms.cmake
+++ b/lib/jxl_cms.cmake
@@ -86,6 +86,20 @@ add_library(jxl_cms ALIAS jxl_cms-static)
 endif()  # BUILD_SHARED_LIBS
 
 set(JPEGXL_CMS_LIBRARY_REQUIRES "")
+
+# Allow adding prefix if CMAKE_INSTALL_INCLUDEDIR not absolute.
+if(IS_ABSOLUTE "${CMAKE_INSTALL_INCLUDEDIR}")
+    set(PKGCONFIG_TARGET_INCLUDES "${CMAKE_INSTALL_INCLUDEDIR}")
+else()
+    set(PKGCONFIG_TARGET_INCLUDES "\${prefix}/${CMAKE_INSTALL_INCLUDEDIR}")
+endif()
+# Allow adding prefix if CMAKE_INSTALL_LIBDIR not absolute.
+if(IS_ABSOLUTE "${CMAKE_INSTALL_LIBDIR}")
+    set(PKGCONFIG_TARGET_LIBS "${CMAKE_INSTALL_LIBDIR}")
+else()
+    set(PKGCONFIG_TARGET_LIBS "\${exec_prefix}/${CMAKE_INSTALL_LIBDIR}")
+endif()
+
 configure_file("${CMAKE_CURRENT_SOURCE_DIR}/jxl/libjxl_cms.pc.in"
                "libjxl_cms.pc" @ONLY)
 install(FILES "${CMAKE_CURRENT_BINARY_DIR}/libjxl_cms.pc"


### PR DESCRIPTION
Without this, the .pc file ends up with those variables empty, breaking the build in hilarious ways as the empty -L / -I eat up the next argument.

This section is straight up copied from the two sibling .cmake files.