### PR TITLE
Open rawdistmap in binary mode for writing

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -34,6 +34,7 @@ Diego Pino <dpino@igalia.com>
 Dirk Lemstra <dirk@lemstra.org>
 Don Olmstead <don.j.olmstead@gmail.com>
 Dong Xu <xdong181@gmail.com>
+estrogently <41487185+estrogently@users.noreply.github.com>
 Even Rouault <even.rouault@spatialys.com>
 Fred Brennan <copypaste@kittens.ph>
 gi-man

--- a/tools/butteraugli_main.cc
+++ b/tools/butteraugli_main.cc
@@ -106,7 +106,7 @@ Status RunButteraugli(const char* pathname1, const char* pathname2,
                          distmap_filename));
   }
   if (!raw_distmap_filename.empty()) {
-    FILE* out = fopen(raw_distmap_filename.c_str(), "w");
+    FILE* out = fopen(raw_distmap_filename.c_str(), "wb");
     JXL_CHECK(out != nullptr);
     fprintf(out, "Pf\n%" PRIuS " %" PRIuS "\n-1.0\n", distmap.xsize(),
             distmap.ysize());


### PR DESCRIPTION
### Description

The raw distmap file created when using the `--rawdistmap` argument of butteraugli_main was opened in text mode. On Windows, this caused any occurrence of 0x0A in floats written to undergo newline correction and have a 0x0D inserted before it, resulting in incorrect output and an invalid PFM (file size after header > w x h x 4 bytes). This PR fixes that by opening the file in binary mode instead.

### Pull Request Checklist

- [x] **CLA Signed**: Have you signed the [Contributor License Agreement](https://code.google.com/legal/individual-cla-v1.0.html) (individual or corporate, as appropriate)? Only contributions from signed contributors can be accepted.
- [x] **Authors**: If this is your first contribution, have you added your name to the [AUTHORS](AUTHORS) file?
- [x] **Code Style**: Have you ensured your code adheres to the project's coding style guidelines? You can use `./ci.sh lint` for automatic code formatting.