### PR TITLE
Implement chunked file input in cjxl.

### DIFF
--- a/lib/extras/dec/pnm.h
+++ b/lib/extras/dec/pnm.h
@@ -34,6 +34,26 @@ Status DecodeImagePNM(Span<const uint8_t> bytes, const ColorHints& color_hints,
 
 void TestCodecPNM();
 
+struct HeaderPNM {
+  size_t xsize;
+  size_t ysize;
+  bool is_gray;    // PGM
+  bool has_alpha;  // PAM
+  size_t bits_per_sample;
+  bool floating_point;
+  bool big_endian;
+  std::vector<JxlExtraChannelType> ec_types;  // PAM
+};
+
+struct ChunkedPNMDecoder {
+  FILE* f;
+  HeaderPNM header = {};
+  size_t data_start;
+};
+
+Status DecodeImagePNM(ChunkedPNMDecoder* dec, const ColorHints& color_hints,
+                      PackedPixelFile* ppf);
+
 }  // namespace extras
 }  // namespace jxl
 

--- a/lib/extras/enc/jxl.cc
+++ b/lib/extras/enc/jxl.cc
@@ -36,6 +36,55 @@ bool SetFrameOptions(const std::vector<JXLOption>& options, size_t frame_index,
   return true;
 }
 
+bool SetupFrame(JxlEncoder* enc, JxlEncoderFrameSettings* settings,
+                const JxlFrameHeader& frame_header,
+                const JXLCompressParams& params, const PackedPixelFile& ppf,
+                size_t frame_index, size_t num_alpha_channels,
+                size_t num_interleaved_alpha, size_t& option_idx) {
+  if (JXL_ENC_SUCCESS != JxlEncoderSetFrameHeader(settings, &frame_header)) {
+    fprintf(stderr, "JxlEncoderSetFrameHeader() failed.\n");
+    return false;
+  }
+  if (!SetFrameOptions(params.options, frame_index, &option_idx, settings)) {
+    return false;
+  }
+  if (num_alpha_channels > 0) {
+    JxlExtraChannelInfo extra_channel_info;
+    JxlEncoderInitExtraChannelInfo(JXL_CHANNEL_ALPHA, &extra_channel_info);
+    extra_channel_info.bits_per_sample = ppf.info.alpha_bits;
+    extra_channel_info.exponent_bits_per_sample = ppf.info.alpha_exponent_bits;
+    if (params.premultiply != -1) {
+      if (params.premultiply != 0 && params.premultiply != 1) {
+        fprintf(stderr, "premultiply must be one of: -1, 0, 1.\n");
+        return false;
+      }
+      extra_channel_info.alpha_premultiplied = params.premultiply;
+    }
+    if (JXL_ENC_SUCCESS !=
+        JxlEncoderSetExtraChannelInfo(enc, 0, &extra_channel_info)) {
+      fprintf(stderr, "JxlEncoderSetExtraChannelInfo() failed.\n");
+      return false;
+    }
+    // We take the extra channel blend info frame_info, but don't do
+    // clamping.
+    JxlBlendInfo extra_channel_blend_info = frame_header.layer_info.blend_info;
+    extra_channel_blend_info.clamp = JXL_FALSE;
+    JxlEncoderSetExtraChannelBlendInfo(settings, 0, &extra_channel_blend_info);
+  }
+  // Add extra channel info for the rest of the extra channels.
+  for (size_t i = 0; i < ppf.info.num_extra_channels; ++i) {
+    if (i < ppf.extra_channels_info.size()) {
+      const auto& ec_info = ppf.extra_channels_info[i].ec_info;
+      if (JXL_ENC_SUCCESS != JxlEncoderSetExtraChannelInfo(
+                                 enc, num_interleaved_alpha + i, &ec_info)) {
+        fprintf(stderr, "JxlEncoderSetExtraChannelInfo() failed.\n");
+        return false;
+      }
+    }
+  }
+  return true;
+}
+
 bool EncodeImageJXL(const JXLCompressParams& params, const PackedPixelFile& ppf,
                     const std::vector<uint8_t>* jpeg_bytes,
                     std::vector<uint8_t>* compressed) {
@@ -222,53 +271,11 @@ bool EncodeImageJXL(const JXLCompressParams& params, const PackedPixelFile& ppf,
       const jxl::extras::PackedFrame& pframe = ppf.frames[num_frame];
       const jxl::extras::PackedImage& pimage = pframe.color;
       JxlPixelFormat ppixelformat = pimage.format;
-      if (JXL_ENC_SUCCESS !=
-          JxlEncoderSetFrameHeader(settings, &pframe.frame_info)) {
-        fprintf(stderr, "JxlEncoderSetFrameHeader() failed.\n");
-        return false;
-      }
-      if (!SetFrameOptions(params.options, num_frame, &option_idx, settings)) {
-        return false;
-      }
-      if (num_alpha_channels > 0) {
-        JxlExtraChannelInfo extra_channel_info;
-        JxlEncoderInitExtraChannelInfo(JXL_CHANNEL_ALPHA, &extra_channel_info);
-        extra_channel_info.bits_per_sample = ppf.info.alpha_bits;
-        extra_channel_info.exponent_bits_per_sample =
-            ppf.info.alpha_exponent_bits;
-        if (params.premultiply != -1) {
-          if (params.premultiply != 0 && params.premultiply != 1) {
-            fprintf(stderr, "premultiply must be one of: -1, 0, 1.\n");
-            return false;
-          }
-          extra_channel_info.alpha_premultiplied = params.premultiply;
-        }
-        if (JXL_ENC_SUCCESS !=
-            JxlEncoderSetExtraChannelInfo(enc, 0, &extra_channel_info)) {
-          fprintf(stderr, "JxlEncoderSetExtraChannelInfo() failed.\n");
-          return false;
-        }
-        // We take the extra channel blend info frame_info, but don't do
-        // clamping.
-        JxlBlendInfo extra_channel_blend_info =
-            pframe.frame_info.layer_info.blend_info;
-        extra_channel_blend_info.clamp = JXL_FALSE;
-        JxlEncoderSetExtraChannelBlendInfo(settings, 0,
-                                           &extra_channel_blend_info);
-      }
       size_t num_interleaved_alpha =
           (ppixelformat.num_channels - ppf.info.num_color_channels);
-      // Add extra channel info for the rest of the extra channels.
-      for (size_t i = 0; i < ppf.info.num_extra_channels; ++i) {
-        if (i < ppf.extra_channels_info.size()) {
-          const auto& ec_info = ppf.extra_channels_info[i].ec_info;
-          if (JXL_ENC_SUCCESS !=
-              JxlEncoderSetExtraChannelInfo(enc, num_interleaved_alpha + i,
-                                            &ec_info)) {
-            fprintf(stderr, "JxlEncoderSetExtraChannelInfo() failed.\n");
-            return false;
-          }
-        }
+      if (!SetupFrame(enc, settings, pframe.frame_info, params, ppf, num_frame,
+                      num_alpha_channels, num_interleaved_alpha, option_idx)) {
+        return false;
       }
       if (JXL_ENC_SUCCESS != JxlEncoderAddImageFrame(settings, &ppixelformat,
                                                      pimage.pixels(),
@@ -287,6 +294,22 @@ bool EncodeImageJXL(const JXLCompressParams& params, const PackedPixelFile& ppf,
           fprintf(stderr, "JxlEncoderSetExtraChannelBuffer() failed.\n");
           return false;
         }
+      }
+    }
+    for (size_t fi = 0; fi < ppf.chunked_frames.size(); ++fi) {
+      ChunkedPackedFrame& chunked_frame = ppf.chunked_frames[fi];
+      size_t num_interleaved_alpha =
+          (chunked_frame.format.num_channels - ppf.info.num_color_channels);
+      if (!SetupFrame(enc, settings, chunked_frame.frame_info, params, ppf, fi,
+                      num_alpha_channels, num_interleaved_alpha, option_idx)) {
+        return false;
+      }
+      const bool last_frame = fi + 1 == ppf.chunked_frames.size();
+      if (JXL_ENC_SUCCESS !=
+          JxlEncoderAddChunkedFrame(settings, last_frame,
+                                    chunked_frame.GetInputSource())) {
+        fprintf(stderr, "JxlEncoderAddChunkedFrame() failed.\n");
+        return false;
       }
     }
   }

--- a/tools/cjxl_main.cc
+++ b/tools/cjxl_main.cc
@@ -32,6 +32,7 @@
 #include "lib/extras/dec/apng.h"
 #include "lib/extras/dec/color_hints.h"
 #include "lib/extras/dec/decode.h"
+#include "lib/extras/dec/pnm.h"
 #include "lib/extras/enc/jxl.h"
 #include "lib/extras/time.h"
 #include "lib/jxl/base/override.h"
@@ -349,6 +350,10 @@ struct CompressArgs {
                             "How many times to compress. (For benchmarking).",
                             &num_reps, &ParseUnsigned, 3);
 
+    cmdline->AddOptionFlag('\0', "streaming_input",
+                           "Enable streaming processing of the input file "
+                           "(works only for PPM and PGM input files).",
+                           &streaming_input, &SetBooleanTrue, 3);
     cmdline->AddOptionFlag('\0', "disable_output",
                            "No output file will be written (for benchmarking)",
                            &disable_output, &SetBooleanTrue, 3);
@@ -459,6 +464,7 @@ struct CompressArgs {
   const char* file_in = nullptr;
   const char* file_out = nullptr;
   jxl::Override print_profile = jxl::Override::kDefault;
+  bool streaming_input = false;
 
   // Decoding source image flags
   ColorHintsProxy color_hints_proxy;
@@ -892,7 +898,7 @@ void ProcessFlags(const jxl::extras::Codec codec,
                     JXL_ENC_FRAME_SETTING_JPEG_COMPRESS_BOXES, params);
   }
   // Set per-frame options.
-  for (size_t num_frame = 0; num_frame < ppf.frames.size(); ++num_frame) {
+  for (size_t num_frame = 0; num_frame < ppf.num_frames(); ++num_frame) {
     if (num_frame < args->frame_indexing.size() &&
         args->frame_indexing[num_frame] == '1') {
       int64_t value = 1;
@@ -974,45 +980,65 @@ int main(int argc, char** argv) {
   // Depending on flags-settings, we want to either load a JPEG and
   // faithfully convert it to JPEG XL, or load (JPEG or non-JPEG)
   // pixel data.
-  std::vector<uint8_t> image_data;
-  jxl::extras::PackedPixelFile ppf;
-  jxl::extras::Codec codec = jxl::extras::Codec::kUnknown;
-  std::vector<uint8_t>* jpeg_bytes = nullptr;
-  double decode_mps = 0;
-  size_t pixels = 0;
-  if (!jpegxl::tools::ReadFile(args.file_in, &image_data)) {
+  jpegxl::tools::FileWrapper f(args.file_in, "rb");
+  if (!f) {
     std::cerr << "Reading image data failed." << std::endl;
     exit(EXIT_FAILURE);
   }
-  if (!jpegxl::tools::IsJPG(image_data)) args.lossless_jpeg = 0;
   jxl::extras::JXLCompressParams params;
-  ProcessFlags(codec, ppf, jpeg_bytes, &cmdline, &args, &params);
-  if (!args.lossless_jpeg) {
-    const double t0 = jxl::Now();
-    jxl::Status status = jxl::extras::DecodeBytes(jxl::Bytes(image_data),
-                                                  args.color_hints_proxy.target,
-                                                  &ppf, nullptr, &codec);
-
-    if (!status) {
-      std::cerr << "Getting pixel data failed." << std::endl;
+  jxl::extras::PackedPixelFile ppf;
+  jxl::extras::Codec codec = jxl::extras::Codec::kUnknown;
+  std::vector<uint8_t> image_data;
+  std::vector<uint8_t>* jpeg_bytes = nullptr;
+  jxl::extras::ChunkedPNMDecoder pnm_dec;
+  size_t pixels = 0;
+  if (args.streaming_input) {
+    pnm_dec.f = f;
+    if (!DecodeImagePNM(&pnm_dec, args.color_hints_proxy.target, &ppf)) {
+      std::cerr << "PNM decoding failed." << std::endl;
       exit(EXIT_FAILURE);
     }
-    if (ppf.frames.empty()) {
-      std::cerr << "No frames on input file." << std::endl;
-      exit(EXIT_FAILURE);
-    }
-
-    const double t1 = jxl::Now();
+    codec = jxl::extras::Codec::kPNM;
+    args.lossless_jpeg = 0;
     pixels = ppf.info.xsize * ppf.info.ysize;
-    decode_mps = pixels * ppf.info.num_color_channels * 1E-6 / (t1 - t0);
-  }
-  if (args.lossless_jpeg && jpegxl::tools::IsJPG(image_data)) {
-    if (!cmdline.GetOption(args.opt_lossless_jpeg_id)->matched()) {
-      std::cerr << "Note: Implicit-default for JPEG is lossless-transcoding. "
-                << "To silence this message, set --lossless_jpeg=(1|0)."
-                << std::endl;
+  } else {
+    double decode_mps = 0;
+    if (!jpegxl::tools::ReadFile(f, &image_data)) {
+      std::cerr << "Reading image data failed." << std::endl;
+      exit(EXIT_FAILURE);
     }
-    jpeg_bytes = &image_data;
+    if (!jpegxl::tools::IsJPG(image_data)) args.lossless_jpeg = 0;
+    ProcessFlags(codec, ppf, jpeg_bytes, &cmdline, &args, &params);
+    if (!args.lossless_jpeg) {
+      const double t0 = jxl::Now();
+      jxl::Status status = jxl::extras::DecodeBytes(
+          jxl::Bytes(image_data), args.color_hints_proxy.target, &ppf, nullptr,
+          &codec);
+
+      if (!status) {
+        std::cerr << "Getting pixel data failed." << std::endl;
+        exit(EXIT_FAILURE);
+      }
+      if (ppf.frames.empty()) {
+        std::cerr << "No frames on input file." << std::endl;
+        exit(EXIT_FAILURE);
+      }
+      pixels = ppf.info.xsize * ppf.info.ysize;
+      const double t1 = jxl::Now();
+      decode_mps = pixels * ppf.info.num_color_channels * 1E-6 / (t1 - t0);
+    }
+    if (!args.quiet) {
+      PrintMode(ppf, decode_mps, image_data.size(), args, cmdline);
+    }
+
+    if (args.lossless_jpeg && jpegxl::tools::IsJPG(image_data)) {
+      if (!cmdline.GetOption(args.opt_lossless_jpeg_id)->matched()) {
+        std::cerr << "Note: Implicit-default for JPEG is lossless-transcoding. "
+                  << "To silence this message, set --lossless_jpeg=(1|0)."
+                  << std::endl;
+      }
+      jpeg_bytes = &image_data;
+    }
   }
 
   ProcessFlags(codec, ppf, jpeg_bytes, &cmdline, &args, &params);
@@ -1035,10 +1061,6 @@ int main(int argc, char** argv) {
       ppf.metadata.iptc.clear();
       args.jpeg_store_metadata = 0;
     }
-  }
-
-  if (!args.quiet) {
-    PrintMode(ppf, decode_mps, image_data.size(), args, cmdline);
   }
 
   size_t num_worker_threads = JxlThreadParallelRunnerDefaultNumWorkerThreads();
@@ -1086,8 +1108,8 @@ int main(int argc, char** argv) {
     if (!args.lossless_jpeg) {
       const double bpp =
           static_cast<double>(compressed.size() * jxl::kBitsPerByte) / pixels;
-      cmdline.VerbosePrintf(0, "(%.3f bpp%s).\n", bpp / ppf.frames.size(),
-                            ppf.frames.size() == 1 ? "" : "/frame");
+      cmdline.VerbosePrintf(0, "(%.3f bpp%s).\n", bpp / ppf.num_frames(),
+                            ppf.num_frames() == 1 ? "" : "/frame");
       JXL_CHECK(stats.Print(num_worker_threads));
     } else {
       cmdline.VerbosePrintf(0, "\n");

--- a/tools/file_io.h
+++ b/tools/file_io.h
@@ -75,10 +75,7 @@ class FileWrapper {
 }  // namespace
 
 template <typename ContainerType>
-static inline bool ReadFile(const std::string& filename,
-                            ContainerType* JXL_RESTRICT bytes) {
-  FileWrapper f(filename, "rb");
-
+static inline bool ReadFile(FileWrapper& f, ContainerType* JXL_RESTRICT bytes) {
   if (!f) return false;
 
   // Get size of file in bytes
@@ -120,6 +117,13 @@ static inline bool ReadFile(const std::string& filename,
   }
 
   return true;
+}
+
+template <typename ContainerType>
+static inline bool ReadFile(const std::string& filename,
+                            ContainerType* JXL_RESTRICT bytes) {
+  FileWrapper f(filename, "rb");
+  return ReadFile(f, bytes);
 }
 
 template <typename ContainerType>

--- a/tools/scripts/roundtrip_test.sh
+++ b/tools/scripts/roundtrip_test.sh
@@ -115,6 +115,10 @@ main() {
 
   roundtrip_test "jxl/flower/flower_small.rgb.png" "-e 1" 0.02
   roundtrip_test "jxl/flower/flower_small.rgb.png" "-e 1 -d 0.0" 0.0
+  roundtrip_test "jxl/flower/flower_small.rgb.depth8.ppm" \
+		 "-e 1 --streaming_input" 0.02
+  roundtrip_test "jxl/flower/flower_small.rgb.depth8.ppm" \
+		 "-e 1 -d 0.0 --streaming_input" 0.0
   roundtrip_test "jxl/flower/flower_cropped.jpg" "-e 1" 0.0
 
   roundtrip_lossless_pnm_test "jxl/flower/flower_small.rgb.depth1.ppm"


### PR DESCRIPTION
This option works only for PPM and PGM for now, and it causes the encoder to not read the entire image file in memory but use the streaming input API of the encoder instead.
