### PR TITLE
continue-on-error for step

### DIFF
--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -354,6 +354,7 @@ jobs:
       fail-fast: false
       matrix:
         include:
+           # TODO(eustas): investigate failures
          - msystem: mingw64
            faulty: true
          - msystem: clang64
@@ -411,6 +412,7 @@ jobs:
             -G Ninja
       - name: CMake build
         run: cmake --build build
+        continue-on-error: ${{ matrix.faulty }}
       - name: Test
         if: |
           github.event_name == 'push' ||

--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -419,6 +419,7 @@ jobs:
           (github.event_name == 'pull_request' &&
            contains(github.event.pull_request.labels.*.name, 'CI:full'))
         run: ctest --test-dir build --parallel 2 --output-on-failure -E "${{ join(matrix.disable_tests, '|') }}"
+        continue-on-error: ${{ matrix.faulty }}
 
   wasm32_build:
     name: WASM wasm32/${{ matrix.variant }}


### PR DESCRIPTION
This marks the expectance for the the build step in the two failing mingw tests as failures, so that they marked as green in the ci, even if they were failures.