### PR TITLE
Remove PassesEncoderState parameter from EncodeFrame.

### DIFF
--- a/lib/jxl/enc_cache.cc
+++ b/lib/jxl/enc_cache.cc
@@ -129,9 +129,6 @@ Status InitializePassesEncoder(const Image3F& opsin, const JxlCmsInterface& cms,
       }
       ib.SetExtraChannels(std::move(extra_channels));
     }
-    std::unique_ptr<PassesEncoderState> state =
-        jxl::make_unique<PassesEncoderState>();
-
     auto special_frame = std::unique_ptr<BitWriter>(new BitWriter());
     FrameInfo dc_frame_info;
     dc_frame_info.frame_type = FrameType::kDCFrame;
@@ -139,8 +136,8 @@ Status InitializePassesEncoder(const Image3F& opsin, const JxlCmsInterface& cms,
     dc_frame_info.ib_needs_color_transform = false;
     dc_frame_info.save_before_color_transform = true;  // Implicitly true
     AuxOut dc_aux_out;
-    JXL_CHECK(EncodeFrame(cparams, dc_frame_info, shared.metadata, ib,
-                          state.get(), cms, pool, special_frame.get(),
+    JXL_CHECK(EncodeFrame(cparams, dc_frame_info, shared.metadata, ib, cms,
+                          pool, special_frame.get(),
                           aux_out ? &dc_aux_out : nullptr));
     if (aux_out) {
       for (const auto& l : dc_aux_out.layers) {

--- a/lib/jxl/enc_frame.h
+++ b/lib/jxl/enc_frame.h
@@ -85,16 +85,14 @@ Status ParamsPostInit(CompressParams* p);
 Status EncodeFrame(const CompressParams& cparams_orig,
                    const FrameInfo& frame_info, const CodecMetadata* metadata,
                    JxlEncoderChunkedFrameAdapter& frame_data,
-                   PassesEncoderState* passes_enc_state,
                    const JxlCmsInterface& cms, ThreadPool* pool,
                    JxlEncoderOutputProcessorWrapper* output_processor,
                    AuxOut* aux_out);
 
 Status EncodeFrame(const CompressParams& cparams_orig,
                    const FrameInfo& frame_info, const CodecMetadata* metadata,
-                   const ImageBundle& ib, PassesEncoderState* passes_enc_state,
-                   const JxlCmsInterface& cms, ThreadPool* pool,
-                   BitWriter* writer, AuxOut* aux_out);
+                   const ImageBundle& ib, const JxlCmsInterface& cms,
+                   ThreadPool* pool, BitWriter* writer, AuxOut* aux_out);
 
 }  // namespace jxl
 

--- a/lib/jxl/enc_heuristics.cc
+++ b/lib/jxl/enc_heuristics.cc
@@ -768,8 +768,9 @@ Status DefaultEncoderHeuristics::LossyFrameHeuristics(
 
   // Find and subtract splines.
   if (cparams.speed_tier <= SpeedTier::kSquirrel) {
-    // If we do already have them, they were passed upstream to EncodeFile.
-    if (!shared.image_features.splines.HasAny()) {
+    if (cparams.custom_splines.HasAny()) {
+      shared.image_features.splines = cparams.custom_splines;
+    } else {
       shared.image_features.splines = FindSplines(*opsin);
     }
     JXL_RETURN_IF_ERROR(shared.image_features.splines.InitializeDrawCache(

--- a/lib/jxl/enc_modular.cc
+++ b/lib/jxl/enc_modular.cc
@@ -976,8 +976,8 @@ Status ModularFrameEncoder::PrepareEncoding(const FrameHeader& frame_header,
   stream_headers_.resize(num_streams);
   tokens_.resize(num_streams);
 
-  if (heuristics->CustomFixedTreeLossless(frame_dim_, &tree_)) {
-    // Using a fixed tree.
+  if (!cparams_.custom_fixed_tree.empty()) {
+    tree_ = cparams_.custom_fixed_tree;
   } else if (cparams_.speed_tier < SpeedTier::kFalcon ||
              !cparams_.modular_mode) {
     // Avoid creating a tree with leaves that don't correspond to any pixels.

--- a/lib/jxl/enc_params.h
+++ b/lib/jxl/enc_params.h
@@ -16,9 +16,12 @@
 
 #include "lib/jxl/base/override.h"
 #include "lib/jxl/butteraugli/butteraugli.h"
+#include "lib/jxl/enc_progressive_split.h"
 #include "lib/jxl/frame_header.h"
+#include "lib/jxl/modular/encoding/dec_ma.h"
 #include "lib/jxl/modular/options.h"
 #include "lib/jxl/modular/transform/transform.h"
+#include "lib/jxl/splines.h"
 
 namespace jxl {
 
@@ -195,6 +198,15 @@ struct CompressParams {
 
   std::vector<float> manual_noise;
   std::vector<float> manual_xyb_factors;
+
+  // If not empty, this tree will be used for dc global section.
+  // Used in jxl_from_tree tool.
+  Tree custom_fixed_tree;
+  // If not empty, these custom splines will be used instead of the computed
+  // ones. Used in jxl_from_tee tool.
+  Splines custom_splines;
+  // If not null, overrides progressive mode settings. Used in decode_test.
+  const ProgressiveMode* custom_progressive_mode = nullptr;
 
   JxlDebugImageCallback debug_image = nullptr;
   void* debug_image_opaque;

--- a/lib/jxl/enc_patch_dictionary.cc
+++ b/lib/jxl/enc_patch_dictionary.cc
@@ -774,11 +774,10 @@ void RoundtripPatchFrame(Image3F* reference_frame,
     }
     ib.SetExtraChannels(std::move(extra_channels));
   }
-  PassesEncoderState roundtrip_state;
   auto special_frame = std::unique_ptr<BitWriter>(new BitWriter());
   AuxOut patch_aux_out;
   JXL_CHECK(EncodeFrame(cparams, patch_frame_info, state->shared.metadata, ib,
-                        &roundtrip_state, cms, pool, special_frame.get(),
+                        cms, pool, special_frame.get(),
                         aux_out ? &patch_aux_out : nullptr));
   if (aux_out) {
     for (const auto& l : patch_aux_out.layers) {

--- a/lib/jxl/encode.cc
+++ b/lib/jxl/encode.cc
@@ -875,8 +875,6 @@ jxl::Status JxlEncoderStruct::ProcessOneEnqueuedInput() {
     JXL_RETURN_IF_ERROR(AppendData(output_processor, header_bytes));
 
     if (input_frame) {
-      jxl::PassesEncoderState enc_state;
-
       frame_index_box.AddFrame(codestream_bytes_written_end_of_frame, duration,
                                input_frame->option_values.frame_index_box);
 
@@ -930,7 +928,7 @@ jxl::Status JxlEncoderStruct::ProcessOneEnqueuedInput() {
       frame_info.name = input_frame->option_values.frame_name;
 
       if (!jxl::EncodeFrame(input_frame->option_values.cparams, frame_info,
-                            &metadata, input_frame->frame_data, &enc_state, cms,
+                            &metadata, input_frame->frame_data, cms,
                             thread_pool.get(), &output_processor,
                             input_frame->option_values.aux_out)) {
         return JXL_API_ERROR(this, JXL_ENC_ERR_GENERIC,

--- a/lib/jxl/gradient_test.cc
+++ b/lib/jxl/gradient_test.cc
@@ -158,8 +158,7 @@ void TestGradient(ThreadPool* pool, uint32_t color0, uint32_t color1,
   CodecInOut io2;
 
   std::vector<uint8_t> compressed;
-  PassesEncoderState enc_state;
-  EXPECT_TRUE(test::EncodeFile(cparams, &io, &enc_state, &compressed, pool));
+  EXPECT_TRUE(test::EncodeFile(cparams, &io, &compressed, pool));
   EXPECT_TRUE(test::DecodeFile({}, Bytes(compressed), &io2, pool));
   EXPECT_TRUE(io2.Main().TransformTo(io2.metadata.m.color_encoding,
                                      *JxlGetDefaultCms(), pool));

--- a/lib/jxl/jxl_test.cc
+++ b/lib/jxl/jxl_test.cc
@@ -629,14 +629,12 @@ TEST(JxlTest, RoundtripGrayscale) {
   EXPECT_EQ(0u, io.metadata.m.bit_depth.exponent_bits_per_sample);
   EXPECT_TRUE(io.metadata.m.color_encoding.Tf().IsSRGB());
 
-  PassesEncoderState enc_state;
-
   {
     CompressParams cparams;
     cparams.butteraugli_distance = 1.0;
 
     std::vector<uint8_t> compressed;
-    EXPECT_TRUE(test::EncodeFile(cparams, &io, &enc_state, &compressed));
+    EXPECT_TRUE(test::EncodeFile(cparams, &io, &compressed));
     CodecInOut io2;
     EXPECT_TRUE(test::DecodeFile({}, Bytes(compressed), &io2));
     EXPECT_TRUE(io2.Main().IsGray());
@@ -655,7 +653,7 @@ TEST(JxlTest, RoundtripGrayscale) {
     cparams.butteraugli_distance = 8.0;
 
     std::vector<uint8_t> compressed;
-    EXPECT_TRUE(test::EncodeFile(cparams, &io, &enc_state, &compressed));
+    EXPECT_TRUE(test::EncodeFile(cparams, &io, &compressed));
     CodecInOut io2;
     EXPECT_TRUE(test::DecodeFile({}, Bytes(compressed), &io2));
     EXPECT_TRUE(io2.Main().IsGray());
@@ -672,7 +670,7 @@ TEST(JxlTest, RoundtripGrayscale) {
     cparams.butteraugli_distance = 1.0;
 
     std::vector<uint8_t> compressed;
-    EXPECT_TRUE(test::EncodeFile(cparams, &io, &enc_state, &compressed));
+    EXPECT_TRUE(test::EncodeFile(cparams, &io, &compressed));
 
     CodecInOut io2;
     JXLDecompressParams dparams;
@@ -706,9 +704,8 @@ TEST(JxlTest, RoundtripAlpha) {
   EXPECT_FALSE(io.metadata.m.bit_depth.floating_point_sample);
   EXPECT_EQ(0u, io.metadata.m.bit_depth.exponent_bits_per_sample);
   EXPECT_TRUE(io.metadata.m.color_encoding.Tf().IsSRGB());
-  PassesEncoderState enc_state;
   std::vector<uint8_t> compressed;
-  EXPECT_TRUE(test::EncodeFile(cparams, &io, &enc_state, &compressed));
+  EXPECT_TRUE(test::EncodeFile(cparams, &io, &compressed));
 
   EXPECT_LE(compressed.size(), 10077u);
 
@@ -805,9 +802,8 @@ TEST(JxlTest, RoundtripAlphaPremultiplied) {
 
   EXPECT_FALSE(io_nopremul.Main().AlphaIsPremultiplied());
 
-  PassesEncoderState enc_state;
   std::vector<uint8_t> compressed;
-  EXPECT_TRUE(test::EncodeFile(cparams, &io, &enc_state, &compressed));
+  EXPECT_TRUE(test::EncodeFile(cparams, &io, &compressed));
   EXPECT_LE(compressed.size(), 10000u);
 
   for (bool use_image_callback : {false, true}) {

--- a/lib/jxl/passes_test.cc
+++ b/lib/jxl/passes_test.cc
@@ -171,8 +171,7 @@ TEST(PassesTest, AllDownsampleFeasible) {
   cparams.speed_tier = SpeedTier::kSquirrel;
   cparams.progressive_mode = true;
   cparams.butteraugli_distance = 1.0;
-  PassesEncoderState enc_state;
-  ASSERT_TRUE(test::EncodeFile(cparams, &io, &enc_state, &compressed, &pool));
+  ASSERT_TRUE(test::EncodeFile(cparams, &io, &compressed, &pool));
 
   EXPECT_LE(compressed.size(), 240000u);
   float target_butteraugli[9] = {};
@@ -217,8 +216,7 @@ TEST(PassesTest, AllDownsampleFeasibleQProgressive) {
   cparams.speed_tier = SpeedTier::kSquirrel;
   cparams.qprogressive_mode = true;
   cparams.butteraugli_distance = 1.0;
-  PassesEncoderState enc_state;
-  ASSERT_TRUE(test::EncodeFile(cparams, &io, &enc_state, &compressed, &pool));
+  ASSERT_TRUE(test::EncodeFile(cparams, &io, &compressed, &pool));
 
   EXPECT_LE(compressed.size(), 220000u);
 
@@ -273,8 +271,7 @@ TEST(PassesTest, ProgressiveDownsample2DegradesCorrectlyGrayscale) {
   cparams.responsive = true;
   cparams.qprogressive_mode = true;
   cparams.butteraugli_distance = 1.0;
-  PassesEncoderState enc_state;
-  ASSERT_TRUE(test::EncodeFile(cparams, &io, &enc_state, &compressed, &pool));
+  ASSERT_TRUE(test::EncodeFile(cparams, &io, &compressed, &pool));
 
   EXPECT_LE(compressed.size(), 10000u);
 
@@ -317,8 +314,7 @@ TEST(PassesTest, ProgressiveDownsample2DegradesCorrectly) {
   cparams.responsive = true;
   cparams.qprogressive_mode = true;
   cparams.butteraugli_distance = 1.0;
-  PassesEncoderState enc_state;
-  ASSERT_TRUE(test::EncodeFile(cparams, &io, &enc_state, &compressed, &pool));
+  ASSERT_TRUE(test::EncodeFile(cparams, &io, &compressed, &pool));
 
   EXPECT_LE(compressed.size(), 220000u);
 
@@ -352,8 +348,7 @@ TEST(PassesTest, NonProgressiveDCImage) {
   cparams.speed_tier = SpeedTier::kSquirrel;
   cparams.progressive_mode = false;
   cparams.butteraugli_distance = 2.0;
-  PassesEncoderState enc_state;
-  ASSERT_TRUE(test::EncodeFile(cparams, &io, &enc_state, &compressed, &pool));
+  ASSERT_TRUE(test::EncodeFile(cparams, &io, &compressed, &pool));
 
   // Even in non-progressive mode, it should be possible to return a DC-only
   // image.

--- a/lib/jxl/render_pipeline/render_pipeline_test.cc
+++ b/lib/jxl/render_pipeline/render_pipeline_test.cc
@@ -218,10 +218,8 @@ TEST_P(RenderPipelineTestParam, PipelineTest) {
 
   std::vector<uint8_t> compressed;
 
-  PassesEncoderState enc_state;
-  enc_state.shared.image_features.splines = config.splines;
-  ASSERT_TRUE(
-      test::EncodeFile(config.cparams, &io, &enc_state, &compressed, &pool));
+  config.cparams.custom_splines = config.splines;
+  ASSERT_TRUE(test::EncodeFile(config.cparams, &io, &compressed, &pool));
 
   CodecInOut io_default;
   ASSERT_TRUE(DecodeFile(Bytes(compressed),

--- a/lib/jxl/test_utils.h
+++ b/lib/jxl/test_utils.h
@@ -183,7 +183,6 @@ Status ReadICC(BitReader* JXL_RESTRICT reader,
 // Compresses pixels from `io` (given in any ColorEncoding).
 // `io->metadata.m.original` must be set.
 Status EncodeFile(const CompressParams& params, const CodecInOut* io,
-                  PassesEncoderState* passes_enc_state,
                   std::vector<uint8_t>* compressed, ThreadPool* pool = nullptr);
 
 }  // namespace test

--- a/tools/djxl_fuzzer_corpus.cc
+++ b/tools/djxl_fuzzer_corpus.cc
@@ -256,11 +256,9 @@ bool GenerateFile(const char* output_dir, const ImageSpec& spec,
   if (spec.params.preview) params.preview = jxl::Override::kOn;
   if (spec.params.noise) params.noise = jxl::Override::kOn;
 
-  jxl::PassesEncoderState passes_encoder_state;
   // EncodeFile replaces output; pass a temporary storage for it.
   std::vector<uint8_t> compressed_image;
-  bool ok = jxl::test::EncodeFile(params, &io, &passes_encoder_state,
-                                  &compressed_image);
+  bool ok = jxl::test::EncodeFile(params, &io, &compressed_image);
   if (!ok) return false;
   compressed.append(compressed_image);
 

--- a/tools/jxl_from_tree.cc
+++ b/tools/jxl_from_tree.cc
@@ -56,8 +56,7 @@ struct SplineData {
   std::vector<Spline> splines;
 };
 
-Splines SplinesFromSplineData(const SplineData& spline_data,
-                              const ColorCorrelationMap& cmap) {
+Splines SplinesFromSplineData(const SplineData& spline_data) {
   std::vector<QuantizedSpline> quantized_splines;
   std::vector<Spline::Point> starting_points;
   quantized_splines.reserve(spline_data.splines.size());
@@ -65,7 +64,7 @@ Splines SplinesFromSplineData(const SplineData& spline_data,
   for (const Spline& spline : spline_data.splines) {
     JXL_CHECK(!spline.control_points.empty());
     quantized_splines.emplace_back(spline, spline_data.quantization_adjustment,
-                                   cmap.YtoXRatio(0), cmap.YtoBRatio(0));
+                                   0.0, 1.0);
     starting_points.push_back(spline.control_points.front());
   }
   return Splines(spline_data.quantization_adjustment,
@@ -415,20 +414,6 @@ bool ParseNode(F& tok, Tree& tree, SplineData& spline_data,
       ParseNode(tok, tree, spline_data, cparams, W, H, io, have_next, x0, y0));
   return true;
 }
-
-class Heuristics : public DefaultEncoderHeuristics {
- public:
-  bool CustomFixedTreeLossless(const FrameDimensions& frame_dim,
-                               Tree* tree) override {
-    *tree = tree_;
-    return true;
-  }
-
-  explicit Heuristics(Tree tree) : tree_(std::move(tree)) {}
-
- private:
-  Tree tree_;
-};
 }  // namespace
 
 int JxlFromTree(const char* in, const char* out, const char* tree_out) {
@@ -477,6 +462,8 @@ int JxlFromTree(const char* in, const char* out, const char* tree_out) {
   cparams.channel_colors_percent = 0;
   cparams.patches = jxl::Override::kOff;
   cparams.already_downsampled = true;
+  cparams.custom_fixed_tree = tree;
+  cparams.custom_splines = SplinesFromSplineData(spline_data);
   PaddedBytes compressed;
 
   io.CheckMetadata();
@@ -492,11 +479,6 @@ int JxlFromTree(const char* in, const char* out, const char* tree_out) {
   writer.ZeroPadToByte();
 
   while (true) {
-    PassesEncoderState enc_state;
-    enc_state.heuristics = jxl::make_unique<Heuristics>(tree);
-    enc_state.shared.image_features.splines =
-        SplinesFromSplineData(spline_data, enc_state.shared.cmap);
-
     FrameInfo info;
     info.is_last = !have_next;
     if (!info.is_last) info.save_as_reference = 1;
@@ -505,9 +487,9 @@ int JxlFromTree(const char* in, const char* out, const char* tree_out) {
     io.frames[0].origin.y0 = y0;
     info.clamp = false;
 
-    JXL_RETURN_IF_ERROR(jxl::EncodeFrame(
-        cparams, info, metadata.get(), io.frames[0], &enc_state,
-        *JxlGetDefaultCms(), nullptr, &writer, nullptr));
+    JXL_RETURN_IF_ERROR(jxl::EncodeFrame(cparams, info, metadata.get(),
+                                         io.frames[0], *JxlGetDefaultCms(),
+                                         nullptr, &writer, nullptr));
     if (!have_next) break;
     tree.clear();
     spline_data.splines.clear();


### PR DESCRIPTION
The relevant custom structs used in tests and jxl_from_tree are passed via cparams instead.
