### PR TITLE
Fix dead-end in jpeg-transcode flow

### DIFF
--- a/lib/jxl/decode.cc
+++ b/lib/jxl/decode.cc
@@ -209,7 +209,6 @@ enum class JpegReconStage : uint32_t {
   kNone,             // Not outputting
   kSettingMetadata,  // Ready to output, must set metadata to the jpeg_data
   kOutputting,       // Currently outputting the JPEG bytes
-  kFinished,         // JPEG reconstruction fully handled
 };
 
 /*
@@ -1704,7 +1703,7 @@ static JxlDecoderStatus HandleBoxes(JxlDecoder* dec) {
       JxlDecoderStatus status =
           dec->jpeg_decoder.WriteOutput(*dec->ib->jpeg_data);
       if (status != JXL_DEC_SUCCESS) return status;
-      dec->recon_output_jpeg = JpegReconStage::kFinished;
+      dec->recon_output_jpeg = JpegReconStage::kNone;
       dec->ib.reset();
       if (dec->events_wanted & JXL_DEC_FULL_IMAGE) {
         // Return the full image event here now, this may be delayed if this

--- a/tools/djxl_fuzzer.cc
+++ b/tools/djxl_fuzzer.cc
@@ -304,6 +304,7 @@ bool DecodeJpegXl(const uint8_t* jxl, size_t size, size_t max_pixels,
         }
       }
     } else if (status == JXL_DEC_PREVIEW_IMAGE) {
+      // TODO(eustas): test JXL_DEC_NEED_PREVIEW_OUT_BUFFER
       if (seen_preview) abort();
       if (!want_preview) abort();
       if (!seen_color_encoding) abort();


### PR DESCRIPTION
This fixes the case when API contract is broken - next `JXL_DEC_FRAME` arrives without `JXL_DEC_FULL_IMAGE`.
However it is unlikely that normal users will face it - that fires on a complex mixture: boxes + lossless jpeg + preview? + multi-frame