### PR TITLE
Remove the copy of the frame header from shared state.

### DIFF
--- a/lib/jxl/blending.cc
+++ b/lib/jxl/blending.cc
@@ -10,21 +10,20 @@
 
 namespace jxl {
 
-bool NeedsBlending(PassesDecoderState* dec_state) {
-  const PassesSharedState& state = *dec_state->shared;
-  if (!(state.frame_header.frame_type == FrameType::kRegularFrame ||
-        state.frame_header.frame_type == FrameType::kSkipProgressive)) {
+bool NeedsBlending(const FrameHeader& frame_header) {
+  if (!(frame_header.frame_type == FrameType::kRegularFrame ||
+        frame_header.frame_type == FrameType::kSkipProgressive)) {
     return false;
   }
-  const auto& info = state.frame_header.blending_info;
+  const auto& info = frame_header.blending_info;
   bool replace_all = (info.mode == BlendMode::kReplace);
-  for (const auto& ec_i : state.frame_header.extra_channel_blending_info) {
+  for (const auto& ec_i : frame_header.extra_channel_blending_info) {
     if (ec_i.mode != BlendMode::kReplace) {
       replace_all = false;
     }
   }
   // Replace the full frame: nothing to do.
-  if (!state.frame_header.custom_size_or_origin && replace_all) {
+  if (!frame_header.custom_size_or_origin && replace_all) {
     return false;
   }
   return true;

--- a/lib/jxl/blending.h
+++ b/lib/jxl/blending.h
@@ -11,7 +11,7 @@
 
 namespace jxl {
 
-bool NeedsBlending(PassesDecoderState* dec_state);
+bool NeedsBlending(const FrameHeader& frame_header);
 
 void PerformBlending(const float* const* bg, const float* const* fg,
                      float* const* out, size_t x0, size_t xsize,

--- a/lib/jxl/dec_cache.h
+++ b/lib/jxl/dec_cache.h
@@ -131,17 +131,16 @@ struct PassesDecoderState {
     bool render_noise;
   };
 
-  Status PreparePipeline(ImageBundle* decoded, PipelineOptions options);
+  Status PreparePipeline(const FrameHeader& frame_header, ImageBundle* decoded,
+                         PipelineOptions options);
 
   // Information for colour conversions.
   OutputEncodingInfo output_encoding_info;
 
   // Initializes decoder-specific structures using information from *shared.
-  Status Init() {
-    x_dm_multiplier =
-        std::pow(1 / (1.25f), shared->frame_header.x_qm_scale - 2.0f);
-    b_dm_multiplier =
-        std::pow(1 / (1.25f), shared->frame_header.b_qm_scale - 2.0f);
+  Status Init(const FrameHeader& frame_header) {
+    x_dm_multiplier = std::pow(1 / (1.25f), frame_header.x_qm_scale - 2.0f);
+    b_dm_multiplier = std::pow(1 / (1.25f), frame_header.b_qm_scale - 2.0f);
 
     main_output.callback = PixelCallback();
     main_output.buffer = nullptr;
@@ -154,7 +153,7 @@ struct PassesDecoderState {
     used_acs = 0;
 
     upsampler8x = GetUpsamplingStage(shared->metadata->transform_data, 0, 3);
-    if (shared->frame_header.loop_filter.epf_iters > 0) {
+    if (frame_header.loop_filter.epf_iters > 0) {
       sigma = ImageF(shared->frame_dim.xsize_blocks + 2 * kSigmaPadding,
                      shared->frame_dim.ysize_blocks + 2 * kSigmaPadding);
     }
@@ -162,7 +161,7 @@ struct PassesDecoderState {
   }
 
   // Initialize the decoder state after all of DC is decoded.
-  Status InitForAC(ThreadPool* pool) {
+  Status InitForAC(size_t num_passes, ThreadPool* pool) {
     shared_storage.coeff_order_size = 0;
     for (uint8_t o = 0; o < AcStrategy::kNumValidStrategies; ++o) {
       if (((1 << o) & used_acs) == 0) continue;
@@ -171,18 +170,12 @@ struct PassesDecoderState {
           std::max(kCoeffOrderOffset[3 * (ord + 1)] * kDCTBlockSize,
                    shared_storage.coeff_order_size);
     }
-    size_t sz = shared_storage.frame_header.passes.num_passes *
-                shared_storage.coeff_order_size;
+    size_t sz = num_passes * shared_storage.coeff_order_size;
     if (sz > shared_storage.coeff_orders.size()) {
       shared_storage.coeff_orders.resize(sz);
     }
     return true;
   }
-
-  // Fills the `state->filter_weights.sigma` image with the precomputed sigma
-  // values in the area inside `block_rect`. Accesses the AC strategy, quant
-  // field and epf_sharpness fields in the corresponding positions.
-  void ComputeSigma(const Rect& block_rect, PassesDecoderState* state);
 };
 
 // Temp images required for decoding a single group. Reduces memory allocations

--- a/lib/jxl/dec_frame.cc
+++ b/lib/jxl/dec_frame.cc
@@ -77,7 +77,8 @@ Status DecodeGlobalDCInfo(BitReader* reader, bool is_jpeg,
 
 Status DecodeFrame(PassesDecoderState* dec_state, ThreadPool* JXL_RESTRICT pool,
                    const uint8_t* next_in, size_t avail_in,
-                   ImageBundle* decoded, const CodecMetadata& metadata,
+                   FrameHeader* frame_header, ImageBundle* decoded,
+                   const CodecMetadata& metadata,
                    bool use_slow_rendering_pipeline) {
   FrameDecoder frame_decoder(dec_state, metadata, pool,
                              use_slow_rendering_pipeline);
@@ -86,6 +87,9 @@ Status DecodeFrame(PassesDecoderState* dec_state, ThreadPool* JXL_RESTRICT pool,
   JXL_RETURN_IF_ERROR(frame_decoder.InitFrame(&reader, decoded,
                                               /*is_preview=*/false));
   JXL_RETURN_IF_ERROR(frame_decoder.InitFrameOutput());
+  if (frame_header) {
+    *frame_header = frame_decoder.GetFrameHeader();
+  }
 
   JXL_RETURN_IF_ERROR(reader.AllReadsWithinBounds());
   size_t header_bytes = reader.TotalBitsConsumed() / kBitsPerByte;
@@ -177,6 +181,13 @@ Status FrameDecoder::InitFrame(BitReader* JXL_RESTRICT br, ImageBundle* decoded,
     section_sizes_sum_ += toc_[i].size;
   }
 
+  if (JXL_DEBUG_V_LEVEL >= 3) {
+    for (size_t i = 0; i < toc_entries; ++i) {
+      JXL_DEBUG_V(3, "TOC entry %" PRIuS " size %" PRIuS " id %" PRIuS "", i,
+                  toc_[i].size, toc_[i].id);
+    }
+  }
+
   JXL_DASSERT((br->TotalBitsConsumed() % kBitsPerByte) == 0);
   const size_t group_codes_begin = br->TotalBitsConsumed() / kBitsPerByte;
   JXL_DASSERT(!toc_.empty());
@@ -199,7 +210,7 @@ Status FrameDecoder::InitFrame(BitReader* JXL_RESTRICT br, ImageBundle* decoded,
 Status FrameDecoder::InitFrameOutput() {
   JXL_RETURN_IF_ERROR(
       InitializePassesSharedState(frame_header_, &dec_state_->shared_storage));
-  JXL_RETURN_IF_ERROR(dec_state_->Init());
+  JXL_RETURN_IF_ERROR(dec_state_->Init(frame_header_));
   modular_frame_decoder_.Init(frame_dim_);
 
   if (decoded_->IsJPEG()) {
@@ -250,7 +261,7 @@ Status FrameDecoder::InitFrameOutput() {
 
 Status FrameDecoder::ProcessDCGlobal(BitReader* br) {
   PassesSharedState& shared = dec_state_->shared_storage;
-  if (shared.frame_header.flags & FrameHeader::kPatches) {
+  if (frame_header_.flags & FrameHeader::kPatches) {
     bool uses_extra_channels = false;
     JXL_RETURN_IF_ERROR(shared.image_features.patches.Decode(
         br, frame_dim_.xsize_padded, frame_dim_.ysize_padded,
@@ -268,11 +279,11 @@ Status FrameDecoder::ProcessDCGlobal(BitReader* br) {
     shared.image_features.patches.Clear();
   }
   shared.image_features.splines.Clear();
-  if (shared.frame_header.flags & FrameHeader::kSplines) {
+  if (frame_header_.flags & FrameHeader::kSplines) {
     JXL_RETURN_IF_ERROR(shared.image_features.splines.Decode(
         br, frame_dim_.xsize * frame_dim_.ysize));
   }
-  if (shared.frame_header.flags & FrameHeader::kNoise) {
+  if (frame_header_.flags & FrameHeader::kNoise) {
     JXL_RETURN_IF_ERROR(DecodeNoise(br, &shared.image_features.noise_params));
   }
   JXL_RETURN_IF_ERROR(dec_state_->shared_storage.matrices.DecodeDC(br));
@@ -282,7 +293,7 @@ Status FrameDecoder::ProcessDCGlobal(BitReader* br) {
         jxl::DecodeGlobalDCInfo(br, decoded_->IsJPEG(), dec_state_, pool_));
   }
   // Splines' draw cache uses the color correlation map.
-  if (shared.frame_header.flags & FrameHeader::kSplines) {
+  if (frame_header_.flags & FrameHeader::kSplines) {
     JXL_RETURN_IF_ERROR(shared.image_features.splines.InitializeDrawCache(
         frame_dim_.xsize_upsampled, frame_dim_.ysize_upsampled,
         dec_state_->shared->cmap));
@@ -299,21 +310,22 @@ Status FrameDecoder::ProcessDCGlobal(BitReader* br) {
 Status FrameDecoder::ProcessDCGroup(size_t dc_group_id, BitReader* br) {
   const size_t gx = dc_group_id % frame_dim_.xsize_dc_groups;
   const size_t gy = dc_group_id / frame_dim_.xsize_dc_groups;
-  const LoopFilter& lf = dec_state_->shared->frame_header.loop_filter;
+  const LoopFilter& lf = frame_header_.loop_filter;
   if (frame_header_.encoding == FrameEncoding::kVarDCT &&
       !(frame_header_.flags & FrameHeader::kUseDcFrame)) {
-    JXL_RETURN_IF_ERROR(
-        modular_frame_decoder_.DecodeVarDCTDC(dc_group_id, br, dec_state_));
+    JXL_RETURN_IF_ERROR(modular_frame_decoder_.DecodeVarDCTDC(
+        frame_header_, dc_group_id, br, dec_state_));
   }
   const Rect mrect(gx * frame_dim_.dc_group_dim, gy * frame_dim_.dc_group_dim,
                    frame_dim_.dc_group_dim, frame_dim_.dc_group_dim);
   JXL_RETURN_IF_ERROR(modular_frame_decoder_.DecodeGroup(
-      mrect, br, 3, 1000, ModularStreamId::ModularDC(dc_group_id),
+      frame_header_, mrect, br, 3, 1000,
+      ModularStreamId::ModularDC(dc_group_id),
       /*zerofill=*/false, nullptr, nullptr,
       /*allow_truncated=*/false));
   if (frame_header_.encoding == FrameEncoding::kVarDCT) {
-    JXL_RETURN_IF_ERROR(
-        modular_frame_decoder_.DecodeAcMetadata(dc_group_id, br, dec_state_));
+    JXL_RETURN_IF_ERROR(modular_frame_decoder_.DecodeAcMetadata(
+        frame_header_, dc_group_id, br, dec_state_));
   } else if (lf.epf_iters > 0) {
     FillImage(kInvSigmaNum / lf.epf_sigma_for_modular, &dec_state_->sigma);
   }
@@ -337,8 +349,9 @@ void FrameDecoder::FinalizeDC() {
 Status FrameDecoder::AllocateOutput() {
   if (allocated_) return true;
   modular_frame_decoder_.MaybeDropFullImage();
-  decoded_->origin = dec_state_->shared->frame_header.frame_origin;
-  JXL_RETURN_IF_ERROR(dec_state_->InitForAC(nullptr));
+  decoded_->origin = frame_header_.frame_origin;
+  JXL_RETURN_IF_ERROR(
+      dec_state_->InitForAC(frame_header_.passes.num_passes, nullptr));
   allocated_ = true;
   return true;
 }
@@ -358,12 +371,17 @@ Status FrameDecoder::ProcessACGlobal(BitReader* br) {
     dec_state_->shared_storage.num_histograms =
         1 + br->ReadBits(num_histo_bits);
 
+    JXL_DEBUG_V(3,
+                "Processing AC global with %d passes and %" PRIuS
+                " sets of histograms",
+                frame_header_.passes.num_passes,
+                dec_state_->shared_storage.num_histograms);
+
     dec_state_->code.resize(kMaxNumPasses);
     dec_state_->context_map.resize(kMaxNumPasses);
     // Read coefficient orders and histograms.
     size_t max_num_bits_ac = 0;
-    for (size_t i = 0;
-         i < dec_state_->shared_storage.frame_header.passes.num_passes; i++) {
+    for (size_t i = 0; i < frame_header_.passes.num_passes; i++) {
       uint16_t used_orders = U32Coder::Read(kOrderEnc, br);
       JXL_RETURN_IF_ERROR(DecodeCoeffOrders(
           used_orders, dec_state_->used_acs,
@@ -381,8 +399,7 @@ Status FrameDecoder::ProcessACGlobal(BitReader* br) {
       max_num_bits_ac =
           std::max(max_num_bits_ac, dec_state_->code[i].max_num_bits);
     }
-    max_num_bits_ac += CeilLog2Nonzero(
-        dec_state_->shared_storage.frame_header.passes.num_passes);
+    max_num_bits_ac += CeilLog2Nonzero(frame_header_.passes.num_passes);
     // 16-bit buffer for decoding to JPEG are not implemented.
     // TODO(veluca): figure out the exact limit - 16 should still work with
     // 16-bit buffers, but we are excluding it for safety.
@@ -465,9 +482,9 @@ Status FrameDecoder::ProcessACGroup(size_t ac_group_id,
   if (frame_header_.encoding == FrameEncoding::kVarDCT) {
     group_dec_caches_[thread].InitOnce(frame_header_.passes.num_passes,
                                        dec_state_->used_acs);
-    JXL_RETURN_IF_ERROR(DecodeGroup(br, num_passes, ac_group_id, dec_state_,
-                                    &group_dec_caches_[thread], thread,
-                                    render_pipeline_input, decoded_,
+    JXL_RETURN_IF_ERROR(DecodeGroup(frame_header_, br, num_passes, ac_group_id,
+                                    dec_state_, &group_dec_caches_[thread],
+                                    thread, render_pipeline_input, decoded_,
                                     decoded_passes_per_ac_group_[ac_group_id],
                                     force_draw, dc_only, &should_run_pipeline));
   }
@@ -484,13 +501,13 @@ Status FrameDecoder::ProcessACGroup(size_t ac_group_id,
     bool modular_pass_ready = true;
     if (i < pass0 + num_passes) {
       JXL_RETURN_IF_ERROR(modular_frame_decoder_.DecodeGroup(
-          mrect, br[i - pass0], minShift, maxShift,
+          frame_header_, mrect, br[i - pass0], minShift, maxShift,
           ModularStreamId::ModularAC(ac_group_id, i),
           /*zerofill=*/false, dec_state_, &render_pipeline_input,
           /*allow_truncated=*/false, &modular_pass_ready));
     } else {
       JXL_RETURN_IF_ERROR(modular_frame_decoder_.DecodeGroup(
-          mrect, nullptr, minShift, maxShift,
+          frame_header_, mrect, nullptr, minShift, maxShift,
           ModularStreamId::ModularAC(ac_group_id, i), /*zerofill=*/true,
           dec_state_, &render_pipeline_input,
           /*allow_truncated=*/false, &modular_pass_ready));
@@ -646,7 +663,7 @@ Status FrameDecoder::ProcessSections(const SectionInfo* sections, size_t num,
     pipeline_options.render_spotcolors = render_spotcolors_;
     pipeline_options.render_noise = true;
     JXL_RETURN_IF_ERROR(
-        dec_state_->PreparePipeline(decoded_, pipeline_options));
+        dec_state_->PreparePipeline(frame_header_, decoded_, pipeline_options));
     FinalizeDC();
     JXL_RETURN_IF_ERROR(AllocateOutput());
     if (progressive_detail_ >= JxlProgressiveDetail::kDC) {
@@ -775,8 +792,8 @@ Status FrameDecoder::Flush() {
   }
 
   // undo global modular transforms and copy int pixel buffers to float ones
-  JXL_RETURN_IF_ERROR(modular_frame_decoder_.FinalizeDecoding(dec_state_, pool_,
-                                                              is_finalized_));
+  JXL_RETURN_IF_ERROR(modular_frame_decoder_.FinalizeDecoding(
+      frame_header_, dec_state_, pool_, is_finalized_));
 
   return true;
 }
@@ -856,7 +873,7 @@ Status FrameDecoder::FinalizeFrame() {
 
   // undo global modular transforms and copy int pixel buffers to float ones
   JXL_RETURN_IF_ERROR(
-      modular_frame_decoder_.FinalizeDecoding(dec_state_, pool_,
+      modular_frame_decoder_.FinalizeDecoding(frame_header_, dec_state_, pool_,
                                               /*inplace=*/true));
 
   if (frame_header_.CanBeReferenced()) {

--- a/lib/jxl/dec_frame.h
+++ b/lib/jxl/dec_frame.h
@@ -31,7 +31,8 @@ namespace jxl {
 // Used in the encoder to model decoder behaviour, and in tests.
 Status DecodeFrame(PassesDecoderState* dec_state, ThreadPool* JXL_RESTRICT pool,
                    const uint8_t* next_in, size_t avail_in,
-                   ImageBundle* decoded, const CodecMetadata& metadata,
+                   FrameHeader* frame_header, ImageBundle* decoded,
+                   const CodecMetadata& metadata,
                    bool use_slow_rendering_pipeline = false);
 
 // TODO(veluca): implement "forced drawing".

--- a/lib/jxl/dec_group.cc
+++ b/lib/jxl/dec_group.cc
@@ -160,14 +160,16 @@ void DequantBlock(const AcStrategy& acs, float inv_global_scale, int quant,
   }
 }
 
-Status DecodeGroupImpl(GetBlock* JXL_RESTRICT get_block,
+Status DecodeGroupImpl(const FrameHeader& frame_header,
+                       GetBlock* JXL_RESTRICT get_block,
                        GroupDecCache* JXL_RESTRICT group_dec_cache,
                        PassesDecoderState* JXL_RESTRICT dec_state,
                        size_t thread, size_t group_idx,
                        RenderPipelineInput& render_pipeline_input,
                        ImageBundle* decoded, DrawMode draw) {
   // TODO(veluca): investigate cache usage in this function.
-  const Rect block_rect = dec_state->shared->BlockGroupRect(group_idx);
+  const Rect block_rect =
+      dec_state->shared->frame_dim.BlockGroupRect(group_idx);
   const AcStrategyImage& ac_strategy = dec_state->shared->ac_strategy;
 
   const size_t xsize_blocks = block_rect.xsize();
@@ -177,8 +179,7 @@ Status DecodeGroupImpl(GetBlock* JXL_RESTRICT get_block,
 
   const float inv_global_scale = dec_state->shared->quantizer.InvGlobalScale();
 
-  const YCbCrChromaSubsampling& cs =
-      dec_state->shared->frame_header.chroma_subsampling;
+  const YCbCrChromaSubsampling& cs = frame_header.chroma_subsampling;
 
   size_t idct_stride[3];
   for (size_t c = 0; c < 3; c++) {
@@ -206,8 +207,7 @@ Status DecodeGroupImpl(GetBlock* JXL_RESTRICT get_block,
       return JXL_FAILURE("The CfL map is not JPEG-compatible");
     }
     jpeg_is_gray = (decoded->jpeg_data->components.size() == 1);
-    jpeg_c_map = JpegOrder(dec_state->shared->frame_header.color_transform,
-                           jpeg_is_gray);
+    jpeg_c_map = JpegOrder(frame_header.color_transform, jpeg_is_gray);
     const std::vector<QuantEncoding>& qe =
         dec_state->shared->matrices.encodings();
     if (qe.empty() || qe[0].mode != QuantEncoding::Mode::kQuantModeRAW ||
@@ -216,8 +216,7 @@ Status DecodeGroupImpl(GetBlock* JXL_RESTRICT get_block,
           "Quantization table is not a JPEG quantization table.");
     }
     for (size_t c = 0; c < 3; c++) {
-      if (dec_state->shared->frame_header.color_transform ==
-          ColorTransform::kNone) {
+      if (frame_header.color_transform == ColorTransform::kNone) {
         dcoff[c] = 1024 / (*qe[0].qraw.qtable)[64 * c];
       }
       for (size_t i = 0; i < 64; i++) {
@@ -462,7 +461,9 @@ Status DecodeACVarBlock(size_t ctx_offset, size_t log2_covered_blocks,
   size_t nzeros =
       decoder->ReadHybridUintInlined<uses_lz77>(nzero_ctx, br, context_map);
   if (nzeros + covered_blocks > size) {
-    return JXL_FAILURE("Invalid AC: nzeros too large");
+    return JXL_FAILURE("Invalid AC: nzeros %" PRIuS " too large for %" PRIuS
+                       " 8x8 blocks",
+                       nzeros, covered_blocks);
   }
   for (size_t y = 0; y < acs.covered_blocks_y(); y++) {
     for (size_t x = 0; x < acs.covered_blocks_x(); x++) {
@@ -496,9 +497,10 @@ Status DecodeACVarBlock(size_t ctx_offset, size_t log2_covered_blocks,
     nzeros -= prev;
   }
   if (JXL_UNLIKELY(nzeros != 0)) {
-    return JXL_FAILURE("Invalid AC: nzeros not 0. Block (%" PRIuS ", %" PRIuS
+    return JXL_FAILURE("Invalid AC: nzeros at end of block is %" PRIuS
+                       ", should be 0. Block (%" PRIuS ", %" PRIuS
                        "), channel %" PRIuS,
-                       bx, by, c);
+                       nzeros, bx, by, c);
   }
 
   return true;
@@ -554,13 +556,14 @@ struct GetBlockFromBitstream : public GetBlock {
     return true;
   }
 
-  Status Init(BitReader* JXL_RESTRICT* JXL_RESTRICT readers, size_t num_passes,
+  Status Init(const FrameHeader& frame_header,
+              BitReader* JXL_RESTRICT* JXL_RESTRICT readers, size_t num_passes,
               size_t group_idx, size_t histo_selector_bits, const Rect& rect,
               GroupDecCache* JXL_RESTRICT group_dec_cache,
               PassesDecoderState* dec_state, size_t first_pass) {
     for (size_t i = 0; i < 3; i++) {
-      hshift[i] = dec_state->shared->frame_header.chroma_subsampling.HShift(i);
-      vshift[i] = dec_state->shared->frame_header.chroma_subsampling.VShift(i);
+      hshift[i] = frame_header.chroma_subsampling.HShift(i);
+      vshift[i] = frame_header.chroma_subsampling.VShift(i);
     }
     this->coeff_order_size = dec_state->shared->coeff_order_size;
     this->coeff_orders =
@@ -568,8 +571,7 @@ struct GetBlockFromBitstream : public GetBlock {
     this->context_map = dec_state->context_map.data() + first_pass;
     this->readers = readers;
     this->num_passes = num_passes;
-    this->shift_for_pass =
-        dec_state->shared->frame_header.passes.shift + first_pass;
+    this->shift_for_pass = frame_header.passes.shift + first_pass;
     this->group_dec_cache = group_dec_cache;
     this->rect = rect;
     block_ctx_map = &dec_state->shared->block_ctx_map;
@@ -663,18 +665,18 @@ HWY_EXPORT(DecodeGroupImpl);
 
 }  // namespace
 
-Status DecodeGroup(BitReader* JXL_RESTRICT* JXL_RESTRICT readers,
+Status DecodeGroup(const FrameHeader& frame_header,
+                   BitReader* JXL_RESTRICT* JXL_RESTRICT readers,
                    size_t num_passes, size_t group_idx,
                    PassesDecoderState* JXL_RESTRICT dec_state,
                    GroupDecCache* JXL_RESTRICT group_dec_cache, size_t thread,
                    RenderPipelineInput& render_pipeline_input,
                    ImageBundle* JXL_RESTRICT decoded, size_t first_pass,
                    bool force_draw, bool dc_only, bool* should_run_pipeline) {
-  DrawMode draw = (num_passes + first_pass ==
-                   dec_state->shared->frame_header.passes.num_passes) ||
-                          force_draw
-                      ? kDraw
-                      : kDontDraw;
+  DrawMode draw =
+      (num_passes + first_pass == frame_header.passes.num_passes) || force_draw
+          ? kDraw
+          : kDontDraw;
 
   if (should_run_pipeline) {
     *should_run_pipeline = draw != kDontDraw;
@@ -682,13 +684,13 @@ Status DecodeGroup(BitReader* JXL_RESTRICT* JXL_RESTRICT readers,
 
   if (draw == kDraw && num_passes == 0 && first_pass == 0) {
     group_dec_cache->InitDCBufferOnce();
-    const YCbCrChromaSubsampling& cs =
-        dec_state->shared->frame_header.chroma_subsampling;
+    const YCbCrChromaSubsampling& cs = frame_header.chroma_subsampling;
     for (size_t c : {0, 1, 2}) {
       size_t hs = cs.HShift(c);
       size_t vs = cs.VShift(c);
       // We reuse filter_input_storage here as it is not currently in use.
-      const Rect src_rect_precs = dec_state->shared->BlockGroupRect(group_idx);
+      const Rect src_rect_precs =
+          dec_state->shared->frame_dim.BlockGroupRect(group_idx);
       const Rect src_rect =
           Rect(src_rect_precs.x0() >> hs, src_rect_precs.y0() >> vs,
                src_rect_precs.xsize() >> hs, src_rect_precs.ysize() >> vs);
@@ -751,14 +753,14 @@ Status DecodeGroup(BitReader* JXL_RESTRICT* JXL_RESTRICT readers,
   }
 
   auto get_block = jxl::make_unique<GetBlockFromBitstream>();
-  JXL_RETURN_IF_ERROR(
-      get_block->Init(readers, num_passes, group_idx, histo_selector_bits,
-                      dec_state->shared->BlockGroupRect(group_idx),
-                      group_dec_cache, dec_state, first_pass));
+  JXL_RETURN_IF_ERROR(get_block->Init(
+      frame_header, readers, num_passes, group_idx, histo_selector_bits,
+      dec_state->shared->frame_dim.BlockGroupRect(group_idx), group_dec_cache,
+      dec_state, first_pass));
 
   JXL_RETURN_IF_ERROR(HWY_DYNAMIC_DISPATCH(DecodeGroupImpl)(
-      get_block.get(), group_dec_cache, dec_state, thread, group_idx,
-      render_pipeline_input, decoded, draw));
+      frame_header, get_block.get(), group_dec_cache, dec_state, thread,
+      group_idx, render_pipeline_input, decoded, draw));
 
   for (size_t pass = 0; pass < num_passes; pass++) {
     if (!get_block->decoders[pass].CheckANSFinalState()) {
@@ -768,7 +770,8 @@ Status DecodeGroup(BitReader* JXL_RESTRICT* JXL_RESTRICT readers,
   return true;
 }
 
-Status DecodeGroupForRoundtrip(const std::vector<std::unique_ptr<ACImage>>& ac,
+Status DecodeGroupForRoundtrip(const FrameHeader& frame_header,
+                               const std::vector<std::unique_ptr<ACImage>>& ac,
                                size_t group_idx,
                                PassesDecoderState* JXL_RESTRICT dec_state,
                                GroupDecCache* JXL_RESTRICT group_dec_cache,
@@ -776,14 +779,13 @@ Status DecodeGroupForRoundtrip(const std::vector<std::unique_ptr<ACImage>>& ac,
                                RenderPipelineInput& render_pipeline_input,
                                ImageBundle* JXL_RESTRICT decoded,
                                AuxOut* aux_out) {
-  GetBlockFromEncoder get_block(ac, group_idx,
-                                dec_state->shared->frame_header.passes.shift);
+  GetBlockFromEncoder get_block(ac, group_idx, frame_header.passes.shift);
   group_dec_cache->InitOnce(
       /*num_passes=*/0,
       /*used_acs=*/(1u << AcStrategy::kNumValidStrategies) - 1);
 
   return HWY_DYNAMIC_DISPATCH(DecodeGroupImpl)(
-      &get_block, group_dec_cache, dec_state, thread, group_idx,
+      frame_header, &get_block, group_dec_cache, dec_state, thread, group_idx,
       render_pipeline_input, decoded, kDraw);
 }
 

--- a/lib/jxl/dec_group.h
+++ b/lib/jxl/dec_group.h
@@ -22,7 +22,8 @@ namespace jxl {
 
 struct AuxOut;
 
-Status DecodeGroup(BitReader* JXL_RESTRICT* JXL_RESTRICT readers,
+Status DecodeGroup(const FrameHeader& frame_header,
+                   BitReader* JXL_RESTRICT* JXL_RESTRICT readers,
                    size_t num_passes, size_t group_idx,
                    PassesDecoderState* JXL_RESTRICT dec_state,
                    GroupDecCache* JXL_RESTRICT group_dec_cache, size_t thread,
@@ -30,7 +31,8 @@ Status DecodeGroup(BitReader* JXL_RESTRICT* JXL_RESTRICT readers,
                    ImageBundle* JXL_RESTRICT decoded, size_t first_pass,
                    bool force_draw, bool dc_only, bool* should_run_pipeline);
 
-Status DecodeGroupForRoundtrip(const std::vector<std::unique_ptr<ACImage>>& ac,
+Status DecodeGroupForRoundtrip(const FrameHeader& frame_header,
+                               const std::vector<std::unique_ptr<ACImage>>& ac,
                                size_t group_idx,
                                PassesDecoderState* JXL_RESTRICT dec_state,
                                GroupDecCache* JXL_RESTRICT group_dec_cache,

--- a/lib/jxl/dec_modular.h
+++ b/lib/jxl/dec_modular.h
@@ -89,17 +89,18 @@ class ModularFrameDecoder {
   void Init(const FrameDimensions& frame_dim) { this->frame_dim = frame_dim; }
   Status DecodeGlobalInfo(BitReader* reader, const FrameHeader& frame_header,
                           bool allow_truncated_group);
-  Status DecodeGroup(const Rect& rect, BitReader* reader, int minShift,
-                     int maxShift, const ModularStreamId& stream, bool zerofill,
+  Status DecodeGroup(const FrameHeader& frame_header, const Rect& rect,
+                     BitReader* reader, int minShift, int maxShift,
+                     const ModularStreamId& stream, bool zerofill,
                      PassesDecoderState* dec_state,
                      RenderPipelineInput* render_pipeline_input,
                      bool allow_truncated, bool* should_run_pipeline = nullptr);
   // Decodes a VarDCT DC group (`group_id`) from the given `reader`.
-  Status DecodeVarDCTDC(size_t group_id, BitReader* reader,
-                        PassesDecoderState* dec_state);
+  Status DecodeVarDCTDC(const FrameHeader& frame_header, size_t group_id,
+                        BitReader* reader, PassesDecoderState* dec_state);
   // Decodes a VarDCT AC Metadata group (`group_id`) from the given `reader`.
-  Status DecodeAcMetadata(size_t group_id, BitReader* reader,
-                          PassesDecoderState* dec_state);
+  Status DecodeAcMetadata(const FrameHeader& frame_header, size_t group_id,
+                          BitReader* reader, PassesDecoderState* dec_state);
   // Decodes a RAW quant table from `br` into the given `encoding`, of size
   // `required_size_x x required_size_y`. If `modular_frame_decoder` is passed,
   // its global tree is used, otherwise no global tree is used.
@@ -110,14 +111,16 @@ class ModularFrameDecoder {
   // if inplace is true, this can only be called once
   // if it is false, it can be called multiple times (e.g. for progressive
   // steps)
-  Status FinalizeDecoding(PassesDecoderState* dec_state, jxl::ThreadPool* pool,
+  Status FinalizeDecoding(const FrameHeader& frame_header,
+                          PassesDecoderState* dec_state, jxl::ThreadPool* pool,
                           bool inplace);
   bool have_dc() const { return have_something; }
   void MaybeDropFullImage();
   bool UsesFullImage() const { return use_full_image; }
 
  private:
-  Status ModularImageToDecodedRect(Image& gi, PassesDecoderState* dec_state,
+  Status ModularImageToDecodedRect(const FrameHeader& frame_header, Image& gi,
+                                   PassesDecoderState* dec_state,
                                    jxl::ThreadPool* pool,
                                    RenderPipelineInput& render_pipeline_input,
                                    Rect modular_rect);

--- a/lib/jxl/enc_adaptive_quantization.h
+++ b/lib/jxl/enc_adaptive_quantization.h
@@ -50,8 +50,8 @@ void AdjustQuantField(const AcStrategyImage& ac_strategy, const Rect& rect,
 // quant_field. Also computes the dequant_map corresponding to the given
 // dequant_float_map and chosen quantization levels.
 // `linear` is only used in Kitten mode or slower.
-void FindBestQuantizer(const Image3F* linear, const Image3F& opsin,
-                       PassesEncoderState* enc_state,
+void FindBestQuantizer(const FrameHeader& frame_header, const Image3F* linear,
+                       const Image3F& opsin, PassesEncoderState* enc_state,
                        const JxlCmsInterface& cms, ThreadPool* pool,
                        AuxOut* aux_out, double rescale = 1.0);
 

--- a/lib/jxl/enc_ar_control_field.cc
+++ b/lib/jxl/enc_ar_control_field.cc
@@ -40,8 +40,8 @@ using hwy::HWY_NAMESPACE::Mul;
 using hwy::HWY_NAMESPACE::MulAdd;
 using hwy::HWY_NAMESPACE::Sqrt;
 
-void ProcessTile(const Image3F& opsin, PassesEncoderState* enc_state,
-                 const Rect& rect,
+void ProcessTile(const FrameHeader& frame_header, const Image3F& opsin,
+                 PassesEncoderState* enc_state, const Rect& rect,
                  ArControlFieldHeuristics::TempImages* temp_image) {
   constexpr size_t N = kBlockDim;
   ImageB* JXL_RESTRICT epf_sharpness = &enc_state->shared.epf_sharpness;
@@ -52,7 +52,7 @@ void ProcessTile(const Image3F& opsin, PassesEncoderState* enc_state,
 
   if (enc_state->cparams.butteraugli_distance < kMinButteraugliForDynamicAR ||
       enc_state->cparams.speed_tier > SpeedTier::kWombat ||
-      enc_state->shared.frame_header.loop_filter.epf_iters == 0) {
+      frame_header.loop_filter.epf_iters == 0) {
     FillPlane(static_cast<uint8_t>(4), epf_sharpness, rect);
     return;
   }
@@ -311,12 +311,13 @@ HWY_AFTER_NAMESPACE();
 namespace jxl {
 HWY_EXPORT(ProcessTile);
 
-void ArControlFieldHeuristics::RunRect(const Rect& block_rect,
+void ArControlFieldHeuristics::RunRect(const FrameHeader& frame_header,
+                                       const Rect& block_rect,
                                        const Image3F& opsin,
                                        PassesEncoderState* enc_state,
                                        size_t thread) {
   HWY_DYNAMIC_DISPATCH(ProcessTile)
-  (opsin, enc_state, block_rect, &temp_images[thread]);
+  (frame_header, opsin, enc_state, block_rect, &temp_images[thread]);
 }
 
 }  // namespace jxl

--- a/lib/jxl/enc_ar_control_field.h
+++ b/lib/jxl/enc_ar_control_field.h
@@ -35,8 +35,9 @@ struct ArControlFieldHeuristics {
     temp_images.resize(num_threads);
   }
 
-  void RunRect(const Rect& block_rect, const Image3F& opsin,
-               PassesEncoderState* enc_state, size_t thread);
+  void RunRect(const FrameHeader& frame_header, const Rect& block_rect,
+               const Image3F& opsin, PassesEncoderState* enc_state,
+               size_t thread);
 
   std::vector<TempImages> temp_images;
   ImageB* epf_sharpness;

--- a/lib/jxl/enc_cache.h
+++ b/lib/jxl/enc_cache.h
@@ -68,7 +68,8 @@ struct PassesEncoderState {
 
 // Initialize per-frame information.
 class ModularFrameEncoder;
-Status InitializePassesEncoder(const Image3F& opsin, const JxlCmsInterface& cms,
+Status InitializePassesEncoder(const FrameHeader& frame_header,
+                               const Image3F& opsin, const JxlCmsInterface& cms,
                                ThreadPool* pool,
                                PassesEncoderState* passes_enc_state,
                                ModularFrameEncoder* modular_frame_encoder,

--- a/lib/jxl/enc_heuristics.h
+++ b/lib/jxl/enc_heuristics.h
@@ -32,7 +32,8 @@ class ModularFrameEncoder;
 // `opsin` image by applying Gaborish, and doing other modifications if
 // necessary. `pool` is used for running the computations on multiple threads.
 // `aux_out` collects statistics and can be used to print debug images.
-Status LossyFrameHeuristics(PassesEncoderState* enc_state,
+Status LossyFrameHeuristics(const FrameHeader& frame_header,
+                            PassesEncoderState* enc_state,
                             ModularFrameEncoder* modular_frame_encoder,
                             const Image3F* original_pixels, Image3F* opsin,
                             const JxlCmsInterface& cms, ThreadPool* pool,

--- a/lib/jxl/enc_modular.h
+++ b/lib/jxl/enc_modular.h
@@ -42,7 +42,8 @@ class ModularFrameEncoder {
   // input DC image, not quantized; the group is specified by `group_index`, and
   // `nl_dc` decides whether to apply a near-lossless processing to the DC or
   // not.
-  void AddVarDCTDC(const Image3F& dc, size_t group_index, bool nl_dc,
+  void AddVarDCTDC(const FrameHeader& frame_header, const Image3F& dc,
+                   size_t group_index, bool nl_dc,
                    PassesEncoderState* enc_state, bool jpeg_transcode);
   // Creates a modular image for the AC metadata of the given group
   // (`group_index`).

--- a/lib/jxl/enc_patch_dictionary.cc
+++ b/lib/jxl/enc_patch_dictionary.cc
@@ -793,7 +793,8 @@ void RoundtripPatchFrame(Image3F* reference_frame,
         *state->shared.metadata));
     const uint8_t* frame_start = encoded.data();
     size_t encoded_size = encoded.size();
-    JXL_CHECK(DecodeFrame(&dec_state, pool, frame_start, encoded_size, &decoded,
+    JXL_CHECK(DecodeFrame(&dec_state, pool, frame_start, encoded_size,
+                          /*frame_header=*/nullptr, &decoded,
                           *state->shared.metadata));
     frame_start += decoded.decoded_bytes();
     encoded_size -= decoded.decoded_bytes();
@@ -802,7 +803,8 @@ void RoundtripPatchFrame(Image3F* reference_frame,
     // if the frame itself uses patches, we need to decode another frame
     if (!ref_xsize) {
       JXL_CHECK(DecodeFrame(&dec_state, pool, frame_start, encoded_size,
-                            &decoded, *state->shared.metadata));
+                            /*frame_header=*/nullptr, &decoded,
+                            *state->shared.metadata));
     }
     JXL_CHECK(encoded_size == 0);
     state->shared.reference_frames[idx] =

--- a/lib/jxl/epf.cc
+++ b/lib/jxl/epf.cc
@@ -46,8 +46,8 @@ JXL_INLINE void RightMirror(float* p, size_t n) {
   }
 }
 
-void ComputeSigma(const Rect& block_rect, PassesDecoderState* state) {
-  const LoopFilter& lf = state->shared->frame_header.loop_filter;
+void ComputeSigma(const LoopFilter& lf, const Rect& block_rect,
+                  PassesDecoderState* state) {
   JXL_CHECK(lf.epf_iters > 0);
   const AcStrategyImage& ac_strategy = state->shared->ac_strategy;
   const float quant_scale = state->shared->quantizer.Scale();

--- a/lib/jxl/epf.h
+++ b/lib/jxl/epf.h
@@ -26,7 +26,8 @@ constexpr float kMinSigma = -3.90524291751269967465540850526868f;
 // Fills the `state->filter_weights.sigma` image with the precomputed sigma
 // values in the area inside `block_rect`. Accesses the AC strategy, quant field
 // and epf_sharpness fields in the corresponding positions.
-void ComputeSigma(const Rect& block_rect, PassesDecoderState* state);
+void ComputeSigma(const LoopFilter& lf, const Rect& block_rect,
+                  PassesDecoderState* state);
 
 }  // namespace jxl
 

--- a/lib/jxl/frame_dimensions.h
+++ b/lib/jxl/frame_dimensions.h
@@ -67,6 +67,22 @@ struct FrameDimensions {
     return rect;
   }
 
+  Rect BlockGroupRect(size_t group_index) const {
+    const size_t gx = group_index % xsize_groups;
+    const size_t gy = group_index / xsize_groups;
+    const Rect rect(gx * (group_dim >> 3), gy * (group_dim >> 3),
+                    group_dim >> 3, group_dim >> 3, xsize_blocks, ysize_blocks);
+    return rect;
+  }
+
+  Rect DCGroupRect(size_t group_index) const {
+    const size_t gx = group_index % xsize_dc_groups;
+    const size_t gy = group_index / xsize_dc_groups;
+    const Rect rect(gx * group_dim, gy * group_dim, group_dim, group_dim,
+                    xsize_blocks, ysize_blocks);
+    return rect;
+  }
+
   // Image size without any upsampling, i.e. original_size / upsampling.
   size_t xsize;
   size_t ysize;

--- a/lib/jxl/passes_state.cc
+++ b/lib/jxl/passes_state.cc
@@ -15,7 +15,6 @@ Status InitializePassesSharedState(const FrameHeader& frame_header,
                                    PassesSharedState* JXL_RESTRICT shared,
                                    bool encoder) {
   JXL_ASSERT(frame_header.nonserialized_metadata != nullptr);
-  shared->frame_header = frame_header;
   shared->metadata = frame_header.nonserialized_metadata;
   shared->frame_dim = frame_header.ToFrameDimensions();
   shared->image_features.patches.SetPassesSharedState(shared);

--- a/lib/jxl/passes_state.h
+++ b/lib/jxl/passes_state.h
@@ -33,11 +33,8 @@ struct ImageFeatures {
 // State common to both encoder and decoder.
 // NOLINTNEXTLINE(clang-analyzer-optin.performance.Padding)
 struct PassesSharedState {
-  PassesSharedState() : frame_header(nullptr) {}
-
   // Headers and metadata.
   const CodecMetadata* metadata;
-  FrameHeader frame_header;
 
   FrameDimensions frame_dim;
 

--- a/lib/jxl/render_pipeline/stage_blending.h
+++ b/lib/jxl/render_pipeline/stage_blending.h
@@ -16,7 +16,7 @@ namespace jxl {
 
 // Applies blending if applicable.
 std::unique_ptr<RenderPipelineStage> GetBlendingStage(
-    const PassesDecoderState* dec_state,
+    const FrameHeader& frame_header, const PassesDecoderState* dec_state,
     const ColorEncoding& frame_color_encoding);
 
 }  // namespace jxl


### PR DESCRIPTION
Instead of having two copies of the frame header in both the encoder and the decoder, we now have only one copy and pass the frame header as argument to the processing functions that need them.
