### PR TITLE
Implement streaming encoder mode with constant memory usage.

### DIFF
--- a/lib/jxl/ans_test.cc
+++ b/lib/jxl/ans_test.cc
@@ -39,7 +39,7 @@ void RoundtripTestcase(int n_histograms, int alphabet_size,
 
   BuildAndEncodeHistograms(HistogramParams(), n_histograms, input_values_vec,
                            &codes, &context_map, &writer, 0, nullptr);
-  WriteTokens(input_values_vec[0], codes, context_map, &writer, 0, nullptr);
+  WriteTokens(input_values_vec[0], codes, context_map, 0, &writer, 0, nullptr);
 
   // Magic bytes + padding
   BitWriter::Allotment allotment_magic2(&writer, 24);
@@ -211,7 +211,8 @@ void TestCheckpointing(bool ans, bool lz77) {
     auto input_values_copy = input_values;
     BuildAndEncodeHistograms(params, 1, input_values_copy, &codes, &context_map,
                              &writer, 0, nullptr);
-    WriteTokens(input_values_copy[0], codes, context_map, &writer, 0, nullptr);
+    WriteTokens(input_values_copy[0], codes, context_map, 0, &writer, 0,
+                nullptr);
     writer.ZeroPadToByte();
   }
 

--- a/lib/jxl/dec_ans.cc
+++ b/lib/jxl/dec_ans.cc
@@ -341,6 +341,9 @@ Status DecodeHistograms(BitReader* br, size_t num_contexts, ANSCode* code,
   if (num_contexts > 1) {
     JXL_RETURN_IF_ERROR(DecodeContextMap(context_map, &num_histograms, br));
   }
+  JXL_DEBUG_V(
+      4, "Decoded context map of size %" PRIuS " and %" PRIuS " histograms",
+      num_contexts, num_histograms);
   code->lz77.nonserialized_distance_context = context_map->back();
   code->use_prefix_code = br->ReadFixedBits<1>();
   if (code->use_prefix_code) {
@@ -354,17 +357,6 @@ Status DecodeHistograms(BitReader* br, size_t num_contexts, ANSCode* code,
   const size_t max_alphabet_size = 1 << code->log_alpha_size;
   JXL_RETURN_IF_ERROR(
       DecodeANSCodes(num_histograms, max_alphabet_size, br, code));
-  // When using LZ77, flat codes might result in valid codestreams with
-  // histograms that potentially allow very large bit counts.
-  // TODO(veluca): in principle, a valid codestream might contain a histogram
-  // that could allow very large numbers of bits that is never used during ANS
-  // decoding. There's no benefit to doing that, though.
-  if (!code->lz77.enabled && code->max_num_bits > 32) {
-    // Just emit a warning as there are many opportunities for false positives.
-    JXL_WARNING("Histogram can represent numbers that are too large: %" PRIuS
-                "\n",
-                code->max_num_bits);
-  }
   return true;
 }
 

--- a/lib/jxl/enc_ans.cc
+++ b/lib/jxl/enc_ans.cc
@@ -473,14 +473,6 @@ size_t BuildAndStoreANSEncodingData(
     return cost;
   }
   JXL_ASSERT(alphabet_size <= ANS_TAB_SIZE);
-  // Ensure we ignore trailing zeros in the histogram.
-  if (alphabet_size != 0) {
-    size_t largest_symbol = 0;
-    for (size_t i = 0; i < alphabet_size; i++) {
-      if (histogram[i] != 0) largest_symbol = i;
-    }
-    alphabet_size = largest_symbol + 1;
-  }
   float cost;
   uint32_t method = ComputeBestMethod(histogram, alphabet_size, &cost,
                                       ans_histogram_strategy);
@@ -497,28 +489,26 @@ size_t BuildAndStoreANSEncodingData(
       counts[0] = ANS_TAB_SIZE;
     }
   }
-  if (method == 0) {
-    counts = CreateFlatHistogram(alphabet_size, ANS_TAB_SIZE);
-    AliasTable::Entry a[ANS_MAX_ALPHABET_SIZE];
-    InitAliasTable(counts, ANS_TAB_SIZE, log_alpha_size, a);
-    ANSBuildInfoTable(counts.data(), a, alphabet_size, log_alpha_size, info);
-    if (writer != nullptr) {
-      EncodeFlatHistogram(alphabet_size, writer);
-    }
-    return cost;
-  }
   int omit_pos = 0;
   uint32_t shift = method - 1;
-  JXL_CHECK(NormalizeCounts(counts.data(), &omit_pos, alphabet_size,
-                            ANS_LOG_TAB_SIZE, shift, &num_symbols, symbols));
+  if (method == 0) {
+    counts = CreateFlatHistogram(alphabet_size, ANS_TAB_SIZE);
+  } else {
+    JXL_CHECK(NormalizeCounts(counts.data(), &omit_pos, alphabet_size,
+                              ANS_LOG_TAB_SIZE, shift, &num_symbols, symbols));
+  }
   AliasTable::Entry a[ANS_MAX_ALPHABET_SIZE];
   InitAliasTable(counts, ANS_TAB_SIZE, log_alpha_size, a);
   ANSBuildInfoTable(counts.data(), a, alphabet_size, log_alpha_size, info);
   if (writer != nullptr) {
-    bool ok = EncodeCounts(counts.data(), alphabet_size, omit_pos, num_symbols,
-                           shift, symbols, writer);
-    (void)ok;
-    JXL_DASSERT(ok);
+    if (method == 0) {
+      EncodeFlatHistogram(alphabet_size, writer);
+    } else {
+      bool ok = EncodeCounts(counts.data(), alphabet_size, omit_pos,
+                             num_symbols, method - 1, symbols, writer);
+      (void)ok;
+      JXL_DASSERT(ok);
+    }
   }
   return cost;
 }
@@ -563,8 +553,10 @@ void ChooseUintConfigs(const HistogramParams& params,
                        std::vector<Histogram>* clustered_histograms,
                        EntropyEncodingData* codes, size_t* log_alpha_size) {
   codes->uint_config.resize(clustered_histograms->size());
-
-  if (params.uint_method == HistogramParams::HybridUintMethod::kNone) return;
+  if (params.streaming_mode ||
+      params.uint_method == HistogramParams::HybridUintMethod::kNone) {
+    return;
+  }
   if (params.uint_method == HistogramParams::HybridUintMethod::k000) {
     codes->uint_config.clear();
     codes->uint_config.resize(clustered_histograms->size(),
@@ -685,6 +677,23 @@ void ChooseUintConfigs(const HistogramParams& params,
 #endif
 }
 
+Histogram HistogramFromSymbolInfo(
+    const std::vector<ANSEncSymbolInfo>& encoding_info, bool use_prefix_code) {
+  Histogram histo;
+  histo.data_.resize(DivCeil(encoding_info.size(), Histogram::kRounding) *
+                     Histogram::kRounding);
+  histo.total_count_ = 0;
+  for (size_t i = 0; i < encoding_info.size(); ++i) {
+    const ANSEncSymbolInfo& info = encoding_info[i];
+    int count = use_prefix_code
+                    ? (info.depth ? (1u << (PREFIX_MAX_BITS - info.depth)) : 0)
+                    : info.freq_;
+    histo.data_[i] = count;
+    histo.total_count_ += count;
+  }
+  return histo;
+}
+
 class HistogramBuilder {
  public:
   explicit HistogramBuilder(const size_t num_contexts)
@@ -699,21 +708,28 @@ class HistogramBuilder {
   size_t BuildAndStoreEntropyCodes(
       const HistogramParams& params,
       const std::vector<std::vector<Token>>& tokens, EntropyEncodingData* codes,
-      std::vector<uint8_t>* context_map, bool use_prefix_code,
-      BitWriter* writer, size_t layer, AuxOut* aux_out) const {
+      std::vector<uint8_t>* context_map, BitWriter* writer, size_t layer,
+      AuxOut* aux_out) const {
+    const size_t prev_histograms = codes->encoding_info.size();
     size_t cost = 0;
-    codes->encoding_info.clear();
-    std::vector<Histogram> clustered_histograms(histograms_);
-    context_map->resize(histograms_.size());
+    std::vector<Histogram> clustered_histograms;
+    for (size_t i = 0; i < prev_histograms; ++i) {
+      clustered_histograms.push_back(HistogramFromSymbolInfo(
+          codes->encoding_info[i], codes->use_prefix_code));
+    }
+    size_t context_offset = context_map->size();
+    context_map->resize(context_offset + histograms_.size());
     if (histograms_.size() > 1) {
       if (!ans_fuzzer_friendly_) {
         std::vector<uint32_t> histogram_symbols;
         ClusterHistograms(params, histograms_, kClustersLimit,
                           &clustered_histograms, &histogram_symbols);
         for (size_t c = 0; c < histograms_.size(); ++c) {
-          (*context_map)[c] = static_cast<uint8_t>(histogram_symbols[c]);
+          (*context_map)[context_offset + c] =
+              static_cast<uint8_t>(histogram_symbols[c]);
         }
       } else {
+        JXL_ASSERT(codes->encoding_info.empty());
         fill(context_map->begin(), context_map->end(), 0);
         size_t max_symbol = 0;
         for (const Histogram& h : histograms_) {
@@ -730,14 +746,16 @@ class HistogramBuilder {
         EncodeContextMap(*context_map, clustered_histograms.size(), writer,
                          layer, aux_out);
       }
+    } else {
+      JXL_ASSERT(codes->encoding_info.empty());
+      clustered_histograms.push_back(histograms_[0]);
     }
     if (aux_out != nullptr) {
-      for (size_t i = 0; i < clustered_histograms.size(); ++i) {
+      for (size_t i = prev_histograms; i < clustered_histograms.size(); ++i) {
         aux_out->layers[layer].clustered_entropy +=
             clustered_histograms[i].ShannonEntropy();
       }
     }
-    codes->use_prefix_code = use_prefix_code;
     size_t log_alpha_size = codes->lz77.enabled ? 8 : 7;  // Sane default.
     if (ans_fuzzer_friendly_) {
       codes->uint_config.clear();
@@ -747,11 +765,15 @@ class HistogramBuilder {
                         codes, &log_alpha_size);
     }
     if (log_alpha_size < 5) log_alpha_size = 5;
+    if (params.streaming_mode) {
+      // TODO(szabadka) Figure out if we can use lower values here.
+      log_alpha_size = 8;
+    }
     SizeWriter size_writer;  // Used if writer == nullptr to estimate costs.
     cost += 1;
-    if (writer) writer->Write(1, use_prefix_code);
+    if (writer) writer->Write(1, codes->use_prefix_code);
 
-    if (use_prefix_code) {
+    if (codes->use_prefix_code) {
       log_alpha_size = PREFIX_MAX_BITS;
     } else {
       cost += 2;
@@ -759,38 +781,39 @@ class HistogramBuilder {
     if (writer == nullptr) {
       EncodeUintConfigs(codes->uint_config, &size_writer, log_alpha_size);
     } else {
-      if (!use_prefix_code) writer->Write(2, log_alpha_size - 5);
+      if (!codes->use_prefix_code) writer->Write(2, log_alpha_size - 5);
       EncodeUintConfigs(codes->uint_config, writer, log_alpha_size);
     }
-    if (use_prefix_code) {
+    if (codes->use_prefix_code) {
       for (size_t c = 0; c < clustered_histograms.size(); ++c) {
-        size_t num_symbol = 1;
-        for (size_t i = 0; i < clustered_histograms[c].data_.size(); i++) {
-          if (clustered_histograms[c].data_[i]) num_symbol = i + 1;
-        }
+        size_t alphabet_size = clustered_histograms[c].alphabet_size();
         if (writer) {
-          StoreVarLenUint16(num_symbol - 1, writer);
+          StoreVarLenUint16(alphabet_size - 1, writer);
         } else {
-          StoreVarLenUint16(num_symbol - 1, &size_writer);
+          StoreVarLenUint16(alphabet_size - 1, &size_writer);
         }
       }
     }
     cost += size_writer.size;
-    for (size_t c = 0; c < clustered_histograms.size(); ++c) {
-      size_t num_symbol = 1;
-      for (size_t i = 0; i < clustered_histograms[c].data_.size(); i++) {
-        if (clustered_histograms[c].data_[i]) num_symbol = i + 1;
-      }
+    for (size_t c = prev_histograms; c < clustered_histograms.size(); ++c) {
+      size_t alphabet_size = clustered_histograms[c].alphabet_size();
       codes->encoding_info.emplace_back();
-      codes->encoding_info.back().resize(std::max<size_t>(1, num_symbol));
-
-      BitWriter::Allotment allotment(writer, 256 + num_symbol * 24);
+      codes->encoding_info.back().resize(alphabet_size);
+      BitWriter* histo_writer = writer;
+      if (params.streaming_mode) {
+        codes->encoded_histograms.emplace_back();
+        histo_writer = &codes->encoded_histograms.back();
+      }
+      BitWriter::Allotment allotment(histo_writer, 256 + alphabet_size * 24);
       cost += BuildAndStoreANSEncodingData(
           params.ans_histogram_strategy, clustered_histograms[c].data_.data(),
-          num_symbol, log_alpha_size, use_prefix_code,
-          codes->encoding_info.back().data(), writer);
-      allotment.FinishedHistogram(writer);
-      allotment.ReclaimAndCharge(writer, layer, aux_out);
+          alphabet_size, log_alpha_size, codes->use_prefix_code,
+          codes->encoding_info.back().data(), histo_writer);
+      allotment.FinishedHistogram(histo_writer);
+      allotment.ReclaimAndCharge(histo_writer, layer, aux_out);
+      if (params.streaming_mode) {
+        writer->AppendUnaligned(*histo_writer);
+      }
     }
     return cost;
   }
@@ -1451,7 +1474,9 @@ void ApplyLZ77_Optimal(const HistogramParams& params, size_t num_contexts,
 void ApplyLZ77(const HistogramParams& params, size_t num_contexts,
                const std::vector<std::vector<Token>>& tokens, LZ77Params& lz77,
                std::vector<std::vector<Token>>& tokens_lz77) {
-  lz77.enabled = false;
+  if (params.update_global_state) {
+    lz77.enabled = false;
+  }
   if (params.force_huffman) {
     lz77.min_symbol = std::min(PREFIX_MAX_ALPHABET_SIZE - 32, 512);
   } else {
@@ -1470,6 +1495,38 @@ void ApplyLZ77(const HistogramParams& params, size_t num_contexts,
   }
 }
 }  // namespace
+
+void EncodeHistograms(const std::vector<uint8_t>& context_map,
+                      const EntropyEncodingData& codes, BitWriter* writer,
+                      size_t layer, AuxOut* aux_out) {
+  BitWriter::Allotment allotment(writer, 128 + kClustersLimit * 136);
+  JXL_CHECK(Bundle::Write(codes.lz77, writer, layer, aux_out));
+  if (codes.lz77.enabled) {
+    EncodeUintConfig(codes.lz77.length_uint_config, writer,
+                     /*log_alpha_size=*/8);
+  }
+  EncodeContextMap(context_map, codes.encoding_info.size(), writer, layer,
+                   aux_out);
+  writer->Write(1, codes.use_prefix_code);
+  size_t log_alpha_size = 8;
+  if (codes.use_prefix_code) {
+    log_alpha_size = PREFIX_MAX_BITS;
+  } else {
+    log_alpha_size = 8;  // streaming_mode
+    writer->Write(2, log_alpha_size - 5);
+  }
+  EncodeUintConfigs(codes.uint_config, writer, log_alpha_size);
+  if (codes.use_prefix_code) {
+    for (const auto& info : codes.encoding_info) {
+      StoreVarLenUint16(info.size() - 1, writer);
+    }
+  }
+  for (const auto& histo_writer : codes.encoded_histograms) {
+    writer->AppendUnaligned(histo_writer);
+  }
+  allotment.FinishedHistogram(writer);
+  allotment.ReclaimAndCharge(writer, layer, aux_out);
+}
 
 size_t BuildAndEncodeHistograms(const HistogramParams& params,
                                 size_t num_contexts,
@@ -1556,26 +1613,55 @@ size_t BuildAndEncodeHistograms(const HistogramParams& params,
     }
   }
 
-  bool use_prefix_code =
-      params.force_huffman || total_tokens < 100 ||
-      params.clustering == HistogramParams::ClusteringType::kFastest ||
-      ans_fuzzer_friendly_;
-  if (!use_prefix_code) {
-    bool all_singleton = true;
-    for (size_t i = 0; i < num_contexts; i++) {
-      if (builder.Histo(i).ShannonEntropy() >= 1e-5) {
-        all_singleton = false;
+  if (params.add_missing_symbols) {
+    for (size_t c = 0; c < num_contexts; ++c) {
+      for (int symbol = 0; symbol < ANS_MAX_ALPHABET_SIZE; ++symbol) {
+        builder.VisitSymbol(symbol, c);
       }
-    }
-    if (all_singleton) {
-      use_prefix_code = true;
     }
   }
 
+  if (params.update_global_state) {
+    bool use_prefix_code =
+        params.force_huffman || total_tokens < 100 ||
+        params.clustering == HistogramParams::ClusteringType::kFastest ||
+        ans_fuzzer_friendly_;
+    if (!use_prefix_code) {
+      bool all_singleton = true;
+      for (size_t i = 0; i < num_contexts; i++) {
+        if (builder.Histo(i).ShannonEntropy() >= 1e-5) {
+          all_singleton = false;
+        }
+      }
+      if (all_singleton) {
+        use_prefix_code = true;
+      }
+    }
+    codes->use_prefix_code = use_prefix_code;
+  }
+
+  if (params.add_fix_histograms) {
+    // TODO(szabadka) Add more fixed histograms.
+    const size_t alphabet_size = ANS_MAX_ALPHABET_SIZE;
+    const size_t log_alpha_size = 8;
+    JXL_ASSERT(alphabet_size == 1u << log_alpha_size);
+    std::vector<int32_t> counts =
+        CreateFlatHistogram(alphabet_size, ANS_TAB_SIZE);
+    codes->encoding_info.emplace_back();
+    codes->encoding_info.back().resize(alphabet_size);
+    codes->encoded_histograms.emplace_back();
+    BitWriter* histo_writer = &codes->encoded_histograms.back();
+    BitWriter::Allotment allotment(histo_writer, 256 + alphabet_size * 24);
+    BuildAndStoreANSEncodingData(params.ans_histogram_strategy, counts.data(),
+                                 alphabet_size, log_alpha_size,
+                                 codes->use_prefix_code,
+                                 &codes->encoding_info.back()[0], histo_writer);
+    allotment.ReclaimAndCharge(histo_writer, 0, nullptr);
+  }
+
   // Encode histograms.
-  total_bits += builder.BuildAndStoreEntropyCodes(params, tokens, codes,
-                                                  context_map, use_prefix_code,
-                                                  writer, layer, aux_out);
+  total_bits += builder.BuildAndStoreEntropyCodes(
+      params, tokens, codes, context_map, writer, layer, aux_out);
   allotment.FinishedHistogram(writer);
   allotment.ReclaimAndCharge(writer, layer, aux_out);
 
@@ -1588,13 +1674,14 @@ size_t BuildAndEncodeHistograms(const HistogramParams& params,
 
 size_t WriteTokens(const std::vector<Token>& tokens,
                    const EntropyEncodingData& codes,
-                   const std::vector<uint8_t>& context_map, BitWriter* writer) {
+                   const std::vector<uint8_t>& context_map,
+                   size_t context_offset, BitWriter* writer) {
   size_t num_extra_bits = 0;
   if (codes.use_prefix_code) {
     for (size_t i = 0; i < tokens.size(); i++) {
       uint32_t tok, nbits, bits;
       const Token& token = tokens[i];
-      size_t histo = context_map[token.context];
+      size_t histo = context_map[context_offset + token.context];
       (token.is_lz77_length ? codes.lz77.length_uint_config
                             : codes.uint_config[histo])
           .Encode(token.value, &tok, &nbits, &bits);
@@ -1635,13 +1722,14 @@ size_t WriteTokens(const std::vector<Token>& tokens,
   if (codes.lz77.enabled || context_map.size() > 1) {
     for (int i = end - 1; i >= 0; --i) {
       const Token token = tokens[i];
-      const uint8_t histo = context_map[token.context];
+      const uint8_t histo = context_map[context_offset + token.context];
       uint32_t tok, nbits, bits;
       (token.is_lz77_length ? codes.lz77.length_uint_config
                             : codes.uint_config[histo])
           .Encode(tokens[i].value, &tok, &nbits, &bits);
       tok += token.is_lz77_length ? codes.lz77.min_symbol : 0;
       const ANSEncSymbolInfo& info = codes.encoding_info[histo][tok];
+      JXL_DASSERT(info.freq_ > 0);
       // Extra bits first as this is reversed.
       addbits(bits, nbits);
       num_extra_bits += nbits;
@@ -1673,10 +1761,11 @@ size_t WriteTokens(const std::vector<Token>& tokens,
 
 void WriteTokens(const std::vector<Token>& tokens,
                  const EntropyEncodingData& codes,
-                 const std::vector<uint8_t>& context_map, BitWriter* writer,
-                 size_t layer, AuxOut* aux_out) {
+                 const std::vector<uint8_t>& context_map, size_t context_offset,
+                 BitWriter* writer, size_t layer, AuxOut* aux_out) {
   BitWriter::Allotment allotment(writer, 32 * tokens.size() + 32 * 1024 * 4);
-  size_t num_extra_bits = WriteTokens(tokens, codes, context_map, writer);
+  size_t num_extra_bits =
+      WriteTokens(tokens, codes, context_map, context_offset, writer);
   allotment.ReclaimAndCharge(writer, layer, aux_out);
   if (aux_out != nullptr) {
     aux_out->layers[layer].extra_bits += num_extra_bits;

--- a/lib/jxl/enc_ans.cc
+++ b/lib/jxl/enc_ans.cc
@@ -1640,8 +1640,10 @@ size_t BuildAndEncodeHistograms(const HistogramParams& params,
     codes->use_prefix_code = use_prefix_code;
   }
 
-  if (params.add_fix_histograms) {
+  if (params.add_fixed_histograms) {
     // TODO(szabadka) Add more fixed histograms.
+    // TODO(szabadka) Reduce alphabet size by choosing a non-default
+    // uint_config.
     const size_t alphabet_size = ANS_MAX_ALPHABET_SIZE;
     const size_t log_alpha_size = 8;
     JXL_ASSERT(alphabet_size == 1u << log_alpha_size);

--- a/lib/jxl/enc_ans.cc
+++ b/lib/jxl/enc_ans.cc
@@ -1474,7 +1474,7 @@ void ApplyLZ77_Optimal(const HistogramParams& params, size_t num_contexts,
 void ApplyLZ77(const HistogramParams& params, size_t num_contexts,
                const std::vector<std::vector<Token>>& tokens, LZ77Params& lz77,
                std::vector<std::vector<Token>>& tokens_lz77) {
-  if (params.update_global_state) {
+  if (params.initialize_global_state) {
     lz77.enabled = false;
   }
   if (params.force_huffman) {
@@ -1621,7 +1621,7 @@ size_t BuildAndEncodeHistograms(const HistogramParams& params,
     }
   }
 
-  if (params.update_global_state) {
+  if (params.initialize_global_state) {
     bool use_prefix_code =
         params.force_huffman || total_tokens < 100 ||
         params.clustering == HistogramParams::ClusteringType::kFastest ||

--- a/lib/jxl/enc_ans.h
+++ b/lib/jxl/enc_ans.h
@@ -17,6 +17,7 @@
 #include "lib/jxl/dec_ans.h"
 #include "lib/jxl/enc_ans_params.h"
 #include "lib/jxl/enc_bit_writer.h"
+#include "lib/jxl/enc_cluster.h"
 
 namespace jxl {
 
@@ -72,14 +73,14 @@ class ANSCoder {
   uint32_t state_;
 };
 
-// RebalanceHistogram requires a signed type.
-using ANSHistBin = int32_t;
+static const int kNumFixedHistograms = 1;
 
 struct EntropyEncodingData {
   std::vector<std::vector<ANSEncSymbolInfo>> encoding_info;
   bool use_prefix_code;
   std::vector<HybridUintConfig> uint_config;
   LZ77Params lz77;
+  std::vector<BitWriter> encoded_histograms;
 };
 
 // Integer to be encoded by an entropy coder, either ANS or Huffman.
@@ -96,6 +97,10 @@ struct Token {
 // histogram (header bits plus data bits).
 float ANSPopulationCost(const ANSHistBin* data, size_t alphabet_size);
 
+void EncodeHistograms(const std::vector<uint8_t>& context_map,
+                      const EntropyEncodingData& codes, BitWriter* writer,
+                      size_t layer, AuxOut* aux_out);
+
 // Apply context clustering, compute histograms and encode them. Returns an
 // estimate of the total bits used for encoding the stream. If `writer` ==
 // nullptr, the bit estimate will not take into account the context map (which
@@ -111,13 +116,14 @@ size_t BuildAndEncodeHistograms(const HistogramParams& params,
 // Write the tokens to a string.
 void WriteTokens(const std::vector<Token>& tokens,
                  const EntropyEncodingData& codes,
-                 const std::vector<uint8_t>& context_map, BitWriter* writer,
-                 size_t layer, AuxOut* aux_out);
+                 const std::vector<uint8_t>& context_map, size_t context_offset,
+                 BitWriter* writer, size_t layer, AuxOut* aux_out);
 
 // Same as above, but assumes allotment created by caller.
 size_t WriteTokens(const std::vector<Token>& tokens,
                    const EntropyEncodingData& codes,
-                   const std::vector<uint8_t>& context_map, BitWriter* writer);
+                   const std::vector<uint8_t>& context_map,
+                   size_t context_offset, BitWriter* writer);
 
 // Exposed for tests; to be used with Writer=BitWriter only.
 template <typename Writer>

--- a/lib/jxl/enc_ans.h
+++ b/lib/jxl/enc_ans.h
@@ -97,6 +97,8 @@ struct Token {
 // histogram (header bits plus data bits).
 float ANSPopulationCost(const ANSHistBin* data, size_t alphabet_size);
 
+// Writes the context map to the bitstream and concatenates the individual
+// histogram bistreams in codes.encoded_histograms. Used in streaming mode.
 void EncodeHistograms(const std::vector<uint8_t>& context_map,
                       const EntropyEncodingData& codes, BitWriter* writer,
                       size_t layer, AuxOut* aux_out);

--- a/lib/jxl/enc_ans_params.h
+++ b/lib/jxl/enc_ans_params.h
@@ -72,7 +72,7 @@ struct HistogramParams {
   std::vector<size_t> image_widths;
   size_t max_histograms = ~0;
   bool force_huffman = false;
-  bool update_global_state = true;
+  bool initialize_global_state = true;
   bool streaming_mode = false;
   bool add_missing_symbols = false;
   bool add_fixed_histograms = false;

--- a/lib/jxl/enc_ans_params.h
+++ b/lib/jxl/enc_ans_params.h
@@ -75,7 +75,7 @@ struct HistogramParams {
   bool update_global_state = true;
   bool streaming_mode = false;
   bool add_missing_symbols = false;
-  bool add_fix_histograms = false;
+  bool add_fixed_histograms = false;
 };
 
 }  // namespace jxl

--- a/lib/jxl/enc_ans_params.h
+++ b/lib/jxl/enc_ans_params.h
@@ -15,6 +15,9 @@
 
 namespace jxl {
 
+// RebalanceHistogram requires a signed type.
+using ANSHistBin = int32_t;
+
 struct HistogramParams {
   enum class ClusteringType {
     kFastest,  // Only 4 clusters.
@@ -69,6 +72,10 @@ struct HistogramParams {
   std::vector<size_t> image_widths;
   size_t max_histograms = ~0;
   bool force_huffman = false;
+  bool update_global_state = true;
+  bool streaming_mode = false;
+  bool add_missing_symbols = false;
+  bool add_fix_histograms = false;
 };
 
 }  // namespace jxl

--- a/lib/jxl/enc_bit_writer.h
+++ b/lib/jxl/enc_bit_writer.h
@@ -66,6 +66,8 @@ struct BitWriter {
   void AppendByteAligned(const std::vector<std::unique_ptr<BitWriter>>& others);
   void AppendByteAligned(const std::vector<BitWriter>& others);
 
+  void AppendUnaligned(const BitWriter& other);
+
   class Allotment {
    public:
     // Expands a BitWriter's storage. Must happen before calling Write or

--- a/lib/jxl/enc_cache.cc
+++ b/lib/jxl/enc_cache.cc
@@ -57,7 +57,7 @@ Status InitializePassesEncoder(const FrameHeader& frame_header,
     enc_state->coeffs.pop_back();
   }
 
-  if (enc_state->update_global_state) {
+  if (enc_state->initialize_global_state) {
     float scale =
         shared.quantizer.ScaleGlobalScale(enc_state->cparams.quant_ac_rescale);
     DequantMatricesScaleDC(&shared.matrices, scale);

--- a/lib/jxl/enc_cache.h
+++ b/lib/jxl/enc_cache.h
@@ -34,6 +34,10 @@ struct AuxOut;
 struct PassesEncoderState {
   PassesSharedState shared;
 
+  bool streaming_mode = false;
+  bool update_global_state = true;
+  size_t dc_group_index = 0;
+
   ImageF initial_quant_field;    // Invalid in Falcon mode.
   ImageF initial_quant_masking;  // Invalid in Falcon mode.
   ImageF initial_quant_masking1x1;  // Invalid in Falcon mode.
@@ -58,6 +62,8 @@ struct PassesEncoderState {
   std::vector<PassData> passes;
   std::vector<uint8_t> histogram_idx;
 
+  // Block sizes seen so far.
+  uint32_t used_acs = 0;
   // Coefficient orders that are non-default.
   std::vector<uint32_t> used_orders;
 

--- a/lib/jxl/enc_cache.h
+++ b/lib/jxl/enc_cache.h
@@ -35,7 +35,7 @@ struct PassesEncoderState {
   PassesSharedState shared;
 
   bool streaming_mode = false;
-  bool update_global_state = true;
+  bool initialize_global_state = true;
   size_t dc_group_index = 0;
 
   ImageF initial_quant_field;    // Invalid in Falcon mode.

--- a/lib/jxl/enc_cluster.cc
+++ b/lib/jxl/enc_cluster.cc
@@ -149,6 +149,8 @@ void FastClusterHistograms(const std::vector<Histogram>& in,
     size_t best = 0;
     float best_dist = std::numeric_limits<float>::max();
     for (size_t j = 0; j < out->size(); j++) {
+      // TODO(szabadka) Choose a different distance metric for previous
+      // histograms (i.e. the cost of the new histogram with the old one).
       if (j < prev_histograms && HasNewSymbol(in[i], (*out)[j])) continue;
       float dist = HistogramDistance(in[i], (*out)[j]);
       if (dist < best_dist) {

--- a/lib/jxl/enc_cluster.cc
+++ b/lib/jxl/enc_cluster.cc
@@ -21,6 +21,7 @@
 
 #include "lib/jxl/ac_context.h"
 #include "lib/jxl/base/fast_math-inl.h"
+#include "lib/jxl/enc_ans.h"
 HWY_BEFORE_NAMESPACE();
 namespace jxl {
 namespace HWY_NAMESPACE {
@@ -81,11 +82,20 @@ float HistogramDistance(const Histogram& a, const Histogram& b) {
   return total_distance - a.entropy_ - b.entropy_;
 }
 
+bool HasNewSymbol(const Histogram& a, const Histogram& b) {
+  for (size_t i = 0; i < a.data_.size(); ++i) {
+    if (a.data_[i] > 0 && (i >= b.data_.size() || b.data_[i] == 0)) {
+      return true;
+    }
+  }
+  return false;
+}
+
 // First step of a k-means clustering with a fancy distance metric.
 void FastClusterHistograms(const std::vector<Histogram>& in,
                            size_t max_histograms, std::vector<Histogram>* out,
                            std::vector<uint32_t>* histogram_symbols) {
-  out->clear();
+  const size_t prev_histograms = out->size();
   out->reserve(max_histograms);
   histogram_symbols->clear();
   histogram_symbols->resize(in.size(), max_histograms);
@@ -101,6 +111,22 @@ void FastClusterHistograms(const std::vector<Histogram>& in,
     HistogramEntropy(in[i]);
     if (in[i].total_count_ > in[largest_idx].total_count_) {
       largest_idx = i;
+    }
+  }
+
+  if (prev_histograms > 0) {
+    for (size_t j = 0; j < prev_histograms; ++j) {
+      HistogramEntropy((*out)[j]);
+    }
+    for (size_t i = 0; i < in.size(); i++) {
+      if (dists[i] == 0.0f) continue;
+      for (size_t j = 0; j < prev_histograms; ++j) {
+        dists[i] = std::min(HistogramDistance(in[i], (*out)[j]), dists[i]);
+      }
+    }
+    auto max_dist = std::max_element(dists.begin(), dists.end());
+    if (*max_dist > 0.0f) {
+      largest_idx = max_dist - dists.begin();
     }
   }
 
@@ -121,16 +147,20 @@ void FastClusterHistograms(const std::vector<Histogram>& in,
   for (size_t i = 0; i < in.size(); i++) {
     if ((*histogram_symbols)[i] != max_histograms) continue;
     size_t best = 0;
-    float best_dist = HistogramDistance(in[i], (*out)[best]);
-    for (size_t j = 1; j < out->size(); j++) {
+    float best_dist = std::numeric_limits<float>::max();
+    for (size_t j = 0; j < out->size(); j++) {
+      if (j < prev_histograms && HasNewSymbol(in[i], (*out)[j])) continue;
       float dist = HistogramDistance(in[i], (*out)[j]);
       if (dist < best_dist) {
         best = j;
         best_dist = dist;
       }
     }
-    (*out)[best].AddHistogram(in[i]);
-    HistogramEntropy((*out)[best]);
+    JXL_ASSERT(best_dist < std::numeric_limits<float>::max());
+    if (best >= prev_histograms) {
+      (*out)[best].AddHistogram(in[i]);
+      HistogramEntropy((*out)[best]);
+    }
     (*histogram_symbols)[i] = best;
   }
 }
@@ -145,6 +175,10 @@ namespace jxl {
 HWY_EXPORT(FastClusterHistograms);  // Local function
 HWY_EXPORT(HistogramEntropy);       // Local function
 
+float Histogram::PopulationCost() const {
+  return ANSPopulationCost(data_.data(), data_.size());
+}
+
 float Histogram::ShannonEntropy() const {
   HWY_DYNAMIC_DISPATCH(HistogramEntropy)(*this);
   return entropy_;
@@ -156,11 +190,14 @@ namespace {
 
 // Reorder histograms in *out so that the new symbols in *symbols come in
 // increasing order.
-void HistogramReindex(std::vector<Histogram>* out,
+void HistogramReindex(std::vector<Histogram>* out, size_t prev_histograms,
                       std::vector<uint32_t>* symbols) {
   std::vector<Histogram> tmp(*out);
   std::map<int, int> new_index;
-  int next_index = 0;
+  for (size_t i = 0; i < prev_histograms; ++i) {
+    new_index[i] = i;
+  }
+  int next_index = prev_histograms;
   for (uint32_t symbol : *symbols) {
     if (new_index.find(symbol) == new_index.end()) {
       new_index[symbol] = next_index;
@@ -183,6 +220,7 @@ void ClusterHistograms(const HistogramParams params,
                        const std::vector<Histogram>& in, size_t max_histograms,
                        std::vector<Histogram>* out,
                        std::vector<uint32_t>* histogram_symbols) {
+  size_t prev_histograms = out->size();
   max_histograms = std::min(max_histograms, params.max_histograms);
   max_histograms = std::min(max_histograms, in.size());
   if (params.clustering == HistogramParams::ClusteringType::kFastest) {
@@ -190,9 +228,10 @@ void ClusterHistograms(const HistogramParams params,
   }
 
   HWY_DYNAMIC_DISPATCH(FastClusterHistograms)
-  (in, max_histograms, out, histogram_symbols);
+  (in, prev_histograms + max_histograms, out, histogram_symbols);
 
-  if (params.clustering == HistogramParams::ClusteringType::kBest) {
+  if (prev_histograms == 0 &&
+      params.clustering == HistogramParams::ClusteringType::kBest) {
     for (size_t i = 0; i < out->size(); i++) {
       (*out)[i].entropy_ =
           ANSPopulationCost((*out)[i].data_.data(), (*out)[i].data_.size());
@@ -286,7 +325,7 @@ void ClusterHistograms(const HistogramParams params,
   }
 
   // Convert the context map to a canonical form.
-  HistogramReindex(out, histogram_symbols);
+  HistogramReindex(out, prev_histograms, histogram_symbols);
 }
 
 }  // namespace jxl

--- a/lib/jxl/enc_cluster.h
+++ b/lib/jxl/enc_cluster.h
@@ -15,7 +15,7 @@
 #include <vector>
 
 #include "lib/jxl/ans_params.h"
-#include "lib/jxl/enc_ans.h"
+#include "lib/jxl/enc_ans_params.h"
 
 namespace jxl {
 
@@ -44,9 +44,15 @@ struct Histogram {
     }
     total_count_ += other.total_count_;
   }
-  float PopulationCost() const {
-    return ANSPopulationCost(data_.data(), data_.size());
+  size_t alphabet_size() const {
+    for (int i = data_.size() - 1; i >= 0; --i) {
+      if (data_[i] > 0) {
+        return i + 1;
+      }
+    }
+    return 1;
   }
+  float PopulationCost() const;
   float ShannonEntropy() const;
 
   std::vector<ANSHistBin> data_;

--- a/lib/jxl/enc_coeff_order.cc
+++ b/lib/jxl/enc_coeff_order.cc
@@ -57,20 +57,22 @@ std::pair<uint32_t, uint32_t> ComputeUsedOrders(
 
 void ComputeCoeffOrder(SpeedTier speed, const ACImage& acs,
                        const AcStrategyImage& ac_strategy,
-                       const FrameDimensions& frame_dim, uint32_t& used_orders,
-                       uint16_t used_acs, coeff_order_t* JXL_RESTRICT order) {
+                       const FrameDimensions& frame_dim,
+                       uint32_t& all_used_orders, uint32_t prev_used_acs,
+                       uint32_t current_used_acs, uint32_t current_used_orders,
+                       coeff_order_t* JXL_RESTRICT order) {
   std::vector<int32_t> num_zeros(kCoeffOrderMaxSize);
   // If compressing at high speed and only using 8x8 DCTs, only consider a
   // subset of blocks.
   double block_fraction = 1.0f;
   // TODO(veluca): figure out why sampling blocks if non-8x8s are used makes
   // encoding significantly less dense.
-  if (speed >= SpeedTier::kSquirrel && used_orders == 1) {
+  if (speed >= SpeedTier::kSquirrel && current_used_orders == 1) {
     block_fraction = 0.5f;
   }
   // No need to compute number of zero coefficients if all orders are the
   // default.
-  if (used_orders != 0) {
+  if (current_used_orders != 0) {
     uint64_t threshold =
         (std::numeric_limits<uint64_t>::max() >> 32) * block_fraction;
     uint64_t s[2] = {static_cast<uint64_t>(0x94D049BB133111EBull),
@@ -157,14 +159,18 @@ void ComputeCoeffOrder(SpeedTier speed, const ACImage& acs,
     size_t sz = kDCTBlockSize * acs.covered_blocks_x() * acs.covered_blocks_y();
 
     // Do nothing for transforms that don't appear.
-    if ((1 << ord) & ~used_acs) continue;
+    if ((1 << ord) & ~current_used_acs) continue;
+
+    // Do nothing if we already commited to this custom order previously.
+    if ((1 << ord) & prev_used_acs) continue;
+    if ((1 << ord) & all_used_orders) continue;
 
     if (natural_order_buffer.size() < sz) natural_order_buffer.resize(sz);
     acs.ComputeNaturalCoeffOrder(natural_order_buffer.data());
 
     // Ensure natural coefficient order is not permuted if the order is
     // not transmitted.
-    if ((1 << ord) & ~used_orders) {
+    if ((1 << ord) & ~current_used_orders) {
       for (size_t c = 0; c < 3; c++) {
         size_t offset = CoeffOrderOffset(ord, c);
         JXL_DASSERT(CoeffOrderOffset(ord, c + 1) - offset == sz);
@@ -203,9 +209,10 @@ void ComputeCoeffOrder(SpeedTier speed, const ACImage& acs,
       }
     }
     if (!is_nondefault) {
-      used_orders &= ~(1 << ord);
+      current_used_orders &= ~(1 << ord);
     }
   }
+  all_used_orders |= current_used_orders;
 }
 
 namespace {
@@ -238,7 +245,7 @@ void EncodePermutation(const coeff_order_t* JXL_RESTRICT order, size_t skip,
   EntropyEncodingData codes;
   BuildAndEncodeHistograms(HistogramParams(), kPermutationContexts, tokens,
                            &codes, &context_map, writer, layer, aux_out);
-  WriteTokens(tokens[0], codes, context_map, writer, layer, aux_out);
+  WriteTokens(tokens[0], codes, context_map, 0, writer, layer, aux_out);
 }
 
 namespace {
@@ -283,7 +290,7 @@ void EncodeCoeffOrders(uint16_t used_orders,
     EntropyEncodingData codes;
     BuildAndEncodeHistograms(HistogramParams(), kPermutationContexts, tokens,
                              &codes, &context_map, writer, layer, aux_out);
-    WriteTokens(tokens[0], codes, context_map, writer, layer, aux_out);
+    WriteTokens(tokens[0], codes, context_map, 0, writer, layer, aux_out);
   }
 }
 

--- a/lib/jxl/enc_coeff_order.h
+++ b/lib/jxl/enc_coeff_order.h
@@ -33,8 +33,10 @@ std::pair<uint32_t, uint32_t> ComputeUsedOrders(
 // permutation will be cheaper to encode.
 void ComputeCoeffOrder(SpeedTier speed, const ACImage& acs,
                        const AcStrategyImage& ac_strategy,
-                       const FrameDimensions& frame_dim, uint32_t& used_orders,
-                       uint16_t used_acs, coeff_order_t* JXL_RESTRICT order);
+                       const FrameDimensions& frame_dim,
+                       uint32_t& all_used_orders, uint32_t prev_used_acs,
+                       uint32_t current_used_acs, uint32_t current_used_orders,
+                       coeff_order_t* JXL_RESTRICT order);
 
 void EncodeCoeffOrders(uint16_t used_orders,
                        const coeff_order_t* JXL_RESTRICT order,

--- a/lib/jxl/enc_context_map.cc
+++ b/lib/jxl/enc_context_map.cc
@@ -70,8 +70,6 @@ void EncodeContextMap(const std::vector<uint8_t>& context_map,
 
   std::vector<uint8_t> transformed_symbols = MoveToFrontTransform(context_map);
   std::vector<std::vector<Token>> tokens(1), mtf_tokens(1);
-  EntropyEncodingData codes;
-  std::vector<uint8_t> sink_context_map;
   for (size_t i = 0; i < context_map.size(); i++) {
     tokens[0].emplace_back(0, context_map[i]);
   }
@@ -80,10 +78,19 @@ void EncodeContextMap(const std::vector<uint8_t>& context_map,
   }
   HistogramParams params;
   params.uint_method = HistogramParams::HybridUintMethod::kContextMap;
-  size_t ans_cost = BuildAndEncodeHistograms(
-      params, 1, tokens, &codes, &sink_context_map, nullptr, 0, nullptr);
-  size_t mtf_cost = BuildAndEncodeHistograms(
-      params, 1, mtf_tokens, &codes, &sink_context_map, nullptr, 0, nullptr);
+  size_t ans_cost, mtf_cost;
+  {
+    EntropyEncodingData codes;
+    std::vector<uint8_t> sink_context_map;
+    ans_cost = BuildAndEncodeHistograms(params, 1, tokens, &codes,
+                                        &sink_context_map, nullptr, 0, nullptr);
+  }
+  {
+    EntropyEncodingData codes;
+    std::vector<uint8_t> sink_context_map;
+    mtf_cost = BuildAndEncodeHistograms(params, 1, mtf_tokens, &codes,
+                                        &sink_context_map, nullptr, 0, nullptr);
+  }
   bool use_mtf = mtf_cost < ans_cost;
   // Rebuild token list.
   tokens[0].clear();
@@ -94,17 +101,23 @@ void EncodeContextMap(const std::vector<uint8_t>& context_map,
   size_t entry_bits = CeilLog2Nonzero(num_histograms);
   size_t simple_cost = entry_bits * context_map.size();
   if (entry_bits < 4 && simple_cost < ans_cost && simple_cost < mtf_cost) {
+    BitWriter::Allotment allotment(writer, 3 + entry_bits * context_map.size());
     writer->Write(1, 1);
     writer->Write(2, entry_bits);
     for (size_t i = 0; i < context_map.size(); i++) {
       writer->Write(entry_bits, context_map[i]);
     }
+    allotment.ReclaimAndCharge(writer, layer, aux_out);
   } else {
+    BitWriter::Allotment allotment(writer, 2 + tokens[0].size() * 24);
     writer->Write(1, 0);
     writer->Write(1, use_mtf);  // Use/don't use MTF.
+    EntropyEncodingData codes;
+    std::vector<uint8_t> sink_context_map;
     BuildAndEncodeHistograms(params, 1, tokens, &codes, &sink_context_map,
                              writer, layer, aux_out);
-    WriteTokens(tokens[0], codes, sink_context_map, writer);
+    WriteTokens(tokens[0], codes, sink_context_map, 0, writer);
+    allotment.ReclaimAndCharge(writer, layer, aux_out);
   }
 }
 

--- a/lib/jxl/enc_entropy_coder.cc
+++ b/lib/jxl/enc_entropy_coder.cc
@@ -164,10 +164,9 @@ void TokenizeCoefficients(const coeff_order_t* JXL_RESTRICT orders,
                           const BlockCtxMap& block_ctx_map) {
   const size_t xsize_blocks = rect.xsize();
   const size_t ysize_blocks = rect.ysize();
-
+  output->clear();
   // TODO(user): update the estimate: usually less coefficients are used.
-  output->reserve(output->size() +
-                  3 * xsize_blocks * ysize_blocks * kDCTBlockSize);
+  output->reserve(3 * xsize_blocks * ysize_blocks * kDCTBlockSize);
 
   size_t offset[3] = {};
   const size_t nzeros_stride = tmp_num_nzeroes->PixelsPerRow();

--- a/lib/jxl/enc_frame.cc
+++ b/lib/jxl/enc_frame.cc
@@ -253,15 +253,16 @@ uint64_t FrameFlagsFromParams(const CompressParams& cparams) {
   return flags;
 }
 
-Status LoopFilterFromParams(const CompressParams& cparams,
+Status LoopFilterFromParams(const CompressParams& cparams, bool streaming_mode,
                             FrameHeader* JXL_RESTRICT frame_header) {
   LoopFilter* loop_filter = &frame_header->loop_filter;
 
   // Gaborish defaults to enabled in Hare or slower.
-  loop_filter->gab = ApplyOverride(
-      cparams.gaborish, cparams.speed_tier <= SpeedTier::kHare &&
-                            frame_header->encoding == FrameEncoding::kVarDCT &&
-                            cparams.decoding_speed_tier < 4);
+  loop_filter->gab =
+      ApplyOverride(cparams.gaborish,
+                    !streaming_mode && cparams.speed_tier <= SpeedTier::kHare &&
+                        frame_header->encoding == FrameEncoding::kVarDCT &&
+                        cparams.decoding_speed_tier < 4);
 
   if (cparams.epf != -1) {
     loop_filter->epf_iters = cparams.epf;
@@ -298,7 +299,7 @@ Status MakeFrameHeader(size_t xsize, size_t ysize,
                        const CompressParams& cparams,
                        const ProgressiveSplitter& progressive_splitter,
                        const FrameInfo& frame_info,
-                       const jpeg::JPEGData* jpeg_data,
+                       const jpeg::JPEGData* jpeg_data, bool streaming_mode,
                        FrameHeader* JXL_RESTRICT frame_header) {
   frame_header->nonserialized_is_preview = frame_info.is_preview;
   frame_header->is_last = frame_info.is_last;
@@ -327,6 +328,8 @@ Status MakeFrameHeader(size_t xsize, size_t ysize,
   if (jpeg_data) {
     // we are transcoding a JPEG, so we don't get to choose
     frame_header->encoding = FrameEncoding::kVarDCT;
+    frame_header->x_qm_scale = 2;
+    frame_header->b_qm_scale = 2;
     JXL_RETURN_IF_ERROR(SetChromaSubsamplingFromJpegData(
         *jpeg_data, &frame_header->chroma_subsampling));
     JXL_RETURN_IF_ERROR(SetColorTransformFromJpegData(
@@ -356,7 +359,8 @@ Status MakeFrameHeader(size_t xsize, size_t ysize,
     frame_header->UpdateFlag(false, FrameHeader::Flags::kNoise);
   }
 
-  JXL_RETURN_IF_ERROR(LoopFilterFromParams(cparams, frame_header));
+  JXL_RETURN_IF_ERROR(
+      LoopFilterFromParams(cparams, streaming_mode, frame_header));
 
   frame_header->dc_level = frame_info.dc_level;
   if (frame_header->dc_level > 2) {
@@ -451,6 +455,11 @@ Status MakeFrameHeader(size_t xsize, size_t ysize,
 
   frame_header->animation_frame.duration = frame_info.duration;
   frame_header->animation_frame.timecode = frame_info.timecode;
+
+  if (jpeg_data) {
+    frame_header->UpdateFlag(false, FrameHeader::kUseDcFrame);
+    frame_header->UpdateFlag(true, FrameHeader::kSkipAdaptiveDCSmoothing);
+  }
 
   return true;
 }
@@ -599,17 +608,10 @@ struct PixelStatsForChromacityAdjustment {
 };
 
 void ComputeChromacityAdjustments(const CompressParams& cparams,
-                                  bool color_is_jpeg, const Image3F& opsin,
+                                  const Image3F& opsin,
                                   FrameHeader* frame_header) {
-  if (frame_header->encoding != FrameEncoding::kVarDCT) {
-    return;
-  }
-  if (color_is_jpeg) {
-    frame_header->x_qm_scale = 2;
-    frame_header->b_qm_scale = 2;
-    return;
-  }
-  if (cparams.max_error_mode) {
+  if (frame_header->encoding != FrameEncoding::kVarDCT ||
+      cparams.max_error_mode) {
     return;
   }
   // 1) Distance based approach for chromacity adjustment:
@@ -724,8 +726,9 @@ void FindIndexOfSumMaximum(const V* array, const size_t len, R* idx, V* sum) {
 }
 
 Status ComputeJPEGTranscodingData(const jpeg::JPEGData& jpeg_data,
-                                  FrameHeader& frame_header, ThreadPool* pool,
-                                  ModularFrameEncoder* modular_frame_encoder,
+                                  const FrameHeader& frame_header,
+                                  ThreadPool* pool,
+                                  ModularFrameEncoder* enc_modular,
                                   PassesEncoderState* enc_state) {
   PassesSharedState& shared = enc_state->shared;
   const FrameDimensions& frame_dim = shared.frame_dim;
@@ -774,7 +777,7 @@ Status ComputeJPEGTranscodingData(const jpeg::JPEGData& jpeg_data,
                                1.0f / dcquantization[2]};
 
   qe[AcStrategy::Type::DCT] = QuantEncoding::RAW(qt);
-  DequantMatricesSetCustom(&shared.matrices, qe, modular_frame_encoder);
+  DequantMatricesSetCustom(&shared.matrices, qe, enc_modular);
 
   // Ensure that InvGlobalScale() is 1.
   shared.quantizer = Quantizer(&shared.matrices, 1, kGlobalScaleDenom);
@@ -1018,23 +1021,19 @@ Status ComputeJPEGTranscodingData(const jpeg::JPEGData& jpeg_data,
   enc_state->shared.block_ctx_map.num_ctxs =
       *std::max_element(ctx_map.begin(), ctx_map.end()) + 1;
 
-  enc_state->histogram_idx.resize(shared.frame_dim.num_groups);
-
   // disable DC frame for now
-  frame_header.UpdateFlag(false, FrameHeader::kUseDcFrame);
   auto compute_dc_coeffs = [&](const uint32_t group_index,
                                size_t /* thread */) {
-    modular_frame_encoder->AddVarDCTDC(frame_header, dc, group_index,
-                                       /*nl_dc=*/false, enc_state,
-                                       /*jpeg_transcode=*/true);
-    modular_frame_encoder->AddACMetadata(group_index, /*jpeg_transcode=*/true,
-                                         enc_state);
+    const Rect r = enc_state->shared.frame_dim.DCGroupRect(group_index);
+    enc_modular->AddVarDCTDC(frame_header, dc, r, group_index,
+                             /*nl_dc=*/false, enc_state,
+                             /*jpeg_transcode=*/true);
+    enc_modular->AddACMetadata(r, group_index, /*jpeg_transcode=*/true,
+                               enc_state);
   };
   JXL_RETURN_IF_ERROR(RunOnPool(pool, 0, shared.frame_dim.num_dc_groups,
                                 ThreadPool::NoInit, compute_dc_coeffs,
                                 "Compute DC coeffs"));
-
-  frame_header.UpdateFlag(true, FrameHeader::kSkipAdaptiveDCSmoothing);
 
   return true;
 }
@@ -1043,19 +1042,16 @@ Status ComputeVarDCTEncodingData(const FrameHeader& frame_header,
                                  const Image3F* linear,
                                  Image3F* JXL_RESTRICT opsin,
                                  const JxlCmsInterface& cms, ThreadPool* pool,
-                                 ModularFrameEncoder* modular_frame_encoder,
+                                 ModularFrameEncoder* enc_modular,
                                  PassesEncoderState* enc_state,
                                  AuxOut* aux_out) {
   JXL_ASSERT((opsin->xsize() % kBlockDim) == 0 &&
              (opsin->ysize() % kBlockDim) == 0);
-  JXL_RETURN_IF_ERROR(LossyFrameHeuristics(frame_header, enc_state,
-                                           modular_frame_encoder, linear, opsin,
-                                           cms, pool, aux_out));
+  JXL_RETURN_IF_ERROR(LossyFrameHeuristics(frame_header, enc_state, enc_modular,
+                                           linear, opsin, cms, pool, aux_out));
 
   JXL_RETURN_IF_ERROR(InitializePassesEncoder(frame_header, *opsin, cms, pool,
-                                              enc_state, modular_frame_encoder,
-                                              aux_out));
-
+                                              enc_state, enc_modular, aux_out));
   return true;
 }
 
@@ -1064,16 +1060,15 @@ void ComputeAllCoeffOrders(PassesEncoderState& enc_state,
   auto used_orders_info = ComputeUsedOrders(
       enc_state.cparams.speed_tier, enc_state.shared.ac_strategy,
       Rect(enc_state.shared.raw_quant_field));
-  enc_state.used_orders.clear();
-  enc_state.used_orders.resize(enc_state.progressive_splitter.GetNumPasses(),
-                               used_orders_info.second);
+  enc_state.used_orders.resize(enc_state.progressive_splitter.GetNumPasses());
   for (size_t i = 0; i < enc_state.progressive_splitter.GetNumPasses(); i++) {
     ComputeCoeffOrder(
         enc_state.cparams.speed_tier, *enc_state.coeffs[i],
         enc_state.shared.ac_strategy, frame_dim, enc_state.used_orders[i],
-        used_orders_info.first,
+        enc_state.used_acs, used_orders_info.first, used_orders_info.second,
         &enc_state.shared.coeff_orders[i * enc_state.shared.coeff_order_size]);
   }
+  enc_state.used_acs |= used_orders_info.first;
 }
 
 // Working area for TokenizeCoefficients (per-group!)
@@ -1100,7 +1095,7 @@ Status TokenizeAllCoefficients(const FrameHeader& frame_header,
   const auto tokenize_group = [&](const uint32_t group_index,
                                   const size_t thread) {
     // Tokenize coefficients.
-    const Rect rect = shared.BlockGroupRect(group_index);
+    const Rect rect = shared.frame_dim.BlockGroupRect(group_index);
     for (size_t idx_pass = 0; idx_pass < enc_state->passes.size(); idx_pass++) {
       JXL_ASSERT(enc_state->coeffs[idx_pass]->Type() == ACType::k32);
       const int32_t* JXL_RESTRICT ac_rows[3] = {
@@ -1134,13 +1129,12 @@ Status EncodeGlobalDCInfo(const PassesSharedState& shared, BitWriter* writer,
 }
 
 Status EncodeGlobalACInfo(PassesEncoderState* enc_state, BitWriter* writer,
-                          ModularFrameEncoder* modular_frame_encoder,
-                          AuxOut* aux_out) {
+                          ModularFrameEncoder* enc_modular, AuxOut* aux_out) {
   PassesSharedState& shared = enc_state->shared;
-  JXL_RETURN_IF_ERROR(DequantMatricesEncode(
-      shared.matrices, writer, kLayerQuant, aux_out, modular_frame_encoder));
+  JXL_RETURN_IF_ERROR(DequantMatricesEncode(shared.matrices, writer,
+                                            kLayerQuant, aux_out, enc_modular));
   size_t num_histo_bits = CeilLog2Nonzero(shared.frame_dim.num_groups);
-  if (num_histo_bits != 0) {
+  if (!enc_state->streaming_mode && num_histo_bits != 0) {
     BitWriter::Allotment allotment(writer, num_histo_bits);
     writer->Write(num_histo_bits, shared.num_histograms - 1);
     allotment.ReclaimAndCharge(writer, kLayerAC, aux_out);
@@ -1148,15 +1142,17 @@ Status EncodeGlobalACInfo(PassesEncoderState* enc_state, BitWriter* writer,
 
   for (size_t i = 0; i < enc_state->progressive_splitter.GetNumPasses(); i++) {
     // Encode coefficient orders.
-    size_t order_bits = 0;
-    JXL_RETURN_IF_ERROR(
-        U32Coder::CanEncode(kOrderEnc, enc_state->used_orders[i], &order_bits));
-    BitWriter::Allotment allotment(writer, order_bits);
-    JXL_CHECK(U32Coder::Write(kOrderEnc, enc_state->used_orders[i], writer));
-    allotment.ReclaimAndCharge(writer, kLayerOrder, aux_out);
-    EncodeCoeffOrders(enc_state->used_orders[i],
-                      &shared.coeff_orders[i * shared.coeff_order_size], writer,
-                      kLayerOrder, aux_out);
+    if (!enc_state->streaming_mode) {
+      size_t order_bits = 0;
+      JXL_RETURN_IF_ERROR(U32Coder::CanEncode(
+          kOrderEnc, enc_state->used_orders[i], &order_bits));
+      BitWriter::Allotment allotment(writer, order_bits);
+      JXL_CHECK(U32Coder::Write(kOrderEnc, enc_state->used_orders[i], writer));
+      allotment.ReclaimAndCharge(writer, kLayerOrder, aux_out);
+      EncodeCoeffOrders(enc_state->used_orders[i],
+                        &shared.coeff_orders[i * shared.coeff_order_size],
+                        writer, kLayerOrder, aux_out);
+    }
 
     // Encode histograms.
     HistogramParams hist_params(enc_state->cparams.speed_tier,
@@ -1167,9 +1163,27 @@ Status EncodeGlobalACInfo(PassesEncoderState* enc_state, BitWriter* writer,
     if (enc_state->cparams.decoding_speed_tier >= 1) {
       hist_params.max_histograms = 6;
     }
+    size_t num_histogram_groups = shared.num_histograms;
+    if (enc_state->streaming_mode) {
+      size_t prev_num_histograms =
+          enc_state->passes[i].codes.encoding_info.size();
+      if (enc_state->update_global_state) {
+        prev_num_histograms += kNumFixedHistograms;
+        hist_params.add_fix_histograms = true;
+      }
+      size_t remaining_histograms = kClustersLimit - prev_num_histograms;
+      size_t max_histograms = remaining_histograms < 20
+                                  ? std::min<size_t>(remaining_histograms, 4)
+                                  : remaining_histograms / 4;
+      hist_params.max_histograms =
+          std::min(max_histograms, hist_params.max_histograms);
+      num_histogram_groups = 1;
+    }
+    hist_params.streaming_mode = enc_state->streaming_mode;
+    hist_params.update_global_state = enc_state->update_global_state;
     BuildAndEncodeHistograms(
         hist_params,
-        shared.num_histograms * shared.block_ctx_map.NumACContexts(),
+        num_histogram_groups * shared.block_ctx_map.NumACContexts(),
         enc_state->passes[i].ac_tokens, &enc_state->passes[i].codes,
         &enc_state->passes[i].context_map, writer, kLayerAC, aux_out);
   }
@@ -1199,28 +1213,31 @@ Status EncodeGroups(const FrameHeader& frame_header,
                                    frame_dim.num_dc_groups));
   };
 
-  if (frame_header.flags & FrameHeader::kPatches) {
-    PatchDictionaryEncoder::Encode(shared.image_features.patches, get_output(0),
-                                   kLayerDictionary, aux_out);
-  }
+  if (enc_state->update_global_state) {
+    if (frame_header.flags & FrameHeader::kPatches) {
+      PatchDictionaryEncoder::Encode(shared.image_features.patches,
+                                     get_output(0), kLayerDictionary, aux_out);
+    }
+    if (frame_header.flags & FrameHeader::kSplines) {
+      EncodeSplines(shared.image_features.splines, get_output(0), kLayerSplines,
+                    HistogramParams(), aux_out);
+    }
+    if (frame_header.flags & FrameHeader::kNoise) {
+      EncodeNoise(shared.image_features.noise_params, get_output(0),
+                  kLayerNoise, aux_out);
+    }
 
-  if (frame_header.flags & FrameHeader::kSplines) {
-    EncodeSplines(shared.image_features.splines, get_output(0), kLayerSplines,
-                  HistogramParams(), aux_out);
+    JXL_RETURN_IF_ERROR(DequantMatricesEncodeDC(shared.matrices, get_output(0),
+                                                kLayerQuant, aux_out));
+    if (frame_header.encoding == FrameEncoding::kVarDCT) {
+      JXL_RETURN_IF_ERROR(EncodeGlobalDCInfo(shared, get_output(0), aux_out));
+    }
+    JXL_RETURN_IF_ERROR(enc_modular->EncodeGlobalInfo(enc_state->streaming_mode,
+                                                      get_output(0), aux_out));
+    JXL_RETURN_IF_ERROR(enc_modular->EncodeStream(get_output(0), aux_out,
+                                                  kLayerModularGlobal,
+                                                  ModularStreamId::Global()));
   }
-  if (frame_header.flags & FrameHeader::kNoise) {
-    EncodeNoise(shared.image_features.noise_params, get_output(0), kLayerNoise,
-                aux_out);
-  }
-
-  JXL_RETURN_IF_ERROR(DequantMatricesEncodeDC(shared.matrices, get_output(0),
-                                              kLayerQuant, aux_out));
-  if (frame_header.encoding == FrameEncoding::kVarDCT) {
-    JXL_RETURN_IF_ERROR(EncodeGlobalDCInfo(shared, get_output(0), aux_out));
-  }
-  JXL_RETURN_IF_ERROR(enc_modular->EncodeGlobalInfo(get_output(0), aux_out));
-  JXL_RETURN_IF_ERROR(enc_modular->EncodeStream(
-      get_output(0), aux_out, kLayerModularGlobal, ModularStreamId::Global()));
 
   std::vector<std::unique_ptr<AuxOut>> aux_outs;
   auto resize_aux_outs = [&aux_outs,
@@ -1243,29 +1260,35 @@ Status EncodeGroups(const FrameHeader& frame_header,
                                     const size_t thread) {
     AuxOut* my_aux_out = aux_outs[thread].get();
     BitWriter* output = get_output(group_index + 1);
+    int modular_group_index = group_index;
+    if (enc_state->streaming_mode) {
+      JXL_ASSERT(group_index == 0);
+      modular_group_index = enc_state->dc_group_index;
+    }
     if (frame_header.encoding == FrameEncoding::kVarDCT &&
         !(frame_header.flags & FrameHeader::kUseDcFrame)) {
       BitWriter::Allotment allotment(output, 2);
-      output->Write(2, enc_modular->extra_dc_precision[group_index]);
+      output->Write(2, enc_modular->extra_dc_precision[modular_group_index]);
       allotment.ReclaimAndCharge(output, kLayerDC, my_aux_out);
-      JXL_CHECK(
-          enc_modular->EncodeStream(output, my_aux_out, kLayerDC,
-                                    ModularStreamId::VarDCTDC(group_index)));
+      JXL_CHECK(enc_modular->EncodeStream(
+          output, my_aux_out, kLayerDC,
+          ModularStreamId::VarDCTDC(modular_group_index)));
     }
-    JXL_CHECK(
-        enc_modular->EncodeStream(output, my_aux_out, kLayerModularDcGroup,
-                                  ModularStreamId::ModularDC(group_index)));
+    JXL_CHECK(enc_modular->EncodeStream(
+        output, my_aux_out, kLayerModularDcGroup,
+        ModularStreamId::ModularDC(modular_group_index)));
     if (frame_header.encoding == FrameEncoding::kVarDCT) {
-      const Rect& rect = enc_state->shared.DCGroupRect(group_index);
+      const Rect& rect = enc_state->shared.frame_dim.DCGroupRect(group_index);
       size_t nb_bits = CeilLog2Nonzero(rect.xsize() * rect.ysize());
       if (nb_bits != 0) {
         BitWriter::Allotment allotment(output, nb_bits);
-        output->Write(nb_bits, enc_modular->ac_metadata_size[group_index] - 1);
+        output->Write(nb_bits,
+                      enc_modular->ac_metadata_size[modular_group_index] - 1);
         allotment.ReclaimAndCharge(output, kLayerControlFields, my_aux_out);
       }
-      JXL_CHECK(
-          enc_modular->EncodeStream(output, my_aux_out, kLayerControlFields,
-                                    ModularStreamId::ACMetadata(group_index)));
+      JXL_CHECK(enc_modular->EncodeStream(
+          output, my_aux_out, kLayerControlFields,
+          ModularStreamId::ACMetadata(modular_group_index)));
     }
   };
   JXL_RETURN_IF_ERROR(RunOnPool(pool, 0, frame_dim.num_dc_groups,
@@ -1317,13 +1340,42 @@ Status EncodeGroups(const FrameHeader& frame_header,
 
 Status ComputeEncodingData(
     const CompressParams& cparams, const FrameInfo& frame_info,
-    const CodecMetadata* metadata, FrameHeader& frame_header,
-    JxlEncoderChunkedFrameAdapter& frame_data, size_t x0, size_t y0,
-    size_t xsize, size_t ysize, const JxlCmsInterface& cms, ThreadPool* pool,
+    const CodecMetadata* metadata, JxlEncoderChunkedFrameAdapter& frame_data,
+    const jpeg::JPEGData* jpeg_data, size_t x0, size_t y0, size_t xsize,
+    size_t ysize, const JxlCmsInterface& cms, ThreadPool* pool,
+    FrameHeader& mutable_frame_header, ModularFrameEncoder& enc_modular,
     PassesEncoderState& enc_state, std::vector<BitWriter>* group_codes,
     AuxOut* aux_out) {
   JXL_ASSERT(x0 + xsize <= frame_data.xsize);
   JXL_ASSERT(y0 + ysize <= frame_data.ysize);
+  const FrameHeader& frame_header = mutable_frame_header;
+  PassesSharedState& shared = enc_state.shared;
+  shared.metadata = metadata;
+  if (enc_state.streaming_mode) {
+    shared.frame_dim.Set(xsize, ysize, /*group_size_shift=*/1,
+                         /*maxhshift=*/0, /*maxvshift=*/0,
+                         /*modular_mode=*/false, /*upsampling=*/1);
+  } else {
+    shared.frame_dim = frame_header.ToFrameDimensions();
+  }
+  shared.image_features.patches.SetPassesSharedState(&shared);
+  const FrameDimensions& frame_dim = shared.frame_dim;
+  shared.ac_strategy =
+      AcStrategyImage(frame_dim.xsize_blocks, frame_dim.ysize_blocks);
+  shared.raw_quant_field =
+      ImageI(frame_dim.xsize_blocks, frame_dim.ysize_blocks);
+  shared.epf_sharpness = ImageB(frame_dim.xsize_blocks, frame_dim.ysize_blocks);
+  shared.cmap = ColorCorrelationMap(frame_dim.xsize, frame_dim.ysize);
+  shared.coeff_order_size = kCoeffOrderMaxSize;
+  if (frame_header.encoding == FrameEncoding::kVarDCT) {
+    shared.coeff_orders.resize(frame_header.passes.num_passes *
+                               kCoeffOrderMaxSize);
+  }
+
+  shared.quant_dc = ImageB(frame_dim.xsize_blocks, frame_dim.ysize_blocks);
+  shared.dc_storage = Image3F(frame_dim.xsize_blocks, frame_dim.ysize_blocks);
+  shared.dc = &shared.dc_storage;
+
   const size_t num_extra_channels = metadata->m.num_extra_channels;
   const ExtraChannelInfo* alpha_eci = metadata->m.Find(ExtraChannel::kAlpha);
   const ExtraChannelInfo* black_eci = metadata->m.Find(ExtraChannel::kBlack);
@@ -1340,10 +1392,7 @@ Status ComputeEncodingData(
   ImageF* black = black_eci ? &extra_channels[black_idx] : nullptr;
   bool has_interleaved_alpha = false;
   JxlChunkedFrameInputSource input = frame_data.GetInputSource();
-  std::unique_ptr<jpeg::JPEGData> jpeg_data;
-  if (frame_data.IsJPEG()) {
-    jpeg_data = make_unique<jpeg::JPEGData>(frame_data.TakeJPEGData());
-  } else {
+  if (!frame_data.IsJPEG()) {
     JXL_RETURN_IF_ERROR(CopyColorChannels(input, x0, y0, xsize, ysize,
                                           frame_info, metadata->m, pool, &color,
                                           alpha, &has_interleaved_alpha));
@@ -1352,18 +1401,8 @@ Status ComputeEncodingData(
                                         metadata->m, has_interleaved_alpha,
                                         pool, &extra_channels));
 
-  PassesSharedState& shared = enc_state.shared;
   shared.image_features.patches.SetPassesSharedState(&shared);
   enc_state.cparams = cparams;
-  SetProgressiveMode(cparams, &enc_state.progressive_splitter);
-
-  JXL_RETURN_IF_ERROR(
-      MakeFrameHeader(xsize, ysize, cparams, enc_state.progressive_splitter,
-                      frame_info, jpeg_data.get(), &frame_header));
-  JXL_RETURN_IF_ERROR(
-      InitializePassesSharedState(frame_header, &shared, /*encoder=*/true));
-  const FrameDimensions& frame_dim = shared.frame_dim;
-  ModularFrameEncoder modular_frame_encoder(frame_header, cparams);
 
   Image3F linear_storage;
   Image3F* linear = nullptr;
@@ -1403,10 +1442,15 @@ Status ComputeEncodingData(
     PadImageToBlockMultipleInPlace(&opsin);
   }
 
-  ComputeChromacityAdjustments(cparams, !!jpeg_data, opsin, &frame_header);
+  if (enc_state.update_global_state && !jpeg_data) {
+    ComputeChromacityAdjustments(cparams, opsin, &mutable_frame_header);
+  }
 
-  ComputeNoiseParams(cparams, !!jpeg_data, opsin, frame_dim, &frame_header,
-                     &shared.image_features.noise_params);
+  if (!enc_state.streaming_mode) {
+    ComputeNoiseParams(cparams, !!jpeg_data, opsin, frame_dim,
+                       &mutable_frame_header,
+                       &shared.image_features.noise_params);
+  }
 
   DownsampleColorChannels(cparams, frame_header, !!jpeg_data, &opsin);
 
@@ -1423,31 +1467,44 @@ Status ComputeEncodingData(
     }
     if (jpeg_data) {
       JXL_RETURN_IF_ERROR(ComputeJPEGTranscodingData(
-          *jpeg_data, frame_header, pool, &modular_frame_encoder, &enc_state));
+          *jpeg_data, frame_header, pool, &enc_modular, &enc_state));
     } else {
-      JXL_RETURN_IF_ERROR(ComputeVarDCTEncodingData(
-          frame_header, linear, &opsin, cms, pool, &modular_frame_encoder,
-          &enc_state, aux_out));
+      JXL_RETURN_IF_ERROR(
+          ComputeVarDCTEncodingData(frame_header, linear, &opsin, cms, pool,
+                                    &enc_modular, &enc_state, aux_out));
     }
     ComputeAllCoeffOrders(enc_state, frame_dim);
-    shared.num_histograms = 1;
+    if (!enc_state.streaming_mode) {
+      shared.num_histograms = 1;
+      enc_state.histogram_idx.resize(frame_dim.num_groups);
+    }
     JXL_RETURN_IF_ERROR(
         TokenizeAllCoefficients(frame_header, pool, &enc_state));
   }
 
-  JXL_RETURN_IF_ERROR(modular_frame_encoder.ComputeEncodingData(
+  JXL_RETURN_IF_ERROR(enc_modular.ComputeEncodingData(
       frame_header, metadata->m, &opsin, extra_channels, &enc_state, cms, pool,
       aux_out,
       /* do_color=*/frame_header.encoding == FrameEncoding::kModular));
+  if (enc_state.update_global_state) {
+    JXL_RETURN_IF_ERROR(enc_modular.ComputeTree(pool));
+  }
+  JXL_RETURN_IF_ERROR(enc_modular.ComputeTokens(pool));
 
-  frame_header.UpdateFlag(shared.image_features.patches.HasAny(),
-                          FrameHeader::kPatches);
-  frame_header.UpdateFlag(shared.image_features.splines.HasAny(),
-                          FrameHeader::kSplines);
+  if (!enc_state.streaming_mode) {
+    mutable_frame_header.UpdateFlag(shared.image_features.patches.HasAny(),
+                                    FrameHeader::kPatches);
+    mutable_frame_header.UpdateFlag(shared.image_features.splines.HasAny(),
+                                    FrameHeader::kSplines);
+  }
 
-  JXL_RETURN_IF_ERROR(EncodeGroups(frame_header, &enc_state,
-                                   &modular_frame_encoder, pool, group_codes,
-                                   aux_out));
+  JXL_RETURN_IF_ERROR(EncodeGroups(frame_header, &enc_state, &enc_modular, pool,
+                                   group_codes, aux_out));
+  if (enc_state.streaming_mode) {
+    const size_t group_index = enc_state.dc_group_index;
+    enc_modular.ClearStreamData(ModularStreamId::VarDCTDC(group_index));
+    enc_modular.ClearStreamData(ModularStreamId::ACMetadata(group_index));
+  }
   return true;
 }
 
@@ -1572,6 +1629,200 @@ bool CanDoStreamingEncoding(const CompressParams& cparams,
   return true;
 }
 
+void ComputePermutationForStreaming(size_t xsize, size_t ysize,
+                                    size_t num_passes,
+                                    std::vector<coeff_order_t>& permutation,
+                                    std::vector<size_t>& dc_group_order) {
+  // This is only valid in VarDCT mode, otherwise there can be group shift.
+  const size_t group_size = 256;
+  const size_t dc_group_size = group_size * kBlockDim;
+  const size_t group_xsize = DivCeil(xsize, group_size);
+  const size_t group_ysize = DivCeil(ysize, group_size);
+  const size_t dc_group_xsize = DivCeil(xsize, dc_group_size);
+  const size_t dc_group_ysize = DivCeil(ysize, dc_group_size);
+  const size_t num_groups = group_xsize * group_ysize;
+  const size_t num_dc_groups = dc_group_xsize * dc_group_ysize;
+  const size_t num_sections = 2 + num_dc_groups + num_passes * num_groups;
+  permutation.resize(num_sections);
+  size_t new_ix = 0;
+  // DC Global is first
+  permutation[0] = new_ix++;
+  // TODO(szabadka) Change the dc group order to center-first.
+  for (size_t dc_y = 0; dc_y < dc_group_ysize; ++dc_y) {
+    for (size_t dc_x = 0; dc_x < dc_group_xsize; ++dc_x) {
+      size_t dc_ix = dc_y * dc_group_xsize + dc_x;
+      dc_group_order.push_back(dc_ix);
+      permutation[1 + dc_ix] = new_ix++;
+      size_t ac_y0 = dc_y * kBlockDim;
+      size_t ac_x0 = dc_x * kBlockDim;
+      size_t ac_y1 = std::min<size_t>(group_ysize, ac_y0 + kBlockDim);
+      size_t ac_x1 = std::min<size_t>(group_xsize, ac_x0 + kBlockDim);
+      for (size_t ac_y = ac_y0; ac_y < ac_y1; ++ac_y) {
+        for (size_t ac_x = ac_x0; ac_x < ac_x1; ++ac_x) {
+          size_t group_ix = ac_y * group_xsize + ac_x;
+          for (size_t pass = 0; pass < num_passes; ++pass) {
+            size_t old_ix =
+                AcGroupIndex(pass, group_ix, num_groups, num_dc_groups);
+            permutation[old_ix] = new_ix++;
+          }
+        }
+      }
+    }
+  }
+  // AC Global is last
+  permutation[1 + num_dc_groups] = new_ix++;
+  JXL_ASSERT(new_ix == num_sections);
+}
+
+constexpr size_t kGroupSizeOffset[4] = {
+    static_cast<size_t>(0),
+    static_cast<size_t>(1024),
+    static_cast<size_t>(17408),
+    static_cast<size_t>(4211712),
+};
+constexpr size_t kTOCBits[4] = {12, 16, 24, 32};
+
+size_t TOCBucket(size_t group_size) {
+  size_t bucket = 0;
+  while (bucket < 3 && group_size >= kGroupSizeOffset[bucket + 1]) ++bucket;
+  return bucket;
+}
+
+size_t TOCSize(const std::vector<size_t>& group_sizes) {
+  size_t toc_bits = 0;
+  for (size_t i = 0; i < group_sizes.size(); i++) {
+    toc_bits += kTOCBits[TOCBucket(group_sizes[i])];
+  }
+  return (toc_bits + 7) / 8;
+}
+
+PaddedBytes EncodeTOC(const std::vector<size_t>& group_sizes, AuxOut* aux_out) {
+  BitWriter writer;
+  BitWriter::Allotment allotment(&writer, 32 * group_sizes.size());
+  for (size_t i = 0; i < group_sizes.size(); i++) {
+    JXL_CHECK(U32Coder::Write(kTocDist, group_sizes[i], &writer));
+  }
+  writer.ZeroPadToByte();  // before first group
+  allotment.ReclaimAndCharge(&writer, kLayerTOC, aux_out);
+  return std::move(writer).TakeBytes();
+}
+
+void ComputeGroupDataOffset(size_t frame_header_size, size_t dc_global_size,
+                            size_t num_sections, size_t& min_dc_global_size,
+                            size_t& group_offset) {
+  size_t max_toc_bits = (num_sections - 1) * 32;
+  size_t min_toc_bits = (num_sections - 1) * 12;
+  size_t max_padding = (max_toc_bits - min_toc_bits + 7) / 8;
+  min_dc_global_size = dc_global_size;
+  size_t dc_global_bucket = TOCBucket(min_dc_global_size);
+  while (TOCBucket(min_dc_global_size + max_padding) > dc_global_bucket) {
+    dc_global_bucket = TOCBucket(min_dc_global_size + max_padding);
+    min_dc_global_size = kGroupSizeOffset[dc_global_bucket];
+  }
+  JXL_ASSERT(TOCBucket(min_dc_global_size) == dc_global_bucket);
+  JXL_ASSERT(TOCBucket(min_dc_global_size + max_padding) == dc_global_bucket);
+  max_toc_bits += kTOCBits[dc_global_bucket];
+  size_t max_toc_size = (max_toc_bits + 7) / 8;
+  group_offset = frame_header_size + max_toc_size + min_dc_global_size;
+}
+
+size_t ComputeDcGlobalPadding(const std::vector<size_t>& group_sizes,
+                              size_t frame_header_size,
+                              size_t group_data_offset,
+                              size_t min_dc_global_size) {
+  std::vector<size_t> new_group_sizes = group_sizes;
+  new_group_sizes[0] = min_dc_global_size;
+  size_t toc_size = TOCSize(new_group_sizes);
+  size_t actual_offset = frame_header_size + toc_size + group_sizes[0];
+  return group_data_offset - actual_offset;
+}
+
+Status OutputGroups(std::vector<BitWriter>&& group_codes,
+                    std::vector<size_t>* group_sizes,
+                    JxlEncoderOutputProcessorWrapper* output_processor) {
+  JXL_ASSERT(group_codes.size() >= 4);
+  {
+    PaddedBytes dc_group = std::move(group_codes[1]).TakeBytes();
+    group_sizes->push_back(dc_group.size());
+    JXL_RETURN_IF_ERROR(AppendData(*output_processor, dc_group));
+  }
+  for (size_t i = 3; i < group_codes.size(); ++i) {
+    PaddedBytes ac_group = std::move(group_codes[i]).TakeBytes();
+    group_sizes->push_back(ac_group.size());
+    JXL_RETURN_IF_ERROR(AppendData(*output_processor, ac_group));
+  }
+  return true;
+}
+
+void RemoveUnusedHistograms(std::vector<uint8_t>& context_map,
+                            EntropyEncodingData& codes) {
+  std::vector<int> remap(256, -1);
+  std::vector<uint8_t> inv_remap;
+  for (size_t i = 0; i < context_map.size(); ++i) {
+    const uint8_t histo_ix = context_map[i];
+    if (remap[histo_ix] == -1) {
+      remap[histo_ix] = inv_remap.size();
+      inv_remap.push_back(histo_ix);
+    }
+    context_map[i] = remap[histo_ix];
+  }
+  EntropyEncodingData new_codes;
+  new_codes.use_prefix_code = codes.use_prefix_code;
+  new_codes.lz77 = codes.lz77;
+  for (uint8_t histo_idx : inv_remap) {
+    new_codes.encoding_info.emplace_back(
+        std::move(codes.encoding_info[histo_idx]));
+    new_codes.uint_config.emplace_back(std::move(codes.uint_config[histo_idx]));
+    new_codes.encoded_histograms.emplace_back(
+        std::move(codes.encoded_histograms[histo_idx]));
+  }
+  codes = std::move(new_codes);
+}
+
+Status OutputAcGlobal(PassesEncoderState& enc_state,
+                      const FrameDimensions& frame_dim,
+                      std::vector<size_t>* group_sizes,
+                      JxlEncoderOutputProcessorWrapper* output_processor,
+                      AuxOut* aux_out) {
+  JXL_ASSERT(frame_dim.num_groups > 1);
+  BitWriter writer;
+  {
+    size_t num_histo_bits = CeilLog2Nonzero(frame_dim.num_groups);
+    BitWriter::Allotment allotment(&writer, num_histo_bits + 1);
+    writer.Write(1, 1);  // default dequant matrices
+    writer.Write(num_histo_bits, frame_dim.num_dc_groups - 1);
+    allotment.ReclaimAndCharge(&writer, kLayerAC, aux_out);
+  }
+  const PassesSharedState& shared = enc_state.shared;
+  for (size_t i = 0; i < enc_state.progressive_splitter.GetNumPasses(); i++) {
+    // Encode coefficient orders.
+    size_t order_bits = 0;
+    JXL_RETURN_IF_ERROR(
+        U32Coder::CanEncode(kOrderEnc, enc_state.used_orders[i], &order_bits));
+    BitWriter::Allotment allotment(&writer, order_bits);
+    JXL_CHECK(U32Coder::Write(kOrderEnc, enc_state.used_orders[i], &writer));
+    allotment.ReclaimAndCharge(&writer, kLayerOrder, aux_out);
+    EncodeCoeffOrders(enc_state.used_orders[i],
+                      &shared.coeff_orders[i * shared.coeff_order_size],
+                      &writer, kLayerOrder, aux_out);
+    // Fix up context map and entropy codes to remove any fix histograms that
+    // were not selected by clustering.
+    RemoveUnusedHistograms(enc_state.passes[i].context_map,
+                           enc_state.passes[i].codes);
+    EncodeHistograms(enc_state.passes[i].context_map, enc_state.passes[i].codes,
+                     &writer, kLayerAC, aux_out);
+  }
+  {
+    BitWriter::Allotment allotment(&writer, 8);
+    writer.ZeroPadToByte();  // end of group.
+    allotment.ReclaimAndCharge(&writer, kLayerAC, aux_out);
+  }
+  PaddedBytes ac_global = std::move(writer).TakeBytes();
+  group_sizes->push_back(ac_global.size());
+  JXL_RETURN_IF_ERROR(AppendData(*output_processor, ac_global));
+  return true;
+}
+
 Status EncodeFrameStreaming(const CompressParams& cparams,
                             const FrameInfo& frame_info,
                             const CodecMetadata* metadata,
@@ -1579,32 +1830,106 @@ Status EncodeFrameStreaming(const CompressParams& cparams,
                             const JxlCmsInterface& cms, ThreadPool* pool,
                             JxlEncoderOutputProcessorWrapper* output_processor,
                             AuxOut* aux_out) {
-  // TODO(szabadka): Call ComputeEncodingData for one DC group at a time and
-  // write the output at a precomputed position.
   PassesEncoderState enc_state;
+  SetProgressiveMode(cparams, &enc_state.progressive_splitter);
   FrameHeader frame_header(metadata);
-  std::vector<BitWriter> group_codes;
-  JXL_RETURN_IF_ERROR(
-      ComputeEncodingData(cparams, frame_info, metadata, frame_header,
-                          frame_data, 0, 0, frame_data.xsize, frame_data.ysize,
-                          cms, pool, enc_state, &group_codes, aux_out));
-
-  BitWriter writer;
-  writer.AppendByteAligned(enc_state.special_frames);
-  JXL_RETURN_IF_ERROR(WriteFrameHeader(frame_header, &writer, aux_out));
-
+  std::unique_ptr<jpeg::JPEGData> jpeg_data;
+  if (frame_data.IsJPEG()) {
+    jpeg_data = make_unique<jpeg::JPEGData>(frame_data.TakeJPEGData());
+  }
+  JXL_RETURN_IF_ERROR(MakeFrameHeader(frame_data.xsize, frame_data.ysize,
+                                      cparams, enc_state.progressive_splitter,
+                                      frame_info, jpeg_data.get(), true,
+                                      &frame_header));
   const size_t num_passes = enc_state.progressive_splitter.GetNumPasses();
+  ModularFrameEncoder enc_modular(frame_header, cparams);
   std::vector<coeff_order_t> permutation;
-  JXL_RETURN_IF_ERROR(PermuteGroups(cparams, enc_state.shared.frame_dim,
-                                    num_passes, &permutation, &group_codes));
-
-  JXL_RETURN_IF_ERROR(
-      WriteGroupOffsets(group_codes, permutation, &writer, aux_out));
-
-  writer.AppendByteAligned(group_codes);
-  PaddedBytes frame_bytes = std::move(writer).TakeBytes();
-  JXL_RETURN_IF_ERROR(AppendData(*output_processor, frame_bytes));
-
+  std::vector<size_t> dc_group_order;
+  ComputePermutationForStreaming(frame_data.xsize, frame_data.ysize, num_passes,
+                                 permutation, dc_group_order);
+  enc_state.shared.num_histograms = dc_group_order.size();
+  // This is only valid in VarDCT mode, otherwise there can be group shift.
+  size_t group_size = 256;
+  size_t dc_group_size = group_size * kBlockDim;
+  size_t dc_group_xsize = DivCeil(frame_data.xsize, dc_group_size);
+  size_t min_dc_global_size = 0;
+  size_t group_data_offset = 0;
+  PaddedBytes frame_header_bytes;
+  PaddedBytes dc_global_bytes;
+  std::vector<size_t> group_sizes;
+  size_t start_pos = output_processor->CurrentPosition();
+  for (size_t i = 0; i < dc_group_order.size(); ++i) {
+    size_t dc_ix = dc_group_order[i];
+    size_t dc_y = dc_ix / dc_group_xsize;
+    size_t dc_x = dc_ix % dc_group_xsize;
+    size_t y0 = dc_y * dc_group_size;
+    size_t x0 = dc_x * dc_group_size;
+    size_t ysize = std::min<size_t>(dc_group_size, frame_data.ysize - y0);
+    size_t xsize = std::min<size_t>(dc_group_size, frame_data.xsize - x0);
+    size_t group_xsize = DivCeil(xsize, group_size);
+    size_t group_ysize = DivCeil(ysize, group_size);
+    JXL_DEBUG_V(2,
+                "Encoding DC group #%" PRIuS " dc_y = %" PRIuS " dc_x = %" PRIuS
+                " (x0, y0) = (%" PRIuS ", %" PRIuS ") (xsize, ysize) = (%" PRIuS
+                ", %" PRIuS ")",
+                dc_ix, dc_y, dc_x, x0, y0, xsize, ysize);
+    enc_state.streaming_mode = true;
+    enc_state.update_global_state = (i == 0);
+    enc_state.dc_group_index = dc_ix;
+    enc_state.histogram_idx =
+        std::vector<uint8_t>(group_xsize * group_ysize, i);
+    std::vector<BitWriter> group_codes;
+    JXL_RETURN_IF_ERROR(ComputeEncodingData(
+        cparams, frame_info, metadata, frame_data, jpeg_data.get(), x0, y0,
+        xsize, ysize, cms, pool, frame_header, enc_modular, enc_state,
+        &group_codes, aux_out));
+    JXL_ASSERT(enc_state.special_frames.empty());
+    if (i == 0) {
+      BitWriter writer;
+      JXL_RETURN_IF_ERROR(WriteFrameHeader(frame_header, &writer, aux_out));
+      BitWriter::Allotment allotment(&writer, 8);
+      writer.Write(1, 1);  // write permutation
+      EncodePermutation(permutation.data(), /*skip=*/0, permutation.size(),
+                        &writer, kLayerHeader, aux_out);
+      writer.ZeroPadToByte();
+      allotment.ReclaimAndCharge(&writer, kLayerHeader, aux_out);
+      frame_header_bytes = std::move(writer).TakeBytes();
+      dc_global_bytes = std::move(group_codes[0]).TakeBytes();
+      ComputeGroupDataOffset(frame_header_bytes.size(), dc_global_bytes.size(),
+                             permutation.size(), min_dc_global_size,
+                             group_data_offset);
+      JXL_DEBUG_V(2, "Frame header size: %" PRIuS, frame_header_bytes.size());
+      JXL_DEBUG_V(2, "DC global size: %" PRIuS ", min size for TOC: %" PRIuS,
+                  dc_global_bytes.size(), min_dc_global_size);
+      JXL_DEBUG_V(2, "Num groups: %" PRIuS " group data offset: %" PRIuS,
+                  permutation.size(), group_data_offset);
+      group_sizes.push_back(dc_global_bytes.size());
+      output_processor->Seek(start_pos + group_data_offset);
+    }
+    JXL_RETURN_IF_ERROR(
+        OutputGroups(std::move(group_codes), &group_sizes, output_processor));
+  }
+  JXL_RETURN_IF_ERROR(OutputAcGlobal(enc_state,
+                                     frame_header.ToFrameDimensions(),
+                                     &group_sizes, output_processor, aux_out));
+  JXL_ASSERT(group_sizes.size() == permutation.size());
+  size_t end_pos = output_processor->CurrentPosition();
+  output_processor->Seek(start_pos);
+  size_t padding_size =
+      ComputeDcGlobalPadding(group_sizes, frame_header_bytes.size(),
+                             group_data_offset, min_dc_global_size);
+  group_sizes[0] += padding_size;
+  PaddedBytes toc_bytes = EncodeTOC(group_sizes, aux_out);
+  std::vector<uint8_t> padding_bytes(padding_size);
+  JXL_RETURN_IF_ERROR(AppendData(*output_processor, frame_header_bytes));
+  JXL_RETURN_IF_ERROR(AppendData(*output_processor, toc_bytes));
+  JXL_RETURN_IF_ERROR(AppendData(*output_processor, dc_global_bytes));
+  JXL_RETURN_IF_ERROR(AppendData(*output_processor, padding_bytes));
+  JXL_DEBUG_V(2, "TOC size: %" PRIuS " padding bytes after DC global: %" PRIuS,
+              toc_bytes.size(), padding_size);
+  JXL_ASSERT(output_processor->CurrentPosition() ==
+             start_pos + group_data_offset);
+  output_processor->Seek(end_pos);
   return true;
 }
 
@@ -1616,18 +1941,28 @@ Status EncodeFrameOneShot(const CompressParams& cparams,
                           JxlEncoderOutputProcessorWrapper* output_processor,
                           AuxOut* aux_out) {
   PassesEncoderState enc_state;
+  SetProgressiveMode(cparams, &enc_state.progressive_splitter);
   std::vector<BitWriter> group_codes;
   FrameHeader frame_header(metadata);
-  JXL_RETURN_IF_ERROR(
-      ComputeEncodingData(cparams, frame_info, metadata, frame_header,
-                          frame_data, 0, 0, frame_data.xsize, frame_data.ysize,
-                          cms, pool, enc_state, &group_codes, aux_out));
+  std::unique_ptr<jpeg::JPEGData> jpeg_data;
+  if (frame_data.IsJPEG()) {
+    jpeg_data = make_unique<jpeg::JPEGData>(frame_data.TakeJPEGData());
+  }
+  JXL_RETURN_IF_ERROR(MakeFrameHeader(frame_data.xsize, frame_data.ysize,
+                                      cparams, enc_state.progressive_splitter,
+                                      frame_info, jpeg_data.get(), false,
+                                      &frame_header));
+  const size_t num_passes = enc_state.progressive_splitter.GetNumPasses();
+  ModularFrameEncoder enc_modular(frame_header, cparams);
+  JXL_RETURN_IF_ERROR(ComputeEncodingData(
+      cparams, frame_info, metadata, frame_data, jpeg_data.get(), 0, 0,
+      frame_data.xsize, frame_data.ysize, cms, pool, frame_header, enc_modular,
+      enc_state, &group_codes, aux_out));
 
   BitWriter writer;
   writer.AppendByteAligned(enc_state.special_frames);
   JXL_RETURN_IF_ERROR(WriteFrameHeader(frame_header, &writer, aux_out));
 
-  const size_t num_passes = enc_state.progressive_splitter.GetNumPasses();
   std::vector<coeff_order_t> permutation;
   JXL_RETURN_IF_ERROR(PermuteGroups(cparams, enc_state.shared.frame_dim,
                                     num_passes, &permutation, &group_codes));

--- a/lib/jxl/enc_frame.cc
+++ b/lib/jxl/enc_frame.cc
@@ -1171,7 +1171,7 @@ Status EncodeGlobalACInfo(PassesEncoderState* enc_state, BitWriter* writer,
     if (enc_state->streaming_mode) {
       size_t prev_num_histograms =
           enc_state->passes[i].codes.encoding_info.size();
-      if (enc_state->update_global_state) {
+      if (enc_state->initialize_global_state) {
         prev_num_histograms += kNumFixedHistograms;
         hist_params.add_fixed_histograms = true;
       }
@@ -1186,7 +1186,7 @@ Status EncodeGlobalACInfo(PassesEncoderState* enc_state, BitWriter* writer,
       num_histogram_groups = 1;
     }
     hist_params.streaming_mode = enc_state->streaming_mode;
-    hist_params.update_global_state = enc_state->update_global_state;
+    hist_params.initialize_global_state = enc_state->initialize_global_state;
     BuildAndEncodeHistograms(
         hist_params,
         num_histogram_groups * shared.block_ctx_map.NumACContexts(),
@@ -1219,7 +1219,7 @@ Status EncodeGroups(const FrameHeader& frame_header,
                                    frame_dim.num_dc_groups));
   };
 
-  if (enc_state->update_global_state) {
+  if (enc_state->initialize_global_state) {
     if (frame_header.flags & FrameHeader::kPatches) {
       PatchDictionaryEncoder::Encode(shared.image_features.patches,
                                      get_output(0), kLayerDictionary, aux_out);
@@ -1448,7 +1448,7 @@ Status ComputeEncodingData(
     PadImageToBlockMultipleInPlace(&opsin);
   }
 
-  if (enc_state.update_global_state && !jpeg_data) {
+  if (enc_state.initialize_global_state && !jpeg_data) {
     ComputeChromacityAdjustments(cparams, opsin, &mutable_frame_header);
   }
 
@@ -1492,7 +1492,7 @@ Status ComputeEncodingData(
       frame_header, metadata->m, &opsin, extra_channels, &enc_state, cms, pool,
       aux_out,
       /* do_color=*/frame_header.encoding == FrameEncoding::kModular));
-  if (enc_state.update_global_state) {
+  if (enc_state.initialize_global_state) {
     JXL_RETURN_IF_ERROR(enc_modular.ComputeTree(pool));
   }
   JXL_RETURN_IF_ERROR(enc_modular.ComputeTokens(pool));
@@ -1880,7 +1880,7 @@ Status EncodeFrameStreaming(const CompressParams& cparams,
                 ", %" PRIuS ")",
                 dc_ix, dc_y, dc_x, x0, y0, xsize, ysize);
     enc_state.streaming_mode = true;
-    enc_state.update_global_state = (i == 0);
+    enc_state.initialize_global_state = (i == 0);
     enc_state.dc_group_index = dc_ix;
     enc_state.histogram_idx =
         std::vector<uint8_t>(group_xsize * group_ysize, i);

--- a/lib/jxl/enc_group.cc
+++ b/lib/jxl/enc_group.cc
@@ -358,8 +358,9 @@ void QuantizeRoundtripYBlockAC(PassesEncoderState* enc_state, const size_t size,
 
 void ComputeCoefficients(size_t group_idx, PassesEncoderState* enc_state,
                          const Image3F& opsin, Image3F* dc) {
-  const Rect block_group_rect = enc_state->shared.BlockGroupRect(group_idx);
-  const Rect group_rect = enc_state->shared.GroupRect(group_idx);
+  const Rect block_group_rect =
+      enc_state->shared.frame_dim.BlockGroupRect(group_idx);
+  const Rect group_rect = enc_state->shared.frame_dim.GroupRect(group_idx);
   const Rect cmap_rect(
       block_group_rect.x0() / kColorTileDimInBlocks,
       block_group_rect.y0() / kColorTileDimInBlocks,
@@ -523,10 +524,12 @@ Status EncodeGroupTokenizedCoefficients(size_t group_idx, size_t pass_idx,
     writer->Write(histo_selector_bits, histogram_idx);
     allotment.ReclaimAndCharge(writer, kLayerAC, aux_out);
   }
+  size_t context_offset =
+      histogram_idx * enc_state.shared.block_ctx_map.NumACContexts();
   WriteTokens(enc_state.passes[pass_idx].ac_tokens[group_idx],
               enc_state.passes[pass_idx].codes,
-              enc_state.passes[pass_idx].context_map, writer, kLayerACTokens,
-              aux_out);
+              enc_state.passes[pass_idx].context_map, context_offset, writer,
+              kLayerACTokens, aux_out);
 
   return true;
 }

--- a/lib/jxl/enc_heuristics.cc
+++ b/lib/jxl/enc_heuristics.cc
@@ -166,6 +166,8 @@ void FindBestBlockEntropyModel(PassesEncoderState& enc_state) {
       *std::max_element(ctx_map.begin(), ctx_map.end()) + 1;
 }
 
+namespace {
+
 void FindBestDequantMatrices(const CompressParams& cparams,
                              const Image3F& opsin,
                              ModularFrameEncoder* modular_frame_encoder,
@@ -189,8 +191,6 @@ void FindBestDequantMatrices(const CompressParams& cparams,
     DequantMatricesSetCustomDC(dequant_matrices, dc_weights);
   }
 }
-
-namespace {
 
 void StoreMin2(const float v, float& min1, float& min2) {
   if (v < min2) {
@@ -707,7 +707,8 @@ Status LossyFrameHeuristics(const FrameHeader& frame_header,
   PassesSharedState& shared = enc_state->shared;
 
   // Find and subtract splines.
-  if (cparams.speed_tier <= SpeedTier::kSquirrel) {
+  if (!enc_state->streaming_mode &&
+      cparams.speed_tier <= SpeedTier::kSquirrel) {
     if (cparams.custom_splines.HasAny()) {
       shared.image_features.splines = cparams.custom_splines;
     } else {
@@ -719,7 +720,8 @@ Status LossyFrameHeuristics(const FrameHeader& frame_header,
   }
 
   // Find and subtract patches/dots.
-  if (ApplyOverride(cparams.patches,
+  if (!enc_state->streaming_mode &&
+      ApplyOverride(cparams.patches,
                     cparams.speed_tier <= SpeedTier::kSquirrel)) {
     FindBestPatchDictionary(*opsin, enc_state, cms, pool, aux_out);
     PatchDictionaryEncoder::SubtractFrom(shared.image_features.patches, opsin);
@@ -730,8 +732,10 @@ Status LossyFrameHeuristics(const FrameHeader& frame_header,
   Quantizer& quantizer = enc_state->shared.quantizer;
   // We don't know the quant field yet, but for computing the global scale
   // assuming that it will be the same as for Falcon mode is good enough.
-  quantizer.ComputeGlobalScaleAndQuant(
-      quant_dc, kAcQuant / cparams.butteraugli_distance, 0);
+  if (enc_state->update_global_state) {
+    quantizer.ComputeGlobalScaleAndQuant(
+        quant_dc, kAcQuant / cparams.butteraugli_distance, 0);
+  }
 
   // TODO(veluca): we can now run all the code from here to FindBestQuantizer
   // (excluded) one rect at a time. Do that.
@@ -778,7 +782,10 @@ Status LossyFrameHeuristics(const FrameHeader& frame_header,
         butteraugli_distance_for_iqf, *opsin, shared.frame_dim, pool, 1.0f,
         &enc_state->initial_quant_masking,
         &enc_state->initial_quant_masking1x1);
-    quantizer.SetQuantField(quant_dc, enc_state->initial_quant_field, nullptr);
+    if (enc_state->update_global_state) {
+      quantizer.SetQuantField(quant_dc, enc_state->initial_quant_field,
+                              nullptr);
+    }
   }
 
   // TODO(veluca): do something about animations.
@@ -794,8 +801,10 @@ Status LossyFrameHeuristics(const FrameHeader& frame_header,
     GaborishInverse(opsin, weight, pool);
   }
 
-  FindBestDequantMatrices(cparams, *opsin, modular_frame_encoder,
-                          &enc_state->shared.matrices);
+  if (enc_state->update_global_state) {
+    FindBestDequantMatrices(cparams, *opsin, modular_frame_encoder,
+                            &enc_state->shared.matrices);
+  }
 
   cfl_heuristics.Init(*opsin);
   acs_heuristics.Init(*opsin, enc_state);
@@ -862,17 +871,21 @@ Status LossyFrameHeuristics(const FrameHeader& frame_header,
       process_tile, "Enc Heuristics"));
 
   acs_heuristics.Finalize(aux_out);
-  if (cparams.speed_tier <= SpeedTier::kHare) {
+  if (cparams.speed_tier <= SpeedTier::kHare &&
+      enc_state->update_global_state) {
     cfl_heuristics.ComputeDC(/*fast=*/cparams.speed_tier >= SpeedTier::kWombat,
                              &enc_state->shared.cmap);
   }
 
   // Refine quantization levels.
-  FindBestQuantizer(frame_header, original_pixels, *opsin, enc_state, cms, pool,
-                    aux_out);
+  if (!enc_state->streaming_mode) {
+    FindBestQuantizer(frame_header, original_pixels, *opsin, enc_state, cms,
+                      pool, aux_out);
+  }
 
   // Choose a context model that depends on the amount of quantization for AC.
-  if (cparams.speed_tier < SpeedTier::kFalcon) {
+  if (cparams.speed_tier < SpeedTier::kFalcon &&
+      enc_state->update_global_state) {
     FindBestBlockEntropyModel(*enc_state);
   }
   return true;

--- a/lib/jxl/enc_heuristics.cc
+++ b/lib/jxl/enc_heuristics.cc
@@ -732,7 +732,7 @@ Status LossyFrameHeuristics(const FrameHeader& frame_header,
   Quantizer& quantizer = enc_state->shared.quantizer;
   // We don't know the quant field yet, but for computing the global scale
   // assuming that it will be the same as for Falcon mode is good enough.
-  if (enc_state->update_global_state) {
+  if (enc_state->initialize_global_state) {
     quantizer.ComputeGlobalScaleAndQuant(
         quant_dc, kAcQuant / cparams.butteraugli_distance, 0);
   }
@@ -782,7 +782,7 @@ Status LossyFrameHeuristics(const FrameHeader& frame_header,
         butteraugli_distance_for_iqf, *opsin, shared.frame_dim, pool, 1.0f,
         &enc_state->initial_quant_masking,
         &enc_state->initial_quant_masking1x1);
-    if (enc_state->update_global_state) {
+    if (enc_state->initialize_global_state) {
       quantizer.SetQuantField(quant_dc, enc_state->initial_quant_field,
                               nullptr);
     }
@@ -801,7 +801,7 @@ Status LossyFrameHeuristics(const FrameHeader& frame_header,
     GaborishInverse(opsin, weight, pool);
   }
 
-  if (enc_state->update_global_state) {
+  if (enc_state->initialize_global_state) {
     FindBestDequantMatrices(cparams, *opsin, modular_frame_encoder,
                             &enc_state->shared.matrices);
   }
@@ -872,7 +872,7 @@ Status LossyFrameHeuristics(const FrameHeader& frame_header,
 
   acs_heuristics.Finalize(aux_out);
   if (cparams.speed_tier <= SpeedTier::kHare &&
-      enc_state->update_global_state) {
+      enc_state->initialize_global_state) {
     cfl_heuristics.ComputeDC(/*fast=*/cparams.speed_tier >= SpeedTier::kWombat,
                              &enc_state->shared.cmap);
   }
@@ -885,7 +885,7 @@ Status LossyFrameHeuristics(const FrameHeader& frame_header,
 
   // Choose a context model that depends on the amount of quantization for AC.
   if (cparams.speed_tier < SpeedTier::kFalcon &&
-      enc_state->update_global_state) {
+      enc_state->initialize_global_state) {
     FindBestBlockEntropyModel(*enc_state);
   }
   return true;

--- a/lib/jxl/enc_heuristics.h
+++ b/lib/jxl/enc_heuristics.h
@@ -44,13 +44,6 @@ void FindBestBlockEntropyModel(PassesEncoderState& enc_state);
 void DownsampleImage2_Iterative(Image3F* output);
 void DownsampleImage2_Sharper(Image3F* opsin);
 
-// Exposed here since it may be used by other EncoderHeuristics
-// implementations outside this project.
-void FindBestDequantMatrices(const CompressParams& cparams,
-                             const Image3F& opsin,
-                             ModularFrameEncoder* modular_frame_encoder,
-                             DequantMatrices* dequant_matrices);
-
 }  // namespace jxl
 
 #endif  // LIB_JXL_ENC_HEURISTICS_H_

--- a/lib/jxl/enc_icc_codec.cc
+++ b/lib/jxl/enc_icc_codec.cc
@@ -424,7 +424,7 @@ Status WriteICC(const IccBytes& icc, BitWriter* JXL_RESTRICT writer,
   params.force_huffman = true;
   BuildAndEncodeHistograms(params, kNumICCContexts, tokens, &code, &context_map,
                            writer, layer, aux_out);
-  WriteTokens(tokens[0], code, context_map, writer, layer, aux_out);
+  WriteTokens(tokens[0], code, context_map, 0, writer, layer, aux_out);
   return true;
 }
 

--- a/lib/jxl/enc_modular.cc
+++ b/lib/jxl/enc_modular.cc
@@ -770,10 +770,8 @@ Status ModularFrameEncoder::ComputeEncodingData(
   }
   JXL_ASSERT(max_bitdepth <= level_max_bitdepth);
 
-  std::vector<uint32_t> quants;
-
   if (!cparams_.ModularPartIsLossless()) {
-    quants.resize(gi.channel.size(), 1);
+    quants_.resize(gi.channel.size(), 1);
     float quantizer = 0.25f;
     if (!cparams_.responsive) {
       JXL_DEBUG_V(1,
@@ -829,7 +827,7 @@ Status ModularFrameEncoder::ComputeEncodingData(
       }
       if (q < 1) q = 1;
       QuantizeChannel(gi.channel[i], q);
-      quants[i] = q;
+      quants_[i] = q;
     }
   }
 
@@ -900,7 +898,13 @@ Status ModularFrameEncoder::ComputeEncodingData(
     }
   }
 
-  if (!quants.empty()) {
+  JXL_RETURN_IF_ERROR(ValidateChannelDimensions(gi, stream_options_[0]));
+  return true;
+}
+
+Status ModularFrameEncoder::ComputeTree(ThreadPool* pool) {
+  std::vector<ModularMultiplierInfo> multiplier_info;
+  if (!quants_.empty()) {
     for (uint32_t stream_id = 0; stream_id < stream_images_.size();
          stream_id++) {
       // skip non-modular stream_ids
@@ -917,59 +921,45 @@ Status ModularFrameEncoder::ComputeEncodingData(
         size_t ch_id = stream_id == 0
                            ? i
                            : gi_channel_[stream_id][i - image.nb_meta_channels];
-        uint32_t q = quants[ch_id];
+        uint32_t q = quants_[ch_id];
         // Inform the tree splitting heuristics that each channel in each group
         // used this quantization factor. This will produce a tree with the
         // given multipliers.
-        if (multiplier_info_.empty() ||
-            multiplier_info_.back().range[1][0] != stream_id ||
-            multiplier_info_.back().multiplier != q) {
+        if (multiplier_info.empty() ||
+            multiplier_info.back().range[1][0] != stream_id ||
+            multiplier_info.back().multiplier != q) {
           StaticPropRange range;
           range[0] = {{i, i + 1}};
           range[1] = {{stream_id, stream_id + 1}};
-          multiplier_info_.push_back({range, (uint32_t)q});
+          multiplier_info.push_back({range, (uint32_t)q});
         } else {
           // Previous channel in the same group had the same quantization
           // factor. Don't provide two different ranges, as that creates
           // unnecessary nodes.
-          multiplier_info_.back().range[0][1] = i + 1;
+          multiplier_info.back().range[0][1] = i + 1;
         }
       }
     }
     // Merge group+channel settings that have the same channels and quantization
     // factors, to avoid unnecessary nodes.
-    std::sort(multiplier_info_.begin(), multiplier_info_.end(),
+    std::sort(multiplier_info.begin(), multiplier_info.end(),
               [](ModularMultiplierInfo a, ModularMultiplierInfo b) {
                 return std::make_tuple(a.range, a.multiplier) <
                        std::make_tuple(b.range, b.multiplier);
               });
     size_t new_num = 1;
-    for (size_t i = 1; i < multiplier_info_.size(); i++) {
-      ModularMultiplierInfo& prev = multiplier_info_[new_num - 1];
-      ModularMultiplierInfo& cur = multiplier_info_[i];
+    for (size_t i = 1; i < multiplier_info.size(); i++) {
+      ModularMultiplierInfo& prev = multiplier_info[new_num - 1];
+      ModularMultiplierInfo& cur = multiplier_info[i];
       if (prev.range[0] == cur.range[0] && prev.multiplier == cur.multiplier &&
           prev.range[1][1] == cur.range[1][0]) {
         prev.range[1][1] = cur.range[1][1];
       } else {
-        multiplier_info_[new_num++] = multiplier_info_[i];
+        multiplier_info[new_num++] = multiplier_info[i];
       }
     }
-    multiplier_info_.resize(new_num);
+    multiplier_info.resize(new_num);
   }
-
-  JXL_RETURN_IF_ERROR(ValidateChannelDimensions(gi, stream_options_[0]));
-
-  return PrepareEncoding(frame_header, pool, aux_out);
-}
-
-Status ModularFrameEncoder::PrepareEncoding(const FrameHeader& frame_header,
-                                            ThreadPool* pool, AuxOut* aux_out) {
-  if (!tree_.empty()) return true;
-
-  // Compute tree.
-  size_t num_streams = stream_images_.size();
-  stream_headers_.resize(num_streams);
-  tokens_.resize(num_streams);
 
   if (!cparams_.custom_fixed_tree.empty()) {
     tree_ = cparams_.custom_fixed_tree;
@@ -1005,7 +995,6 @@ Status ModularFrameEncoder::PrepareEncoding(const FrameHeader& frame_header,
           uint32_t stop = useful_splits[chunk + 1];
           while (start < stop && stream_images_[start].empty()) ++start;
           while (start < stop && stream_images_[stop - 1].empty()) --stop;
-          uint32_t max_c = 0;
           if (stream_options_[start].tree_kind !=
               ModularOptions::TreeKind::kLearn) {
             for (size_t i = start; i < stop; i++) {
@@ -1029,6 +1018,7 @@ Status ModularFrameEncoder::PrepareEncoding(const FrameHeader& frame_header,
             invalid_force_wp.test_and_set(std::memory_order_acq_rel);
             return;
           }
+          uint32_t max_c = 0;
           std::vector<pixel_type> pixel_samples;
           std::vector<pixel_type> diff_samples;
           std::vector<uint32_t> group_pixel_count;
@@ -1042,7 +1032,7 @@ Status ModularFrameEncoder::PrepareEncoding(const FrameHeader& frame_header,
           StaticPropRange range;
           range[0] = {{0, max_c}};
           range[1] = {{start, stop}};
-          auto local_multiplier_info = multiplier_info_;
+          auto local_multiplier_info = multiplier_info;
 
           tree_samples.PreQuantizeProperties(
               range, local_multiplier_info, group_pixel_count,
@@ -1099,7 +1089,13 @@ Status ModularFrameEncoder::PrepareEncoding(const FrameHeader& frame_header,
       PrintTree(tree_, aux_out->debug_prefix + "/global_tree");
     }
   } */
+  return true;
+}
 
+Status ModularFrameEncoder::ComputeTokens(ThreadPool* pool) {
+  size_t num_streams = stream_images_.size();
+  stream_headers_.resize(num_streams);
+  tokens_.resize(num_streams);
   image_widths_.resize(num_streams);
   JXL_RETURN_IF_ERROR(RunOnPool(
       pool, 0, num_streams, ThreadPool::NoInit,
@@ -1119,7 +1115,8 @@ Status ModularFrameEncoder::PrepareEncoding(const FrameHeader& frame_header,
   return true;
 }
 
-Status ModularFrameEncoder::EncodeGlobalInfo(BitWriter* writer,
+Status ModularFrameEncoder::EncodeGlobalInfo(bool streaming_mode,
+                                             BitWriter* writer,
                                              AuxOut* aux_out) {
   BitWriter::Allotment allotment(writer, 1);
   // If we are using brotli, or not using modular mode.
@@ -1172,10 +1169,17 @@ Status ModularFrameEncoder::EncodeGlobalInfo(BitWriter* writer,
     params.uint_method = HistogramParams::HybridUintMethod::k000;
     params.force_huffman = true;
   }
-  BuildAndEncodeHistograms(params, kNumTreeContexts, tree_tokens_, &code_,
-                           &context_map_, writer, kLayerModularTree, aux_out);
-  WriteTokens(tree_tokens_[0], code_, context_map_, writer, kLayerModularTree,
-              aux_out);
+  {
+    EntropyEncodingData tree_code;
+    std::vector<uint8_t> tree_context_map;
+    BuildAndEncodeHistograms(params, kNumTreeContexts, tree_tokens_, &tree_code,
+                             &tree_context_map, writer, kLayerModularTree,
+                             aux_out);
+    WriteTokens(tree_tokens_[0], tree_code, tree_context_map, 0, writer,
+                kLayerModularTree, aux_out);
+  }
+  params.streaming_mode = streaming_mode;
+  params.add_missing_symbols = streaming_mode;
   params.image_widths = image_widths_;
   // Write histograms.
   BuildAndEncodeHistograms(params, (tree_.size() + 1) / 2, tokens_, &code_,
@@ -1192,8 +1196,17 @@ Status ModularFrameEncoder::EncodeStream(BitWriter* writer, AuxOut* aux_out,
   }
   JXL_RETURN_IF_ERROR(
       Bundle::Write(stream_headers_[stream_id], writer, layer, aux_out));
-  WriteTokens(tokens_[stream_id], code_, context_map_, writer, layer, aux_out);
+  WriteTokens(tokens_[stream_id], code_, context_map_, 0, writer, layer,
+              aux_out);
   return true;
+}
+
+void ModularFrameEncoder::ClearStreamData(const ModularStreamId& stream) {
+  size_t stream_id = stream.ID(frame_dim_);
+  Image empty_image;
+  std::vector<Token> empty_tokens;
+  std::swap(stream_images_[stream_id], empty_image);
+  std::swap(tokens_[stream_id], empty_tokens);
 }
 
 namespace {
@@ -1497,10 +1510,10 @@ int QuantizeGradient(const int32_t* qrow, size_t onerow, size_t c, size_t x,
 }
 
 void ModularFrameEncoder::AddVarDCTDC(const FrameHeader& frame_header,
-                                      const Image3F& dc, size_t group_index,
-                                      bool nl_dc, PassesEncoderState* enc_state,
+                                      const Image3F& dc, const Rect& r,
+                                      size_t group_index, bool nl_dc,
+                                      PassesEncoderState* enc_state,
                                       bool jpeg_transcode) {
-  const Rect r = enc_state->shared.DCGroupRect(group_index);
   extra_dc_precision[group_index] = nl_dc ? 1 : 0;
   float mul = 1 << extra_dc_precision[group_index];
 
@@ -1641,9 +1654,9 @@ void ModularFrameEncoder::AddVarDCTDC(const FrameHeader& frame_header,
             frame_header.chroma_subsampling, enc_state->shared.block_ctx_map);
 }
 
-void ModularFrameEncoder::AddACMetadata(size_t group_index, bool jpeg_transcode,
+void ModularFrameEncoder::AddACMetadata(const Rect& r, size_t group_index,
+                                        bool jpeg_transcode,
                                         PassesEncoderState* enc_state) {
-  const Rect r = enc_state->shared.DCGroupRect(group_index);
   size_t stream_id = ModularStreamId::ACMetadata(group_index).ID(frame_dim_);
   stream_options_[stream_id].max_chan_size = 0xFFFFFF;
   stream_options_[stream_id].wp_tree_mode = ModularOptions::TreeMode::kNoWP;

--- a/lib/jxl/enc_patch_dictionary.cc
+++ b/lib/jxl/enc_patch_dictionary.cc
@@ -111,7 +111,7 @@ void PatchDictionaryEncoder::Encode(const PatchDictionary& pdic,
   BuildAndEncodeHistograms(HistogramParams(), kNumPatchDictionaryContexts,
                            tokens, &codes, &context_map, writer, layer,
                            aux_out);
-  WriteTokens(tokens[0], codes, context_map, writer, layer, aux_out);
+  WriteTokens(tokens[0], codes, context_map, 0, writer, layer, aux_out);
 }
 
 // static

--- a/lib/jxl/enc_splines.cc
+++ b/lib/jxl/enc_splines.cc
@@ -86,7 +86,7 @@ void EncodeSplines(const Splines& splines, BitWriter* writer,
   std::vector<uint8_t> context_map;
   BuildAndEncodeHistograms(histogram_params, kNumSplineContexts, tokens, &codes,
                            &context_map, writer, layer, aux_out);
-  WriteTokens(tokens[0], codes, context_map, writer, layer, aux_out);
+  WriteTokens(tokens[0], codes, context_map, 0, writer, layer, aux_out);
 }
 
 Splines FindSplines(const Image3F& opsin) {

--- a/lib/jxl/modular/encoding/enc_encoding.cc
+++ b/lib/jxl/modular/encoding/enc_encoding.cc
@@ -513,7 +513,7 @@ Status ModularEncode(const Image &image, const ModularOptions &options,
     BuildAndEncodeHistograms(HistogramParams(), kNumTreeContexts, tree_tokens,
                              &code, &context_map, writer, kLayerModularTree,
                              aux_out);
-    WriteTokens(tree_tokens[0], code, context_map, writer, kLayerModularTree,
+    WriteTokens(tree_tokens[0], code, context_map, 0, writer, kLayerModularTree,
                 aux_out);
   }
 
@@ -562,7 +562,8 @@ Status ModularEncode(const Image &image, const ModularOptions &options,
     BuildAndEncodeHistograms(histo_params, (tree->size() + 1) / 2,
                              tokens_storage, &code, &context_map, writer, layer,
                              aux_out);
-    WriteTokens(tokens_storage[0], code, context_map, writer, layer, aux_out);
+    WriteTokens(tokens_storage[0], code, context_map, 0, writer, layer,
+                aux_out);
   } else {
     *width = image_width;
   }

--- a/lib/jxl/passes_state.h
+++ b/lib/jxl/passes_state.h
@@ -33,7 +33,6 @@ struct ImageFeatures {
 // State common to both encoder and decoder.
 // NOLINTNEXTLINE(clang-analyzer-optin.performance.Padding)
 struct PassesSharedState {
-  // Headers and metadata.
   const CodecMetadata* metadata;
 
   FrameDimensions frame_dim;
@@ -78,40 +77,6 @@ struct PassesSharedState {
   // Number of pre-clustered set of histograms (with the same ctx map), per
   // pass. Encoded as num_histograms_ - 1.
   size_t num_histograms = 0;
-
-  bool IsGrayscale() const { return metadata->m.color_encoding.IsGray(); }
-
-  Rect GroupRect(size_t group_index) const {
-    return frame_dim.GroupRect(group_index);
-  }
-
-  Rect PaddedGroupRect(size_t group_index) const {
-    const size_t gx = group_index % frame_dim.xsize_groups;
-    const size_t gy = group_index / frame_dim.xsize_groups;
-    const Rect rect(gx * frame_dim.group_dim, gy * frame_dim.group_dim,
-                    frame_dim.group_dim, frame_dim.group_dim,
-                    frame_dim.xsize_padded, frame_dim.ysize_padded);
-    return rect;
-  }
-
-  Rect BlockGroupRect(size_t group_index) const {
-    const size_t gx = group_index % frame_dim.xsize_groups;
-    const size_t gy = group_index / frame_dim.xsize_groups;
-    const Rect rect(gx * (frame_dim.group_dim >> 3),
-                    gy * (frame_dim.group_dim >> 3), frame_dim.group_dim >> 3,
-                    frame_dim.group_dim >> 3, frame_dim.xsize_blocks,
-                    frame_dim.ysize_blocks);
-    return rect;
-  }
-
-  Rect DCGroupRect(size_t group_index) const {
-    const size_t gx = group_index % frame_dim.xsize_dc_groups;
-    const size_t gy = group_index / frame_dim.xsize_dc_groups;
-    const Rect rect(gx * frame_dim.group_dim, gy * frame_dim.group_dim,
-                    frame_dim.group_dim, frame_dim.group_dim,
-                    frame_dim.xsize_blocks, frame_dim.ysize_blocks);
-    return rect;
-  }
 };
 
 // Initialized the state information that is shared between encoder and decoder.


### PR DESCRIPTION
All the internal images are now limited to the 2048x2048 DC group size, and the maximum memory usage is around 500 MB.

Benchmark results:
```
Encoding           kPixels    Bytes          BPP  E MP/s  D MP/s     Max norm  SSIMULACRA2   PSNR        pnorm       BPP*pnorm   QABPP   Bugs
---------------------------------------------------------------------------------------------------------------------------------------------
jxl:d0.1:1          156870 125499004    6.4001333   2.883  17.712   0.33339094  93.97017505  55.04   0.11910771  0.762305231867   6.400      0
jxl:d0.1:3          156870 118196370    6.0277173   1.342  14.221   0.33339094  93.97017505  55.04   0.11910771  0.717947620036   6.028      0
jxl:d0.1:4          156870 117892031    6.0121968   1.501  14.289   0.33382890  94.00462704  55.04   0.11907577  0.715906976850   6.012      0
jxl:d0.1:5          156870 139407423    7.1094276   0.777  14.252   0.34058568  93.91823707  57.02   0.10181720  0.723862019767   7.109      0
jxl:d0.1:6          156870 140721309    7.1764325   0.568  13.979   0.34023632  93.89339858  57.11   0.10187573  0.731104323064   7.176      0
jxl:d0.1:7          156870 141506387    7.2164695   0.560  14.325   0.33378362  93.90823930  57.19   0.10142266  0.731913544176   7.216      0
jxl:d0.1:1:buf3     156870 124186341    6.3331908   4.689  16.793   0.33339094  93.97017505  55.04   0.11910771  0.754331862831   6.333      0
jxl:d0.1:3:buf3     156870 118645467    6.0506202   3.936  15.506   0.33339094  93.97017505  55.04   0.11910771  0.720675522105   6.051      0
jxl:d0.1:4:buf3     156870 119051450    6.0713243   4.091  15.353   0.33382890  94.00462704  55.04   0.11907577  0.722947623654   6.071      0
jxl:d0.1:5:buf3     156870 124960819    6.3726872   1.788  13.883   0.42522492  93.86107006  55.38   0.11737111  0.747969378745   6.373      0
jxl:d0.1:6:buf3     156870 125038021    6.3766243   1.194  14.652   0.42531900  93.88796957  55.40   0.11745910  0.748992546623   6.377      0
jxl:d0.1:7:buf3     156870 125896374    6.4203982   1.156  14.181   0.43496868  93.90811739  55.47   0.11689811  0.750532425816   6.420      0
jxl:d1:1            156870 30373676    1.5489810   3.437  24.764   1.43588506  86.14940783  43.59   0.58841531  0.911444150987   2.257      0
jxl:d1:3            156870 27841570    1.4198500   2.069  26.847   1.43588506  86.14940783  43.59   0.58841531  0.835461474297   2.068      0
jxl:d1:4            156870 28110273    1.4335532   2.860  24.650   1.43953718  86.43275684  43.61   0.58675396  0.841142996644   2.092      0
jxl:d1:5            156870 23502237    1.1985549   0.913  23.353   1.49287327  84.49628039  43.63   0.58180371  0.697323707375   1.816      0
jxl:d1:6            156870 23686906    1.2079726   0.852  24.001   1.48966351  84.58298559  43.65   0.58294516  0.704181767609   1.829      0
jxl:d1:7            156870 23680833    1.2076629   0.662  24.676   1.49379655  84.59488978  43.66   0.58316869  0.704271179346   1.829      0
jxl:d1:1:buf3       156870 30144399    1.5372885   6.648  28.425   1.43588506  86.14940783  43.59   0.58841531  0.904564075601   2.240      0
jxl:d1:3:buf3       156870 28077983    1.4319065   6.575  26.224   1.43588506  86.14940783  43.59   0.58841531  0.842555684628   2.085      0
jxl:d1:4:buf3       156870 28586708    1.4578501   6.951  28.615   1.43953718  86.43275684  43.61   0.58675396  0.855399349245   2.127      0
jxl:d1:5:buf3       156870 23664692    1.2068397   2.236  25.647   1.79721683  84.31625183  43.00   0.62510227  0.754398246796   2.203      0
jxl:d1:6:buf3       156870 23700533    1.2086675   1.586  25.146   1.79445658  84.33377882  43.02   0.62494042  0.755345188024   2.201      0
jxl:d1:7:buf3       156870 23699715    1.2086258   1.441  24.907   1.79768241  84.34806803  43.03   0.62501552  0.755409881140   2.202      0
jxl:d10:1           156870  4634629    0.2363544   6.664  10.740   6.71570493  38.19963812  35.71   2.25288348  0.532478951288   1.600      0
jxl:d10:3           156870  3819655    0.1947928   5.277  12.029   6.71570493  38.19963812  35.71   2.25288348  0.438845458543   1.320      0
jxl:d10:4           156870  4137919    0.2110235   5.224  11.493   6.71726114  40.72074578  35.94   2.19382440  0.462948398734   1.427      0
jxl:d10:5           156870  3064736    0.1562938   1.756  12.541   9.14517281  30.37032353  35.23   2.69294022  0.420889917659   1.429      0
jxl:d10:6           156870  3123745    0.1593031   1.146  13.002   9.35053938  31.50052643  35.32   2.68063191  0.427033058530   1.496      0
jxl:d10:7           156870  3129105    0.1595765   0.913  13.258   9.23112087  31.60086736  35.33   2.67094507  0.426220007652   1.486      0
jxl:d10:1:buf3      156870  4788892    0.2442214   9.607  12.413   6.71570493  38.19963812  35.71   2.25288348  0.550202441230   1.652      0
jxl:d10:3:buf3      156870  4017087    0.2048613   9.304  11.483   6.71570493  38.19963812  35.71   2.25288348  0.461528694744   1.388      0
jxl:d10:4:buf3      156870  4396053    0.2241876   8.637  11.715   6.71726114  40.72074578  35.94   2.19382440  0.491828307200   1.516      0
jxl:d10:5:buf3      156870  3738546    0.1906564   2.497  11.388   7.36731798  37.57962463  35.82   2.26285872  0.431428576133   1.419      0
jxl:d10:6:buf3      156870  3790243    0.1932929   1.851  11.352   7.39668835  38.22880038  35.86   2.25680857  0.436224963822   1.442      0
jxl:d10:7:buf3      156870  3791016    0.1933323   1.679  11.463   7.40258595  38.25278127  35.86   2.25490305  0.435945531927   1.444      0
Aggregate:          156870 23301908    1.1883387   2.288  16.536   1.59684548  66.47757179  44.19   0.54200030  0.644079906108   2.696      0
```

