### PR TITLE
mmap-backed implementation of PNM streaming input.

### DIFF
--- a/lib/extras/dec/pnm.h
+++ b/lib/extras/dec/pnm.h
@@ -16,6 +16,7 @@
 #include <mutex>
 
 #include "lib/extras/dec/color_hints.h"
+#include "lib/extras/mmap.h"
 #include "lib/extras/packed_image.h"
 #include "lib/jxl/base/data_parallel.h"
 #include "lib/jxl/base/span.h"
@@ -46,14 +47,20 @@ struct HeaderPNM {
   std::vector<JxlExtraChannelType> ec_types;  // PAM
 };
 
-struct ChunkedPNMDecoder {
-  FILE* f;
-  HeaderPNM header = {};
-  size_t data_start;
-};
+class ChunkedPNMDecoder {
+ public:
+  static StatusOr<ChunkedPNMDecoder> Init(const char* file_path);
+  // Initializes `ppf` with a pointer to this `ChunkedPNMDecoder`.
+  jxl::Status InitializePPF(const ColorHints& color_hints,
+                            PackedPixelFile* ppf);
 
-Status DecodeImagePNM(ChunkedPNMDecoder* dec, const ColorHints& color_hints,
-                      PackedPixelFile* ppf);
+ private:
+  HeaderPNM header_ = {};
+  size_t data_start_ = 0;
+  MemoryMappedFile pnm_;
+
+  friend struct PNMChunkedInputFrame;
+};
 
 }  // namespace extras
 }  // namespace jxl

--- a/lib/extras/mmap.cc
+++ b/lib/extras/mmap.cc
@@ -1,0 +1,146 @@
+// Copyright (c) the JPEG XL Project Authors. All rights reserved.
+//
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+#include "mmap.h"
+
+#include <cstdint>
+#include <memory>
+
+#include "lib/jxl/base/common.h"
+
+#if __unix__
+#include <fcntl.h>
+#include <sys/mman.h>
+#include <unistd.h>
+
+namespace jxl {
+
+struct MemoryMappedFileImpl {
+  static StatusOr<std::unique_ptr<MemoryMappedFileImpl>> Init(
+      const char* path) {
+    auto f = make_unique<MemoryMappedFileImpl>();
+    f->fd = open(path, O_RDONLY);
+    if (f->fd == -1) {
+      return JXL_FAILURE("Cannot open file %s", path);
+    }
+    f->mmap_len = lseek(f->fd, 0, SEEK_END);
+    lseek(f->fd, 0, SEEK_SET);
+
+    f->ptr = mmap(nullptr, f->mmap_len, PROT_READ, MAP_SHARED, f->fd, 0);
+    if (f->ptr == MAP_FAILED) {
+      return JXL_FAILURE("mmap failure");
+    }
+    return f;
+  }
+
+  const uint8_t* data() const { return reinterpret_cast<const uint8_t*>(ptr); }
+  size_t size() const { return mmap_len; }
+
+  ~MemoryMappedFileImpl() {
+    if (fd != -1) {
+      close(fd);
+    }
+    if (ptr != nullptr) {
+      munmap(ptr, mmap_len);
+    }
+  }
+
+  int fd = -1;
+  size_t mmap_len = 0;
+  void* ptr = nullptr;
+};
+
+}  // namespace jxl
+
+#elif __WIN32__
+#include <string.h>
+#include <windows.h>
+
+namespace {
+
+struct HandleDeleter {
+  void operator()(const HANDLE handle) const {
+    if (handle != INVALID_HANDLE_VALUE) {
+      CloseHandle(handle);
+    }
+  }
+};
+using HandleUniquePtr =
+    std::unique_ptr<std::remove_pointer<HANDLE>::type, HandleDeleter>;
+
+}  // namespace
+
+namespace jxl {
+
+struct MemoryMappedFileImpl {
+  static StatusOr<std::unique_ptr<MemoryMappedFileImpl>> Init(
+      const char* path) {
+    auto f = make_unique<MemoryMappedFileImpl>();
+    std::wstring stemp = std::wstring(path, path + strlen(path));
+    f->handle.reset(CreateFileW(stemp.c_str(), GENERIC_READ, FILE_SHARE_READ,
+                                nullptr, OPEN_EXISTING,
+                                FILE_FLAG_SEQUENTIAL_SCAN, nullptr));
+    if (f->handle.get() == INVALID_HANDLE_VALUE) {
+      return JXL_FAILURE("Cannot open file %s", path);
+    }
+    if (!GetFileSizeEx(f->handle.get(), &f->fsize)) {
+      return JXL_FAILURE("Cannot get file size (%s)", path);
+    }
+    f->handle_mapping.reset(CreateFileMappingW(f->handle.get(), nullptr,
+                                               PAGE_READONLY, 0, 0, nullptr));
+    if (f->handle_mapping == nullptr) {
+      return JXL_FAILURE("Cannot create memory mapping (%s)", path);
+    }
+    f->ptr = MapViewOfFile(f->handle_mapping.get(), FILE_MAP_READ, 0, 0, 0);
+    return f;
+  }
+
+  const uint8_t* data() const { return reinterpret_cast<const uint8_t*>(ptr); }
+  size_t size() const { return fsize.QuadPart; }
+
+  HandleUniquePtr handle;
+  HandleUniquePtr handle_mapping;
+  LARGE_INTEGER fsize;
+  void* ptr = nullptr;
+};
+
+}  // namespace jxl
+
+#else
+
+namespace jxl {
+
+struct MemoryMappedFileImpl {
+  static StatusOr<std::unique_ptr<MemoryMappedFileImpl>> Init(
+      const char* path) {
+    return JXL_FAILURE("Memory mapping not supported on this system");
+  }
+
+  const uint8_t* data() const { return nullptr; }
+  size_t size() const { return 0; }
+};
+
+}  // namespace jxl
+
+#endif
+
+namespace jxl {
+
+StatusOr<MemoryMappedFile> MemoryMappedFile::Init(const char* path) {
+  JXL_ASSIGN_OR_RETURN(auto mmf, MemoryMappedFileImpl::Init(path));
+  MemoryMappedFile ret;
+  ret.impl_ = std::move(mmf);
+  return ret;
+}
+
+MemoryMappedFile::MemoryMappedFile() = default;
+MemoryMappedFile::~MemoryMappedFile() = default;
+MemoryMappedFile::MemoryMappedFile(MemoryMappedFile&&) noexcept = default;
+MemoryMappedFile& MemoryMappedFile::operator=(MemoryMappedFile&&) noexcept =
+    default;
+
+const uint8_t* MemoryMappedFile::data() const { return impl_->data(); }
+size_t MemoryMappedFile::size() const { return impl_->size(); }
+}  // namespace jxl

--- a/lib/extras/mmap.h
+++ b/lib/extras/mmap.h
@@ -1,0 +1,31 @@
+// Copyright (c) the JPEG XL Project Authors. All rights reserved.
+//
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+#ifndef LIB_EXTRAS_MMAP_H_
+#define LIB_EXTRAS_MMAP_H_
+
+#include <memory>
+
+#include "lib/jxl/base/status.h"
+
+namespace jxl {
+struct MemoryMappedFileImpl;
+
+class MemoryMappedFile {
+ public:
+  static StatusOr<MemoryMappedFile> Init(const char* path);
+  const uint8_t* data() const;
+  size_t size() const;
+  MemoryMappedFile();
+  ~MemoryMappedFile();
+  MemoryMappedFile(MemoryMappedFile&&) noexcept;
+  MemoryMappedFile& operator=(MemoryMappedFile&&) noexcept;
+
+ private:
+  std::unique_ptr<MemoryMappedFileImpl> impl_;
+};
+}  // namespace jxl
+
+#endif

--- a/lib/extras/packed_image.h
+++ b/lib/extras/packed_image.h
@@ -19,6 +19,7 @@
 
 #include <algorithm>
 #include <cmath>
+#include <functional>
 #include <memory>
 #include <mutex>
 #include <set>
@@ -195,26 +196,17 @@ class PackedFrame {
 
 class ChunkedPackedFrame {
  public:
-  typedef void (*ReadLine)(void* opaque, size_t xpos, size_t ypos, size_t xsize,
-                           uint8_t* buffer, size_t len);
-  ChunkedPackedFrame(size_t xsize, size_t ysize, const JxlPixelFormat& format,
-                     void* opaque, ReadLine read_line)
+  ChunkedPackedFrame(
+      size_t xsize, size_t ysize,
+      std::function<JxlChunkedFrameInputSource()> get_input_source)
       : xsize(xsize),
         ysize(ysize),
-        format(format),
-        opaque_(opaque),
-        read_line_(read_line),
-        mtx_(new std::mutex()) {}
-
-  JxlChunkedFrameInputSource GetInputSource() {
-    return JxlChunkedFrameInputSource{
-        this,
-        METHOD_TO_C_CALLBACK(&ChunkedPackedFrame::GetColorChannelsPixelFormat),
-        METHOD_TO_C_CALLBACK(&ChunkedPackedFrame::GetColorChannelDataAt),
-        METHOD_TO_C_CALLBACK(&ChunkedPackedFrame::GetExtraChannelPixelFormat),
-        METHOD_TO_C_CALLBACK(&ChunkedPackedFrame::GetExtraChannelDataAt),
-        METHOD_TO_C_CALLBACK(&ChunkedPackedFrame::ReleaseCurrentData)};
+        get_input_source_(std::move(get_input_source)) {
+    const auto input_source = get_input_source_();
+    input_source.get_color_channels_pixel_format(input_source.opaque, &format);
   }
+
+  JxlChunkedFrameInputSource GetInputSource() { return get_input_source_(); }
 
   // The Frame metadata.
   JxlFrameHeader frame_info = {};
@@ -225,50 +217,7 @@ class ChunkedPackedFrame {
   JxlPixelFormat format;
 
  private:
-  void GetColorChannelsPixelFormat(JxlPixelFormat* pixel_format) {
-    *pixel_format = format;
-  }
-
-  const void* GetColorChannelDataAt(size_t xpos, size_t ypos, size_t xsize,
-                                    size_t ysize, size_t* row_offset) {
-    const std::lock_guard<std::mutex> lock(*mtx_);
-    size_t bytes_per_channel =
-        PackedImage::BitsPerChannel(format.data_type) / jxl::kBitsPerByte;
-    size_t bytes_per_pixel = bytes_per_channel * format.num_channels;
-    *row_offset = xsize * bytes_per_pixel;
-    uint8_t* buffer = reinterpret_cast<uint8_t*>(malloc(ysize * (*row_offset)));
-    for (size_t y = 0; y < ysize; ++y) {
-      read_line_(opaque_, xpos, ypos + y, xsize, &buffer[y * (*row_offset)],
-                 *row_offset);
-    }
-    buffers_.insert(buffer);
-    return buffer;
-  }
-
-  void GetExtraChannelPixelFormat(size_t ec_index,
-                                  JxlPixelFormat* pixel_format) {
-    JXL_ABORT("Not implemented");
-  }
-
-  const void* GetExtraChannelDataAt(size_t ec_index, size_t xpos, size_t ypos,
-                                    size_t xsize, size_t ysize,
-                                    size_t* row_offset) {
-    JXL_ABORT("Not implemented");
-  }
-
-  void ReleaseCurrentData(const void* buffer) {
-    const std::lock_guard<std::mutex> lock(*mtx_);
-    auto iter = buffers_.find(const_cast<void*>(buffer));
-    if (iter != buffers_.end()) {
-      free(*iter);
-      buffers_.erase(iter);
-    }
-  }
-
-  void* opaque_;
-  ReadLine read_line_;
-  std::set<void*> buffers_;
-  std::unique_ptr<std::mutex> mtx_;
+  std::function<JxlChunkedFrameInputSource()> get_input_source_;
 };
 
 // Optional metadata associated with a file

--- a/lib/jxl_lists.bzl
+++ b/lib/jxl_lists.bzl
@@ -445,6 +445,8 @@ libjxl_extras_sources = [
     "extras/enc/encode.h",
     "extras/exif.cc",
     "extras/exif.h",
+    "extras/mmap.cc",
+    "extras/mmap.h",
     "extras/packed_image.h",
     "extras/size_constraints.h",
     "extras/time.cc",

--- a/lib/jxl_lists.cmake
+++ b/lib/jxl_lists.cmake
@@ -445,6 +445,8 @@ set(JPEGXL_INTERNAL_EXTRAS_SOURCES
   extras/enc/encode.h
   extras/exif.cc
   extras/exif.h
+  extras/mmap.cc
+  extras/mmap.h
   extras/packed_image.h
   extras/size_constraints.h
   extras/time.cc


### PR DESCRIPTION
This PR recovers most of the low-core speed loss from using streaming input/output for fast lossless.

Memory usage may be increased, depending on OS choices. However, in case of out of memory, the OS should always unmap pages loaded because of this change.

```
Before:
7216 x 5412, geomean: 76.994 MP/s [76.29, 79.14], 20 reps, 2 threads.
3.67user 9.16system 0:10.18elapsed 126%CPU (0avgtext+0avgdata 8936maxresident)k
680inputs+223752outputs (4major+319857minor)pagefaults 0swaps

After:
7216 x 5412, geomean: 327.330 MP/s [296.45, 338.47], 20 reps, 2 threads.
3.28user 0.83system 0:02.47elapsed 166%CPU (0avgtext+0avgdata 123000maxresident)k
0inputs+111872outputs (10major+309603minor)pagefaults 0swaps

Non-streaming:
7216 x 5412, geomean: 369.804 MP/s [258.03, 371.21], 20 reps, 2 threads.
2.98user 0.69system 0:02.34elapsed 157%CPU (0avgtext+0avgdata 447432maxresident)k
784inputs+111872outputs (4major+517554minor)pagefaults 0swaps
```