### PR TITLE
Fix link

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -83,6 +83,7 @@ Stephan T. Lavavej <stl@nuwen.net>
 StepSecurity Bot <bot@stepsecurity.io>
 Sylvestre Ledru <sylvestre@debian.org>
 Thomas Bonfort <thomas.bonfort@airbus.com>
+Timo Rothenpieler <timo@rothenpieler.org>
 tmkk <tmkkmac@gmail.com>
 Vincent Torri <vincent.torri@gmail.com>
 xiota

--- a/lib/jxl/libjxl_cms.pc.in
+++ b/lib/jxl/libjxl_cms.pc.in
@@ -7,7 +7,7 @@ Name: libjxl_cms
 Description: CMS support library for libjxl
 Version: @JPEGXL_LIBRARY_VERSION@
 Requires.private: @JPEGXL_CMS_LIBRARY_REQUIRES@
-Libs: @JXL_CMS_PK_LIBS@ -L${libdir} -ljxl_cms
+Libs: -L${libdir} -ljxl_cms @JXL_CMS_PK_LIBS@
 Libs.private: -lm
 Cflags: -I${includedir}
 Cflags.private: -DJXL_CMS_STATIC_DEFINE

--- a/lib/jxl_cms.cmake
+++ b/lib/jxl_cms.cmake
@@ -24,13 +24,14 @@ target_include_directories(jxl_cms PUBLIC
   "$<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}>")
 
 set(JXL_CMS_PK_LIBS "")
+set(JPEGXL_CMS_LIBRARY_REQUIRES "")
 
 if (JPEGXL_ENABLE_SKCMS)
   target_link_libraries(jxl_cms PRIVATE skcms)
 else()
   target_link_libraries(jxl_cms PRIVATE lcms2)
   if (JPEGXL_FORCE_SYSTEM_LCMS2)
-    set(JXL_CMS_PK_LIBS "-llcms2")
+    set(JPEGXL_CMS_LIBRARY_REQUIRES "lcms2")
   endif()
 endif()
 
@@ -57,7 +58,6 @@ install(TARGETS jxl_cms
         LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
         ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR})
 
-set(JPEGXL_CMS_LIBRARY_REQUIRES "")
 configure_file("${CMAKE_CURRENT_SOURCE_DIR}/jxl/libjxl_cms.pc.in"
                "libjxl_cms.pc" @ONLY)
 install(FILES "${CMAKE_CURRENT_BINARY_DIR}/libjxl_cms.pc"


### PR DESCRIPTION
This fixes some issues I discovered when linking an external lcms2 library.
For one, the order of the dependency libraries are wrong. They need to come after the library that needs their symbols.

Furthermore, lcms2 can be built split into multiple libraries. The easiest way to deal with that is to simply require its pkg-config file as a dependency instead of manually linking to its lib.