### PR TITLE
Fixes #3018 - can't save 32-bit float JXL to PNG

### DIFF
--- a/lib/extras/dec/jxl.h
+++ b/lib/extras/dec/jxl.h
@@ -59,7 +59,7 @@ struct JXLDecompressParams {
   bool unpremultiply_alpha = false;
 
   // Controls the effective bit depth of the output pixels.
-  JxlBitDepth output_bitdepth = {JXL_BIT_DEPTH_FROM_CODESTREAM, 0, 0};
+  JxlBitDepth output_bitdepth = {JXL_BIT_DEPTH_FROM_PIXEL_FORMAT, 0, 0};
 };
 
 bool DecodeImageJXL(const uint8_t* bytes, size_t bytes_size,


### PR DESCRIPTION
In #1823 djxl got `bits_per_sample` argument.

It is said, that default behavior is to export with full bit depth of output format. But #2591 has broken this contract to save with with depth of input format. After that change it become impossible to fulfill the contract (`bits_per_sample` both `-1` and `0` meant the same).