### PR TITLE
When building with skcms, incorporate it into libjxl_cms

### DIFF
--- a/lib/jxl/cms/jxl_cms.cc
+++ b/lib/jxl/cms/jxl_cms.cc
@@ -1324,7 +1324,7 @@ float* JxlCmsGetDstBuf(void* cms_data, size_t thread) {
 
 extern "C" {
 
-const JxlCmsInterface* JxlGetDefaultCms() {
+JXL_CMS_EXPORT const JxlCmsInterface* JxlGetDefaultCms() {
   static constexpr JxlCmsInterface kInterface = {
       /*set_fields_data=*/nullptr,
       /*set_fields_from_icc=*/&JxlCmsSetFieldsFromICC,

--- a/lib/jxl_cms.cmake
+++ b/lib/jxl_cms.cmake
@@ -12,7 +12,10 @@ add_library(jxl_cms
   ${JPEGXL_INTERNAL_CMS_SOURCES}
 )
 target_compile_options(jxl_cms PRIVATE "${JPEGXL_INTERNAL_FLAGS}")
-set_target_properties(jxl_cms PROPERTIES POSITION_INDEPENDENT_CODE ON)
+set_target_properties(jxl_cms PROPERTIES
+        POSITION_INDEPENDENT_CODE ON
+        CXX_VISIBILITY_PRESET hidden
+        VISIBILITY_INLINES_HIDDEN 1)
 target_link_libraries(jxl_cms PUBLIC jxl_base)
 target_include_directories(jxl_cms PRIVATE
   ${JXL_HWY_INCLUDE_DIRS}
@@ -26,7 +29,7 @@ target_include_directories(jxl_cms PUBLIC
 set(JPEGXL_CMS_LIBRARY_REQUIRES "")
 
 if (JPEGXL_ENABLE_SKCMS)
-  target_link_libraries(jxl_cms PRIVATE skcms)
+  target_link_skcms(jxl_cms)
 else()
   target_link_libraries(jxl_cms PRIVATE lcms2)
   if (JPEGXL_FORCE_SYSTEM_LCMS2)

--- a/third_party/skcms.cmake
+++ b/third_party/skcms.cmake
@@ -12,17 +12,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-add_library(skcms STATIC EXCLUDE_FROM_ALL skcms/skcms.cc)
-target_include_directories(skcms PUBLIC "${CMAKE_CURRENT_LIST_DIR}/skcms/")
+function(target_link_skcms TARGET_NAME)
+  target_sources(${TARGET_NAME} PRIVATE "${PROJECT_SOURCE_DIR}/third_party/skcms/skcms.cc")
+  target_include_directories(${TARGET_NAME} PRIVATE "${PROJECT_SOURCE_DIR}/third_party/skcms/")
 
-include(CheckCXXCompilerFlag)
-check_cxx_compiler_flag("-Wno-psabi" CXX_WPSABI_SUPPORTED)
-if(CXX_WPSABI_SUPPORTED)
-  target_compile_options(skcms PRIVATE -Wno-psabi)
-endif()
-
-set_target_properties(skcms PROPERTIES
-  POSITION_INDEPENDENT_CODE ON
-  CXX_VISIBILITY_PRESET hidden
-  VISIBILITY_INLINES_HIDDEN 1
-)
+  include(CheckCXXCompilerFlag)
+  check_cxx_compiler_flag("-Wno-psabi" CXX_WPSABI_SUPPORTED)
+  if(CXX_WPSABI_SUPPORTED)
+    set_source_files_properties("${PROJECT_SOURCE_DIR}/third_party/skcms/skcms.cc"
+      PROPERTIES COMPILE_OPTIONS "-Wno-psabi"
+      TARGET_DIRECTORY ${TARGET_NAME})
+  endif()
+endfunction()


### PR DESCRIPTION
This ensures that when libjxl_cms is built statically and installed system-wide (which skcms won’t be), its users are able to link to it.

Fixes #3021.