### PR TITLE
Modify the sampling algorithm in fast-lossless streaming mode.

### DIFF
--- a/lib/jxl/enc_fast_lossless.h
+++ b/lib/jxl/enc_fast_lossless.h
@@ -69,7 +69,7 @@ struct JxlFastLosslessFrameState;
 // JxlFastLosslessFreeFrameState.
 JxlFastLosslessFrameState* JxlFastLosslessPrepareFrame(
     JxlChunkedFrameInputSource input, size_t width, size_t height,
-    size_t nb_chans, size_t bitdepth, int big_endian, int effort);
+    size_t nb_chans, size_t bitdepth, int big_endian, int effort, int oneshot);
 
 #if !FJXL_STANDALONE
 class JxlEncoderOutputProcessorWrapper;

--- a/lib/jxl/encode.cc
+++ b/lib/jxl/encode.cc
@@ -2252,7 +2252,7 @@ JxlEncoderStatus JxlEncoderAddImageFrameInternal(
     auto frame_state = JxlFastLosslessPrepareFrame(
         frame_data.GetInputSource(), xsize, ysize, num_channels,
         frame_settings->enc->metadata.m.bit_depth.bits_per_sample, big_endian,
-        /*effort=*/2);
+        /*effort=*/2, /*oneshot=*/!frame_data.StreamingInput());
     if (!streaming) {
       JxlFastLosslessProcessFrame(frame_state, /*is_last=*/false,
                                   frame_settings->enc->thread_pool.get(),

--- a/lib/jxl/encode_internal.h
+++ b/lib/jxl/encode_internal.h
@@ -267,6 +267,8 @@ class JxlEncoderChunkedFrameAdapter {
     return true;
   }
 
+  bool StreamingInput() const { return has_input_source_; }
+
   const size_t xsize;
   const size_t ysize;
 


### PR DESCRIPTION
This should reduce the amount of input requests significantly.

Size in streaming mode increases by up to ~5% depending on image content.
```
Before:
artificial.ppm: Compressed to 2105.3 kB (2.677 bpp).
big_building.ppm: Compressed to 57276.8 kB (11.733 bpp).
big_tree.ppm: Compressed to 48669.9 kB (14.056 bpp).
cathedral.ppm: Compressed to 9031.3 kB (12.010 bpp).
fireworks.ppm: Compressed to 5973.9 kB (6.479 bpp).
flower_foveon.ppm: Compressed to 3130.9 kB (7.304 bpp).
hdr.ppm: Compressed to 6949.5 kB (8.837 bpp).
leaves_iso_1600.ppm: Compressed to 10643.3 kB (14.153 bpp).
leaves_iso_200.ppm: Compressed to 9060.4 kB (12.048 bpp).
nightshot_iso_100.ppm: Compressed to 7719.1 kB (8.372 bpp).
nightshot_iso_1600.ppm: Compressed to 12916.3 kB (14.009 bpp).
spider_web.ppm: Compressed to 9820.6 kB (6.482 bpp).

After:
artificial.ppm: Compressed to 2254.0 kB (2.866 bpp).
big_building.ppm: Compressed to 57796.4 kB (11.840 bpp).
big_tree.ppm: Compressed to 48756.1 kB (14.081 bpp).
cathedral.ppm: Compressed to 9065.3 kB (12.055 bpp).
fireworks.ppm: Compressed to 6155.3 kB (6.676 bpp).
flower_foveon.ppm: Compressed to 3285.1 kB (7.664 bpp).
hdr.ppm: Compressed to 6949.4 kB (8.837 bpp).
leaves_iso_1600.ppm: Compressed to 10651.1 kB (14.164 bpp).
leaves_iso_200.ppm: Compressed to 9088.3 kB (12.086 bpp).
nightshot_iso_100.ppm: Compressed to 7878.6 kB (8.545 bpp).
nightshot_iso_1600.ppm: Compressed to 12916.5 kB (14.009 bpp).
spider_web.ppm: Compressed to 9822.5 kB (6.483 bpp).
```