### PR TITLE
enc_aux_out.cc: define `__STDC_FORMAT_MACROS` if undefined

### DIFF
--- a/lib/jxl/enc_aux_out.cc
+++ b/lib/jxl/enc_aux_out.cc
@@ -5,6 +5,10 @@
 
 #include "lib/jxl/enc_aux_out.h"
 
+#ifndef __STDC_FORMAT_MACROS
+#define __STDC_FORMAT_MACROS
+#endif
+
 #include <inttypes.h>
 #include <stddef.h>
 #include <stdint.h>


### PR DESCRIPTION
Fixes: https://github.com/libjxl/libjxl/issues/3091
See also: https://github.com/libjxl/libjxl/commit/97ec970d06ad04254f2cdcbe0bf8bba3166372b6

<!-- Thank you for considering a contribution to `libjxl`! -->

### Description

Some platforms need `__STDC_FORMAT_MACROS` defined prior to including `inttypes.h`, otherwise all PRI* defines are unavailable, which breaks the build. See the issue.

### Pull Request Checklist

Perhaps CLA is signed, since I contributed earlier.

- [x] **CLA Signed**: Have you signed the [Contributor License Agreement](https://code.google.com/legal/individual-cla-v1.0.html) (individual or corporate, as appropriate)? Only contributions from signed contributors can be accepted.
- [ ] **Authors**: Have you considered adding your name to the [AUTHORS](AUTHORS) file?
- [ ] **Code Style**: Have you ensured your code adheres to the project's coding style guidelines? You can use `./ci.sh lint` for automatic code formatting.


Please review the full [contributing guidelines](https://github.com/libjxl/libjxl/blob/main/CONTRIBUTING.md) for more details.
