### PR TITLE
Enable Gaborish for streaming mode.

### DIFF
--- a/lib/include/jxl/encode.h
+++ b/lib/include/jxl/encode.h
@@ -824,8 +824,8 @@ struct JxlChunkedFrameInputSource {
 
   /**
    * Callback to retrieve a rectangle of color channel data at a specific
-   * location. It is guaranteed that xpos and ypos are multiples of 128. xsize,
-   * ysize will be multiples of 128, unless the resulting rectangle would be out
+   * location. It is guaranteed that xpos and ypos are multiples of 8. xsize,
+   * ysize will be multiples of 8, unless the resulting rectangle would be out
    * of image bounds. Moreover, xsize and ysize will be at most 2048. The
    * returned data will be assumed to be in the format returned by the
    * (preceding) call to get_color_channels_pixel_format, except the `align`
@@ -868,7 +868,7 @@ struct JxlChunkedFrameInputSource {
   /**
    * Callback to retrieve a rectangle of extra channel `ec_index` data at a
    * specific location. It is guaranteed that xpos and ypos are multiples of
-   * 128. xsize, ysize will be multiples of 128, unless the resulting rectangle
+   * 8. xsize, ysize will be multiples of 8, unless the resulting rectangle
    * would be out of image bounds. Moreover, xsize and ysize will be at most
    * 2048. The returned data will be assumed to be in the format returned by the
    * (preceding) call to get_extra_channels_pixel_format_at with the

--- a/lib/jxl/enc_ac_strategy.h
+++ b/lib/jxl/enc_ac_strategy.h
@@ -25,11 +25,11 @@ struct AuxOut;
 
 struct ACSConfig {
   const DequantMatrices* JXL_RESTRICT dequant;
-  float* JXL_RESTRICT quant_field_row;
+  const float* JXL_RESTRICT quant_field_row;
   size_t quant_field_stride;
-  float* JXL_RESTRICT masking_field_row;
+  const float* JXL_RESTRICT masking_field_row;
   size_t masking_field_stride;
-  float* JXL_RESTRICT masking1x1_field_row;
+  const float* JXL_RESTRICT masking1x1_field_row;
   size_t masking1x1_field_stride;
   const float* JXL_RESTRICT src_rows[3];
   size_t src_stride;
@@ -43,7 +43,7 @@ struct ACSConfig {
     JXL_DASSERT(masking_field_row[by * masking_field_stride + bx] > 0);
     return masking_field_row[by * masking_field_stride + bx];
   }
-  float* MaskingPtr1x1(size_t bx, size_t by) const {
+  const float* MaskingPtr1x1(size_t bx, size_t by) const {
     JXL_DASSERT(masking1x1_field_row[by * masking1x1_field_stride + bx] > 0);
     return &masking1x1_field_row[by * masking1x1_field_stride + bx];
   }
@@ -54,11 +54,16 @@ struct ACSConfig {
 };
 
 struct AcStrategyHeuristics {
-  void Init(const Image3F& src, PassesEncoderState* enc_state);
-  void ProcessRect(const Rect& rect);
-  void Finalize(AuxOut* aux_out);
+  AcStrategyHeuristics(const CompressParams& cparams) : cparams(cparams) {}
+  void Init(const Image3F& src, const Rect& rect_in, const ImageF& quant_field,
+            const ImageF& mask, const ImageF& mask1x1,
+            DequantMatrices* matrices);
+  void ProcessRect(const Rect& rect, const ColorCorrelationMap& cmap,
+                   AcStrategyImage* ac_strategy);
+  void Finalize(const FrameDimensions& frame_dim,
+                const AcStrategyImage& ac_strategy, AuxOut* aux_out);
+  const CompressParams& cparams;
   ACSConfig config;
-  PassesEncoderState* enc_state;
 };
 
 }  // namespace jxl

--- a/lib/jxl/enc_adaptive_quantization.h
+++ b/lib/jxl/enc_adaptive_quantization.h
@@ -37,8 +37,8 @@ struct AuxOut;
 // fine-grained quantization should be enough. Returns a mask, too, which
 // can later be used to make better decisions about ac strategy.
 ImageF InitialQuantField(float butteraugli_target, const Image3F& opsin,
-                         const FrameDimensions& frame_dim, ThreadPool* pool,
-                         float rescale, ImageF* initial_quant_mask,
+                         const Rect& rect, ThreadPool* pool, float rescale,
+                         ImageF* initial_quant_mask,
                          ImageF* initial_quant_mask1x1);
 
 float InitialQuantDC(float butteraugli_target);
@@ -51,7 +51,8 @@ void AdjustQuantField(const AcStrategyImage& ac_strategy, const Rect& rect,
 // dequant_float_map and chosen quantization levels.
 // `linear` is only used in Kitten mode or slower.
 void FindBestQuantizer(const FrameHeader& frame_header, const Image3F* linear,
-                       const Image3F& opsin, PassesEncoderState* enc_state,
+                       const Image3F& opsin, ImageF& quant_field,
+                       PassesEncoderState* enc_state,
                        const JxlCmsInterface& cms, ThreadPool* pool,
                        AuxOut* aux_out, double rescale = 1.0);
 

--- a/lib/jxl/enc_ar_control_field.h
+++ b/lib/jxl/enc_ar_control_field.h
@@ -36,14 +36,13 @@ struct ArControlFieldHeuristics {
     temp_images.resize(num_threads);
   }
 
-  void RunRect(const FrameHeader& frame_header, const Rect& block_rect,
-               const Image3F& opsin, PassesEncoderState* enc_state,
+  void RunRect(const CompressParams& cparams, const FrameHeader& frame_header,
+               const Rect& block_rect, const Image3F& opsin,
+               const Rect& opsin_rect, const ImageF& quant_field,
+               const AcStrategyImage& ac_strategy, ImageB* epf_sharpness,
                size_t thread);
 
   std::vector<TempImages> temp_images;
-  ImageB* epf_sharpness;
-  ImageF* quant;
-  bool all_default;
 };
 
 }  // namespace jxl

--- a/lib/jxl/enc_cache.cc
+++ b/lib/jxl/enc_cache.cc
@@ -35,8 +35,9 @@
 namespace jxl {
 
 Status InitializePassesEncoder(const FrameHeader& frame_header,
-                               const Image3F& opsin, const JxlCmsInterface& cms,
-                               ThreadPool* pool, PassesEncoderState* enc_state,
+                               const Image3F& opsin, const Rect& rect,
+                               const JxlCmsInterface& cms, ThreadPool* pool,
+                               PassesEncoderState* enc_state,
                                ModularFrameEncoder* modular_frame_encoder,
                                AuxOut* aux_out) {
   PassesSharedState& JXL_RESTRICT shared = enc_state->shared;
@@ -68,7 +69,7 @@ Status InitializePassesEncoder(const FrameHeader& frame_header,
   JXL_RETURN_IF_ERROR(RunOnPool(
       pool, 0, shared.frame_dim.num_groups, ThreadPool::NoInit,
       [&](size_t group_idx, size_t _) {
-        ComputeCoefficients(group_idx, enc_state, opsin, &dc);
+        ComputeCoefficients(group_idx, enc_state, opsin, rect, &dc);
       },
       "Compute coeffs"));
 

--- a/lib/jxl/enc_cache.h
+++ b/lib/jxl/enc_cache.h
@@ -40,10 +40,6 @@ struct PassesEncoderState {
   bool initialize_global_state = true;
   size_t dc_group_index = 0;
 
-  ImageF initial_quant_field;    // Invalid in Falcon mode.
-  ImageF initial_quant_masking;  // Invalid in Falcon mode.
-  ImageF initial_quant_masking1x1;  // Invalid in Falcon mode.
-
   // Per-pass DCT coefficients for the image. One row per group.
   std::vector<std::unique_ptr<ACImage>> coeffs;
 
@@ -77,8 +73,8 @@ struct PassesEncoderState {
 // Initialize per-frame information.
 class ModularFrameEncoder;
 Status InitializePassesEncoder(const FrameHeader& frame_header,
-                               const Image3F& opsin, const JxlCmsInterface& cms,
-                               ThreadPool* pool,
+                               const Image3F& opsin, const Rect& rect,
+                               const JxlCmsInterface& cms, ThreadPool* pool,
                                PassesEncoderState* passes_enc_state,
                                ModularFrameEncoder* modular_frame_encoder,
                                AuxOut* aux_out);

--- a/lib/jxl/enc_chroma_from_luma.h
+++ b/lib/jxl/enc_chroma_from_luma.h
@@ -29,13 +29,13 @@ void ColorCorrelationMapEncodeDC(const ColorCorrelationMap& map,
                                  AuxOut* aux_out);
 
 struct CfLHeuristics {
-  void Init(const Image3F& opsin);
+  void Init(const Rect& rect);
 
   void PrepareForThreads(size_t num_threads) {
     mem = hwy::AllocateAligned<float>(num_threads * ItemsPerThread());
   }
 
-  void ComputeTile(const Rect& r, const Image3F& opsin,
+  void ComputeTile(const Rect& r, const Image3F& opsin, const Rect& opsin_rect,
                    const DequantMatrices& dequant,
                    const AcStrategyImage* ac_strategy,
                    const ImageI* raw_quant_field, const Quantizer* quantizer,

--- a/lib/jxl/enc_gaborish.cc
+++ b/lib/jxl/enc_gaborish.cc
@@ -15,7 +15,8 @@
 
 namespace jxl {
 
-void GaborishInverse(Image3F* in_out, float mul[3], ThreadPool* pool) {
+void GaborishInverse(Image3F* in_out, const Rect& rect, float mul[3],
+                     ThreadPool* pool) {
   WeightsSymmetric5 weights[3];
   // Only an approximation. One or even two 3x3, and rank-1 (separable) 5x5
   // are insufficient. The numbers here have been obtained by butteraugli
@@ -48,11 +49,9 @@ void GaborishInverse(Image3F* in_out, float mul[3], ThreadPool* pool) {
   // image and reuse the existing planes of the in/out image.
   ImageF temp(in_out->Plane(2).xsize(), in_out->Plane(2).ysize());
   CopyImageTo(in_out->Plane(2), &temp);
-  Symmetric5(in_out->Plane(0), Rect(*in_out), weights[0], pool,
-             &in_out->Plane(2));
-  Symmetric5(in_out->Plane(1), Rect(*in_out), weights[1], pool,
-             &in_out->Plane(0));
-  Symmetric5(temp, Rect(*in_out), weights[2], pool, &in_out->Plane(1));
+  Symmetric5(in_out->Plane(0), rect, weights[0], pool, &in_out->Plane(2), rect);
+  Symmetric5(in_out->Plane(1), rect, weights[1], pool, &in_out->Plane(0), rect);
+  Symmetric5(temp, rect, weights[2], pool, &in_out->Plane(1), rect);
   // Now planes are 1, 2, 0.
   in_out->Plane(0).Swap(in_out->Plane(1));
   // 2 1 0

--- a/lib/jxl/enc_gaborish.h
+++ b/lib/jxl/enc_gaborish.h
@@ -19,7 +19,8 @@ namespace jxl {
 // Used in encoder to reduce the impact of the decoder's smoothing.
 // This is not exact. Works in-place to reduce memory use.
 // The input is typically in XYB space.
-void GaborishInverse(Image3F* in_out, float mul[3], ThreadPool* pool);
+void GaborishInverse(Image3F* in_out, const Rect& rect, float mul[3],
+                     ThreadPool* pool);
 
 }  // namespace jxl
 

--- a/lib/jxl/enc_gaborish_test.cc
+++ b/lib/jxl/enc_gaborish_test.cc
@@ -47,7 +47,7 @@ void TestRoundTrip(const Image3F& in, float max_l1) {
       w,
       w,
   };
-  GaborishInverse(&fwd, weights, null_pool);
+  GaborishInverse(&fwd, Rect(fwd), weights, null_pool);
   JXL_ASSERT_OK(VerifyRelativeError(in, fwd, max_l1, 1E-4f, _));
 }
 

--- a/lib/jxl/enc_group.cc
+++ b/lib/jxl/enc_group.cc
@@ -357,15 +357,17 @@ void QuantizeRoundtripYBlockAC(PassesEncoderState* enc_state, const size_t size,
 }
 
 void ComputeCoefficients(size_t group_idx, PassesEncoderState* enc_state,
-                         const Image3F& opsin, Image3F* dc) {
+                         const Image3F& opsin, const Rect& rect, Image3F* dc) {
   const Rect block_group_rect =
       enc_state->shared.frame_dim.BlockGroupRect(group_idx);
-  const Rect group_rect = enc_state->shared.frame_dim.GroupRect(group_idx);
   const Rect cmap_rect(
       block_group_rect.x0() / kColorTileDimInBlocks,
       block_group_rect.y0() / kColorTileDimInBlocks,
       DivCeil(block_group_rect.xsize(), kColorTileDimInBlocks),
       DivCeil(block_group_rect.ysize(), kColorTileDimInBlocks));
+  const Rect group_rect =
+      enc_state->shared.frame_dim.GroupRect(group_idx).Translate(rect.x0(),
+                                                                 rect.y0());
 
   const size_t xsize_blocks = block_group_rect.xsize();
   const size_t ysize_blocks = block_group_rect.ysize();
@@ -504,9 +506,9 @@ HWY_AFTER_NAMESPACE();
 namespace jxl {
 HWY_EXPORT(ComputeCoefficients);
 void ComputeCoefficients(size_t group_idx, PassesEncoderState* enc_state,
-                         const Image3F& opsin, Image3F* dc) {
+                         const Image3F& opsin, const Rect& rect, Image3F* dc) {
   return HWY_DYNAMIC_DISPATCH(ComputeCoefficients)(group_idx, enc_state, opsin,
-                                                   dc);
+                                                   rect, dc);
 }
 
 Status EncodeGroupTokenizedCoefficients(size_t group_idx, size_t pass_idx,

--- a/lib/jxl/enc_group.h
+++ b/lib/jxl/enc_group.h
@@ -20,7 +20,7 @@ struct PassesEncoderState;
 
 // Fills DC
 void ComputeCoefficients(size_t group_idx, PassesEncoderState* enc_state,
-                         const Image3F& opsin, Image3F* dc);
+                         const Image3F& opsin, const Rect& rect, Image3F* dc);
 
 Status EncodeGroupTokenizedCoefficients(size_t group_idx, size_t pass_idx,
                                         size_t histogram_idx,

--- a/lib/jxl/enc_heuristics.cc
+++ b/lib/jxl/enc_heuristics.cc
@@ -30,8 +30,10 @@ namespace jxl {
 
 struct AuxOut;
 
-void FindBestBlockEntropyModel(PassesEncoderState& enc_state) {
-  if (enc_state.cparams.decoding_speed_tier >= 1) {
+void FindBestBlockEntropyModel(const CompressParams& cparams, const ImageI& rqf,
+                               const AcStrategyImage& ac_strategy,
+                               BlockCtxMap* block_ctx_map) {
+  if (cparams.decoding_speed_tier >= 1) {
     static constexpr uint8_t kSimpleCtxMap[] = {
         // Cluster all blocks together
         0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,  //
@@ -42,20 +44,18 @@ void FindBestBlockEntropyModel(PassesEncoderState& enc_state) {
         3 * kNumOrders == sizeof(kSimpleCtxMap) / sizeof *kSimpleCtxMap,
         "Update simple context map");
 
-    auto bcm = enc_state.shared.block_ctx_map;
+    auto bcm = *block_ctx_map;
     bcm.ctx_map.assign(std::begin(kSimpleCtxMap), std::end(kSimpleCtxMap));
     bcm.num_ctxs = 2;
     bcm.num_dc_ctxs = 1;
     return;
   }
-  if (enc_state.cparams.speed_tier >= SpeedTier::kFalcon) {
+  if (cparams.speed_tier >= SpeedTier::kFalcon) {
     return;
   }
-  const ImageI& rqf = enc_state.shared.raw_quant_field;
   // No need to change context modeling for small images.
   size_t tot = rqf.xsize() * rqf.ysize();
-  size_t size_for_ctx_model =
-      (1 << 10) * enc_state.cparams.butteraugli_distance;
+  size_t size_for_ctx_model = (1 << 10) * cparams.butteraugli_distance;
   if (tot < size_for_ctx_model) return;
 
   struct OccCounters {
@@ -79,14 +79,13 @@ void FindBestBlockEntropyModel(PassesEncoderState& enc_state) {
     size_t ord_counts[kNumOrders] = {};
   };
   // The OccCounters struct is too big to allocate on the stack.
-  std::unique_ptr<OccCounters> counters(
-      new OccCounters(rqf, enc_state.shared.ac_strategy));
+  std::unique_ptr<OccCounters> counters(new OccCounters(rqf, ac_strategy));
 
   // Splitting the context model according to the quantization field seems to
   // mostly benefit only large images.
-  size_t size_for_qf_split = (1 << 13) * enc_state.cparams.butteraugli_distance;
+  size_t size_for_qf_split = (1 << 13) * cparams.butteraugli_distance;
   size_t num_qf_segments = tot < size_for_qf_split ? 1 : 2;
-  std::vector<uint32_t>& qft = enc_state.shared.block_ctx_map.qf_thresholds;
+  std::vector<uint32_t>& qft = block_ctx_map->qf_thresholds;
   qft.clear();
   // Divide the quant field in up to num_qf_segments segments.
   size_t cumsum = 0;
@@ -153,7 +152,7 @@ void FindBestBlockEntropyModel(PassesEncoderState& enc_state) {
     remap[i] = remap_remap[remap[i]];
   }
   // Write the block context map.
-  auto& ctx_map = enc_state.shared.block_ctx_map.ctx_map;
+  auto& ctx_map = block_ctx_map->ctx_map;
   ctx_map = remap;
   ctx_map.resize(remap.size() * 3);
   // for chroma, only use up to nb_clusters_chroma separate block contexts
@@ -162,14 +161,13 @@ void FindBestBlockEntropyModel(PassesEncoderState& enc_state) {
     ctx_map[i] = num + Clamp1((int)remap[i % remap.size()], 0,
                               (int)nb_clusters_chroma - 1);
   }
-  enc_state.shared.block_ctx_map.num_ctxs =
+  block_ctx_map->num_ctxs =
       *std::max_element(ctx_map.begin(), ctx_map.end()) + 1;
 }
 
 namespace {
 
 void FindBestDequantMatrices(const CompressParams& cparams,
-                             const Image3F& opsin,
                              ModularFrameEncoder* modular_frame_encoder,
                              DequantMatrices* dequant_matrices) {
   // TODO(veluca): quant matrices for no-gaborish.
@@ -701,38 +699,47 @@ Status LossyFrameHeuristics(const FrameHeader& frame_header,
                             PassesEncoderState* enc_state,
                             ModularFrameEncoder* modular_frame_encoder,
                             const Image3F* original_pixels, Image3F* opsin,
-                            const JxlCmsInterface& cms, ThreadPool* pool,
-                            AuxOut* aux_out) {
-  CompressParams& cparams = enc_state->cparams;
+                            const Rect& rect, const JxlCmsInterface& cms,
+                            ThreadPool* pool, AuxOut* aux_out) {
+  const CompressParams& cparams = enc_state->cparams;
+  const bool streaming_mode = enc_state->streaming_mode;
+  const bool initialize_global_state = enc_state->initialize_global_state;
   PassesSharedState& shared = enc_state->shared;
+  const FrameDimensions& frame_dim = shared.frame_dim;
+  ImageFeatures& image_features = shared.image_features;
+  DequantMatrices& matrices = shared.matrices;
+  Quantizer& quantizer = shared.quantizer;
+  ImageI& raw_quant_field = shared.raw_quant_field;
+  ColorCorrelationMap& cmap = shared.cmap;
+  AcStrategyImage& ac_strategy = shared.ac_strategy;
+  ImageB& epf_sharpness = shared.epf_sharpness;
+  BlockCtxMap& block_ctx_map = shared.block_ctx_map;
 
   // Find and subtract splines.
-  if (!enc_state->streaming_mode &&
-      cparams.speed_tier <= SpeedTier::kSquirrel) {
+  if (!streaming_mode && cparams.speed_tier <= SpeedTier::kSquirrel) {
     if (cparams.custom_splines.HasAny()) {
-      shared.image_features.splines = cparams.custom_splines;
+      image_features.splines = cparams.custom_splines;
     } else {
-      shared.image_features.splines = FindSplines(*opsin);
+      image_features.splines = FindSplines(*opsin);
     }
-    JXL_RETURN_IF_ERROR(shared.image_features.splines.InitializeDrawCache(
-        opsin->xsize(), opsin->ysize(), shared.cmap));
-    shared.image_features.splines.SubtractFrom(opsin);
+    JXL_RETURN_IF_ERROR(image_features.splines.InitializeDrawCache(
+        opsin->xsize(), opsin->ysize(), cmap));
+    image_features.splines.SubtractFrom(opsin);
   }
 
   // Find and subtract patches/dots.
-  if (!enc_state->streaming_mode &&
+  if (!streaming_mode &&
       ApplyOverride(cparams.patches,
                     cparams.speed_tier <= SpeedTier::kSquirrel)) {
     FindBestPatchDictionary(*opsin, enc_state, cms, pool, aux_out);
-    PatchDictionaryEncoder::SubtractFrom(shared.image_features.patches, opsin);
+    PatchDictionaryEncoder::SubtractFrom(image_features.patches, opsin);
   }
 
   static const float kAcQuant = 0.79f;
   const float quant_dc = InitialQuantDC(cparams.butteraugli_distance);
-  Quantizer& quantizer = enc_state->shared.quantizer;
   // We don't know the quant field yet, but for computing the global scale
   // assuming that it will be the same as for Falcon mode is good enough.
-  if (enc_state->initialize_global_state) {
+  if (initialize_global_state) {
     quantizer.ComputeGlobalScaleAndQuant(
         quant_dc, kAcQuant / cparams.butteraugli_distance, 0);
   }
@@ -757,34 +764,35 @@ Status LossyFrameHeuristics(const FrameHeader& frame_header,
   // output: Gaborished XYB, CfL, ACS, raw quant field, EPF control field.
 
   ArControlFieldHeuristics ar_heuristics;
-  AcStrategyHeuristics acs_heuristics;
+  AcStrategyHeuristics acs_heuristics(cparams);
   CfLHeuristics cfl_heuristics;
+  ImageF initial_quant_field;
+  ImageF initial_quant_masking;
+  ImageF initial_quant_masking1x1;
 
   // Compute an initial estimate of the quantization field.
   // Call InitialQuantField only in Hare mode or slower. Otherwise, rely
   // on simple heuristics in FindBestAcStrategy, or set a constant for Falcon
   // mode.
   if (cparams.speed_tier > SpeedTier::kHare) {
-    enc_state->initial_quant_field =
-        ImageF(shared.frame_dim.xsize_blocks, shared.frame_dim.ysize_blocks);
-    enc_state->initial_quant_masking =
-        ImageF(shared.frame_dim.xsize_blocks, shared.frame_dim.ysize_blocks);
+    initial_quant_field =
+        ImageF(frame_dim.xsize_blocks, frame_dim.ysize_blocks);
+    initial_quant_masking =
+        ImageF(frame_dim.xsize_blocks, frame_dim.ysize_blocks);
     float q = kAcQuant / cparams.butteraugli_distance;
-    FillImage(q, &enc_state->initial_quant_field);
-    FillImage(1.0f / (q + 0.001f), &enc_state->initial_quant_masking);
+    FillImage(q, &initial_quant_field);
+    FillImage(1.0f / (q + 0.001f), &initial_quant_masking);
   } else {
     // Call this here, as it relies on pre-gaborish values.
     float butteraugli_distance_for_iqf = cparams.butteraugli_distance;
     if (!frame_header.loop_filter.gab) {
       butteraugli_distance_for_iqf *= 0.73f;
     }
-    enc_state->initial_quant_field = InitialQuantField(
-        butteraugli_distance_for_iqf, *opsin, shared.frame_dim, pool, 1.0f,
-        &enc_state->initial_quant_masking,
-        &enc_state->initial_quant_masking1x1);
-    if (enc_state->initialize_global_state) {
-      quantizer.SetQuantField(quant_dc, enc_state->initial_quant_field,
-                              nullptr);
+    initial_quant_field = InitialQuantField(
+        butteraugli_distance_for_iqf, *opsin, rect, pool, 1.0f,
+        &initial_quant_masking, &initial_quant_masking1x1);
+    if (initialize_global_state) {
+      quantizer.SetQuantField(quant_dc, initial_quant_field, nullptr);
     }
   }
 
@@ -798,71 +806,67 @@ Status LossyFrameHeuristics(const FrameHeader& frame_header,
         0.99406123118127299f,
         0.99719338015886894f,
     };
-    GaborishInverse(opsin, weight, pool);
+    GaborishInverse(opsin, rect, weight, pool);
   }
 
-  if (enc_state->initialize_global_state) {
-    FindBestDequantMatrices(cparams, *opsin, modular_frame_encoder,
-                            &enc_state->shared.matrices);
+  if (initialize_global_state) {
+    FindBestDequantMatrices(cparams, modular_frame_encoder, &matrices);
   }
 
-  cfl_heuristics.Init(*opsin);
-  acs_heuristics.Init(*opsin, enc_state);
+  cfl_heuristics.Init(rect);
+  acs_heuristics.Init(*opsin, rect, initial_quant_field, initial_quant_masking,
+                      initial_quant_masking1x1, &matrices);
 
   auto process_tile = [&](const uint32_t tid, const size_t thread) {
-    size_t n_enc_tiles =
-        DivCeil(enc_state->shared.frame_dim.xsize_blocks, kEncTileDimInBlocks);
+    size_t n_enc_tiles = DivCeil(frame_dim.xsize_blocks, kEncTileDimInBlocks);
     size_t tx = tid % n_enc_tiles;
     size_t ty = tid / n_enc_tiles;
     size_t by0 = ty * kEncTileDimInBlocks;
-    size_t by1 = std::min((ty + 1) * kEncTileDimInBlocks,
-                          enc_state->shared.frame_dim.ysize_blocks);
+    size_t by1 =
+        std::min((ty + 1) * kEncTileDimInBlocks, frame_dim.ysize_blocks);
     size_t bx0 = tx * kEncTileDimInBlocks;
-    size_t bx1 = std::min((tx + 1) * kEncTileDimInBlocks,
-                          enc_state->shared.frame_dim.xsize_blocks);
+    size_t bx1 =
+        std::min((tx + 1) * kEncTileDimInBlocks, frame_dim.xsize_blocks);
     Rect r(bx0, by0, bx1 - bx0, by1 - by0);
 
     // For speeds up to Wombat, we only compute the color correlation map
     // once we know the transform type and the quantization map.
     if (cparams.speed_tier <= SpeedTier::kSquirrel) {
-      cfl_heuristics.ComputeTile(r, *opsin, enc_state->shared.matrices,
+      cfl_heuristics.ComputeTile(r, *opsin, rect, matrices,
                                  /*ac_strategy=*/nullptr,
                                  /*raw_quant_field=*/nullptr,
                                  /*quantizer=*/nullptr, /*fast=*/false, thread,
-                                 &enc_state->shared.cmap);
+                                 &cmap);
     }
 
     // Choose block sizes.
-    acs_heuristics.ProcessRect(r);
+    acs_heuristics.ProcessRect(r, cmap, &ac_strategy);
 
     // Choose amount of post-processing smoothing.
     // TODO(veluca): should this go *after* AdjustQuantField?
-    ar_heuristics.RunRect(frame_header, r, *opsin, enc_state, thread);
+    ar_heuristics.RunRect(cparams, frame_header, r, *opsin, rect,
+                          initial_quant_field, ac_strategy, &epf_sharpness,
+                          thread);
 
     // Always set the initial quant field, so we can compute the CfL map with
     // more accuracy. The initial quant field might change in slower modes, but
     // adjusting the quant field with butteraugli when all the other encoding
     // parameters are fixed is likely a more reliable choice anyway.
-    AdjustQuantField(enc_state->shared.ac_strategy, r,
-                     cparams.butteraugli_distance,
-                     &enc_state->initial_quant_field);
-    quantizer.SetQuantFieldRect(enc_state->initial_quant_field, r,
-                                &enc_state->shared.raw_quant_field);
+    AdjustQuantField(ac_strategy, r, cparams.butteraugli_distance,
+                     &initial_quant_field);
+    quantizer.SetQuantFieldRect(initial_quant_field, r, &raw_quant_field);
 
     // Compute a non-default CfL map if we are at Hare speed, or slower.
     if (cparams.speed_tier <= SpeedTier::kHare) {
       cfl_heuristics.ComputeTile(
-          r, *opsin, enc_state->shared.matrices, &enc_state->shared.ac_strategy,
-          &enc_state->shared.raw_quant_field, &enc_state->shared.quantizer,
-          /*fast=*/cparams.speed_tier >= SpeedTier::kWombat, thread,
-          &enc_state->shared.cmap);
+          r, *opsin, rect, matrices, &ac_strategy, &raw_quant_field, &quantizer,
+          /*fast=*/cparams.speed_tier >= SpeedTier::kWombat, thread, &cmap);
     }
   };
   JXL_RETURN_IF_ERROR(RunOnPool(
       pool, 0,
-      DivCeil(enc_state->shared.frame_dim.xsize_blocks, kEncTileDimInBlocks) *
-          DivCeil(enc_state->shared.frame_dim.ysize_blocks,
-                  kEncTileDimInBlocks),
+      DivCeil(frame_dim.xsize_blocks, kEncTileDimInBlocks) *
+          DivCeil(frame_dim.ysize_blocks, kEncTileDimInBlocks),
       [&](const size_t num_threads) {
         ar_heuristics.PrepareForThreads(num_threads);
         cfl_heuristics.PrepareForThreads(num_threads);
@@ -870,23 +874,22 @@ Status LossyFrameHeuristics(const FrameHeader& frame_header,
       },
       process_tile, "Enc Heuristics"));
 
-  acs_heuristics.Finalize(aux_out);
-  if (cparams.speed_tier <= SpeedTier::kHare &&
-      enc_state->initialize_global_state) {
+  acs_heuristics.Finalize(frame_dim, ac_strategy, aux_out);
+  if (cparams.speed_tier <= SpeedTier::kHare && initialize_global_state) {
     cfl_heuristics.ComputeDC(/*fast=*/cparams.speed_tier >= SpeedTier::kWombat,
-                             &enc_state->shared.cmap);
+                             &cmap);
   }
 
   // Refine quantization levels.
-  if (!enc_state->streaming_mode) {
-    FindBestQuantizer(frame_header, original_pixels, *opsin, enc_state, cms,
-                      pool, aux_out);
+  if (!streaming_mode) {
+    FindBestQuantizer(frame_header, original_pixels, *opsin,
+                      initial_quant_field, enc_state, cms, pool, aux_out);
   }
 
   // Choose a context model that depends on the amount of quantization for AC.
-  if (cparams.speed_tier < SpeedTier::kFalcon &&
-      enc_state->initialize_global_state) {
-    FindBestBlockEntropyModel(*enc_state);
+  if (cparams.speed_tier < SpeedTier::kFalcon && initialize_global_state) {
+    FindBestBlockEntropyModel(cparams, raw_quant_field, ac_strategy,
+                              &block_ctx_map);
   }
   return true;
 }

--- a/lib/jxl/enc_heuristics.h
+++ b/lib/jxl/enc_heuristics.h
@@ -37,8 +37,8 @@ Status LossyFrameHeuristics(const FrameHeader& frame_header,
                             PassesEncoderState* enc_state,
                             ModularFrameEncoder* modular_frame_encoder,
                             const Image3F* original_pixels, Image3F* opsin,
-                            const JxlCmsInterface& cms, ThreadPool* pool,
-                            AuxOut* aux_out);
+                            const Rect& rect, const JxlCmsInterface& cms,
+                            ThreadPool* pool, AuxOut* aux_out);
 
 void FindBestBlockEntropyModel(PassesEncoderState& enc_state);
 

--- a/lib/jxl/enc_modular.cc
+++ b/lib/jxl/enc_modular.cc
@@ -490,7 +490,7 @@ Status ModularFrameEncoder::ComputeEncodingData(
   if (do_color && frame_header.loop_filter.gab) {
     float w = 0.9908511000000001f;
     float weights[3] = {w, w, w};
-    GaborishInverse(color, weights, pool);
+    GaborishInverse(color, Rect(*color), weights, pool);
   }
 
   if (do_color && metadata.bit_depth.bits_per_sample <= 16 &&

--- a/lib/jxl/image.h
+++ b/lib/jxl/image.h
@@ -328,6 +328,14 @@ class RectT {
     return CeilShiftRight(shift, shift);
   }
 
+  RectT<T> Extend(T border, RectT<T> parent) {
+    T new_x0 = x0() > parent.x0() + border ? x0() - border : parent.x0();
+    T new_y0 = y0() > parent.y0() + border ? y0() - border : parent.y0();
+    T new_x1 = x1() + border > parent.x1() ? parent.x1() : x1() + border;
+    T new_y1 = y1() + border > parent.y1() ? parent.y1() : y1() + border;
+    return RectT<T>(new_x0, new_y0, new_x1 - new_x0, new_y1 - new_y0);
+  }
+
   template <typename U>
   RectT<U> As() const {
     return RectT<U>(U(x0_), U(y0_), U(xsize_), U(ysize_));


### PR DESCRIPTION
Benchmark results:

```
Encoding         kPixels    Bytes          BPP  E MP/s  D MP/s     Max norm  SSIMULACRA2   PSNR        pnorm       BPP*pnorm   QABPP   Bugs
-------------------------------------------------------------------------------------------------------------------------------------------
BEFORE:
jxl:d1:1:buf3     156870 30083811    1.5341986  10.752  38.434   1.43588506  86.14940783  43.59   0.58841531  0.902745969086   2.236      0
jxl:d1:3:buf3     156870 28045193    1.4302342   9.866  36.601   1.43588506  86.14940783  43.59   0.58841531  0.841571732152   2.083      0
jxl:d1:4:buf3     156870 28554209    1.4561928   9.028  26.851   1.43953718  86.43275684  43.61   0.58675396  0.854426882480   2.124      0
jxl:d1:5:buf3     156870 23633360    1.2052419   3.013  39.530   1.79721683  84.31625183  43.00   0.62510227  0.753399425182   2.200      0
jxl:d1:6:buf3     156870 23674553    1.2073426   1.983  33.965   1.79445658  84.33377882  43.02   0.62494042  0.754517195337   2.198      0
jxl:d1:7:buf3     156870 23673497    1.2072888   1.838  35.483   1.79768241  84.34806803  43.03   0.62501552  0.754574202894   2.200      0
Aggregate:        156870 26140979    1.3331241   4.681  34.876   1.60676159  85.28287355  43.31   0.60615554  0.808080568276   2.173      0
AFTER:
jxl:d1:1:buf3     156870 30083811    1.5341986  10.613  33.186   1.43588506  86.14940783  43.59   0.58841531  0.902745969086   2.236      0
jxl:d1:3:buf3     156870 28045193    1.4302342   9.603  27.285   1.43588506  86.14940783  43.59   0.58841531  0.841571732152   2.083      0
jxl:d1:4:buf3     156870 28554209    1.4561928   9.798  36.369   1.43953718  86.43275684  43.61   0.58675396  0.854426882480   2.124      0
jxl:d1:5:buf3     156870 23896866    1.2186800   2.893  32.202   1.55262351  84.46145230  43.60   0.58417125  0.711917821691   1.924      0
jxl:d1:6:buf3     156870 23920039    1.2198618   1.966  33.068   1.55949380  84.52573644  43.61   0.58583763  0.714640932605   1.931      0
jxl:d1:7:buf3     156870 23905801    1.2191357   1.902  32.774   1.57113087  84.54468962  43.62   0.58616382  0.714613224299   1.941      0
Aggregate:        156870 26277130    1.3400675   4.702  32.365   1.49780084  85.37278849  43.60   0.58662433  0.786116177600   2.037      0
```

Benchmark for non-streaming version:
```
Encoding      kPixels    Bytes          BPP  E MP/s  D MP/s     Max norm  SSIMULACRA2   PSNR        pnorm       BPP*pnorm   QABPP   Bugs
----------------------------------------------------------------------------------------------------------------------------------------
BEFORE
jxl:d1:1       156870 30373676    1.5489810   8.143  31.981   1.43588506  86.14940783  43.59   0.58841531  0.911444150987   2.257      0
jxl:d1:3       156870 27841570    1.4198500   6.575  26.044   1.43588506  86.14940783  43.59   0.58841531  0.835461474297   2.068      0
jxl:d1:4       156870 28110273    1.4335532   5.841  26.211   1.43953718  86.43275684  43.61   0.58675396  0.841142996644   2.092      0
jxl:d1:5       156870 23502237    1.1985549   2.767  28.016   1.49287327  84.49628039  43.63   0.58180371  0.697323707375   1.816      0
jxl:d1:6       156870 23686906    1.2079726   1.947  29.632   1.48966351  84.58298559  43.65   0.58294516  0.704181767609   1.829      0
jxl:d1:7       156870 23680833    1.2076629   1.630  31.128   1.49379655  84.59488978  43.66   0.58316869  0.704271179346   1.829      0
Aggregate:     156870 26062242    1.3291087   3.742  28.745   1.46434745  85.39673797  43.62   0.58524412  0.777853077772   1.975      0
AFTER
jxl:d1:1       156870 30373676    1.5489810   9.095  33.038   1.43588506  86.14940783  43.59   0.58841531  0.911444150987   2.257      0
jxl:d1:3       156870 27841570    1.4198500   7.070  30.094   1.43588506  86.14940783  43.59   0.58841531  0.835461474297   2.068      0
jxl:d1:4       156870 28110273    1.4335532   6.687  30.892   1.43953718  86.43275684  43.61   0.58675396  0.841142996644   2.092      0
jxl:d1:5       156870 23502237    1.1985549   2.602  29.446   1.49287327  84.49628039  43.63   0.58180371  0.697323707375   1.816      0
jxl:d1:6       156870 23686906    1.2079726   1.931  36.871   1.48966351  84.58298559  43.65   0.58294516  0.704181767609   1.829      0
jxl:d1:7       156870 23680833    1.2076629   1.678  34.066   1.49379655  84.59488978  43.66   0.58316869  0.704271179346   1.829      0
Aggregate:     156870 26062242    1.3291087   3.919  32.302   1.46434745  85.39673797  43.62   0.58524412  0.777853077772   1.975      0
```
