### PR TITLE
Use border pixels of tiles in streaming adaptive quantization.

### DIFF
--- a/lib/jxl/enc_adaptive_quantization.cc
+++ b/lib/jxl/enc_adaptive_quantization.cc
@@ -408,8 +408,10 @@ struct AdaptiveQuantizationImpl {
   void ComputeTile(float butteraugli_target, float scale, const Image3F& xyb,
                    const Rect& rect_in, const Rect& rect_out, const int thread,
                    ImageF* mask, ImageF* mask1x1) {
-    const size_t xsize = rect_in.xsize();
-    const size_t ysize = rect_in.ysize();
+    JXL_ASSERT(rect_in.x0() % 8 == 0);
+    JXL_ASSERT(rect_in.y0() % 8 == 0);
+    const size_t xsize = xyb.xsize();
+    const size_t ysize = xyb.ysize();
 
     // The XYB gamma is 3.0 to be able to decode faster with two muls.
     // Butteraugli's gamma is matching the gamma of human eye, around 2.6.
@@ -420,21 +422,30 @@ struct AdaptiveQuantizationImpl {
 
     const HWY_FULL(float) df;
 
-    size_t y_start = rect_out.y0() * 8;
-    size_t y_end = y_start + rect_out.ysize() * 8;
+    size_t y_start_1x1 = rect_in.y0() + rect_out.y0() * 8;
+    size_t y_end_1x1 = y_start_1x1 + rect_out.ysize() * 8;
 
-    size_t x_start = rect_out.x0() * 8;
-    size_t x_end = x_start + rect_out.xsize() * 8;
+    size_t x_start_1x1 = rect_in.x0() + rect_out.x0() * 8;
+    size_t x_end_1x1 = x_start_1x1 + rect_out.xsize() * 8;
+
+    if (rect_in.x0() != 0 && rect_out.x0() == 0) x_start_1x1 -= 2;
+    if (rect_in.x1() < xsize && rect_out.x1() * 8 == rect_in.xsize()) {
+      x_end_1x1 += 2;
+    }
+    if (rect_in.y0() != 0 && rect_out.y0() == 0) y_start_1x1 -= 2;
+    if (rect_in.y1() < ysize && rect_out.y1() * 8 == rect_in.ysize()) {
+      y_end_1x1 += 2;
+    }
 
     // Computes image (padded to multiple of 8x8) of local pixel differences.
     // Subsample both directions by 4.
     // 1x1 Laplacian of intensity.
-    for (size_t y = y_start; y < y_end; ++y) {
+    for (size_t y = y_start_1x1; y < y_end_1x1; ++y) {
       const size_t y2 = y + 1 < ysize ? y + 1 : y;
       const size_t y1 = y > 0 ? y - 1 : y;
-      const float* row_in = rect_in.ConstPlaneRow(xyb, 1, y);
-      const float* row_in1 = rect_in.ConstPlaneRow(xyb, 1, y1);
-      const float* row_in2 = rect_in.ConstPlaneRow(xyb, 1, y2);
+      const float* row_in = xyb.ConstPlaneRow(1, y);
+      const float* row_in1 = xyb.ConstPlaneRow(1, y1);
+      const float* row_in2 = xyb.ConstPlaneRow(1, y2);
       float* mask1x1_out = mask1x1->Row(y);
       auto scalar_pixel1x1 = [&](size_t x) {
         const size_t x2 = x + 1 < xsize ? x + 1 : x;
@@ -451,15 +462,21 @@ struct AdaptiveQuantizationImpl {
         static const float kOffset = 0.01;
         mask1x1_out[x] = kMul / (diff + kOffset);
       };
-      for (size_t x = x_start; x < x_end; ++x) {
+      for (size_t x = x_start_1x1; x < x_end_1x1; ++x) {
         scalar_pixel1x1(x);
       }
     }
 
+    size_t y_start = rect_in.y0() + rect_out.y0() * 8;
+    size_t y_end = y_start + rect_out.ysize() * 8;
+
+    size_t x_start = rect_in.x0() + rect_out.x0() * 8;
+    size_t x_end = x_start + rect_out.xsize() * 8;
+
     if (x_start != 0) x_start -= 4;
-    if (x_end != rect_in.xsize()) x_end += 4;
+    if (x_end != xsize) x_end += 4;
     if (y_start != 0) y_start -= 4;
-    if (y_end != rect_in.ysize()) y_end += 4;
+    if (y_end != ysize) y_end += 4;
     pre_erosion[thread].ShrinkTo((x_end - x_start) / 4, (y_end - y_start) / 4);
 
     static const float limit = 0.2f;
@@ -467,9 +484,9 @@ struct AdaptiveQuantizationImpl {
       size_t y2 = y + 1 < ysize ? y + 1 : y;
       size_t y1 = y > 0 ? y - 1 : y;
 
-      const float* row_in = rect_in.ConstPlaneRow(xyb, 1, y);
-      const float* row_in1 = rect_in.ConstPlaneRow(xyb, 1, y1);
-      const float* row_in2 = rect_in.ConstPlaneRow(xyb, 1, y2);
+      const float* row_in = xyb.ConstPlaneRow(1, y);
+      const float* row_in1 = xyb.ConstPlaneRow(1, y1);
+      const float* row_in2 = xyb.ConstPlaneRow(1, y2);
       float* JXL_RESTRICT row_out = diff_buffer.Row(thread);
 
       auto scalar_pixel = [&](size_t x) {
@@ -552,7 +569,8 @@ struct AdaptiveQuantizationImpl {
   ImageF diff_buffer;
 };
 
-static void Blur1x1Masking(ThreadPool* pool, ImageF* mask1x1) {
+static void Blur1x1Masking(ThreadPool* pool, ImageF* mask1x1,
+                           const Rect& rect) {
   // Blur the mask1x1 to obtain the masking image.
   // Before blurring it contains an image of absolute value of the
   // Laplacian of the intensity channel.
@@ -578,10 +596,9 @@ static void Blur1x1Masking(ThreadPool* pool, ImageF* mask1x1) {
                         {HWY_REP4(normalize_mul * kFilterMask1x1[1])},
                         {HWY_REP4(normalize_mul * kFilterMask1x1[4])},
                         {HWY_REP4(normalize_mul * kFilterMask1x1[3])}};
-  Rect from_rect(0, 0, mask1x1->xsize(), mask1x1->ysize());
-  ImageF temp(mask1x1->xsize(), mask1x1->ysize());
-  Symmetric5(*mask1x1, from_rect, weights, pool, &temp);
-  CopyImageTo(temp, mask1x1);  // TODO: make it a swap
+  ImageF temp(rect.xsize(), rect.ysize());
+  Symmetric5(*mask1x1, rect, weights, pool, &temp);
+  *mask1x1 = std::move(temp);
 }
 
 ImageF AdaptiveQuantizationMap(const float butteraugli_target,
@@ -595,7 +612,7 @@ ImageF AdaptiveQuantizationMap(const float butteraugli_target,
   const size_t ysize_blocks = rect.ysize() / kBlockDim;
   impl.aq_map = ImageF(xsize_blocks, ysize_blocks);
   *mask = ImageF(xsize_blocks, ysize_blocks);
-  *mask1x1 = ImageF(rect.xsize(), rect.ysize());
+  *mask1x1 = ImageF(xyb.xsize(), xyb.ysize());
   JXL_CHECK(RunOnPool(
       pool, 0,
       DivCeil(xsize_blocks, kEncTileDimInBlocks) *
@@ -618,7 +635,7 @@ ImageF AdaptiveQuantizationMap(const float butteraugli_target,
       },
       "AQ DiffPrecompute"));
 
-  Blur1x1Masking(pool, mask1x1);
+  Blur1x1Masking(pool, mask1x1, rect);
   return std::move(impl).aq_map;
 }
 


### PR DESCRIPTION
This makes the streaming and non-streaming versions of the adaptive quantization map the same.

Benchmark results for non-streaming mode:
```
Encoding      kPixels    Bytes          BPP  E MP/s  D MP/s     Max norm  SSIMULACRA2   PSNR        pnorm       BPP*pnorm   QABPP   Bugs
----------------------------------------------------------------------------------------------------------------------------------------
BEFORE
jxl:d1:1       156870 30373676    1.5489810   8.015  34.055   1.43588506  86.14940783  43.59   0.58841531  0.911444150987   2.257      0
jxl:d1:3       156870 27841570    1.4198500   6.669  30.050   1.43588506  86.14940783  43.59   0.58841531  0.835461474297   2.068      0
jxl:d1:4       156870 28110273    1.4335532   5.963  28.523   1.43953718  86.43275684  43.61   0.58675396  0.841142996644   2.092      0
jxl:d1:5       156870 23502237    1.1985549   2.678  30.200   1.49287327  84.49628039  43.63   0.58180371  0.697323707375   1.816      0
jxl:d1:6       156870 23686906    1.2079726   1.904  32.576   1.48966351  84.58298559  43.65   0.58294516  0.704181767609   1.829      0
jxl:d1:7       156870 23680833    1.2076629   1.613  32.047   1.49379655  84.59488978  43.66   0.58316869  0.704271179346   1.829      0
Aggregate:     156870 26062242    1.3291087   3.714  31.188   1.46434745  85.39673797  43.62   0.58524412  0.777853077772   1.975      0
AFTER
jxl:d1:1       156870 30373676    1.5489810   8.767  33.694   1.43588506  86.14940783  43.59   0.58841531  0.911444150987   2.257      0
jxl:d1:3       156870 27841570    1.4198500   6.944  27.465   1.43588506  86.14940783  43.59   0.58841531  0.835461474297   2.068      0
jxl:d1:4       156870 28110273    1.4335532   6.927  30.727   1.43953718  86.43275684  43.61   0.58675396  0.841142996644   2.092      0
jxl:d1:5       156870 23502237    1.1985549   2.717  29.306   1.49287327  84.49628039  43.63   0.58180371  0.697323707375   1.816      0
jxl:d1:6       156870 23686906    1.2079726   1.932  35.990   1.48966351  84.58298559  43.65   0.58294516  0.704181767609   1.829      0
jxl:d1:7       156870 23680833    1.2076629   1.560  31.818   1.49379655  84.59488978  43.66   0.58316869  0.704271179346   1.829      0
Aggregate:     156870 26062242    1.3291087   3.888  31.377   1.46434745  85.39673797  43.62   0.58524412  0.777853077772   1.975      0
```

Benchmark results for streaming mode:
```
Encoding         kPixels    Bytes          BPP  E MP/s  D MP/s     Max norm  SSIMULACRA2   PSNR        pnorm       BPP*pnorm   QABPP   Bugs
-------------------------------------------------------------------------------------------------------------------------------------------
BEFORE
jxl:d1:1:buf3     156870 30083811    1.5341986  11.110  37.957   1.43588506  86.14940783  43.59   0.58841531  0.902745969086   2.236      0
jxl:d1:3:buf3     156870 28045193    1.4302342   9.639  30.386   1.43588506  86.14940783  43.59   0.58841531  0.841571732152   2.083      0
jxl:d1:4:buf3     156870 28554209    1.4561928   8.903  27.073   1.43953718  86.43275684  43.61   0.58675396  0.854426882480   2.124      0
jxl:d1:5:buf3     156870 23896866    1.2186800   2.781  28.349   1.55262351  84.46145230  43.60   0.58417125  0.711917821691   1.924      0
jxl:d1:6:buf3     156870 23920039    1.2198618   1.921  35.461   1.55949380  84.52573644  43.61   0.58583763  0.714640932605   1.931      0
jxl:d1:7:buf3     156870 23905801    1.2191357   1.840  35.391   1.57113087  84.54468962  43.62   0.58616382  0.714613224299   1.941      0
Aggregate:        156870 26277130    1.3400675   4.591  32.182   1.49780084  85.37278849  43.60   0.58662433  0.786116177600   2.037      0
AFTER
jxl:d1:1:buf3     156870 30083811    1.5341986  12.804  42.462   1.43588506  86.14940783  43.59   0.58841531  0.902745969086   2.236      0
jxl:d1:3:buf3     156870 28045193    1.4302342  11.117  35.403   1.43588506  86.14940783  43.59   0.58841531  0.841571732152   2.083      0
jxl:d1:4:buf3     156870 28554209    1.4561928  11.604  39.470   1.43953718  86.43275684  43.61   0.58675396  0.854426882480   2.124      0
jxl:d1:5:buf3     156870 23897266    1.2187004   2.915  28.982   1.55238955  84.46277919  43.60   0.58415926  0.711915134812   1.924      0
jxl:d1:6:buf3     156870 23919772    1.2198482   1.980  31.089   1.55957184  84.52259981  43.61   0.58584385  0.714640540364   1.931      0
jxl:d1:7:buf3     156870 23904227    1.2190554   1.896  31.723   1.57105970  84.55115327  43.62   0.58615018  0.714549543453   1.940      0
Aggregate:        156870 26276866    1.3400540   5.123  34.533   1.49776440  85.37357179  43.60   0.58662108  0.786103935336   2.037      0
```
