### PR TITLE
Add encoder option to disable full image based heuristics.

### DIFF
--- a/lib/include/jxl/encode.h
+++ b/lib/include/jxl/encode.h
@@ -378,6 +378,14 @@ typedef enum {
    */
   JXL_ENC_FRAME_SETTING_JPEG_KEEP_JUMBF = 37,
 
+  /** If this mode is disabled, the encoder will not make any image quality
+   * decisions that are computed based on the full image, but stored only once
+   * (e.g. the X quant multiplier in the frame header). Used mainly for testing
+   * equivalence of streaming and non-streaming code.
+   * 0 = disabled, 1 = enabled (default)
+   */
+  JXL_ENC_FRAME_SETTING_USE_FULL_IMAGE_HEURISTICS = 38,
+
   /** Enum value not to be used as an option. This value is added to force the
    * C compiler to have the enum to take a known size.
    */

--- a/lib/jxl/enc_frame.cc
+++ b/lib/jxl/enc_frame.cc
@@ -630,7 +630,8 @@ void ComputeChromacityAdjustments(const CompressParams& cparams,
   // look at the individual pixels and make a guess how difficult
   // the image would be based on the worst case pixel.
   PixelStatsForChromacityAdjustment pixel_stats;
-  if (cparams.speed_tier <= SpeedTier::kWombat) {
+  if (cparams.speed_tier <= SpeedTier::kWombat &&
+      cparams.use_full_image_heuristics) {
     pixel_stats.Calc(&opsin, rect);
   }
   // For X take the most severe adjustment.

--- a/lib/jxl/enc_heuristics.cc
+++ b/lib/jxl/enc_heuristics.cc
@@ -791,7 +791,9 @@ Status LossyFrameHeuristics(const FrameHeader& frame_header,
     initial_quant_field = InitialQuantField(
         butteraugli_distance_for_iqf, *opsin, rect, pool, 1.0f,
         &initial_quant_masking, &initial_quant_masking1x1);
-    if (initialize_global_state) {
+    // TODO(szabadka) Support changing the quantization of the quant field per
+    // group by applying different multipliers in modular mode.
+    if (cparams.use_full_image_heuristics && initialize_global_state) {
       quantizer.SetQuantField(quant_dc, initial_quant_field, nullptr);
     }
   }
@@ -875,7 +877,8 @@ Status LossyFrameHeuristics(const FrameHeader& frame_header,
       process_tile, "Enc Heuristics"));
 
   acs_heuristics.Finalize(frame_dim, ac_strategy, aux_out);
-  if (cparams.speed_tier <= SpeedTier::kHare && initialize_global_state) {
+  if (cparams.speed_tier <= SpeedTier::kHare &&
+      cparams.use_full_image_heuristics && initialize_global_state) {
     cfl_heuristics.ComputeDC(/*fast=*/cparams.speed_tier >= SpeedTier::kWombat,
                              &cmap);
   }

--- a/lib/jxl/enc_params.h
+++ b/lib/jxl/enc_params.h
@@ -198,6 +198,8 @@ struct CompressParams {
 
   // See JXL_ENC_FRAME_SETTING_BUFFERING option value.
   int buffering = 0;
+  // See JXL_ENC_FRAME_SETTING_USE_FULL_IMAGE_HEURISTICS option value.
+  bool use_full_image_heuristics = true;
 
   std::vector<float> manual_noise;
   std::vector<float> manual_xyb_factors;

--- a/lib/jxl/encode.cc
+++ b/lib/jxl/encode.cc
@@ -1760,6 +1760,13 @@ JxlEncoderStatus JxlEncoderFrameSettingsSetOption(
     case JXL_ENC_FRAME_SETTING_JPEG_KEEP_JUMBF:
       frame_settings->values.cparams.jpeg_keep_jumbf = value;
       break;
+    case JXL_ENC_FRAME_SETTING_USE_FULL_IMAGE_HEURISTICS:
+      if (value < 0 || value > 1) {
+        return JXL_API_ERROR(frame_settings->enc, JXL_ENC_ERR_NOT_SUPPORTED,
+                             "Option value has to be 0 or 1");
+      }
+      frame_settings->values.cparams.use_full_image_heuristics = value;
+      break;
 
     default:
       return JXL_API_ERROR(frame_settings->enc, JXL_ENC_ERR_NOT_SUPPORTED,
@@ -1855,6 +1862,7 @@ JxlEncoderStatus JxlEncoderFrameSettingsSetFloatOption(
     case JXL_ENC_FRAME_SETTING_JPEG_KEEP_EXIF:
     case JXL_ENC_FRAME_SETTING_JPEG_KEEP_XMP:
     case JXL_ENC_FRAME_SETTING_JPEG_KEEP_JUMBF:
+    case JXL_ENC_FRAME_SETTING_USE_FULL_IMAGE_HEURISTICS:
       return JXL_API_ERROR(frame_settings->enc, JXL_ENC_ERR_NOT_SUPPORTED,
                            "Int option, try setting it with "
                            "JxlEncoderFrameSettingsSetOption");

--- a/tools/benchmark/benchmark_codec_jxl.cc
+++ b/tools/benchmark/benchmark_codec_jxl.cc
@@ -231,6 +231,12 @@ class JxlCodec : public ImageCodec {
         return JXL_FAILURE("Invalid epf value");
       }
       cparams_.AddOption(JXL_ENC_FRAME_SETTING_EPF, val);
+    } else if (param.substr(0, 2) == "fi") {
+      val = strtol(param.substr(2).c_str(), nullptr, 10);
+      if (val != 0 && val != 1) {
+        return JXL_FAILURE("Invalid option value");
+      }
+      cparams_.AddOption(JXL_ENC_FRAME_SETTING_USE_FULL_IMAGE_HEURISTICS, val);
     } else if (param.substr(0, 3) == "buf") {
       val = strtol(param.substr(3).c_str(), nullptr, 10);
       if (val > 3) {


### PR DESCRIPTION
This will be used for testing equivalence of streaming and non-streaming modes. This change is a no-op by default.
