### PR TITLE
Use borders for EPF field in streaming mode.

### DIFF
--- a/lib/jxl/enc_gaborish.cc
+++ b/lib/jxl/enc_gaborish.cc
@@ -49,9 +49,12 @@ void GaborishInverse(Image3F* in_out, const Rect& rect, float mul[3],
   // image and reuse the existing planes of the in/out image.
   ImageF temp(in_out->Plane(2).xsize(), in_out->Plane(2).ysize());
   CopyImageTo(in_out->Plane(2), &temp);
-  Symmetric5(in_out->Plane(0), rect, weights[0], pool, &in_out->Plane(2), rect);
-  Symmetric5(in_out->Plane(1), rect, weights[1], pool, &in_out->Plane(0), rect);
-  Symmetric5(temp, rect, weights[2], pool, &in_out->Plane(1), rect);
+  Rect xrect = rect.Extend(3, Rect(*in_out));
+  Symmetric5(in_out->Plane(0), xrect, weights[0], pool, &in_out->Plane(2),
+             xrect);
+  Symmetric5(in_out->Plane(1), xrect, weights[1], pool, &in_out->Plane(0),
+             xrect);
+  Symmetric5(temp, xrect, weights[2], pool, &in_out->Plane(1), xrect);
   // Now planes are 1, 2, 0.
   in_out->Plane(0).Swap(in_out->Plane(1));
   // 2 1 0

--- a/lib/jxl/image.h
+++ b/lib/jxl/image.h
@@ -328,7 +328,7 @@ class RectT {
     return CeilShiftRight(shift, shift);
   }
 
-  RectT<T> Extend(T border, RectT<T> parent) {
+  RectT<T> Extend(T border, RectT<T> parent) const {
     T new_x0 = x0() > parent.x0() + border ? x0() - border : parent.x0();
     T new_y0 = y0() > parent.y0() + border ? y0() - border : parent.y0();
     T new_x1 = x1() + border > parent.x1() ? parent.x1() : x1() + border;


### PR DESCRIPTION
With this change the streaming mode and non-streaming mode produce the same pixels up to effort 6 (with the no-full-image-heuristic mode).

Benchmark results:

```
Encoding               kPixels    Bytes          BPP  E MP/s  D MP/s     Max norm  SSIMULACRA2   PSNR        pnorm       BPP*pnorm   QABPP   Bugs
-------------------------------------------------------------------------------------------------------------------------------------------------
BEFORE:
jxl:d0.1:fi0:6          156870 139354770    7.1067425   1.335  19.288   0.34056786  93.91142399  57.02   0.10183740  0.723732157417   7.107      0
jxl:d0.1:fi0:6:buf3     156870 140549699    7.1676808   1.491  21.354   0.34056786  93.91142399  57.02   0.10183740  0.729937962522   7.168      0
jxl:d1:fi0:6            156870 25205202    1.2854019   1.599  33.886   1.38187748  85.76058975  44.05   0.54908533  0.705795306849   1.813      0
jxl:d1:6:fi0:buf3       156870 25718639    1.3115858   1.667  39.145   1.38187748  85.76868256  44.05   0.54908421  0.720171082885   1.850      0
jxl:d10:fi0:6           156870  3847908    0.1962336   1.843  20.170   7.29646408  40.38657889  36.29   2.15167551  0.422231077705   1.436      0
jxl:d10:fi0:6:buf3      156870  4092990    0.2087322   1.876  21.430   7.29646408  40.38528073  36.29   2.15169221  0.449127421054   1.527      0
Aggregate:              156870 24182018    1.2332221   1.624  24.862   1.50867334  68.77315058  45.01   0.49367566  0.608811721788   2.685      0
AFTER:
jxl:d0.1:fi0:6          156870 139354770    7.1067425   1.310  17.895   0.34056786  93.91142399  57.02   0.10183740  0.723732157417   7.107      0
jxl:d0.1:fi0:6:buf3     156870 140549699    7.1676808   1.426  19.441   0.34056786  93.91142399  57.02   0.10183740  0.729937962522   7.168      0
jxl:d1:fi0:6            156870 25205202    1.2854019   1.672  34.863   1.38187748  85.76058975  44.05   0.54908533  0.705795306849   1.813      0
jxl:d1:6:fi0:buf3       156870 25718393    1.3115733   1.711  39.384   1.38187748  85.76058975  44.05   0.54908533  0.720165665766   1.850      0
jxl:d10:fi0:6           156870  3847908    0.1962336   1.800  17.774   7.29646408  40.38657889  36.29   2.15167551  0.422231077705   1.436      0
jxl:d10:fi0:6:buf3      156870  4092906    0.2087279   1.863  19.427   7.29646408  40.38657889  36.29   2.15167551  0.449114716704   1.527      0
Aggregate:              156870 24181897    1.2332159   1.618  23.418   1.50867334  68.77243744  45.01   0.49367519  0.608808088293   2.685      0
```
