### PR TITLE
djxl: Request float pixel formats if --disable_output is set

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -88,6 +88,7 @@ Thomas Bonfort <thomas.bonfort@airbus.com>
 Timo Rothenpieler <timo@rothenpieler.org>
 tmkk <tmkkmac@gmail.com>
 Vincent Torri <vincent.torri@gmail.com>
+Wonwoo Choi <chwo9843@gmail.com>
 xiota
 Yonatan Nebenzhal <yonatan.nebenzhl@gmail.com>
 Ziemowit Zabawa <ziemek.zabawa@outlook.com>

--- a/tools/djxl_main.cc
+++ b/tools/djxl_main.cc
@@ -552,6 +552,15 @@ int main(int argc, const char* argv[]) {
         AddFormatsWithAlphaChannel(&accepted_formats);
       }
     }
+    if (filename_out.empty()) {
+      // Decoding to pixels only, fill in float pixel formats
+      for (const uint32_t num_channels : {1, 2, 3, 4}) {
+        for (JxlEndianness endianness : {JXL_BIG_ENDIAN, JXL_LITTLE_ENDIAN}) {
+          accepted_formats.push_back(JxlPixelFormat{
+              num_channels, JXL_TYPE_FLOAT, endianness, /*align=*/0});
+        }
+      }
+    }
     jxl::extras::PackedPixelFile ppf;
     size_t decoded_bytes = 0;
     for (size_t i = 0; i < num_reps; ++i) {


### PR DESCRIPTION
### Description
djxl was not doing anything if `--disable_output` is set, due to the changes introduced in v0.9.0 (presumably #2686) that decodes only image metadata when the list of accepted pixel format is empty.