### PR TITLE
Encode each modular stream in streaming mode independently.

### DIFF
--- a/lib/jxl/enc_frame.cc
+++ b/lib/jxl/enc_frame.cc
@@ -1509,16 +1509,15 @@ Status ComputeEncodingData(
         TokenizeAllCoefficients(frame_header, pool, &enc_state));
   }
 
-  JXL_RETURN_IF_ERROR(enc_modular.ComputeEncodingData(
-      frame_header, metadata->m, &opsin, extra_channels, &enc_state, cms, pool,
-      aux_out,
-      /* do_color=*/frame_header.encoding == FrameEncoding::kModular));
-  if (enc_state.initialize_global_state) {
-    JXL_RETURN_IF_ERROR(enc_modular.ComputeTree(pool));
-  }
-  JXL_RETURN_IF_ERROR(enc_modular.ComputeTokens(pool));
-
   if (!enc_state.streaming_mode) {
+    if (cparams.modular_mode || !extra_channels.empty()) {
+      JXL_RETURN_IF_ERROR(enc_modular.ComputeEncodingData(
+          frame_header, metadata->m, &opsin, extra_channels, &enc_state, cms,
+          pool, aux_out, /*do_color=*/cparams.modular_mode));
+    }
+    JXL_RETURN_IF_ERROR(enc_modular.ComputeTree(pool));
+    JXL_RETURN_IF_ERROR(enc_modular.ComputeTokens(pool));
+
     mutable_frame_header.UpdateFlag(shared.image_features.patches.HasAny(),
                                     FrameHeader::kPatches);
     mutable_frame_header.UpdateFlag(shared.image_features.splines.HasAny(),

--- a/lib/jxl/enc_modular.cc
+++ b/lib/jxl/enc_modular.cc
@@ -73,115 +73,6 @@ static const float squeeze_luma_qtable[16] = {
 static const float squeeze_chroma_qtable[16] = {
     1024, 512, 256, 128, 64, 32, 16, 8, 4, 2, 1, 0.5, 0.5, 0.5, 0.5, 0.5};
 
-// `cutoffs` must be sorted.
-Tree MakeFixedTree(int property, const std::vector<int32_t>& cutoffs,
-                   Predictor pred, size_t num_pixels) {
-  size_t log_px = CeilLog2Nonzero(num_pixels);
-  size_t min_gap = 0;
-  // Reduce fixed tree height when encoding small images.
-  if (log_px < 14) {
-    min_gap = 8 * (14 - log_px);
-  }
-  Tree tree;
-  struct NodeInfo {
-    size_t begin, end, pos;
-  };
-  std::queue<NodeInfo> q;
-  // Leaf IDs will be set by roundtrip decoding the tree.
-  tree.push_back(PropertyDecisionNode::Leaf(pred));
-  q.push(NodeInfo{0, cutoffs.size(), 0});
-  while (!q.empty()) {
-    NodeInfo info = q.front();
-    q.pop();
-    if (info.begin + min_gap >= info.end) continue;
-    uint32_t split = (info.begin + info.end) / 2;
-    tree[info.pos] =
-        PropertyDecisionNode::Split(property, cutoffs[split], tree.size());
-    q.push(NodeInfo{split + 1, info.end, tree.size()});
-    tree.push_back(PropertyDecisionNode::Leaf(pred));
-    q.push(NodeInfo{info.begin, split, tree.size()});
-    tree.push_back(PropertyDecisionNode::Leaf(pred));
-  }
-  return tree;
-}
-
-Tree PredefinedTree(ModularOptions::TreeKind tree_kind, size_t total_pixels) {
-  if (tree_kind == ModularOptions::TreeKind::kJpegTranscodeACMeta ||
-      tree_kind == ModularOptions::TreeKind::kTrivialTreeNoPredictor) {
-    // All the data is 0, so no need for a fancy tree.
-    return {PropertyDecisionNode::Leaf(Predictor::Zero)};
-  }
-  if (tree_kind == ModularOptions::TreeKind::kFalconACMeta) {
-    // All the data is 0 except the quant field. TODO(veluca): make that 0 too.
-    return {PropertyDecisionNode::Leaf(Predictor::Left)};
-  }
-  if (tree_kind == ModularOptions::TreeKind::kACMeta) {
-    // Small image.
-    if (total_pixels < 1024) {
-      return {PropertyDecisionNode::Leaf(Predictor::Left)};
-    }
-    Tree tree;
-    // 0: c > 1
-    tree.push_back(PropertyDecisionNode::Split(0, 1, 1));
-    // 1: c > 2
-    tree.push_back(PropertyDecisionNode::Split(0, 2, 3));
-    // 2: c > 0
-    tree.push_back(PropertyDecisionNode::Split(0, 0, 5));
-    // 3: EPF control field (all 0 or 4), top > 0
-    tree.push_back(PropertyDecisionNode::Split(6, 0, 21));
-    // 4: ACS+QF, y > 0
-    tree.push_back(PropertyDecisionNode::Split(2, 0, 7));
-    // 5: CfL x
-    tree.push_back(PropertyDecisionNode::Leaf(Predictor::Gradient));
-    // 6: CfL b
-    tree.push_back(PropertyDecisionNode::Leaf(Predictor::Gradient));
-    // 7: QF: split according to the left quant value.
-    tree.push_back(PropertyDecisionNode::Split(7, 5, 9));
-    // 8: ACS: split in 4 segments (8x8 from 0 to 3, large square 4-5, large
-    // rectangular 6-11, 8x8 12+), according to previous ACS value.
-    tree.push_back(PropertyDecisionNode::Split(7, 5, 15));
-    // QF
-    tree.push_back(PropertyDecisionNode::Split(7, 11, 11));
-    tree.push_back(PropertyDecisionNode::Split(7, 3, 13));
-    tree.push_back(PropertyDecisionNode::Leaf(Predictor::Left));
-    tree.push_back(PropertyDecisionNode::Leaf(Predictor::Left));
-    tree.push_back(PropertyDecisionNode::Leaf(Predictor::Left));
-    tree.push_back(PropertyDecisionNode::Leaf(Predictor::Left));
-    // ACS
-    tree.push_back(PropertyDecisionNode::Split(7, 11, 17));
-    tree.push_back(PropertyDecisionNode::Split(7, 3, 19));
-    tree.push_back(PropertyDecisionNode::Leaf(Predictor::Zero));
-    tree.push_back(PropertyDecisionNode::Leaf(Predictor::Zero));
-    tree.push_back(PropertyDecisionNode::Leaf(Predictor::Zero));
-    tree.push_back(PropertyDecisionNode::Leaf(Predictor::Zero));
-    // EPF, left > 0
-    tree.push_back(PropertyDecisionNode::Split(7, 0, 23));
-    tree.push_back(PropertyDecisionNode::Split(7, 0, 25));
-    tree.push_back(PropertyDecisionNode::Leaf(Predictor::Zero));
-    tree.push_back(PropertyDecisionNode::Leaf(Predictor::Zero));
-    tree.push_back(PropertyDecisionNode::Leaf(Predictor::Zero));
-    tree.push_back(PropertyDecisionNode::Leaf(Predictor::Zero));
-    return tree;
-  }
-  if (tree_kind == ModularOptions::TreeKind::kWPFixedDC) {
-    std::vector<int32_t> cutoffs = {
-        -500, -392, -255, -191, -127, -95, -63, -47, -31, -23, -15,
-        -11,  -7,   -4,   -3,   -1,   0,   1,   3,   5,   7,   11,
-        15,   23,   31,   47,   63,   95,  127, 191, 255, 392, 500};
-    return MakeFixedTree(kWPProp, cutoffs, Predictor::Weighted, total_pixels);
-  }
-  if (tree_kind == ModularOptions::TreeKind::kGradientFixedDC) {
-    std::vector<int32_t> cutoffs = {
-        -500, -392, -255, -191, -127, -95, -63, -47, -31, -23, -15,
-        -11,  -7,   -4,   -3,   -1,   0,   1,   3,   5,   7,   11,
-        15,   23,   31,   47,   63,   95,  127, 191, 255, 392, 500};
-    return MakeFixedTree(kGradientProp, cutoffs, Predictor::Gradient,
-                         total_pixels);
-  }
-  JXL_UNREACHABLE("Unreachable");
-  return {};
-}
-
 // Merges the trees in `trees` using nodes that decide on stream_id, as defined
 // by `tree_splits`.
 void MergeTrees(const std::vector<Tree>& trees,
@@ -1194,19 +1085,23 @@ Status ModularFrameEncoder::EncodeStream(BitWriter* writer, AuxOut* aux_out,
   if (stream_images_[stream_id].channel.empty()) {
     return true;  // Image with no channels, header never gets decoded.
   }
-  JXL_RETURN_IF_ERROR(
-      Bundle::Write(stream_headers_[stream_id], writer, layer, aux_out));
-  WriteTokens(tokens_[stream_id], code_, context_map_, 0, writer, layer,
-              aux_out);
+  if (tokens_.empty()) {
+    JXL_RETURN_IF_ERROR(ModularGenericCompress(
+        stream_images_[stream_id], stream_options_[stream_id], writer, aux_out,
+        layer, stream_id));
+  } else {
+    JXL_RETURN_IF_ERROR(
+        Bundle::Write(stream_headers_[stream_id], writer, layer, aux_out));
+    WriteTokens(tokens_[stream_id], code_, context_map_, 0, writer, layer,
+                aux_out);
+  }
   return true;
 }
 
 void ModularFrameEncoder::ClearStreamData(const ModularStreamId& stream) {
   size_t stream_id = stream.ID(frame_dim_);
   Image empty_image;
-  std::vector<Token> empty_tokens;
   std::swap(stream_images_[stream_id], empty_image);
-  std::swap(tokens_[stream_id], empty_tokens);
 }
 
 namespace {

--- a/lib/jxl/modular/encoding/enc_encoding.cc
+++ b/lib/jxl/modular/encoding/enc_encoding.cc
@@ -67,6 +67,38 @@ inline std::array<uint8_t, 3> PredictorColor(Predictor p) {
   };
 }
 
+// `cutoffs` must be sorted.
+Tree MakeFixedTree(int property, const std::vector<int32_t> &cutoffs,
+                   Predictor pred, size_t num_pixels) {
+  size_t log_px = CeilLog2Nonzero(num_pixels);
+  size_t min_gap = 0;
+  // Reduce fixed tree height when encoding small images.
+  if (log_px < 14) {
+    min_gap = 8 * (14 - log_px);
+  }
+  Tree tree;
+  struct NodeInfo {
+    size_t begin, end, pos;
+  };
+  std::queue<NodeInfo> q;
+  // Leaf IDs will be set by roundtrip decoding the tree.
+  tree.push_back(PropertyDecisionNode::Leaf(pred));
+  q.push(NodeInfo{0, cutoffs.size(), 0});
+  while (!q.empty()) {
+    NodeInfo info = q.front();
+    q.pop();
+    if (info.begin + min_gap >= info.end) continue;
+    uint32_t split = (info.begin + info.end) / 2;
+    tree[info.pos] =
+        PropertyDecisionNode::Split(property, cutoffs[split], tree.size());
+    q.push(NodeInfo{split + 1, info.end, tree.size()});
+    tree.push_back(PropertyDecisionNode::Leaf(pred));
+    q.push(NodeInfo{info.begin, split, tree.size()});
+    tree.push_back(PropertyDecisionNode::Leaf(pred));
+  }
+  return tree;
+}
+
 }  // namespace
 
 void GatherTreeData(const Image &image, pixel_type chan, size_t group_id,
@@ -166,6 +198,83 @@ void GatherTreeData(const Image &image, pixel_type chan, size_t group_id,
       }
     }
   }
+}
+
+Tree PredefinedTree(ModularOptions::TreeKind tree_kind, size_t total_pixels) {
+  if (tree_kind == ModularOptions::TreeKind::kJpegTranscodeACMeta ||
+      tree_kind == ModularOptions::TreeKind::kTrivialTreeNoPredictor) {
+    // All the data is 0, so no need for a fancy tree.
+    return {PropertyDecisionNode::Leaf(Predictor::Zero)};
+  }
+  if (tree_kind == ModularOptions::TreeKind::kFalconACMeta) {
+    // All the data is 0 except the quant field. TODO(veluca): make that 0 too.
+    return {PropertyDecisionNode::Leaf(Predictor::Left)};
+  }
+  if (tree_kind == ModularOptions::TreeKind::kACMeta) {
+    // Small image.
+    if (total_pixels < 1024) {
+      return {PropertyDecisionNode::Leaf(Predictor::Left)};
+    }
+    Tree tree;
+    // 0: c > 1
+    tree.push_back(PropertyDecisionNode::Split(0, 1, 1));
+    // 1: c > 2
+    tree.push_back(PropertyDecisionNode::Split(0, 2, 3));
+    // 2: c > 0
+    tree.push_back(PropertyDecisionNode::Split(0, 0, 5));
+    // 3: EPF control field (all 0 or 4), top > 0
+    tree.push_back(PropertyDecisionNode::Split(6, 0, 21));
+    // 4: ACS+QF, y > 0
+    tree.push_back(PropertyDecisionNode::Split(2, 0, 7));
+    // 5: CfL x
+    tree.push_back(PropertyDecisionNode::Leaf(Predictor::Gradient));
+    // 6: CfL b
+    tree.push_back(PropertyDecisionNode::Leaf(Predictor::Gradient));
+    // 7: QF: split according to the left quant value.
+    tree.push_back(PropertyDecisionNode::Split(7, 5, 9));
+    // 8: ACS: split in 4 segments (8x8 from 0 to 3, large square 4-5, large
+    // rectangular 6-11, 8x8 12+), according to previous ACS value.
+    tree.push_back(PropertyDecisionNode::Split(7, 5, 15));
+    // QF
+    tree.push_back(PropertyDecisionNode::Split(7, 11, 11));
+    tree.push_back(PropertyDecisionNode::Split(7, 3, 13));
+    tree.push_back(PropertyDecisionNode::Leaf(Predictor::Left));
+    tree.push_back(PropertyDecisionNode::Leaf(Predictor::Left));
+    tree.push_back(PropertyDecisionNode::Leaf(Predictor::Left));
+    tree.push_back(PropertyDecisionNode::Leaf(Predictor::Left));
+    // ACS
+    tree.push_back(PropertyDecisionNode::Split(7, 11, 17));
+    tree.push_back(PropertyDecisionNode::Split(7, 3, 19));
+    tree.push_back(PropertyDecisionNode::Leaf(Predictor::Zero));
+    tree.push_back(PropertyDecisionNode::Leaf(Predictor::Zero));
+    tree.push_back(PropertyDecisionNode::Leaf(Predictor::Zero));
+    tree.push_back(PropertyDecisionNode::Leaf(Predictor::Zero));
+    // EPF, left > 0
+    tree.push_back(PropertyDecisionNode::Split(7, 0, 23));
+    tree.push_back(PropertyDecisionNode::Split(7, 0, 25));
+    tree.push_back(PropertyDecisionNode::Leaf(Predictor::Zero));
+    tree.push_back(PropertyDecisionNode::Leaf(Predictor::Zero));
+    tree.push_back(PropertyDecisionNode::Leaf(Predictor::Zero));
+    tree.push_back(PropertyDecisionNode::Leaf(Predictor::Zero));
+    return tree;
+  }
+  if (tree_kind == ModularOptions::TreeKind::kWPFixedDC) {
+    std::vector<int32_t> cutoffs = {
+        -500, -392, -255, -191, -127, -95, -63, -47, -31, -23, -15,
+        -11,  -7,   -4,   -3,   -1,   0,   1,   3,   5,   7,   11,
+        15,   23,   31,   47,   63,   95,  127, 191, 255, 392, 500};
+    return MakeFixedTree(kWPProp, cutoffs, Predictor::Weighted, total_pixels);
+  }
+  if (tree_kind == ModularOptions::TreeKind::kGradientFixedDC) {
+    std::vector<int32_t> cutoffs = {
+        -500, -392, -255, -191, -127, -95, -63, -47, -31, -23, -15,
+        -11,  -7,   -4,   -3,   -1,   0,   1,   3,   5,   7,   11,
+        15,   23,   31,   47,   63,   95,  127, 191, 255, 392, 500};
+    return MakeFixedTree(kGradientProp, cutoffs, Predictor::Gradient,
+                         total_pixels);
+  }
+  JXL_UNREACHABLE("Unreachable");
+  return {};
 }
 
 Tree LearnTree(TreeSamples &&tree_samples, size_t total_pixels,
@@ -494,8 +603,11 @@ Status ModularEncode(const Image &image, const ModularOptions &options,
     std::vector<uint8_t> context_map;
 
     std::vector<std::vector<Token>> tree_tokens(1);
+
     tree_storage =
-        LearnTree(std::move(tree_samples_storage), *total_pixels, options);
+        options.tree_kind == ModularOptions::TreeKind::kLearn
+            ? LearnTree(std::move(tree_samples_storage), *total_pixels, options)
+            : PredefinedTree(options.tree_kind, *total_pixels);
     tree = &tree_storage;
     tokens = &tokens_storage[0];
 

--- a/lib/jxl/modular/encoding/enc_encoding.h
+++ b/lib/jxl/modular/encoding/enc_encoding.h
@@ -21,6 +21,8 @@ namespace jxl {
 struct AuxOut;
 struct GroupHeader;
 
+Tree PredefinedTree(ModularOptions::TreeKind tree_kind, size_t total_pixels);
+
 Tree LearnTree(TreeSamples &&tree_samples, size_t total_pixels,
                const ModularOptions &options,
                const std::vector<ModularMultiplierInfo> &multiplier_info = {},


### PR DESCRIPTION
Benchmark results for streaming mode:

```
Encoding           kPixels    Bytes          BPP  E MP/s  D MP/s     Max norm  SSIMULACRA2   PSNR        pnorm       BPP*pnorm   QABPP   Bugs
---------------------------------------------------------------------------------------------------------------------------------------------
BEFORE:
jxl:d0.1:3:buf3     156870 118508714    6.0436461   7.982  22.493   0.33339094  93.97017505  55.04   0.11910771  0.719844857924   6.044      0
jxl:d0.1:6:buf3     156870 140715150    7.1761184   1.604  19.944   0.34002929  93.91114463  57.04   0.10192990  0.731461036514   7.176      0
jxl:d1:3:buf3       156870 28045193    1.4302342   9.947  32.182   1.43588506  86.14940783  43.59   0.58841531  0.841571732152   2.083      0
jxl:d1:6:buf3       156870 23919522    1.2198354   1.871  36.290   1.55957184  84.51739359  43.61   0.58584505  0.714634541037   1.931      0
jxl:d10:3:buf3      156870  4009051    0.2044515  14.562  18.632   6.71570493  38.19963812  35.71   2.25288348  0.460605427563   1.385      0
jxl:d10:6:buf3      156870  3375188    0.1721261   1.965  19.196   9.02995909  31.53903913  35.32   2.67511882  0.460457747644   1.565      0
Aggregate:          156870 23085552    1.1773051   4.354  23.922   1.57723146  65.28331684  44.27   0.54154141  0.637559439915   2.689      0
AFTER:
jxl:d0.1:3:buf3     156870 118146043    6.0251508   5.697  21.614   0.33339094  93.97017505  55.04   0.11910771  0.717641924101   6.025      0
jxl:d0.1:6:buf3     156870 139822977    7.1306199   1.496  19.926   0.34002929  93.91114463  57.04   0.10192990  0.726823371079   7.131      0
jxl:d1:3:buf3       156870 27853998    1.4204838   8.392  34.730   1.43588506  86.14940783  43.59   0.58841531  0.835834409990   2.069      0
jxl:d1:6:buf3       156870 23521180    1.1995210   1.808  36.334   1.55957184  84.51739359  43.61   0.58584505  0.702733427279   1.900      0
jxl:d10:3:buf3      156870  3826007    0.1951167  11.300  21.785   6.71570493  38.19963812  35.71   2.25288348  0.439575248630   1.322      0
jxl:d10:6:buf3      156870  3167927    0.1615563   2.062  20.146   9.02995909  31.53903913  35.32   2.67511882  0.432182305436   1.469      0
Aggregate:          156870 22541227    1.1495458   3.800  24.903   1.57723146  65.28331684  44.27   0.54154141  0.622526666306   2.626      0
```

Benchmark results for non-streaming mode:

```
Encoding           kPixels    Bytes          BPP  E MP/s  D MP/s     Max norm  SSIMULACRA2   PSNR        pnorm       BPP*pnorm   QABPP   Bugs
---------------------------------------------------------------------------------------------------------------------------------------------
BEFORE:
jxl:d0.1:3     156870 118196370    6.0277173   4.571  22.712   0.33339094  93.97017505  55.04   0.11910771  0.717947620036   6.028      0
jxl:d0.1:6     156870 140721249    7.1764295   1.411  19.442   0.34023632  93.89343486  57.11   0.10187564  0.731103368052   7.176      0
jxl:d1:3       156870 27841570    1.4198500   8.199  34.502   1.43588506  86.14940783  43.59   0.58841531  0.835461474297   2.068      0
jxl:d1:6       156870 23686906    1.2079726   1.739  34.308   1.48966351  84.58298559  43.65   0.58294516  0.704181767609   1.829      0
jxl:d10:3      156870  3819655    0.1947928  11.515  15.828   6.71570493  38.19963812  35.71   2.25288348  0.438845458543   1.320      0
jxl:d10:6      156870  3123745    0.1593031   1.972  18.542   9.35053938  31.50052643  35.32   2.68063191  0.427033058530   1.496      0
Aggregate:     156870 22532581    1.1491049   3.575  23.137   1.57450882  65.27641153  44.29   0.54123138  0.621931626891   2.620      0
AFTER:
jxl:d0.1:3     156870 118196370    6.0277173   4.698  20.373   0.33339094  93.97017505  55.04   0.11910771  0.717947620036   6.028      0
jxl:d0.1:6     156870 140721249    7.1764295   1.364  16.953   0.34023632  93.89343486  57.11   0.10187564  0.731103368052   7.176      0
jxl:d1:3       156870 27841570    1.4198500   8.174  30.218   1.43588506  86.14940783  43.59   0.58841531  0.835461474297   2.068      0
jxl:d1:6       156870 23686906    1.2079726   1.753  34.447   1.48966351  84.58298559  43.65   0.58294516  0.704181767609   1.829      0
jxl:d10:3      156870  3819655    0.1947928  11.678  15.795   6.71570493  38.19963812  35.71   2.25288348  0.438845458543   1.320      0
jxl:d10:6      156870  3123745    0.1593031   1.991  18.476   9.35053938  31.50052643  35.32   2.68063191  0.427033058530   1.496      0
Aggregate:     156870 22532581    1.1491049   3.588  21.718   1.57450882  65.27641153  44.29   0.54123138  0.621931626891   2.620      0
```
