### PR TITLE
Simplify adaptive quantization field quantization.

### DIFF
--- a/lib/jxl/decode_test.cc
+++ b/lib/jxl/decode_test.cc
@@ -1660,7 +1660,7 @@ TEST(DecodeTest, PixelTestWithICCProfileLossy) {
   EXPECT_THAT(
       ButteraugliDistance(io0.frames, io1.frames, ba, *JxlGetDefaultCms(),
                           /*distmap=*/nullptr, nullptr),
-      IsSlightlyBelow(0.55f));
+      IsSlightlyBelow(0.56f));
 
   JxlDecoderDestroy(dec);
 }
@@ -2104,7 +2104,7 @@ TEST(DecodeTest, PixelTestOpaqueSrgbLossyNoise) {
     EXPECT_THAT(
         ButteraugliDistance(io0.frames, io1.frames, ba, *JxlGetDefaultCms(),
                             /*distmap=*/nullptr, nullptr),
-        IsSlightlyBelow(1.2222f));
+        IsSlightlyBelow(1.3f));
 
     JxlDecoderDestroy(dec);
   }

--- a/lib/jxl/enc_heuristics.cc
+++ b/lib/jxl/enc_heuristics.cc
@@ -735,14 +735,7 @@ Status LossyFrameHeuristics(const FrameHeader& frame_header,
     PatchDictionaryEncoder::SubtractFrom(image_features.patches, opsin);
   }
 
-  static const float kAcQuant = 0.79f;
   const float quant_dc = InitialQuantDC(cparams.butteraugli_distance);
-  // We don't know the quant field yet, but for computing the global scale
-  // assuming that it will be the same as for Falcon mode is good enough.
-  if (initialize_global_state) {
-    quantizer.ComputeGlobalScaleAndQuant(
-        quant_dc, kAcQuant / cparams.butteraugli_distance, 0);
-  }
 
   // TODO(veluca): we can now run all the code from here to FindBestQuantizer
   // (excluded) one rect at a time. Do that.
@@ -779,9 +772,10 @@ Status LossyFrameHeuristics(const FrameHeader& frame_header,
         ImageF(frame_dim.xsize_blocks, frame_dim.ysize_blocks);
     initial_quant_masking =
         ImageF(frame_dim.xsize_blocks, frame_dim.ysize_blocks);
-    float q = kAcQuant / cparams.butteraugli_distance;
+    float q = 0.79 / cparams.butteraugli_distance;
     FillImage(q, &initial_quant_field);
     FillImage(1.0f / (q + 0.001f), &initial_quant_masking);
+    quantizer.ComputeGlobalScaleAndQuant(quant_dc, q, 0);
   } else {
     // Call this here, as it relies on pre-gaborish values.
     float butteraugli_distance_for_iqf = cparams.butteraugli_distance;
@@ -791,11 +785,8 @@ Status LossyFrameHeuristics(const FrameHeader& frame_header,
     initial_quant_field = InitialQuantField(
         butteraugli_distance_for_iqf, *opsin, rect, pool, 1.0f,
         &initial_quant_masking, &initial_quant_masking1x1);
-    // TODO(szabadka) Support changing the quantization of the quant field per
-    // group by applying different multipliers in modular mode.
-    if (cparams.use_full_image_heuristics && initialize_global_state) {
-      quantizer.SetQuantField(quant_dc, initial_quant_field, nullptr);
-    }
+    float q = 0.39 / cparams.butteraugli_distance;
+    quantizer.ComputeGlobalScaleAndQuant(quant_dc, q, 0);
   }
 
   // TODO(veluca): do something about animations.

--- a/lib/jxl/jxl_test.cc
+++ b/lib/jxl/jxl_test.cc
@@ -122,7 +122,7 @@ TEST(JxlTest, RoundtripSmallD1) {
 
   {
     PackedPixelFile ppf_out;
-    EXPECT_NEAR(Roundtrip(t.ppf(), {}, {}, pool, &ppf_out), 1027, 40);
+    EXPECT_NEAR(Roundtrip(t.ppf(), {}, {}, pool, &ppf_out), 916, 40);
     EXPECT_THAT(ButteraugliDistance(t.ppf(), ppf_out), IsSlightlyBelow(0.888));
   }
 
@@ -357,8 +357,8 @@ TEST(JxlTest, RoundtripLargeFast) {
   cparams.AddOption(JXL_ENC_FRAME_SETTING_EFFORT, 7);  // kSquirrel
 
   PackedPixelFile ppf_out;
-  EXPECT_NEAR(Roundtrip(t.ppf(), cparams, {}, &pool, &ppf_out), 505555, 5000);
-  EXPECT_THAT(ComputeDistance2(t.ppf(), ppf_out), IsSlightlyBelow(75));
+  EXPECT_NEAR(Roundtrip(t.ppf(), cparams, {}, &pool, &ppf_out), 492867, 5000);
+  EXPECT_THAT(ComputeDistance2(t.ppf(), ppf_out), IsSlightlyBelow(78));
 }
 
 TEST(JxlTest, RoundtripDotsForceEpf) {
@@ -374,7 +374,7 @@ TEST(JxlTest, RoundtripDotsForceEpf) {
   cparams.AddOption(JXL_ENC_FRAME_SETTING_DOTS, 1);
 
   PackedPixelFile ppf_out;
-  EXPECT_NEAR(Roundtrip(t.ppf(), cparams, {}, &pool, &ppf_out), 40777, 300);
+  EXPECT_NEAR(Roundtrip(t.ppf(), cparams, {}, &pool, &ppf_out), 41355, 300);
   EXPECT_THAT(ComputeDistance2(t.ppf(), ppf_out), IsSlightlyBelow(18));
 }
 
@@ -454,7 +454,7 @@ TEST(JxlTest, RoundtripSmallNL) {
   t.SetDimensions(xsize, ysize);
 
   PackedPixelFile ppf_out;
-  EXPECT_NEAR(Roundtrip(t.ppf(), {}, {}, pool, &ppf_out), 1027, 45);
+  EXPECT_NEAR(Roundtrip(t.ppf(), {}, {}, pool, &ppf_out), 916, 45);
   EXPECT_THAT(ButteraugliDistance(t.ppf(), ppf_out), IsSlightlyBelow(0.82));
 }
 
@@ -470,7 +470,7 @@ TEST(JxlTest, RoundtripNoGaborishNoAR) {
   cparams.AddOption(JXL_ENC_FRAME_SETTING_GABORISH, 0);
 
   PackedPixelFile ppf_out;
-  EXPECT_NEAR(Roundtrip(t.ppf(), cparams, {}, pool, &ppf_out), 41769, 400);
+  EXPECT_NEAR(Roundtrip(t.ppf(), cparams, {}, pool, &ppf_out), 41142, 400);
   EXPECT_THAT(ButteraugliDistance(t.ppf(), ppf_out), IsSlightlyBelow(1.8));
 }
 
@@ -488,7 +488,7 @@ TEST(JxlTest, RoundtripSmallNoGaborish) {
   cparams.AddOption(JXL_ENC_FRAME_SETTING_GABORISH, 0);
 
   PackedPixelFile ppf_out;
-  EXPECT_NEAR(Roundtrip(t.ppf(), cparams, {}, pool, &ppf_out), 1032, 20);
+  EXPECT_NEAR(Roundtrip(t.ppf(), cparams, {}, pool, &ppf_out), 1006, 20);
   EXPECT_THAT(ButteraugliDistance(t.ppf(), ppf_out), IsSlightlyBelow(1.1));
 }
 
@@ -861,7 +861,7 @@ TEST(JxlTest, RoundtripAlphaResampling) {
   cparams.AddOption(JXL_ENC_FRAME_SETTING_EXTRA_CHANNEL_RESAMPLING, 2);
 
   PackedPixelFile ppf_out;
-  EXPECT_NEAR(Roundtrip(t.ppf(), cparams, {}, pool, &ppf_out), 13655, 130);
+  EXPECT_NEAR(Roundtrip(t.ppf(), cparams, {}, pool, &ppf_out), 13507, 130);
   EXPECT_THAT(ButteraugliDistance(t.ppf(), ppf_out), IsSlightlyBelow(5.2));
 }
 
@@ -1136,7 +1136,7 @@ TEST(JxlTest, RoundtripNoise) {
   cparams.AddOption(JXL_ENC_FRAME_SETTING_NOISE, 1);
 
   PackedPixelFile ppf_out;
-  EXPECT_NEAR(Roundtrip(t.ppf(), cparams, {}, pool, &ppf_out), 42345, 750);
+  EXPECT_NEAR(Roundtrip(t.ppf(), cparams, {}, pool, &ppf_out), 41009, 750);
   EXPECT_THAT(ButteraugliDistance(t.ppf(), ppf_out), IsSlightlyBelow(1.35));
 }
 
@@ -1468,7 +1468,7 @@ TEST(JxlTest, RoundtripProgressive) {
   cparams.AddOption(JXL_ENC_FRAME_SETTING_RESPONSIVE, 1);
 
   PackedPixelFile ppf_out;
-  EXPECT_NEAR(Roundtrip(t.ppf(), cparams, {}, &pool, &ppf_out), 71444, 750);
+  EXPECT_NEAR(Roundtrip(t.ppf(), cparams, {}, &pool, &ppf_out), 70544, 750);
   EXPECT_THAT(ButteraugliDistance(t.ppf(), ppf_out), IsSlightlyBelow(1.4));
 }
 

--- a/tools/scripts/jxl-eval.sh
+++ b/tools/scripts/jxl-eval.sh
@@ -68,7 +68,7 @@ create_report() {
      --codec="${codec}" \
      --save_compressed \
      --write_html_report \
-     "${use_decompressed}" \
+     ${use_decompressed} \
      --originals_url="${originals}" \
      $@
    gsutil -m rsync "${output_dir}" "${GSROOT}/${bucket}"


### PR DESCRIPTION
This change removes the non-streamable heuristics for quantizing the adaptive quantization field that depends on global statistics.

Benchmark on 31 images:
```
Encoding      kPixels    Bytes          BPP  E MP/s  D MP/s     Max norm  SSIMULACRA2   PSNR        pnorm       BPP*pnorm   QABPP   Bugs
----------------------------------------------------------------------------------------------------------------------------------------
BEFORE:
jxl:d0.1:6      13270 12626327    7.6116954   0.800  16.867   0.31356426  95.36709772  55.37   0.10249605  0.780168699734   7.612      0
jxl:d0.5:6      13270  4762922    2.8712952   1.031  27.333   0.79376823  91.31835271  45.82   0.34330964  0.985743308245   2.902      0
jxl:d1:6        13270  2929121    1.7658007   1.097  28.909   1.37083528  86.59828991  41.93   0.58743719  1.037296992767   2.456      0
jxl:d2:6        13270  1762251    1.0623610   1.181  29.549   2.40937345  78.47490573  38.44   0.98458201  1.045981572202   2.626      0
jxl:d4:6        13270   985152    0.5938922   1.290  20.340   4.04650500  64.05694095  35.19   1.63003048  0.968062368079   2.492      0
jxl:d6:6        13270   698400    0.4210257   1.288  19.970   5.53929131  52.61293576  33.59   2.13779214  0.900065419496   2.397      0
jxl:d8:6        13270   554619    0.3343483   1.379  17.663   6.79444214  42.76406848  32.58   2.60772434  0.871888186416   2.316      0
jxl:d10:6       13270   458340    0.2763072   1.356  18.282   8.26532363  33.13149523  31.72   3.10633697  0.858303127639   2.314      0
Aggregate:      13270  1647567    0.9932248   1.162  21.834   2.38153629  64.03198159  38.67   0.93306036  0.926738705566   2.867      0
AFTER:
jxl:d0.1:6      13270 12626327    7.6116954   0.793  16.656   0.31356426  95.36709772  55.37   0.10249605  0.780168699734   7.612      0
jxl:d0.5:6      13270  4753176    2.8654199   0.944  28.382   0.78818077  91.29063799  45.78   0.34252479  0.981477345732   2.884      0
jxl:d1:6        13270  2926722    1.7643545   1.113  29.382   1.38540105  86.55411648  41.87   0.58855921  1.038427070311   2.463      0
jxl:d2:6        13270  1761734    1.0620494   1.187  28.985   2.45503627  78.39755412  38.38   0.98866200  1.050007852961   2.682      0
jxl:d4:6        13270   989931    0.5967732   1.317  19.631   4.10670901  64.15329516  35.15   1.63361759  0.974899157458   2.529      0
jxl:d6:6        13270   697480    0.4204711   1.317  18.396   5.52171582  52.48821825  33.55   2.15146613  0.904629284779   2.376      0
jxl:d8:6        13270   555002    0.3345792   1.359  18.911   6.60062574  42.82917207  32.55   2.61131175  0.873690555978   2.257      0
jxl:d10:6       13270   458836    0.2766062   1.282  18.188   8.19222769  33.38775238  31.71   3.10927996  0.860046004954   2.296      0
Aggregate:      13270  1648007    0.9934895   1.147  21.746   2.38035985  64.08447620  38.63   0.93477067  0.928684883673   2.863      0
```

Benchmark on imagecompression.info rgb8 images:

```
Encoding      kPixels    Bytes          BPP  E MP/s  D MP/s     Max norm  SSIMULACRA2   PSNR        pnorm       BPP*pnorm   QABPP   Bugs
----------------------------------------------------------------------------------------------------------------------------------------
BEFORE:
jxl:d0.1:6     156870 140721249    7.1764295   1.019  17.276   0.34023632  93.89343486  57.11   0.10187564  0.731103368052   7.176      0
jxl:d0.5:6     156870 45573291    2.3241231   1.168  25.668   0.85461875  89.98876106  47.45   0.33826889  0.786178552636   2.359      0
jxl:d1:6       156870 23686906    1.2079726   1.267  27.876   1.48966351  84.58298559  43.65   0.58294516  0.704181767609   1.829      0
jxl:d2:6       156870 12550793    0.6400588   1.350  31.790   2.43930144  76.33179663  40.76   0.90823432  0.581323412178   1.586      0
jxl:d4:6       156870  6556411    0.3343605   1.410  18.603   4.07893872  60.90603443  38.30   1.41242811  0.472260109155   1.380      0
jxl:d6:6       156870  4742323    0.2418465   1.435  19.534   5.58528272  49.73394235  37.04   1.82294170  0.440872134410   1.374      0
jxl:d8:6       156870  3761135    0.1918084   1.462  16.349   7.25453807  40.24390452  36.11   2.24346435  0.430315345507   1.409      0
jxl:d10:6      156870  3123745    0.1593031   1.402  16.723   9.35053938  31.50052643  35.32   2.68063191  0.427033058530   1.496      0
Aggregate:     156870 12745670    0.6499971   1.306  21.083   2.52126322  61.67979063  41.46   0.85385021  0.555000151056   1.935      0
AFTER:
jxl:d0.1:6     156870 140721249    7.1764295   1.022  17.007   0.34023632  93.89343486  57.11   0.10187564  0.731103368052   7.176      0
jxl:d0.5:6     156870 45129499    2.3014908   1.131  25.826   0.88576661  89.92011008  47.35   0.34189545  0.786869251948   2.342      0
jxl:d1:6       156870 23491856    1.1980255   1.235  28.941   1.55298587  84.48789796  43.56   0.58936610  0.706075623429   1.886      0
jxl:d2:6       156870 12496514    0.6372908   1.352  30.788   2.44624248  76.16679033  40.70   0.91550166  0.583440742830   1.576      0
jxl:d4:6       156870  6543536    0.3337039   1.356  20.331   4.00739558  60.70254403  38.25   1.42342722  0.475003164424   1.348      0
jxl:d6:6       156870  4729462    0.2411907   1.431  20.906   5.44758267  49.45526499  37.00   1.82907117  0.441154876613   1.318      0
jxl:d8:6       156870  3783398    0.1929438   1.411  16.873   7.42769868  40.41793878  36.12   2.23622766  0.431466204663   1.456      0
jxl:d10:6      156870  3143974    0.1603348   1.417  16.651   9.27436095  31.73506020  35.33   2.67495846  0.428888821330   1.498      0
Aggregate:     156870 12722251    0.6488028   1.286  21.563   2.53802802  61.66988540  41.42   0.85763177  0.556433865127   1.932      0
```

Images for viewing:
BEFORE:
https://storage.googleapis.com/jxl-quality/eval/szabadka/jyrki31/2dd57778/exp/index.jxl_d1_6.html 
https://storage.googleapis.com/jxl-quality/eval/szabadka/jyrki31/2dd57778/exp/index.jxl_d4_6.html
AFTER:
https://storage.googleapis.com/jxl-quality/eval/szabadka/jyrki31/dee05eb2/exp/index.jxl_d1_6.html 
https://storage.googleapis.com/jxl-quality/eval/szabadka/jyrki31/dee05eb2/exp/index.jxl_d4_6.html
