### PR TITLE
Use pixel stats based chromacity adjustment from effort 7.

### DIFF
--- a/lib/jxl/enc_frame.cc
+++ b/lib/jxl/enc_frame.cc
@@ -630,8 +630,7 @@ void ComputeChromacityAdjustments(const CompressParams& cparams,
   // look at the individual pixels and make a guess how difficult
   // the image would be based on the worst case pixel.
   PixelStatsForChromacityAdjustment pixel_stats;
-  if (cparams.speed_tier <= SpeedTier::kWombat &&
-      cparams.use_full_image_heuristics) {
+  if (cparams.speed_tier <= SpeedTier::kSquirrel) {
     pixel_stats.Calc(&opsin, rect);
   }
   // For X take the most severe adjustment.


### PR DESCRIPTION
Benchmark results:

```
Encoding      kPixels    Bytes          BPP  E MP/s  D MP/s     Max norm  SSIMULACRA2   PSNR        pnorm       BPP*pnorm   QABPP   Bugs
----------------------------------------------------------------------------------------------------------------------------------------
BEFORE
jxl:d0.1:6      16460 14855553    7.2201252   0.734  14.748   0.32632550  95.55052636  55.98   0.10797757  0.779611600960   7.220      0
jxl:d1:6        16460  3619784    1.7592946   1.003  22.865   1.33882102  86.96879756  42.79   0.56881514  1.000713393425   2.388      0
jxl:d2:6        16460  2224826    1.0813143   1.009  23.328   2.30537368  79.11047984  39.21   0.95280424  1.030280878257   2.555      0
jxl:d8:6        16460   742198    0.3607245   1.086  14.263   6.53787903  44.03287471  33.05   2.55529638  0.921758112130   2.399      0
Aggregate:      16460  3069706    1.4919447   0.948  18.302   1.60190935  73.35030126  41.97   0.62185255  0.927769632727   3.206      0
AFTER
jxl:d0.1:6      16460 14834232    7.2097628   0.746  15.086   0.32637776  95.55130928  55.96   0.10799932  0.778649500993   7.210      0
jxl:d1:6        16460  3580887    1.7403898   0.962  22.214   1.34434093  86.85866684  42.69   0.57248910  0.996354180348   2.370      0
jxl:d2:6        16460  2222451    1.0801600   1.071  23.273   2.30525423  79.09447014  39.20   0.95293900  1.029326620502   2.552      0
jxl:d8:6        16460   741578    0.3604232   1.109  15.112   6.53737284  44.01132169  33.04   2.55544959  0.921043333050   2.397      0
Aggregate:      16460  3058871    1.4866786   0.961  18.529   1.60357034  73.31453483  41.94   0.62291698  0.926077336892   3.198      0
```

Images to view:
BEFORE:
https://storage.googleapis.com/jxl-quality/eval/szabadka/jyrki-split-2021-01/8500fa0f/exp/index.jxl_d1_6.html
AFTER:
https://storage.googleapis.com/jxl-quality/eval/szabadka/jyrki-split-2021-01/86f005ef/exp/index.jxl_d1_6.html

