### PR TITLE
Remove custom DC chroma-from luma heuristics.

### DIFF
--- a/lib/jxl/enc_chroma_from_luma.h
+++ b/lib/jxl/enc_chroma_from_luma.h
@@ -41,8 +41,6 @@ struct CfLHeuristics {
                    const ImageI* raw_quant_field, const Quantizer* quantizer,
                    bool fast, size_t thread, ColorCorrelationMap* cmap);
 
-  void ComputeDC(bool fast, ColorCorrelationMap* cmap);
-
   ImageF dc_values;
   hwy::AlignedFreeUniquePtr<float[]> mem;
 

--- a/lib/jxl/enc_heuristics.cc
+++ b/lib/jxl/enc_heuristics.cc
@@ -900,11 +900,6 @@ Status LossyFrameHeuristics(const FrameHeader& frame_header,
       process_tile, "Enc Heuristics"));
 
   acs_heuristics.Finalize(frame_dim, ac_strategy, aux_out);
-  if (cparams.speed_tier <= SpeedTier::kHare &&
-      cparams.use_full_image_heuristics && initialize_global_state) {
-    cfl_heuristics.ComputeDC(/*fast=*/cparams.speed_tier >= SpeedTier::kWombat,
-                             &cmap);
-  }
 
   // Refine quantization levels.
   if (!streaming_mode) {


### PR DESCRIPTION
This is a global image heuristics that could introduce pixel differences in streaming mode, but it does not make a difference in practice.

Benchmark results on small images:

```
Encoding      kPixels    Bytes          BPP  E MP/s  D MP/s     Max norm  SSIMULACRA2   PSNR        pnorm       BPP*pnorm   QABPP   Bugs
----------------------------------------------------------------------------------------------------------------------------------------
BEFORE:
jxl:d0.1        13270 12575672    7.5811584   0.688  16.435   0.31300673  95.34879620  55.43   0.10223163  0.775034177620   7.581      0
jxl:d1          13270  2923926    1.7626689   0.946  26.249   1.36367276  86.74409296  41.97   0.58689168  1.034495722999   2.443      0
jxl:d2          13270  1760918    1.0615574   1.046  25.471   2.40538614  78.59199131  38.46   0.98401481  1.044588255612   2.622      0
jxl:d4          13270   987515    0.5953167   1.070  18.380   4.05354002  64.20526494  35.21   1.62944122  0.970033578803   2.500      0
jxl:d10         13270   459615    0.2770758   1.132  15.896   8.21227587  33.59905971  31.73   3.09457716  0.857432378712   2.316      0
jxl:d25         13270   233311    0.1406500   0.425  32.520  17.23911727  -3.38288472  29.22   5.72309615  0.804953192864   2.442      0
Aggregate:      13270  1378325    0.8309139   0.840  21.699   2.89541138  67.50970911  37.81   1.09287206  0.908082545257   2.970      0
AFTER:
jxl:d0.1        13270 12575672    7.5811584   0.663  16.623   0.31300673  95.34879620  55.43   0.10223163  0.775034177620   7.581      0
jxl:d1          13270  2923926    1.7626689   0.937  26.385   1.36367276  86.74409296  41.97   0.58689168  1.034495722999   2.443      0
jxl:d2          13270  1760918    1.0615574   1.024  28.999   2.40538614  78.59199131  38.46   0.98401481  1.044588255612   2.622      0
jxl:d4          13270   987515    0.5953167   1.024  19.922   4.05354002  64.20526494  35.21   1.62944122  0.970033578803   2.500      0
jxl:d10         13270   459617    0.2770770   1.096  17.678   8.21245470  33.60248985  31.73   3.09460566  0.857444005974   2.316      0
jxl:d25         13270   233311    0.1406500   0.413  34.010  17.23911727  -3.38288472  29.22   5.72309615  0.804953192864   2.442      0
Aggregate:      13270  1378326    0.8309145   0.816  23.110   2.89542189  67.51108747  37.81   1.09287373  0.908084597597   2.970      0
```

Benchmark results on large images:

```
Encoding      kPixels    Bytes          BPP  E MP/s  D MP/s     Max norm  SSIMULACRA2   PSNR        pnorm       BPP*pnorm   QABPP   Bugs
----------------------------------------------------------------------------------------------------------------------------------------
BEFORE:
jxl:d0.1       156870 141506375    7.2164689   1.184  19.071   0.33378362  93.90796617  57.19   0.10142253  0.731912536759   7.216      0
jxl:d1         156870 23680833    1.2076629   1.483  37.685   1.49379655  84.59488978  43.66   0.58316869  0.704271179346   1.829      0
jxl:d2         156870 12549909    0.6400138   1.495  36.675   2.43318214  76.33449477  40.77   0.90836418  0.581365583904   1.583      0
jxl:d4         156870  6562226    0.3346570   1.538  25.637   3.98894320  60.92577458  38.31   1.41160054  0.472402012783   1.349      0
jxl:d10        156870  3129105    0.1595765   1.514  19.183   9.23112087  31.60086736  35.33   2.67094507  0.426220007652   1.486      0
jxl:d25        156870  1287142    0.0656410   0.584  48.264  20.23156577  -4.80761872  32.95   5.12571861  0.336457304743   1.349      0
Aggregate:     156870 10177753    0.5190398   1.236  29.245   3.10941589  65.08089133  40.69   1.00628275  0.522300761557   1.959      0
AFTER:
jxl:d0.1       156870 141506375    7.2164689   1.185  19.338   0.33378362  93.90796617  57.19   0.10142253  0.731912536759   7.216      0
jxl:d1         156870 23680833    1.2076629   1.445  35.092   1.49379655  84.59488978  43.66   0.58316869  0.704271179346   1.829      0
jxl:d2         156870 12549909    0.6400138   1.491  38.072   2.43318214  76.33449477  40.77   0.90836418  0.581365583904   1.583      0
jxl:d4         156870  6562226    0.3346570   1.498  25.340   3.98894320  60.92577458  38.31   1.41160054  0.472402012783   1.349      0
jxl:d10        156870  3129105    0.1595765   1.443  19.400   9.23112087  31.60086736  35.33   2.67094507  0.426220007652   1.486      0
jxl:d25        156870  1287142    0.0656410   0.566  48.692  20.23156577  -4.80761872  32.95   5.12571861  0.336457304743   1.349      0
Aggregate:     156870 10177753    0.5190398   1.209  29.189   3.10941589  65.08089133  40.69   1.00628275  0.522300761557   1.959      0
```
