### PR TITLE
Fix jxl_export CMake target to be a INTERFACE library

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -69,6 +69,7 @@ Maarten DB <anonymous.maarten@gmail.com>
 Marcin Konicki <ahwayakchih@gmail.com>
 Martin Strunz
 Mathieu Malaterre <mathieu.malaterre@gmail.com>
+Michał Górny <mgorny@gentoo.org>
 Mikk Leini <mikk.leini@krakul.eu>
 Misaki Kasumi <misakikasumi@outlook.com>
 Moonchild Straver <moonchild@palemoon.org>

--- a/lib/jxl.cmake
+++ b/lib/jxl.cmake
@@ -60,7 +60,7 @@ include(GenerateExportHeader)
 
 # CMake does not allow generate_export_header for INTERFACE library, so we
 # add this stub library just for file generation.
-add_library(jxl_export OBJECT ${JPEGXL_INTERNAL_PUBLIC_HEADERS})
+add_library(jxl_export INTERFACE ${JPEGXL_INTERNAL_PUBLIC_HEADERS})
 set_target_properties(jxl_export PROPERTIES
   CXX_VISIBILITY_PRESET hidden
   VISIBILITY_INLINES_HIDDEN 1


### PR DESCRIPTION
### Description

Fix the jxl_export target to be a INTERFACE library rather than an OBJECT library.  The latter type is only correct for libraries that actually include any source files, and therefore produce an actual object file.  Using it with jxl_export causes CMake to produce an invalid ninja file.  While ninja ignores the problem, samurai is more strict and rejects the file:

    samu: file is missing and not created by any action: 'lib/CMakeFiles/jxl_export.dir'

INTERFACE libraries "do not compile sources and do not produce library artifacts on disk", and therefore are more correct for a header-only target.  See:
https://cmake.org/cmake/help/latest/command/add_library.html#interface-libraries

### Pull Request Checklist

- [x] **CLA Signed**: Have you signed the [Contributor License Agreement](https://code.google.com/legal/individual-cla-v1.0.html) (individual or corporate, as appropriate)? Only contributions from signed contributors can be accepted.
- [x] **Authors**: Have you considered adding your name to the [AUTHORS](AUTHORS) file?
- [x] **Code Style**: Have you ensured your code adheres to the project's coding style guidelines? You can use `./ci.sh lint` for automatic code formatting.


Please review the full [contributing guidelines](https://github.com/libjxl/libjxl/blob/main/CONTRIBUTING.md) for more details.
