### PR TITLE
Change definition of JXL_DEBUG_V when JXL_DEBUG_V_LEVEL is zero.

### DIFF
--- a/lib/jxl/base/status.h
+++ b/lib/jxl/base/status.h
@@ -127,8 +127,12 @@ inline JXL_NOINLINE bool Debug(const char* format, ...) {
 // JXL_DEBUG version that prints the debug message if the global verbose level
 // defined at compile time by JXL_DEBUG_V_LEVEL is greater or equal than the
 // passed level.
+#if JXL_DEBUG_V_LEVEL > 0
 #define JXL_DEBUG_V(level, format, ...) \
   JXL_DEBUG(level <= JXL_DEBUG_V_LEVEL, format, ##__VA_ARGS__)
+#else
+#define JXL_DEBUG_V(level, format, ...)
+#endif
 
 // Warnings (via JXL_WARNING) are enabled by default in debug builds (opt and
 // debug).


### PR DESCRIPTION
### Description

This is a small tweak in the definition of `JXL_DEBUG_V_LEVEL` that removes the `JXL_DEBUG` blocks when `JXL_DEBUG_V_LEVEL` is `0`.

### Pull Request Checklist

- [x] **CLA Signed**: Have you signed the [Contributor License Agreement](https://code.google.com/legal/individual-cla-v1.0.html) (individual or corporate, as appropriate)? Only contributions from signed contributors can be accepted.
- [x] **Authors**: Have you considered adding your name to the [AUTHORS](AUTHORS) file?
- [x] **Code Style**: Have you ensured your code adheres to the project's coding style guidelines? You can use `./ci.sh lint` for automatic code formatting.


Please review the full [contributing guidelines](https://github.com/libjxl/libjxl/blob/main/CONTRIBUTING.md) for more details.
