### PR TITLE
GDK Pixbuf Loader Fixes

### DIFF
--- a/lib/jxl/decode.cc
+++ b/lib/jxl/decode.cc
@@ -2348,27 +2348,38 @@ JXL_EXPORT JxlDecoderStatus JxlDecoderSetCms(JxlDecoder* dec,
   return JXL_DEC_SUCCESS;
 }
 
-JXL_EXPORT JxlDecoderStatus JxlDecoderPreviewOutBufferSize(
-    const JxlDecoder* dec, const JxlPixelFormat* format, size_t* size) {
+static JxlDecoderStatus GetMinSize(const JxlDecoder* dec,
+                                   const JxlPixelFormat* format,
+                                   size_t num_channels, size_t* min_size,
+                                   bool preview) {
   size_t bits;
   JxlDecoderStatus status = PrepareSizeCheck(dec, format, &bits);
   if (status != JXL_DEC_SUCCESS) return status;
-  if (format->num_channels < 3 &&
-      !dec->image_metadata.color_encoding.IsGray()) {
-    return JXL_API_ERROR("Number of channels is too low for color output");
+  size_t xsize, ysize;
+  if (preview) {
+    xsize = dec->metadata.oriented_preview_xsize(dec->keep_orientation);
+    ysize = dec->metadata.oriented_preview_ysize(dec->keep_orientation);
+  } else {
+    GetCurrentDimensions(dec, xsize, ysize);
   }
-
-  size_t xsize = dec->metadata.oriented_preview_xsize(dec->keep_orientation);
-  size_t ysize = dec->metadata.oriented_preview_ysize(dec->keep_orientation);
-
+  if (num_channels == 0) num_channels = format->num_channels;
   size_t row_size =
-      jxl::DivCeil(xsize * format->num_channels * bits, jxl::kBitsPerByte);
+      jxl::DivCeil(xsize * num_channels * bits, jxl::kBitsPerByte);
   size_t last_row_size = row_size;
   if (format->align > 1) {
     row_size = jxl::DivCeil(row_size, format->align) * format->align;
   }
-  *size = row_size * (ysize - 1) + last_row_size;
+  *min_size = row_size * (ysize - 1) + last_row_size;
   return JXL_DEC_SUCCESS;
+}
+
+JXL_EXPORT JxlDecoderStatus JxlDecoderPreviewOutBufferSize(
+    const JxlDecoder* dec, const JxlPixelFormat* format, size_t* size) {
+  if (format->num_channels < 3 &&
+      !dec->image_metadata.color_encoding.IsGray()) {
+    return JXL_API_ERROR("Number of channels is too low for color output");
+  }
+  return GetMinSize(dec, format, 0, size, true);
 }
 
 JXL_EXPORT JxlDecoderStatus JxlDecoderSetPreviewOutBuffer(
@@ -2401,23 +2412,12 @@ JXL_EXPORT JxlDecoderStatus JxlDecoderSetPreviewOutBuffer(
 
 JXL_EXPORT JxlDecoderStatus JxlDecoderImageOutBufferSize(
     const JxlDecoder* dec, const JxlPixelFormat* format, size_t* size) {
-  size_t bits;
-  JxlDecoderStatus status = PrepareSizeCheck(dec, format, &bits);
-  if (status != JXL_DEC_SUCCESS) return status;
   if (format->num_channels < 3 &&
       !dec->image_metadata.color_encoding.IsGray()) {
     return JXL_API_ERROR("Number of channels is too low for color output");
   }
-  size_t xsize, ysize;
-  GetCurrentDimensions(dec, xsize, ysize);
-  size_t row_size =
-      jxl::DivCeil(xsize * format->num_channels * bits, jxl::kBitsPerByte);
-  if (format->align > 1) {
-    row_size = jxl::DivCeil(row_size, format->align) * format->align;
-  }
-  *size = row_size * ysize;
 
-  return JXL_DEC_SUCCESS;
+  return GetMinSize(dec, format, 0, size, false);
 }
 
 JxlDecoderStatus JxlDecoderSetImageOutBuffer(JxlDecoder* dec,
@@ -2463,22 +2463,7 @@ JxlDecoderStatus JxlDecoderExtraChannelBufferSize(const JxlDecoder* dec,
     return JXL_API_ERROR("Invalid extra channel index");
   }
 
-  size_t num_channels = 1;  // Do not use format's num_channels
-
-  size_t bits;
-  JxlDecoderStatus status = PrepareSizeCheck(dec, format, &bits);
-  if (status != JXL_DEC_SUCCESS) return status;
-
-  size_t xsize, ysize;
-  GetCurrentDimensions(dec, xsize, ysize);
-  size_t row_size =
-      jxl::DivCeil(xsize * num_channels * bits, jxl::kBitsPerByte);
-  if (format->align > 1) {
-    row_size = jxl::DivCeil(row_size, format->align) * format->align;
-  }
-  *size = row_size * ysize;
-
-  return JXL_DEC_SUCCESS;
+  return GetMinSize(dec, format, 1, size, false);
 }
 
 JxlDecoderStatus JxlDecoderSetExtraChannelBuffer(JxlDecoder* dec,

--- a/lib/jxl/decode_test.cc
+++ b/lib/jxl/decode_test.cc
@@ -2575,7 +2575,11 @@ TEST(DecodeTest, AlignTest) {
   size_t align = 17;
   JxlPixelFormat format = {3, JXL_TYPE_UINT8, JXL_LITTLE_ENDIAN, align};
   // On purpose not using jxl::RoundUpTo to test it independently.
-  size_t expected_line_bytes = (1 * 3 * xsize + align - 1) / align * align;
+  size_t expected_line_size_last = 1 * 3 * xsize;
+  size_t expected_line_size =
+      ((expected_line_size_last + align - 1) / align) * align;
+  size_t expected_pixels_size =
+      expected_line_size * (ysize - 1) + expected_line_size_last;
 
   for (int use_callback = 0; use_callback <= 1; ++use_callback) {
     std::vector<uint8_t> pixels2 = jxl::DecodeWithAPI(
@@ -2583,7 +2587,7 @@ TEST(DecodeTest, AlignTest) {
         /*set_buffer_early=*/false,
         /*use_resizable_runner=*/false, /*require_boxes=*/false,
         /*expect_success=*/true);
-    EXPECT_EQ(expected_line_bytes * ysize, pixels2.size());
+    EXPECT_EQ(expected_pixels_size, pixels2.size());
     EXPECT_EQ(0u, jxl::test::ComparePixels(pixels.data(), pixels2.data(), xsize,
                                            ysize, format_orig, format));
   }

--- a/plugins/gdk-pixbuf/pixbufloader-jxl.c
+++ b/plugins/gdk-pixbuf/pixbufloader-jxl.c
@@ -491,9 +491,8 @@ static gboolean load_increment(gpointer context, const guchar *buf, guint size,
                           decoder_state->frames->len - 1)
                 .data;
         decoder_state->pixel_format.align = gdk_pixbuf_get_rowstride(output);
-        guchar *dst = gdk_pixbuf_get_pixels(output);
-        size_t num_pixels = decoder_state->xsize * decoder_state->ysize;
-        size_t size = num_pixels * decoder_state->pixel_format.num_channels;
+        guint size;
+        guchar *dst = gdk_pixbuf_get_pixels_with_length(output, &size);
         if (JXL_DEC_SUCCESS != JxlDecoderSetImageOutBuffer(
                                    decoder_state->decoder,
                                    &decoder_state->pixel_format, dst, size)) {


### PR DESCRIPTION
**plugins/gdk-pixbuf: consider stride when passing buffer to libjxl**
    
    This change uses gdk_pixbuf_get_pixels_with_length to get the actual
    size of the buffer, with stride taken into account. The previous code
    just multiplies width by height and ignores stride.
    
    Signed-off-by: Leo Izen <leo.izen@gmail.com>

**lib/jxl/decode.cc: deduplicate and correct min_size calculation**
    
    Code to calculate the proper size of the buffer exists in three places
    in this function - one for the standard buffer, one for the extra
    channel buffer, and one for the preview buffer. However, only the code
    for the preview buffer correctly took into account the last row size
    possibly being slightly smaller than the remaining rows.
    
    This commit separates the code out into a separate function to remove
    duplicate code, and uses the algorithm from the prevew buffer which was
    the only correct one.
    
    Signed-off-by: Leo Izen <leo.izen@gmail.com>

Fixes #3144.