### PR TITLE
Add documentation to JxlEncoderAddJPEGFrame indicating it's for lossless compression only

### DIFF
--- a/lib/include/jxl/encode.h
+++ b/lib/include/jxl/encode.h
@@ -603,6 +603,10 @@ JXL_EXPORT JxlEncoderStatus JxlEncoderSetFrameBitDepth(
  * JxlEncoderCloseFrames must be called before the next
  * @ref JxlEncoderProcessOutput call.
  *
+ * Note, this can only be used to add JPEG frames for lossless compression. To
+ * encode with lossy compression, the JPEG must be decoded manually and a pixel
+ * buffer added using JxlEncoderAddImageFrame.
+ *
  * @param frame_settings set of options and metadata for this frame. Also
  * includes reference to the encoder object.
  * @param buffer bytes to read JPEG from. Owned by the caller and its contents


### PR DESCRIPTION
Adds additional documentation to JxlEncoderAddJPEGFrame to make it clear that this function can only be used for lossless JPEG transcoding.

### Description

This PR resolves the [issue I raised here.](https://github.com/libjxl/libjxl/issues/3210) It adds an extra sentence to the `JxlEncoderAddJPEGFrame` function doc comment to make it clear that it can only be used for lossless JPEG transcoding. 

### Pull Request Checklist

- [X] **CLA Signed**: Have you signed the [Contributor License Agreement](https://code.google.com/legal/individual-cla-v1.0.html) (individual or corporate, as appropriate)? Only contributions from signed contributors can be accepted.
- [X] **Authors**: Have you considered adding your name to the [AUTHORS](AUTHORS) file?
- [X] **Code Style**: Have you ensured your code adheres to the project's coding style guidelines? You can use `./ci.sh lint` for automatic code formatting.