### PR TITLE
Do not encode alpha lossily by default in VarDCT mode.

### DIFF
--- a/lib/extras/enc/jxl.h
+++ b/lib/extras/enc/jxl.h
@@ -38,7 +38,7 @@ struct JXLCompressParams {
   std::vector<JXLOption> options;
   // Target butteraugli distance, 0.0 means lossless.
   float distance = 1.0f;
-  float alpha_distance = 1.0f;
+  float alpha_distance = 0.0f;
   // If set to true, forces container mode.
   bool use_container = false;
   // Whether to enable/disable byte-exact jpeg reconstruction for jpeg inputs.

--- a/lib/jxl/enc_frame.cc
+++ b/lib/jxl/enc_frame.cc
@@ -1446,7 +1446,7 @@ Status ComputeEncodingData(
     bool lossless = cparams.IsLossless();
     if (alpha && !alpha_eci->alpha_associated &&
         frame_header.frame_type == FrameType::kRegularFrame &&
-        !ApplyOverride(cparams.keep_invisible, lossless) &&
+        !ApplyOverride(cparams.keep_invisible, true) &&
         cparams.ec_resampling == cparams.resampling) {
       // simplify invisible pixels
       SimplifyInvisible(&color, *alpha, lossless);

--- a/lib/jxl/enc_modular.cc
+++ b/lib/jxl/enc_modular.cc
@@ -674,8 +674,8 @@ Status ModularFrameEncoder::ComputeEncodingData(
       bitdepth_correction = maxval / 255.f;
     }
     std::vector<float> quantizers;
-    float dist = cparams_.butteraugli_distance;
     for (size_t i = 0; i < 3; i++) {
+      float dist = cparams_.butteraugli_distance;
       quantizers.push_back(quantizer * dist * bitdepth_correction);
     }
     for (size_t i = 0; i < extra_channels.size(); i++) {
@@ -683,6 +683,7 @@ Status ModularFrameEncoder::ComputeEncodingData(
           metadata.extra_channel_info[i].bit_depth.bits_per_sample;
       pixel_type ec_maxval = ec_bitdepth < 32 ? (1u << ec_bitdepth) - 1 : 0;
       bitdepth_correction = ec_maxval / 255.f;
+      float dist = 0;
       if (i < cparams_.ec_distance.size()) dist = cparams_.ec_distance[i];
       if (dist < 0) dist = cparams_.butteraugli_distance;
       quantizers.push_back(quantizer * dist * bitdepth_correction);

--- a/lib/jxl/enc_params.h
+++ b/lib/jxl/enc_params.h
@@ -106,7 +106,7 @@ struct CompressParams {
   int progressive_dc = -1;
 
   // If on: preserve color of invisible pixels (if off: don't care)
-  // Default: on for lossless, off for lossy
+  // Default: on
   Override keep_invisible = Override::kDefault;
 
   JxlCmsInterface cms;
@@ -159,9 +159,6 @@ struct CompressParams {
       if (f > 0) return false;
       if (f < 0 && butteraugli_distance != 0) return false;
     }
-    // if no explicit ec_distance given, and using vardct, then the modular part
-    // is empty or not lossless
-    if (!modular_mode && ec_distance.empty()) return false;
     // all modular channels are encoded at distance 0
     return true;
   }

--- a/lib/jxl/encode.cc
+++ b/lib/jxl/encode.cc
@@ -1436,7 +1436,7 @@ JxlEncoderFrameSettings* JxlEncoderFrameSettingsCreate(
   }
   opts->values.cparams.level = enc->codestream_level;
   opts->values.cparams.ec_distance.resize(enc->metadata.m.num_extra_channels,
-                                          -1);
+                                          0);
 
   JxlEncoderFrameSettings* ret = opts.get();
   enc->encoder_options.emplace_back(std::move(opts));
@@ -1489,7 +1489,7 @@ JxlEncoderStatus JxlEncoderSetExtraChannelDistance(
     // This can only happen if JxlEncoderFrameSettingsCreate() was called before
     // JxlEncoderSetBasicInfo().
     frame_settings->values.cparams.ec_distance.resize(
-        frame_settings->enc->metadata.m.num_extra_channels, -1);
+        frame_settings->enc->metadata.m.num_extra_channels, 0);
   }
 
   frame_settings->values.cparams.ec_distance[index] = distance;

--- a/lib/jxl/encode_test.cc
+++ b/lib/jxl/encode_test.cc
@@ -241,7 +241,7 @@ void VerifyFrameEncoding(size_t xsize, size_t ysize, JxlEncoder* enc,
 
 void VerifyFrameEncoding(JxlEncoder* enc,
                          const JxlEncoderFrameSettings* frame_settings) {
-  VerifyFrameEncoding(63, 129, enc, frame_settings, 2700,
+  VerifyFrameEncoding(63, 129, enc, frame_settings, 27000,
                       /*lossy_use_original_profile=*/false);
 }
 
@@ -256,7 +256,7 @@ TEST(EncodeTest, EncoderResetTest) {
   JxlEncoderPtr enc = JxlEncoderMake(nullptr);
   EXPECT_NE(nullptr, enc.get());
   VerifyFrameEncoding(50, 200, enc.get(),
-                      JxlEncoderFrameSettingsCreate(enc.get(), nullptr), 4300,
+                      JxlEncoderFrameSettingsCreate(enc.get(), nullptr), 4550,
                       false);
   // Encoder should become reusable for a new image from scratch after using
   // reset.
@@ -438,7 +438,7 @@ TEST(EncodeTest, frame_settingsTest) {
               JxlEncoderFrameSettingsSetOption(
                   frame_settings, JXL_ENC_FRAME_SETTING_PHOTON_NOISE, 50.0f));
 
-    VerifyFrameEncoding(63, 129, enc.get(), frame_settings, 2500, false);
+    VerifyFrameEncoding(63, 129, enc.get(), frame_settings, 3700, false);
   }
 
   {
@@ -458,7 +458,7 @@ TEST(EncodeTest, frame_settingsTest) {
     JxlEncoderFrameSettings* frame_settings =
         JxlEncoderFrameSettingsCreate(enc.get(), NULL);
     EXPECT_EQ(JXL_ENC_SUCCESS, JxlEncoderSetFrameDistance(frame_settings, 0.5));
-    VerifyFrameEncoding(63, 129, enc.get(), frame_settings, 3030, false);
+    VerifyFrameEncoding(63, 129, enc.get(), frame_settings, 3130, false);
     EXPECT_EQ(0.5, enc->last_used_cparams.butteraugli_distance);
   }
 
@@ -519,7 +519,7 @@ TEST(EncodeTest, frame_settingsTest) {
     EXPECT_EQ(JXL_ENC_SUCCESS,
               JxlEncoderFrameSettingsSetOption(
                   frame_settings, JXL_ENC_FRAME_SETTING_PROGRESSIVE_DC, 2));
-    VerifyFrameEncoding(63, 129, enc.get(), frame_settings, 2830,
+    VerifyFrameEncoding(63, 129, enc.get(), frame_settings, 3430,
                         /*lossy_use_original_profile=*/false);
     EXPECT_EQ(false, enc->last_used_cparams.responsive);
     EXPECT_EQ(jxl::Override::kOn, enc->last_used_cparams.progressive_mode);

--- a/tools/cjxl_main.cc
+++ b/tools/cjxl_main.cc
@@ -151,7 +151,7 @@ struct CompressArgs {
         "Target visual distance for the alpha channel, lower = higher "
         "quality.\n"
         "    0.0 = mathematically lossless. 1.0 = visually lossless.\n"
-        "    Default is to use the same value as for the color image.\n"
+        "    Default is 0.\n"
         "    Recommended range: 0.5 .. 3.0. Allowed range: 0.0 ... 25.0.",
         &alpha_distance, &ParseFloat, 1);
 
@@ -667,8 +667,7 @@ void SetDistanceFromFlags(CommandLineParser* cmdline, CompressArgs* args,
     args->lossless_jpeg = 0;
   }
   params->distance = args->distance;
-  params->alpha_distance =
-      alpha_distance_set ? args->alpha_distance : params->distance;
+  params->alpha_distance = alpha_distance_set ? args->alpha_distance : 0;
 }
 
 void ProcessFlags(const jxl::extras::Codec codec,


### PR DESCRIPTION
This is in preparation to adding support for streaming-mode extra channel coding.
