### PR TITLE
Fix #2581 in a different way

### DIFF
--- a/lib/extras/dec/apng.cc
+++ b/lib/extras/dec/apng.cc
@@ -813,6 +813,8 @@ Status DecodeImageAPNG(const Span<const uint8_t> bytes,
             have_cicp = true;
             have_color = true;
             ppf->icc.clear();
+            ppf->primary_color_representation =
+                PackedPixelFile::kColorEncodingIsPrimary;
           }
         } else if (!have_cicp && id == kId_iCCP) {
           if (processing_data(png_ptr, info_ptr, chunk.data(), chunk.size())) {
@@ -830,6 +832,7 @@ Status DecodeImageAPNG(const Span<const uint8_t> bytes,
                                  &profile, &proflen);
           if (ok && proflen) {
             ppf->icc.assign(profile, profile + proflen);
+            ppf->primary_color_representation = PackedPixelFile::kIccIsPrimary;
             have_color = true;
             have_iccp = true;
           } else {

--- a/lib/extras/dec/color_hints.cc
+++ b/lib/extras/dec/color_hints.cc
@@ -43,20 +43,21 @@ Status ApplyColorHints(const ColorHints& color_hints,
         } else if (key == "icc") {
           const uint8_t* data = reinterpret_cast<const uint8_t*>(value.data());
           std::vector<uint8_t> icc(data, data + value.size());
-          ppf->icc.swap(icc);
+          ppf->icc = std::move(icc);
+          ppf->primary_color_representation = PackedPixelFile::kIccIsPrimary;
           got_color_space = true;
         } else if (key == "exif") {
           const uint8_t* data = reinterpret_cast<const uint8_t*>(value.data());
           std::vector<uint8_t> blob(data, data + value.size());
-          ppf->metadata.exif.swap(blob);
+          ppf->metadata.exif = std::move(blob);
         } else if (key == "xmp") {
           const uint8_t* data = reinterpret_cast<const uint8_t*>(value.data());
           std::vector<uint8_t> blob(data, data + value.size());
-          ppf->metadata.xmp.swap(blob);
+          ppf->metadata.xmp = std::move(blob);
         } else if (key == "jumbf") {
           const uint8_t* data = reinterpret_cast<const uint8_t*>(value.data());
           std::vector<uint8_t> blob(data, data + value.size());
-          ppf->metadata.jumbf.swap(blob);
+          ppf->metadata.jumbf = std::move(blob);
         } else {
           JXL_WARNING("Ignoring %s hint", key.c_str());
         }

--- a/lib/extras/dec/jpegli.cc
+++ b/lib/extras/dec/jpegli.cc
@@ -188,7 +188,11 @@ Status DecodeJpeg(const std::vector<uint8_t>& compressed,
     } else if (dparams.force_grayscale) {
       cinfo.out_color_space = JCS_GRAYSCALE;
     }
-    if (!ReadICCProfile(&cinfo, &ppf->icc)) {
+    if (ReadICCProfile(&cinfo, &ppf->icc)) {
+      ppf->primary_color_representation = PackedPixelFile::kIccIsPrimary;
+    } else {
+      ppf->primary_color_representation =
+          PackedPixelFile::kColorEncodingIsPrimary;
       ppf->icc.clear();
       // Default to SRGB
       ppf->color_encoding.color_space =

--- a/lib/extras/dec/jpg.cc
+++ b/lib/extras/dec/jpg.cc
@@ -242,7 +242,11 @@ Status DecodeImageJPG(const Span<const uint8_t> bytes,
     if (nbcomp != 1 && nbcomp != 3) {
       return failure("unsupported number of components in JPEG");
     }
-    if (!ReadICCProfile(&cinfo, &ppf->icc)) {
+    if (ReadICCProfile(&cinfo, &ppf->icc)) {
+      ppf->primary_color_representation = PackedPixelFile::kIccIsPrimary;
+    } else {
+      ppf->primary_color_representation =
+          PackedPixelFile::kColorEncodingIsPrimary;
       ppf->icc.clear();
       // Default to SRGB
       // Actually, (cinfo.output_components == nbcomp) will be checked after

--- a/lib/extras/dec/jxl.h
+++ b/lib/extras/dec/jxl.h
@@ -41,10 +41,6 @@ struct JXLDecompressParams {
   // Whether truncated input should be treated as an error.
   bool allow_partial_input = false;
 
-  // Set to true if an ICC profile has to be synthesized for Enum color
-  // encodings
-  bool need_icc = false;
-
   // How many passes to decode at most. By default, decode everything.
   uint32_t max_passes = std::numeric_limits<uint32_t>::max();
 

--- a/lib/extras/enc/apng.cc
+++ b/lib/extras/enc/apng.cc
@@ -344,11 +344,13 @@ Status APNGEncoder::EncodePackedPixelFileToAPNG(
                  PNG_INTERLACE_NONE, PNG_COMPRESSION_TYPE_BASE,
                  PNG_FILTER_TYPE_BASE);
     if (count == 0) {
-      if (!ppf.icc.empty()) {
-        png_set_benign_errors(png_ptr, 1);
-        png_set_iCCP(png_ptr, info_ptr, "1", 0, ppf.icc.data(), ppf.icc.size());
-      } else if (!MaybeAddSRGB(ppf.color_encoding, png_ptr, info_ptr)) {
+      if (!MaybeAddSRGB(ppf.color_encoding, png_ptr, info_ptr)) {
         MaybeAddCICP(ppf.color_encoding, png_ptr, info_ptr);
+        if (!ppf.icc.empty()) {
+          png_set_benign_errors(png_ptr, 1);
+          png_set_iCCP(png_ptr, info_ptr, "1", 0, ppf.icc.data(),
+                       ppf.icc.size());
+        }
         MaybeAddCHRM(ppf.color_encoding, png_ptr, info_ptr);
         MaybeAddGAMA(ppf.color_encoding, png_ptr, info_ptr);
       }

--- a/lib/extras/enc/jpegli.cc
+++ b/lib/extras/enc/jpegli.cc
@@ -71,7 +71,7 @@ Status VerifyInput(const PackedPixelFile& ppf) {
 
 Status GetColorEncoding(const PackedPixelFile& ppf,
                         ColorEncoding* color_encoding) {
-  if (!ppf.icc.empty()) {
+  if (ppf.primary_color_representation == PackedPixelFile::kIccIsPrimary) {
     IccBytes icc = ppf.icc;
     JXL_RETURN_IF_ERROR(
         color_encoding->SetICC(std::move(icc), JxlGetDefaultCms()));

--- a/lib/extras/enc/jxl.cc
+++ b/lib/extras/enc/jxl.cc
@@ -258,7 +258,7 @@ bool EncodeImageJXL(const JXLCompressParams& params, const PackedPixelFile& ppf,
       fprintf(stderr, "JxlEncoderSetFrameLossless() failed.\n");
       return false;
     }
-    if (!ppf.icc.empty()) {
+    if (ppf.primary_color_representation == PackedPixelFile::kIccIsPrimary) {
       if (JXL_ENC_SUCCESS !=
           JxlEncoderSetICCProfile(enc, ppf.icc.data(), ppf.icc.size())) {
         fprintf(stderr, "JxlEncoderSetICCProfile() failed.\n");

--- a/lib/extras/packed_image.h
+++ b/lib/extras/packed_image.h
@@ -244,9 +244,21 @@ class PackedPixelFile {
   std::vector<PackedExtraChannel> extra_channels_info;
 
   // Color information of the decoded pixels.
-  // If the icc is empty, the JxlColorEncoding should be used instead.
-  std::vector<uint8_t> icc;
+  // `primary_color_representation` indicates whether `color_encoding` or `icc`
+  // is the “authoritative” encoding of the colorspace, as opposed to a fallback
+  // encoding. For example, if `color_encoding` is the primary one, as would
+  // occur when decoding a jxl file with such a representation, then `enc/jxl`
+  // will use it and ignore the ICC profile, whereas `enc/png` will include the
+  // ICC profile for compatibility.
+  // If `icc` is the primary representation, `enc/jxl` will preserve it when
+  // compressing losslessly, but *may* encode it as a color_encoding when
+  // compressing lossily.
+  enum {
+    kColorEncodingIsPrimary,
+    kIccIsPrimary
+  } primary_color_representation = kColorEncodingIsPrimary;
   JxlColorEncoding color_encoding = {};
+  std::vector<uint8_t> icc;
   // The icc profile of the original image.
   std::vector<uint8_t> orig_icc;
 

--- a/lib/extras/packed_image_convert.cc
+++ b/lib/extras/packed_image_convert.cc
@@ -113,7 +113,7 @@ Status ConvertPackedPixelFileToCodecInOut(const PackedPixelFile& ppf,
   io->metadata.m.animation.num_loops = ppf.info.animation.num_loops;
 
   // Convert the color encoding.
-  if (!ppf.icc.empty()) {
+  if (ppf.primary_color_representation == PackedPixelFile::kIccIsPrimary) {
     IccBytes icc = ppf.icc;
     if (!io->metadata.m.color_encoding.SetICC(std::move(icc),
                                               JxlGetDefaultCms())) {
@@ -274,6 +274,9 @@ Status ConvertCodecInOutToPackedPixelFile(const CodecInOut& io,
 
   // Convert the color encoding
   ppf->icc.assign(c_desired.ICC().begin(), c_desired.ICC().end());
+  ppf->primary_color_representation =
+      c_desired.WantICC() ? PackedPixelFile::kIccIsPrimary
+                          : PackedPixelFile::kColorEncodingIsPrimary;
   ppf->color_encoding = c_desired.ToExternal();
 
   // Convert the extra blobs

--- a/lib/jxl/blending_test.cc
+++ b/lib/jxl/blending_test.cc
@@ -40,8 +40,10 @@ TEST(BlendingTest, Crops) {
         jxl::test::ReadTestData(filename.str());
     extras::PackedPixelFile decoded_frame_ppf;
     decoded_frame_ppf.info = decoded.info;
-    decoded_frame_ppf.icc = decoded.icc;
+    decoded_frame_ppf.primary_color_representation =
+        decoded.primary_color_representation;
     decoded_frame_ppf.color_encoding = decoded.color_encoding;
+    decoded_frame_ppf.icc = decoded.icc;
     decoded_frame_ppf.extra_channels_info = decoded.extra_channels_info;
     decoded_frame_ppf.frames.emplace_back(std::move(decoded_frame));
     extras::PackedPixelFile expected_frame_ppf;

--- a/lib/jxl/jxl_test.cc
+++ b/lib/jxl/jxl_test.cc
@@ -1065,7 +1065,7 @@ TEST(JxlTest, RoundtripLossless16Alpha) {
 
   PackedPixelFile ppf_out;
   // TODO(szabadka) Investigate big size difference on i686
-  EXPECT_NEAR(Roundtrip(t.ppf(), cparams, dparams, pool, &ppf_out), 4884, 100);
+  EXPECT_NEAR(Roundtrip(t.ppf(), cparams, dparams, pool, &ppf_out), 4665, 100);
   EXPECT_EQ(ComputeDistance2(t.ppf(), ppf_out), 0.0);
   EXPECT_EQ(ppf_out.info.alpha_bits, 16);
   EXPECT_TRUE(test::SameAlpha(t.ppf(), ppf_out));
@@ -1101,7 +1101,7 @@ TEST(JxlTest, RoundtripLossless16AlphaNotMisdetectedAs8Bit) {
   dparams.accepted_formats.push_back(t.ppf().frames[0].color.format);
 
   PackedPixelFile ppf_out;
-  EXPECT_NEAR(Roundtrip(t.ppf(), cparams, dparams, pool, &ppf_out), 591, 50);
+  EXPECT_NEAR(Roundtrip(t.ppf(), cparams, dparams, pool, &ppf_out), 372, 50);
   EXPECT_EQ(ComputeDistance2(t.ppf(), ppf_out), 0.0);
   EXPECT_EQ(ppf_out.info.bits_per_sample, 16);
   EXPECT_EQ(ppf_out.info.alpha_bits, 16);

--- a/tools/djxl_main.cc
+++ b/tools/djxl_main.cc
@@ -386,7 +386,6 @@ bool DecompressJxlToPackedPixelFile(
   dparams.runner = JxlThreadParallelRunner;
   dparams.runner_opaque = runner;
   dparams.allow_partial_input = args.allow_partial_files;
-  dparams.need_icc = !args.icc_out.empty();
   if (args.bits_per_sample == 0) {
     dparams.output_bitdepth.type = JXL_BIT_DEPTH_FROM_CODESTREAM;
   } else if (args.bits_per_sample > 0) {


### PR DESCRIPTION
Always produce the ICC profile, but also indicate whether it’s the primary colorspace representation or not.

This lets `enc/jxl` ignore it if it’s not, and `enc/apng` include it for compatibility, helping with #2289.