### PR TITLE
Update modular efforts to faster settings.

### DIFF
--- a/lib/jxl/enc_modular.cc
+++ b/lib/jxl/enc_modular.cc
@@ -1345,6 +1345,7 @@ Status ModularFrameEncoder::PrepareStreamParams(const Rect& rect,
       case SpeedTier::kKitten:
         nb_rcts_to_try = 9;
         break;
+      case SpeedTier::kTectonicPlate:
       case SpeedTier::kGlacier:
       case SpeedTier::kTortoise:
         nb_rcts_to_try = 19;

--- a/lib/jxl/enc_params.h
+++ b/lib/jxl/enc_params.h
@@ -25,8 +25,10 @@
 namespace jxl {
 
 enum class SpeedTier {
-  // Try multiple combinations of Tortoise flags for modular mode. Otherwise
-  // like kTortoise.
+  // Try multiple combinations of Glacier flags for modular mode. Otherwise
+  // like kGlacier.
+  kTectonicPlate = -1,
+  // Learn a global tree in Modular mode.
   kGlacier = 0,
   // Turns on FindBestQuantizationHQ loop. Equivalent to "guetzli" mode.
   kTortoise = 1,

--- a/lib/jxl/encode.cc
+++ b/lib/jxl/encode.cc
@@ -1537,14 +1537,14 @@ JxlEncoderStatus JxlEncoderFrameSettingsSetOption(
   switch (option) {
     case JXL_ENC_FRAME_SETTING_EFFORT:
       if (frame_settings->enc->allow_expert_options) {
+        if (value < 1 || value > 11) {
+          return JXL_API_ERROR(frame_settings->enc, JXL_ENC_ERR_NOT_SUPPORTED,
+                               "Encode effort has to be in [1..11]");
+        }
+      } else {
         if (value < 1 || value > 10) {
           return JXL_API_ERROR(frame_settings->enc, JXL_ENC_ERR_NOT_SUPPORTED,
                                "Encode effort has to be in [1..10]");
-        }
-      } else {
-        if (value < 1 || value > 9) {
-          return JXL_API_ERROR(frame_settings->enc, JXL_ENC_ERR_NOT_SUPPORTED,
-                               "Encode effort has to be in [1..9]");
         }
       }
       frame_settings->values.cparams.speed_tier =

--- a/lib/jxl/encode_test.cc
+++ b/lib/jxl/encode_test.cc
@@ -368,14 +368,14 @@ TEST(EncodeTest, frame_settingsTest) {
       EXPECT_EQ(JXL_ENC_SUCCESS, JxlEncoderFrameSettingsSetOption(
                                      frame_settings, options[i], in_range[i]));
     }
-    // Effort 10 should only work when expert options are allowed
+    // Effort 11 should only work when expert options are allowed
     EXPECT_EQ(JXL_ENC_ERROR,
               JxlEncoderFrameSettingsSetOption(
-                  frame_settings, JXL_ENC_FRAME_SETTING_EFFORT, 10));
+                  frame_settings, JXL_ENC_FRAME_SETTING_EFFORT, 11));
     JxlEncoderAllowExpertOptions(enc.get());
     EXPECT_EQ(JXL_ENC_SUCCESS,
               JxlEncoderFrameSettingsSetOption(
-                  frame_settings, JXL_ENC_FRAME_SETTING_EFFORT, 10));
+                  frame_settings, JXL_ENC_FRAME_SETTING_EFFORT, 11));
 
     // Non-existing option
     EXPECT_EQ(JXL_ENC_ERROR,

--- a/lib/jxl/modular_test.cc
+++ b/lib/jxl/modular_test.cc
@@ -330,7 +330,7 @@ TEST_P(ModularTestParam, RoundtripLossless) {
   CodecInOut io2;
   size_t compressed_size;
   JXL_EXPECT_OK(Roundtrip(&io, cparams, {}, &io2, _, &compressed_size));
-  EXPECT_LE(compressed_size, bitdepth * xsize * ysize / 3);
+  EXPECT_LE(compressed_size, bitdepth * xsize * ysize / 3 * 1.1);
   EXPECT_LE(0, ComputeDistance2(io.Main(), io2.Main(), *JxlGetDefaultCms()));
   size_t different = 0;
   for (size_t c = 0; c < 3; c++) {

--- a/tools/cjxl_main.cc
+++ b/tools/cjxl_main.cc
@@ -389,7 +389,7 @@ struct CompressArgs {
 
     cmdline->AddOptionFlag('\0', "allow_expert_options",
                            "Allow specifying advanced options; this allows "
-                           "setting effort to 10, for\n"
+                           "setting effort to 11, for\n"
                            "    somewhat better lossless compression at the "
                            "cost of a massive speed hit.",
                            &allow_expert_options, &SetBooleanTrue, 3);
@@ -423,7 +423,7 @@ struct CompressArgs {
         "    5=gradient, 6=weighted, 7=topright, 8=topleft, 9=leftleft, "
         "10=avg1, 11=avg2, 12=avg3,\n"
         "    13=toptop predictive average, 14=mix 5 and 6, 15=mix everything.\n"
-        "    Default is 14 at effort < 9 and 15 at effort 9.",
+        "    Default is 14 at effort < 9 and 15 at effort 9-10.",
         &modular_predictor, &ParseInt64, 4);
 
     cmdline->AddOptionValue(
@@ -713,9 +713,9 @@ void ProcessFlags(const jxl::extras::Codec codec,
       "effort", static_cast<int64_t>(args->effort),
       JXL_ENC_FRAME_SETTING_EFFORT, params, [args](int64_t x) -> std::string {
         if (args->allow_expert_options) {
-          return (1 <= x && x <= 10) ? "" : "Valid range is {1, 2, ..., 10}.";
+          return (1 <= x && x <= 11) ? "" : "Valid range is {1, 2, ..., 11}.";
         } else {
-          return (1 <= x && x <= 9) ? "" : "Valid range is {1, 2, ..., 9}.";
+          return (1 <= x && x <= 10) ? "" : "Valid range is {1, 2, ..., 10}.";
         }
       });
   ProcessFlag("brotli_effort", static_cast<int64_t>(args->brotli_effort),
@@ -1153,7 +1153,8 @@ int main(int argc, char** argv) {
   params.runner = JxlThreadParallelRunner;
   params.runner_opaque = runner.get();
 
-  if (args.effort <= 6 || (args.streaming_input && args.streaming_output)) {
+  if ((args.effort < 7 || (args.effort == 7 && args.distance < 3)) ||
+      args.streaming_input) {
     params.options.emplace_back(jxl::extras::JXLOption(
         JXL_ENC_FRAME_SETTING_BUFFERING, static_cast<int64_t>(3), 0));
   }


### PR DESCRIPTION
```
Before:
Encoding [Modular, lossless, effort: 7]
Compressed to 137.9 kB (9.629 bpp).
444 x 258, geomean: 0.370 MP/s [0.35, 0.52], 20 reps, 72 threads.
7.69user 3.43system 0:06.12elapsed 181%CPU (0avgtext+0avgdata 96460maxresident)k

Encoding [Modular, lossless, effort: 8]
Compressed to 137.6 kB (9.606 bpp).
444 x 258, geomean: 0.148 MP/s [0.15, 0.15], 5 reps, 72 threads.
4.05user 0.87system 0:03.84elapsed 128%CPU (0avgtext+0avgdata 36848maxresident)k

Encoding [Modular, lossless, effort: 9]
Compressed to 137.3 kB (9.586 bpp).
444 x 258, geomean: 0.038 MP/s [0.04, 0.04], 5 reps, 72 threads.
15.46user 0.88system 0:14.99elapsed 109%CPU (0avgtext+0avgdata 67496maxresident)k

Encoding [Modular, lossless, effort: 7]
Compressed to 47974.1 kB (9.827 bpp).
7216 x 5412, geomean: 0.255 MP/s [0.25, 0.26], 5 reps, 72 threads.
847.79user 141.99system 12:48.70elapsed 128%CPU (0avgtext+0avgdata 7066772maxresident)k

Encoding [Modular, lossless, effort: 8]
Compressed to 47582.7 kB (9.747 bpp).
7216 x 5412, second: 0.141 MP/s [0.14, 0.14], 2 reps, 72 threads.
655.49user 37.07system 9:18.64elapsed 123%CPU (0avgtext+0avgdata 5266892maxresident)k

Encoding [Modular, lossless, effort: 9]
Compressed to 47531.4 kB (9.737 bpp).
7216 x 5412, second: 0.039 MP/s [0.04, 0.04], 2 reps, 72 threads.
2206.83user 36.33system 33:36.39elapsed 111%CPU (0avgtext+0avgdata 6862308maxresident)k

After:
Encoding [Modular, lossless, effort: 7]
Compressed to 138.0 kB (9.637 bpp).
444 x 258, geomean: 0.516 MP/s [0.42, 0.61], 20 reps, 72 threads.
7.84user 3.47system 0:04.56elapsed 248%CPU (0avgtext+0avgdata 51700maxresident)k

Encoding [Modular, lossless, effort: 8]
Compressed to 137.9 kB (9.631 bpp).
444 x 258, geomean: 0.411 MP/s [0.39, 0.60], 5 reps, 72 threads.
2.30user 0.81system 0:01.33elapsed 234%CPU (0avgtext+0avgdata 35928maxresident)k

Encoding [Modular, lossless, effort: 9]
Compressed to 137.8 kB (9.621 bpp).
444 x 258, geomean: 0.073 MP/s [0.07, 0.07], 5 reps, 72 threads.
13.81user 0.64system 0:07.89elapsed 183%CPU (0avgtext+0avgdata 55336maxresident)k

Encoding [Modular, lossless, effort: 7]
Compressed to 48235.9 kB (9.881 bpp).
7216 x 5412, geomean: 10.826 MP/s [10.47, 11.02], 5 reps, 72 threads.
609.18user 138.46system 0:19.57elapsed 3819%CPU (0avgtext+0avgdata 1003488maxresident)k

Encoding [Modular, lossless, effort: 8]
Compressed to 47937.9 kB (9.820 bpp).
7216 x 5412, second: 6.096 MP/s [6.04, 6.10], 2 reps, 72 threads.
363.07user 28.97system 0:14.32elapsed 2737%CPU (0avgtext+0avgdata 4934312maxresident)k

Encoding [Modular, lossless, effort: 9]
Compressed to 47811.7 kB (9.794 bpp).
7216 x 5412, second: 2.333 MP/s [2.33, 2.34], 2 reps, 72 threads.
1747.88user 31.96system 0:34.88elapsed 5102%CPU (0avgtext+0avgdata 5146160maxresident)k
```