### PR TITLE
Fix effort2/3 streaming vs nonstreaming

### DIFF
--- a/lib/jxl/common.h
+++ b/lib/jxl/common.h
@@ -33,6 +33,38 @@ constexpr size_t kMaxNumPasses = 11;
 // Maximum number of reference frames.
 constexpr size_t kMaxNumReferenceFrames = 4;
 
+enum class SpeedTier {
+  // Try multiple combinations of Glacier flags for modular mode. Otherwise
+  // like kGlacier.
+  kTectonicPlate = -1,
+  // Learn a global tree in Modular mode.
+  kGlacier = 0,
+  // Turns on FindBestQuantizationHQ loop. Equivalent to "guetzli" mode.
+  kTortoise = 1,
+  // Turns on FindBestQuantization butteraugli loop.
+  kKitten = 2,
+  // Turns on dots, patches, and spline detection by default, as well as full
+  // context clustering. Default.
+  kSquirrel = 3,
+  // Turns on error diffusion and full AC strategy heuristics. Equivalent to
+  // "fast" mode.
+  kWombat = 4,
+  // Turns on gaborish by default, non-default cmap, initial quant field.
+  kHare = 5,
+  // Turns on simple heuristics for AC strategy, quant field, and clustering;
+  // also enables coefficient reordering.
+  kCheetah = 6,
+  // Turns off most encoder features. Does context clustering.
+  // Modular: uses fixed tree with Weighted predictor.
+  kFalcon = 7,
+  // Currently fastest possible setting for VarDCT.
+  // Modular: uses fixed tree with Gradient predictor.
+  kThunder = 8,
+  // VarDCT: same as kThunder.
+  // Modular: no tree, Gradient predictor, fast histograms
+  kLightning = 9
+};
+
 }  // namespace jxl
 
 #endif  // LIB_JXL_COMMON_H_

--- a/lib/jxl/enc_ans_params.h
+++ b/lib/jxl/enc_ans_params.h
@@ -11,9 +11,14 @@
 #include <stdint.h>
 #include <stdlib.h>
 
-#include "lib/jxl/enc_params.h"
+#include <vector>
+
+#include "lib/jxl/common.h"
 
 namespace jxl {
+
+// Forward declaration to break include cycle.
+struct CompressParams;
 
 // RebalanceHistogram requires a signed type.
 using ANSHistBin = int32_t;
@@ -64,6 +69,10 @@ struct HistogramParams {
       ans_histogram_strategy = ANSHistogramStrategy::kApproximate;
     }
   }
+
+  static HistogramParams ForModular(
+      const CompressParams& cparams,
+      const std::vector<uint8_t>& extra_dc_precision);
 
   ClusteringType clustering = ClusteringType::kBest;
   HybridUintMethod uint_method = HybridUintMethod::kBest;

--- a/lib/jxl/enc_cluster.h
+++ b/lib/jxl/enc_cluster.h
@@ -15,6 +15,7 @@
 #include <vector>
 
 #include "lib/jxl/ans_params.h"
+#include "lib/jxl/base/common.h"
 #include "lib/jxl/enc_ans_params.h"
 
 namespace jxl {

--- a/lib/jxl/enc_context_map.cc
+++ b/lib/jxl/enc_context_map.cc
@@ -18,6 +18,7 @@
 #include "lib/jxl/enc_ans.h"
 #include "lib/jxl/enc_aux_out.h"
 #include "lib/jxl/entropy_coder.h"
+#include "lib/jxl/fields.h"
 #include "lib/jxl/pack_signed.h"
 
 namespace jxl {

--- a/lib/jxl/enc_frame.cc
+++ b/lib/jxl/enc_frame.cc
@@ -1527,7 +1527,7 @@ Status ComputeEncodingData(
     if (cparams.speed_tier < SpeedTier::kTortoise ||
         !cparams.ModularPartIsLossless() || cparams.responsive ||
         !cparams.custom_fixed_tree.empty()) {
-      // Use local trees if doing lossless modular.
+      // Use local trees if doing lossless modular, unless at very slow speeds.
       JXL_RETURN_IF_ERROR(enc_modular.ComputeTree(pool));
       JXL_RETURN_IF_ERROR(enc_modular.ComputeTokens(pool));
     }

--- a/lib/jxl/enc_icc_codec.cc
+++ b/lib/jxl/enc_icc_codec.cc
@@ -13,6 +13,7 @@
 #include <vector>
 
 #include "lib/jxl/base/byte_order.h"
+#include "lib/jxl/color_encoding_internal.h"
 #include "lib/jxl/enc_ans.h"
 #include "lib/jxl/enc_aux_out.h"
 #include "lib/jxl/fields.h"

--- a/lib/jxl/enc_modular.cc
+++ b/lib/jxl/enc_modular.cc
@@ -731,6 +731,13 @@ Status ModularFrameEncoder::ComputeEncodingData(
 
   // Fill other groups.
   stream_options_[0] = cparams_.options;
+  if (cparams_.speed_tier == SpeedTier::kFalcon) {
+    stream_options_[0].tree_kind = ModularOptions::TreeKind::kWPFixedDC;
+  } else if (cparams_.speed_tier == SpeedTier::kThunder) {
+    stream_options_[0].tree_kind = ModularOptions::TreeKind::kGradientFixedDC;
+  }
+  stream_options_[0].histogram_params =
+      HistogramParams::ForModular(cparams_, {});
 
   // DC
   for (size_t group_id = 0; group_id < patch_dim.num_dc_groups; group_id++) {
@@ -777,7 +784,7 @@ Status ModularFrameEncoder::ComputeEncodingData(
       pool, 0, stream_params_.size(), ThreadPool::NoInit,
       [&](const uint32_t i, size_t /* thread */) {
         size_t stream = stream_params_[i].id.ID(frame_dim_);
-        stream_options_[stream] = cparams_.options;
+        stream_options_[stream] = stream_options_[0];
         JXL_CHECK(PrepareStreamParams(
             stream_params_[i].rect, cparams_, stream_params_[i].minShift,
             stream_params_[i].maxShift, stream_params_[i].id, do_color));
@@ -1027,46 +1034,8 @@ Status ModularFrameEncoder::EncodeGlobalInfo(bool streaming_mode,
   allotment.ReclaimAndCharge(writer, kLayerModularTree, aux_out);
 
   // Write tree
-  HistogramParams params;
-  if (cparams_.speed_tier > SpeedTier::kKitten) {
-    params.clustering = HistogramParams::ClusteringType::kFast;
-    params.ans_histogram_strategy =
-        cparams_.speed_tier > SpeedTier::kThunder
-            ? HistogramParams::ANSHistogramStrategy::kFast
-            : HistogramParams::ANSHistogramStrategy::kApproximate;
-    params.lz77_method =
-        cparams_.decoding_speed_tier >= 3 && cparams_.modular_mode
-            ? (cparams_.speed_tier >= SpeedTier::kFalcon
-                   ? HistogramParams::LZ77Method::kRLE
-                   : HistogramParams::LZ77Method::kLZ77)
-            : HistogramParams::LZ77Method::kNone;
-    // Near-lossless DC, as well as modular mode, require choosing hybrid uint
-    // more carefully.
-    if ((!extra_dc_precision.empty() && extra_dc_precision[0] != 0) ||
-        (cparams_.modular_mode && cparams_.speed_tier < SpeedTier::kCheetah)) {
-      params.uint_method = HistogramParams::HybridUintMethod::kFast;
-    } else {
-      params.uint_method = HistogramParams::HybridUintMethod::kNone;
-    }
-  } else if (cparams_.speed_tier <= SpeedTier::kTortoise) {
-    params.lz77_method = HistogramParams::LZ77Method::kOptimal;
-  } else {
-    params.lz77_method = HistogramParams::LZ77Method::kLZ77;
-  }
-  if (cparams_.decoding_speed_tier >= 1) {
-    params.max_histograms = 12;
-  }
-  if (cparams_.decoding_speed_tier >= 1 && cparams_.responsive) {
-    params.lz77_method = cparams_.speed_tier >= SpeedTier::kCheetah
-                             ? HistogramParams::LZ77Method::kRLE
-                         : cparams_.speed_tier >= SpeedTier::kKitten
-                             ? HistogramParams::LZ77Method::kLZ77
-                             : HistogramParams::LZ77Method::kOptimal;
-  }
-  if (cparams_.decoding_speed_tier >= 2 && cparams_.responsive) {
-    params.uint_method = HistogramParams::HybridUintMethod::k000;
-    params.force_huffman = true;
-  }
+  HistogramParams params =
+      HistogramParams::ForModular(cparams_, extra_dc_precision);
   {
     EntropyEncodingData tree_code;
     std::vector<uint8_t> tree_context_map;

--- a/lib/jxl/enc_params.h
+++ b/lib/jxl/enc_params.h
@@ -15,6 +15,7 @@
 #include <vector>
 
 #include "lib/jxl/base/override.h"
+#include "lib/jxl/common.h"
 #include "lib/jxl/enc_progressive_split.h"
 #include "lib/jxl/frame_dimensions.h"
 #include "lib/jxl/frame_header.h"
@@ -23,38 +24,6 @@
 #include "lib/jxl/splines.h"
 
 namespace jxl {
-
-enum class SpeedTier {
-  // Try multiple combinations of Glacier flags for modular mode. Otherwise
-  // like kGlacier.
-  kTectonicPlate = -1,
-  // Learn a global tree in Modular mode.
-  kGlacier = 0,
-  // Turns on FindBestQuantizationHQ loop. Equivalent to "guetzli" mode.
-  kTortoise = 1,
-  // Turns on FindBestQuantization butteraugli loop.
-  kKitten = 2,
-  // Turns on dots, patches, and spline detection by default, as well as full
-  // context clustering. Default.
-  kSquirrel = 3,
-  // Turns on error diffusion and full AC strategy heuristics. Equivalent to
-  // "fast" mode.
-  kWombat = 4,
-  // Turns on gaborish by default, non-default cmap, initial quant field.
-  kHare = 5,
-  // Turns on simple heuristics for AC strategy, quant field, and clustering;
-  // also enables coefficient reordering.
-  kCheetah = 6,
-  // Turns off most encoder features. Does context clustering.
-  // Modular: uses fixed tree with Weighted predictor.
-  kFalcon = 7,
-  // Currently fastest possible setting for VarDCT.
-  // Modular: uses fixed tree with Gradient predictor.
-  kThunder = 8,
-  // VarDCT: same as kThunder.
-  // Modular: no tree, Gradient predictor, fast histograms
-  kLightning = 9
-};
 
 // NOLINTNEXTLINE(clang-analyzer-optin.performance.Padding)
 struct CompressParams {

--- a/lib/jxl/jxl_test.cc
+++ b/lib/jxl/jxl_test.cc
@@ -879,7 +879,7 @@ TEST(JxlTest, RoundtripAlphaResamplingOnlyAlpha) {
   cparams.AddOption(JXL_ENC_FRAME_SETTING_EXTRA_CHANNEL_RESAMPLING, 2);
 
   PackedPixelFile ppf_out;
-  EXPECT_NEAR(Roundtrip(t.ppf(), cparams, {}, pool, &ppf_out), 33571, 400);
+  EXPECT_NEAR(Roundtrip(t.ppf(), cparams, {}, pool, &ppf_out), 34000, 500);
   EXPECT_THAT(ButteraugliDistance(t.ppf(), ppf_out), IsSlightlyBelow(1.49));
 }
 

--- a/lib/jxl/modular/encoding/enc_encoding.cc
+++ b/lib/jxl/modular/encoding/enc_encoding.cc
@@ -557,7 +557,8 @@ Status ModularEncode(const Image &image, const ModularOptions &options,
   size_t total_pixels_storage = 0;
   if (!total_pixels) total_pixels = &total_pixels_storage;
   // If there's no tree, compute one (or gather data to).
-  if (tree == nullptr) {
+  if (tree == nullptr &&
+      options.tree_kind == ModularOptions::TreeKind::kLearn) {
     bool gather_data = tree_samples != nullptr;
     if (tree_samples == nullptr) {
       JXL_RETURN_IF_ERROR(tree_samples_storage.SetPredictor(
@@ -622,9 +623,9 @@ Status ModularEncode(const Image &image, const ModularOptions &options,
     } */
 
     // Write tree
-    BuildAndEncodeHistograms(HistogramParams(), kNumTreeContexts, tree_tokens,
-                             &code, &context_map, writer, kLayerModularTree,
-                             aux_out);
+    BuildAndEncodeHistograms(options.histogram_params, kNumTreeContexts,
+                             tree_tokens, &code, &context_map, writer,
+                             kLayerModularTree, aux_out);
     WriteTokens(tree_tokens[0], code, context_map, 0, writer, kLayerModularTree,
                 aux_out);
   }
@@ -669,7 +670,7 @@ Status ModularEncode(const Image &image, const ModularOptions &options,
   if (!header->use_global_tree) {
     EntropyEncodingData code;
     std::vector<uint8_t> context_map;
-    HistogramParams histo_params;
+    HistogramParams histo_params = options.histogram_params;
     histo_params.image_widths.push_back(image_width);
     BuildAndEncodeHistograms(histo_params, (tree->size() + 1) / 2,
                              tokens_storage, &code, &context_map, writer, layer,

--- a/lib/jxl/modular/options.h
+++ b/lib/jxl/modular/options.h
@@ -11,6 +11,8 @@
 #include <array>
 #include <vector>
 
+#include "lib/jxl/enc_ans_params.h"
+
 namespace jxl {
 
 using PropertyVal = int32_t;
@@ -107,6 +109,8 @@ struct ModularOptions {
     kGradientFixedDC,
   };
   TreeKind tree_kind = TreeKind::kLearn;
+
+  HistogramParams histogram_params;
 
   // Ignore the image and just pretend all tokens are zeroes
   bool zero_tokens = false;


### PR DESCRIPTION
```
/home/veluca/libjxl/testdata/jxl/flower/flower.png
Encoding         kPixels    Bytes          BPP  E MP/s  D MP/s     Max norm  SSIMULACRA2   PSNR        pnorm       BPP*pnorm   QABPP   Bugs
-------------------------------------------------------------------------------------------------------------------------------------------
jxl:2:d0:buf3       3429  3196707    7.4575810  55.181 161.038         -nan 100.00000000  99.99   0.00000000  0.000000000000   7.458      0
jxl:2:d0            3429  3304063    7.7080312  32.291 112.184         -nan 100.00000000  99.99   0.00000000  0.000000000000   7.708      0
jxl:3:d0:buf3       3429  2971057    6.9311633  17.053  30.484         -nan 100.00000000  99.99   0.00000000  0.000000000000   6.931      0
jxl:3:d0            3429  2975615    6.9417966  17.882  32.558         -nan 100.00000000  99.99   0.00000000  0.000000000000   6.942      0
Aggregate:          3429  3108563    7.2519511  27.150  65.072   0.00000000 100.00000000  99.99   0.00000000  0.000000000000   7.252      0
```
