### PR TITLE
have default buffering mode as in cjxl

### DIFF
--- a/lib/include/jxl/encode.h
+++ b/lib/include/jxl/encode.h
@@ -341,6 +341,7 @@ typedef enum {
   JXL_ENC_FRAME_SETTING_JPEG_COMPRESS_BOXES = 33,
 
   /** Control what kind of buffering is used, when using chunked image frames.
+   * -1 = default (let the encoder decide)
    * 0 = buffers everything, basically the same as non-streamed code path
    (mainly for testing)
    * 1 = buffers everything for images that are smaller than 2048 x 2048, and
@@ -351,7 +352,7 @@ typedef enum {
    *
    * When using streaming input and output the encoder minimizes memory usage at
    * the cost of compression density. Also note that images produced with
-   * streaming mode might can not be decoded progressively.
+   * streaming mode might not be progressively decodeable.
    */
   JXL_ENC_FRAME_SETTING_BUFFERING = 34,
 

--- a/lib/jxl/enc_frame.cc
+++ b/lib/jxl/enc_frame.cc
@@ -1636,6 +1636,14 @@ bool CanDoStreamingEncoding(const CompressParams& cparams,
   if (cparams.buffering == 0) {
     return false;
   }
+  if (cparams.buffering == -1) {
+    if (cparams.speed_tier < SpeedTier::kSquirrel) return false;
+    if (cparams.speed_tier == SpeedTier::kSquirrel &&
+        cparams.butteraugli_distance >= 3.f) {
+      return false;
+    }
+  }
+
   // TODO(veluca): handle different values of `buffering`.
   if (frame_data.xsize <= 2048 && frame_data.ysize <= 2048) {
     return false;

--- a/lib/jxl/enc_frame.cc
+++ b/lib/jxl/enc_frame.cc
@@ -1637,7 +1637,11 @@ bool CanDoStreamingEncoding(const CompressParams& cparams,
     return false;
   }
   if (cparams.buffering == -1) {
-    if (cparams.speed_tier < SpeedTier::kSquirrel) return false;
+    if (cparams.speed_tier < SpeedTier::kTortoise) return false;
+    if (cparams.speed_tier < SpeedTier::kSquirrel &&
+        cparams.butteraugli_distance > 0.5f) {
+      return false;
+    }
     if (cparams.speed_tier == SpeedTier::kSquirrel &&
         cparams.butteraugli_distance >= 3.f) {
       return false;

--- a/lib/jxl/enc_params.h
+++ b/lib/jxl/enc_params.h
@@ -162,7 +162,7 @@ struct CompressParams {
   int level = -1;
 
   // See JXL_ENC_FRAME_SETTING_BUFFERING option value.
-  int buffering = 0;
+  int buffering = -1;
   // See JXL_ENC_FRAME_SETTING_USE_FULL_IMAGE_HEURISTICS option value.
   bool use_full_image_heuristics = true;
 

--- a/lib/jxl/encode.cc
+++ b/lib/jxl/encode.cc
@@ -1747,9 +1747,9 @@ JxlEncoderStatus JxlEncoderFrameSettingsSetOption(
       frame_settings->values.cparams.jpeg_compress_boxes = value;
       break;
     case JXL_ENC_FRAME_SETTING_BUFFERING:
-      if (value < 0 || value > 3) {
+      if (value < -1 || value > 3) {
         return JXL_API_ERROR(frame_settings->enc, JXL_ENC_ERR_NOT_SUPPORTED,
-                             "Buffering has to be in [0..3]");
+                             "Buffering has to be in [-1..3]");
       }
       frame_settings->values.cparams.buffering = value;
       break;

--- a/lib/jxl/encode_test.cc
+++ b/lib/jxl/encode_test.cc
@@ -347,7 +347,7 @@ TEST(EncodeTest, frame_settingsTest) {
         JXL_ENC_FRAME_SETTING_JPEG_KEEP_JUMBF};
     const int too_low[nb_options] = {0,  -2, -2, 3,  -2, -2, -2, -2,
                                      -2, -2, -2, -2, -2, -2, -2, -2,
-                                     -2, -1, -2, -1, -2, -2, -2};
+                                     -2, -1, -2, -2, -2, -2, -2};
     const int too_high[nb_options] = {11, 12, 5,     16, 6,  2, 4,  -3,
                                       -3, 3,  70914, 3,  42, 4, 16, 12,
                                       2,  2,  2,     4,  2,  2, 2};

--- a/lib/jxl/jxl_test.cc
+++ b/lib/jxl/jxl_test.cc
@@ -355,7 +355,7 @@ TEST(JxlTest, RoundtripLargeFast) {
   cparams.AddOption(JXL_ENC_FRAME_SETTING_EFFORT, 7);  // kSquirrel
 
   PackedPixelFile ppf_out;
-  EXPECT_NEAR(Roundtrip(t.ppf(), cparams, {}, &pool, &ppf_out), 492867, 5000);
+  EXPECT_NEAR(Roundtrip(t.ppf(), cparams, {}, &pool, &ppf_out), 503000, 10000);
   EXPECT_THAT(ComputeDistance2(t.ppf(), ppf_out), IsSlightlyBelow(78));
 }
 

--- a/lib/jxl/jxl_test.cc
+++ b/lib/jxl/jxl_test.cc
@@ -355,7 +355,7 @@ TEST(JxlTest, RoundtripLargeFast) {
   cparams.AddOption(JXL_ENC_FRAME_SETTING_EFFORT, 7);  // kSquirrel
 
   PackedPixelFile ppf_out;
-  EXPECT_NEAR(Roundtrip(t.ppf(), cparams, {}, &pool, &ppf_out), 503000, 10000);
+  EXPECT_NEAR(Roundtrip(t.ppf(), cparams, {}, &pool, &ppf_out), 503000, 12000);
   EXPECT_THAT(ComputeDistance2(t.ppf(), ppf_out), IsSlightlyBelow(78));
 }
 

--- a/tools/cjxl_main.cc
+++ b/tools/cjxl_main.cc
@@ -1153,8 +1153,7 @@ int main(int argc, char** argv) {
   params.runner = JxlThreadParallelRunner;
   params.runner_opaque = runner.get();
 
-  if ((args.effort < 7 || (args.effort == 7 && args.distance < 3)) ||
-      args.streaming_input) {
+  if (args.streaming_input) {
     params.options.emplace_back(jxl::extras::JXLOption(
         JXL_ENC_FRAME_SETTING_BUFFERING, static_cast<int64_t>(3), 0));
   }

--- a/tools/streaming_fuzzer.cc
+++ b/tools/streaming_fuzzer.cc
@@ -163,11 +163,9 @@ std::vector<uint8_t> Encode(const FuzzSpec& spec, bool streaming) {
     }
   }
 
-  if (streaming) {
-    JXL_CHECK(JxlEncoderFrameSettingsSetOption(frame_settings,
-                                               JXL_ENC_FRAME_SETTING_BUFFERING,
-                                               3) == JXL_ENC_SUCCESS);
-  }
+  JXL_CHECK(JxlEncoderFrameSettingsSetOption(
+                frame_settings, JXL_ENC_FRAME_SETTING_BUFFERING,
+                streaming ? 3 : 0) == JXL_ENC_SUCCESS);
 
   JxlBasicInfo basic_info;
   JxlEncoderInitBasicInfo(&basic_info);


### PR DESCRIPTION
Moves the cjxl logic to decide what kind of buffering to use to the library itself.

This makes the default libjxl behavior significantly faster for large images.