### PR TITLE
Switch to Thunder mode if fjxl cannot handle Lightning.

### DIFF
--- a/lib/jxl/enc_frame.cc
+++ b/lib/jxl/enc_frame.cc
@@ -2031,6 +2031,11 @@ Status EncodeFrame(const CompressParams& cparams_orig,
       !cparams.IsLossless()) {
     cparams.speed_tier = SpeedTier::kGlacier;
   }
+  // Lightning mode is handled externally, so switch to Thunder mode to handle
+  // potentially weird cases.
+  if (cparams.speed_tier == SpeedTier::kLightning) {
+    cparams.speed_tier = SpeedTier::kThunder;
+  }
   if (cparams.speed_tier == SpeedTier::kTectonicPlate) {
     std::vector<CompressParams> all_params;
     std::vector<size_t> size;


### PR DESCRIPTION
As this happens only when weird combinations of options were requested, this is simpler than trying to fix all the corner cases and should not affect most sensible usages.
