### PR TITLE
Fix non-squeeze modular on small images.

### DIFF
--- a/lib/jxl/enc_modular.cc
+++ b/lib/jxl/enc_modular.cc
@@ -255,7 +255,8 @@ ModularFrameEncoder::ModularFrameEncoder(const FrameHeader& frame_header,
       // Same, but for the non-Squeeze case.
       prop_order = {0, 1, 15, 9, 10, 11, 12, 13, 14, 2, 3, 4, 5, 6, 7, 8};
       // if few groups, don't use group as a property
-      if (num_streams < 30 && cparams_.speed_tier > SpeedTier::kTortoise) {
+      if (num_streams < 30 && cparams_.speed_tier > SpeedTier::kTortoise &&
+          cparams_orig.ModularPartIsLossless()) {
         prop_order.erase(prop_order.begin() + 1);
       }
     }


### PR DESCRIPTION
Ensure that the group ID is always avaliable as a property if doing modular lossy.
