### PR TITLE
Include `-lm` and the C++ standard library in pkgconfig “Libs” as appropriate

### DIFF
--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -11,17 +11,15 @@ project(SAMPLE_LIBJXL LANGUAGES C CXX)
 
 # Use pkg-config to find libjxl.
 find_package(PkgConfig)
-pkg_check_modules(Jxl REQUIRED IMPORTED_TARGET libjxl)
-pkg_check_modules(JxlCms REQUIRED IMPORTED_TARGET libjxl_cms)
-pkg_check_modules(JxlThreads REQUIRED IMPORTED_TARGET libjxl_threads)
+pkg_check_modules(Jxl REQUIRED IMPORTED_TARGET libjxl libjxl_cms libjxl_threads)
 
 # Build the example encoder/decoder binaries using the default shared libraries
 # installed.
 add_executable(decode_oneshot decode_oneshot.cc)
-target_link_libraries(decode_oneshot PkgConfig::Jxl PkgConfig::JxlCms PkgConfig::JxlThreads)
+target_link_libraries(decode_oneshot PkgConfig::Jxl)
 
 add_executable(decode_progressive decode_progressive.cc)
-target_link_libraries(decode_progressive PkgConfig::Jxl PkgConfig::JxlCms PkgConfig::JxlThreads)
+target_link_libraries(decode_progressive PkgConfig::Jxl)
 
 add_executable(encode_oneshot encode_oneshot.cc)
-target_link_libraries(encode_oneshot PkgConfig::Jxl PkgConfig::JxlCms PkgConfig::JxlThreads)
+target_link_libraries(encode_oneshot PkgConfig::Jxl)

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -149,6 +149,16 @@ else()
     set(PKGCONFIG_TARGET_LIBS "\${exec_prefix}/${CMAKE_INSTALL_LIBDIR}")
 endif()
 
+include(CheckCXXSymbolExists)
+set(PKGCONFIG_CXX_LIB "")
+check_cxx_symbol_exists(__GLIBCXX__ iostream LIBSTDCXX)
+check_cxx_symbol_exists(_LIBCPP_VERSION iostream LIBCXX)
+if(LIBSTDCXX)
+  set(PKGCONFIG_CXX_LIB "-lstdc++")
+elseif(LIBCXX)
+  set(PKGCONFIG_CXX_LIB "-lc++")
+endif()
+
 # The jxl_cms library definition.
 include(jxl_cms.cmake)
 # The jxl library definition.

--- a/lib/jxl.cmake
+++ b/lib/jxl.cmake
@@ -269,8 +269,10 @@ set(JPEGXL_LIBRARY_REQUIRES
 
 if (BUILD_SHARED_LIBS)
   set(JPEGXL_REQUIRES_TYPE "Requires.private")
+  set(JPEGXL_PRIVATE_LIBS "-lm ${PKGCONFIG_CXX_LIB}")
 else()
   set(JPEGXL_REQUIRES_TYPE "Requires")
+  set(JPEGXL_PUBLIC_LIBS "-lm ${PKGCONFIG_CXX_LIB}")
 endif()
 
 configure_file("${CMAKE_CURRENT_SOURCE_DIR}/jxl/libjxl.pc.in"

--- a/lib/jxl/libjxl.pc.in
+++ b/lib/jxl/libjxl.pc.in
@@ -7,7 +7,7 @@ Name: libjxl
 Description: Loads and saves JPEG XL files
 Version: @JPEGXL_LIBRARY_VERSION@
 @JPEGXL_REQUIRES_TYPE@: @JPEGXL_LIBRARY_REQUIRES@
-Libs: -L${libdir} -ljxl
-Libs.private: -lm
+Libs: -L${libdir} -ljxl @JPEGXL_PUBLIC_LIBS@
+Libs.private: @JPEGXL_PRIVATE_LIBS@
 Cflags: -I${includedir}
 Cflags.private: -DJXL_STATIC_DEFINE

--- a/lib/jxl/libjxl_cms.pc.in
+++ b/lib/jxl/libjxl_cms.pc.in
@@ -7,7 +7,7 @@ Name: libjxl_cms
 Description: CMS support library for libjxl
 Version: @JPEGXL_LIBRARY_VERSION@
 @JPEGXL_REQUIRES_TYPE@: @JPEGXL_CMS_LIBRARY_REQUIRES@
-Libs: -L${libdir} -ljxl_cms
-Libs.private: -lm
+Libs: -L${libdir} -ljxl_cms @JPEGXL_CMS_PUBLIC_LIBS@
+Libs.private: @JPEGXL_CMS_PRIVATE_LIBS@
 Cflags: -I${includedir}
 Cflags.private: -DJXL_CMS_STATIC_DEFINE

--- a/lib/jxl_cms.cmake
+++ b/lib/jxl_cms.cmake
@@ -62,8 +62,10 @@ install(TARGETS jxl_cms
 
 if (BUILD_SHARED_LIBS)
   set(JPEGXL_REQUIRES_TYPE "Requires.private")
+  set(JPEGXL_CMS_PRIVATE_LIBS "-lm ${PKGCONFIG_CXX_LIB}")
 else()
   set(JPEGXL_REQUIRES_TYPE "Requires")
+  set(JPEGXL_CMS_PRIVATE_LIBS "-lm ${PKGCONFIG_CXX_LIB}")
 endif()
 
 configure_file("${CMAKE_CURRENT_SOURCE_DIR}/jxl/libjxl_cms.pc.in"


### PR DESCRIPTION
This ensures that if libjxl is built statically, C programs that use it will still link properly.