### PR TITLE
fix jxl_from_tree splines passing

### DIFF
--- a/lib/jxl/enc_heuristics.cc
+++ b/lib/jxl/enc_heuristics.cc
@@ -739,10 +739,11 @@ Status LossyFrameHeuristics(const FrameHeader& frame_header,
   BlockCtxMap& block_ctx_map = shared.block_ctx_map;
 
   // Find and subtract splines.
+  if (cparams.custom_splines.HasAny()) {
+    image_features.splines = cparams.custom_splines;
+  }
   if (!streaming_mode && cparams.speed_tier <= SpeedTier::kSquirrel) {
-    if (cparams.custom_splines.HasAny()) {
-      image_features.splines = cparams.custom_splines;
-    } else {
+    if (!cparams.custom_splines.HasAny()) {
       image_features.splines = FindSplines(*opsin);
     }
     JXL_RETURN_IF_ERROR(image_features.splines.InitializeDrawCache(

--- a/lib/jxl/enc_modular.cc
+++ b/lib/jxl/enc_modular.cc
@@ -423,6 +423,12 @@ Status ModularFrameEncoder::ComputeEncodingData(
         enc_state->shared.image_features.patches, color);
   }
 
+  if (cparams_.custom_splines.HasAny()) {
+    PassesSharedState& shared = enc_state->shared;
+    ImageFeatures& image_features = shared.image_features;
+    image_features.splines = cparams_.custom_splines;
+  }
+
   // Convert ImageBundle to modular Image object
   const size_t xsize = patch_dim.xsize;
   const size_t ysize = patch_dim.ysize;


### PR DESCRIPTION
Fixes the passing of splines from jxl_from_tree to the encoder.