### PR TITLE
Update documentation to reflect new effort range

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed / clarified
  - decoder/encoder API: return failure when surface allocation fail
+ - encoder API / cjxl: updated modular effort levels to faster settings; the
+   effort range is now 1-10, with 11 available in advanced mode.
 
 ## [0.9.2] - 2024-02-07
 

--- a/lib/include/jxl/encode.h
+++ b/lib/include/jxl/encode.h
@@ -126,7 +126,7 @@ typedef enum {
 typedef enum {
   /** Sets encoder effort/speed level without affecting decoding speed. Valid
    * values are, from faster to slower speed: 1:lightning 2:thunder 3:falcon
-   * 4:cheetah 5:hare 6:wombat 7:squirrel 8:kitten 9:tortoise.
+   * 4:cheetah 5:hare 6:wombat 7:squirrel 8:kitten 9:tortoise 10:glacier.
    * Default: squirrel (7).
    */
   JXL_ENC_FRAME_SETTING_EFFORT = 0,
@@ -1530,7 +1530,7 @@ JXL_EXPORT void JxlColorEncodingSetToLinearSRGB(
 /**
  * Enables usage of expert options.
  *
- * At the moment, the only expert option is setting an effort value of 10,
+ * At the moment, the only expert option is setting an effort value of 11,
  * which gives the best compression for pixel-lossless modes but is very slow.
  *
  * @param enc encoder object.

--- a/tools/cjxl_main.cc
+++ b/tools/cjxl_main.cc
@@ -126,7 +126,7 @@ struct CompressArgs {
 
     cmdline->AddOptionValue(
         'e', "effort", "EFFORT",
-        "Encoder effort setting. Range: 1 .. 9.\n"
+        "Encoder effort setting. Range: 1 .. 10.\n"
         "    Default: 7. Higher numbers allow more computation "
         "at the expense of time.\n"
         "    For lossless, generally it will produce smaller files.\n"


### PR DESCRIPTION
<!-- Thank you for considering a contribution to `libjxl`! -->

### Description
The help text for cjxl's `-e` option, and the encode.h API documentation were still giving 1-9 as the valid range of effort levels, which is no longer accurate since #3248.

I also added a changelog entry, as existing API users might want to know that "10 is the new 9" for modular mode.

### Pull Request Checklist

- [x] **CLA Signed**: Have you signed the [Contributor License Agreement](https://code.google.com/legal/individual-cla-v1.0.html) (individual or corporate, as appropriate)? Only contributions from signed contributors can be accepted.
- [x] **Authors**: Have you considered adding your name to the [AUTHORS](AUTHORS) file?
- [x] **Code Style**: Have you ensured your code adheres to the project's coding style guidelines? You can use `./ci.sh lint` for automatic code formatting.


Please review the full [contributing guidelines](https://github.com/libjxl/libjxl/blob/main/CONTRIBUTING.md) for more details.
