### PR TITLE
Do not use Variable predictor by default at e9.

### DIFF
--- a/lib/jxl/enc_modular.cc
+++ b/lib/jxl/enc_modular.cc
@@ -321,7 +321,7 @@ ModularFrameEncoder::ModularFrameEncoder(const FrameHeader& frame_header,
 
   if (cparams_.options.predictor == static_cast<Predictor>(-1)) {
     // no explicit predictor(s) given, set a good default
-    if ((cparams_.speed_tier <= SpeedTier::kTortoise ||
+    if ((cparams_.speed_tier <= SpeedTier::kGlacier ||
          cparams_.modular_mode == false) &&
         cparams_.IsLossless() && cparams_.responsive == false) {
       // TODO(veluca): allow all predictors that don't break residual


### PR DESCRIPTION
This is a pessimization for photographic content with local trees.

Fixes #3323.