### PR TITLE
fix bug in lossless e1 palette writing

### DIFF
--- a/lib/jxl/enc_fast_lossless.cc
+++ b/lib/jxl/enc_fast_lossless.cc
@@ -3576,8 +3576,7 @@ void PrepareDCGlobalPalette(bool is_single_group, size_t width, size_t height,
   int16_t p[4][32 + 1024] = {};
   uint8_t prgba[4];
   size_t i = 0;
-  size_t have_zero = 0;
-  if (palette[pcolors - 1] == 0) have_zero = 1;
+  size_t have_zero = 1;
   for (; i < pcolors; i++) {
     memcpy(prgba, &palette[i], 4);
     p[0][16 + i + have_zero] = prgba[0];


### PR DESCRIPTION
Fixes #3357 

There was a bug in the lossless e1 encoder in the specific case that

- a palette could be used
- the palette does _not_ contain the color black (all-zeroes)

In the original palette detection code, we would write a palette without the color black in this particular case, but that was changed to make the palette detection faster and now we simply always have the color black in the palette even if it is not actually used in the image. However the code that writes the palette itself was not properly updated to reflect that, so it wrote a wrong palette, which caused all palette indices to be off-by-one. This fixes that.