### PR TITLE
stop producing non-spec compliant files

### DIFF
--- a/lib/jxl/modular/encoding/enc_encoding.cc
+++ b/lib/jxl/modular/encoding/enc_encoding.cc
@@ -642,16 +642,22 @@ Status ModularEncode(const Image &image, const ModularOptions &options,
   }
 
   size_t image_width = 0;
+  size_t image_width_bug = 0;
   size_t total_tokens = 0;
   for (size_t i = 0; i < nb_channels; i++) {
-    if (i >= image.nb_meta_channels &&
-        (image.channel[i].w > options.max_chan_size ||
-         image.channel[i].h > options.max_chan_size)) {
-      break;
+    if (i >= image.nb_meta_channels) {
+      if (image.channel[i].w > options.max_chan_size ||
+          image.channel[i].h > options.max_chan_size) {
+        break;
+      }
+      if (image.channel[i].w > image_width) image_width = image.channel[i].w;
     }
-    if (image.channel[i].w > image_width) image_width = image.channel[i].w;
+    if (image.channel[i].w > image_width_bug)
+      image_width_bug = image.channel[i].w;
     total_tokens += image.channel[i].w * image.channel[i].h;
   }
+  if (image_width_bug != image_width) image_width = 0;
+
   if (options.zero_tokens) {
     tokens->resize(tokens->size() + total_tokens, {0, 0});
   } else {


### PR DESCRIPTION
This fixes the encoder to compute the `distance_multiplier` for lz77 correctly (i.e. not looking at meta-channels), while also avoiding to use it when the incorrect computation is different, so it does not produce files that cannot be decoded by a decoder that does the computation incorrectly (like the libjxl decoder at the moment).

At some point we can change this and turn it into an encoder option to allow producing bitstreams that cannot be decoded by non-spec-conforming decoders, but let's first make sure that such decoders are more ubiquitous :)