### PR TITLE
Fix assert in CMS stage

### DIFF
--- a/lib/extras/enc/jpegli.cc
+++ b/lib/extras/enc/jpegli.cc
@@ -480,7 +480,7 @@ Status EncodeJpeg(const PackedPixelFile& ppf, const JpegSettings& jpeg_settings,
         ToFloatRow(&pixels[y * image.stride], image.format, 3 * image.xsize,
                    src_buf);
         // convert to linear srgb
-        if (!c_transform.Run(0, src_buf, dst_buf)) {
+        if (!c_transform.Run(0, src_buf, dst_buf, image.xsize)) {
           return false;
         }
         // deinterleave channels

--- a/lib/jxl/color_encoding_internal.h
+++ b/lib/jxl/color_encoding_internal.h
@@ -314,7 +314,6 @@ class ColorSpaceTransform {
 
   Status Init(const ColorEncoding& c_src, const ColorEncoding& c_dst,
               float intensity_target, size_t xsize, size_t num_threads) {
-    xsize_ = xsize;
     JxlColorProfile input_profile;
     icc_src_ = c_src.ICC();
     input_profile.icc.data = icc_src_.data();
@@ -343,9 +342,10 @@ class ColorSpaceTransform {
     return cms_.get_dst_buf(cms_data_, thread);
   }
 
-  Status Run(const size_t thread, const float* buf_src, float* buf_dst) {
+  Status Run(const size_t thread, const float* buf_src, float* buf_dst,
+             size_t xsize) {
     // TODO(eustas): convert false to Status?
-    return FROM_JXL_BOOL(cms_.run(cms_data_, thread, buf_src, buf_dst, xsize_));
+    return FROM_JXL_BOOL(cms_.run(cms_data_, thread, buf_src, buf_dst, xsize));
   }
 
  private:
@@ -354,7 +354,6 @@ class ColorSpaceTransform {
   // The interface may retain pointers into these.
   IccBytes icc_src_;
   IccBytes icc_dst_;
-  size_t xsize_;
 };
 
 }  // namespace jxl

--- a/lib/jxl/enc_image_bundle.cc
+++ b/lib/jxl/enc_image_bundle.cc
@@ -72,7 +72,7 @@ Status ApplyColorTransform(const ColorEncoding& c_current,
           }
         }
         float* JXL_RESTRICT dst_buf = c_transform.BufDst(thread);
-        if (!c_transform.Run(thread, src_buf, dst_buf)) {
+        if (!c_transform.Run(thread, src_buf, dst_buf, rect.xsize())) {
           has_error = true;
           return;
         }

--- a/lib/jxl/enc_xyb.cc
+++ b/lib/jxl/enc_xyb.cc
@@ -245,7 +245,7 @@ StatusOr<Image3F> TransformToLinearRGB(const Image3F& in,
           }
         }
         float* JXL_RESTRICT dst_buf = c_transform.BufDst(thread);
-        if (!c_transform.Run(thread, src_buf, dst_buf)) {
+        if (!c_transform.Run(thread, src_buf, dst_buf, in.xsize())) {
           has_error = true;
           return;
         }

--- a/lib/jxl/render_pipeline/stage_cms.cc
+++ b/lib/jxl/render_pipeline/stage_cms.cc
@@ -44,7 +44,7 @@ class CmsStage : public RenderPipelineStage {
   Status ProcessRow(const RowInfo& input_rows, const RowInfo& output_rows,
                     size_t xextra, size_t xsize, size_t xpos, size_t ypos,
                     size_t thread_id) const final {
-    JXL_ASSERT(xsize == xsize_);
+    JXL_ASSERT(xsize <= xsize_);
     // TODO(firsching): handle grey case seperately
     //  interleave
     float* JXL_RESTRICT row0 = GetInputRow(input_rows, 0, 0);
@@ -60,7 +60,7 @@ class CmsStage : public RenderPipelineStage {
     const float* buf_src = mutable_buf_src;
     float* JXL_RESTRICT buf_dst = color_space_transform->BufDst(thread_id);
     JXL_RETURN_IF_ERROR(
-        color_space_transform->Run(thread_id, buf_src, buf_dst));
+        color_space_transform->Run(thread_id, buf_src, buf_dst, xsize));
     // de-interleave
     for (size_t x = 0; x < xsize; x++) {
       row0[x] = buf_dst[3 * x + 0];


### PR DESCRIPTION
Also transform only as many pixels as needed.

Fixes #3348.
