### PR TITLE
preserve bitdepth when taking jxl input

### DIFF
--- a/lib/extras/dec/decode.cc
+++ b/lib/extras/dec/decode.cc
@@ -117,6 +117,7 @@ Status DecodeBytes(const Span<const uint8_t> bytes,
       dparams.accepted_formats.push_back(
           {num_channels, JXL_TYPE_FLOAT, JXL_LITTLE_ENDIAN, /*align=*/0});
     }
+    dparams.output_bitdepth.type = JXL_BIT_DEPTH_FROM_CODESTREAM;
     size_t decoded_bytes;
     if (DecodeImageJXL(bytes.data(), bytes.size(), dparams, &decoded_bytes,
                        ppf) &&


### PR DESCRIPTION
Otherwise it defaults to taking the bitdepth from the pixel format, which is always float32.