### PR TITLE
include local jxl headers before system headers

### DIFF
--- a/lib/jxl.cmake
+++ b/lib/jxl.cmake
@@ -80,10 +80,10 @@ foreach(path ${JPEGXL_INTERNAL_PUBLIC_HEADERS})
 endforeach()
 
 add_library(jxl_base INTERFACE)
-target_include_directories(jxl_base SYSTEM INTERFACE
+target_include_directories(jxl_base SYSTEM BEFORE INTERFACE
   "$<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/include>"
 )
-target_include_directories(jxl_base INTERFACE
+target_include_directories(jxl_base BEFORE INTERFACE
   ${PROJECT_SOURCE_DIR}
   ${JXL_HWY_INCLUDE_DIRS}
 )
@@ -104,7 +104,7 @@ add_library(jxl_dec-obj OBJECT ${JPEGXL_INTERNAL_DEC_SOURCES})
 target_compile_options(jxl_dec-obj PRIVATE ${JPEGXL_INTERNAL_FLAGS})
 target_compile_options(jxl_dec-obj PUBLIC ${JPEGXL_COVERAGE_FLAGS})
 set_property(TARGET jxl_dec-obj PROPERTY POSITION_INDEPENDENT_CODE ON)
-target_include_directories(jxl_dec-obj PUBLIC
+target_include_directories(jxl_dec-obj BEFORE PUBLIC
   "$<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}>"
   "${JXL_HWY_INCLUDE_DIRS}"
   "$<BUILD_INTERFACE:$<TARGET_PROPERTY:brotlicommon,INTERFACE_INCLUDE_DIRECTORIES>>"
@@ -119,7 +119,7 @@ add_library(jxl_enc-obj OBJECT ${JPEGXL_INTERNAL_ENC_SOURCES})
 target_compile_options(jxl_enc-obj PRIVATE ${JPEGXL_INTERNAL_FLAGS})
 target_compile_options(jxl_enc-obj PUBLIC ${JPEGXL_COVERAGE_FLAGS})
 set_property(TARGET jxl_enc-obj PROPERTY POSITION_INDEPENDENT_CODE ON)
-target_include_directories(jxl_enc-obj PUBLIC
+target_include_directories(jxl_enc-obj BEFORE PUBLIC
   ${PROJECT_SOURCE_DIR}
   ${JXL_HWY_INCLUDE_DIRS}
   $<TARGET_PROPERTY:brotlicommon,INTERFACE_INCLUDE_DIRECTORIES>
@@ -172,7 +172,7 @@ target_link_libraries(jxl-internal PUBLIC
   jxl_cms
   jxl_base
 )
-target_include_directories(jxl-internal PUBLIC
+target_include_directories(jxl-internal BEFORE PUBLIC
   "$<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}>")
 
 target_compile_definitions(jxl-internal INTERFACE -DJXL_STATIC_DEFINE)

--- a/lib/jxl_cms.cmake
+++ b/lib/jxl_cms.cmake
@@ -23,7 +23,7 @@ target_include_directories(jxl_cms PRIVATE
 generate_export_header(jxl_cms
   BASE_NAME JXL_CMS
   EXPORT_FILE_NAME include/jxl/jxl_cms_export.h)
-target_include_directories(jxl_cms PUBLIC
+target_include_directories(jxl_cms BEFORE PUBLIC
   "$<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}>")
 
 set(JPEGXL_CMS_LIBRARY_REQUIRES "")

--- a/lib/jxl_extras.cmake
+++ b/lib/jxl_extras.cmake
@@ -118,7 +118,7 @@ foreach(LIB ${JXL_EXTRAS_OBJECT_LIBRARIES})
   target_compile_options("${LIB}" PRIVATE "${JPEGXL_INTERNAL_FLAGS}")
   target_compile_definitions("${LIB}" PRIVATE -DJXL_EXPORT=)
   set_property(TARGET "${LIB}" PROPERTY POSITION_INDEPENDENT_CODE ON)
-  target_include_directories("${LIB}" PRIVATE
+  target_include_directories("${LIB}" BEFORE PRIVATE
     ${PROJECT_SOURCE_DIR}
     ${CMAKE_CURRENT_SOURCE_DIR}/include
     ${CMAKE_CURRENT_BINARY_DIR}/include


### PR DESCRIPTION
When building a local git version of libjxl on a system that already has libjxl headers system-installed, the build can fail because the system headers might be outdated. This should fix that (at least it does for me).
