### PR TITLE
Add possibility to skip most worflows (for debugging)

### DIFF
--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -13,7 +13,7 @@ on:
       - main
       - v*.*.x
   pull_request:
-    types: [opened, reopened, labeled, synchronize]
+    types: [opened, reopened, labeled, unlabeled, synchronize]
 
 permissions:
   contents: read
@@ -25,6 +25,7 @@ concurrency:
 jobs:
   build_test:
     name: ${{ startsWith(matrix.os, 'macos-') && 'MacOS' || 'Ubuntu' }} Build ${{ matrix.name }}
+    if: ${{ !contains(github.event.pull_request.labels.*.name, 'CI:none') }}
     runs-on: ${{ matrix.os || 'ubuntu-latest' }}
     strategy:
       fail-fast: false

--- a/.github/workflows/build_test_bazel.yml
+++ b/.github/workflows/build_test_bazel.yml
@@ -13,7 +13,7 @@ on:
       - main
       - v*.*.x
   pull_request:
-    types: [opened, reopened, labeled, synchronize]
+    types: [opened, reopened, labeled, unlabeled, synchronize]
 
 permissions:
   contents: read
@@ -25,6 +25,7 @@ concurrency:
 jobs:
   build_test:
     name: Bazel
+    if: ${{ !contains(github.event.pull_request.labels.*.name, 'CI:none') }}
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false

--- a/.github/workflows/build_test_cross.yml
+++ b/.github/workflows/build_test_cross.yml
@@ -13,7 +13,7 @@ on:
       - main
       - v*.*.x
   pull_request:
-    types: [opened, reopened, labeled, synchronize]
+    types: [opened, reopened, labeled, unlabeled, synchronize]
 
 permissions:
   contents: read
@@ -25,6 +25,7 @@ concurrency:
 jobs:
   compile:
     name: Cross-compiling ${{ matrix.identifier }}
+    if: ${{ !contains(github.event.pull_request.labels.*.name, 'CI:none') }}
     runs-on: [ubuntu-latest]
     container:
       image: debian:bookworm
@@ -204,6 +205,7 @@ jobs:
 
   test:
     name: Testing ${{ matrix.identifier }} shard ${{ matrix.shard_number }}
+    if: ${{ !contains(github.event.pull_request.labels.*.name, 'CI:none') }}
     needs: compile
     runs-on: [ubuntu-latest]
     container:

--- a/.github/workflows/build_test_md.yml
+++ b/.github/workflows/build_test_md.yml
@@ -8,7 +8,7 @@
 name: Build/Test MD
 on:
   pull_request:
-    types: [opened, reopened, labeled, synchronize]
+    types: [opened, reopened, labeled, unlabeled, synchronize]
     paths:
       - '**.md'
 
@@ -22,6 +22,7 @@ concurrency:
 jobs:
   build_test:
     name: Ubuntu Build ${{ matrix.name }}
+    if: ${{ !contains(github.event.pull_request.labels.*.name, 'CI:none') }}
     # Include all names of required jobs here
     strategy:
       matrix:
@@ -44,6 +45,7 @@ jobs:
 
   windows_msys:
     name: Windows MSYS2 / ${{ matrix.msystem }}
+    if: ${{ !contains(github.event.pull_request.labels.*.name, 'CI:none') }}
     # Include all msystem of required jobs here
     strategy:
       matrix:

--- a/.github/workflows/build_test_msys2.yml
+++ b/.github/workflows/build_test_msys2.yml
@@ -13,7 +13,7 @@ on:
       - main
       - v*.*.x
   pull_request:
-    types: [opened, reopened, labeled, synchronize]
+    types: [opened, reopened, labeled, unlabeled, synchronize]
 
 permissions:
   contents: read
@@ -25,6 +25,7 @@ concurrency:
 jobs:
   build_test:
     name: Windows MSYS2 / ${{ matrix.msystem }}
+    if: ${{ !contains(github.event.pull_request.labels.*.name, 'CI:none') }}
     runs-on: windows-latest
     continue-on-error: ${{ matrix.faulty || false }}
     strategy:

--- a/.github/workflows/build_test_wasm.yml
+++ b/.github/workflows/build_test_wasm.yml
@@ -13,7 +13,7 @@ on:
       - main
       - v*.*.x
   pull_request:
-    types: [opened, reopened, labeled, synchronize]
+    types: [opened, reopened, labeled, unlabeled, synchronize]
 
 permissions:
   contents: read
@@ -25,6 +25,7 @@ concurrency:
 jobs:
   build_test:
     name: WASM wasm32/${{ matrix.variant }}
+    if: ${{ !contains(github.event.pull_request.labels.*.name, 'CI:none') }}
     runs-on: ubuntu-latest
     env:
       CCACHE_DIR: ${{ github.workspace }}/.ccache

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -35,6 +35,7 @@ concurrency:
 jobs:
   analyze:
     name: Analyze
+    if: ${{ !contains(github.event.pull_request.labels.*.name, 'CI:none') }}
     runs-on: ubuntu-latest
     permissions:
       actions: read

--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -13,7 +13,7 @@ on:
       - main
       - v*.*.x
   pull_request:
-    types: [opened, reopened, labeled, synchronize]
+    types: [opened, reopened, labeled, unlabeled, synchronize]
 
 permissions:
   contents: read
@@ -30,6 +30,7 @@ concurrency:
 jobs:
   warmup: # If necessary, fetch files just once, before tests are run.
     name: Warmup caches
+    if: ${{ !contains(github.event.pull_request.labels.*.name, 'CI:none') }}
     runs-on: ubuntu-latest
     steps:
     - name: Harden Runner
@@ -54,6 +55,7 @@ jobs:
 
   build:
     name: Conformance Build ${{ matrix.name }}
+    if: ${{ !contains(github.event.pull_request.labels.*.name, 'CI:none') }}
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -167,6 +169,7 @@ jobs:
 
   run:
     name: Conformance Test ${{ matrix.name }} on ${{ matrix.target }}
+    if: ${{ !contains(github.event.pull_request.labels.*.name, 'CI:none') }}
     needs: [warmup, build]
     runs-on: ubuntu-latest
     strategy:

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -23,6 +23,7 @@ concurrency:
 
 jobs:
   dependency-review:
+    if: ${{ !contains(github.event.pull_request.labels.*.name, 'CI:none') }}
     runs-on: ubuntu-latest
     steps:
       - name: Harden Runner

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -11,7 +11,7 @@ name: CIFuzz
 on:
   merge_group:
   pull_request:
-    types: [opened, reopened, synchronize]
+    types: [opened, reopened, labeled, unlabeled, synchronize]
     paths:
       - '**.c'
       - '**.cc'
@@ -29,6 +29,7 @@ concurrency:
 
 jobs:
   fuzzing:
+    if: ${{ !contains(github.event.pull_request.labels.*.name, 'CI:none') }}
     runs-on: ubuntu-latest
     steps:
     - name: Harden Runner

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -9,7 +9,7 @@ name: PR
 on:
   merge_group:
   pull_request:
-    types: [opened, reopened, synchronize]
+    types: [opened, reopened, labeled, unlabeled, synchronize]
 
 permissions:
   contents: read
@@ -21,6 +21,7 @@ concurrency:
 jobs:
   # Checks that the AUTHORS files is updated with new contributors.
   authors:
+    if: ${{ !contains(github.event.pull_request.labels.*.name, 'CI:none') }}
     runs-on: [ubuntu-latest]
     steps:
     - name: Harden Runner
@@ -37,6 +38,7 @@ jobs:
         ./ci.sh authors
 
   format:
+    if: ${{ !contains(github.event.pull_request.labels.*.name, 'CI:none') }}
     runs-on: [ubuntu-latest]
     steps:
     - name: Harden Runner

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -19,7 +19,7 @@ on:
       - main
       - v*.*.x
   pull_request:
-    types: [opened, reopened, labeled, synchronize]
+    types: [opened, reopened, labeled, unlabeled, synchronize]
     paths-ignore:
       - '**.md'
       - 'AUTHORS'
@@ -37,6 +37,7 @@ concurrency:
 jobs:
   ubuntu_static_x86_64:
     name: Release linux x86_64 static
+    if: ${{ !contains(github.event.pull_request.labels.*.name, 'CI:none') }}
     runs-on: [ubuntu-latest]
     steps:
     - name: Harden Runner
@@ -114,6 +115,7 @@ jobs:
   # Build .deb packages Ubuntu/Debian
   release_ubuntu_pkg:
     name: .deb packages / ${{ matrix.os }}
+    if: ${{ !contains(github.event.pull_request.labels.*.name, 'CI:none') }}
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -244,6 +246,7 @@ jobs:
 
   windows_build:
     name: Windows Build (vcpkg / ${{ matrix.triplet }})
+    if: ${{ !contains(github.event.pull_request.labels.*.name, 'CI:none') }}
     runs-on: [windows-2022]
     strategy:
       fail-fast: false


### PR DESCRIPTION
With label 'CI:none' most workflows will be disabled; new/debugged workflows could be enabled manually.
Obviously, PR could not be landed while until this label is removed.