### PR TITLE
tweak palette heuristics

### DIFF
--- a/lib/jxl/enc_modular.cc
+++ b/lib/jxl/enc_modular.cc
@@ -300,13 +300,12 @@ bool do_transform(Image& image, const Transform& tr,
 
 bool maybe_do_transform(Image& image, const Transform& tr,
                         const CompressParams& cparams,
-                        const weighted::Header& wp_header,
+                        const weighted::Header& wp_header, float cost_before,
                         jxl::ThreadPool* pool = nullptr,
                         bool force_jxlart = false) {
   if (force_jxlart || cparams.speed_tier >= SpeedTier::kSquirrel) {
     return do_transform(image, tr, wp_header, pool, force_jxlart);
   }
-  float cost_before = EstimateCost(image);
   bool did_it = do_transform(image, tr, wp_header, pool);
   if (did_it) {
     float cost_after = EstimateCost(image);
@@ -319,6 +318,106 @@ bool maybe_do_transform(Image& image, const Transform& tr,
     }
   }
   return did_it;
+}
+
+void try_palettes(Image& gi, int& max_bitdepth, int& maxval,
+                  const CompressParams& cparams_, float channel_colors_percent,
+                  jxl::ThreadPool* pool = nullptr) {
+  float cost_before = 0.f;
+  size_t did_palette = 0;
+  float nb_pixels = gi.channel[0].w * gi.channel[0].h;
+
+  if (cparams_.palette_colors != 0 || cparams_.lossy_palette) {
+    // when not estimating, assume 5 bpp (arbitrarily)
+    cost_before = cparams_.speed_tier <= SpeedTier::kSquirrel ? EstimateCost(gi)
+                                                              : nb_pixels * 5.f;
+    // all-channel palette (e.g. RGBA)
+    if (gi.channel.size() - gi.nb_meta_channels > 1) {
+      Transform maybe_palette(TransformId::kPalette);
+      maybe_palette.begin_c = gi.nb_meta_channels;
+      maybe_palette.num_c = gi.channel.size() - gi.nb_meta_channels;
+      // Heuristic choice of max colors for a palette:
+      // max_colors = nb_pixels * estimated_bpp_without_palette * 0.0005 +
+      //              + nb_pixels / 128 + 128
+      //       (estimated_bpp_without_palette = cost_before / nb_pixels)
+      // Rationale: small image with large palette is not effective;
+      // also if the entropy (estimated bpp) is low (e.g. mostly solid/gradient
+      // areas), palette is less useful and may even be counterproductive.
+      maybe_palette.nb_colors = std::min(
+          static_cast<int>(cost_before * 0.0005f + nb_pixels / 128 + 128),
+          std::abs(cparams_.palette_colors));
+      maybe_palette.ordered_palette = cparams_.palette_colors >= 0;
+      maybe_palette.lossy_palette =
+          (cparams_.lossy_palette && maybe_palette.num_c == 3);
+      if (maybe_palette.lossy_palette) {
+        maybe_palette.predictor = Predictor::Average4;
+      }
+      // TODO(veluca): use a custom weighted header if using the weighted
+      // predictor.
+      if (maybe_do_transform(gi, maybe_palette, cparams_, weighted::Header(),
+                             cost_before, pool, cparams_.options.zero_tokens)) {
+        did_palette = 1;
+      };
+    }
+    // all-minus-one-channel palette (RGB with separate alpha, or CMY with
+    // separate K)
+    if (!did_palette && gi.channel.size() - gi.nb_meta_channels > 3) {
+      Transform maybe_palette_3(TransformId::kPalette);
+      maybe_palette_3.begin_c = gi.nb_meta_channels;
+      maybe_palette_3.num_c = gi.channel.size() - gi.nb_meta_channels - 1;
+      maybe_palette_3.nb_colors = std::min(
+          static_cast<int>(cost_before * 0.0005f + nb_pixels / 128 + 128),
+          std::abs(cparams_.palette_colors));
+      maybe_palette_3.ordered_palette = cparams_.palette_colors >= 0;
+      maybe_palette_3.lossy_palette = cparams_.lossy_palette;
+      if (maybe_palette_3.lossy_palette) {
+        maybe_palette_3.predictor = Predictor::Average4;
+      }
+      if (maybe_do_transform(gi, maybe_palette_3, cparams_, weighted::Header(),
+                             cost_before, pool, cparams_.options.zero_tokens)) {
+        did_palette = 1;
+      }
+    }
+  }
+
+  if (channel_colors_percent > 0) {
+    // single channel palette (like FLIF's ChannelCompact)
+    size_t nb_channels = gi.channel.size() - gi.nb_meta_channels - did_palette;
+    int orig_bitdepth = max_bitdepth;
+    max_bitdepth = 0;
+    if (nb_channels > 0 && (did_palette || cost_before == 0)) {
+      cost_before =
+          cparams_.speed_tier < SpeedTier::kSquirrel ? EstimateCost(gi) : 0;
+    }
+    for (size_t i = did_palette; i < nb_channels + did_palette; i++) {
+      int32_t min;
+      int32_t max;
+      compute_minmax(gi.channel[gi.nb_meta_channels + i], &min, &max);
+      int64_t colors = static_cast<int64_t>(max) - min + 1;
+      JXL_DEBUG_V(10, "Channel %" PRIuS ": range=%i..%i", i, min, max);
+      Transform maybe_palette_1(TransformId::kPalette);
+      maybe_palette_1.begin_c = i + gi.nb_meta_channels;
+      maybe_palette_1.num_c = 1;
+      // simple heuristic: if less than X percent of the values in the range
+      // actually occur, it is probably worth it to do a compaction
+      // (but only if the channel palette is less than 6% the size of the
+      // image itself)
+      maybe_palette_1.nb_colors =
+          std::min(static_cast<int>(nb_pixels / 16),
+                   static_cast<int>(channel_colors_percent / 100. * colors));
+      if (maybe_do_transform(gi, maybe_palette_1, cparams_, weighted::Header(),
+                             cost_before, pool)) {
+        // effective bit depth is lower, adjust quantization accordingly
+        compute_minmax(gi.channel[gi.nb_meta_channels + i], &min, &max);
+        if (max < maxval) maxval = max;
+        int ch_bitdepth =
+            (max > 0 ? CeilLog2Nonzero(static_cast<uint32_t>(max)) : 0);
+        if (ch_bitdepth > max_bitdepth) max_bitdepth = ch_bitdepth;
+      } else {
+        max_bitdepth = orig_bitdepth;
+      }
+    }
+  }
 }
 
 }  // namespace
@@ -479,7 +578,6 @@ ModularFrameEncoder::ModularFrameEncoder(const FrameHeader& frame_header,
       cparams_.options.predictor = Predictor::Gradient;
     }
   } else {
-    delta_pred_ = cparams_.options.predictor;
     if (cparams_.lossy_palette) cparams_.options.predictor = Predictor::Zero;
   }
   if (!cparams_.ModularPartIsLossless()) {
@@ -721,81 +819,16 @@ Status ModularFrameEncoder::ComputeEncodingData(
     cparams_.lossy_palette = false;
   }
 
-  // Global palette
-  if ((cparams_.palette_colors != 0 || cparams_.lossy_palette) && !groupwise) {
-    // all-channel palette (e.g. RGBA)
-    if (gi.channel.size() - gi.nb_meta_channels > 1) {
-      Transform maybe_palette(TransformId::kPalette);
-      maybe_palette.begin_c = gi.nb_meta_channels;
-      maybe_palette.num_c = gi.channel.size() - gi.nb_meta_channels;
-      maybe_palette.nb_colors = std::min(static_cast<int>(xsize * ysize / 2),
-                                         std::abs(cparams_.palette_colors));
-      maybe_palette.ordered_palette = cparams_.palette_colors >= 0;
-      maybe_palette.lossy_palette =
-          (cparams_.lossy_palette && maybe_palette.num_c == 3);
-      if (maybe_palette.lossy_palette) {
-        maybe_palette.predictor = delta_pred_;
-      }
-      // TODO(veluca): use a custom weighted header if using the weighted
-      // predictor.
-      maybe_do_transform(gi, maybe_palette, cparams_, weighted::Header(), pool,
-                         cparams_.options.zero_tokens);
-    }
-    // all-minus-one-channel palette (RGB with separate alpha, or CMY with
-    // separate K)
-    if (gi.channel.size() - gi.nb_meta_channels > 3) {
-      Transform maybe_palette_3(TransformId::kPalette);
-      maybe_palette_3.begin_c = gi.nb_meta_channels;
-      maybe_palette_3.num_c = gi.channel.size() - gi.nb_meta_channels - 1;
-      maybe_palette_3.nb_colors = std::min(static_cast<int>(xsize * ysize / 3),
-                                           std::abs(cparams_.palette_colors));
-      maybe_palette_3.ordered_palette = cparams_.palette_colors >= 0;
-      maybe_palette_3.lossy_palette = cparams_.lossy_palette;
-      if (maybe_palette_3.lossy_palette) {
-        maybe_palette_3.predictor = delta_pred_;
-      }
-      maybe_do_transform(gi, maybe_palette_3, cparams_, weighted::Header(),
-                         pool, cparams_.options.zero_tokens);
-    }
-  }
-
-  // Global channel palette
-  if (!groupwise && cparams_.channel_colors_pre_transform_percent > 0 &&
-      !cparams_.lossy_palette &&
+  // Global palette transforms
+  float channel_colors_percent = 0;
+  if (!cparams_.lossy_palette &&
       (cparams_.speed_tier <= SpeedTier::kThunder ||
        (do_color && metadata.bit_depth.bits_per_sample > 8))) {
-    // single channel palette (like FLIF's ChannelCompact)
-    size_t nb_channels = gi.channel.size() - gi.nb_meta_channels;
-    int orig_bitdepth = max_bitdepth;
-    max_bitdepth = 0;
-    for (size_t i = 0; i < nb_channels; i++) {
-      int32_t min;
-      int32_t max;
-      compute_minmax(gi.channel[gi.nb_meta_channels + i], &min, &max);
-      int64_t colors = static_cast<int64_t>(max) - min + 1;
-      JXL_DEBUG_V(10, "Channel %" PRIuS ": range=%i..%i", i, min, max);
-      Transform maybe_palette_1(TransformId::kPalette);
-      maybe_palette_1.begin_c = i + gi.nb_meta_channels;
-      maybe_palette_1.num_c = 1;
-      // simple heuristic: if less than X percent of the values in the range
-      // actually occur, it is probably worth it to do a compaction
-      // (but only if the channel palette is less than 6% the size of the
-      // image itself)
-      maybe_palette_1.nb_colors = std::min(
-          static_cast<int>(xsize * ysize / 16),
-          static_cast<int>(cparams_.channel_colors_pre_transform_percent /
-                           100. * colors));
-      if (maybe_do_transform(gi, maybe_palette_1, cparams_, weighted::Header(),
-                             pool)) {
-        // effective bit depth is lower, adjust quantization accordingly
-        compute_minmax(gi.channel[gi.nb_meta_channels + i], &min, &max);
-        if (max < maxval) maxval = max;
-        int ch_bitdepth =
-            (max > 0 ? CeilLog2Nonzero(static_cast<uint32_t>(max)) : 0);
-        if (ch_bitdepth > max_bitdepth) max_bitdepth = ch_bitdepth;
-      } else
-        max_bitdepth = orig_bitdepth;
-    }
+    channel_colors_percent = cparams_.channel_colors_pre_transform_percent;
+  }
+  if (!groupwise) {
+    try_palettes(gi, max_bitdepth, maxval, cparams_, channel_colors_percent,
+                 pool);
   }
 
   // don't do an RCT if we're short on bits
@@ -1319,61 +1352,17 @@ Status ModularFrameEncoder::PrepareStreamParams(const Rect& rect,
     if (gi.channel.empty()) return true;
     // Do some per-group transforms
 
-    // Local palette
+    // Local palette transforms
     // TODO(veluca): make this work with quantize-after-prediction in lossy
     // mode.
-    if (cparams_.butteraugli_distance == 0.f && cparams_.palette_colors != 0 &&
+    if (cparams_.butteraugli_distance == 0.f && !cparams_.lossy_palette &&
         cparams_.speed_tier < SpeedTier::kCheetah) {
-      // all-channel palette (e.g. RGBA)
-      if (gi.channel.size() - gi.nb_meta_channels > 1) {
-        Transform maybe_palette(TransformId::kPalette);
-        maybe_palette.begin_c = gi.nb_meta_channels;
-        maybe_palette.num_c = gi.channel.size() - gi.nb_meta_channels;
-        maybe_palette.nb_colors = std::abs(cparams_.palette_colors);
-        maybe_palette.ordered_palette = cparams_.palette_colors >= 0;
-        maybe_do_transform(gi, maybe_palette, cparams_, weighted::Header());
+      int max_bitdepth = 0, maxval = 0;  // don't care about that here
+      float channel_color_percent = 0;
+      if (!(cparams_.responsive && cparams_.decoding_speed_tier >= 1)) {
+        channel_color_percent = cparams_.channel_colors_percent;
       }
-      // all-minus-one-channel palette (RGB with separate alpha, or CMY with
-      // separate K)
-      if (gi.channel.size() - gi.nb_meta_channels > 3) {
-        Transform maybe_palette_3(TransformId::kPalette);
-        maybe_palette_3.begin_c = gi.nb_meta_channels;
-        maybe_palette_3.num_c = gi.channel.size() - gi.nb_meta_channels - 1;
-        maybe_palette_3.nb_colors = std::abs(cparams_.palette_colors);
-        maybe_palette_3.ordered_palette = cparams_.palette_colors >= 0;
-        maybe_palette_3.lossy_palette = cparams_.lossy_palette;
-        if (maybe_palette_3.lossy_palette) {
-          maybe_palette_3.predictor = Predictor::Weighted;
-        }
-        maybe_do_transform(gi, maybe_palette_3, cparams_, weighted::Header());
-      }
-    }
-
-    // Local channel palette
-    if (cparams_.channel_colors_percent > 0 &&
-        cparams_.butteraugli_distance == 0.f && !cparams_.lossy_palette &&
-        cparams_.speed_tier < SpeedTier::kCheetah &&
-        !(cparams_.responsive && cparams_.decoding_speed_tier >= 1)) {
-      // single channel palette (like FLIF's ChannelCompact)
-      size_t nb_channels = gi.channel.size() - gi.nb_meta_channels;
-      for (size_t i = 0; i < nb_channels; i++) {
-        int32_t min;
-        int32_t max;
-        compute_minmax(gi.channel[gi.nb_meta_channels + i], &min, &max);
-        int64_t colors = static_cast<int64_t>(max) - min + 1;
-        JXL_DEBUG_V(10, "Channel %" PRIuS ": range=%i..%i", i, min, max);
-        Transform maybe_palette_1(TransformId::kPalette);
-        maybe_palette_1.begin_c = i + gi.nb_meta_channels;
-        maybe_palette_1.num_c = 1;
-        // simple heuristic: if less than X percent of the values in the range
-        // actually occur, it is probably worth it to do a compaction
-        // (but only if the channel palette is less than 80% the size of the
-        // image itself)
-        maybe_palette_1.nb_colors = std::min(
-            static_cast<int>(xsize * ysize * 0.8),
-            static_cast<int>(cparams_.channel_colors_percent / 100. * colors));
-        maybe_do_transform(gi, maybe_palette_1, cparams_, weighted::Header());
-      }
+      try_palettes(gi, max_bitdepth, maxval, cparams_, channel_color_percent);
     }
   }
 

--- a/lib/jxl/enc_modular.h
+++ b/lib/jxl/enc_modular.h
@@ -107,7 +107,6 @@ class ModularFrameEncoder {
   std::vector<size_t> tree_splits_;
   std::vector<std::vector<uint32_t>> gi_channel_;
   std::vector<size_t> image_widths_;
-  Predictor delta_pred_ = Predictor::Average4;
 
   struct GroupParams {
     Rect rect;

--- a/lib/jxl/encode_test.cc
+++ b/lib/jxl/encode_test.cc
@@ -451,7 +451,7 @@ TEST(EncodeTest, FrameSettingsTest) {
         JxlEncoderFrameSettingsCreate(enc.get(), nullptr);
     EXPECT_EQ(JXL_ENC_SUCCESS,
               JxlEncoderSetFrameLossless(frame_settings, JXL_TRUE));
-    VerifyFrameEncoding(63, 129, enc.get(), frame_settings, 3000, false);
+    VerifyFrameEncoding(63, 129, enc.get(), frame_settings, 3600, false);
     EXPECT_EQ(true, enc->last_used_cparams.IsLossless());
   }
 

--- a/lib/jxl/modular/transform/enc_palette.cc
+++ b/lib/jxl/modular/transform/enc_palette.cc
@@ -170,6 +170,7 @@ Status FwdPaletteIteration(Image &input, uint32_t begin_c, uint32_t end_c,
 
   size_t w = input.channel[begin_c].w;
   size_t h = input.channel[begin_c].h;
+  if (!lossy && nb_colors < 2) return false;
 
   if (!lossy && nb == 1) {
     // Channel palette special case
@@ -320,6 +321,20 @@ Status FwdPaletteIteration(Image &input, uint32_t begin_c, uint32_t end_c,
     }
   }
 
+  std::map<std::vector<pixel_type>, bool> implicit_color;
+  std::vector<std::vector<pixel_type>> implicit_colors;
+  implicit_colors.reserve(palette_internal::kImplicitPaletteSize);
+  for (size_t k = 0; k < palette_internal::kImplicitPaletteSize; k++) {
+    for (size_t i = 0; i < nb; i++) {
+      color[i] = palette_internal::GetPaletteValue(nullptr, k, i, 0, 0,
+                                                   input.bitdepth);
+    }
+    implicit_color[color] = true;
+    implicit_colors.push_back(color);
+  }
+
+  std::map<std::vector<pixel_type>, size_t> color_freq_map;
+  uint32_t implicit_colors_used = 0;
   for (size_t y = 0; y < h; y++) {
     for (uint32_t c = 0; c < nb; c++) {
       p_in[c] = input.channel[begin_c + c].Row(y);
@@ -331,15 +346,39 @@ Status FwdPaletteIteration(Image &input, uint32_t begin_c, uint32_t end_c,
       }
       const bool new_color = candidate_palette.insert(color).second;
       if (new_color) {
-        candidate_palette_imageorder.push_back(color);
+        if (implicit_color[color]) {
+          implicit_colors_used++;
+        } else {
+          candidate_palette_imageorder.push_back(color);
+          if (candidate_palette_imageorder.size() > nb_colors) {
+            return false;  // too many colors
+          }
+        }
       }
-      if (candidate_palette.size() > nb_colors) {
-        return false;  // too many colors
-      }
+      color_freq_map[color] += 1;
     }
   }
 
-  nb_colors = nb_deltas + candidate_palette.size();
+  nb_colors = nb_deltas + candidate_palette_imageorder.size();
+
+  // not useful to make a single-color palette
+  if (!lossy && nb_colors + implicit_colors_used == 1) return false;
+  // TODO(jon): if this happens (e.g. solid white group), special-case it for
+  // faster encode
+
+  for (size_t k = 0; k < palette_internal::kImplicitPaletteSize; k++) {
+    color = implicit_colors[k];
+    // still add the color to the explicit palette if it is frequent enough
+    if (color_freq_map[color] > 10) {
+      nb_colors++;
+      candidate_palette_imageorder.push_back(color);
+    }
+  }
+  for (size_t k = 0; k < palette_internal::kImplicitPaletteSize; k++) {
+    color = implicit_colors[k];
+    inv_palette[color] = nb_colors + k;
+  }
+
   JXL_DEBUG_V(6, "Channels %i-%i can be represented using a %i-color palette.",
               begin_c, end_c, nb_colors);
 
@@ -359,25 +398,33 @@ Status FwdPaletteIteration(Image &input, uint32_t begin_c, uint32_t end_c,
       }
     }
   }
-
+  // Separate the palette in two buckets, first the common colors, then the
+  // rare colors.
+  // Within each bucket, the colors are sorted on luma (times alpha).
+  float freq_threshold = 4;  // arbitrary threshold
   int x = 0;
   if (ordered && nb >= 3) {
     JXL_DEBUG_V(7, "Palette of %i colors, using luma order", nb_colors);
     // sort on luma (multiplied by alpha if available)
     std::sort(candidate_palette_imageorder.begin(),
               candidate_palette_imageorder.end(),
-              [](std::vector<pixel_type> ap, std::vector<pixel_type> bp) {
+              [&](std::vector<pixel_type> ap, std::vector<pixel_type> bp) {
                 float ay;
                 float by;
                 ay = (0.299f * ap[0] + 0.587f * ap[1] + 0.114f * ap[2] + 0.1f);
                 if (ap.size() > 3) ay *= 1.f + ap[3];
                 by = (0.299f * bp[0] + 0.587f * bp[1] + 0.114f * bp[2] + 0.1f);
                 if (bp.size() > 3) by *= 1.f + bp[3];
+                // put common colors first, transparent dark to opaque bright,
+                // then rare colors, bright to dark
+                ay = color_freq_map[ap] > freq_threshold ? -ay : ay;
+                by = color_freq_map[bp] > freq_threshold ? -by : by;
                 return ay < by;
               });
   } else {
     JXL_DEBUG_V(7, "Palette of %i colors, using image order", nb_colors);
   }
+
   for (auto pcol : candidate_palette_imageorder) {
     JXL_DEBUG_V(9, "  Color %i :  ", x);
     for (size_t i = 0; i < nb; i++) {

--- a/lib/jxl/modular/transform/palette.h
+++ b/lib/jxl/modular/transform/palette.h
@@ -30,6 +30,8 @@ static constexpr int kSmallCube = 4;
 static constexpr int kSmallCubeBits = 2;
 // kSmallCube ** 3
 static constexpr int kLargeCubeOffset = kSmallCube * kSmallCube * kSmallCube;
+static constexpr int kImplicitPaletteSize =
+    kLargeCubeOffset + kLargeCube * kLargeCube * kLargeCube;
 
 static inline pixel_type Scale(uint64_t value, uint64_t bit_depth,
                                uint64_t denom) {

--- a/lib/jxl/modular_test.cc
+++ b/lib/jxl/modular_test.cc
@@ -144,6 +144,7 @@ TEST(ModularTest, RoundtripLossyDeltaPaletteWP) {
   cparams.SetLossless();
   cparams.lossy_palette = true;
   cparams.palette_colors = 0;
+  // TODO(jon): this is currently ignored, and Avg4 is always used instead
   cparams.options.predictor = jxl::Predictor::Weighted;
 
   CodecInOut io_out;
@@ -154,12 +155,12 @@ TEST(ModularTest, RoundtripLossyDeltaPaletteWP) {
 
   size_t compressed_size;
   JXL_EXPECT_OK(Roundtrip(&io, cparams, {}, &io_out, _, &compressed_size));
-  EXPECT_LE(compressed_size, 7000u);
+  EXPECT_LE(compressed_size, 6500u);
   EXPECT_SLIGHTLY_BELOW(
       ButteraugliDistance(io.frames, io_out.frames, ButteraugliParams(),
                           *JxlGetDefaultCms(),
                           /*distmap=*/nullptr),
-      10.1);
+      1.5);
 }
 
 TEST(ModularTest, RoundtripLossy) {


### PR DESCRIPTION
Some tweaks to the modular palette heuristics:

- Refactored some code (there was some near-duplicate code between global and group encoding)
- Change the max_colors heuristic to make it less likely to use palette when the image/group has low entropy already anyway (e.g. the group is only a smooth gradient, which has few enough colors for doing a palette but also palette doesn't help)
- Actually use the implicit palette if these colors happen to occur in the image (but still make them explicit if they are frequent)
- Tweak the palette ordering: still luma sorted, but first the 'common' colors and then the 'rare' colors
- Don't do palette if the whole group is just a single color (it's slightly cheaper not to)

# Results

## QOI test set

Before:
benchmark_xl v0.10.0 453f1127 [NEON]
12 total threads, 17088 tasks, 6 threads, 2 inner threads
```
Encoding      kPixels    Bytes          BPP  E MP/s  D MP/s     Max norm  SSIMULACRA2   PSNR        pnorm       BPP*pnorm   QABPP   Bugs
----------------------------------------------------------------------------------------------------------------------------------------
jxl:d0:4      1321975 813352177    4.9220412   3.663  18.466          nan 100.00000000  99.99   0.00000000  0.000000000000   4.922      0
jxl:d0:5      1321975 786705494    4.7607875   2.556  18.754          nan 100.00000000  99.22   0.00000000  0.000000000000   4.761      0
jxl:d0:6      1321975 774050078    4.6842026   1.801  17.320          nan 100.00000000  99.99   0.00000000  0.000000000000   4.684      0
jxl:d0:7      1321975 747782641    4.5252439   1.236  16.101          nan 100.00000000  99.24   0.00000000  0.000000000000   4.525      0
jxl:d0:8      1321975 732645434    4.4336403   0.403  15.206          nan 100.00000000  99.19   0.00000000  0.000000000000   4.434      0
jxl:d0:9      1321975 724420391    4.3838661   0.212  14.877          nan 100.00000000  99.09   0.00000000  0.000000000000   4.384      0
Aggregate:    1321975 762523609    4.6144496   1.101  16.720   0.00000000 100.00000000  99.45   0.00000000  0.000000000000   4.614      0
```

After:
benchmark_xl v0.10.0 8c7f3833 [NEON]
12 total threads, 17088 tasks, 6 threads, 2 inner threads
```
Encoding      kPixels    Bytes          BPP  E MP/s  D MP/s     Max norm  SSIMULACRA2   PSNR        pnorm       BPP*pnorm   QABPP   Bugs
----------------------------------------------------------------------------------------------------------------------------------------
jxl:d0:4      1321975 813579664    4.9234178   3.674  18.429          nan 100.00000000  99.99   0.00000000  0.000000000000   4.923      0
jxl:d0:5      1321975 785292105    4.7522343   2.437  17.808          nan 100.00000000  99.14   0.00000000  0.000000000000   4.752      0
jxl:d0:6      1321975 772569948    4.6752455   1.743  16.399          nan 100.00000000  99.21   0.00000000  0.000000000000   4.675      0
jxl:d0:7      1321975 745875196    4.5137009   1.169  15.259          nan 100.00000000  99.21   0.00000000  0.000000000000   4.514      0
jxl:d0:8      1321975 731995894    4.4297096   0.405  14.482          nan 100.00000000  99.47   0.00000000  0.000000000000   4.430      0
jxl:d0:9      1321975 723616280    4.3789999   0.207  14.115          nan 100.00000000  99.15   0.00000000  0.000000000000   4.379      0
Aggregate:    1321975 761509591    4.6083132   1.073  16.001   0.00000000 100.00000000  99.36   0.00000000  0.000000000000   4.608      0
```

Overall a 0.25% compression improvement at default effort.

Most of the bytes in the full QOI testset go to photographic images where nothing or not much changes; for non-photographic images (especially small ones) the improvement can be larger.

For example, for the specific subset `icon64` (a set of 64x64 rendered vector icons), the improvement is quite significant:

### icon64
Before:
benchmark_xl v0.10.0 453f1127 [NEON]
12 total threads, 1278 tasks, 12 threads, 0 inner threads
```
Encoding      kPixels    Bytes          BPP  E MP/s  D MP/s     Max norm  SSIMULACRA2   PSNR        pnorm       BPP*pnorm   QABPP   Bugs
----------------------------------------------------------------------------------------------------------------------------------------
jxl:d0:4          872   708994    6.5011920   1.366   7.894          nan 100.00000000  99.99   0.00000000  0.000000000000   6.501      0
jxl:d0:5          872   681801    6.2518431   0.984   7.347          nan 100.00000000  99.99   0.00000000  0.000000000000   6.252      0
jxl:d0:6          872   660630    6.0577135   0.779   6.804          nan 100.00000000  99.99   0.00000000  0.000000000000   6.058      0
jxl:d0:7          872   653946    5.9964239   0.590   7.291          nan 100.00000000  99.99   0.00000000  0.000000000000   5.996      0
jxl:d0:8          872   610334    5.5965192   0.248   6.321          nan 100.00000000  99.99   0.00000000  0.000000000000   5.597      0
jxl:d0:9          872   649023    5.9512819   0.126   6.126          nan 100.00000000  99.99   0.00000000  0.000000000000   5.951      0
Aggregate:        872   660092    6.0527830   0.518   6.937   0.00000000 100.00000000  99.99   0.00000000  0.000000000000   6.053      0
```

After:
benchmark_xl v0.10.0 8c7f3833 [NEON]
12 total threads, 1278 tasks, 12 threads, 0 inner threads
```
Encoding      kPixels    Bytes          BPP  E MP/s  D MP/s     Max norm  SSIMULACRA2   PSNR        pnorm       BPP*pnorm   QABPP   Bugs
----------------------------------------------------------------------------------------------------------------------------------------
jxl:d0:4          872   652203    5.9804412   1.181   5.094          nan 100.00000000  99.99   0.00000000  0.000000000000   5.980      0
jxl:d0:5          872   607202    5.5678000   0.799   4.991          nan 100.00000000  99.99   0.00000000  0.000000000000   5.568      0
jxl:d0:6          872   598654    5.4894183   0.701   5.025          nan 100.00000000  99.99   0.00000000  0.000000000000   5.489      0
jxl:d0:7          872   591846    5.4269916   0.524   4.684          nan 100.00000000  99.99   0.00000000  0.000000000000   5.427      0
jxl:d0:8          872   566868    5.1979533   0.229   4.745          nan 100.00000000  99.99   0.00000000  0.000000000000   5.198      0
jxl:d0:9          872   555405    5.0928422   0.119   4.747          nan 100.00000000  99.99   0.00000000  0.000000000000   5.093      0
Aggregate:        872   594564    5.4519160   0.460   4.878   0.00000000 100.00000000  99.99   0.00000000  0.000000000000   5.452      0
```

(9.5% compression improvement at default effort for these icons)


## Set of large manga images

Before:
benchmark_xl v0.10.0 453f1127 [NEON]
12 total threads, 246 tasks, 0 threads, 8 inner threads
```
Encoding      kPixels    Bytes          BPP  E MP/s  D MP/s     Max norm  SSIMULACRA2   PSNR        pnorm       BPP*pnorm   QABPP   Bugs
----------------------------------------------------------------------------------------------------------------------------------------
jxl:d0:4       299731 166674831    4.4486396  16.941  90.134          nan 100.00000000  99.99   0.00000000  0.000000000000   4.449      0
jxl:d0:5       299731 159307724    4.2520076  12.261  90.202          nan 100.00000000  99.99   0.00000000  0.000000000000   4.252      0
jxl:d0:6       299731 156628791    4.1805055   8.369  81.711          nan 100.00000000  99.99   0.00000000  0.000000000000   4.181      0
jxl:d0:7       299731 151337716    4.0392839   5.807  76.123          nan 100.00000000  99.99   0.00000000  0.000000000000   4.039      0
jxl:d0:8       299731 148798488    3.9715105   2.095  72.507          nan 100.00000000  99.99   0.00000000  0.000000000000   3.972      0
jxl:d0:9       299731 147334255    3.9324294   1.075  70.774          nan 100.00000000  99.99   0.00000000  0.000000000000   3.932      0
Aggregate:     299731 154871432    4.1336006   5.323  79.865   0.00000000 100.00000000  99.99   0.00000000  0.000000000000   4.134      0
```

After:
benchmark_xl v0.10.0 8c7f3833 [NEON]
12 total threads, 246 tasks, 0 threads, 8 inner threads
```
Encoding      kPixels    Bytes          BPP  E MP/s  D MP/s     Max norm  SSIMULACRA2   PSNR        pnorm       BPP*pnorm   QABPP   Bugs
----------------------------------------------------------------------------------------------------------------------------------------
jxl:d0:4       299731 166674831    4.4486396  17.012  88.900          nan 100.00000000  99.99   0.00000000  0.000000000000   4.449      0
jxl:d0:5       299731 157296296    4.1983215  11.776  85.809          nan 100.00000000  99.99   0.00000000  0.000000000000   4.198      0
jxl:d0:6       299731 154674529    4.1283452   8.202  78.467          nan 100.00000000  99.99   0.00000000  0.000000000000   4.128      0
jxl:d0:7       299731 149960989    4.0025383   5.604  73.752          nan 100.00000000  99.99   0.00000000  0.000000000000   4.003      0
jxl:d0:8       299731 147630150    3.9403270   2.065  70.100          nan 100.00000000  99.99   0.00000000  0.000000000000   3.940      0
jxl:d0:9       299731 145998497    3.8967773   1.045  67.579          nan 100.00000000  99.99   0.00000000  0.000000000000   3.897      0
Aggregate:     299731 153550597    4.0983468   5.204  77.044   0.00000000 100.00000000  99.99   0.00000000  0.000000000000   4.098      0
```

About 1% smaller at default effort.