### PR TITLE
Corrected the checkout instruction in developing_in_github.md.

### DIFF
--- a/doc/developing_in_github.md
+++ b/doc/developing_in_github.md
@@ -93,7 +93,7 @@ fork. You can use any other name for your fork if you want. Use the following
 commands to set things up, replacing `{{USERNAME}}` with your GitHub username:
 
 ```bash
-git clone git https://github.com/libjxl/libjxl --recursive
+git clone https://github.com/libjxl/libjxl --recursive
 cd libjxl
 git remote set-url --push origin git@github.com:{{USERNAME}}/libjxl.git
 git remote add myfork git@github.com:{{USERNAME}}/libjxl.git


### PR DESCRIPTION
At least for me, "git clone git https://github.com/libjxl/libjxl --recursive" causes an error "fatal: repository git does not exist".

I believe the extra "git" is a typo.