### PR TITLE
add shorthand colorspace descriptions

### DIFF
--- a/lib/extras/dec/color_description.cc
+++ b/lib/extras/dec/color_description.cc
@@ -203,12 +203,38 @@ Status ParseTransferFunction(Tokenizer* tokenizer, JxlColorEncoding* c) {
 
 Status ParseDescription(const std::string& description, JxlColorEncoding* c) {
   *c = {};
-  Tokenizer tokenizer(&description, '_');
-  JXL_RETURN_IF_ERROR(ParseColorSpace(&tokenizer, c));
-  JXL_RETURN_IF_ERROR(ParseWhitePoint(&tokenizer, c));
-  JXL_RETURN_IF_ERROR(ParsePrimaries(&tokenizer, c));
-  JXL_RETURN_IF_ERROR(ParseRenderingIntent(&tokenizer, c));
-  JXL_RETURN_IF_ERROR(ParseTransferFunction(&tokenizer, c));
+  if (description == "sRGB") {
+    c->color_space = JXL_COLOR_SPACE_RGB;
+    c->white_point = JXL_WHITE_POINT_D65;
+    c->primaries = JXL_PRIMARIES_SRGB;
+    c->transfer_function = JXL_TRANSFER_FUNCTION_SRGB;
+    c->rendering_intent = JXL_RENDERING_INTENT_PERCEPTUAL;
+  } else if (description == "DisplayP3") {
+    c->color_space = JXL_COLOR_SPACE_RGB;
+    c->white_point = JXL_WHITE_POINT_D65;
+    c->primaries = JXL_PRIMARIES_P3;
+    c->transfer_function = JXL_TRANSFER_FUNCTION_SRGB;
+    c->rendering_intent = JXL_RENDERING_INTENT_PERCEPTUAL;
+  } else if (description == "Rec2100PQ") {
+    c->color_space = JXL_COLOR_SPACE_RGB;
+    c->white_point = JXL_WHITE_POINT_D65;
+    c->primaries = JXL_PRIMARIES_2100;
+    c->transfer_function = JXL_TRANSFER_FUNCTION_PQ;
+    c->rendering_intent = JXL_RENDERING_INTENT_RELATIVE;
+  } else if (description == "Rec2100HLG") {
+    c->color_space = JXL_COLOR_SPACE_RGB;
+    c->white_point = JXL_WHITE_POINT_D65;
+    c->primaries = JXL_PRIMARIES_2100;
+    c->transfer_function = JXL_TRANSFER_FUNCTION_HLG;
+    c->rendering_intent = JXL_RENDERING_INTENT_RELATIVE;
+  } else {
+    Tokenizer tokenizer(&description, '_');
+    JXL_RETURN_IF_ERROR(ParseColorSpace(&tokenizer, c));
+    JXL_RETURN_IF_ERROR(ParseWhitePoint(&tokenizer, c));
+    JXL_RETURN_IF_ERROR(ParsePrimaries(&tokenizer, c));
+    JXL_RETURN_IF_ERROR(ParseRenderingIntent(&tokenizer, c));
+    JXL_RETURN_IF_ERROR(ParseTransferFunction(&tokenizer, c));
+  }
   return true;
 }
 

--- a/lib/extras/jpegli_test.cc
+++ b/lib/extras/jpegli_test.cc
@@ -255,7 +255,7 @@ TEST(JpegliTest, JpegliHDRRoundtripTest) {
   std::string testimage = "jxl/hdr_room.png";
   PackedPixelFile ppf_in;
   ASSERT_TRUE(ReadTestImage(testimage, &ppf_in));
-  EXPECT_EQ("RGB_D65_202_Rel_HLG", Description(ppf_in.color_encoding));
+  EXPECT_EQ("Rec2100HLG", Description(ppf_in.color_encoding));
   EXPECT_EQ(16, ppf_in.info.bits_per_sample);
 
   std::vector<uint8_t> compressed;

--- a/lib/jxl/cms/jxl_cms_internal.h
+++ b/lib/jxl/cms/jxl_cms_internal.h
@@ -849,6 +849,20 @@ static std::string ToString(JxlRenderingIntent rendering_intent) {
 }
 
 static std::string ColorEncodingDescriptionImpl(const JxlColorEncoding& c) {
+  if (c.color_space == JXL_COLOR_SPACE_RGB &&
+      c.white_point == JXL_WHITE_POINT_D65) {
+    if (c.rendering_intent == JXL_RENDERING_INTENT_PERCEPTUAL &&
+        c.transfer_function == JXL_TRANSFER_FUNCTION_SRGB) {
+      if (c.primaries == JXL_PRIMARIES_SRGB) return "sRGB";
+      if (c.primaries == JXL_PRIMARIES_P3) return "DisplayP3";
+    }
+    if (c.rendering_intent == JXL_RENDERING_INTENT_RELATIVE &&
+        c.primaries == JXL_PRIMARIES_2100) {
+      if (c.transfer_function == JXL_TRANSFER_FUNCTION_PQ) return "Rec2100PQ";
+      if (c.transfer_function == JXL_TRANSFER_FUNCTION_HLG) return "Rec2100HLG";
+    }
+  }
+
   std::string d = ToString(c.color_space);
 
   bool explicit_wp_tf = (c.color_space != JXL_COLOR_SPACE_XYB);

--- a/tools/cjxl_main.cc
+++ b/tools/cjxl_main.cc
@@ -229,6 +229,7 @@ struct CompressArgs {
         "rendering intent\n"
         "      -x color_space=RGB_D65_202_Rel_PeQ is Rec.2100 PQ with relative "
         "rendering intent\n"
+        "    Shorthands: sRGB, DisplayP3, Rec2100PQ, Rec2100HLG\n"
         "    The key 'icc_pathname' refers to a binary file containing an ICC "
         "profile.\n"
         "    The keys 'exif', 'xmp', and 'jumbf' refer to a binary file "


### PR DESCRIPTION
Adds a few special values for the colorspace description strings: `sRGB`, `DisplayP3`, `Rec2100PQ`, and `Rec2100HLG`. These are probably the most commonly used and relevant color spaces right now and in the foreseeable future.

This makes it somewhat more convenient to manually specify these colorspaces when e.g. using `cjxl` on a ppm or pfm input, that is, you can now also do `-x color_space=sRGB` instead of having to do `-x color_space=RGB_D65_SRG_Per_SRG` which I find hard to remember.

It also has the effect of making the description string a little shorter (and arguably easier to understand) in the corresponding synthesized ICC profiles.