### PR TITLE
add tool to simplify ICC profiles

### DIFF
--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -188,6 +188,7 @@ if(JPEGXL_ENABLE_DEVTOOLS)
     ssimulacra2
     xyb_range
     jxl_from_tree
+    icc_simplify
   )
 
   add_executable(ssimulacra_main ssimulacra_main.cc ssimulacra.cc)
@@ -208,6 +209,7 @@ if(JPEGXL_ENABLE_DEVTOOLS)
   add_executable(generate_lut_template hdr/generate_lut_template.cc)
   add_executable(xyb_range xyb_range.cc)
   add_executable(jxl_from_tree jxl_from_tree.cc)
+  add_executable(icc_simplify icc_simplify.cc)
 
   list(APPEND FUZZER_CORPUS_BINARIES djxl_fuzzer_corpus)
   add_executable(djxl_fuzzer_corpus djxl_fuzzer_corpus.cc)

--- a/tools/icc_simplify.cc
+++ b/tools/icc_simplify.cc
@@ -1,0 +1,80 @@
+// Copyright (c) the JPEG XL Project Authors. All rights reserved.
+//
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+#include <stdio.h>
+#include <stdlib.h>
+
+#include "lib/extras/codec.h"
+#include "lib/extras/dec/color_description.h"
+#include "lib/jxl/codec_in_out.h"
+#include "tools/args.h"
+#include "tools/cmdline.h"
+#include "tools/file_io.h"
+#include "tools/hdr/image_utils.h"
+#include "tools/thread_pool_internal.h"
+
+int main(int argc, const char** argv) {
+  jpegxl::tools::ThreadPoolInternal pool;
+
+  jpegxl::tools::CommandLineParser parser;
+  const char* input_filename = nullptr;
+  auto input_filename_option = parser.AddPositionalOption(
+      "INPUT", true,
+      "input ICC profile, image file containing ICC profile or tags, or "
+      "description string\n"
+      "    Description string syntax: "
+      "ColorModel_WhitePoint_Primaries_RenderingIntent_TransferFunction\n"
+      "              {RGB,Gra,XYB}_{D65,EER,DCI}_{SRG,202,DCI}_"
+      "{Per,Rel,Sat,Abs}_{SRG,Lin,709,PeQ,HLG}\n",
+      &input_filename, 0);
+  const char* output_filename = nullptr;
+  auto output_filename_option = parser.AddPositionalOption(
+      "OUTPUT.icc", true, "output ICC profile filename", &output_filename, 0);
+
+  if (!parser.Parse(argc, argv)) {
+    fprintf(stderr, "See -h for help.\n");
+    return EXIT_FAILURE;
+  }
+
+  if (parser.HelpFlagPassed()) {
+    parser.PrintHelp();
+    return EXIT_SUCCESS;
+  }
+
+  if (!parser.GetOption(input_filename_option)->matched()) {
+    fprintf(stderr, "Missing input filename/string.\nSee -h for help.\n");
+    return EXIT_FAILURE;
+  }
+  if (!parser.GetOption(output_filename_option)->matched()) {
+    fprintf(stderr, "Missing output filename.\nSee -h for help.\n");
+    return EXIT_FAILURE;
+  }
+
+  jxl::CodecInOut io;
+  std::vector<uint8_t> encoded;
+  JxlColorEncoding c_descr;
+  if (jpegxl::tools::ReadFile(input_filename, &encoded)) {
+    bool icc_signature = true;
+    if (encoded.size() < 128) {
+      icc_signature = false;
+    } else {
+      if (encoded[36] != 'a') icc_signature = false;
+      if (encoded[37] != 'c') icc_signature = false;
+      if (encoded[38] != 's') icc_signature = false;
+      if (encoded[39] != 'p') icc_signature = false;
+    }
+
+    if (!icc_signature || !io.metadata.m.color_encoding.SetICC(
+                              std::move(encoded), JxlGetDefaultCms())) {
+      JXL_CHECK(jxl::SetFromBytes(jxl::Bytes(encoded), {}, &io, pool.get()));
+    }
+  } else if (jxl::ParseDescription(input_filename, &c_descr)) {
+    JXL_CHECK(io.metadata.m.color_encoding.FromExternal(c_descr));
+  }
+
+  jxl::ColorEncoding c_out = io.metadata.m.color_encoding;
+  JXL_CHECK(c_out.CreateICC());
+  JXL_CHECK(jpegxl::tools::WriteFile(output_filename, c_out.ICC()));
+}


### PR DESCRIPTION
Adds a new tool called `icc_simplify` that can be used to simplify/rewrite/fix/normalize ICC profiles. It uses the libjxl encoder-side logic to interpret an input ICC profile and the decoder-side logic to synthesize an output ICC profile. For ICC profiles found in the wild, the effect is generally that the output profile is smaller than the input profile, sometimes substantially, since things like description strings in various languages or redundant transfer function tables will get stripped.

The tool also allows synthesizing profiles from a colorspace description string, as well as from an input image that might contain an ICC profile or some other way to signal the colorspace — in particular, PNG has various other ways to signal the colorspace.