### PR TITLE
jpegli: force samp factors to 1x1 for single-component images

### DIFF
--- a/lib/jpegli/encode.cc
+++ b/lib/jpegli/encode.cc
@@ -283,14 +283,14 @@ void ProcessCompressionParams(j_compress_ptr cinfo) {
       JPEGLI_ERROR("Invalid sampling factor %d x %d", comp->h_samp_factor,
                    comp->v_samp_factor);
     }
+    if (cinfo->num_components == 1) {
+      // Force samp factors to 1x1 for single-component images.
+      comp->h_samp_factor = comp->v_samp_factor = 1;
+    }
     cinfo->max_h_samp_factor =
         std::max(comp->h_samp_factor, cinfo->max_h_samp_factor);
     cinfo->max_v_samp_factor =
         std::max(comp->v_samp_factor, cinfo->max_v_samp_factor);
-  }
-  if (cinfo->num_components == 1 &&
-      (cinfo->max_h_samp_factor != 1 || cinfo->max_v_samp_factor != 1)) {
-    JPEGLI_ERROR("Sampling is not supported for simgle component image.");
   }
   size_t iMCU_width = DCTSIZE * cinfo->max_h_samp_factor;
   size_t iMCU_height = DCTSIZE * cinfo->max_v_samp_factor;


### PR DESCRIPTION
### Description

In accordance with IJG JPEG, see:
https://github.com/libjpeg-turbo/ijg/blob/jpeg-9e/transupp.c#L1879-L1880
https://github.com/libjpeg-turbo/ijg/blob/jpeg-9e/transupp.c#L2145-L2150

Helps: https://github.com/libvips/libvips/pull/3924.

### Pull Request Checklist

- [x] **CLA Signed**: Have you signed the [Contributor License Agreement](https://code.google.com/legal/individual-cla-v1.0.html) (individual or corporate, as appropriate)? Only contributions from signed contributors can be accepted.
- [x] **Authors**: Have you considered adding your name to the [AUTHORS](AUTHORS) file?
- [x] **Code Style**: Have you ensured your code adheres to the project's coding style guidelines? You can use `./ci.sh lint` for automatic code formatting.