### PR TITLE
Return error in case of truncated streams for jpeg reconstruction.

### DIFF
--- a/lib/extras/dec/jxl.cc
+++ b/lib/extras/dec/jxl.cc
@@ -211,7 +211,7 @@ bool DecodeImageJXL(const uint8_t* bytes, size_t bytes_size,
     return false;
   }
   uint32_t progression_index = 0;
-  bool codestream_done = accepted_formats.empty();
+  bool codestream_done = jpeg_bytes == nullptr && accepted_formats.empty();
   BoxProcessor boxes(dec);
   for (;;) {
     JxlDecoderStatus status = JxlDecoderProcessInput(dec);

--- a/lib/jxl/jxl_test.cc
+++ b/lib/jxl/jxl_test.cc
@@ -1316,8 +1316,13 @@ size_t RoundtripJpeg(const std::vector<uint8_t>& jpeg_in, ThreadPool* pool) {
                                      &compressed));
 
   jxl::JXLDecompressParams dparams;
-  test::DefaultAcceptedFormats(dparams);
   test::SetThreadParallelRunner(dparams, pool);
+  {
+    std::vector<uint8_t> out;
+    jxl::PackedPixelFile ppf;
+    EXPECT_FALSE(DecodeImageJXL(compressed.data(), compressed.size() - 1,
+                                dparams, nullptr, &ppf, &out));
+  }
   std::vector<uint8_t> out;
   jxl::PackedPixelFile ppf;
   EXPECT_TRUE(DecodeImageJXL(compressed.data(), compressed.size(), dparams,


### PR DESCRIPTION
If jpeg bytes were requested, we returned success even if the stream was truncated, without filling in the jpeg bytes. This can cause djxl to return successfully without writing any output file.
