### PR TITLE
Revert "Reject IDAT after fcTL"

### DIFF
--- a/lib/extras/dec/apng.cc
+++ b/lib/extras/dec/apng.cc
@@ -598,7 +598,6 @@ Status DecodeImageAPNG(const Span<const uint8_t> bytes,
   std::vector<std::vector<uint8_t>> chunksInfo;
   bool isAnimated = false;
   bool hasInfo = false;
-  bool seenFctl = false;
   APNGFrame frameRaw = {};
   uint32_t num_channels;
   JxlPixelFormat format = {};
@@ -670,7 +669,6 @@ Status DecodeImageAPNG(const Span<const uint8_t> bytes,
       while (!r.Eof()) {
         id = read_chunk(&r, &chunk);
         if (!id) break;
-        seenFctl |= (id == kId_fcTL);
 
         if (id == kId_acTL && !hasInfo && !isAnimated) {
           isAnimated = true;
@@ -734,10 +732,6 @@ Status DecodeImageAPNG(const Span<const uint8_t> bytes,
           }
         } else if (id == kId_IDAT) {
           // First IDAT chunk means we now have all header info
-          if (seenFctl) {
-            // `fcTL` chunk must appear after all `IDAT` chunks
-            return JXL_FAILURE("IDAT chunk after fcTL chunk");
-          }
           hasInfo = true;
           JXL_CHECK(w == png_get_image_width(png_ptr, info_ptr));
           JXL_CHECK(h == png_get_image_height(png_ptr, info_ptr));


### PR DESCRIPTION
Fixes #3430

Those files are valid:

https://wiki.mozilla.org/APNG_Specification#Chunk_Sequence_Numbers

> The `fcTL` chunk is an ancillary chunk as defined in the PNG Specification. It must appear before the `IDAT` or `fdAT` chunks of the frame to which it applies