### PR TITLE
add graphviz in documentation

### DIFF
--- a/doc/developing_in_debian.md
+++ b/doc/developing_in_debian.md
@@ -12,7 +12,8 @@ dependencies that need to be installed on your system first:
 
 ```bash
 sudo apt install cmake clang doxygen g++ extra-cmake-modules \
-  libgif-dev libjpeg-dev ninja-build libgoogle-perftools-dev
+  libgif-dev libjpeg-dev ninja-build libgoogle-perftools-dev \
+  graphviz
 ```
 
 Make sure your default `clang` compiler is at least version 6 by running


### PR DESCRIPTION
fixes
```
error: ignoring \dot command because HAVE_DOT is not set (warning treated as error, aborting now)
```
which happens when graphviz is not present