### PR TITLE
Support more color transforms in jpegli decoder.

### DIFF
--- a/lib/jpegli/color_transform.cc
+++ b/lib/jpegli/color_transform.cc
@@ -26,11 +26,16 @@ using hwy::HWY_NAMESPACE::Mul;
 using hwy::HWY_NAMESPACE::MulAdd;
 using hwy::HWY_NAMESPACE::Sub;
 
-void YCbCrToRGB(float* row[kMaxComponents], size_t xsize) {
+template <int kRed, int kGreen, int kBlue, int kAlpha>
+void YCbCrToExtRGB(float* row[kMaxComponents], size_t xsize) {
   const HWY_CAPPED(float, 8) df;
-  float* JXL_RESTRICT row0 = row[0];
-  float* JXL_RESTRICT row1 = row[1];
-  float* JXL_RESTRICT row2 = row[2];
+  const float* row_y = row[0];
+  const float* row_cb = row[1];
+  const float* row_cr = row[2];
+  float* row_r = row[kRed];
+  float* row_g = row[kGreen];
+  float* row_b = row[kBlue];
+  float* row_a = row[kAlpha];
 
   // Full-range BT.601 as defined by JFIF Clause 7:
   // https://www.itu.int/rec/T-REC-T.871-201105-I/en
@@ -38,18 +43,46 @@ void YCbCrToRGB(float* row[kMaxComponents], size_t xsize) {
   const auto cgcb = Set(df, -0.114f * 1.772f / 0.587f);
   const auto cgcr = Set(df, -0.299f * 1.402f / 0.587f);
   const auto cbcb = Set(df, 1.772f);
+  const auto alpha_opaque = Set(df, 127.0f / 255.0f);
 
   for (size_t x = 0; x < xsize; x += Lanes(df)) {
-    const auto y_vec = Load(df, row0 + x);
-    const auto cb_vec = Load(df, row1 + x);
-    const auto cr_vec = Load(df, row2 + x);
+    const auto y_vec = Load(df, row_y + x);
+    const auto cb_vec = Load(df, row_cb + x);
+    const auto cr_vec = Load(df, row_cr + x);
     const auto r_vec = MulAdd(crcr, cr_vec, y_vec);
     const auto g_vec = MulAdd(cgcr, cr_vec, MulAdd(cgcb, cb_vec, y_vec));
     const auto b_vec = MulAdd(cbcb, cb_vec, y_vec);
-    Store(r_vec, df, row0 + x);
-    Store(g_vec, df, row1 + x);
-    Store(b_vec, df, row2 + x);
+    Store(r_vec, df, row_r + x);
+    Store(g_vec, df, row_g + x);
+    Store(b_vec, df, row_b + x);
+    if (kAlpha >= 0) {
+      Store(alpha_opaque, df, row_a + x);
+    }
   }
+}
+
+void YCbCrToRGB(float* row[kMaxComponents], size_t xsize) {
+  YCbCrToExtRGB<0, 1, 2, -1>(row, xsize);
+}
+
+void YCbCrToBGR(float* row[kMaxComponents], size_t xsize) {
+  YCbCrToExtRGB<2, 1, 0, -1>(row, xsize);
+}
+
+void YCbCrToRGBA(float* row[kMaxComponents], size_t xsize) {
+  YCbCrToExtRGB<0, 1, 2, 3>(row, xsize);
+}
+
+void YCbCrToBGRA(float* row[kMaxComponents], size_t xsize) {
+  YCbCrToExtRGB<2, 1, 0, 3>(row, xsize);
+}
+
+void YCbCrToARGB(float* row[kMaxComponents], size_t xsize) {
+  YCbCrToExtRGB<1, 2, 3, 0>(row, xsize);
+}
+
+void YCbCrToABGR(float* row[kMaxComponents], size_t xsize) {
+  YCbCrToExtRGB<3, 2, 1, 0>(row, xsize);
 }
 
 void YCCKToCMYK(float* row[kMaxComponents], size_t xsize) {
@@ -127,6 +160,11 @@ namespace jpegli {
 HWY_EXPORT(CMYKToYCCK);
 HWY_EXPORT(YCCKToCMYK);
 HWY_EXPORT(YCbCrToRGB);
+HWY_EXPORT(YCbCrToBGR);
+HWY_EXPORT(YCbCrToRGBA);
+HWY_EXPORT(YCbCrToBGRA);
+HWY_EXPORT(YCbCrToARGB);
+HWY_EXPORT(YCbCrToABGR);
 HWY_EXPORT(RGBToYCbCr);
 
 bool CheckColorSpaceComponents(int num_components, J_COLOR_SPACE colorspace) {
@@ -164,14 +202,71 @@ bool CheckColorSpaceComponents(int num_components, J_COLOR_SPACE colorspace) {
 
 void NullTransform(float* row[kMaxComponents], size_t len) {}
 
+void FillAlpha(float* row, size_t len) {
+  static const float kAlpha = 127.0f / 255.0f;
+  for (size_t i = 0; i < len; ++i) {
+    row[i] = kAlpha;
+  }
+}
+
+// Works for BGR as well.
 void GrayscaleToRGB(float* row[kMaxComponents], size_t len) {
   memcpy(row[1], row[0], len * sizeof(row[1][0]));
   memcpy(row[2], row[0], len * sizeof(row[2][0]));
 }
 
+// Works for BGRA as well.
+void GrayscaleToRGBA(float* row[kMaxComponents], size_t len) {
+  memcpy(row[1], row[0], len * sizeof(row[1][0]));
+  memcpy(row[2], row[0], len * sizeof(row[2][0]));
+  FillAlpha(row[3], len);
+}
+
+// Works for ABGR as well.
+void GrayscaleToARGB(float* row[kMaxComponents], size_t len) {
+  memcpy(row[1], row[0], len * sizeof(row[1][0]));
+  memcpy(row[2], row[0], len * sizeof(row[2][0]));
+  memcpy(row[3], row[0], len * sizeof(row[1][0]));
+  FillAlpha(row[0], len);
+}
+
 void GrayscaleToYCbCr(float* row[kMaxComponents], size_t len) {
   memset(row[1], 0, len * sizeof(row[1][0]));
   memset(row[2], 0, len * sizeof(row[2][0]));
+}
+
+void RGBToBGR(float* row[kMaxComponents], size_t len) {
+  for (size_t i = 0; i < len; ++i) {
+    std::swap(row[0][i], row[2][i]);
+  }
+}
+
+void RGBToRGBA(float* row[kMaxComponents], size_t len) {
+  FillAlpha(row[3], len);
+}
+
+void RGBToBGRA(float* row[kMaxComponents], size_t len) {
+  static const float kAlpha = 127.0f / 255.0f;
+  for (size_t i = 0; i < len; ++i) {
+    std::swap(row[0][i], row[2][i]);
+    row[3][i] = kAlpha;
+  }
+}
+
+void RGBToARGB(float* row[kMaxComponents], size_t len) {
+  memcpy(row[3], row[2], len * sizeof(row[1][0]));
+  memcpy(row[2], row[1], len * sizeof(row[2][0]));
+  memcpy(row[1], row[0], len * sizeof(row[1][0]));
+  FillAlpha(row[0], len);
+}
+
+void RGBToABGR(float* row[kMaxComponents], size_t len) {
+  static const float kAlpha = 127.0f / 255.0f;
+  for (size_t i = 0; i < len; ++i) {
+    std::swap(row[1][i], row[2][i]);
+    row[3][i] = row[0][i];
+    row[0][i] = kAlpha;
+  }
 }
 
 void ChooseColorTransform(j_compress_ptr cinfo) {
@@ -257,18 +352,123 @@ void ChooseColorTransform(j_decompress_ptr cinfo) {
 
   m->color_transform = nullptr;
   if (cinfo->jpeg_color_space == JCS_GRAYSCALE) {
-    if (cinfo->out_color_space == JCS_RGB) {
-      m->color_transform = GrayscaleToRGB;
+    switch (cinfo->out_color_space) {
+      case JCS_RGB:
+        m->color_transform = GrayscaleToRGB;
+        break;
+#ifdef JCS_EXTENSIONS
+      case JCS_EXT_RGB:
+      case JCS_EXT_BGR:
+        m->color_transform = GrayscaleToRGB;
+        break;
+      case JCS_EXT_RGBX:
+      case JCS_EXT_BGRX:
+        m->color_transform = GrayscaleToRGBA;
+        break;
+      case JCS_EXT_XRGB:
+      case JCS_EXT_XBGR:
+        m->color_transform = GrayscaleToARGB;
+        break;
+#endif
+#ifdef JCS_ALPHA_EXTENSIONS
+      case JCS_EXT_RGBA:
+      case JCS_EXT_BGRA:
+        m->color_transform = GrayscaleToRGBA;
+        break;
+      case JCS_EXT_ARGB:
+      case JCS_EXT_ABGR:
+        m->color_transform = GrayscaleToARGB;
+        break;
+#endif
+      default:
+        m->color_transform = nullptr;
     }
   } else if (cinfo->jpeg_color_space == JCS_RGB) {
-    if (cinfo->out_color_space == JCS_GRAYSCALE) {
-      m->color_transform = HWY_DYNAMIC_DISPATCH(RGBToYCbCr);
+    switch (cinfo->out_color_space) {
+      case JCS_GRAYSCALE:
+        m->color_transform = HWY_DYNAMIC_DISPATCH(RGBToYCbCr);
+        break;
+#ifdef JCS_EXTENSIONS
+      case JCS_EXT_RGB:
+        m->color_transform = NullTransform;
+        break;
+      case JCS_EXT_BGR:
+        m->color_transform = RGBToBGR;
+        break;
+      case JCS_EXT_RGBX:
+        m->color_transform = RGBToRGBA;
+        break;
+      case JCS_EXT_BGRX:
+        m->color_transform = RGBToBGRA;
+        break;
+      case JCS_EXT_XRGB:
+        m->color_transform = RGBToARGB;
+        break;
+      case JCS_EXT_XBGR:
+        m->color_transform = RGBToABGR;
+        break;
+#endif
+#ifdef JCS_ALPHA_EXTENSIONS
+      case JCS_EXT_RGBA:
+        m->color_transform = RGBToRGBA;
+        break;
+      case JCS_EXT_BGRA:
+        m->color_transform = RGBToBGRA;
+        break;
+      case JCS_EXT_ARGB:
+        m->color_transform = RGBToARGB;
+        break;
+      case JCS_EXT_ABGR:
+        m->color_transform = RGBToABGR;
+        break;
+#endif
+      default:
+        m->color_transform = nullptr;
     }
   } else if (cinfo->jpeg_color_space == JCS_YCbCr) {
-    if (cinfo->out_color_space == JCS_RGB) {
-      m->color_transform = HWY_DYNAMIC_DISPATCH(YCbCrToRGB);
-    } else if (cinfo->out_color_space == JCS_GRAYSCALE) {
-      m->color_transform = NullTransform;
+    switch (cinfo->out_color_space) {
+      case JCS_GRAYSCALE:
+        m->color_transform = NullTransform;
+        break;
+      case JCS_RGB:
+        m->color_transform = HWY_DYNAMIC_DISPATCH(YCbCrToRGB);
+        break;
+#ifdef JCS_EXTENSIONS
+      case JCS_EXT_RGB:
+        m->color_transform = HWY_DYNAMIC_DISPATCH(YCbCrToRGB);
+        break;
+      case JCS_EXT_BGR:
+        m->color_transform = HWY_DYNAMIC_DISPATCH(YCbCrToBGR);
+        break;
+      case JCS_EXT_RGBX:
+        m->color_transform = HWY_DYNAMIC_DISPATCH(YCbCrToRGBA);
+        break;
+      case JCS_EXT_BGRX:
+        m->color_transform = HWY_DYNAMIC_DISPATCH(YCbCrToBGRA);
+        break;
+      case JCS_EXT_XRGB:
+        m->color_transform = HWY_DYNAMIC_DISPATCH(YCbCrToARGB);
+        break;
+      case JCS_EXT_XBGR:
+        m->color_transform = HWY_DYNAMIC_DISPATCH(YCbCrToABGR);
+        break;
+#endif
+#ifdef JCS_ALPHA_EXTENSIONS
+      case JCS_EXT_RGBA:
+        m->color_transform = HWY_DYNAMIC_DISPATCH(YCbCrToRGBA);
+        break;
+      case JCS_EXT_BGRA:
+        m->color_transform = HWY_DYNAMIC_DISPATCH(YCbCrToBGRA);
+        break;
+      case JCS_EXT_ARGB:
+        m->color_transform = HWY_DYNAMIC_DISPATCH(YCbCrToARGB);
+        break;
+      case JCS_EXT_ABGR:
+        m->color_transform = HWY_DYNAMIC_DISPATCH(YCbCrToABGR);
+        break;
+#endif
+      default:
+        m->color_transform = nullptr;
     }
   } else if (cinfo->jpeg_color_space == JCS_YCCK) {
     if (cinfo->out_color_space == JCS_CMYK) {

--- a/lib/jpegli/decode.cc
+++ b/lib/jpegli/decode.cc
@@ -723,16 +723,36 @@ void jpegli_calc_output_dimensions(j_decompress_ptr cinfo) {
       }
     }
   }
-  if (cinfo->out_color_space == JCS_GRAYSCALE) {
-    cinfo->out_color_components = 1;
-  } else if (cinfo->out_color_space == JCS_RGB ||
-             cinfo->out_color_space == JCS_YCbCr) {
-    cinfo->out_color_components = 3;
-  } else if (cinfo->out_color_space == JCS_CMYK ||
-             cinfo->out_color_space == JCS_YCCK) {
-    cinfo->out_color_components = 4;
-  } else {
-    cinfo->out_color_components = cinfo->num_components;
+  switch (cinfo->out_color_space) {
+    case JCS_GRAYSCALE:
+      cinfo->out_color_components = 1;
+      break;
+    case JCS_RGB:
+    case JCS_YCbCr:
+#ifdef JCS_EXTENSIONS
+    case JCS_EXT_RGB:
+    case JCS_EXT_BGR:
+#endif
+      cinfo->out_color_components = 3;
+      break;
+    case JCS_CMYK:
+    case JCS_YCCK:
+#ifdef JCS_EXTENSIONS
+    case JCS_EXT_RGBX:
+    case JCS_EXT_BGRX:
+    case JCS_EXT_XBGR:
+    case JCS_EXT_XRGB:
+#endif
+#ifdef JCS_ALPHA_EXTENSIONS
+    case JCS_EXT_RGBA:
+    case JCS_EXT_BGRA:
+    case JCS_EXT_ABGR:
+    case JCS_EXT_ARGB:
+#endif
+      cinfo->out_color_components = 4;
+      break;
+    default:
+      cinfo->out_color_components = cinfo->num_components;
   }
   cinfo->output_components =
       cinfo->quantize_colors ? 1 : cinfo->out_color_components;

--- a/lib/jpegli/decode_api_test.cc
+++ b/lib/jpegli/decode_api_test.cc
@@ -904,7 +904,9 @@ std::vector<TestConfig> GenerateTests(bool buffered) {
     all_tests.push_back(config);
   }
   // Tests for color transforms.
-  for (J_COLOR_SPACE out_color_space : {JCS_RGB, JCS_GRAYSCALE}) {
+  for (J_COLOR_SPACE out_color_space :
+       {JCS_RGB, JCS_GRAYSCALE, JCS_EXT_RGB, JCS_EXT_BGR, JCS_EXT_RGBA,
+        JCS_EXT_BGRA, JCS_EXT_ARGB, JCS_EXT_ABGR}) {
     TestConfig config;
     config.input.xsize = config.input.ysize = 256;
     config.input.color_space = JCS_GRAYSCALE;
@@ -913,7 +915,9 @@ std::vector<TestConfig> GenerateTests(bool buffered) {
     all_tests.push_back(config);
   }
   for (J_COLOR_SPACE jpeg_color_space : {JCS_RGB, JCS_YCbCr}) {
-    for (J_COLOR_SPACE out_color_space : {JCS_RGB, JCS_YCbCr, JCS_GRAYSCALE}) {
+    for (J_COLOR_SPACE out_color_space :
+         {JCS_RGB, JCS_YCbCr, JCS_GRAYSCALE, JCS_EXT_RGB, JCS_EXT_BGR,
+          JCS_EXT_RGBA, JCS_EXT_BGRA, JCS_EXT_ARGB, JCS_EXT_ABGR}) {
       if (jpeg_color_space == JCS_RGB && out_color_space == JCS_YCbCr) continue;
       TestConfig config;
       config.input.xsize = config.input.ysize = 256;

--- a/lib/jpegli/test_utils.cc
+++ b/lib/jpegli/test_utils.cc
@@ -171,6 +171,18 @@ std::string ColorSpaceName(J_COLOR_SPACE colorspace) {
       return "CMYK";
     case JCS_YCCK:
       return "YCCK";
+    case JCS_EXT_RGB:
+      return "EXT_RGB";
+    case JCS_EXT_BGR:
+      return "EXT_BGR";
+    case JCS_EXT_RGBA:
+      return "EXT_RGBA";
+    case JCS_EXT_BGRA:
+      return "EXT_BGRA";
+    case JCS_EXT_ARGB:
+      return "EXT_ARGB";
+    case JCS_EXT_ABGR:
+      return "EXT_ABGR";
     default:
       return "";
   }


### PR DESCRIPTION
Add color transforms to the JCS_EXT_* color spaces, since it is used in Chrome.
