### PR TITLE
Support more color transforms in jpegli encoder.

### DIFF
--- a/lib/jpegli/encode.cc
+++ b/lib/jpegli/encode.cc
@@ -713,18 +713,31 @@ void jpegli_set_defaults(j_compress_ptr cinfo) {
 
 void jpegli_default_colorspace(j_compress_ptr cinfo) {
   CheckState(cinfo, jpegli::kEncStart);
+  if (cinfo->in_color_space == JCS_RGB && cinfo->master->xyb_mode) {
+    jpegli_set_colorspace(cinfo, JCS_RGB);
+    return;
+  }
   switch (cinfo->in_color_space) {
     case JCS_GRAYSCALE:
       jpegli_set_colorspace(cinfo, JCS_GRAYSCALE);
       break;
-    case JCS_RGB: {
-      if (cinfo->master->xyb_mode) {
-        jpegli_set_colorspace(cinfo, JCS_RGB);
-      } else {
-        jpegli_set_colorspace(cinfo, JCS_YCbCr);
-      }
+    case JCS_RGB:
+#ifdef JCS_EXTENSIONS
+    case JCS_EXT_RGB:
+    case JCS_EXT_BGR:
+    case JCS_EXT_RGBX:
+    case JCS_EXT_BGRX:
+    case JCS_EXT_XRGB:
+    case JCS_EXT_XBGR:
+#endif
+#if JCS_ALPHA_EXTENSIONS
+    case JCS_EXT_RGBA:
+    case JCS_EXT_BGRA:
+    case JCS_EXT_ARGB:
+    case JCS_EXT_ABGR:
+#endif
+      jpegli_set_colorspace(cinfo, JCS_YCbCr);
       break;
-    }
     case JCS_YCbCr:
       jpegli_set_colorspace(cinfo, JCS_YCbCr);
       break;

--- a/lib/jpegli/encode_api_test.cc
+++ b/lib/jpegli/encode_api_test.cc
@@ -522,9 +522,11 @@ std::vector<TestConfig> GenerateTests() {
     all_tests.push_back(config);
   }
 
-  for (J_COLOR_SPACE in_color_space : {JCS_RGB, JCS_YCbCr, JCS_GRAYSCALE}) {
+  for (J_COLOR_SPACE in_color_space :
+       {JCS_RGB, JCS_YCbCr, JCS_GRAYSCALE, JCS_EXT_RGB, JCS_EXT_BGR,
+        JCS_EXT_RGBA, JCS_EXT_BGRA, JCS_EXT_ARGB, JCS_EXT_ABGR}) {
     for (J_COLOR_SPACE jpeg_color_space : {JCS_RGB, JCS_YCbCr, JCS_GRAYSCALE}) {
-      if (jpeg_color_space == JCS_RGB && in_color_space == JCS_YCbCr) continue;
+      if (jpeg_color_space == JCS_RGB && in_color_space >= JCS_YCbCr) continue;
       TestConfig config;
       config.input.xsize = config.input.ysize = 256;
       config.input.color_space = in_color_space;

--- a/lib/jpegli/test_utils.cc
+++ b/lib/jpegli/test_utils.cc
@@ -313,9 +313,12 @@ std::ostream& operator<<(std::ostream& os, const CompressParams& jparams) {
 void SetNumChannels(J_COLOR_SPACE colorspace, size_t* channels) {
   if (colorspace == JCS_GRAYSCALE) {
     *channels = 1;
-  } else if (colorspace == JCS_RGB || colorspace == JCS_YCbCr) {
+  } else if (colorspace == JCS_RGB || colorspace == JCS_YCbCr ||
+             colorspace == JCS_EXT_RGB || colorspace == JCS_EXT_BGR) {
     *channels = 3;
-  } else if (colorspace == JCS_CMYK || colorspace == JCS_YCCK) {
+  } else if (colorspace == JCS_CMYK || colorspace == JCS_YCCK ||
+             colorspace == JCS_EXT_RGBA || colorspace == JCS_EXT_BGRA ||
+             colorspace == JCS_EXT_ARGB || colorspace == JCS_EXT_ABGR) {
     *channels = 4;
   } else if (colorspace == JCS_UNKNOWN) {
     JXL_CHECK(*channels <= 4);
@@ -342,7 +345,28 @@ void ConvertPixel(const uint8_t* input_rgb, uint8_t* out,
   if (colorspace == JCS_GRAYSCALE) {
     const float Y = 0.299f * r + 0.587f * g + 0.114f * b;
     out8[0] = static_cast<uint8_t>(std::round(Y * kMul));
-  } else if (colorspace == JCS_RGB || colorspace == JCS_UNKNOWN) {
+  } else if (colorspace == JCS_RGB || colorspace == JCS_EXT_RGB ||
+             colorspace == JCS_EXT_RGBA) {
+    out8[0] = input_rgb[0];
+    out8[1] = input_rgb[1];
+    out8[2] = input_rgb[2];
+    if (colorspace == JCS_EXT_RGBA) out8[3] = 255;
+  } else if (colorspace == JCS_EXT_BGR || colorspace == JCS_EXT_BGRA) {
+    out8[2] = input_rgb[0];
+    out8[1] = input_rgb[1];
+    out8[0] = input_rgb[2];
+    if (colorspace == JCS_EXT_BGRA) out8[3] = 255;
+  } else if (colorspace == JCS_EXT_ABGR) {
+    out8[0] = 255;
+    out8[3] = input_rgb[0];
+    out8[2] = input_rgb[1];
+    out8[1] = input_rgb[2];
+  } else if (colorspace == JCS_EXT_ARGB) {
+    out8[0] = 255;
+    out8[1] = input_rgb[0];
+    out8[2] = input_rgb[1];
+    out8[3] = input_rgb[2];
+  } else if (colorspace == JCS_UNKNOWN) {
     for (size_t c = 0; c < num_channels; ++c) {
       out8[c] = input_rgb[std::min<size_t>(2, c)];
     }
@@ -402,9 +426,23 @@ void ConvertPixel(const uint8_t* input_rgb, uint8_t* out,
 void ConvertToGrayscale(TestImage* img) {
   if (img->color_space == JCS_GRAYSCALE) return;
   JXL_CHECK(img->data_type == JPEGLI_TYPE_UINT8);
-  for (size_t i = 0; i < img->pixels.size(); i += 3) {
-    if (img->color_space == JCS_RGB) {
-      ConvertPixel(&img->pixels[i], &img->pixels[i / 3], JCS_GRAYSCALE, 1);
+  bool rgb_pre_alpha =
+      img->color_space == JCS_EXT_ARGB || img->color_space == JCS_EXT_ABGR;
+  bool rgb_post_alpha =
+      img->color_space == JCS_EXT_RGBA || img->color_space == JCS_EXT_BGRA;
+  bool rgb_alpha = rgb_pre_alpha || rgb_post_alpha;
+  bool is_rgb = img->color_space == JCS_RGB ||
+                img->color_space == JCS_EXT_RGB ||
+                img->color_space == JCS_EXT_BGR || rgb_alpha;
+  bool switch_br = img->color_space == JCS_EXT_BGR ||
+                   img->color_space == JCS_EXT_ABGR ||
+                   img->color_space == JCS_EXT_BGRA;
+  size_t stride = rgb_alpha ? 4 : 3;
+  size_t offset = rgb_pre_alpha ? 1 : 0;
+  for (size_t i = offset; i < img->pixels.size(); i += stride) {
+    if (is_rgb) {
+      if (switch_br) std::swap(img->pixels[i], img->pixels[i + 2]);
+      ConvertPixel(&img->pixels[i], &img->pixels[i / stride], JCS_GRAYSCALE, 1);
     } else if (img->color_space == JCS_YCbCr) {
       img->pixels[i / 3] = img->pixels[i];
     }


### PR DESCRIPTION
Add color transforms from the JCS_EXT_* color spaces, since it is used in Chrome (for e.g. creating thumbnails on the "New Tab" page).
