### PR TITLE
de-duplicate list of supported input/output codecs for tool help screens

### DIFF
--- a/lib/extras/dec/decode.cc
+++ b/lib/extras/dec/decode.cc
@@ -91,6 +91,15 @@ bool CanDecode(Codec codec) {
   }
 }
 
+std::string ListOfDecodeCodecs() {
+  std::string list_of_codecs("JXL, PPM, PNM, PFM, PAM, PGX");
+  if (CanDecode(Codec::kPNG)) list_of_codecs.append(", PNG, APNG");
+  if (CanDecode(Codec::kGIF)) list_of_codecs.append(", GIF");
+  if (CanDecode(Codec::kJPG)) list_of_codecs.append(", JPEG");
+  if (CanDecode(Codec::kEXR)) list_of_codecs.append(", EXR");
+  return list_of_codecs;
+}
+
 Status DecodeBytes(const Span<const uint8_t> bytes,
                    const ColorHints& color_hints, extras::PackedPixelFile* ppf,
                    const SizeConstraints* constraints, Codec* orig_codec) {

--- a/lib/extras/dec/decode.h
+++ b/lib/extras/dec/decode.h
@@ -38,6 +38,8 @@ enum class Codec : uint32_t {
 
 bool CanDecode(Codec codec);
 
+std::string ListOfDecodeCodecs();
+
 // If and only if extension is ".pfm", *bits_per_sample is updated to 32 so
 // that Encode() would encode to PFM instead of PPM.
 Codec CodecFromPath(const std::string& path,

--- a/lib/extras/enc/encode.cc
+++ b/lib/extras/enc/encode.cc
@@ -134,5 +134,13 @@ std::unique_ptr<Encoder> Encoder::FromExtension(std::string extension) {
   return nullptr;
 }
 
+std::string ListOfEncodeCodecs() {
+  std::string list_of_codecs("PPM, PNM, PFM, PAM, PGX");
+  if (GetAPNGEncoder()) list_of_codecs.append(", PNG, APNG");
+  if (GetJPEGEncoder()) list_of_codecs.append(", JPEG");
+  if (GetEXREncoder()) list_of_codecs.append(", EXR");
+  return list_of_codecs;
+}
+
 }  // namespace extras
 }  // namespace jxl

--- a/lib/extras/enc/encode.h
+++ b/lib/extras/enc/encode.h
@@ -82,6 +82,8 @@ class Encoder {
   std::unordered_map<std::string, std::string> options_;
 };
 
+std::string ListOfEncodeCodecs();
+
 }  // namespace extras
 }  // namespace jxl
 

--- a/tools/cjpegli.cc
+++ b/tools/cjpegli.cc
@@ -26,20 +26,11 @@ namespace {
 struct Args {
   void AddCommandLineOptions(CommandLineParser* cmdline) {
     std::string input_help("the input can be ");
-    if (jxl::extras::CanDecode(jxl::extras::Codec::kPNG)) {
-      input_help.append("PNG, APNG, ");
-    }
-    if (jxl::extras::CanDecode(jxl::extras::Codec::kGIF)) {
-      input_help.append("GIF, ");
-    }
-    if (jxl::extras::CanDecode(jxl::extras::Codec::kEXR)) {
-      input_help.append("EXR, ");
-    }
-    input_help.append("PPM, PFM, or PGX");
+    input_help.append(jxl::extras::ListOfDecodeCodecs());
     cmdline->AddPositionalOption("INPUT", /* required = */ true, input_help,
                                  &file_in);
     cmdline->AddPositionalOption("OUTPUT", /* required = */ true,
-                                 "the compressed JPG output file", &file_out);
+                                 "the compressed JPEG output file", &file_out);
 
     cmdline->AddOptionFlag('\0', "disable_output",
                            "No output file will be written (for benchmarking)",

--- a/tools/cjxl_main.cc
+++ b/tools/cjxl_main.cc
@@ -77,21 +77,10 @@ struct CompressArgs {
   // CompressArgs() = default;
   void AddCommandLineOptions(CommandLineParser* cmdline) {
     std::string input_help("the input can be ");
-    if (jxl::extras::CanDecode(jxl::extras::Codec::kPNG)) {
-      input_help.append("PNG, APNG, ");
+    input_help.append(jxl::extras::ListOfDecodeCodecs());
+    if (!jxl::extras::CanDecode(jxl::extras::Codec::kJPG)) {
+      input_help.append(", JPEG (lossless recompression only)");
     }
-    if (jxl::extras::CanDecode(jxl::extras::Codec::kGIF)) {
-      input_help.append("GIF, ");
-    }
-    if (jxl::extras::CanDecode(jxl::extras::Codec::kJPG)) {
-      input_help.append("JPEG, ");
-    } else {
-      input_help.append("JPEG (lossless recompression only), ");
-    }
-    if (jxl::extras::CanDecode(jxl::extras::Codec::kEXR)) {
-      input_help.append("EXR, ");
-    }
-    input_help.append("PPM, PFM, PAM, PGX, or JXL");
     // Positional arguments.
     cmdline->AddPositionalOption("INPUT", /* required = */ true, input_help,
                                  &file_in);

--- a/tools/djpegli.cc
+++ b/tools/djpegli.cc
@@ -26,12 +26,9 @@ namespace {
 struct Args {
   void AddCommandLineOptions(CommandLineParser* cmdline) {
     std::string output_help("The output can be ");
-    if (jxl::extras::GetAPNGEncoder()) {
-      output_help.append("PNG, ");
-    }
-    output_help.append("PFM or PPM/PGM/PNM");
+    output_help.append(jxl::extras::ListOfEncodeCodecs());
     cmdline->AddPositionalOption("INPUT", /* required = */ true,
-                                 "The JPG input file.", &file_in);
+                                 "The JPEG input file.", &file_in);
 
     cmdline->AddPositionalOption("OUTPUT", /* required = */ true, output_help,
                                  &file_out);

--- a/tools/djxl_main.cc
+++ b/tools/djxl_main.cc
@@ -43,19 +43,12 @@ struct DecompressArgs {
 
   void AddCommandLineOptions(CommandLineParser* cmdline) {
     std::string output_help("The output format can be ");
-    if (jxl::extras::GetAPNGEncoder()) {
-      output_help.append("PNG, APNG, ");
-    }
-    if (jxl::extras::GetJPEGEncoder()) {
-      output_help.append("JPEG, ");
-    } else {
-      output_help.append("JPEG (lossless reconstruction only), ");
-    }
-    if (jxl::extras::GetEXREncoder()) {
-      output_help.append("EXR, ");
+    output_help.append(jxl::extras::ListOfEncodeCodecs());
+    if (!jxl::extras::GetJPEGEncoder()) {
+      output_help.append(", JPEG (lossless reconstruction only)");
     }
     output_help.append(
-        "PGM (for greyscale input), PPM (for color input), PNM, PFM, or PAM.\n"
+        "\n"
         "    To extract metadata, use output format EXIF, XMP, or JUMBF.\n"
         "    The format is selected based on extension ('filename.png') or can "
         "be overwritten by using --output_format.\n"


### PR DESCRIPTION
Fixes https://github.com/libjxl/libjxl/issues/3498

(btw why don't we support JXL as an output format? e.g. using fast lossless encoding it could perhaps be a good alternative to PNG or PPM...)
