### PR TITLE
Increase quality in chromacity planes.

### DIFF
--- a/lib/jxl/decode_test.cc
+++ b/lib/jxl/decode_test.cc
@@ -1701,7 +1701,7 @@ TEST(DecodeTest, PixelTestWithICCProfileLossy) {
   EXPECT_SLIGHTLY_BELOW(
       ButteraugliDistance(io0.frames, io1.frames, ba, *JxlGetDefaultCms(),
                           /*distmap=*/nullptr, nullptr),
-      0.56f);
+      0.58f);
 
   JxlDecoderDestroy(dec);
 }
@@ -2151,7 +2151,7 @@ TEST(DecodeTest, PixelTestOpaqueSrgbLossyNoise) {
     EXPECT_SLIGHTLY_BELOW(
         ButteraugliDistance(io0.frames, io1.frames, ba, *JxlGetDefaultCms(),
                             /*distmap=*/nullptr, nullptr),
-        1.3f);
+        1.9f);
 
     JxlDecoderDestroy(dec);
   }

--- a/lib/jxl/enc_adaptive_quantization.cc
+++ b/lib/jxl/enc_adaptive_quantization.cc
@@ -766,7 +766,7 @@ StatusOr<ImageF> TileDistMap(const ImageF& distmap, int tile_size, int margin,
 
 const float kDcQuantPow = 0.83f;
 const float kDcQuant = 1.095924047623553f;
-const float kAcQuant = 0.7381485255235064f;
+const float kAcQuant = 0.725f;
 
 // Computes the decoded image for a given set of compression parameters.
 StatusOr<ImageBundle> RoundtripImage(const FrameHeader& frame_header,

--- a/lib/jxl/enc_frame.cc
+++ b/lib/jxl/enc_frame.cc
@@ -583,10 +583,13 @@ struct PixelStatsForChromacityAdjustment {
     CalcExposedBlue(&opsin->Plane(1), &opsin->Plane(2), rect);
   }
   int HowMuchIsXChannelPixelized() const {
-    if (dx >= 0.03) {
+    if (dx >= 0.026) {
+      return 3;
+    }
+    if (dx >= 0.022) {
       return 2;
     }
-    if (dx >= 0.017) {
+    if (dx >= 0.015) {
       return 1;
     }
     return 0;
@@ -614,17 +617,12 @@ void ComputeChromacityAdjustments(const CompressParams& cparams,
     return;
   }
   // 1) Distance based approach for chromacity adjustment:
-  float x_qm_scale_steps[4] = {1.25f, 7.0f, 15.0f, 24.0f};
-  frame_header->x_qm_scale = 2;
+  float x_qm_scale_steps[3] = {2.5f, 5.5f, 9.5f};
+  frame_header->x_qm_scale = 3;
   for (float x_qm_scale_step : x_qm_scale_steps) {
     if (cparams.original_butteraugli_distance > x_qm_scale_step) {
       frame_header->x_qm_scale++;
     }
-  }
-  if (cparams.butteraugli_distance < 0.299f) {
-    // Favor chromacity preservation for making images appear more
-    // faithful to original even with extreme (5-10x) zooming.
-    frame_header->x_qm_scale++;
   }
   // 2) Pixel-based approach for chromacity adjustment:
   // look at the individual pixels and make a guess how difficult

--- a/lib/jxl/encode_test.cc
+++ b/lib/jxl/encode_test.cc
@@ -233,7 +233,7 @@ void VerifyFrameEncoding(size_t xsize, size_t ysize, JxlEncoder* enc,
 
   static constexpr double kMaxButteraugli =
 #if JXL_HIGH_PRECISION
-      1.84;
+      3.2;
 #else
       8.7;
 #endif
@@ -461,7 +461,7 @@ TEST(EncodeTest, FrameSettingsTest) {
     JxlEncoderFrameSettings* frame_settings =
         JxlEncoderFrameSettingsCreate(enc.get(), nullptr);
     EXPECT_EQ(JXL_ENC_SUCCESS, JxlEncoderSetFrameDistance(frame_settings, 0.5));
-    VerifyFrameEncoding(63, 129, enc.get(), frame_settings, 3130, false);
+    VerifyFrameEncoding(63, 129, enc.get(), frame_settings, 3200, false);
     EXPECT_EQ(0.5, enc->last_used_cparams.butteraugli_distance);
   }
 

--- a/lib/jxl/jxl_test.cc
+++ b/lib/jxl/jxl_test.cc
@@ -120,7 +120,7 @@ TEST(JxlTest, RoundtripSmallD1) {
   {
     PackedPixelFile ppf_out;
     EXPECT_NEAR(Roundtrip(t.ppf(), {}, {}, pool, &ppf_out), 916, 40);
-    EXPECT_SLIGHTLY_BELOW(ButteraugliDistance(t.ppf(), ppf_out), 0.888);
+    EXPECT_SLIGHTLY_BELOW(ButteraugliDistance(t.ppf(), ppf_out), 0.92);
   }
 
   // With a lower intensity target than the default, the bitrate should be
@@ -179,7 +179,7 @@ TEST(JxlTest, RoundtripResample2MT) {
   cparams.AddOption(JXL_ENC_FRAME_SETTING_EFFORT, 3);  // kFalcon
 
   PackedPixelFile ppf_out;
-  EXPECT_NEAR(Roundtrip(t.ppf(), cparams, {}, pool.get(), &ppf_out), 203300,
+  EXPECT_NEAR(Roundtrip(t.ppf(), cparams, {}, pool.get(), &ppf_out), 206917,
               2000);
   EXPECT_SLIGHTLY_BELOW(ComputeDistance2(t.ppf(), ppf_out), 340);
 }
@@ -201,7 +201,7 @@ TEST(JxlTest, RoundtripOutOfOrderProcessing) {
   cparams.AddOption(JXL_ENC_FRAME_SETTING_EPF, 3);
 
   PackedPixelFile ppf_out;
-  EXPECT_NEAR(Roundtrip(t.ppf(), cparams, {}, &pool, &ppf_out), 27444, 400);
+  EXPECT_NEAR(Roundtrip(t.ppf(), cparams, {}, &pool, &ppf_out), 26933, 400);
   EXPECT_LE(ButteraugliDistance(t.ppf(), ppf_out), 1.35);
 }
 
@@ -221,7 +221,7 @@ TEST(JxlTest, RoundtripOutOfOrderProcessingBorder) {
   cparams.AddOption(JXL_ENC_FRAME_SETTING_RESAMPLING, 2);
 
   PackedPixelFile ppf_out;
-  EXPECT_NEAR(Roundtrip(t.ppf(), cparams, {}, &pool, &ppf_out), 10065, 200);
+  EXPECT_NEAR(Roundtrip(t.ppf(), cparams, {}, &pool, &ppf_out), 9747, 200);
   EXPECT_LE(ButteraugliDistance(t.ppf(), ppf_out), 2.9);
 }
 
@@ -236,7 +236,7 @@ TEST(JxlTest, RoundtripResample4) {
   cparams.AddOption(JXL_ENC_FRAME_SETTING_RESAMPLING, 4);
 
   PackedPixelFile ppf_out;
-  EXPECT_NEAR(Roundtrip(t.ppf(), cparams, {}, pool, &ppf_out), 5758, 100);
+  EXPECT_NEAR(Roundtrip(t.ppf(), cparams, {}, pool, &ppf_out), 5888, 100);
   EXPECT_SLIGHTLY_BELOW(ButteraugliDistance(t.ppf(), ppf_out), 22);
 }
 
@@ -296,7 +296,7 @@ TEST(JxlTest, RoundtripMultiGroup) {
   auto run_kitten = std::async(std::launch::async, test, SpeedTier::kKitten,
                                1.0f, 63624u, 8.5);
   auto run_wombat = std::async(std::launch::async, test, SpeedTier::kWombat,
-                               2.0f, 39620u, 15.5);
+                               2.0f, 38536u, 15.7);
 }
 
 TEST(JxlTest, RoundtripRGBToGrayscale) {
@@ -505,7 +505,7 @@ TEST(JxlTest, RoundtripSmallNL) {
 
   PackedPixelFile ppf_out;
   EXPECT_NEAR(Roundtrip(t.ppf(), {}, {}, pool, &ppf_out), 916, 45);
-  EXPECT_SLIGHTLY_BELOW(ButteraugliDistance(t.ppf(), ppf_out), 0.82);
+  EXPECT_SLIGHTLY_BELOW(ButteraugliDistance(t.ppf(), ppf_out), 0.92);
 }
 
 TEST(JxlTest, RoundtripNoGaborishNoAR) {
@@ -539,7 +539,7 @@ TEST(JxlTest, RoundtripSmallNoGaborish) {
 
   PackedPixelFile ppf_out;
   EXPECT_NEAR(Roundtrip(t.ppf(), cparams, {}, pool, &ppf_out), 1006, 20);
-  EXPECT_SLIGHTLY_BELOW(ButteraugliDistance(t.ppf(), ppf_out), 1.1);
+  EXPECT_SLIGHTLY_BELOW(ButteraugliDistance(t.ppf(), ppf_out), 1.2);
 }
 
 TEST(JxlTest, RoundtripSmallPatchesAlpha) {
@@ -895,7 +895,7 @@ TEST(JxlTest, RoundtripAlphaPremultiplied) {
             ButteraugliDistance(io_nopremul.frames, io2.frames,
                                 ButteraugliParams(), *JxlGetDefaultCms(),
                                 /*distmap=*/nullptr),
-            1.0);
+            1.1);
       }
     }
   }
@@ -936,7 +936,7 @@ TEST(JxlTest, RoundtripAlphaResamplingOnlyAlpha) {
   cparams.AddOption(JXL_ENC_FRAME_SETTING_EXTRA_CHANNEL_RESAMPLING, 2);
 
   PackedPixelFile ppf_out;
-  EXPECT_NEAR(Roundtrip(t.ppf(), cparams, {}, pool, &ppf_out), 32000, 1000);
+  EXPECT_NEAR(Roundtrip(t.ppf(), cparams, {}, pool, &ppf_out), 33179, 1000);
   EXPECT_SLIGHTLY_BELOW(ButteraugliDistance(t.ppf(), ppf_out), 1.52);
 }
 

--- a/lib/jxl/passes_test.cc
+++ b/lib/jxl/passes_test.cc
@@ -52,7 +52,7 @@ TEST(PassesTest, RoundtripSmallPasses) {
       ButteraugliDistance(io.frames, io2.frames, ButteraugliParams(),
                           *JxlGetDefaultCms(),
                           /*distmap=*/nullptr),
-      0.8222);
+      1.0);
 }
 
 TEST(PassesTest, RoundtripUnalignedPasses) {

--- a/lib/jxl/render_pipeline/render_pipeline_test.cc
+++ b/lib/jxl/render_pipeline/render_pipeline_test.cc
@@ -247,7 +247,7 @@ TEST_P(RenderPipelineTestParam, PipelineTest) {
   ASSERT_EQ(io_default.frames.size(), io_slow_pipeline.frames.size());
   for (size_t i = 0; i < io_default.frames.size(); i++) {
 #if JXL_HIGH_PRECISION
-    constexpr float kMaxError = 5e-5;
+    constexpr float kMaxError = 2e-4;
 #else
     constexpr float kMaxError = 5e-4;
 #endif

--- a/lib/jxl/roundtrip_test.cc
+++ b/lib/jxl/roundtrip_test.cc
@@ -433,7 +433,7 @@ void VerifyRoundtripCompression(
     float butteraugli_score = ButteraugliDistance(
         original_io.frames, decoded_io.frames, ba, *JxlGetDefaultCms(),
         /*distmap=*/nullptr, nullptr);
-    float target_score = 1.3f;
+    float target_score = 1.4f;
     // upsampling mode 1 (unlike default and NN) does not downscale back to the
     // already downsampled image
     if (upsampling_mode == 1 && resampling >= 4 && already_downsampled)


### PR DESCRIPTION
This is done so that chromaticty related quality degradations are mitigated.

Benchmark results:
```
Encoding      kPixels    Bytes          BPP  E MP/s  D MP/s     Max norm  SSIMULACRA2   PSNR        pnorm       BPP*pnorm   QABPP   Bugs
----------------------------------------------------------------------------------------------------------------------------------------
BEFORE
jxl:d0.1        20795 17954256    6.9068854   1.278  15.017   0.35805166  95.37202576  55.88   0.11725678  0.809879134700   6.907      0
jxl:d0.25       20795 11185575    4.3030179   1.378  17.422   0.47584089  93.97937085  51.22   0.19450189  0.836945112541   4.328      0
jxl:d0.5        20795  7260540    2.7930825   1.506  19.257   0.78400613  91.40084419  47.11   0.33293958  0.929927705908   2.898      0
jxl:d1          20795  4635025    1.7830639   1.707  20.122   1.35159355  86.82420712  43.18   0.56550572  1.008332862242   2.518      0
jxl:d2          20795  2869138    1.1037387   1.913  22.033   2.43613682  78.67848098  39.50   0.96569109  1.065870639037   2.832      0
jxl:d4          20795  1671713    0.6430971   1.854  14.454   4.07309831  64.89573571  36.07   1.60210624  1.030309882887   2.732      0
jxl:d8          20795   997343    0.3836714   1.830  13.715   6.48889710  45.41867421  33.20   2.53086088  0.971018832102   2.530      0
Aggregate:      20795  4407874    1.6956806   1.621  17.186   1.41969739  77.30240788  43.08   0.55785734  0.945947835245   3.301      0
AFTER
jxl:d0.1        20795 17960414    6.9092543   1.266  14.045   0.35676469  95.37045907  55.92   0.11743201  0.811367620746   6.909      0
jxl:d0.25       20795 11211481    4.3129837   1.428  17.480   0.47188711  93.95812476  51.27   0.19471022  0.839782033058   4.323      0
jxl:d0.5        20795  7343631    2.8250470   1.557  20.361   0.77713256  91.44634906  47.21   0.33192928  0.937715835158   2.911      0
jxl:d1          20795  4677692    1.7994777   1.724  21.743   1.34254171  86.90547291  43.27   0.56234123  1.011920474406   2.522      0
jxl:d2          20795  2886906    1.1105739   1.780  21.182   2.41345744  78.64070212  39.51   0.96381616  1.070389106583   2.822      0
jxl:d4          20795  1697421    0.6529868   1.806  14.919   4.09606455  65.00253199  36.14   1.60465567  1.047818979605   2.800      0
jxl:d8          20795  1000234    0.3847835   1.862  14.273   6.58003645  45.10259245  33.21   2.54751704  0.980242539117   2.576      0
Aggregate:      20795  4437904    1.7072329   1.618  17.438   1.41620256  77.25130756  43.13   0.55786685  0.952408666680   3.322      0
```

Images before:
https://storage.googleapis.com/jxl-quality/eval/szabadka/jyrki_split_2024-03-23/f1e75e6e/base/index.jxl_d2.html

Images after:
https://storage.googleapis.com/jxl-quality/eval/szabadka/jyrki_split_2024-03-23/6011aa43/base/index.jxl_d2.html
