### PR TITLE
benchmark_utils: use correct environ on macOS

### DIFF
--- a/tools/benchmark/benchmark_utils.cc
+++ b/tools/benchmark/benchmark_utils.cc
@@ -28,10 +28,10 @@
 #include <utility>
 
 #ifdef __APPLE__
-  #include <crt_externs.h>
-  #define environ (*_NSGetEnviron())
+#include <crt_externs.h>
+#define environ (*_NSGetEnviron())
 #else
-  extern char **environ;  // NOLINT
+extern char** environ;  // NOLINT
 #endif
 
 namespace jpegxl {

--- a/tools/benchmark/benchmark_utils.cc
+++ b/tools/benchmark/benchmark_utils.cc
@@ -27,7 +27,12 @@
 #include <cstdlib>
 #include <utility>
 
-extern char** environ;  // NOLINT
+#ifdef __APPLE__
+  #include <crt_externs.h>
+  #define environ (*_NSGetEnviron())
+#else
+  extern char **environ;  // NOLINT
+#endif
 
 namespace jpegxl {
 namespace tools {


### PR DESCRIPTION
<!-- Thank you for considering a contribution to `libjxl`! -->

### Description

Use a dedicated `environ` definition on macOS, which is supported on all macOS versions.

### Pull Request Checklist

- [x] **CLA Signed**: Have you signed the [Contributor License Agreement](https://code.google.com/legal/individual-cla-v1.0.html) (individual or corporate, as appropriate)? Only contributions from signed contributors can be accepted.
- [ ] **Authors**: Have you considered adding your name to the [AUTHORS](AUTHORS) file?
- [x] **Code Style**: Have you ensured your code adheres to the project's coding style guidelines? You can use `./ci.sh lint` for automatic code formatting.


Please review the full [contributing guidelines](https://github.com/libjxl/libjxl/blob/main/CONTRIBUTING.md) for more details.
