### PR TITLE
Fix compile error caused by moved rect.h

### DIFF
--- a/tools/comparison_viewer/image_loading.cc
+++ b/tools/comparison_viewer/image_loading.cc
@@ -12,9 +12,9 @@
 #include <cstdint>
 #include <vector>
 
-#include "lib/base/rect.h"
 #include "lib/extras/codec.h"
 #include "lib/extras/dec/color_hints.h"
+#include "lib/jxl/base/rect.h"
 #include "lib/jxl/image_bundle.h"
 #include "lib/jxl/image_metadata.h"
 #include "tools/file_io.h"


### PR DESCRIPTION
### Description
`base/rect.h` was moved to `jxl/base/rect.h`, but the include was not updated in `tools/comparison_viewer/image_loading.cc`.
