### PR TITLE
Add an option for disabling perceptual optimizations.

### DIFF
--- a/lib/extras/enc/jxl.cc
+++ b/lib/extras/enc/jxl.cc
@@ -223,7 +223,14 @@ bool EncodeImageJXL(const JXLCompressParams& params, const PackedPixelFile& ppf,
         std::max<uint32_t>(num_alpha_channels, ppf.info.num_extra_channels);
     basic_info.num_color_channels = ppf.info.num_color_channels;
     const bool lossless = (params.distance == 0);
-    basic_info.uses_original_profile = TO_JXL_BOOL(lossless);
+    auto non_perceptual_option = std::find_if(
+        params.options.begin(), params.options.end(), [](JXLOption option) {
+          return option.id ==
+                 JXL_ENC_FRAME_SETTING_DISABLE_PERCEPTUAL_HEURISTICS;
+        });
+    const bool non_perceptual = non_perceptual_option != params.options.end() &&
+                                non_perceptual_option->ival == 1;
+    basic_info.uses_original_profile = TO_JXL_BOOL(lossless || non_perceptual);
     if (params.override_bitdepth != 0) {
       basic_info.bits_per_sample = params.override_bitdepth;
       basic_info.exponent_bits_per_sample =

--- a/lib/include/jxl/encode.h
+++ b/lib/include/jxl/encode.h
@@ -388,6 +388,11 @@ typedef enum {
    */
   JXL_ENC_FRAME_SETTING_USE_FULL_IMAGE_HEURISTICS = 38,
 
+  /** Disable perceptual optimizations. 0 = optimizations enabled (default), 1 =
+   * optimizations disabled.
+   */
+  JXL_ENC_FRAME_SETTING_DISABLE_PERCEPTUAL_HEURISTICS = 39,
+
   /** Enum value not to be used as an option. This value is added to force the
    * C compiler to have the enum to take a known size.
    */

--- a/lib/jxl/enc_heuristics.cc
+++ b/lib/jxl/enc_heuristics.cc
@@ -30,6 +30,7 @@
 #include "lib/jxl/chroma_from_luma.h"
 #include "lib/jxl/coeff_order.h"
 #include "lib/jxl/coeff_order_fwd.h"
+#include "lib/jxl/common.h"
 #include "lib/jxl/dec_group.h"
 #include "lib/jxl/dec_xyb.h"
 #include "lib/jxl/enc_ac_strategy.h"
@@ -200,19 +201,19 @@ Status FindBestDequantMatrices(const CompressParams& cparams,
   // TODO(veluca): quant matrices for no-gaborish.
   // TODO(veluca): heuristics for in-bitstream quant tables.
   *dequant_matrices = DequantMatrices();
-  if (cparams.max_error_mode) {
+  if (cparams.max_error_mode || cparams.disable_percepeptual_optimizations) {
+    constexpr float kMSEWeights[3] = {0.001, 0.001, 0.001};
+    const float* wp = cparams.disable_percepeptual_optimizations
+                          ? kMSEWeights
+                          : cparams.max_error;
     // Set numerators of all quantization matrices to constant values.
-    float weights[3][1] = {{1.0f / cparams.max_error[0]},
-                           {1.0f / cparams.max_error[1]},
-                           {1.0f / cparams.max_error[2]}};
+    float weights[3][1] = {{1.0f / wp[0]}, {1.0f / wp[1]}, {1.0f / wp[2]}};
     DctQuantWeightParams dct_params(weights);
     std::vector<QuantEncoding> encodings(DequantMatrices::kNum,
                                          QuantEncoding::DCT(dct_params));
     JXL_RETURN_IF_ERROR(DequantMatricesSetCustom(dequant_matrices, encodings,
                                                  modular_frame_encoder));
-    float dc_weights[3] = {1.0f / cparams.max_error[0],
-                           1.0f / cparams.max_error[1],
-                           1.0f / cparams.max_error[2]};
+    float dc_weights[3] = {1.0f / wp[0], 1.0f / wp[1], 1.0f / wp[2]};
     DequantMatricesSetCustomDC(dequant_matrices, dc_weights);
   }
   return true;
@@ -1003,7 +1004,8 @@ Status LossyFrameHeuristics(const FrameHeader& frame_header,
   // Call InitialQuantField only in Hare mode or slower. Otherwise, rely
   // on simple heuristics in FindBestAcStrategy, or set a constant for Falcon
   // mode.
-  if (cparams.speed_tier > SpeedTier::kHare) {
+  if (cparams.speed_tier > SpeedTier::kHare ||
+      cparams.disable_percepeptual_optimizations) {
     JXL_ASSIGN_OR_RETURN(
         initial_quant_field,
         ImageF::Create(frame_dim.xsize_blocks, frame_dim.ysize_blocks));
@@ -1012,7 +1014,13 @@ Status LossyFrameHeuristics(const FrameHeader& frame_header,
         ImageF::Create(frame_dim.xsize_blocks, frame_dim.ysize_blocks));
     float q = 0.79 / cparams.butteraugli_distance;
     FillImage(q, &initial_quant_field);
-    FillImage(1.0f / (q + 0.001f), &initial_quant_masking);
+    float masking = 1.0f / (q + 0.001f);
+    FillImage(masking, &initial_quant_masking);
+    if (cparams.disable_percepeptual_optimizations) {
+      JXL_ASSIGN_OR_RETURN(initial_quant_masking1x1,
+                           ImageF::Create(frame_dim.xsize, frame_dim.ysize));
+      FillImage(masking, &initial_quant_masking1x1);
+    }
     quantizer.ComputeGlobalScaleAndQuant(quant_dc, q, 0);
   } else {
     // Call this here, as it relies on pre-gaborish values.
@@ -1105,7 +1113,7 @@ Status LossyFrameHeuristics(const FrameHeader& frame_header,
   JXL_RETURN_IF_ERROR(acs_heuristics.Finalize(frame_dim, ac_strategy, aux_out));
 
   // Refine quantization levels.
-  if (!streaming_mode) {
+  if (!streaming_mode && !cparams.disable_percepeptual_optimizations) {
     ImageB& epf_sharpness = shared.epf_sharpness;
     FillPlane(static_cast<uint8_t>(4), &epf_sharpness, Rect(epf_sharpness));
     JXL_RETURN_IF_ERROR(FindBestQuantizer(frame_header, original_pixels, *opsin,

--- a/lib/jxl/enc_params.h
+++ b/lib/jxl/enc_params.h
@@ -37,6 +37,8 @@ struct CompressParams {
   bool max_error_mode = false;
   float max_error[3] = {0.0, 0.0, 0.0};
 
+  bool disable_percepeptual_optimizations = false;
+
   SpeedTier speed_tier = SpeedTier::kSquirrel;
   int brotli_effort = -1;
 

--- a/lib/jxl/enc_patch_dictionary.cc
+++ b/lib/jxl/enc_patch_dictionary.cc
@@ -588,7 +588,8 @@ Status FindBestPatchDictionary(const Image3F& opsin,
       ApplyOverride(
           state->cparams.dots,
           state->cparams.speed_tier <= SpeedTier::kSquirrel &&
-              state->cparams.butteraugli_distance >= kMinButteraugliForDots)) {
+              state->cparams.butteraugli_distance >= kMinButteraugliForDots &&
+              !state->cparams.disable_percepeptual_optimizations)) {
     Rect rect(0, 0, state->shared.frame_dim.xsize,
               state->shared.frame_dim.ysize);
     JXL_ASSIGN_OR_RETURN(info, FindDotDictionary(state->cparams, opsin, rect,

--- a/lib/jxl/jxl_test.cc
+++ b/lib/jxl/jxl_test.cc
@@ -1180,13 +1180,34 @@ TEST(JxlTest, RoundtripDots) {
             JXL_TRANSFER_FUNCTION_SRGB);
 
   JXLCompressParams cparams;
-  cparams.AddOption(JXL_ENC_FRAME_SETTING_EFFORT, 7);  // kSkirrel
+  cparams.AddOption(JXL_ENC_FRAME_SETTING_EFFORT, 7);  // kSquirrel
   cparams.AddOption(JXL_ENC_FRAME_SETTING_DOTS, 1);
   cparams.distance = 0.04;
 
   PackedPixelFile ppf_out;
   EXPECT_NEAR(Roundtrip(t.ppf(), cparams, {}, pool, &ppf_out), 280333, 4000);
   EXPECT_SLIGHTLY_BELOW(ButteraugliDistance(t.ppf(), ppf_out), 0.35);
+}
+
+TEST(JxlTest, RoundtripDisablePerceptual) {
+  ThreadPool* pool = nullptr;
+  const std::vector<uint8_t> orig = ReadTestData("jxl/flower/flower.png");
+  TestImage t;
+  t.DecodeFromBytes(orig).ClearMetadata();
+  ASSERT_NE(t.ppf().info.xsize, 0);
+  EXPECT_EQ(t.ppf().info.bits_per_sample, 8);
+  EXPECT_EQ(t.ppf().color_encoding.transfer_function,
+            JXL_TRANSFER_FUNCTION_SRGB);
+
+  JXLCompressParams cparams;
+  cparams.AddOption(JXL_ENC_FRAME_SETTING_EFFORT, 7);  // kSquirrel
+  cparams.AddOption(JXL_ENC_FRAME_SETTING_DISABLE_PERCEPTUAL_HEURISTICS, 1);
+  cparams.distance = 1.0;
+
+  PackedPixelFile ppf_out;
+  EXPECT_NEAR(Roundtrip(t.ppf(), cparams, {}, pool, &ppf_out), 477778, 4000);
+  // TODO(veluca): figure out why we can't get below this value.
+  EXPECT_SLIGHTLY_BELOW(ButteraugliDistance(t.ppf(), ppf_out), 11.0);
 }
 
 TEST(JxlTest, RoundtripNoise) {

--- a/tools/benchmark/benchmark_codec_jxl.cc
+++ b/tools/benchmark/benchmark_codec_jxl.cc
@@ -247,6 +247,9 @@ class JxlCodec : public ImageCodec {
     } else if (param.substr(0, 16) == "faster_decoding=") {
       val = strtol(param.substr(16).c_str(), nullptr, 10);
       cparams_.AddOption(JXL_ENC_FRAME_SETTING_DECODING_SPEED, val);
+    } else if (param == "noperc") {
+      cparams_.AddOption(JXL_ENC_FRAME_SETTING_DISABLE_PERCEPTUAL_HEURISTICS,
+                         1);
     } else {
       return JXL_FAILURE("Unrecognized param");
     }

--- a/tools/cjxl_main.cc
+++ b/tools/cjxl_main.cc
@@ -384,6 +384,11 @@ struct CompressArgs {
                            "cost of a massive speed hit.",
                            &allow_expert_options, &SetBooleanTrue, 3);
 
+    cmdline->AddOptionFlag('\0', "disable_perceptual_optimizations",
+                           "Disable perceptual optimizations",
+                           &disable_perceptual_optimizations, &SetBooleanTrue,
+                           4);
+
     cmdline->AddHelpText("\nModular mode options:", 4);
 
     // modular mode options
@@ -506,6 +511,7 @@ struct CompressArgs {
   jxl::Override noise = jxl::Override::kDefault;
 
   bool allow_expert_options = false;
+  bool disable_perceptual_optimizations = false;
 
   size_t faster_decoding = 0;
   int64_t resampling = -1;
@@ -686,6 +692,9 @@ void ProcessFlags(const jxl::extras::Codec codec,
   ProcessBoolFlag(args->noise, JXL_ENC_FRAME_SETTING_NOISE, params);
 
   params->allow_expert_options = args->allow_expert_options;
+  if (args->disable_perceptual_optimizations) {
+    params->AddOption(JXL_ENC_FRAME_SETTING_DISABLE_PERCEPTUAL_HEURISTICS, 1);
+  }
 
   if (!args->frame_indexing.empty()) {
     bool must_be_all_zeros = args->frame_indexing[0] != '1';


### PR DESCRIPTION
There still likely is something off with the implementation, but this lays the groundwork.