### PR TITLE
minimal enc_heuristics improvement

### DIFF
--- a/lib/jxl/enc_ac_strategy.cc
+++ b/lib/jxl/enc_ac_strategy.cc
@@ -451,11 +451,11 @@ float EstimateEntropy(const AcStrategy& acs, float entropy_mul, size_t x,
         }
       }
       static const double kChannelMul[3] = {
-          10.2,
-          1.0,
-          1.03,
+          pow(10.2, 8.0),
+          pow(1.0, 8.0),
+          pow(1.03, 8.0),
       };
-      lossc = Mul(Set(df8, pow(kChannelMul[c], 8.0)), lossc);
+      lossc = Mul(Set(df8, kChannelMul[c]), lossc);
       loss = Add(loss, lossc);
     }
     entropy += config.cost_delta * GetLane(SumOfLanes(df, entropy_v));
@@ -846,7 +846,7 @@ void ProcessRectACS(const CompressParams& cparams, const ACSConfig& config,
     float entropy_mul;
   };
   // These numbers need to be figured out manually and looking at
-  // ringing next to sky etc. Optimization will find larger numbers
+  // ringing next to sky etc. Optimization will find smaller numbers
   // and produce more ringing than is ideal. Larger numbers will
   // help stop ringing.
   const float entropy_mul16X8 = 1.25;

--- a/lib/jxl/encode_test.cc
+++ b/lib/jxl/encode_test.cc
@@ -259,7 +259,7 @@ TEST(EncodeTest, EncoderResetTest) {
   JxlEncoderPtr enc = JxlEncoderMake(nullptr);
   EXPECT_NE(nullptr, enc.get());
   VerifyFrameEncoding(50, 200, enc.get(),
-                      JxlEncoderFrameSettingsCreate(enc.get(), nullptr), 4570,
+                      JxlEncoderFrameSettingsCreate(enc.get(), nullptr), 4577,
                       false);
   // Encoder should become reusable for a new image from scratch after using
   // reset.


### PR DESCRIPTION
```
Before:

Encoding      kPixels    Bytes          BPP  E MP/s  D MP/s     Max norm  SSIMULACRA2   PSNR        pnorm       BPP*pnorm   QABPP   Bugs
----------------------------------------------------------------------------------------------------------------------------------------
jxl:d0.1        20315 17771024    6.9979205   1.070  10.836   0.35756577  95.39413774  55.88   0.11792287  0.825214859523   6.998      0
jxl:d0.5        20315  7252143    2.8557679   1.261  15.667   0.78009917  91.43862540  47.13   0.33393541  0.953642033483   2.944      0
jxl:d0.8        20315  5355383    2.1088568   1.171  16.131   1.11966839  88.71172911  44.48   0.47360329  0.998761497683   2.496      0
jxl:d1          20315  4592636    1.8085003   1.165  16.544   1.34746867  86.90689460  43.25   0.56298728  1.018162650761   2.541      0
jxl:d1.5        20315  3483779    1.3718516   1.168  15.881   1.88466094  82.72685713  41.10   0.76582699  1.050601014528   2.689      0
jxl:d2.0        20315  2830552    1.1146222   1.214  16.671   2.40886266  78.69670524  39.60   0.95547086  1.064989027935   2.826      0
jxl:d2.5        20315  2381541    0.9378095   1.221  16.602   2.85901054  74.91580977  38.41   1.13024207  1.059951713525   2.814      0
jxl:d3          20315  2075694    0.8173722   1.173  16.569   3.25119916  71.60765923  37.58   1.28681452  1.051806455371   2.776      0
jxl:d5          20315  1413373    0.5565617   1.044  10.980   4.58866332  60.40797085  35.39   1.79915249  1.001339422166   2.657      0
jxl:d10         20315   859141    0.3383148   1.038  11.884   7.58547653  39.41476555  32.61   2.89739841  0.980232759266   2.566      0
Aggregate:      20315  3367670    1.3261301   1.150  14.568   1.90155439  74.94757542  41.09   0.75253821  0.997963544376   2.967      0

After:

jxl:d0.1        20315 17771024    6.9979205   1.077  10.255   0.35756577  95.39413774  55.88   0.11792287  0.825214859523   6.998      0
jxl:d0.5        20315  7252143    2.8557679   1.287  15.124   0.78009917  91.43862540  47.13   0.33393541  0.953642033483   2.944      0
jxl:d0.8        20315  5363198    2.1119342   1.162  15.660   1.11808133  88.71449750  44.49   0.47287594  0.998682857933   2.498      0
jxl:d1          20315  4603082    1.8126137   1.207  16.544   1.34310821  86.92441895  43.26   0.56190222  1.018511676188   2.539      0
jxl:d1.5        20315  3493018    1.3754898   1.205  15.822   1.86482998  82.75997012  41.13   0.76257997  1.048920975049   2.679      0
jxl:d2.0        20315  2839864    1.1182891   1.233  16.680   2.39538877  78.76238966  39.63   0.95207627  1.064696518711   2.823      0
jxl:d2.5        20315  2390345    0.9412763   1.252  16.746   2.85224490  74.97863810  38.44   1.12701990  1.060837154023   2.820      0
jxl:d3          20315  2083852    0.8205847   1.191  16.735   3.25656987  71.69784136  37.60   1.28318000  1.052957893138   2.793      0
jxl:d5          20315  1396548    0.5499363   1.182  11.476   4.58515346  60.33355388  35.30   1.81020579  0.995497945222   2.624      0
jxl:d10         20315   842090    0.3316004   1.168  12.580   7.63349125  39.09399046  32.54   2.92331122  0.969371201332   2.517      0
Aggregate:      20315  3362708    1.3241760   1.195  14.563   1.89851036  74.90381740  41.09   0.75239306  0.996300812242   2.959      0
```

