### PR TITLE
minor optimization for enc_heuristics

### DIFF
--- a/lib/jxl/enc_heuristics.cc
+++ b/lib/jxl/enc_heuristics.cc
@@ -834,7 +834,7 @@ float ComputeBlockL2Distance(const Image3F& a, const Image3F& b,
   Rect rect(bx * kBlockDim, by * kBlockDim, kBlockDim, kBlockDim, a.xsize(),
             a.ysize());
   float err2 = 0.0f;
-  static const float kXYBWeights[] = {36.0f, 1.0f, 0.3f};
+  static const float kXYBWeights[] = {36.0f, 1.0f, 0.2f};
   for (size_t y = 0; y < rect.ysize(); ++y) {
     const float* row_a_x = rect.ConstPlaneRow(a, 0, y);
     const float* row_a_y = rect.ConstPlaneRow(a, 1, y);
@@ -843,6 +843,7 @@ float ComputeBlockL2Distance(const Image3F& a, const Image3F& b,
     const float* row_b_y = rect.ConstPlaneRow(b, 1, y);
     const float* row_b_b = rect.ConstPlaneRow(b, 2, y);
     const float* row_mask = rect.ConstRow(mask1x1, y);
+
     for (size_t x = 0; x < rect.xsize(); ++x) {
       float mask = row_mask[x];
       for (size_t c = 0; c < 3; ++c) {
@@ -852,7 +853,7 @@ float ComputeBlockL2Distance(const Image3F& a, const Image3F& b,
         err2 += (kXYBWeights[0] * diff_x * diff_x +
                  kXYBWeights[1] * diff_y * diff_y +
                  kXYBWeights[2] * diff_b * diff_b) *
-                mask;
+                mask * mask;
       }
     }
   }


### PR DESCRIPTION
```
Before:

Encoding      kPixels    Bytes          BPP  E MP/s  D MP/s     Max norm  SSIMULACRA2   PSNR        pnorm       BPP*pnorm   QABPP   Bugs
----------------------------------------------------------------------------------------------------------------------------------------
jxl:d0.1        20315 17771024    6.9979205   1.072  10.153   0.35756577  95.39413774  55.88   0.11792287  0.825214859523   6.998      0
jxl:d0.5        20315  7252143    2.8557679   1.278  14.595   0.78009917  91.43862540  47.13   0.33393541  0.953642033483   2.944      0
jxl:d0.8        20315  5363198    2.1119342   1.180  15.134   1.11808133  88.71449750  44.49   0.47287594  0.998682857933   2.498      0
jxl:d1          20315  4603082    1.8126137   1.202  16.286   1.34310821  86.92441895  43.26   0.56190222  1.018511676188   2.539      0
jxl:d1.5        20315  3493018    1.3754898   1.200  15.527   1.86482998  82.75997012  41.13   0.76257997  1.048920975049   2.679      0
jxl:d2.0        20315  2839864    1.1182891   1.222  16.554   2.39538877  78.76238966  39.63   0.95207627  1.064696518711   2.823      0
jxl:d2.5        20315  2390345    0.9412763   1.234  15.872   2.85224490  74.97863810  38.44   1.12701990  1.060837154023   2.820      0
jxl:d3          20315  2083852    0.8205847   1.182  16.514   3.25656987  71.69784136  37.60   1.28318000  1.052957893138   2.793      0
jxl:d5          20315  1396548    0.5499363   1.151  11.355   4.58515346  60.33355388  35.30   1.81020579  0.995497945222   2.624      0
jxl:d10         20315   842090    0.3316004   1.182  12.256   7.63349125  39.09399046  32.54   2.92331122  0.969371201332   2.517      0
Aggregate:      20315  3362708    1.3241760   1.189  14.238   1.89851036  74.90381740  41.09   0.75239306  0.996300812242   2.959      0

After:

Encoding      kPixels    Bytes          BPP  E MP/s  D MP/s     Max norm  SSIMULACRA2   PSNR        pnorm       BPP*pnorm   QABPP   Bugs
----------------------------------------------------------------------------------------------------------------------------------------
jxl:d0.1        20315 17771024    6.9979205   1.080  10.130   0.35756577  95.39413774  55.88   0.11792287  0.825214859523   6.998      0
jxl:d0.5        20315  7252143    2.8557679   1.298  15.061   0.78009917  91.43862540  47.13   0.33393541  0.953642033483   2.944      0
jxl:d0.8        20315  5367111    2.1134751   1.174  15.263   1.11498186  88.72067125  44.51   0.47189587  0.997340150865   2.494      0
jxl:d1          20315  4606615    1.8140049   1.184  16.058   1.33978720  86.93643661  43.28   0.56051359  1.016774427528   2.535      0
jxl:d1.5        20315  3495106    1.3763120   1.174  15.498   1.86243967  82.75276197  41.14   0.76111748  1.047535130323   2.673      0
jxl:d2.0        20315  2841131    1.1187880   1.223  16.434   2.39270883  78.72248340  39.64   0.95068901  1.063619476080   2.823      0
jxl:d2.5        20315  2391176    0.9416036   1.205  16.258   2.85363662  74.90745005  38.44   1.12566896  1.059933899631   2.821      0
jxl:d3          20315  2084298    0.8207603   1.196  16.639   3.27099277  71.57564628  37.60   1.28291115  1.052962585207   2.801      0
jxl:d5          20315  1396215    0.5498052   1.188  11.067   4.60528606  60.08180640  35.30   1.81269081  0.996626849726   2.631      0
jxl:d10         20315   841857    0.3315087   1.153  11.835   7.65826483  38.55099789  32.51   2.92552904  0.969838209567   2.531      0
Aggregate:      20315  3363578    1.3245185   1.186  14.217   1.89943602  74.74511614  41.09   0.75185110  0.995840722234   2.960      0
```

The results are somewhat smoother with ringing artefacts usually disappearing. SSIMULACRA2 doesn't like it much, probably because the variance is reduced as a consequence and compression tends to reduce variance by itself. For the eye, the new results look slightly better.

<!-- Thank you for considering a contribution to `libjxl`! -->

### Description

<!-- Please provide a brief description of the changes in this PR and any additional context (e.g., why these changes were made, related issues, etc.). -->

### Pull Request Checklist

- [x] **CLA Signed**: Have you signed the [Contributor License Agreement](https://code.google.com/legal/individual-cla-v1.0.html) (individual or corporate, as appropriate)? Only contributions from signed contributors can be accepted.
- [x] **Authors**: Have you considered adding your name to the [AUTHORS](AUTHORS) file?
- [x] **Code Style**: Have you ensured your code adheres to the project's coding style guidelines? You can use `./ci.sh lint` for automatic code formatting.


Please review the full [contributing guidelines](https://github.com/libjxl/libjxl/blob/main/CONTRIBUTING.md) for more details.
