### PR TITLE
typos in color encoding

### DIFF
--- a/lib/include/jxl/color_encoding.h
+++ b/lib/include/jxl/color_encoding.h
@@ -32,9 +32,9 @@ typedef enum {
   JXL_COLOR_SPACE_UNKNOWN,
 } JxlColorSpace;
 
-/** Built-in whitepoints for color encoding. When decoding, the numerical xy
- * whitepoint value can be read from the @ref JxlColorEncoding white_point field
- * regardless of the enum value. When encoding, enum values except
+/** Built-in white points for color encoding. When decoding, the numerical xy
+ * white point value can be read from the @ref JxlColorEncoding white_point
+ * field regardless of the enum value. When encoding, enum values except
  * ::JXL_WHITE_POINT_CUSTOM override the numerical fields. Some enum values
  * match a subset of CICP (Rec. ITU-T H.273 | ISO/IEC 23091-2:2019(E)), however
  * the white point and RGB primaries are separate enums here.
@@ -78,7 +78,7 @@ typedef enum {
  * of CICP (Rec. ITU-T H.273 | ISO/IEC 23091-2:2019(E)) unless specified
  * otherwise. */
 typedef enum {
-  /** As specified in SMPTE RP 431-2 */
+  /** As specified in ITU-R BT.709-6 */
   JXL_TRANSFER_FUNCTION_709 = 1,
   /** None of the other table entries describe the transfer function. */
   JXL_TRANSFER_FUNCTION_UNKNOWN = 2,
@@ -97,7 +97,7 @@ typedef enum {
   JXL_TRANSFER_FUNCTION_GAMMA = 65535,
 } JxlTransferFunction;
 
-/** Renderig intent for color encoding, as specified in ISO 15076-1:2010 */
+/** Rendering intent for color encoding, as specified in ISO 15076-1:2010 */
 typedef enum {
   /** vendor-specific */
   JXL_RENDERING_INTENT_PERCEPTUAL = 0,
@@ -117,7 +117,7 @@ typedef struct {
   JxlColorSpace color_space;
 
   /** Built-in white point. If this value is ::JXL_WHITE_POINT_CUSTOM, must
-   * use the numerical whitepoint values from white_point_xy.
+   * use the numerical white point values from white_point_xy.
    */
   JxlWhitePoint white_point;
 

--- a/lib/jxl/cms/jxl_cms_internal.h
+++ b/lib/jxl/cms/jxl_cms_internal.h
@@ -76,7 +76,7 @@ constexpr Matrix3x3 kBradfordInv{{{0.9869929f, -0.1470543f, 0.1599627f},
                                   {0.4323053f, 0.5183603f, 0.0492912f},
                                   {-0.0085287f, 0.0400428f, 0.9684867f}}};
 
-// Adapts whitepoint x, y to D50
+// Adapts white point x, y to D50
 static Status AdaptToXYZD50(float wx, float wy, Matrix3x3& matrix) {
   bool ok = (wx >= 0) && (wx <= 1) && (wy > 0) && (wy <= 1);
   if (!ok) {
@@ -359,7 +359,7 @@ static Status CreateICCChadMatrix(double wx, double wy, Matrix3x3& result) {
   return true;
 }
 
-// Creates RGB to XYZ matrix given RGB primaries and whitepoint in xy.
+// Creates RGB to XYZ matrix given RGB primaries and white point in xy.
 static Status CreateICCRGBMatrix(double rx, double ry, double gx, double gy,
                                  double bx, double by, double wx, double wy,
                                  Matrix3x3& result) {

--- a/lib/jxl/color_encoding_internal.h
+++ b/lib/jxl/color_encoding_internal.h
@@ -155,7 +155,7 @@ struct ColorEncoding : public Fields {
   }
 
   // Sets the raw ICC profile bytes, without parsing the ICC, and without
-  // updating the direct fields such as whitepoint, primaries and color
+  // updating the direct fields such as white point, primaries and color
   // space. Functions to get and set fields, such as SetWhitePoint, cannot be
   // used anymore after this and functions such as IsSRGB return false no matter
   // what the contents of the icc profile.


### PR DESCRIPTION
and using "white point" (with a space) consistently

closes #3553 