### PR TITLE
Fixed --keep_invisible defaults.

### DIFF
--- a/lib/jxl/enc_frame.cc
+++ b/lib/jxl/enc_frame.cc
@@ -1516,7 +1516,7 @@ Status ComputeEncodingData(
     bool lossless = cparams.IsLossless();
     if (alpha && !alpha_eci->alpha_associated &&
         frame_header.frame_type == FrameType::kRegularFrame &&
-        !ApplyOverride(cparams.keep_invisible, true) &&
+        !ApplyOverride(cparams.keep_invisible, cparams.IsLossless()) &&
         cparams.ec_resampling == cparams.resampling &&
         !cparams.disable_percepeptual_optimizations) {
       // simplify invisible pixels

--- a/lib/jxl/jxl_test.cc
+++ b/lib/jxl/jxl_test.cc
@@ -382,15 +382,9 @@ JXL_X86_64_TEST(JxlTest, RoundtripLargeEmptyModular) {
   cparams.AddOption(JXL_ENC_FRAME_SETTING_DECODING_SPEED, 2);
 
   PackedPixelFile ppf_out;
-  EXPECT_NEAR(Roundtrip(t.ppf(), cparams, {}, pool.get(), &ppf_out), 3474795,
+  EXPECT_NEAR(Roundtrip(t.ppf(), cparams, {}, pool.get(), &ppf_out), 669009,
               100000);
-  EXPECT_SLIGHTLY_BELOW(ComputeDistance2(t.ppf(), ppf_out),
-#if JXL_HIGH_PRECISION
-                        2050
-#else
-                        12100
-#endif
-  );
+  EXPECT_SLIGHTLY_BELOW(ButteraugliDistance(t.ppf(), ppf_out), 0.19);
 }
 
 TEST(JxlTest, RoundtripOutputColorSpace) {


### PR DESCRIPTION
<!-- Thank you for considering a contribution to `libjxl`! -->

### Description

Set the flag --keep_invisible to default to 1 for lossless processing, and 0 for lossy.

Change the test target file size since the new default flag will create a smaller file.

Switched test comparison method to Butteraugli which handles the invisible pixels correctly.

### Pull Request Checklist

- [x] **CLA Signed**: Have you signed the [Contributor License Agreement](https://code.google.com/legal/individual-cla-v1.0.html) (individual or corporate, as appropriate)? Only contributions from signed contributors can be accepted.
- [x] **Authors**: Have you considered adding your name to the [AUTHORS](AUTHORS) file?
- [x] **Code Style**: Have you ensured your code adheres to the project's coding style guidelines? You can use `./ci.sh lint` for automatic code formatting.


Please review the full [contributing guidelines](https://github.com/libjxl/libjxl/blob/main/CONTRIBUTING.md) for more details.
