### PR TITLE
fix arithmetic issue in dot detection

### DIFF
--- a/lib/jxl/enc_linalg.cc
+++ b/lib/jxl/enc_linalg.cc
@@ -17,7 +17,7 @@ void ConvertToDiagonal(const Matrix2x2& A, Vector2& diag, Matrix2x2& U) {
   JXL_ASSERT(std::abs(A[0][1] - A[1][0]) < 1e-15);
 #endif
 
-  if (std::abs(A[0][1]) < 1e-15) {
+  if (std::abs(A[0][1]) < 1e-10) {
     // Already diagonal.
     diag[0] = A[0][0];
     diag[1] = A[1][1];

--- a/lib/jxl/enc_linalg.cc
+++ b/lib/jxl/enc_linalg.cc
@@ -17,7 +17,11 @@ void ConvertToDiagonal(const Matrix2x2& A, Vector2& diag, Matrix2x2& U) {
   JXL_ASSERT(std::abs(A[0][1] - A[1][0]) < 1e-15);
 #endif
 
-  if (std::abs(A[0][1]) < 1e-10) {
+  double b = -(A[0][0] + A[1][1]);
+  double c = A[0][0] * A[1][1] - A[0][1] * A[0][1];
+  double d = b * b - 4.0 * c;
+
+  if (std::abs(A[0][1]) < 1e-10 || d < 0) {
     // Already diagonal.
     diag[0] = A[0][0];
     diag[1] = A[1][1];
@@ -25,9 +29,7 @@ void ConvertToDiagonal(const Matrix2x2& A, Vector2& diag, Matrix2x2& U) {
     U[0][1] = U[1][0] = 0.0;
     return;
   }
-  double b = -(A[0][0] + A[1][1]);
-  double c = A[0][0] * A[1][1] - A[0][1] * A[0][1];
-  double d = b * b - 4.0 * c;
+
   double sqd = std::sqrt(d);
   double l1 = (-b - sqd) * 0.5;
   double l2 = (-b + sqd) * 0.5;

--- a/lib/jxl/enc_linalg_test.cc
+++ b/lib/jxl/enc_linalg_test.cc
@@ -73,14 +73,24 @@ TEST(LinAlgTest, ConvertToDiagonal) {
     VerifyOrthogonal(U, 1e-12);
     VerifyMatrixEqual(A, MatMul(U, MatMul(Diagonal(d), Transpose(U))), 1e-12);
   }
+  {
+    Matrix2x2 A;
+    A[0] = {0.000208649, 1.13687e-12};
+    A[1] = {1.13687e-12, 0.000208649};
+    Matrix2x2 U;
+    Vector2 d;
+    ConvertToDiagonal(A, d, U);
+    VerifyOrthogonal(U, 1e-12);
+    VerifyMatrixEqual(A, MatMul(U, MatMul(Diagonal(d), Transpose(U))), 1e-11);
+  }
   Rng rng(0);
-  for (size_t i = 0; i < 100; ++i) {
+  for (size_t i = 0; i < 1000000; ++i) {
     Matrix2x2 A = RandomSymmetricMatrix(rng, -1.0, 1.0);
     Matrix2x2 U;
     Vector2 d;
     ConvertToDiagonal(A, d, U);
     VerifyOrthogonal(U, 1e-12);
-    VerifyMatrixEqual(A, MatMul(U, MatMul(Diagonal(d), Transpose(U))), 1e-12);
+    VerifyMatrixEqual(A, MatMul(U, MatMul(Diagonal(d), Transpose(U))), 5e-10);
   }
 }
 


### PR DESCRIPTION
The bound was too tight, I encountered a case where it produced NaN output with that number equal to 1.13687e-12.

Haven't tested if this new bound is safe but it should at least be safer than the current one.