### PR TITLE
Fix advice in output for error JXL_ENC_ERR_JBRD

### DIFF
--- a/lib/extras/enc/jxl.cc
+++ b/lib/extras/enc/jxl.cc
@@ -202,7 +202,7 @@ bool EncodeImageJXL(const JXLCompressParams& params, const PackedPixelFile& ppf,
         fprintf(stderr,
                 "JPEG bitstream reconstruction data could not be created. "
                 "Possibly there is too much tail data.\n"
-                "Try using --jpeg_store_metadata 0, to losslessly "
+                "Try using --allow_jpeg_reconstruction 0, to losslessly "
                 "recompress the JPEG image data without bitstream "
                 "reconstruction data.\n");
       } else {


### PR DESCRIPTION
Updates the message output upon an JXL_ENC_ERR_JBRD error (JPEG bitstream reconstruction data could not be represented) to suggest passing --allow_jpeg_reconstruction 0. It previously suggested "Try using --jpeg_store_metadata 0", which will trigger an unknown-argument error.

params->jpeg_store_metadata exists but derives its value from params->allow_jpeg_reconstruction (tools/cjxl_main.cc:921) so I believe this is the correct parameter to suggest.