### PR TITLE
Gaborish adjustment, more precise for high quality

### DIFF
--- a/lib/jxl/enc_gaborish.cc
+++ b/lib/jxl/enc_gaborish.cc
@@ -28,8 +28,9 @@ Status GaborishInverse(Image3F* in_out, const Rect& rect, const float mul[3],
   // more favorable for good rate-distortion compromises rather than
   // just using mathematical optimization to find the inverse.
   static const float kGaborish[5] = {
-      -0.090881924078487886f, -0.043663953593472138f, 0.01392497846646211f,
-      0.0036189602184591141f, 0.0030557936884763499f};
+      -0.09495815671340026, -0.041031725066768575,  0.013710004822696948,
+      0.006510206083837737, -0.0014789063378272242,
+  };
   for (int i = 0; i < 3; ++i) {
     double sum = 1.0 + mul[i] * 4 *
                            (kGaborish[0] + kGaborish[1] + kGaborish[2] +

--- a/lib/jxl/enc_heuristics.cc
+++ b/lib/jxl/enc_heuristics.cc
@@ -1080,11 +1080,12 @@ Status LossyFrameHeuristics(const FrameHeader& frame_header,
 
   // Apply inverse-gaborish.
   if (frame_header.loop_filter.gab) {
-    // Unsure why better to do some more gaborish on X and B than Y.
+    // Changing the weight here to 0.99f would help to reduce ringing in
+    // generation loss.
     float weight[3] = {
-        1.0036278514398933f,
-        0.99406123118127299f,
-        0.99719338015886894f,
+        1.0f,
+        1.0f,
+        1.0f,
     };
     JXL_RETURN_IF_ERROR(GaborishInverse(opsin, rect, weight, pool));
   }

--- a/lib/jxl/passes_test.cc
+++ b/lib/jxl/passes_test.cc
@@ -105,7 +105,7 @@ TEST(PassesTest, RoundtripMultiGroupPasses) {
         target_distance + threshold);
   };
 
-  auto run1 = std::async(std::launch::async, test, 1.0f, 0.15f);
+  auto run1 = std::async(std::launch::async, test, 1.0f, 0.25f);
   auto run2 = std::async(std::launch::async, test, 2.0f, 0.0f);
 }
 

--- a/lib/jxl/roundtrip_test.cc
+++ b/lib/jxl/roundtrip_test.cc
@@ -434,7 +434,7 @@ void VerifyRoundtripCompression(
     float butteraugli_score = ButteraugliDistance(
         original_io.frames, decoded_io.frames, ba, *JxlGetDefaultCms(),
         /*distmap=*/nullptr, nullptr);
-    float target_score = 1.4f;
+    float target_score = 1.5f;
     // upsampling mode 1 (unlike default and NN) does not downscale back to the
     // already downsampled image
     if (upsampling_mode == 1 && resampling >= 4 && already_downsampled)


### PR DESCRIPTION
This greatly reduces generation loss, but other issues in generation loss remain.

```
Before:

Encoding      kPixels    Bytes          BPP  E MP/s  D MP/s     Max norm  SSIMULACRA2   PSNR        pnorm       BPP*pnorm   QABPP   Bugs
----------------------------------------------------------------------------------------------------------------------------------------
jxl:d0.1        20315 17771024    6.9979205   1.083  10.777   0.35756577  95.39413774  55.88   0.11792287  0.825214859523   6.998      0
jxl:d0.5        20315  7252143    2.8557679   1.284  15.072   0.78009917  91.43862540  47.13   0.33393541  0.953642033483   2.944      0
jxl:d0.8        20315  5367111    2.1134751   1.174  15.958   1.11498186  88.72067125  44.51   0.47189587  0.997340150865   2.494      0
jxl:d1          20315  4606615    1.8140049   1.198  16.140   1.33978720  86.93643661  43.28   0.56051359  1.016774427528   2.535      0
jxl:d1.5        20315  3495106    1.3763120   1.171  15.575   1.86243967  82.75276197  41.14   0.76111748  1.047535130323   2.673      0
jxl:d2.0        20315  2841131    1.1187880   1.219  16.153   2.39270883  78.72248340  39.64   0.95068901  1.063619476080   2.823      0
jxl:d2.5        20315  2391176    0.9416036   1.230  16.769   2.85363662  74.90745005  38.44   1.12566896  1.059933899631   2.821      0
jxl:d3          20315  2084298    0.8207603   1.169  16.651   3.27099277  71.57564628  37.60   1.28291115  1.052962585207   2.801      0
jxl:d5          20315  1396215    0.5498052   1.175  11.051   4.60528606  60.08180640  35.30   1.81269081  0.996626849726   2.631      0
jxl:d10         20315   841857    0.3315087   1.176  12.008   7.65826483  38.55099789  32.51   2.92552904  0.969838209567   2.531      0
Aggregate:      20315  3363578    1.3245185   1.187  14.425   1.89943602  74.74511614  41.09   0.75185110  0.995840722234   2.960      0

After:

Encoding      kPixels    Bytes          BPP  E MP/s  D MP/s     Max norm  SSIMULACRA2   PSNR        pnorm       BPP*pnorm   QABPP   Bugs
----------------------------------------------------------------------------------------------------------------------------------------
jxl:d0.1        20315 17766371    6.9960882   1.093  10.338   0.32866526  95.56544829  56.41   0.10370099  0.725501299870   7.014      0
jxl:d0.5        20315  7257022    2.8576892   1.284  15.103   0.77189099  91.50635825  47.20   0.32944160  0.941441693676   2.940      0
jxl:d0.8        20315  5369016    2.1142252   1.180  15.430   1.11768504  88.79989471  44.53   0.46965892  0.992964741019   2.493      0
jxl:d1          20315  4609246    1.8150410   1.196  15.738   1.33782778  86.98780844  43.30   0.55832773  1.013387710805   2.536      0
jxl:d1.5        20315  3497199    1.3771362   1.207  15.962   1.85855401  82.81295438  41.16   0.76009258  1.046751002825   2.656      0
jxl:d2.0        20315  2843156    1.1195854   1.220  16.059   2.41777601  78.77166762  39.63   0.94948695  1.063031760887   2.848      0
jxl:d2.5        20315  2394127    0.9427656   1.228  16.526   2.84988972  74.99224027  38.44   1.12556297  1.061142061097   2.819      0
jxl:d3          20315  2083912    0.8206083   1.184  16.452   3.26822970  71.60239559  37.59   1.28327248  1.053064099262   2.811      0
jxl:d5          20315  1395134    0.5493795   1.180  11.168   4.60916078  60.13079585  35.29   1.81183388  0.995384445464   2.621      0
jxl:d10         20315   842026    0.3315752   1.174  11.917   7.64110776  38.58375043  32.51   2.92833970  0.970964848671   2.514      0
Aggregate:      20315  3364628    1.3249321   1.194  14.276   1.88258220  74.80896744  41.14   0.74046019  0.981059483733   2.959      0
```