### PR TITLE
more benchmark_xl output

### DIFF
--- a/tools/benchmark/benchmark_stats.h
+++ b/tools/benchmark/benchmark_stats.h
@@ -63,6 +63,8 @@ struct BenchmarkStats {
   double psnr = 0.0;
   double ssimulacra2 = 0.0;
   std::vector<float> distances;
+  std::vector<float> pnorms;
+  std::vector<float> ssimulacra2s;
   size_t total_errors = 0;
   JxlStats jxl_stats;
   std::vector<float> extra_metrics;

--- a/tools/benchmark/benchmark_xl.cc
+++ b/tools/benchmark/benchmark_xl.cc
@@ -273,13 +273,16 @@ void DoCompress(const std::string& filename, const PackedPixelFile& ppf,
         compressed->empty()
             ? 0
             : jxl::ComputePSNR(ib1, ib2, *JxlGetDefaultCms()) * input_pixels;
-    s->distance_p_norm +=
-        ComputeDistanceP(distmap, ButteraugliParams(), Args()->error_pnorm) *
-        input_pixels;
+    double pnorm =
+        ComputeDistanceP(distmap, ButteraugliParams(), Args()->error_pnorm);
+    s->distance_p_norm += pnorm * input_pixels;
     JXL_ASSIGN_OR_DIE(Msssim msssim, ComputeSSIMULACRA2(ib1, ib2));
-    s->ssimulacra2 += msssim.Score() * input_pixels;
+    double ssimulacra2 = msssim.Score();
+    s->ssimulacra2 += ssimulacra2 * input_pixels;
     s->max_distance = std::max(s->max_distance, distance);
     s->distances.push_back(distance);
+    s->pnorms.push_back(pnorm);
+    s->ssimulacra2s.push_back(ssimulacra2);
   }
 
   s->total_compressed_size += compressed->size();
@@ -677,12 +680,12 @@ struct StatPrinter {
         t.stats.total_input_pixels / (1000000.0 * t.stats.total_time_decode);
     if (Args()->print_details_csv) {
       printf("%s,%s,%" PRIdS ",%" PRIdS ",%" PRIdS
-             ",%.8f,%.8f,%.8f,%.8f,%.8f,%.8f,%.8f,%.8f",
+             ",%.8f,%.8f,%.8f,%.8f,%.8f,%.8f,%.8f,%.8f,%.8f",
              (*methods_)[t.idx_method].c_str(),
              FileBaseName((*fnames_)[t.idx_image]).c_str(),
              t.stats.total_errors, t.stats.total_compressed_size, pixels,
-             enc_mps, dec_mps, comp_bpp, t.stats.max_distance, psnr, p_norm,
-             bpp_p_norm, adj_comp_bpp);
+             enc_mps, dec_mps, comp_bpp, t.stats.max_distance, ssimulacra2,
+             psnr, p_norm, bpp_p_norm, adj_comp_bpp);
       for (float m : t.stats.extra_metrics) {
         printf(",%.8f", m);
       }
@@ -754,7 +757,10 @@ struct StatPrinter {
       }
       printf("```\n");
     }
-    if (fnames_->size() == 1) printf("%s\n", (*fnames_)[0].c_str());
+    if (fnames_->size() == 1)
+      printf("%s\n", (*fnames_)[0].c_str());
+    else
+      printf("%" PRIuS " images\n", fnames_->size());
     printf("%s", PrintHeader(*extra_metrics_names_).c_str());
     fflush(stdout);
   }
@@ -1073,7 +1079,7 @@ class Benchmark {
       // Print CSV header
       printf(
           "method,image,error,size,pixels,enc_speed,dec_speed,"
-          "bpp,dist,psnr,p,bppp,qabpp");
+          "bpp,maxnorm,ssimulacra2,psnr,pnorm,bppp,qabpp");
       for (const std::string& s : extra_metrics_names) {
         printf(",%s", s.c_str());
       }


### PR DESCRIPTION
Fixes https://github.com/libjxl/libjxl/issues/3585

Also adds more details when using the flag `--print_distance_percentiles`.

Also fixes the aggregate value for ssimulacra2: it was ignoring negative values and taking the geomean of just the positive ones; now it just takes the arithmetic mean of all ssimulacra2 values.

Before:
```
Encoding      kPixels    Bytes          BPP  E MP/s  D MP/s     Max norm  SSIMULACRA2   PSNR        pnorm       BPP*pnorm   QABPP   Bugs
----------------------------------------------------------------------------------------------------------------------------------------
50th/90th percentile distance: 0.74641287  0.89263189
jxl:d0.5        13562  4936672    2.9119624   2.323  34.301   0.76519037  91.52246513  46.23   0.34268783  0.997894059218   2.913      0
50th/90th percentile distance: 1.30287242  1.55675101
jxl:d1          13562  3045965    1.7967034   2.239  34.252   1.35021809  86.95225346  42.34   0.58427450  1.049767991430   2.440      0
50th/90th percentile distance: 2.29967427  2.89556241
jxl:d2          13562  1835797    1.0828695   2.292  32.952   2.41013471  78.73319052  38.83   0.97862361  1.059721707947   2.693      0
50th/90th percentile distance: 3.09834218  3.91219139
jxl:d3          13562  1334015    0.7868867   2.248  33.389   3.23678298  71.66090226  36.88   1.31249357  1.032783716883   2.611      0
50th/90th percentile distance: 15.69093132  17.99648857
jxl:d24         13562   270716    0.1596855   0.605  38.327  16.06720416  -2.15884859  29.27   5.74953159  0.918116671120   2.607      0
50th/90th percentile distance: 16.13576889  18.36326790
jxl:d25         13562   261793    0.1544221   0.606  35.376  16.68272962  -3.80875468  29.17   5.89834294  0.910834629742   2.593      0
Aggregate:      13562  1173373    0.6921298   1.463  34.723   3.59547238  81.85819581  36.57   1.43471342  0.993007961883   2.639      0
```


After:
```
46 images
Encoding      kPixels    Bytes          BPP  E MP/s  D MP/s     Max norm  SSIMULACRA2   PSNR        pnorm       BPP*pnorm   QABPP   Bugs
----------------------------------------------------------------------------------------------------------------------------------------
   _________________________________________| median:         0.74641287  91.96166229          0.33922365
  /                                         | p10 (worst):    0.89263189  89.77494049          0.38702947
 /                                          | p5 (worst):     0.93385208  89.31037903          0.39110589
jxl:d0.5        13562  4936672    2.9119624   2.315  31.096   0.76519037  91.52246533  46.23   0.34268782  0.997894047755   2.913      0
   _________________________________________| median:         1.30287242  88.15885162          0.57385707
  /                                         | p10 (worst):    1.55675101  82.56882477          0.70896733
 /                                          | p5 (worst):     1.61269927  82.47370911          0.72702777
jxl:d1          13562  3045965    1.7967034   2.205  34.431   1.35021809  86.95225222  42.34   0.58427450  1.049767990116   2.440      0
   _________________________________________| median:         2.29967427  80.39791870          0.95846683
  /                                         | p10 (worst):    2.89556241  70.31759644          1.26363790
 /                                          | p5 (worst):     2.96536636  68.60237885          1.32267296
jxl:d2          13562  1835797    1.0828695   2.306  34.101   2.41013471  78.73319006  38.83   0.97862363  1.059721729400   2.693      0
   _________________________________________| median:         3.09834218  73.34270477          1.27836907
  /                                         | p10 (worst):    3.91219139  60.53897095          1.67121387
 /                                          | p5 (worst):     4.07968855  55.49774170          1.81831229
jxl:d3          13562  1334015    0.7868867   2.316  32.388   3.23678298  71.66090188  36.88   1.31249357  1.032783719159   2.611      0
   _________________________________________| median:        15.69093132   5.88187265          6.02538586
  /                                         | p10 (worst):   17.99648857 -26.42949295          6.62558889
 /                                          | p5 (worst):    18.10667038 -35.92488098          6.94895744
jxl:d24         13562   270716    0.1596855   0.606  34.924  16.06720416  -2.15884861  29.27   5.74953159  0.918116671543   2.607      0
   _________________________________________| median:        16.13576889   4.86366034          6.11648321
  /                                         | p10 (worst):   18.36326790 -28.11663246          6.71656990
 /                                          | p5 (worst):    18.51855659 -36.31728745          7.22389078
jxl:d25         13562   261793    0.1544221   0.609  37.065  16.68272962  -3.80875474  29.17   5.89834299  0.910834637497   2.593      0
Aggregate:      13562  1173373    0.6921298   1.469  33.948   3.59547238  53.81686769  36.57   1.43471343  0.993007964975   2.639      0
```