### PR TITLE
add unknown and optional extra channels in PAM

### DIFF
--- a/lib/extras/dec/pnm.cc
+++ b/lib/extras/dec/pnm.cc
@@ -227,6 +227,10 @@ class Parser {
           header->ec_types.push_back(JXL_CHANNEL_CFA);
         } else if (MatchString("Thermal")) {
           header->ec_types.push_back(JXL_CHANNEL_THERMAL);
+        } else if (MatchString("Unknown")) {
+          header->ec_types.push_back(JXL_CHANNEL_UNKNOWN);
+        } else if (MatchString("Optional")) {
+          header->ec_types.push_back(JXL_CHANNEL_OPTIONAL);
         } else {
           return JXL_FAILURE("PAM: unknown TUPLTYPE");
         }

--- a/lib/extras/enc/pnm.cc
+++ b/lib/extras/enc/pnm.cc
@@ -299,6 +299,10 @@ class PAMEncoder : public BasePNMEncoder {
         return std::string("CFA");
       case JXL_CHANNEL_THERMAL:
         return std::string("Thermal");
+      case JXL_CHANNEL_UNKNOWN:
+        return std::string("Unknown");
+      case JXL_CHANNEL_OPTIONAL:
+        return std::string("Optional");
       default:
         return std::string("UNKNOWN");
     }


### PR DESCRIPTION
This allows you to have kUnknown and kOptional extra channels in PAM input/output.
For example, for 21-channel 16-bit multispectral images, where the first three are RGB and then there are 18 additional channels that are represented as extra channels of type kOptional, you could use a (somewhat nonstandard) PAM file with a header like this:

```
P7
WIDTH 4865
HEIGHT 4091
DEPTH 21
MAXVAL 65535
TUPLTYPE RGB
TUPLTYPE Optional
TUPLTYPE Optional
TUPLTYPE Optional
[...]
TUPLTYPE Optional
ENDHDR
```

Not the most beautiful way to deal with this type of data, but at least this provides a way to do it.