### PR TITLE
fix issues in pam encode/decode

### DIFF
--- a/lib/extras/dec/pnm.cc
+++ b/lib/extras/dec/pnm.cc
@@ -476,7 +476,7 @@ Status DecodeImagePNM(const Span<const uint8_t> bytes,
   ppf->info.num_extra_channels = num_alpha_channels + header.ec_types.size();
 
   for (auto type : header.ec_types) {
-    PackedExtraChannel pec;
+    PackedExtraChannel pec = {};
     pec.ec_info.bits_per_sample = ppf->info.bits_per_sample;
     pec.ec_info.type = type;
     ppf->extra_channels_info.emplace_back(std::move(pec));

--- a/lib/extras/enc/pnm.cc
+++ b/lib/extras/enc/pnm.cc
@@ -26,7 +26,7 @@ namespace jxl {
 namespace extras {
 namespace {
 
-constexpr size_t kMaxHeaderSize = 200;
+constexpr size_t kMaxHeaderSize = 2000;
 
 class BasePNMEncoder : public Encoder {
  public:


### PR DESCRIPTION
Fixes two issues in PAM handling:

- `pec.ec_info` was not initialized, causing bogus values in `exponent_bits` and failure the encode.
- maximum header size when writing a PAM file was too small for e.g. the multispectral use case with 21 channel images.