### PR TITLE
improve lossless e2/e3 for > 10-bit images and make -E 1 do something when doing -e 2

### DIFF
--- a/lib/jxl/enc_modular.cc
+++ b/lib/jxl/enc_modular.cc
@@ -1131,8 +1131,8 @@ Status ModularFrameEncoder::ComputeTree(ThreadPool* pool) {
                 total_pixels += ch.w * ch.h;
               }
             }
-            trees[chunk] =
-                PredefinedTree(stream_options_[start].tree_kind, total_pixels);
+            trees[chunk] = PredefinedTree(stream_options_[start].tree_kind,
+                                          total_pixels, 8, 0);
             return;
           }
           TreeSamples tree_samples;
@@ -1187,17 +1187,20 @@ Status ModularFrameEncoder::ComputeTree(ThreadPool* pool) {
   } else {
     // Fixed tree.
     size_t total_pixels = 0;
+    int max_bitdepth = 0;
     for (const Image& img : stream_images_) {
+      max_bitdepth = std::max(max_bitdepth, img.bitdepth);
       for (const Channel& ch : img.channel) {
         total_pixels += ch.w * ch.h;
       }
     }
     if (cparams_.speed_tier <= SpeedTier::kFalcon) {
-      tree_ =
-          PredefinedTree(ModularOptions::TreeKind::kWPFixedDC, total_pixels);
+      tree_ = PredefinedTree(ModularOptions::TreeKind::kWPFixedDC, total_pixels,
+                             max_bitdepth, stream_options_[0].max_properties);
     } else if (cparams_.speed_tier <= SpeedTier::kThunder) {
       tree_ = PredefinedTree(ModularOptions::TreeKind::kGradientFixedDC,
-                             total_pixels);
+                             total_pixels, max_bitdepth,
+                             stream_options_[0].max_properties);
     } else {
       tree_ = {PropertyDecisionNode::Leaf(Predictor::Gradient)};
     }

--- a/lib/jxl/encode.cc
+++ b/lib/jxl/encode.cc
@@ -588,7 +588,9 @@ JxlEncoderStatus CheckValidBitdepth(uint32_t bits_per_sample,
   } else if ((exponent_bits_per_sample > 8) ||
              (bits_per_sample > 24 + exponent_bits_per_sample) ||
              (bits_per_sample < 3 + exponent_bits_per_sample)) {
-    return JXL_API_ERROR_NOSET("Invalid float description");
+    return JXL_API_ERROR_NOSET(
+        "Invalid float description: bits per sample = %u, exp bits = %u",
+        bits_per_sample, exponent_bits_per_sample);
   }
   return JxlErrorOrStatus::Success();
 }

--- a/lib/jxl/modular/encoding/enc_encoding.cc
+++ b/lib/jxl/modular/encoding/enc_encoding.cc
@@ -66,7 +66,7 @@ Tree MakeFixedTree(int property, const std::vector<int32_t> &cutoffs,
   if (log_px < 14) {
     min_gap = 8 * (14 - log_px);
   }
-  const size_t shift = bitdepth > 10 ? bitdepth - 10 : 0;
+  const size_t shift = bitdepth > 11 ? std::min(4, bitdepth - 11) : 0;
   Tree tree;
   struct NodeInfo {
     size_t begin, end, pos;
@@ -350,7 +350,7 @@ Status EncodeModularChannelMAANS(const Image &image, pixel_type chan,
   // Check if this tree is a WP-only tree with a small enough property value
   // range.
   // Initialized to avoid clang-tidy complaining.
-  auto tree_lut = jxl::make_unique<TreeLut<uint16_t, false>>();
+  auto tree_lut = jxl::make_unique<TreeLut<uint8_t, false, false>>();
   if (is_wp_only) {
     is_wp_only = TreeToLookupTable(tree, *tree_lut);
   }
@@ -383,7 +383,7 @@ Status EncodeModularChannelMAANS(const Image &image, pixel_type chan,
             kPropRangeFast + std::min(std::max(-kPropRangeFast, properties[0]),
                                       kPropRangeFast - 1);
         uint32_t ctx_id = tree_lut->context_lookup[pos];
-        int32_t residual = r[x] - guess - tree_lut->offsets[pos];
+        int32_t residual = r[x] - guess;
         *tokenp++ = Token(ctx_id, PackSigned(residual));
         wp_state.UpdateErrors(r[x], x, y, channel.w);
       }
@@ -426,7 +426,7 @@ Status EncodeModularChannelMAANS(const Image &image, pixel_type chan,
                 std::max<pixel_type_w>(-kPropRangeFast, top + left - topleft),
                 kPropRangeFast - 1);
         uint32_t ctx_id = tree_lut->context_lookup[pos];
-        int32_t residual = r[x] - guess - tree_lut->offsets[pos];
+        int32_t residual = r[x] - guess;
         *tokenp++ = Token(ctx_id, PackSigned(residual));
       }
     }

--- a/lib/jxl/modular/encoding/enc_encoding.h
+++ b/lib/jxl/modular/encoding/enc_encoding.h
@@ -24,7 +24,8 @@ struct AuxOut;
 enum class LayerType : uint8_t;
 struct GroupHeader;
 
-Tree PredefinedTree(ModularOptions::TreeKind tree_kind, size_t total_pixels);
+Tree PredefinedTree(ModularOptions::TreeKind tree_kind, size_t total_pixels,
+                    int bitdepth, int prevprop);
 
 Tree LearnTree(TreeSamples &&tree_samples, size_t total_pixels,
                const ModularOptions &options,

--- a/lib/jxl/modular/encoding/encoding.cc
+++ b/lib/jxl/modular/encoding/encoding.cc
@@ -140,7 +140,7 @@ Status DecodeModularChannelMAANS(BitReader *br, ANSSymbolReader *reader,
                                  const Tree &global_tree,
                                  const weighted::Header &wp_header,
                                  pixel_type chan, size_t group_id,
-                                 TreeLut<uint8_t, true> &tree_lut,
+                                 TreeLut<uint8_t, false, false> &tree_lut,
                                  Image *image) {
   JxlMemoryManager *memory_manager = image->memory_manager();
   Channel &channel = image->channel[chan];
@@ -303,9 +303,7 @@ Status DecodeModularChannelMAANS(BitReader *br, ANSSymbolReader *reader,
         uint32_t ctx_id = tree_lut.context_lookup[pos];
         uint64_t v =
             reader->ReadHybridUintClusteredMaybeInlined<uses_lz77>(ctx_id, br);
-        r[x] = make_pixel(
-            v, tree_lut.multipliers[pos],
-            static_cast<pixel_type_w>(tree_lut.offsets[pos]) + guess);
+        r[x] = make_pixel(v, 1, guess);
       }
     }
   } else if (!uses_lz77 && is_wp_only && channel.w > 8) {
@@ -336,9 +334,7 @@ Status DecodeModularChannelMAANS(BitReader *br, ANSSymbolReader *reader,
         uint32_t ctx_id = tree_lut.context_lookup[pos];
         uint64_t v =
             reader->ReadHybridUintClusteredInlined<uses_lz77>(ctx_id, br);
-        r[x] = make_pixel(
-            v, tree_lut.multipliers[pos],
-            static_cast<pixel_type_w>(tree_lut.offsets[pos]) + guess);
+        r[x] = make_pixel(v, 1, guess);
         wp_state.UpdateErrors(r[x], x, y, channel.w);
       }
       for (x = 1; x + 1 < channel.w; x++) {
@@ -352,9 +348,7 @@ Status DecodeModularChannelMAANS(BitReader *br, ANSSymbolReader *reader,
         uint32_t ctx_id = tree_lut.context_lookup[pos];
         uint64_t v =
             reader->ReadHybridUintClusteredInlined<uses_lz77>(ctx_id, br);
-        r[x] = make_pixel(
-            v, tree_lut.multipliers[pos],
-            static_cast<pixel_type_w>(tree_lut.offsets[pos]) + guess);
+        r[x] = make_pixel(v, 1, guess);
         wp_state.UpdateErrors(r[x], x, y, channel.w);
       }
       {
@@ -368,9 +362,7 @@ Status DecodeModularChannelMAANS(BitReader *br, ANSSymbolReader *reader,
         uint32_t ctx_id = tree_lut.context_lookup[pos];
         uint64_t v =
             reader->ReadHybridUintClusteredInlined<uses_lz77>(ctx_id, br);
-        r[x] = make_pixel(
-            v, tree_lut.multipliers[pos],
-            static_cast<pixel_type_w>(tree_lut.offsets[pos]) + guess);
+        r[x] = make_pixel(v, 1, guess);
         wp_state.UpdateErrors(r[x], x, y, channel.w);
       }
     }
@@ -489,7 +481,7 @@ Status DecodeModularChannelMAANS(BitReader *br, ANSSymbolReader *reader,
                                  const Tree &global_tree,
                                  const weighted::Header &wp_header,
                                  pixel_type chan, size_t group_id,
-                                 TreeLut<uint8_t, true> &tree_lut,
+                                 TreeLut<uint8_t, false, false> &tree_lut,
                                  Image *image) {
   if (reader->UsesLZ77()) {
     return detail::DecodeModularChannelMAANS</*uses_lz77=*/true>(
@@ -627,7 +619,7 @@ Status ModularDecode(BitReader *br, Image &image, GroupHeader &header,
   // Read channels
   JXL_ASSIGN_OR_RETURN(ANSSymbolReader reader,
                        ANSSymbolReader::Create(code, br, distance_multiplier));
-  auto tree_lut = jxl::make_unique<TreeLut<uint8_t, true>>();
+  auto tree_lut = jxl::make_unique<TreeLut<uint8_t, false, false>>();
   for (; next_channel < nb_channels; next_channel++) {
     Channel &channel = image.channel[next_channel];
     if (!channel.w || !channel.h) {

--- a/lib/jxl/modular/encoding/encoding.h
+++ b/lib/jxl/modular/encoding/encoding.h
@@ -27,7 +27,7 @@ struct ANSCode;
 class BitReader;
 
 // Valid range of properties for using lookup tables instead of trees.
-constexpr int32_t kPropRangeFast = 512;
+constexpr int32_t kPropRangeFast = 512 << 6;
 
 struct GroupHeader : public Fields {
   GroupHeader();

--- a/lib/jxl/modular/encoding/encoding.h
+++ b/lib/jxl/modular/encoding/encoding.h
@@ -27,7 +27,7 @@ struct ANSCode;
 class BitReader;
 
 // Valid range of properties for using lookup tables instead of trees.
-constexpr int32_t kPropRangeFast = 512 << 6;
+constexpr int32_t kPropRangeFast = 512 << 4;
 
 struct GroupHeader : public Fields {
   GroupHeader();
@@ -59,15 +59,16 @@ FlatTree FilterTree(const Tree &global_tree,
                     size_t *num_props, bool *use_wp, bool *wp_only,
                     bool *gradient_only);
 
-template <typename T, bool HAS_MULTIPLIERS>
+template <typename T, bool HAS_OFFSETS, bool HAS_MULTIPLIERS>
 struct TreeLut {
   std::array<T, 2 * kPropRangeFast> context_lookup;
-  std::array<int8_t, 2 * kPropRangeFast> offsets;
+  std::array<int8_t, HAS_OFFSETS ? (2 * kPropRangeFast) : 0> offsets;
   std::array<int8_t, HAS_MULTIPLIERS ? (2 * kPropRangeFast) : 0> multipliers;
 };
 
-template <typename T, bool HAS_MULTIPLIERS>
-bool TreeToLookupTable(const FlatTree &tree, TreeLut<T, HAS_MULTIPLIERS> &lut) {
+template <typename T, bool HAS_OFFSETS, bool HAS_MULTIPLIERS>
+bool TreeToLookupTable(const FlatTree &tree,
+                       TreeLut<T, HAS_OFFSETS, HAS_MULTIPLIERS> &lut) {
   struct TreeRange {
     // Begin *excluded*, end *included*. This works best with > vs <= decision
     // nodes.
@@ -98,12 +99,17 @@ bool TreeToLookupTable(const FlatTree &tree, TreeLut<T, HAS_MULTIPLIERS> &lut) {
       if (!HAS_MULTIPLIERS && node.multiplier != 1) {
         return false;
       }
+      if (!HAS_OFFSETS && node.predictor_offset != 0) {
+        return false;
+      }
       for (int i = cur.begin + 1; i < cur.end + 1; i++) {
         lut.context_lookup[i + kPropRangeFast] = node.childID;
         if (HAS_MULTIPLIERS) {
           lut.multipliers[i + kPropRangeFast] = node.multiplier;
         }
-        lut.offsets[i + kPropRangeFast] = node.predictor_offset;
+        if (HAS_OFFSETS) {
+          lut.offsets[i + kPropRangeFast] = node.predictor_offset;
+        }
       }
       continue;
     }


### PR DESCRIPTION
The cutoffs used in the predefined trees for e2 (and the fallback e1 path) and e3 lossless encoding were designed with 8-bit images (possibly up to 10-bit) in mind. For higher bit depth images, compression improves when scaling up the cutoff values according to the bit depth.

Also: when explicitly enabling the previous channel extra properties (as set by the `-E` option in cjxl), we can use a previous channel  gradient difference property as context (based on the decoded value of the previous channel at the current pixel position), instead of the usual MA tree property we use in e2. This adds some encode/decode slowdown and is not necessarily better, but it can improve compression. This can be useful in particular for multi-spectral images with many correlated channels, like this example image with 21 channels with 16-bit data:

Before:
```
radiance-21.jxl
Encoding       kPixels    Bytes          BPP  E MP/s  D MP/s     Max norm  SSIMULACRA2   PSNR        pnorm       BPP*pnorm   QABPP   Bugs
-----------------------------------------------------------------------------------------------------------------------------------------
jxl:d0:2         19902 396731430  159.4682655  16.820  31.253          nan 100.00000000  99.99   0.00000000  0.000000000000 159.468      0
jxl:d0:2:E1      19902 396731430  159.4682655  16.815  31.294          nan 100.00000000  99.99   0.00000000  0.000000000000 159.468      0
jxl:d0:3         19902 436822417  175.5830466   9.447  13.736          nan 100.00000000  99.99   0.00000000  0.000000000000 175.583      0
Aggregate:       19902 409668631  164.6684410  13.876  23.772   0.00000000 100.00000000  99.99   0.00000000  0.000000000000 164.668      0
```

After:
```
radiance-21.jxl
Encoding       kPixels    Bytes          BPP  E MP/s  D MP/s     Max norm  SSIMULACRA2   PSNR        pnorm       BPP*pnorm   QABPP   Bugs
-----------------------------------------------------------------------------------------------------------------------------------------
jxl:d0:2         19902 387149978  155.6169510  11.994  14.058          nan 100.00000000  99.99   0.00000000  0.000000000000 155.617      0
jxl:d0:2:E1      19902 343799453  138.1919815  10.345  13.996          nan 100.00000000  99.99   0.00000000  0.000000000000 138.192      0
jxl:d0:3         19902 426401702  171.3943859   7.986  10.054          nan 100.00000000  99.99   0.00000000  0.000000000000 171.394      0
Aggregate:       19902 384297698  154.4704622   9.970  12.553   0.00000000 100.00000000  99.99   0.00000000  0.000000000000 154.470      0
```

Note: enc/dec speed does get worse, likely because before, the fixed MA tree ended up mostly collapsing when encoding 16-bit data with thresholds designed for 8-bit. The speeds are still quite reasonable for a 21-channel image.