### PR TITLE
don't do a funky conversion from uint8 to float

### DIFF
--- a/lib/jxl/base/float.h
+++ b/lib/jxl/base/float.h
@@ -62,9 +62,7 @@ static Status JXL_INLINE LoadFloatRow(const uint8_t* src, size_t count,
 
     case JXL_TYPE_UINT8:
       for (size_t i = 0; i < count; ++i) {
-        // Integer multiply uint8 value before scaling so that the UINT8 value
-        // and the corresponding UINT16 value convert to the same float
-        callback(i, (src[stride * i] * 257) * scale);
+        callback(i, src[stride * i] * scale);
       }
       return true;
 

--- a/lib/jxl/blending_test.cc
+++ b/lib/jxl/blending_test.cc
@@ -24,7 +24,7 @@ TEST(BlendingTest, Crops) {
   const std::vector<uint8_t> compressed =
       jxl::test::ReadTestData("jxl/blending/cropped_traffic_light.jxl");
   extras::JXLDecompressParams dparams;
-  dparams.accepted_formats = {{3, JXL_TYPE_UINT16, JXL_LITTLE_ENDIAN, 0}};
+  dparams.accepted_formats = {{3, JXL_TYPE_UINT8, JXL_LITTLE_ENDIAN, 0}};
   extras::PackedPixelFile decoded;
   ASSERT_TRUE(DecodeImageJXL(compressed.data(), compressed.size(), dparams,
                              /*decoded_bytes=*/nullptr, &decoded));

--- a/lib/jxl/enc_external_image.cc
+++ b/lib/jxl/enc_external_image.cc
@@ -58,14 +58,7 @@ Status ConvertFromExternalNoSizeCheck(const uint8_t* data, size_t xsize,
   size_t bytes_per_pixel = format.num_channels * bytes_per_channel;
   size_t pixel_offset = c * bytes_per_channel;
   // Only for uint8/16.
-  float scale = 1.0f;
-  if (format.data_type == JXL_TYPE_UINT8) {
-    // We will do an integer multiplication by 257 in LoadFloatRow so that a
-    // UINT8 value and the corresponding UINT16 value convert to the same float
-    scale = 1.0f / (257 * ((1ull << bits_per_sample) - 1));
-  } else {
-    scale = 1.0f / ((1ull << bits_per_sample) - 1);
-  }
+  float scale = 1.0f / ((1ull << bits_per_sample) - 1);
 
   const bool little_endian =
       format.endianness == JXL_LITTLE_ENDIAN ||

--- a/lib/jxl/jxl_test.cc
+++ b/lib/jxl/jxl_test.cc
@@ -955,8 +955,8 @@ TEST(JxlTest, RoundtripAlphaResampling) {
   cparams.AddOption(JXL_ENC_FRAME_SETTING_EXTRA_CHANNEL_RESAMPLING, 2);
 
   PackedPixelFile ppf_out;
-  EXPECT_NEAR(Roundtrip(t.ppf(), cparams, {}, pool, &ppf_out), 13507, 130);
-  EXPECT_SLIGHTLY_BELOW(ButteraugliDistance(t.ppf(), ppf_out), 5.2);
+  EXPECT_NEAR(Roundtrip(t.ppf(), cparams, {}, pool, &ppf_out), 13600, 130);
+  EXPECT_SLIGHTLY_BELOW(ButteraugliDistance(t.ppf(), ppf_out), 5.0);
 }
 
 TEST(JxlTest, RoundtripAlphaResamplingOnlyAlpha) {

--- a/lib/jxl/jxl_test.cc
+++ b/lib/jxl/jxl_test.cc
@@ -621,7 +621,7 @@ TEST(JxlTest, RoundtripSmallPatches) {
 
   PackedPixelFile ppf_out;
   EXPECT_NEAR(Roundtrip(t.ppf(), cparams, {}, pool, &ppf_out), 486, 100);
-  EXPECT_SLIGHTLY_BELOW(ButteraugliDistance(t.ppf(), ppf_out), 0.018f);
+  EXPECT_SLIGHTLY_BELOW(ButteraugliDistance(t.ppf(), ppf_out), 0.015f);
 }
 
 // TODO(szabadka) Add encoder and decoder API functions that accept frame

--- a/lib/jxl/modular_test.cc
+++ b/lib/jxl/modular_test.cc
@@ -75,7 +75,7 @@ void TestLosslessGroups(size_t group_size_shift) {
   cparams.distance = 0.0f;
   cparams.AddOption(JXL_ENC_FRAME_SETTING_MODULAR_GROUP_SIZE, group_size_shift);
   extras::JXLDecompressParams dparams;
-  dparams.accepted_formats = {{3, JXL_TYPE_UINT16, JXL_LITTLE_ENDIAN, 0}};
+  dparams.accepted_formats = {{3, JXL_TYPE_UINT8, JXL_LITTLE_ENDIAN, 0}};
 
   extras::PackedPixelFile ppf_out;
   size_t compressed_size =
@@ -111,7 +111,7 @@ TEST(ModularTest, RoundtripLosslessCustomWpPermuteRCT) {
   // slowest speed so different WP modes are tried
   cparams.AddOption(JXL_ENC_FRAME_SETTING_EFFORT, 9);
   extras::JXLDecompressParams dparams;
-  dparams.accepted_formats = {{3, JXL_TYPE_UINT16, JXL_LITTLE_ENDIAN, 0}};
+  dparams.accepted_formats = {{3, JXL_TYPE_UINT8, JXL_LITTLE_ENDIAN, 0}};
 
   extras::PackedPixelFile ppf_out;
   size_t compressed_size =

--- a/lib/jxl/speed_tier_test.cc
+++ b/lib/jxl/speed_tier_test.cc
@@ -100,7 +100,7 @@ TEST_P(SpeedTierTest, Roundtrip) {
   cparams.AddOption(JXL_ENC_FRAME_SETTING_EFFORT,
                     10 - static_cast<int>(params.speed_tier));
   extras::JXLDecompressParams dparams;
-  dparams.accepted_formats = {{3, JXL_TYPE_UINT16, JXL_LITTLE_ENDIAN, 0}};
+  dparams.accepted_formats = {{3, JXL_TYPE_UINT8, JXL_LITTLE_ENDIAN, 0}};
 
   {
     extras::PackedPixelFile ppf_out;

--- a/tools/benchmark/benchmark_codec_jxl.cc
+++ b/tools/benchmark/benchmark_codec_jxl.cc
@@ -305,7 +305,7 @@ class JxlCodec : public ImageCodec {
     dparams_.runner = pool->runner();
     dparams_.runner_opaque = pool->runner_opaque();
     dparams_.memory_manager = memory_manager_;
-    JxlDataType data_type = uint8_ ? JXL_TYPE_UINT8 : JXL_TYPE_UINT16;
+    JxlDataType data_type = uint8_ ? JXL_TYPE_UINT8 : JXL_TYPE_FLOAT;
     for (uint32_t c = 1; c <= 4; ++c) {
       dparams_.accepted_formats.push_back({c, data_type, JXL_LITTLE_ENDIAN, 0});
     }

--- a/tools/scripts/roundtrip_test.sh
+++ b/tools/scripts/roundtrip_test.sh
@@ -73,7 +73,7 @@ roundtrip_test() {
       # Test decoding to 16 bit png.
       "${decoder}" "${jxlfn}" "${outfn}" --bits_per_sample 16
       local dist="$("${comparator}" "${infn}" "${outfn}")"
-      python3 -c "import sys; sys.exit(not ${dist} <= ${maxdist})"
+      python3 -c "import sys; sys.exit(not ${dist} <= ${maxdist} + 0.0002)"
 
       # Test decoding to pfm.
       local outfn="$(mktemp -p "$tmpdir").pfm"


### PR DESCRIPTION
When loading 8-bit images to float, we used to do `* 257 * (1.0f / 65535)` instead of just `* (1.0f / 255)`, which in floating point arithmetic is somehow not quite the same thing. For example, for the 8-bit value 254, the first formula produces the value 0.996078431606292724609375, while the second produces the value 0.996078491210937500000000, a difference of 5.96046e-08. This was basically a hack to ensure uint8 images decoded to uint16 buffers would still map all values to the same float32 values.

However, it only works for uint8 and uint16. For e.g. 10-bit or 12-bit images, this kind of trick doesn't work: while 65535 = 255*257, i.e. the uint16 maxval is an integer multiple of the uint8 maxval, so uint8 values can be represented exactly as uint16 values, but this is not the case for uint10 or uint12 values: there are no exactly corresponding uint16 values in the first place, so mapping them to the same float32 value would require a larger amount of cheating.

I assume that the main reason to do this hack was to allow benchmark_xl to decode jxl to uint16 and still get perfect metric scores when doing lossless encoding of 8-bit images (which would not work if uint8 values map to slightly different floats than the corresponding uint16 values). But then when decoding the jxl to a float buffer and comparing it to a funky-converted 8-bit png, as is done when you do `ssimulacra2 orig.png orig.png.jxl`, you get slight differences, see https://github.com/libjxl/libjxl/issues/3594.

Also when running benchmark_xl on 10-bit or 12-bit images, lossless jxl does not look lossless since it decodes the jxl to uint16. Decoding jxl to float in benchmark_xl and removing the funky slightly-incorrect uint8-to-float conversion solves these problems.

Before, on a 12-bit image:
```
507.ppm
Encoding      kPixels    Bytes          BPP  E MP/s  D MP/s     Max norm  SSIMULACRA2   PSNR        pnorm       BPP*pnorm   QABPP   Bugs
----------------------------------------------------------------------------------------------------------------------------------------
jxl:d0:2         1019  2045874   16.0536252  35.766 147.727   0.00227312  95.17732340 110.55   0.00118253  0.018983878811  16.054      0
Aggregate:       1019  2045874   16.0536252  35.766 147.727   0.00227312  95.17732340 110.55   0.00118253  0.018983878811  16.054      0
```

After:
```
507.ppm
Encoding      kPixels    Bytes          BPP  E MP/s  D MP/s     Max norm  SSIMULACRA2   PSNR        pnorm       BPP*pnorm   QABPP   Bugs
----------------------------------------------------------------------------------------------------------------------------------------
jxl:d0:2         1019  2045874   16.0536252  38.642 152.748          nan 100.00000000  99.99   0.00000000  0.000000000000  16.054      0
Aggregate:       1019  2045874   16.0536252  38.642 152.748   0.00000000 100.00000000  99.99   0.00000000  0.000000000000  16.054      0
```


Before:
```
$ cjxl -d 0 bees.png bees.png.jxl; ssimulacra2 bees.png bees.png.jxl
98.56508389
```

After:
```
$ cjxl -d 0 bees.png bees.png.jxl; ssimulacra2 bees.png bees.png.jxl
100.00000000
```
