### PR TITLE
Avoid Abort in release build, part 1

### DIFF
--- a/ci.sh
+++ b/ci.sh
@@ -498,7 +498,7 @@ cmd_release() {
 
 cmd_opt() {
   CMAKE_BUILD_TYPE="RelWithDebInfo"
-  CMAKE_CXX_FLAGS+=" -DJXL_DEBUG_WARNING -DJXL_DEBUG_ON_ERROR"
+  CMAKE_CXX_FLAGS+=" -DJXL_DEBUG_BUILD -DJXL_DEBUG_ON_ERROR"
   cmake_configure "$@"
   cmake_build_and_test
 }

--- a/lib/extras/compressed_icc.cc
+++ b/lib/extras/compressed_icc.cc
@@ -5,6 +5,7 @@
 
 #include <jxl/compressed_icc.h>
 
+#include "lib/jxl/enc_aux_out.h"
 #include "lib/jxl/enc_icc_codec.h"
 #include "lib/jxl/icc_codec.h"
 
@@ -14,7 +15,7 @@ JXL_BOOL JxlICCProfileEncode(JxlMemoryManager* memory_manager,
                              size_t* compressed_icc_size) {
   jxl::BitWriter writer(memory_manager);
   JXL_RETURN_IF_ERROR(jxl::WriteICC(jxl::Span<const uint8_t>(icc, icc_size),
-                                    &writer, 0, nullptr));
+                                    &writer, jxl::LayerType::Header, nullptr));
   writer.ZeroPadToByte();
   *compressed_icc_size = writer.GetSpan().size();
   *compressed_icc = static_cast<uint8_t*>(

--- a/lib/extras/dec/jpegli.cc
+++ b/lib/extras/dec/jpegli.cc
@@ -14,6 +14,7 @@
 #include <vector>
 
 #include "lib/jpegli/decode.h"
+#include "lib/jxl/base/compiler_specific.h"
 #include "lib/jxl/base/sanitizers.h"
 #include "lib/jxl/base/status.h"
 
@@ -114,12 +115,12 @@ void MyErrorExit(j_common_ptr cinfo) {
 }
 
 void MyOutputMessage(j_common_ptr cinfo) {
-#if JXL_DEBUG_WARNING == 1
-  char buf[JMSG_LENGTH_MAX + 1];
-  (*cinfo->err->format_message)(cinfo, buf);
-  buf[JMSG_LENGTH_MAX] = 0;
-  JXL_WARNING("%s", buf);
-#endif
+  if (JXL_DEBUG_BUILD) {
+    char buf[JMSG_LENGTH_MAX + 1];
+    (*cinfo->err->format_message)(cinfo, buf);
+    buf[JMSG_LENGTH_MAX] = 0;
+    JXL_WARNING("%s", buf);
+  }
 }
 
 void UnmapColors(uint8_t* row, size_t xsize, int components,

--- a/lib/extras/dec/jpg.cc
+++ b/lib/extras/dec/jpg.cc
@@ -16,6 +16,7 @@
 #include <vector>
 
 #include "lib/extras/size_constraints.h"
+#include "lib/jxl/base/compiler_specific.h"
 #include "lib/jxl/base/sanitizers.h"
 #include "lib/jxl/base/status.h"
 
@@ -155,12 +156,12 @@ void MyErrorExit(j_common_ptr cinfo) {
 }
 
 void MyOutputMessage(j_common_ptr cinfo) {
-#if JXL_DEBUG_WARNING == 1
-  char buf[JMSG_LENGTH_MAX + 1];
-  (*cinfo->err->format_message)(cinfo, buf);
-  buf[JMSG_LENGTH_MAX] = 0;
-  JXL_WARNING("%s", buf);
-#endif
+  if (JXL_DEBUG_BUILD) {
+    char buf[JMSG_LENGTH_MAX + 1];
+    (*cinfo->err->format_message)(cinfo, buf);
+    buf[JMSG_LENGTH_MAX] = 0;
+    JXL_WARNING("%s", buf);
+  }
 }
 
 void UnmapColors(uint8_t* row, size_t xsize, int components,

--- a/lib/extras/gain_map.cc
+++ b/lib/extras/gain_map.cc
@@ -14,6 +14,7 @@
 #include "lib/jxl/base/common.h"
 #include "lib/jxl/color_encoding_internal.h"
 #include "lib/jxl/dec_bit_reader.h"
+#include "lib/jxl/enc_aux_out.h"
 #include "lib/jxl/enc_bit_writer.h"
 #include "lib/jxl/fields.h"
 #include "lib/jxl/memory_manager_internal.h"
@@ -90,7 +91,7 @@ JXL_BOOL JxlGainMapWriteBundle(const JxlGainMapBundle* map_bundle,
     JXL_RETURN_IF_ERROR(
         internal_color_encoding.FromExternal(map_bundle->color_encoding));
     if (!jxl::Bundle::Write(internal_color_encoding, &color_encoding_writer,
-                            /*layer=*/0, nullptr)) {
+                            jxl::LayerType::Header, nullptr)) {
       return JXL_FALSE;
     }
   }

--- a/lib/extras/gain_map_test.cc
+++ b/lib/extras/gain_map_test.cc
@@ -6,34 +6,17 @@
 #include "jxl/gain_map.h"
 
 #include <jxl/encode.h>
-#include <stdint.h>
 
-#include <fstream>
+#include <algorithm>
+#include <cstddef>
+#include <cstdint>
+#include <string>
+#include <vector>
 
-#include "lib/jxl/base/span.h"
-#include "lib/jxl/base/status.h"
-#include "lib/jxl/fields.h"
-#include "lib/jxl/test_memory_manager.h"
 #include "lib/jxl/test_utils.h"
 #include "lib/jxl/testing.h"
 
 namespace {
-bool ColorEncodingsEqual(const JxlColorEncoding& lhs,
-                         const JxlColorEncoding& rhs) {
-  return lhs.color_space == rhs.color_space &&
-         lhs.white_point == rhs.white_point &&
-         std::memcmp(lhs.white_point_xy, rhs.white_point_xy,
-                     sizeof(lhs.white_point_xy)) == 0 &&
-         lhs.primaries == rhs.primaries &&
-         std::memcmp(lhs.primaries_red_xy, rhs.primaries_red_xy,
-                     sizeof(lhs.primaries_red_xy)) == 0 &&
-         std::memcmp(lhs.primaries_green_xy, rhs.primaries_green_xy,
-                     sizeof(lhs.primaries_green_xy)) == 0 &&
-         std::memcmp(lhs.primaries_blue_xy, rhs.primaries_blue_xy,
-                     sizeof(lhs.primaries_blue_xy)) == 0 &&
-         lhs.transfer_function == rhs.transfer_function &&
-         lhs.gamma == rhs.gamma && lhs.rendering_intent == rhs.rendering_intent;
-}
 
 std::vector<uint8_t> GoldenTestGainMap(bool has_icc, bool has_color_encoding) {
   // Define the parts of the gain map

--- a/lib/extras/packed_image_convert.cc
+++ b/lib/extras/packed_image_convert.cc
@@ -199,7 +199,7 @@ Status ConvertPackedPixelFileToCodecInOut(const PackedPixelFile& ppf,
   } else {
     SetIntensityTarget(&io->metadata.m);
   }
-  io->CheckMetadata();
+  JXL_RETURN_IF_ERROR(io->CheckMetadata());
   return true;
 }
 

--- a/lib/jxl/ac_strategy.cc
+++ b/lib/jxl/ac_strategy.cc
@@ -96,7 +96,7 @@ StatusOr<AcStrategyImage> AcStrategyImage::Create(
   return img;
 }
 
-size_t AcStrategyImage::CountBlocks(AcStrategy::Type type) const {
+size_t AcStrategyImage::CountBlocks(AcStrategyType type) const {
   size_t ret = 0;
   for (size_t y = 0; y < layers_.ysize(); y++) {
     const uint8_t* JXL_RESTRICT row = layers_.ConstRow(y);

--- a/lib/jxl/ac_strategy.h
+++ b/lib/jxl/ac_strategy.h
@@ -31,6 +31,53 @@
 
 namespace jxl {
 
+// Raw strategy types.
+enum class AcStrategyType : uint32_t {
+  // Regular block size DCT
+  DCT = 0,
+  // Encode pixels without transforming
+  IDENTITY = 1,
+  // Use 2-by-2 DCT
+  DCT2X2 = 2,
+  // Use 4-by-4 DCT
+  DCT4X4 = 3,
+  // Use 16-by-16 DCT
+  DCT16X16 = 4,
+  // Use 32-by-32 DCT
+  DCT32X32 = 5,
+  // Use 16-by-8 DCT
+  DCT16X8 = 6,
+  // Use 8-by-16 DCT
+  DCT8X16 = 7,
+  // Use 32-by-8 DCT
+  DCT32X8 = 8,
+  // Use 8-by-32 DCT
+  DCT8X32 = 9,
+  // Use 32-by-16 DCT
+  DCT32X16 = 10,
+  // Use 16-by-32 DCT
+  DCT16X32 = 11,
+  // 4x8 and 8x4 DCT
+  DCT4X8 = 12,
+  DCT8X4 = 13,
+  // Corner-DCT.
+  AFV0 = 14,
+  AFV1 = 15,
+  AFV2 = 16,
+  AFV3 = 17,
+  // Larger DCTs
+  DCT64X64 = 18,
+  DCT64X32 = 19,
+  DCT32X64 = 20,
+  // No transforms smaller than 64x64 are allowed below.
+  DCT128X128 = 21,
+  DCT128X64 = 22,
+  DCT64X128 = 23,
+  DCT256X256 = 24,
+  DCT256X128 = 25,
+  DCT128X256 = 26
+};
+
 class AcStrategy {
  public:
   // Extremal values for the number of blocks/coefficients of a single strategy.
@@ -42,55 +89,10 @@ class AcStrategy {
   static_assert((kMaxCoeffArea * sizeof(float)) % hwy::kMaxVectorSize == 0,
                 "Coefficient area is not a multiple of vector size");
 
-  // Raw strategy types.
-  enum Type : uint32_t {
-    // Regular block size DCT
-    DCT = 0,
-    // Encode pixels without transforming
-    IDENTITY = 1,
-    // Use 2-by-2 DCT
-    DCT2X2 = 2,
-    // Use 4-by-4 DCT
-    DCT4X4 = 3,
-    // Use 16-by-16 DCT
-    DCT16X16 = 4,
-    // Use 32-by-32 DCT
-    DCT32X32 = 5,
-    // Use 16-by-8 DCT
-    DCT16X8 = 6,
-    // Use 8-by-16 DCT
-    DCT8X16 = 7,
-    // Use 32-by-8 DCT
-    DCT32X8 = 8,
-    // Use 8-by-32 DCT
-    DCT8X32 = 9,
-    // Use 32-by-16 DCT
-    DCT32X16 = 10,
-    // Use 16-by-32 DCT
-    DCT16X32 = 11,
-    // 4x8 and 8x4 DCT
-    DCT4X8 = 12,
-    DCT8X4 = 13,
-    // Corner-DCT.
-    AFV0 = 14,
-    AFV1 = 15,
-    AFV2 = 16,
-    AFV3 = 17,
-    // Larger DCTs
-    DCT64X64 = 18,
-    DCT64X32 = 19,
-    DCT32X64 = 20,
-    DCT128X128 = 21,
-    DCT128X64 = 22,
-    DCT64X128 = 23,
-    DCT256X256 = 24,
-    DCT256X128 = 25,
-    DCT128X256 = 26,
-    // Marker for num of valid strategies.
-    kNumValidStrategies
-  };
+  static constexpr uint8_t kNumValidStrategies =
+      static_cast<uint8_t>(AcStrategyType::DCT128X256) + 1;
 
-  static constexpr uint32_t TypeBit(const Type type) {
+  static constexpr uint32_t TypeBit(const AcStrategyType type) {
     return 1u << static_cast<uint32_t>(type);
   }
 
@@ -100,15 +102,17 @@ class AcStrategy {
 
   JXL_INLINE bool IsMultiblock() const {
     constexpr uint32_t bits =
-        TypeBit(Type::DCT16X16) | TypeBit(Type::DCT32X32) |
-        TypeBit(Type::DCT16X8) | TypeBit(Type::DCT8X16) |
-        TypeBit(Type::DCT32X8) | TypeBit(Type::DCT8X32) |
-        TypeBit(Type::DCT16X32) | TypeBit(Type::DCT32X16) |
-        TypeBit(Type::DCT32X64) | TypeBit(Type::DCT64X32) |
-        TypeBit(Type::DCT64X64) | TypeBit(DCT64X128) | TypeBit(DCT128X64) |
-        TypeBit(DCT128X128) | TypeBit(DCT128X256) | TypeBit(DCT256X128) |
-        TypeBit(DCT256X256);
-    JXL_DASSERT(Strategy() < kNumValidStrategies);
+        TypeBit(AcStrategyType::DCT16X16) | TypeBit(AcStrategyType::DCT32X32) |
+        TypeBit(AcStrategyType::DCT16X8) | TypeBit(AcStrategyType::DCT8X16) |
+        TypeBit(AcStrategyType::DCT32X8) | TypeBit(AcStrategyType::DCT8X32) |
+        TypeBit(AcStrategyType::DCT16X32) | TypeBit(AcStrategyType::DCT32X16) |
+        TypeBit(AcStrategyType::DCT32X64) | TypeBit(AcStrategyType::DCT64X32) |
+        TypeBit(AcStrategyType::DCT64X64) | TypeBit(AcStrategyType::DCT64X128) |
+        TypeBit(AcStrategyType::DCT128X64) |
+        TypeBit(AcStrategyType::DCT128X128) |
+        TypeBit(AcStrategyType::DCT128X256) |
+        TypeBit(AcStrategyType::DCT256X128) |
+        TypeBit(AcStrategyType::DCT256X256);
     return ((1u << static_cast<uint32_t>(Strategy())) & bits) != 0;
   }
 
@@ -117,17 +121,16 @@ class AcStrategy {
     return static_cast<uint8_t>(strategy_);
   }
 
-  JXL_INLINE Type Strategy() const { return strategy_; }
+  JXL_INLINE AcStrategyType Strategy() const { return strategy_; }
 
   // Inverse check
   static JXL_INLINE constexpr bool IsRawStrategyValid(int raw_strategy) {
-    return raw_strategy < static_cast<int32_t>(kNumValidStrategies) &&
-           raw_strategy >= 0;
+    return raw_strategy < kNumValidStrategies && raw_strategy >= 0;
   }
   static JXL_INLINE AcStrategy FromRawStrategy(uint8_t raw_strategy) {
-    return FromRawStrategy(static_cast<Type>(raw_strategy));
+    return FromRawStrategy(static_cast<AcStrategyType>(raw_strategy));
   }
-  static JXL_INLINE AcStrategy FromRawStrategy(Type raw_strategy) {
+  static JXL_INLINE AcStrategy FromRawStrategy(AcStrategyType raw_strategy) {
     JXL_DASSERT(IsRawStrategyValid(static_cast<uint32_t>(raw_strategy)));
     return AcStrategy(raw_strategy, /*is_first=*/true);
   }
@@ -171,12 +174,12 @@ class AcStrategy {
 
  private:
   friend class AcStrategyRow;
-  JXL_INLINE AcStrategy(Type strategy, bool is_first)
+  JXL_INLINE AcStrategy(AcStrategyType strategy, bool is_first)
       : strategy_(strategy), is_first_(is_first) {
     JXL_DASSERT(IsMultiblock() || is_first == true);
   }
 
-  Type strategy_;
+  AcStrategyType strategy_;
   bool is_first_;
 };
 
@@ -185,7 +188,7 @@ class AcStrategyRow {
  public:
   explicit AcStrategyRow(const uint8_t* row) : row_(row) {}
   AcStrategy operator[](size_t x) const {
-    AcStrategy::Type strategy = static_cast<AcStrategy::Type>(row_[x] >> 1);
+    AcStrategyType strategy = static_cast<AcStrategyType>(row_[x] >> 1);
     bool is_first = static_cast<bool>(row_[x] & 1);
     return AcStrategy(strategy, is_first);
   }
@@ -204,14 +207,14 @@ class AcStrategyImage {
   AcStrategyImage& operator=(AcStrategyImage&&) = default;
 
   void FillDCT8(const Rect& rect) {
-    FillPlane<uint8_t>((static_cast<uint8_t>(AcStrategy::Type::DCT) << 1) | 1,
+    FillPlane<uint8_t>((static_cast<uint8_t>(AcStrategyType::DCT) << 1) | 1,
                        &layers_, rect);
   }
   void FillDCT8() { FillDCT8(Rect(layers_)); }
 
   void FillInvalid() { FillImage(INVALID, &layers_); }
 
-  void Set(size_t x, size_t y, AcStrategy::Type type) {
+  void Set(size_t x, size_t y, AcStrategyType type) {
 #if JXL_ENABLE_ASSERT
     AcStrategy acs = AcStrategy::FromRawStrategy(type);
 #endif  // JXL_ENABLE_ASSERT
@@ -220,7 +223,7 @@ class AcStrategyImage {
     JXL_CHECK(SetNoBoundsCheck(x, y, type, /*check=*/false));
   }
 
-  Status SetNoBoundsCheck(size_t x, size_t y, AcStrategy::Type type,
+  Status SetNoBoundsCheck(size_t x, size_t y, AcStrategyType type,
                           bool check = true) {
     AcStrategy acs = AcStrategy::FromRawStrategy(type);
     for (size_t iy = 0; iy < acs.covered_blocks_y(); iy++) {
@@ -252,7 +255,7 @@ class AcStrategyImage {
   size_t ysize() const { return layers_.ysize(); }
 
   // Count the number of blocks of a given type.
-  size_t CountBlocks(AcStrategy::Type type) const;
+  size_t CountBlocks(AcStrategyType type) const;
 
   JxlMemoryManager* memory_manager() const { return layers_.memory_manager(); }
 

--- a/lib/jxl/ac_strategy_test.cc
+++ b/lib/jxl/ac_strategy_test.cc
@@ -25,7 +25,7 @@ namespace {
 class AcStrategyRoundtrip : public ::hwy::TestWithParamTargetAndT<int> {
  protected:
   void Run() {
-    const AcStrategy::Type type = static_cast<AcStrategy::Type>(GetParam());
+    const AcStrategyType type = static_cast<AcStrategyType>(GetParam());
     const AcStrategy acs = AcStrategy::FromRawStrategy(type);
     const size_t dct_scratch_size =
         3 * (MaxVectorSize() / sizeof(float)) * AcStrategy::kMaxBlockDim;
@@ -37,7 +37,7 @@ class AcStrategyRoundtrip : public ::hwy::TestWithParamTargetAndT<int> {
     float* input = idct + AcStrategy::kMaxCoeffArea;
     float* scratch_space = input + AcStrategy::kMaxCoeffArea;
 
-    Rng rng(type * 65537 + 13);
+    Rng rng(static_cast<int>(type) * 65537 + 13);
 
     for (size_t j = 0; j < 64; j++) {
       size_t i = (acs.log2_covered_blocks()
@@ -53,7 +53,7 @@ class AcStrategyRoundtrip : public ::hwy::TestWithParamTargetAndT<int> {
                         scratch_space);
       for (size_t j = 0; j < 64u << acs.log2_covered_blocks(); j++) {
         ASSERT_NEAR(idct[j], j == i ? 0.2f : 0, 2e-6)
-            << "j = " << j << " i = " << i << " acs " << type;
+            << "j = " << j << " i = " << i << " acs " << static_cast<int>(type);
       }
     }
     // Test DC.
@@ -70,7 +70,8 @@ class AcStrategyRoundtrip : public ::hwy::TestWithParamTargetAndT<int> {
         dc[y * acs.covered_blocks_x() * 8 + x] = 0.2;
         for (size_t j = 0; j < 64u << acs.log2_covered_blocks(); j++) {
           ASSERT_NEAR(idct[j], dc[j], 1e-6)
-              << "j = " << j << " x = " << x << " y = " << y << " acs " << type;
+              << "j = " << j << " x = " << x << " y = " << y << " acs "
+              << static_cast<int>(type);
         }
       }
     }
@@ -79,8 +80,7 @@ class AcStrategyRoundtrip : public ::hwy::TestWithParamTargetAndT<int> {
 
 HWY_TARGET_INSTANTIATE_TEST_SUITE_P_T(
     AcStrategyRoundtrip,
-    ::testing::Range(0,
-                     static_cast<int>(AcStrategy::Type::kNumValidStrategies)));
+    ::testing::Range(0, static_cast<int>(AcStrategy::kNumValidStrategies)));
 
 TEST_P(AcStrategyRoundtrip, Test) { Run(); }
 
@@ -89,7 +89,7 @@ class AcStrategyRoundtripDownsample
     : public ::hwy::TestWithParamTargetAndT<int> {
  protected:
   void Run() {
-    const AcStrategy::Type type = static_cast<AcStrategy::Type>(GetParam());
+    const AcStrategyType type = static_cast<AcStrategyType>(GetParam());
     const AcStrategy acs = AcStrategy::FromRawStrategy(type);
     const size_t dct_scratch_size =
         3 * (MaxVectorSize() / sizeof(float)) * AcStrategy::kMaxBlockDim;
@@ -102,7 +102,7 @@ class AcStrategyRoundtripDownsample
     float* scratch_space = dc + AcStrategy::kMaxCoeffArea;
 
     std::fill_n(coeffs, AcStrategy::kMaxCoeffArea, 0.0f);
-    Rng rng(type * 65537 + 13);
+    Rng rng(static_cast<int>(type) * 65537 + 13);
 
     for (size_t y = 0; y < acs.covered_blocks_y(); y++) {
       for (size_t x = 0; x < acs.covered_blocks_x(); x++) {
@@ -130,7 +130,7 @@ class AcStrategyRoundtripDownsample
             }
             sum /= 64.0f;
             ASSERT_NEAR(sum, dc[dy * 8 * acs.covered_blocks_x() + dx], 1e-6)
-                << "acs " << type;
+                << "acs " << static_cast<int>(type);
           }
         }
       }
@@ -140,8 +140,7 @@ class AcStrategyRoundtripDownsample
 
 HWY_TARGET_INSTANTIATE_TEST_SUITE_P_T(
     AcStrategyRoundtripDownsample,
-    ::testing::Range(0,
-                     static_cast<int>(AcStrategy::Type::kNumValidStrategies)));
+    ::testing::Range(0, static_cast<int>(AcStrategy::kNumValidStrategies)));
 
 TEST_P(AcStrategyRoundtripDownsample, Test) { Run(); }
 
@@ -150,7 +149,7 @@ TEST_P(AcStrategyRoundtripDownsample, Test) { Run(); }
 class AcStrategyDownsample : public ::hwy::TestWithParamTargetAndT<int> {
  protected:
   void Run() {
-    const AcStrategy::Type type = static_cast<AcStrategy::Type>(GetParam());
+    const AcStrategyType type = static_cast<AcStrategyType>(GetParam());
     const AcStrategy acs = AcStrategy::FromRawStrategy(type);
     const size_t dct_scratch_size =
         3 * (MaxVectorSize() / sizeof(float)) * AcStrategy::kMaxBlockDim;
@@ -165,7 +164,7 @@ class AcStrategyDownsample : public ::hwy::TestWithParamTargetAndT<int> {
     float* coeffs = idct + AcStrategy::kMaxCoeffArea;
     float* scratch_space = coeffs + AcStrategy::kMaxCoeffArea;
 
-    Rng rng(type * 65537 + 13);
+    Rng rng(static_cast<int>(type) * 65537 + 13);
 
     for (size_t y = 0; y < cy; y++) {
       for (size_t x = 0; x < cx; x++) {
@@ -195,7 +194,7 @@ class AcStrategyDownsample : public ::hwy::TestWithParamTargetAndT<int> {
             ASSERT_NEAR(
                 sum, idct_acs_downsampled[dy * 8 * acs.covered_blocks_x() + dx],
                 1e-6)
-                << " acs " << type;
+                << " acs " << static_cast<int>(type);
           }
         }
       }
@@ -205,8 +204,7 @@ class AcStrategyDownsample : public ::hwy::TestWithParamTargetAndT<int> {
 
 HWY_TARGET_INSTANTIATE_TEST_SUITE_P_T(
     AcStrategyDownsample,
-    ::testing::Range(0,
-                     static_cast<int>(AcStrategy::Type::kNumValidStrategies)));
+    ::testing::Range(0, static_cast<int>(AcStrategy::kNumValidStrategies)));
 
 TEST_P(AcStrategyDownsample, Test) { Run(); }
 
@@ -229,7 +227,7 @@ TEST_P(AcStrategyTargetTest, RoundtripAFVDCT) {
 }
 
 TEST_P(AcStrategyTargetTest, BenchmarkAFV) {
-  const AcStrategy::Type type = AcStrategy::Type::AFV0;
+  const AcStrategyType type = AcStrategyType::AFV0;
   HWY_ALIGN_MAX float pixels[64] = {1};
   HWY_ALIGN_MAX float coeffs[64] = {};
   const size_t dct_scratch_size =

--- a/lib/jxl/base/compiler_specific.h
+++ b/lib/jxl/base/compiler_specific.h
@@ -62,14 +62,6 @@
 #endif
 
 #if JXL_COMPILER_MSVC
-#define JXL_UNREACHABLE_BUILTIN __assume(false)
-#elif JXL_COMPILER_CLANG || JXL_COMPILER_GCC >= 405
-#define JXL_UNREACHABLE_BUILTIN __builtin_unreachable()
-#else
-#define JXL_UNREACHABLE_BUILTIN
-#endif
-
-#if JXL_COMPILER_MSVC
 #define JXL_MAYBE_UNUSED
 #else
 // Encountered "attribute list cannot appear here" when using the C++17
@@ -164,5 +156,15 @@ using ssize_t = intptr_t;
 
 // Known / distinguished C++ standards.
 #define JXL_CXX_17 201703
+
+// In most cases we consider build as "debug". Use `NDEBUG` for release build.
+#if defined(JXL_DEBUG_BUILD)
+#undef JXL_DEBUG_BUILD
+#define JXL_DEBUG_BUILD 1
+#elif defined(NDEBUG)
+#define JXL_DEBUG_BUILD 0
+#else
+#define JXL_DEBUG_BUILD 1
+#endif
 
 #endif  // LIB_JXL_BASE_COMPILER_SPECIFIC_H_

--- a/lib/jxl/bit_reader_test.cc
+++ b/lib/jxl/bit_reader_test.cc
@@ -77,7 +77,7 @@ TEST(BitReaderTest, TestRoundTrip) {
         }
 
         writer.ZeroPadToByte();
-        allotment.ReclaimAndCharge(&writer, 0, nullptr);
+        allotment.ReclaimAndCharge(&writer, LayerType::Header, nullptr);
         BitReader reader(writer.GetSpan());
         for (const Symbol& s : symbols) {
           EXPECT_EQ(s.value, reader.ReadBits(s.num_bits));
@@ -114,8 +114,8 @@ TEST(BitReaderTest, TestSkip) {
           EXPECT_EQ(task + skip + 3, writer.BitsWritten());
           writer.ZeroPadToByte();
           AuxOut aux_out;
-          allotment.ReclaimAndCharge(&writer, 0, &aux_out);
-          EXPECT_LT(aux_out.layers[0].total_bits, kSize * 8);
+          allotment.ReclaimAndCharge(&writer, LayerType::Header, &aux_out);
+          EXPECT_LT(aux_out.layer(LayerType::Header).total_bits, kSize * 8);
 
           BitReader reader1(writer.GetSpan());
           BitReader reader2(writer.GetSpan());
@@ -164,7 +164,7 @@ TEST(BitReaderTest, TestOrder) {
     }
 
     writer.ZeroPadToByte();
-    allotment.ReclaimAndCharge(&writer, 0, nullptr);
+    allotment.ReclaimAndCharge(&writer, LayerType::Header, nullptr);
     BitReader reader(writer.GetSpan());
     EXPECT_EQ(0x1Fu, reader.ReadFixedBits<8>());
     EXPECT_EQ(0xFCu, reader.ReadFixedBits<8>());
@@ -179,7 +179,7 @@ TEST(BitReaderTest, TestOrder) {
     writer.Write(8, 0x3F);
 
     writer.ZeroPadToByte();
-    allotment.ReclaimAndCharge(&writer, 0, nullptr);
+    allotment.ReclaimAndCharge(&writer, LayerType::Header, nullptr);
     BitReader reader(writer.GetSpan());
     EXPECT_EQ(0xF8u, reader.ReadFixedBits<8>());
     EXPECT_EQ(0x3Fu, reader.ReadFixedBits<8>());
@@ -193,7 +193,7 @@ TEST(BitReaderTest, TestOrder) {
     writer.Write(16, 0xF83F);
 
     writer.ZeroPadToByte();
-    allotment.ReclaimAndCharge(&writer, 0, nullptr);
+    allotment.ReclaimAndCharge(&writer, LayerType::Header, nullptr);
     BitReader reader(writer.GetSpan());
     EXPECT_EQ(0x3Fu, reader.ReadFixedBits<8>());
     EXPECT_EQ(0xF8u, reader.ReadFixedBits<8>());
@@ -210,7 +210,7 @@ TEST(BitReaderTest, TestOrder) {
     writer.Write(4, 8);
 
     writer.ZeroPadToByte();
-    allotment.ReclaimAndCharge(&writer, 0, nullptr);
+    allotment.ReclaimAndCharge(&writer, LayerType::Header, nullptr);
     BitReader reader(writer.GetSpan());
     EXPECT_EQ(0xBDu, reader.ReadFixedBits<8>());
     EXPECT_EQ(0x8Du, reader.ReadFixedBits<8>());

--- a/lib/jxl/blending.cc
+++ b/lib/jxl/blending.cc
@@ -56,104 +56,133 @@ Status PerformBlending(
                        ImageF::Create(memory_manager, xsize, 3 + num_ec));
   // Blend extra channels first so that we use the pre-blending alpha.
   for (size_t i = 0; i < num_ec; i++) {
-    if (ec_blending[i].mode == PatchBlendMode::kAdd) {
-      for (size_t x = 0; x < xsize; x++) {
-        tmp.Row(3 + i)[x] = bg[3 + i][x + x0] + fg[3 + i][x + x0];
+    switch (ec_blending[i].mode) {
+      case PatchBlendMode::kAdd:
+        for (size_t x = 0; x < xsize; x++) {
+          tmp.Row(3 + i)[x] = bg[3 + i][x + x0] + fg[3 + i][x + x0];
+        }
+        continue;
+
+      case PatchBlendMode::kBlendAbove: {
+        size_t alpha = ec_blending[i].alpha_channel;
+        bool is_premultiplied = extra_channel_info[alpha].alpha_associated;
+        PerformAlphaBlending(bg[3 + i] + x0, bg[3 + alpha] + x0, fg[3 + i] + x0,
+                             fg[3 + alpha] + x0, tmp.Row(3 + i), xsize,
+                             is_premultiplied, ec_blending[i].clamp);
+        continue;
       }
-    } else if (ec_blending[i].mode == PatchBlendMode::kBlendAbove) {
-      size_t alpha = ec_blending[i].alpha_channel;
-      bool is_premultiplied = extra_channel_info[alpha].alpha_associated;
-      PerformAlphaBlending(bg[3 + i] + x0, bg[3 + alpha] + x0, fg[3 + i] + x0,
-                           fg[3 + alpha] + x0, tmp.Row(3 + i), xsize,
-                           is_premultiplied, ec_blending[i].clamp);
-    } else if (ec_blending[i].mode == PatchBlendMode::kBlendBelow) {
-      size_t alpha = ec_blending[i].alpha_channel;
-      bool is_premultiplied = extra_channel_info[alpha].alpha_associated;
-      PerformAlphaBlending(fg[3 + i] + x0, fg[3 + alpha] + x0, bg[3 + i] + x0,
-                           bg[3 + alpha] + x0, tmp.Row(3 + i), xsize,
-                           is_premultiplied, ec_blending[i].clamp);
-    } else if (ec_blending[i].mode == PatchBlendMode::kAlphaWeightedAddAbove) {
-      size_t alpha = ec_blending[i].alpha_channel;
-      PerformAlphaWeightedAdd(bg[3 + i] + x0, fg[3 + i] + x0,
-                              fg[3 + alpha] + x0, tmp.Row(3 + i), xsize,
-                              ec_blending[i].clamp);
-    } else if (ec_blending[i].mode == PatchBlendMode::kAlphaWeightedAddBelow) {
-      size_t alpha = ec_blending[i].alpha_channel;
-      PerformAlphaWeightedAdd(fg[3 + i] + x0, bg[3 + i] + x0,
-                              bg[3 + alpha] + x0, tmp.Row(3 + i), xsize,
-                              ec_blending[i].clamp);
-    } else if (ec_blending[i].mode == PatchBlendMode::kMul) {
-      PerformMulBlending(bg[3 + i] + x0, fg[3 + i] + x0, tmp.Row(3 + i), xsize,
-                         ec_blending[i].clamp);
-    } else if (ec_blending[i].mode == PatchBlendMode::kReplace) {
-      memcpy(tmp.Row(3 + i), fg[3 + i] + x0, xsize * sizeof(**fg));
-    } else if (ec_blending[i].mode == PatchBlendMode::kNone) {
-      if (xsize) memcpy(tmp.Row(3 + i), bg[3 + i] + x0, xsize * sizeof(**fg));
-    } else {
-      JXL_UNREACHABLE("new PatchBlendMode?");
+
+      case PatchBlendMode::kBlendBelow: {
+        size_t alpha = ec_blending[i].alpha_channel;
+        bool is_premultiplied = extra_channel_info[alpha].alpha_associated;
+        PerformAlphaBlending(fg[3 + i] + x0, fg[3 + alpha] + x0, bg[3 + i] + x0,
+                             bg[3 + alpha] + x0, tmp.Row(3 + i), xsize,
+                             is_premultiplied, ec_blending[i].clamp);
+        continue;
+      }
+
+      case PatchBlendMode::kAlphaWeightedAddAbove: {
+        size_t alpha = ec_blending[i].alpha_channel;
+        PerformAlphaWeightedAdd(bg[3 + i] + x0, fg[3 + i] + x0,
+                                fg[3 + alpha] + x0, tmp.Row(3 + i), xsize,
+                                ec_blending[i].clamp);
+        continue;
+      }
+
+      case PatchBlendMode::kAlphaWeightedAddBelow: {
+        size_t alpha = ec_blending[i].alpha_channel;
+        PerformAlphaWeightedAdd(fg[3 + i] + x0, bg[3 + i] + x0,
+                                bg[3 + alpha] + x0, tmp.Row(3 + i), xsize,
+                                ec_blending[i].clamp);
+        continue;
+      }
+
+      case PatchBlendMode::kMul:
+        PerformMulBlending(bg[3 + i] + x0, fg[3 + i] + x0, tmp.Row(3 + i),
+                           xsize, ec_blending[i].clamp);
+        continue;
+
+      case PatchBlendMode::kReplace:
+        if (xsize) memcpy(tmp.Row(3 + i), fg[3 + i] + x0, xsize * sizeof(**fg));
+        continue;
+
+      case PatchBlendMode::kNone:
+        if (xsize) memcpy(tmp.Row(3 + i), bg[3 + i] + x0, xsize * sizeof(**fg));
+        continue;
     }
   }
   size_t alpha = color_blending.alpha_channel;
 
-  if (color_blending.mode == PatchBlendMode::kAdd ||
-      (color_blending.mode == PatchBlendMode::kAlphaWeightedAddAbove &&
-       !has_alpha) ||
-      (color_blending.mode == PatchBlendMode::kAlphaWeightedAddBelow &&
-       !has_alpha)) {
+  const auto add = [&]() {
     for (int p = 0; p < 3; p++) {
       float* out = tmp.Row(p);
       for (size_t x = 0; x < xsize; x++) {
         out[x] = bg[p][x + x0] + fg[p][x + x0];
       }
     }
-  } else if (color_blending.mode == PatchBlendMode::kBlendAbove
-             // blend without alpha is just replace
-             && has_alpha) {
+  };
+
+  const auto blend_weighted = [&](const float* const* bottom,
+                                  const float* const* top) {
     bool is_premultiplied = extra_channel_info[alpha].alpha_associated;
     PerformAlphaBlending(
-        {bg[0] + x0, bg[1] + x0, bg[2] + x0, bg[3 + alpha] + x0},
-        {fg[0] + x0, fg[1] + x0, fg[2] + x0, fg[3 + alpha] + x0},
+        {bottom[0] + x0, bottom[1] + x0, bottom[2] + x0,
+         bottom[3 + alpha] + x0},
+        {top[0] + x0, top[1] + x0, top[2] + x0, top[3 + alpha] + x0},
         {tmp.Row(0), tmp.Row(1), tmp.Row(2), tmp.Row(3 + alpha)}, xsize,
         is_premultiplied, color_blending.clamp);
-  } else if (color_blending.mode == PatchBlendMode::kBlendBelow
-             // blend without alpha is just replace
-             && has_alpha) {
-    bool is_premultiplied = extra_channel_info[alpha].alpha_associated;
-    PerformAlphaBlending(
-        {fg[0] + x0, fg[1] + x0, fg[2] + x0, fg[3 + alpha] + x0},
-        {bg[0] + x0, bg[1] + x0, bg[2] + x0, bg[3 + alpha] + x0},
-        {tmp.Row(0), tmp.Row(1), tmp.Row(2), tmp.Row(3 + alpha)}, xsize,
-        is_premultiplied, color_blending.clamp);
-  } else if (color_blending.mode == PatchBlendMode::kAlphaWeightedAddAbove) {
-    JXL_DASSERT(has_alpha);
+  };
+
+  const auto add_weighted = [&](const float* const* bottom,
+                                const float* const* top) {
     for (size_t c = 0; c < 3; c++) {
-      PerformAlphaWeightedAdd(bg[c] + x0, fg[c] + x0, fg[3 + alpha] + x0,
+      PerformAlphaWeightedAdd(bottom[c] + x0, top[c] + x0, top[3 + alpha] + x0,
                               tmp.Row(c), xsize, color_blending.clamp);
     }
-  } else if (color_blending.mode == PatchBlendMode::kAlphaWeightedAddBelow) {
-    JXL_DASSERT(has_alpha);
-    for (size_t c = 0; c < 3; c++) {
-      PerformAlphaWeightedAdd(fg[c] + x0, bg[c] + x0, bg[3 + alpha] + x0,
-                              tmp.Row(c), xsize, color_blending.clamp);
-    }
-  } else if (color_blending.mode == PatchBlendMode::kMul) {
-    for (int p = 0; p < 3; p++) {
-      PerformMulBlending(bg[p] + x0, fg[p] + x0, tmp.Row(p), xsize,
-                         color_blending.clamp);
-    }
-  } else if (color_blending.mode == PatchBlendMode::kReplace ||
-             color_blending.mode == PatchBlendMode::kBlendAbove ||
-             color_blending.mode == PatchBlendMode::kBlendBelow) {  // kReplace
+  };
+
+  const auto copy = [&](const float* const* src) {
     for (size_t p = 0; p < 3; p++) {
-      memcpy(tmp.Row(p), fg[p] + x0, xsize * sizeof(**fg));
+      memcpy(tmp.Row(p), src[p] + x0, xsize * sizeof(**src));
     }
-  } else if (color_blending.mode == PatchBlendMode::kNone) {
-    for (size_t p = 0; p < 3; p++) {
-      memcpy(tmp.Row(p), bg[p] + x0, xsize * sizeof(**fg));
-    }
-  } else {
-    JXL_UNREACHABLE("new PatchBlendMode?");
+  };
+
+  switch (color_blending.mode) {
+    case PatchBlendMode::kAdd:
+      add();
+      break;
+
+    case PatchBlendMode::kAlphaWeightedAddAbove:
+      has_alpha ? add_weighted(bg, fg) : add();
+      break;
+
+    case PatchBlendMode::kAlphaWeightedAddBelow:
+      has_alpha ? add_weighted(fg, bg) : add();
+      break;
+
+    case PatchBlendMode::kBlendAbove:
+      has_alpha ? blend_weighted(bg, fg) : copy(fg);
+      break;
+
+    case PatchBlendMode::kBlendBelow:
+      has_alpha ? blend_weighted(fg, bg) : copy(fg);
+      break;
+
+    case PatchBlendMode::kMul:
+      for (int p = 0; p < 3; p++) {
+        PerformMulBlending(bg[p] + x0, fg[p] + x0, tmp.Row(p), xsize,
+                           color_blending.clamp);
+      }
+      break;
+
+    case PatchBlendMode::kReplace:
+      copy(fg);
+      break;
+
+    case PatchBlendMode::kNone:
+      copy(bg);
   }
+
   for (size_t i = 0; i < 3 + num_ec; i++) {
     if (xsize != 0) memcpy(out[i] + x0, tmp.Row(i), xsize * sizeof(**out));
   }

--- a/lib/jxl/cms/color_encoding_cms.h
+++ b/lib/jxl/cms/color_encoding_cms.h
@@ -353,13 +353,13 @@ struct ColorEncoding {
   PrimariesCIExy GetPrimaries() const {
     JXL_DASSERT(have_fields);
     JXL_ASSERT(HasPrimaries());
-    PrimariesCIExy xy;
+    PrimariesCIExy xy{};
     switch (primaries) {
       case Primaries::kCustom:
         xy.r = red.GetValue();
         xy.g = green.GetValue();
         xy.b = blue.GetValue();
-        return xy;
+        break;
 
       case Primaries::kSRGB:
         xy.r.x = 0.639998686;
@@ -368,7 +368,7 @@ struct ColorEncoding {
         xy.g.y = 0.600003357;
         xy.b.x = 0.150002046;
         xy.b.y = 0.059997204;
-        return xy;
+        break;
 
       case Primaries::k2100:
         xy.r.x = 0.708;
@@ -377,7 +377,7 @@ struct ColorEncoding {
         xy.g.y = 0.797;
         xy.b.x = 0.131;
         xy.b.y = 0.046;
-        return xy;
+        break;
 
       case Primaries::kP3:
         xy.r.x = 0.680;
@@ -386,9 +386,13 @@ struct ColorEncoding {
         xy.g.y = 0.690;
         xy.b.x = 0.150;
         xy.b.y = 0.060;
-        return xy;
+        break;
+
+      default:
+        JXL_DEBUG_ABORT("internal: unexpected Primaries: %d",
+                        static_cast<int>(primaries));
     }
-    JXL_UNREACHABLE("Invalid Primaries %u", static_cast<uint32_t>(primaries));
+    return xy;
   }
 
   Status SetPrimaries(const PrimariesCIExy& xy) {
@@ -429,28 +433,32 @@ struct ColorEncoding {
 
   CIExy GetWhitePoint() const {
     JXL_DASSERT(have_fields);
-    CIExy xy;
+    CIExy xy{};
     switch (white_point) {
       case WhitePoint::kCustom:
-        return white.GetValue();
+        xy = white.GetValue();
+        break;
 
       case WhitePoint::kD65:
         xy.x = 0.3127;
         xy.y = 0.3290;
-        return xy;
+        break;
 
       case WhitePoint::kDCI:
         // From https://ieeexplore.ieee.org/document/7290729 C.2 page 11
         xy.x = 0.314;
         xy.y = 0.351;
-        return xy;
+        break;
 
       case WhitePoint::kE:
         xy.x = xy.y = 1.0 / 3;
-        return xy;
+        break;
+
+      default:
+        JXL_DEBUG_ABORT("internal: unexpected WhitePoint: %d",
+                        static_cast<int>(white_point));
     }
-    JXL_UNREACHABLE("Invalid WhitePoint %u",
-                    static_cast<uint32_t>(white_point));
+    return xy;
   }
 
   Status SetWhitePoint(const CIExy& xy) {

--- a/lib/jxl/cms/jxl_cms.cc
+++ b/lib/jxl/cms/jxl_cms.cc
@@ -27,7 +27,6 @@
 #include "lib/jxl/base/compiler_specific.h"
 #include "lib/jxl/base/matrix_ops.h"
 #include "lib/jxl/base/printf_macros.h"
-#include "lib/jxl/base/span.h"
 #include "lib/jxl/base/status.h"
 #include "lib/jxl/cms/jxl_cms_internal.h"
 #include "lib/jxl/cms/transfer_functions-inl.h"
@@ -37,6 +36,7 @@
 #else  // JPEGXL_ENABLE_SKCMS
 #include "lcms2.h"
 #include "lcms2_plugin.h"
+#include "lib/jxl/base/span.h"
 #endif  // JPEGXL_ENABLE_SKCMS
 
 #define JXL_CMS_VERBOSE 0

--- a/lib/jxl/cms/jxl_cms_internal.h
+++ b/lib/jxl/cms/jxl_cms_internal.h
@@ -774,9 +774,12 @@ static std::string ToString(JxlColorSpace color_space) {
       return "XYB";
     case JXL_COLOR_SPACE_UNKNOWN:
       return "CS?";
+    default:
+      // Should not happen - visitor fails if enum is invalid.
+      JXL_DEBUG_ABORT("Invalid ColorSpace %u",
+                      static_cast<uint32_t>(color_space));
+      return "Invalid";
   }
-  // Should not happen - visitor fails if enum is invalid.
-  JXL_UNREACHABLE("Invalid ColorSpace %u", static_cast<uint32_t>(color_space));
 }
 
 static std::string ToString(JxlWhitePoint white_point) {
@@ -789,9 +792,12 @@ static std::string ToString(JxlWhitePoint white_point) {
       return "EER";
     case JXL_WHITE_POINT_DCI:
       return "DCI";
+    default:
+      // Should not happen - visitor fails if enum is invalid.
+      JXL_DEBUG_ABORT("Invalid WhitePoint %u",
+                      static_cast<uint32_t>(white_point));
+      return "Invalid";
   }
-  // Should not happen - visitor fails if enum is invalid.
-  JXL_UNREACHABLE("Invalid WhitePoint %u", static_cast<uint32_t>(white_point));
 }
 
 static std::string ToString(JxlPrimaries primaries) {
@@ -804,9 +810,11 @@ static std::string ToString(JxlPrimaries primaries) {
       return "DCI";
     case JXL_PRIMARIES_CUSTOM:
       return "Cst";
+    default:
+      // Should not happen - visitor fails if enum is invalid.
+      JXL_DEBUG_ABORT("Invalid Primaries %u", static_cast<uint32_t>(primaries));
+      return "Invalid";
   }
-  // Should not happen - visitor fails if enum is invalid.
-  JXL_UNREACHABLE("Invalid Primaries %u", static_cast<uint32_t>(primaries));
 }
 
 static std::string ToString(JxlTransferFunction transfer_function) {
@@ -826,11 +834,14 @@ static std::string ToString(JxlTransferFunction transfer_function) {
     case JXL_TRANSFER_FUNCTION_UNKNOWN:
       return "TF?";
     case JXL_TRANSFER_FUNCTION_GAMMA:
-      JXL_UNREACHABLE("Invalid TransferFunction: gamma");
+      JXL_DEBUG_ABORT("Invalid TransferFunction: gamma");
+      return "Invalid";
+    default:
+      // Should not happen - visitor fails if enum is invalid.
+      JXL_DEBUG_ABORT("Invalid TransferFunction %u",
+                      static_cast<uint32_t>(transfer_function));
+      return "Invalid";
   }
-  // Should not happen - visitor fails if enum is invalid.
-  JXL_UNREACHABLE("Invalid TransferFunction %u",
-                  static_cast<uint32_t>(transfer_function));
 }
 
 static std::string ToString(JxlRenderingIntent rendering_intent) {
@@ -845,8 +856,9 @@ static std::string ToString(JxlRenderingIntent rendering_intent) {
       return "Abs";
   }
   // Should not happen - visitor fails if enum is invalid.
-  JXL_UNREACHABLE("Invalid RenderingIntent %u",
+  JXL_DEBUG_ABORT("Invalid RenderingIntent %u",
                   static_cast<uint32_t>(rendering_intent));
+  return "Invalid";
 }
 
 static std::string ColorEncodingDescriptionImpl(const JxlColorEncoding& c) {
@@ -1051,7 +1063,8 @@ static Status MaybeCreateProfileImpl(const JxlColorEncoding& c,
               CreateICCCurvParaTag({2.6, 1.0, 0.0, 1.0, 0.0}, 3, &tags));
           break;
         default:
-          JXL_UNREACHABLE("Unknown TF %u", static_cast<unsigned int>(tf));
+          return JXL_UNREACHABLE("unknown TF %u",
+                                 static_cast<unsigned int>(tf));
       }
     }
     FinalizeICCTag(&tags, &tag_offset, &tag_size);

--- a/lib/jxl/codec_in_out.h
+++ b/lib/jxl/codec_in_out.h
@@ -72,17 +72,20 @@ class CodecInOut {
     JXL_CHECK(metadata.size.Set(xsize, ysize));
   }
 
-  void CheckMetadata() const {
+  Status CheckMetadata() const {
     JXL_CHECK(metadata.m.bit_depth.bits_per_sample != 0);
     JXL_CHECK(!metadata.m.color_encoding.ICC().empty());
 
-    if (preview_frame.xsize() != 0) preview_frame.VerifyMetadata();
+    if (preview_frame.xsize() != 0) {
+      JXL_RETURN_IF_ERROR(preview_frame.VerifyMetadata());
+    }
     JXL_CHECK(preview_frame.metadata() == &metadata.m);
 
     for (const ImageBundle& ib : frames) {
-      ib.VerifyMetadata();
+      JXL_RETURN_IF_ERROR(ib.VerifyMetadata());
       JXL_CHECK(ib.metadata() == &metadata.m);
     }
+    return true;
   }
 
   size_t xsize() const { return metadata.size.xsize(); }

--- a/lib/jxl/coeff_order.cc
+++ b/lib/jxl/coeff_order.cc
@@ -11,6 +11,7 @@
 #include <cstdint>
 #include <vector>
 
+#include "lib/jxl/ac_strategy.h"
 #include "lib/jxl/base/status.h"
 #include "lib/jxl/coeff_order_fwd.h"
 #include "lib/jxl/dec_ans.h"
@@ -19,6 +20,9 @@
 #include "lib/jxl/modular/encoding/encoding.h"
 
 namespace jxl {
+
+static_assert(AcStrategy::kNumValidStrategies == kStrategyOrder.size(),
+              "Update this array when adding or removing AC strategies.");
 
 uint32_t CoeffOrderContext(uint32_t val) {
   uint32_t token, nbits, bits;

--- a/lib/jxl/coeff_order.h
+++ b/lib/jxl/coeff_order.h
@@ -12,7 +12,6 @@
 #include <cstddef>
 #include <cstdint>
 
-#include "lib/jxl/ac_strategy.h"
 #include "lib/jxl/base/compiler_specific.h"
 #include "lib/jxl/base/status.h"
 #include "lib/jxl/coeff_order_fwd.h"
@@ -42,14 +41,10 @@ static JXL_MAYBE_UNUSED constexpr size_t kCoeffOrderMaxSize =
 
 // Mapping from AC strategy to order bucket. Strategies with different natural
 // orders must have different buckets.
-constexpr uint8_t kStrategyOrder[] = {
+constexpr std::array<uint8_t, 27> kStrategyOrder = {
     0, 1, 1, 1, 2, 3, 4, 4, 5,  5,  6,  6,  1,  1,
     1, 1, 1, 1, 7, 8, 8, 9, 10, 10, 11, 12, 12,
 };
-
-static_assert(AcStrategy::kNumValidStrategies ==
-                  sizeof(kStrategyOrder) / sizeof(*kStrategyOrder),
-              "Update this array when adding or removing AC strategies.");
 
 constexpr JXL_MAYBE_UNUSED uint32_t kPermutationContexts = 8;
 

--- a/lib/jxl/coeff_order_test.cc
+++ b/lib/jxl/coeff_order_test.cc
@@ -20,6 +20,7 @@
 #include "lib/jxl/base/status.h"
 #include "lib/jxl/coeff_order_fwd.h"
 #include "lib/jxl/dec_bit_reader.h"
+#include "lib/jxl/enc_aux_out.h"
 #include "lib/jxl/enc_bit_writer.h"
 #include "lib/jxl/enc_coeff_order.h"
 #include "lib/jxl/test_memory_manager.h"
@@ -32,7 +33,7 @@ void RoundtripPermutation(coeff_order_t* perm, coeff_order_t* out, size_t len,
                           size_t* size) {
   JxlMemoryManager* memory_manager = jxl::test::MemoryManager();
   BitWriter writer{memory_manager};
-  EncodePermutation(perm, 0, len, &writer, 0, nullptr);
+  EncodePermutation(perm, 0, len, &writer, LayerType::Header, nullptr);
   writer.ZeroPadToByte();
   Status status = true;
   {

--- a/lib/jxl/dec_cache.cc
+++ b/lib/jxl/dec_cache.cc
@@ -7,8 +7,12 @@
 
 #include <jxl/memory_manager.h>
 
+#include <algorithm>
+
+#include "lib/jxl/ac_strategy.h"
 #include "lib/jxl/base/status.h"
 #include "lib/jxl/blending.h"
+#include "lib/jxl/coeff_order.h"
 #include "lib/jxl/common.h"  // JXL_HIGH_PRECISION
 #include "lib/jxl/render_pipeline/stage_blending.h"
 #include "lib/jxl/render_pipeline/stage_chroma_upsampling.h"
@@ -28,6 +32,63 @@
 #include "lib/jxl/render_pipeline/stage_ycbcr.h"
 
 namespace jxl {
+
+Status GroupDecCache::InitOnce(JxlMemoryManager* memory_manager,
+                               size_t num_passes, size_t used_acs) {
+  for (size_t i = 0; i < num_passes; i++) {
+    if (num_nzeroes[i].xsize() == 0) {
+      // Allocate enough for a whole group - partial groups on the
+      // right/bottom border just use a subset. The valid size is passed via
+      // Rect.
+
+      JXL_ASSIGN_OR_RETURN(num_nzeroes[i],
+                           Image3I::Create(memory_manager, kGroupDimInBlocks,
+                                           kGroupDimInBlocks));
+    }
+  }
+  size_t max_block_area = 0;
+
+  for (uint8_t o = 0; o < AcStrategy::kNumValidStrategies; ++o) {
+    AcStrategy acs = AcStrategy::FromRawStrategy(o);
+    if ((used_acs & (1 << o)) == 0) continue;
+    size_t area =
+        acs.covered_blocks_x() * acs.covered_blocks_y() * kDCTBlockSize;
+    max_block_area = std::max(area, max_block_area);
+  }
+
+  if (max_block_area > max_block_area_) {
+    max_block_area_ = max_block_area;
+    // We need 3x float blocks for dequantized coefficients and 1x for scratch
+    // space for transforms.
+    float_memory_ = hwy::AllocateAligned<float>(max_block_area_ * 7);
+    // We need 3x int32 or int16 blocks for quantized coefficients.
+    int32_memory_ = hwy::AllocateAligned<int32_t>(max_block_area_ * 3);
+    int16_memory_ = hwy::AllocateAligned<int16_t>(max_block_area_ * 3);
+  }
+
+  dec_group_block = float_memory_.get();
+  scratch_space = dec_group_block + max_block_area_ * 3;
+  dec_group_qblock = int32_memory_.get();
+  dec_group_qblock16 = int16_memory_.get();
+  return true;
+}
+
+// Initialize the decoder state after all of DC is decoded.
+Status PassesDecoderState::InitForAC(size_t num_passes, ThreadPool* pool) {
+  shared_storage.coeff_order_size = 0;
+  for (uint8_t o = 0; o < AcStrategy::kNumValidStrategies; ++o) {
+    if (((1 << o) & used_acs) == 0) continue;
+    uint8_t ord = kStrategyOrder[o];
+    shared_storage.coeff_order_size =
+        std::max(kCoeffOrderOffset[3 * (ord + 1)] * kDCTBlockSize,
+                 shared_storage.coeff_order_size);
+  }
+  size_t sz = num_passes * shared_storage.coeff_order_size;
+  if (sz > shared_storage.coeff_orders.size()) {
+    shared_storage.coeff_orders.resize(sz);
+  }
+  return true;
+}
 
 Status PassesDecoderState::PreparePipeline(const FrameHeader& frame_header,
                                            const ImageMetadata* metadata,
@@ -53,28 +114,34 @@ Status PassesDecoderState::PreparePipeline(const FrameHeader& frame_header,
   if (!frame_header.chroma_subsampling.Is444()) {
     for (size_t c = 0; c < 3; c++) {
       if (frame_header.chroma_subsampling.HShift(c) != 0) {
-        builder.AddStage(GetChromaUpsamplingStage(c, /*horizontal=*/true));
+        JXL_RETURN_IF_ERROR(
+            builder.AddStage(GetChromaUpsamplingStage(c, /*horizontal=*/true)));
       }
       if (frame_header.chroma_subsampling.VShift(c) != 0) {
-        builder.AddStage(GetChromaUpsamplingStage(c, /*horizontal=*/false));
+        JXL_RETURN_IF_ERROR(builder.AddStage(
+            GetChromaUpsamplingStage(c, /*horizontal=*/false)));
       }
     }
   }
 
   if (frame_header.loop_filter.gab) {
-    builder.AddStage(GetGaborishStage(frame_header.loop_filter));
+    JXL_RETURN_IF_ERROR(
+        builder.AddStage(GetGaborishStage(frame_header.loop_filter)));
   }
 
   {
     const LoopFilter& lf = frame_header.loop_filter;
     if (lf.epf_iters >= 3) {
-      builder.AddStage(GetEPFStage(lf, sigma, 0));
+      JXL_RETURN_IF_ERROR(
+          builder.AddStage(GetEPFStage(lf, sigma, EpfStage::Zero)));
     }
     if (lf.epf_iters >= 1) {
-      builder.AddStage(GetEPFStage(lf, sigma, 1));
+      JXL_RETURN_IF_ERROR(
+          builder.AddStage(GetEPFStage(lf, sigma, EpfStage::One)));
     }
     if (lf.epf_iters >= 2) {
-      builder.AddStage(GetEPFStage(lf, sigma, 2));
+      JXL_RETURN_IF_ERROR(
+          builder.AddStage(GetEPFStage(lf, sigma, EpfStage::Two)));
     }
   }
 
@@ -91,20 +158,21 @@ Status PassesDecoderState::PreparePipeline(const FrameHeader& frame_header,
     for (size_t ec = 0; ec < frame_header.extra_channel_upsampling.size();
          ec++) {
       if (frame_header.extra_channel_upsampling[ec] != 1) {
-        builder.AddStage(GetUpsamplingStage(
+        JXL_RETURN_IF_ERROR(builder.AddStage(GetUpsamplingStage(
             frame_header.nonserialized_metadata->transform_data, 3 + ec,
-            CeilLog2Nonzero(frame_header.extra_channel_upsampling[ec])));
+            CeilLog2Nonzero(frame_header.extra_channel_upsampling[ec]))));
       }
     }
   }
 
   if ((frame_header.flags & FrameHeader::kPatches) != 0) {
-    builder.AddStage(GetPatchesStage(
+    JXL_RETURN_IF_ERROR(builder.AddStage(GetPatchesStage(
         &shared->image_features.patches,
-        &frame_header.nonserialized_metadata->m.extra_channel_info));
+        &frame_header.nonserialized_metadata->m.extra_channel_info)));
   }
   if ((frame_header.flags & FrameHeader::kSplines) != 0) {
-    builder.AddStage(GetSplineStage(&shared->image_features.splines));
+    JXL_RETURN_IF_ERROR(
+        builder.AddStage(GetSplineStage(&shared->image_features.splines)));
   }
 
   if (frame_header.upsampling != 1) {
@@ -112,25 +180,25 @@ Status PassesDecoderState::PreparePipeline(const FrameHeader& frame_header,
         3 +
         (late_ec_upsample ? frame_header.extra_channel_upsampling.size() : 0);
     for (size_t c = 0; c < nb_channels; c++) {
-      builder.AddStage(GetUpsamplingStage(
+      JXL_RETURN_IF_ERROR(builder.AddStage(GetUpsamplingStage(
           frame_header.nonserialized_metadata->transform_data, c,
-          CeilLog2Nonzero(frame_header.upsampling)));
+          CeilLog2Nonzero(frame_header.upsampling))));
     }
   }
   if (render_noise) {
-    builder.AddStage(GetConvolveNoiseStage(num_c));
-    builder.AddStage(GetAddNoiseStage(shared->image_features.noise_params,
-                                      shared->cmap.base(), num_c));
+    JXL_RETURN_IF_ERROR(builder.AddStage(GetConvolveNoiseStage(num_c)));
+    JXL_RETURN_IF_ERROR(builder.AddStage(GetAddNoiseStage(
+        shared->image_features.noise_params, shared->cmap.base(), num_c)));
   }
   if (frame_header.dc_level != 0) {
-    builder.AddStage(GetWriteToImage3FStage(
-        memory_manager, &shared_storage.dc_frames[frame_header.dc_level - 1]));
+    JXL_RETURN_IF_ERROR(builder.AddStage(GetWriteToImage3FStage(
+        memory_manager, &shared_storage.dc_frames[frame_header.dc_level - 1])));
   }
 
   if (frame_header.CanBeReferenced() &&
       frame_header.save_before_color_transform) {
-    builder.AddStage(GetWriteToImageBundleStage(&frame_storage_for_referencing,
-                                                output_encoding_info));
+    JXL_RETURN_IF_ERROR(builder.AddStage(GetWriteToImageBundleStage(
+        &frame_storage_for_referencing, output_encoding_info)));
   }
 
   bool has_alpha = false;
@@ -152,16 +220,16 @@ Status PassesDecoderState::PreparePipeline(const FrameHeader& frame_header,
                !metadata->Find(ExtraChannel::kSpotColor));
     bool is_rgba = (main_output.format.num_channels == 4);
     uint8_t* rgb_output = reinterpret_cast<uint8_t*>(main_output.buffer);
-    builder.AddStage(GetFastXYBTosRGB8Stage(rgb_output, main_output.stride,
-                                            width, height, is_rgba, has_alpha,
-                                            alpha_c));
+    JXL_RETURN_IF_ERROR(builder.AddStage(
+        GetFastXYBTosRGB8Stage(rgb_output, main_output.stride, width, height,
+                               is_rgba, has_alpha, alpha_c)));
 #endif
   } else {
     bool linear = false;
     if (frame_header.color_transform == ColorTransform::kYCbCr) {
-      builder.AddStage(GetYCbCrStage());
+      JXL_RETURN_IF_ERROR(builder.AddStage(GetYCbCrStage()));
     } else if (frame_header.color_transform == ColorTransform::kXYB) {
-      builder.AddStage(GetXYBStage(output_encoding_info));
+      JXL_RETURN_IF_ERROR(builder.AddStage(GetXYBStage(output_encoding_info)));
       if (output_encoding_info.color_encoding.GetColorSpace() !=
           ColorSpace::kXYB) {
         linear = true;
@@ -170,21 +238,23 @@ Status PassesDecoderState::PreparePipeline(const FrameHeader& frame_header,
 
     if (options.coalescing && NeedsBlending(frame_header)) {
       if (linear) {
-        builder.AddStage(GetFromLinearStage(output_encoding_info));
+        JXL_RETURN_IF_ERROR(
+            builder.AddStage(GetFromLinearStage(output_encoding_info)));
         linear = false;
       }
-      builder.AddStage(GetBlendingStage(frame_header, this,
-                                        output_encoding_info.color_encoding));
+      JXL_RETURN_IF_ERROR(builder.AddStage(GetBlendingStage(
+          frame_header, this, output_encoding_info.color_encoding)));
     }
 
     if (options.coalescing && frame_header.CanBeReferenced() &&
         !frame_header.save_before_color_transform) {
       if (linear) {
-        builder.AddStage(GetFromLinearStage(output_encoding_info));
+        JXL_RETURN_IF_ERROR(
+            builder.AddStage(GetFromLinearStage(output_encoding_info)));
         linear = false;
       }
-      builder.AddStage(GetWriteToImageBundleStage(
-          &frame_storage_for_referencing, output_encoding_info));
+      JXL_RETURN_IF_ERROR(builder.AddStage(GetWriteToImageBundleStage(
+          &frame_storage_for_referencing, output_encoding_info)));
     }
 
     if (options.render_spotcolors &&
@@ -193,7 +263,8 @@ Status PassesDecoderState::PreparePipeline(const FrameHeader& frame_header,
         // Don't use Find() because there may be multiple spot color channels.
         const ExtraChannelInfo& eci = metadata->extra_channel_info[i];
         if (eci.type == ExtraChannel::kSpotColor) {
-          builder.AddStage(GetSpotColorStage(3 + i, eci.spot_color));
+          JXL_RETURN_IF_ERROR(
+              builder.AddStage(GetSpotColorStage(3 + i, eci.spot_color)));
         }
       }
     }
@@ -208,14 +279,14 @@ Status PassesDecoderState::PreparePipeline(const FrameHeader& frame_header,
           }
           auto cms_stage = GetCmsStage(output_encoding_info);
           if (cms_stage) {
-            builder.AddStage(std::move(cms_stage));
+            JXL_RETURN_IF_ERROR(builder.AddStage(std::move(cms_stage)));
           }
         } else {
-          builder.AddStage(std::move(to_linear_stage));
+          JXL_RETURN_IF_ERROR(builder.AddStage(std::move(to_linear_stage)));
         }
         linear = true;
       }
-      builder.AddStage(std::move(tone_mapping_stage));
+      JXL_RETURN_IF_ERROR(builder.AddStage(std::move(tone_mapping_stage)));
     }
 
     if (linear) {
@@ -237,14 +308,15 @@ Status PassesDecoderState::PreparePipeline(const FrameHeader& frame_header,
         // - mixing_color_and_grey: cms stage can't handle that
         // TODO(firsching): remove "mixing_color_and_grey" condition after
         // adding support for greyscale to cms stage.
-        builder.AddStage(GetFromLinearStage(output_encoding_info));
+        JXL_RETURN_IF_ERROR(
+            builder.AddStage(GetFromLinearStage(output_encoding_info)));
       } else {
         if (!output_encoding_info.linear_color_encoding.CreateICC()) {
           return JXL_FAILURE("Failed to create ICC");
         }
         auto cms_stage = GetCmsStage(output_encoding_info);
         if (cms_stage) {
-          builder.AddStage(std::move(cms_stage));
+          JXL_RETURN_IF_ERROR(builder.AddStage(std::move(cms_stage)));
         }
       }
       linear = false;
@@ -252,12 +324,12 @@ Status PassesDecoderState::PreparePipeline(const FrameHeader& frame_header,
     (void)linear;
 
     if (main_output.callback.IsPresent() || main_output.buffer) {
-      builder.AddStage(GetWriteToOutputStage(
+      JXL_RETURN_IF_ERROR(builder.AddStage(GetWriteToOutputStage(
           main_output, width, height, has_alpha, unpremul_alpha, alpha_c,
-          undo_orientation, extra_output, memory_manager));
+          undo_orientation, extra_output, memory_manager)));
     } else {
-      builder.AddStage(
-          GetWriteToImageBundleStage(decoded, output_encoding_info));
+      JXL_RETURN_IF_ERROR(builder.AddStage(
+          GetWriteToImageBundleStage(decoded, output_encoding_info)));
     }
   }
   JXL_ASSIGN_OR_RETURN(render_pipeline,

--- a/lib/jxl/dec_frame.cc
+++ b/lib/jxl/dec_frame.cc
@@ -447,6 +447,9 @@ Status FrameDecoder::ProcessACGlobal(BitReader* br) {
     bool is_gray = (num_components == 1);
     auto jpeg_c_map = JpegOrder(frame_header_.color_transform, is_gray);
     size_t qt_set = 0;
+    JXL_CHECK(num_components <= 3);
+    JXL_CHECK(qe[0].qraw.qtable->size() == 3 * 8 * 8);
+    int* qtable = qe[0].qraw.qtable->data();
     for (size_t c = 0; c < num_components; c++) {
       // TODO(eustas): why 1-st quant table for gray?
       size_t quant_c = is_gray ? 1 : c;
@@ -456,7 +459,7 @@ Status FrameDecoder::ProcessACGlobal(BitReader* br) {
       for (size_t x = 0; x < 8; x++) {
         for (size_t y = 0; y < 8; y++) {
           jpeg_data->quant[qpos].values[x * 8 + y] =
-              (*qe[0].qraw.qtable)[quant_c * 64 + y * 8 + x];
+              qtable[quant_c * 64 + y * 8 + x];
         }
       }
     }

--- a/lib/jxl/dec_group.cc
+++ b/lib/jxl/dec_group.cc
@@ -139,7 +139,7 @@ void DequantLane(Vec<D> scaled_dequant_x, Vec<D> scaled_dequant_y,
 template <ACType ac_type>
 void DequantBlock(const AcStrategy& acs, float inv_global_scale, int quant,
                   float x_dm_multiplier, float b_dm_multiplier, Vec<D> x_cc_mul,
-                  Vec<D> b_cc_mul, size_t kind, size_t size,
+                  Vec<D> b_cc_mul, AcStrategyType kind, size_t size,
                   const Quantizer& quantizer, size_t covered_blocks,
                   const size_t* sbx,
                   const float* JXL_RESTRICT* JXL_RESTRICT dc_row,
@@ -224,14 +224,16 @@ Status DecodeGroupImpl(const FrameHeader& frame_header,
       return JXL_FAILURE(
           "Quantization table is not a JPEG quantization table.");
     }
+    JXL_CHECK(qe[0].qraw.qtable->size() == 3 * 8 * 8);
+    int* qtable = qe[0].qraw.qtable->data();
     for (size_t c = 0; c < 3; c++) {
       if (frame_header.color_transform == ColorTransform::kNone) {
-        dcoff[c] = 1024 / (*qe[0].qraw.qtable)[64 * c];
+        dcoff[c] = 1024 / qtable[64 * c];
       }
       for (size_t i = 0; i < 64; i++) {
         // Transpose the matrix, as it will be used on the transposed block.
-        int n = qe[0].qraw.qtable->at(64 + i);
-        int d = qe[0].qraw.qtable->at(64 * c + i);
+        int n = qtable[64 + i];
+        int d = qtable[64 * c + i];
         if (n <= 0 || d <= 0 || n >= 65536 || d >= 65536) {
           return JXL_FAILURE("Invalid JPEG quantization table");
         }
@@ -345,7 +347,7 @@ Status DecodeGroupImpl(const FrameHeader& frame_header,
         }
 
         if (JXL_UNLIKELY(jpeg_data)) {
-          if (acs.Strategy() != AcStrategy::Type::DCT) {
+          if (acs.Strategy() != AcStrategyType::DCT) {
             return JXL_FAILURE(
                 "Can only decode to JPEG if only DCT-8 is used.");
           }
@@ -414,7 +416,7 @@ Status DecodeGroupImpl(const FrameHeader& frame_header,
           // Dequantize and add predictions.
           dequant_block(
               acs, inv_global_scale, row_quant[bx], dec_state->x_dm_multiplier,
-              dec_state->b_dm_multiplier, x_cc_mul, b_cc_mul, acs.RawStrategy(),
+              dec_state->b_dm_multiplier, x_cc_mul, b_cc_mul, acs.Strategy(),
               size, dec_state->shared->quantizer,
               acs.covered_blocks_y() * acs.covered_blocks_x(), sbx, dc_rows,
               dc_stride,

--- a/lib/jxl/dec_modular.h
+++ b/lib/jxl/dec_modular.h
@@ -29,13 +29,13 @@
 namespace jxl {
 
 struct ModularStreamId {
-  enum Kind {
-    kGlobalData,
-    kVarDCTDC,
-    kModularDC,
-    kACMetadata,
-    kQuantTable,
-    kModularAC
+  enum class Kind {
+    GlobalData,
+    VarDCTDC,
+    ModularDC,
+    ACMetadata,
+    QuantTable,
+    ModularAC
   };
   Kind kind;
   size_t quant_table_id;
@@ -44,46 +44,46 @@ struct ModularStreamId {
   size_t ID(const FrameDimensions& frame_dim) const {
     size_t id = 0;
     switch (kind) {
-      case kGlobalData:
+      case Kind::GlobalData:
         id = 0;
         break;
-      case kVarDCTDC:
+      case Kind::VarDCTDC:
         id = 1 + group_id;
         break;
-      case kModularDC:
+      case Kind::ModularDC:
         id = 1 + frame_dim.num_dc_groups + group_id;
         break;
-      case kACMetadata:
+      case Kind::ACMetadata:
         id = 1 + 2 * frame_dim.num_dc_groups + group_id;
         break;
-      case kQuantTable:
+      case Kind::QuantTable:
         id = 1 + 3 * frame_dim.num_dc_groups + quant_table_id;
         break;
-      case kModularAC:
-        id = 1 + 3 * frame_dim.num_dc_groups + DequantMatrices::kNum +
+      case Kind::ModularAC:
+        id = 1 + 3 * frame_dim.num_dc_groups + kNumQuantTables +
              frame_dim.num_groups * pass_id + group_id;
         break;
     };
     return id;
   }
   static ModularStreamId Global() {
-    return ModularStreamId{kGlobalData, 0, 0, 0};
+    return ModularStreamId{Kind::GlobalData, 0, 0, 0};
   }
   static ModularStreamId VarDCTDC(size_t group_id) {
-    return ModularStreamId{kVarDCTDC, 0, group_id, 0};
+    return ModularStreamId{Kind::VarDCTDC, 0, group_id, 0};
   }
   static ModularStreamId ModularDC(size_t group_id) {
-    return ModularStreamId{kModularDC, 0, group_id, 0};
+    return ModularStreamId{Kind::ModularDC, 0, group_id, 0};
   }
   static ModularStreamId ACMetadata(size_t group_id) {
-    return ModularStreamId{kACMetadata, 0, group_id, 0};
+    return ModularStreamId{Kind::ACMetadata, 0, group_id, 0};
   }
   static ModularStreamId QuantTable(size_t quant_table_id) {
-    JXL_ASSERT(quant_table_id < DequantMatrices::kNum);
-    return ModularStreamId{kQuantTable, quant_table_id, 0, 0};
+    JXL_ASSERT(quant_table_id < kNumQuantTables);
+    return ModularStreamId{Kind::QuantTable, quant_table_id, 0, 0};
   }
   static ModularStreamId ModularAC(size_t group_id, size_t pass_id) {
-    return ModularStreamId{kModularAC, 0, group_id, pass_id};
+    return ModularStreamId{Kind::ModularAC, 0, group_id, pass_id};
   }
   static size_t Num(const FrameDimensions& frame_dim, size_t passes) {
     return ModularAC(0, passes).ID(frame_dim);

--- a/lib/jxl/dec_patch_dictionary.cc
+++ b/lib/jxl/dec_patch_dictionary.cc
@@ -133,8 +133,7 @@ Status PatchDictionary::Decode(JxlMemoryManager* memory_manager, BitReader* br,
       }
       for (size_t j = 0; j < blendings_stride_; j++) {
         uint32_t blend_mode = read_num(kPatchBlendModeContext);
-        if (blend_mode >=
-            static_cast<uint32_t>(PatchBlendMode::kNumBlendModes)) {
+        if (blend_mode >= kNumPatchBlendModes) {
           return JXL_FAILURE("Invalid patch blend mode: %u", blend_mode);
         }
         PatchBlending info;

--- a/lib/jxl/dec_patch_dictionary.h
+++ b/lib/jxl/dec_patch_dictionary.h
@@ -65,8 +65,10 @@ enum class PatchBlendMode : uint8_t {
   // For other channels: sample = old + alpha * new
   kAlphaWeightedAddAbove = 6,
   kAlphaWeightedAddBelow = 7,
-  kNumBlendModes,
 };
+
+constexpr uint8_t kNumPatchBlendModes =
+    static_cast<uint8_t>(PatchBlendMode::kAlphaWeightedAddBelow) + 1;
 
 inline bool UsesAlpha(PatchBlendMode mode) {
   return mode == PatchBlendMode::kBlendAbove ||

--- a/lib/jxl/dec_transforms-inl.h
+++ b/lib/jxl/dec_transforms-inl.h
@@ -448,12 +448,12 @@ void AFVTransformToPixels(const float* JXL_RESTRICT coefficients,
       scratch_space);
 }
 
-HWY_MAYBE_UNUSED void TransformToPixels(const AcStrategy::Type strategy,
+HWY_MAYBE_UNUSED void TransformToPixels(const AcStrategyType strategy,
                                         float* JXL_RESTRICT coefficients,
                                         float* JXL_RESTRICT pixels,
                                         size_t pixels_stride,
                                         float* scratch_space) {
-  using Type = AcStrategy::Type;
+  using Type = AcStrategyType;
   switch (strategy) {
     case Type::IDENTITY: {
       float dcs[4] = {};
@@ -680,16 +680,14 @@ HWY_MAYBE_UNUSED void TransformToPixels(const AcStrategy::Type strategy,
                                     scratch_space);
       break;
     }
-    case Type::kNumValidStrategies:
-      JXL_UNREACHABLE("Invalid strategy");
   }
 }
 
-HWY_MAYBE_UNUSED void LowestFrequenciesFromDC(const AcStrategy::Type strategy,
+HWY_MAYBE_UNUSED void LowestFrequenciesFromDC(const AcStrategyType strategy,
                                               const float* dc, size_t dc_stride,
                                               float* llf,
                                               float* JXL_RESTRICT scratch) {
-  using Type = AcStrategy::Type;
+  using Type = AcStrategyType;
   HWY_ALIGN float warm_block[4 * 4];
   HWY_ALIGN float warm_scratch_space[4 * 4 * 4];
   switch (strategy) {
@@ -811,8 +809,6 @@ HWY_MAYBE_UNUSED void LowestFrequenciesFromDC(const AcStrategy::Type strategy,
     case Type::IDENTITY:
       llf[0] = dc[0];
       break;
-    case Type::kNumValidStrategies:
-      JXL_UNREACHABLE("Invalid strategy");
   };
 }
 

--- a/lib/jxl/dec_transforms_testonly.cc
+++ b/lib/jxl/dec_transforms_testonly.cc
@@ -16,7 +16,7 @@ namespace jxl {
 
 #if HWY_ONCE
 HWY_EXPORT(TransformToPixels);
-void TransformToPixels(AcStrategy::Type strategy,
+void TransformToPixels(AcStrategyType strategy,
                        float* JXL_RESTRICT coefficients,
                        float* JXL_RESTRICT pixels, size_t pixels_stride,
                        float* scratch_space) {
@@ -25,7 +25,7 @@ void TransformToPixels(AcStrategy::Type strategy,
 }
 
 HWY_EXPORT(LowestFrequenciesFromDC);
-void LowestFrequenciesFromDC(const jxl::AcStrategy::Type strategy,
+void LowestFrequenciesFromDC(const jxl::AcStrategyType strategy,
                              const float* dc, size_t dc_stride, float* llf,
                              float* JXL_RESTRICT scratch) {
   HWY_DYNAMIC_DISPATCH(LowestFrequenciesFromDC)

--- a/lib/jxl/dec_transforms_testonly.h
+++ b/lib/jxl/dec_transforms_testonly.h
@@ -9,19 +9,21 @@
 // Facade for (non-inlined) inverse integral transforms.
 
 #include <cstddef>
+#include <cstdint>
 
-#include "lib/jxl/ac_strategy.h"
 #include "lib/jxl/base/compiler_specific.h"
 
 namespace jxl {
 
-void TransformToPixels(AcStrategy::Type strategy,
+enum class AcStrategyType : uint32_t;
+
+void TransformToPixels(AcStrategyType strategy,
                        float* JXL_RESTRICT coefficients,
                        float* JXL_RESTRICT pixels, size_t pixels_stride,
                        float* JXL_RESTRICT scratch_space);
 
 // Equivalent of the above for DC image.
-void LowestFrequenciesFromDC(jxl::AcStrategy::Type strategy, const float* dc,
+void LowestFrequenciesFromDC(AcStrategyType strategy, const float* dc,
                              size_t dc_stride, float* llf,
                              float* JXL_RESTRICT scratch);
 

--- a/lib/jxl/dec_xyb-inl.h
+++ b/lib/jxl/dec_xyb-inl.h
@@ -91,9 +91,9 @@ inline HWY_MAYBE_UNUSED bool HasFastXYBTosRGB8() {
 #endif
 }
 
-inline HWY_MAYBE_UNUSED void FastXYBTosRGB8(const float* input[4],
-                                            uint8_t* output, bool is_rgba,
-                                            size_t xsize) {
+inline HWY_MAYBE_UNUSED Status FastXYBTosRGB8(const float* input[4],
+                                              uint8_t* output, bool is_rgba,
+                                              size_t xsize) {
   // This function is very NEON-specific. As such, it uses intrinsics directly.
 #if HWY_TARGET == HWY_NEON
   // WARNING: doing fixed point arithmetic correctly is very complicated.
@@ -328,12 +328,13 @@ inline HWY_MAYBE_UNUSED void FastXYBTosRGB8(const float* input[4],
       }
     }
   }
+  return true;
 #else
   (void)input;
   (void)output;
   (void)is_rgba;
   (void)xsize;
-  JXL_UNREACHABLE("Unreachable");
+  return JXL_UNREACHABLE("unsupported platform");
 #endif
 }
 

--- a/lib/jxl/dec_xyb.cc
+++ b/lib/jxl/dec_xyb.cc
@@ -178,9 +178,9 @@ HWY_EXPORT(HasFastXYBTosRGB8);
 bool HasFastXYBTosRGB8() { return HWY_DYNAMIC_DISPATCH(HasFastXYBTosRGB8)(); }
 
 HWY_EXPORT(FastXYBTosRGB8);
-void FastXYBTosRGB8(const float* input[4], uint8_t* output, bool is_rgba,
-                    size_t xsize) {
-  HWY_DYNAMIC_DISPATCH(FastXYBTosRGB8)(input, output, is_rgba, xsize);
+Status FastXYBTosRGB8(const float* input[4], uint8_t* output, bool is_rgba,
+                      size_t xsize) {
+  return HWY_DYNAMIC_DISPATCH(FastXYBTosRGB8)(input, output, is_rgba, xsize);
 }
 
 void OpsinParams::Init(float intensity_target) {

--- a/lib/jxl/dec_xyb.h
+++ b/lib/jxl/dec_xyb.h
@@ -92,8 +92,8 @@ void OpsinToLinear(const Image3F& opsin, const Rect& rect, ThreadPool* pool,
 void YcbcrToRgb(const Image3F& ycbcr, Image3F* rgb, const Rect& rect);
 
 bool HasFastXYBTosRGB8();
-void FastXYBTosRGB8(const float* input[4], uint8_t* output, bool is_rgba,
-                    size_t xsize);
+Status FastXYBTosRGB8(const float* input[4], uint8_t* output, bool is_rgba,
+                      size_t xsize);
 
 }  // namespace jxl
 

--- a/lib/jxl/decode_test.cc
+++ b/lib/jxl/decode_test.cc
@@ -726,7 +726,8 @@ std::vector<uint8_t> GetTestHeader(size_t xsize, size_t ysize,
   // SizeHeader
   jxl::CodecMetadata metadata;
   EXPECT_TRUE(metadata.size.Set(xsize, ysize));
-  EXPECT_TRUE(WriteSizeHeader(metadata.size, &writer, 0, nullptr));
+  EXPECT_TRUE(
+      WriteSizeHeader(metadata.size, &writer, jxl::LayerType::Header, nullptr));
 
   if (!metadata_default) {
     metadata.m.SetUintSamples(bits_per_sample);
@@ -744,18 +745,20 @@ std::vector<uint8_t> GetTestHeader(size_t xsize, size_t ysize,
         metadata.m.color_encoding.SetICC(std::move(copy), JxlGetDefaultCms()));
   }
 
-  EXPECT_TRUE(jxl::Bundle::Write(metadata.m, &writer, 0, nullptr));
+  EXPECT_TRUE(
+      jxl::Bundle::Write(metadata.m, &writer, jxl::LayerType::Header, nullptr));
   metadata.transform_data.nonserialized_xyb_encoded = metadata.m.xyb_encoded;
-  EXPECT_TRUE(jxl::Bundle::Write(metadata.transform_data, &writer, 0, nullptr));
+  EXPECT_TRUE(jxl::Bundle::Write(metadata.transform_data, &writer,
+                                 jxl::LayerType::Header, nullptr));
 
   if (!icc_profile.empty()) {
     EXPECT_TRUE(metadata.m.color_encoding.WantICC());
-    EXPECT_TRUE(jxl::WriteICC(jxl::Span<const uint8_t>(icc_profile), &writer, 0,
-                              nullptr));
+    EXPECT_TRUE(jxl::WriteICC(jxl::Span<const uint8_t>(icc_profile), &writer,
+                              jxl::LayerType::Header, nullptr));
   }
 
   writer.ZeroPadToByte();
-  allotment.ReclaimAndCharge(&writer, 0, nullptr);
+  allotment.ReclaimAndCharge(&writer, jxl::LayerType::Header, nullptr);
   return std::vector<uint8_t>(
       writer.GetSpan().data(),
       writer.GetSpan().data() + writer.GetSpan().size());

--- a/lib/jxl/decode_to_jpeg.cc
+++ b/lib/jxl/decode_to_jpeg.cc
@@ -25,9 +25,10 @@ namespace jxl {
 JxlDecoderStatus JxlToJpegDecoder::Process(const uint8_t** next_in,
                                            size_t* avail_in) {
   if (!inside_box_) {
-    JXL_UNREACHABLE(
+    JXL_WARNING(
         "processing of JPEG reconstruction data outside JPEG reconstruction "
         "box");
+    return JXL_DEC_ERROR;
   }
   Span<const uint8_t> to_decode;
   if (box_until_eof_) {
@@ -51,7 +52,8 @@ JxlDecoderStatus JxlToJpegDecoder::Process(const uint8_t** next_in,
     to_decode = Bytes(buffer_.data(), buffer_.size());
   }
   if (!box_until_eof_ && to_decode.size() > box_size_) {
-    JXL_UNREACHABLE("JPEG reconstruction data to decode larger than expected");
+    JXL_WARNING("JPEG reconstruction data to decode larger than expected");
+    return JXL_DEC_ERROR;
   }
   if (box_until_eof_ || to_decode.size() == box_size_) {
     // If undefined size, or the right size, try to decode.

--- a/lib/jxl/enc_ac_strategy.h
+++ b/lib/jxl/enc_ac_strategy.h
@@ -10,7 +10,6 @@
 #include <cstdint>
 #include <hwy/aligned_allocator.h>
 
-#include "lib/jxl/ac_strategy.h"
 #include "lib/jxl/base/compiler_specific.h"
 #include "lib/jxl/base/rect.h"
 #include "lib/jxl/base/status.h"
@@ -27,6 +26,7 @@
 namespace jxl {
 
 struct AuxOut;
+class AcStrategyImage;
 
 // AC strategy selection: utility struct.
 
@@ -67,8 +67,8 @@ struct AcStrategyHeuristics {
             const ImageF& mask, const ImageF& mask1x1,
             DequantMatrices* matrices);
   void PrepareForThreads(std::size_t num_threads);
-  void ProcessRect(const Rect& rect, const ColorCorrelationMap& cmap,
-                   AcStrategyImage* ac_strategy, size_t thread);
+  Status ProcessRect(const Rect& rect, const ColorCorrelationMap& cmap,
+                     AcStrategyImage* ac_strategy, size_t thread);
   Status Finalize(const FrameDimensions& frame_dim,
                   const AcStrategyImage& ac_strategy, AuxOut* aux_out);
   const CompressParams& cparams;

--- a/lib/jxl/enc_adaptive_quantization.h
+++ b/lib/jxl/enc_adaptive_quantization.h
@@ -8,7 +8,6 @@
 
 #include <jxl/cms_interface.h>
 
-#include "lib/jxl/ac_strategy.h"
 #include "lib/jxl/base/data_parallel.h"
 #include "lib/jxl/base/rect.h"
 #include "lib/jxl/base/status.h"
@@ -25,6 +24,7 @@
 namespace jxl {
 
 struct AuxOut;
+class AcStrategyImage;
 
 // Returns an image subsampled by kBlockDim in each direction. If the value
 // at pixel (x,y) in the returned image is greater than 1.0, it means that

--- a/lib/jxl/enc_ans.cc
+++ b/lib/jxl/enc_ans.cc
@@ -9,7 +9,6 @@
 #include <jxl/types.h>
 
 #include <algorithm>
-#include <array>
 #include <cmath>
 #include <cstdint>
 #include <limits>
@@ -458,7 +457,8 @@ size_t BuildAndStoreANSEncodingData(
             &tmp_writer, 8 * alphabet_size + 8);  // safe upper bound
         BuildAndStoreHuffmanTree(histo.data(), alphabet_size, depths.data(),
                                  bits.data(), &tmp_writer);
-        allotment.ReclaimAndCharge(&tmp_writer, 0, /*aux_out=*/nullptr);
+        allotment.ReclaimAndCharge(&tmp_writer, LayerType::Header,
+                                   /*aux_out=*/nullptr);
         cost = tmp_writer.BitsWritten();
       } else {
         size_t start = writer->BitsWritten();
@@ -716,7 +716,7 @@ class HistogramBuilder {
   size_t BuildAndStoreEntropyCodes(
       JxlMemoryManager* memory_manager, const HistogramParams& params,
       const std::vector<std::vector<Token>>& tokens, EntropyEncodingData* codes,
-      std::vector<uint8_t>* context_map, BitWriter* writer, size_t layer,
+      std::vector<uint8_t>* context_map, BitWriter* writer, LayerType layer,
       AuxOut* aux_out) const {
     const size_t prev_histograms = codes->encoding_info.size();
     size_t cost = 0;
@@ -760,7 +760,7 @@ class HistogramBuilder {
     }
     if (aux_out != nullptr) {
       for (size_t i = prev_histograms; i < clustered_histograms.size(); ++i) {
-        aux_out->layers[layer].clustered_entropy +=
+        aux_out->layer(layer).clustered_entropy +=
             clustered_histograms[i].ShannonEntropy();
       }
     }
@@ -1489,23 +1489,25 @@ void ApplyLZ77(const HistogramParams& params, size_t num_contexts,
   } else {
     lz77.min_symbol = 224;
   }
-  if (params.lz77_method == HistogramParams::LZ77Method::kNone) {
-    return;
-  } else if (params.lz77_method == HistogramParams::LZ77Method::kRLE) {
-    ApplyLZ77_RLE(params, num_contexts, tokens, lz77, tokens_lz77);
-  } else if (params.lz77_method == HistogramParams::LZ77Method::kLZ77) {
-    ApplyLZ77_LZ77(params, num_contexts, tokens, lz77, tokens_lz77);
-  } else if (params.lz77_method == HistogramParams::LZ77Method::kOptimal) {
-    ApplyLZ77_Optimal(params, num_contexts, tokens, lz77, tokens_lz77);
-  } else {
-    JXL_UNREACHABLE("Not implemented");
+  switch (params.lz77_method) {
+    case HistogramParams::LZ77Method::kNone:
+      return;
+    case HistogramParams::LZ77Method::kRLE:
+      ApplyLZ77_RLE(params, num_contexts, tokens, lz77, tokens_lz77);
+      return;
+    case HistogramParams::LZ77Method::kLZ77:
+      ApplyLZ77_LZ77(params, num_contexts, tokens, lz77, tokens_lz77);
+      return;
+    case HistogramParams::LZ77Method::kOptimal:
+      ApplyLZ77_Optimal(params, num_contexts, tokens, lz77, tokens_lz77);
+      return;
   }
 }
 }  // namespace
 
 void EncodeHistograms(const std::vector<uint8_t>& context_map,
                       const EntropyEncodingData& codes, BitWriter* writer,
-                      size_t layer, AuxOut* aux_out) {
+                      LayerType layer, AuxOut* aux_out) {
   BitWriter::Allotment allotment(writer, 128 + kClustersLimit * 136);
   JXL_CHECK(Bundle::Write(codes.lz77, writer, layer, aux_out));
   if (codes.lz77.enabled) {
@@ -1539,7 +1541,7 @@ size_t BuildAndEncodeHistograms(
     JxlMemoryManager* memory_manager, const HistogramParams& params,
     size_t num_contexts, std::vector<std::vector<Token>>& tokens,
     EntropyEncodingData* codes, std::vector<uint8_t>* context_map,
-    BitWriter* writer, size_t layer, AuxOut* aux_out) {
+    BitWriter* writer, LayerType layer, AuxOut* aux_out) {
   size_t total_bits = 0;
   codes->lz77.nonserialized_distance_context = num_contexts;
   std::vector<std::vector<Token>> tokens_lz77;
@@ -1660,7 +1662,7 @@ size_t BuildAndEncodeHistograms(
         memory_manager, params.ans_histogram_strategy, counts.data(),
         alphabet_size, log_alpha_size, codes->use_prefix_code,
         codes->encoding_info.back().data(), histo_writer);
-    allotment.ReclaimAndCharge(histo_writer, 0, nullptr);
+    allotment.ReclaimAndCharge(histo_writer, LayerType::Header, nullptr);
   }
 
   // Encode histograms.
@@ -1671,7 +1673,7 @@ size_t BuildAndEncodeHistograms(
   allotment.ReclaimAndCharge(writer, layer, aux_out);
 
   if (aux_out != nullptr) {
-    aux_out->layers[layer].num_clustered_histograms +=
+    aux_out->layer(layer).num_clustered_histograms +=
         codes->encoding_info.size();
   }
   return total_bits;
@@ -1767,14 +1769,14 @@ size_t WriteTokens(const std::vector<Token>& tokens,
 void WriteTokens(const std::vector<Token>& tokens,
                  const EntropyEncodingData& codes,
                  const std::vector<uint8_t>& context_map, size_t context_offset,
-                 BitWriter* writer, size_t layer, AuxOut* aux_out) {
+                 BitWriter* writer, LayerType layer, AuxOut* aux_out) {
   // Theoretically, we could have 15 prefix code bits + 31 extra bits.
   BitWriter::Allotment allotment(writer, 46 * tokens.size() + 32 * 1024 * 4);
   size_t num_extra_bits =
       WriteTokens(tokens, codes, context_map, context_offset, writer);
   allotment.ReclaimAndCharge(writer, layer, aux_out);
   if (aux_out != nullptr) {
-    aux_out->layers[layer].extra_bits += num_extra_bits;
+    aux_out->layer(layer).extra_bits += num_extra_bits;
   }
 }
 

--- a/lib/jxl/enc_ans.h
+++ b/lib/jxl/enc_ans.h
@@ -23,6 +23,7 @@
 namespace jxl {
 
 struct AuxOut;
+enum class LayerType : uint8_t;
 
 #define USE_MULT_BY_RECIPROCAL
 
@@ -102,7 +103,7 @@ float ANSPopulationCost(const ANSHistBin* data, size_t alphabet_size);
 // histogram bistreams in codes.encoded_histograms. Used in streaming mode.
 void EncodeHistograms(const std::vector<uint8_t>& context_map,
                       const EntropyEncodingData& codes, BitWriter* writer,
-                      size_t layer, AuxOut* aux_out);
+                      LayerType layer, AuxOut* aux_out);
 
 // Apply context clustering, compute histograms and encode them. Returns an
 // estimate of the total bits used for encoding the stream. If `writer` ==
@@ -112,13 +113,13 @@ size_t BuildAndEncodeHistograms(
     JxlMemoryManager* memory_manager, const HistogramParams& params,
     size_t num_contexts, std::vector<std::vector<Token>>& tokens,
     EntropyEncodingData* codes, std::vector<uint8_t>* context_map,
-    BitWriter* writer, size_t layer, AuxOut* aux_out);
+    BitWriter* writer, LayerType layer, AuxOut* aux_out);
 
 // Write the tokens to a string.
 void WriteTokens(const std::vector<Token>& tokens,
                  const EntropyEncodingData& codes,
                  const std::vector<uint8_t>& context_map, size_t context_offset,
-                 BitWriter* writer, size_t layer, AuxOut* aux_out);
+                 BitWriter* writer, LayerType layer, AuxOut* aux_out);
 
 // Same as above, but assumes allotment created by caller.
 size_t WriteTokens(const std::vector<Token>& tokens,

--- a/lib/jxl/enc_aux_out.h
+++ b/lib/jxl/enc_aux_out.h
@@ -8,37 +8,37 @@
 
 // Optional output information for debugging and analyzing size usage.
 
-#include <stddef.h>
-
 #include <array>
-#include <functional>
-#include <string>
+#include <cstddef>
+#include <cstdint>
 
 namespace jxl {
 
 struct ColorEncoding;
 
 // For LayerName and AuxOut::layers[] index. Order does not matter.
-enum {
-  kLayerHeader = 0,
-  kLayerTOC,
-  kLayerDictionary,
-  kLayerSplines,
-  kLayerNoise,
-  kLayerQuant,
-  kLayerModularTree,
-  kLayerModularGlobal,
-  kLayerDC,
-  kLayerModularDcGroup,
-  kLayerControlFields,
-  kLayerOrder,
-  kLayerAC,
-  kLayerACTokens,
-  kLayerModularAcGroup,
-  kNumImageLayers
+enum class LayerType : uint8_t {
+  Header = 0,
+  Toc,
+  Dictionary,
+  Splines,
+  Noise,
+  Quant,
+  ModularTree,
+  ModularGlobal,
+  Dc,
+  ModularDcGroup,
+  ControlFields,
+  Order,
+  Ac,
+  AcTokens,
+  ModularAcGroup,
 };
 
-const char* LayerName(size_t layer);
+constexpr uint8_t kNumImageLayers =
+    static_cast<uint8_t>(LayerType::ModularAcGroup) + 1;
+
+const char* LayerName(LayerType layer);
 
 // Statistics gathered during compression or decompression.
 struct AuxOut {
@@ -80,6 +80,14 @@ struct AuxOut {
   }
 
   std::array<LayerTotals, kNumImageLayers> layers;
+
+  const LayerTotals& layer(LayerType idx) const {
+    return layers[static_cast<uint8_t>(idx)];
+  }
+  LayerTotals& layer(LayerType idx) {
+    return layers[static_cast<uint8_t>(idx)];
+  }
+
   size_t num_blocks = 0;
 
   // Number of blocks that use larger DCT (set by ac_strategy).

--- a/lib/jxl/enc_bit_writer.h
+++ b/lib/jxl/enc_bit_writer.h
@@ -25,6 +25,7 @@
 namespace jxl {
 
 struct AuxOut;
+enum class LayerType : uint8_t;
 
 struct BitWriter {
   // Upper bound on `n_bits` in each call to Write. We shift a 64-bit word by
@@ -91,7 +92,7 @@ struct BitWriter {
       return histogram_bits_;
     }
 
-    void ReclaimAndCharge(BitWriter* JXL_RESTRICT writer, size_t layer,
+    void ReclaimAndCharge(BitWriter* JXL_RESTRICT writer, LayerType layer,
                           AuxOut* JXL_RESTRICT aux_out);
 
    private:

--- a/lib/jxl/enc_cache.cc
+++ b/lib/jxl/enc_cache.cc
@@ -173,7 +173,7 @@ Status InitializePassesEncoder(const FrameHeader& frame_header,
                           aux_out ? &dc_aux_out : nullptr));
     if (aux_out) {
       for (const auto& l : dc_aux_out.layers) {
-        aux_out->layers[kLayerDC].Assimilate(l);
+        aux_out->layer(LayerType::Dc).Assimilate(l);
       }
     }
     const Span<const uint8_t> encoded = special_frame->GetSpan();

--- a/lib/jxl/enc_chroma_from_luma.cc
+++ b/lib/jxl/enc_chroma_from_luma.cc
@@ -256,7 +256,7 @@ void ComputeTile(const Image3F& opsin, const Rect& opsin_rect,
 
     for (size_t x = x0; x < x1; x++) {
       AcStrategy acs = use_dct8
-                           ? AcStrategy::FromRawStrategy(AcStrategy::Type::DCT)
+                           ? AcStrategy::FromRawStrategy(AcStrategyType::DCT)
                            : ac_strategy->ConstRow(y)[x];
       if (!acs.IsFirstBlock()) continue;
       size_t xs = acs.covered_blocks_x();
@@ -375,7 +375,7 @@ void CfLHeuristics::ComputeTile(const Rect& r, const Image3F& opsin,
 }
 
 void ColorCorrelationEncodeDC(const ColorCorrelation& color_correlation,
-                              BitWriter* writer, size_t layer,
+                              BitWriter* writer, LayerType layer,
                               AuxOut* aux_out) {
   float color_factor = color_correlation.GetColorFactor();
   float base_correlation_x = color_correlation.GetBaseCorrelationX();

--- a/lib/jxl/enc_chroma_from_luma.h
+++ b/lib/jxl/enc_chroma_from_luma.h
@@ -12,6 +12,7 @@
 #include <jxl/memory_manager.h>
 
 #include <cstddef>
+#include <cstdint>
 #include <hwy/aligned_allocator.h>
 
 #include "lib/jxl/ac_strategy.h"
@@ -26,10 +27,12 @@
 namespace jxl {
 
 struct AuxOut;
+enum class LayerType : uint8_t;
 class Quantizer;
 
 void ColorCorrelationEncodeDC(const ColorCorrelation& color_correlation,
-                              BitWriter* writer, size_t layer, AuxOut* aux_out);
+                              BitWriter* writer, LayerType layer,
+                              AuxOut* aux_out);
 
 struct CfLHeuristics {
   Status Init(JxlMemoryManager* memory_manager, const Rect& rect);

--- a/lib/jxl/enc_coeff_order.cc
+++ b/lib/jxl/enc_coeff_order.cc
@@ -28,6 +28,7 @@
 #include <hwy/aligned_allocator.h>
 #include <vector>
 
+#include "lib/jxl/ac_strategy.h"
 #include "lib/jxl/base/rect.h"
 #include "lib/jxl/coeff_order.h"
 #include "lib/jxl/coeff_order_fwd.h"
@@ -39,6 +40,7 @@
 namespace jxl {
 
 struct AuxOut;
+enum class LayerType : uint8_t;
 
 std::pair<uint32_t, uint32_t> ComputeUsedOrders(
     const SpeedTier speed, const AcStrategyImage& ac_strategy,
@@ -251,7 +253,7 @@ void TokenizePermutation(const coeff_order_t* JXL_RESTRICT order, size_t skip,
 }  // namespace
 
 void EncodePermutation(const coeff_order_t* JXL_RESTRICT order, size_t skip,
-                       size_t size, BitWriter* writer, int layer,
+                       size_t size, BitWriter* writer, LayerType layer,
                        AuxOut* aux_out) {
   JxlMemoryManager* memory_manager = writer->memory_manager();
   std::vector<std::vector<Token>> tokens(1);
@@ -279,7 +281,7 @@ void EncodeCoeffOrder(const coeff_order_t* JXL_RESTRICT order, AcStrategy acs,
 
 void EncodeCoeffOrders(uint16_t used_orders,
                        const coeff_order_t* JXL_RESTRICT order,
-                       BitWriter* writer, size_t layer,
+                       BitWriter* writer, LayerType layer,
                        AuxOut* JXL_RESTRICT aux_out) {
   JxlMemoryManager* memory_manager = writer->memory_manager();
   auto mem = hwy::AllocateAligned<coeff_order_t>(AcStrategy::kMaxCoeffArea);

--- a/lib/jxl/enc_coeff_order.h
+++ b/lib/jxl/enc_coeff_order.h
@@ -9,7 +9,6 @@
 #include <cstddef>
 #include <cstdint>
 
-#include "lib/jxl/ac_strategy.h"
 #include "lib/jxl/base/compiler_specific.h"
 #include "lib/jxl/base/rect.h"
 #include "lib/jxl/coeff_order_fwd.h"
@@ -21,6 +20,8 @@
 namespace jxl {
 
 struct AuxOut;
+class AcStrategyImage;
+enum class LayerType : uint8_t;
 
 // Orders that are actually used in part of image. `rect` is in block units.
 // Returns {orders that are used, orders that might be made non-default}.
@@ -39,14 +40,14 @@ void ComputeCoeffOrder(SpeedTier speed, const ACImage& acs,
 
 void EncodeCoeffOrders(uint16_t used_orders,
                        const coeff_order_t* JXL_RESTRICT order,
-                       BitWriter* writer, size_t layer,
+                       BitWriter* writer, LayerType layer,
                        AuxOut* JXL_RESTRICT aux_out);
 
 // Encoding/decoding of a single permutation. `size`: number of elements in the
 // permutation. `skip`: number of elements to skip from the *beginning* of the
 // permutation.
 void EncodePermutation(const coeff_order_t* JXL_RESTRICT order, size_t skip,
-                       size_t size, BitWriter* writer, int layer,
+                       size_t size, BitWriter* writer, LayerType layer,
                        AuxOut* aux_out);
 
 }  // namespace jxl

--- a/lib/jxl/enc_context_map.cc
+++ b/lib/jxl/enc_context_map.cc
@@ -9,10 +9,10 @@
 
 #include <jxl/memory_manager.h>
 #include <jxl/types.h>
-#include <stdint.h>
 
 #include <algorithm>
 #include <cstddef>
+#include <cstdint>
 #include <vector>
 
 #include "lib/jxl/base/bits.h"
@@ -61,7 +61,7 @@ std::vector<uint8_t> MoveToFrontTransform(const std::vector<uint8_t>& v) {
 }  // namespace
 
 void EncodeContextMap(const std::vector<uint8_t>& context_map,
-                      size_t num_histograms, BitWriter* writer, size_t layer,
+                      size_t num_histograms, BitWriter* writer, LayerType layer,
                       AuxOut* aux_out) {
   if (num_histograms == 1) {
     // Simple code
@@ -88,16 +88,16 @@ void EncodeContextMap(const std::vector<uint8_t>& context_map,
   {
     EntropyEncodingData codes;
     std::vector<uint8_t> sink_context_map;
-    ans_cost =
-        BuildAndEncodeHistograms(memory_manager, params, 1, tokens, &codes,
-                                 &sink_context_map, nullptr, 0, nullptr);
+    ans_cost = BuildAndEncodeHistograms(memory_manager, params, 1, tokens,
+                                        &codes, &sink_context_map, nullptr,
+                                        LayerType::Header, nullptr);
   }
   {
     EntropyEncodingData codes;
     std::vector<uint8_t> sink_context_map;
-    mtf_cost =
-        BuildAndEncodeHistograms(memory_manager, params, 1, mtf_tokens, &codes,
-                                 &sink_context_map, nullptr, 0, nullptr);
+    mtf_cost = BuildAndEncodeHistograms(memory_manager, params, 1, mtf_tokens,
+                                        &codes, &sink_context_map, nullptr,
+                                        LayerType::Header, nullptr);
   }
   bool use_mtf = mtf_cost < ans_cost;
   // Rebuild token list.
@@ -142,7 +142,7 @@ void EncodeBlockCtxMap(const BlockCtxMap& block_ctx_map, BitWriter* writer,
       ctx_map.size() == 21 &&
       std::equal(ctx_map.begin(), ctx_map.end(), BlockCtxMap::kDefaultCtxMap)) {
     writer->Write(1, 1);  // default
-    allotment.ReclaimAndCharge(writer, kLayerAC, aux_out);
+    allotment.ReclaimAndCharge(writer, LayerType::Ac, aux_out);
     return;
   }
   writer->Write(1, 0);
@@ -156,8 +156,9 @@ void EncodeBlockCtxMap(const BlockCtxMap& block_ctx_map, BitWriter* writer,
   for (uint32_t i : qft) {
     JXL_CHECK(U32Coder::Write(kQFThresholdDist, i - 1, writer));
   }
-  EncodeContextMap(ctx_map, block_ctx_map.num_ctxs, writer, kLayerAC, aux_out);
-  allotment.ReclaimAndCharge(writer, kLayerAC, aux_out);
+  EncodeContextMap(ctx_map, block_ctx_map.num_ctxs, writer, LayerType::Ac,
+                   aux_out);
+  allotment.ReclaimAndCharge(writer, LayerType::Ac, aux_out);
 }
 
 }  // namespace jxl

--- a/lib/jxl/enc_context_map.h
+++ b/lib/jxl/enc_context_map.h
@@ -16,6 +16,7 @@
 namespace jxl {
 
 struct AuxOut;
+enum class LayerType : uint8_t;
 
 // Max limit is 255 because encoding assumes numbers < 255
 // More clusters can help compression, but makes encode/decode somewhat slower
@@ -24,7 +25,7 @@ static const size_t kClustersLimit = 128;
 // Encodes the given context map to the bit stream. The number of different
 // histogram ids is given by num_histograms.
 void EncodeContextMap(const std::vector<uint8_t>& context_map,
-                      size_t num_histograms, BitWriter* writer, size_t layer,
+                      size_t num_histograms, BitWriter* writer, LayerType layer,
                       AuxOut* aux_out);
 
 void EncodeBlockCtxMap(const BlockCtxMap& block_ctx_map, BitWriter* writer,

--- a/lib/jxl/enc_entropy_coder.h
+++ b/lib/jxl/enc_entropy_coder.h
@@ -12,7 +12,6 @@
 #include <vector>
 
 #include "lib/jxl/ac_context.h"  // BlockCtxMap
-#include "lib/jxl/ac_strategy.h"
 #include "lib/jxl/base/compiler_specific.h"
 #include "lib/jxl/base/rect.h"
 #include "lib/jxl/coeff_order_fwd.h"
@@ -24,6 +23,8 @@
 // strategy and quantization field.
 
 namespace jxl {
+
+class AcStrategyImage;
 
 // Generate DCT NxN quantized AC values tokens.
 // Only the subset "rect" [in units of blocks] within all images.

--- a/lib/jxl/enc_external_image.cc
+++ b/lib/jxl/enc_external_image.cc
@@ -16,6 +16,7 @@
 #include "lib/jxl/base/common.h"
 #include "lib/jxl/base/float.h"
 #include "lib/jxl/base/printf_macros.h"
+#include "lib/jxl/base/status.h"
 
 namespace jxl {
 namespace {
@@ -246,7 +247,7 @@ Status BufferToImageBundle(const JxlPixelFormat& pixel_format, uint32_t xsize,
   JXL_RETURN_IF_ERROR(ConvertFromExternal(
       jxl::Bytes(static_cast<const uint8_t*>(buffer), size), xsize, ysize,
       c_current, bitdepth, pixel_format, pool, ib));
-  ib->VerifyMetadata();
+  JXL_RETURN_IF_ERROR(ib->VerifyMetadata());
 
   return true;
 }

--- a/lib/jxl/enc_fields.cc
+++ b/lib/jxl/enc_fields.cc
@@ -72,7 +72,7 @@ class WriteVisitor : public VisitorBase {
 };
 }  // namespace
 
-Status Bundle::Write(const Fields& fields, BitWriter* writer, size_t layer,
+Status Bundle::Write(const Fields& fields, BitWriter* writer, LayerType layer,
                      AuxOut* aux_out) {
   size_t extension_bits;
   size_t total_bits;
@@ -203,40 +203,40 @@ Status WriteCodestreamHeaders(CodecMetadata* metadata, BitWriter* writer,
   BitWriter::Allotment allotment(writer, 16);
   writer->Write(8, 0xFF);
   writer->Write(8, kCodestreamMarker);
-  allotment.ReclaimAndCharge(writer, kLayerHeader, aux_out);
+  allotment.ReclaimAndCharge(writer, LayerType::Header, aux_out);
 
   JXL_RETURN_IF_ERROR(
-      WriteSizeHeader(metadata->size, writer, kLayerHeader, aux_out));
+      WriteSizeHeader(metadata->size, writer, LayerType::Header, aux_out));
 
   JXL_RETURN_IF_ERROR(
-      WriteImageMetadata(metadata->m, writer, kLayerHeader, aux_out));
+      WriteImageMetadata(metadata->m, writer, LayerType::Header, aux_out));
 
   metadata->transform_data.nonserialized_xyb_encoded = metadata->m.xyb_encoded;
-  JXL_RETURN_IF_ERROR(
-      Bundle::Write(metadata->transform_data, writer, kLayerHeader, aux_out));
+  JXL_RETURN_IF_ERROR(Bundle::Write(metadata->transform_data, writer,
+                                    LayerType::Header, aux_out));
 
   return true;
 }
 
 Status WriteFrameHeader(const FrameHeader& frame,
                         BitWriter* JXL_RESTRICT writer, AuxOut* aux_out) {
-  return Bundle::Write(frame, writer, kLayerHeader, aux_out);
+  return Bundle::Write(frame, writer, LayerType::Header, aux_out);
 }
 
 Status WriteImageMetadata(const ImageMetadata& metadata,
-                          BitWriter* JXL_RESTRICT writer, size_t layer,
+                          BitWriter* JXL_RESTRICT writer, LayerType layer,
                           AuxOut* aux_out) {
   return Bundle::Write(metadata, writer, layer, aux_out);
 }
 
 Status WriteQuantizerParams(const QuantizerParams& params,
-                            BitWriter* JXL_RESTRICT writer, size_t layer,
+                            BitWriter* JXL_RESTRICT writer, LayerType layer,
                             AuxOut* aux_out) {
   return Bundle::Write(params, writer, layer, aux_out);
 }
 
 Status WriteSizeHeader(const SizeHeader& size, BitWriter* JXL_RESTRICT writer,
-                       size_t layer, AuxOut* aux_out) {
+                       LayerType layer, AuxOut* aux_out) {
   return Bundle::Write(size, writer, layer, aux_out);
 }
 

--- a/lib/jxl/enc_fields.h
+++ b/lib/jxl/enc_fields.h
@@ -6,6 +6,8 @@
 #ifndef LIB_JXL_ENC_FIELDS_H_
 #define LIB_JXL_ENC_FIELDS_H_
 
+#include <cstdint>
+
 #include "lib/jxl/base/status.h"
 #include "lib/jxl/enc_bit_writer.h"
 #include "lib/jxl/frame_header.h"
@@ -16,6 +18,7 @@
 namespace jxl {
 
 struct AuxOut;
+enum class LayerType : uint8_t;
 
 // Write headers from the CodecMetadata. Also may modify nonserialized_...
 // fields of the metadata.
@@ -26,11 +29,11 @@ Status WriteFrameHeader(const FrameHeader& frame,
                         BitWriter* JXL_RESTRICT writer, AuxOut* aux_out);
 
 Status WriteQuantizerParams(const QuantizerParams& params,
-                            BitWriter* JXL_RESTRICT writer, size_t layer,
+                            BitWriter* JXL_RESTRICT writer, LayerType layer,
                             AuxOut* aux_out);
 
 Status WriteSizeHeader(const SizeHeader& size, BitWriter* JXL_RESTRICT writer,
-                       size_t layer, AuxOut* aux_out);
+                       LayerType layer, AuxOut* aux_out);
 
 }  // namespace jxl
 

--- a/lib/jxl/enc_heuristics.cc
+++ b/lib/jxl/enc_heuristics.cc
@@ -213,7 +213,7 @@ Status FindBestDequantMatrices(JxlMemoryManager* memory_manager,
     // Set numerators of all quantization matrices to constant values.
     float weights[3][1] = {{1.0f / wp[0]}, {1.0f / wp[1]}, {1.0f / wp[2]}};
     DctQuantWeightParams dct_params(weights);
-    std::vector<QuantEncoding> encodings(DequantMatrices::kNum,
+    std::vector<QuantEncoding> encodings(kNumQuantTables,
                                          QuantEncoding::DCT(dct_params));
     JXL_RETURN_IF_ERROR(DequantMatricesSetCustom(dequant_matrices, encodings,
                                                  modular_frame_encoder));
@@ -1021,7 +1021,8 @@ Status LossyFrameHeuristics(const FrameHeader& frame_header,
                     cparams.speed_tier <= SpeedTier::kSquirrel)) {
     JXL_RETURN_IF_ERROR(
         FindBestPatchDictionary(*opsin, enc_state, cms, pool, aux_out));
-    PatchDictionaryEncoder::SubtractFrom(image_features.patches, opsin);
+    JXL_RETURN_IF_ERROR(
+        PatchDictionaryEncoder::SubtractFrom(image_features.patches, opsin));
   }
 
   const float quant_dc = InitialQuantDC(cparams.butteraugli_distance);
@@ -1111,7 +1112,9 @@ Status LossyFrameHeuristics(const FrameHeader& frame_header,
   acs_heuristics.Init(*opsin, rect, initial_quant_field, initial_quant_masking,
                       initial_quant_masking1x1, &matrices);
 
+  std::atomic<bool> has_error{false};
   auto process_tile = [&](const uint32_t tid, const size_t thread) {
+    if (has_error) return;
     size_t n_enc_tiles = DivCeil(frame_dim.xsize_blocks, kEncTileDimInBlocks);
     size_t tx = tid % n_enc_tiles;
     size_t ty = tid / n_enc_tiles;
@@ -1134,7 +1137,10 @@ Status LossyFrameHeuristics(const FrameHeader& frame_header,
     }
 
     // Choose block sizes.
-    acs_heuristics.ProcessRect(r, cmap, &ac_strategy, thread);
+    if (!acs_heuristics.ProcessRect(r, cmap, &ac_strategy, thread)) {
+      has_error = true;
+      return;
+    }
 
     // Always set the initial quant field, so we can compute the CfL map with
     // more accuracy. The initial quant field might change in slower modes, but
@@ -1161,6 +1167,9 @@ Status LossyFrameHeuristics(const FrameHeader& frame_header,
         return true;
       },
       process_tile, "Enc Heuristics"));
+  if (has_error) {
+    return JXL_FAILURE("process_tile failed");
+  }
 
   JXL_RETURN_IF_ERROR(acs_heuristics.Finalize(frame_dim, ac_strategy, aux_out));
 

--- a/lib/jxl/enc_icc_codec.cc
+++ b/lib/jxl/enc_icc_codec.cc
@@ -430,7 +430,7 @@ Status PredictICC(const uint8_t* icc, size_t size, PaddedBytes* result) {
 }
 
 Status WriteICC(const Span<const uint8_t> icc, BitWriter* JXL_RESTRICT writer,
-                size_t layer, AuxOut* JXL_RESTRICT aux_out) {
+                LayerType layer, AuxOut* JXL_RESTRICT aux_out) {
   if (icc.empty()) return JXL_FAILURE("ICC must be non-empty");
   JxlMemoryManager* memory_manager = writer->memory_manager();
   PaddedBytes enc{memory_manager};

--- a/lib/jxl/enc_icc_codec.h
+++ b/lib/jxl/enc_icc_codec.h
@@ -8,7 +8,6 @@
 
 // Compressed representation of ICC profiles.
 
-#include <cstddef>
 #include <cstdint>
 #include <vector>
 
@@ -20,10 +19,12 @@
 namespace jxl {
 
 struct AuxOut;
+enum class LayerType : uint8_t;
+class PaddedBytes;
 
 // Should still be called if `icc.empty()` - if so, writes only 1 bit.
 Status WriteICC(Span<const uint8_t> icc, BitWriter* JXL_RESTRICT writer,
-                size_t layer, AuxOut* JXL_RESTRICT aux_out);
+                LayerType layer, AuxOut* JXL_RESTRICT aux_out);
 
 }  // namespace jxl
 

--- a/lib/jxl/enc_modular.h
+++ b/lib/jxl/enc_modular.h
@@ -35,6 +35,7 @@
 namespace jxl {
 
 struct AuxOut;
+enum class LayerType : uint8_t;
 
 class ModularFrameEncoder {
  public:
@@ -55,7 +56,7 @@ class ModularFrameEncoder {
                           AuxOut* aux_out);
   // Encodes a specific modular image (identified by `stream`) in the `writer`,
   // assigning bits to the provided `layer`.
-  Status EncodeStream(BitWriter* writer, AuxOut* aux_out, size_t layer,
+  Status EncodeStream(BitWriter* writer, AuxOut* aux_out, LayerType layer,
                       const ModularStreamId& stream);
 
   void ClearStreamData(const ModularStreamId& stream);

--- a/lib/jxl/enc_noise.cc
+++ b/lib/jxl/enc_noise.cc
@@ -354,7 +354,7 @@ Status GetNoiseParameter(const Image3F& opsin, NoiseParams* noise_params,
 }
 
 void EncodeNoise(const NoiseParams& noise_params, BitWriter* writer,
-                 size_t layer, AuxOut* aux_out) {
+                 LayerType layer, AuxOut* aux_out) {
   JXL_ASSERT(noise_params.HasAny());
 
   BitWriter::Allotment allotment(writer, NoiseParams::kNumNoisePoints * 16);

--- a/lib/jxl/enc_noise.h
+++ b/lib/jxl/enc_noise.h
@@ -8,7 +8,7 @@
 
 // Noise parameter estimation.
 
-#include <stddef.h>
+#include <cstdint>
 
 #include "lib/jxl/base/status.h"
 #include "lib/jxl/enc_bit_writer.h"
@@ -18,6 +18,7 @@
 namespace jxl {
 
 struct AuxOut;
+enum class LayerType : uint8_t;
 
 // Get parameters of the noise for NoiseParams model
 // Returns whether a valid noise model (with HasAny()) is set.
@@ -27,7 +28,7 @@ Status GetNoiseParameter(const Image3F& opsin, NoiseParams* noise_params,
 // Does not write anything if `noise_params` are empty. Otherwise, caller must
 // set FrameHeader.flags.kNoise.
 void EncodeNoise(const NoiseParams& noise_params, BitWriter* writer,
-                 size_t layer, AuxOut* aux_out);
+                 LayerType layer, AuxOut* aux_out);
 
 }  // namespace jxl
 

--- a/lib/jxl/enc_patch_dictionary.cc
+++ b/lib/jxl/enc_patch_dictionary.cc
@@ -44,7 +44,7 @@ static constexpr size_t kPatchFrameReferenceId = 3;
 
 // static
 void PatchDictionaryEncoder::Encode(const PatchDictionary& pdic,
-                                    BitWriter* writer, size_t layer,
+                                    BitWriter* writer, LayerType layer,
                                     AuxOut* aux_out) {
   JXL_ASSERT(pdic.HasAny());
   JxlMemoryManager* memory_manager = writer->memory_manager();
@@ -116,8 +116,8 @@ void PatchDictionaryEncoder::Encode(const PatchDictionary& pdic,
 }
 
 // static
-void PatchDictionaryEncoder::SubtractFrom(const PatchDictionary& pdic,
-                                          Image3F* opsin) {
+Status PatchDictionaryEncoder::SubtractFrom(const PatchDictionary& pdic,
+                                            Image3F* opsin) {
   // TODO(veluca): this can likely be optimized knowing it runs on full images.
   for (size_t y = 0; y < opsin->ysize(); y++) {
     float* JXL_RESTRICT rows[3] = {
@@ -159,13 +159,14 @@ void PatchDictionaryEncoder::SubtractFrom(const PatchDictionary& pdic,
           } else if (mode == PatchBlendMode::kNone) {
             // Nothing to do.
           } else {
-            JXL_UNREACHABLE("Blending mode %u not yet implemented",
-                            static_cast<uint32_t>(mode));
+            return JXL_UNREACHABLE("blending mode %u not yet implemented",
+                                   static_cast<uint32_t>(mode));
           }
         }
       }
     }
   }
+  return true;
 }
 
 namespace {
@@ -814,7 +815,7 @@ Status RoundtripPatchFrame(Image3F* reference_frame,
       cms, pool, special_frame.get(), aux_out ? &patch_aux_out : nullptr));
   if (aux_out) {
     for (const auto& l : patch_aux_out.layers) {
-      aux_out->layers[kLayerDictionary].Assimilate(l);
+      aux_out->layer(LayerType::Dictionary).Assimilate(l);
     }
   }
   const Span<const uint8_t> encoded = special_frame->GetSpan();

--- a/lib/jxl/enc_patch_dictionary.h
+++ b/lib/jxl/enc_patch_dictionary.h
@@ -29,6 +29,7 @@
 namespace jxl {
 
 struct AuxOut;
+enum class LayerType : uint8_t;
 
 constexpr size_t kMaxPatchSize = 32;
 
@@ -78,7 +79,7 @@ class PatchDictionaryEncoder {
  public:
   // Only call if HasAny().
   static void Encode(const PatchDictionary& pdic, BitWriter* writer,
-                     size_t layer, AuxOut* aux_out);
+                     LayerType layer, AuxOut* aux_out);
 
   static void SetPositions(PatchDictionary* pdic,
                            std::vector<PatchPosition> positions,
@@ -92,7 +93,7 @@ class PatchDictionaryEncoder {
     pdic->ComputePatchTree();
   }
 
-  static void SubtractFrom(const PatchDictionary& pdic, Image3F* opsin);
+  static Status SubtractFrom(const PatchDictionary& pdic, Image3F* opsin);
 };
 
 Status FindBestPatchDictionary(const Image3F& opsin,

--- a/lib/jxl/enc_progressive_split.h
+++ b/lib/jxl/enc_progressive_split.h
@@ -6,28 +6,21 @@
 #ifndef LIB_JXL_PROGRESSIVE_SPLIT_H_
 #define LIB_JXL_PROGRESSIVE_SPLIT_H_
 
-#include <stddef.h>
-#include <stdint.h>
-
+#include <cstddef>
+#include <cstdint>
 #include <limits>
-#include <memory>
-#include <vector>
 
-#include "lib/jxl/ac_strategy.h"
 #include "lib/jxl/base/compiler_specific.h"
 #include "lib/jxl/base/status.h"
-#include "lib/jxl/chroma_from_luma.h"
 #include "lib/jxl/common.h"  // kMaxNumPasses
-#include "lib/jxl/dct_util.h"
 #include "lib/jxl/frame_header.h"
-#include "lib/jxl/image.h"
-#include "lib/jxl/image_ops.h"
-#include "lib/jxl/splines.h"
 
 // Functions to split DCT coefficients in multiple passes. All the passes of a
 // single frame are added together.
 
 namespace jxl {
+
+class AcStrategy;
 
 constexpr size_t kNoDownsamplingFactor = std::numeric_limits<size_t>::max();
 

--- a/lib/jxl/enc_quant_weights.h
+++ b/lib/jxl/enc_quant_weights.h
@@ -8,7 +8,7 @@
 
 #include <jxl/memory_manager.h>
 
-#include <cstddef>
+#include <cstdint>
 #include <vector>
 
 #include "lib/jxl/base/status.h"
@@ -17,14 +17,15 @@
 namespace jxl {
 
 struct AuxOut;
+enum class LayerType : uint8_t;
 struct BitWriter;
 
 Status DequantMatricesEncode(
     JxlMemoryManager* memory_manager, const DequantMatrices& matrices,
-    BitWriter* writer, size_t layer, AuxOut* aux_out,
+    BitWriter* writer, LayerType layer, AuxOut* aux_out,
     ModularFrameEncoder* modular_frame_encoder = nullptr);
 Status DequantMatricesEncodeDC(const DequantMatrices& matrices,
-                               BitWriter* writer, size_t layer,
+                               BitWriter* writer, LayerType layer,
                                AuxOut* aux_out);
 // For consistency with QuantEncoding, higher values correspond to more
 // precision.

--- a/lib/jxl/enc_splines.cc
+++ b/lib/jxl/enc_splines.cc
@@ -3,6 +3,8 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
+#include <cstdint>
+
 #include "lib/jxl/base/status.h"
 #include "lib/jxl/enc_ans.h"
 #include "lib/jxl/pack_signed.h"
@@ -11,6 +13,7 @@
 namespace jxl {
 
 struct AuxOut;
+enum class LayerType : uint8_t;
 
 class QuantizedSplineEncoder {
  public:
@@ -59,8 +62,8 @@ void EncodeAllStartingPoints(const std::vector<Spline::Point>& points,
 }  // namespace
 
 void EncodeSplines(const Splines& splines, BitWriter* writer,
-                   const size_t layer, const HistogramParams& histogram_params,
-                   AuxOut* aux_out) {
+                   const LayerType layer,
+                   const HistogramParams& histogram_params, AuxOut* aux_out) {
   JXL_ASSERT(splines.HasAny());
 
   const std::vector<QuantizedSpline>& quantized_splines =

--- a/lib/jxl/enc_splines.h
+++ b/lib/jxl/enc_splines.h
@@ -6,7 +6,7 @@
 #ifndef LIB_JXL_ENC_SPLINES_H_
 #define LIB_JXL_ENC_SPLINES_H_
 
-#include <cstddef>
+#include <cstdint>
 
 #include "lib/jxl/enc_ans_params.h"
 #include "lib/jxl/enc_bit_writer.h"
@@ -16,9 +16,10 @@
 namespace jxl {
 
 struct AuxOut;
+enum class LayerType : uint8_t;
 
 // Only call if splines.HasAny().
-void EncodeSplines(const Splines& splines, BitWriter* writer, size_t layer,
+void EncodeSplines(const Splines& splines, BitWriter* writer, LayerType layer,
                    const HistogramParams& histogram_params, AuxOut* aux_out);
 
 Splines FindSplines(const Image3F& opsin);

--- a/lib/jxl/enc_toc.cc
+++ b/lib/jxl/enc_toc.cc
@@ -25,7 +25,7 @@ Status WriteGroupOffsets(
     writer->Write(1, 1);  // permutation
     JXL_DASSERT(permutation.size() == group_codes.size());
     EncodePermutation(permutation.data(), /*skip=*/0, permutation.size(),
-                      writer, /* layer= */ 0, aux_out);
+                      writer, LayerType::Header, aux_out);
 
   } else {
     writer->Write(1, 0);  // no permutation
@@ -38,7 +38,7 @@ Status WriteGroupOffsets(
     JXL_RETURN_IF_ERROR(U32Coder::Write(kTocDist, group_size, writer));
   }
   writer->ZeroPadToByte();  // before first group
-  allotment.ReclaimAndCharge(writer, kLayerTOC, aux_out);
+  allotment.ReclaimAndCharge(writer, LayerType::Toc, aux_out);
   return true;
 }
 

--- a/lib/jxl/enc_transforms-inl.h
+++ b/lib/jxl/enc_transforms-inl.h
@@ -10,16 +10,19 @@
 #define LIB_JXL_ENC_TRANSFORMS_INL_H_
 #endif
 
-#include <stddef.h>
-
+#include <cstddef>
+#include <cstdint>
 #include <hwy/highway.h>
 
 #include "lib/jxl/ac_strategy.h"
-#include "lib/jxl/coeff_order_fwd.h"
 #include "lib/jxl/dct-inl.h"
 #include "lib/jxl/dct_scales.h"
+
 HWY_BEFORE_NAMESPACE();
 namespace jxl {
+
+enum class AcStrategyType : uint32_t;
+
 namespace HWY_NAMESPACE {
 namespace {
 
@@ -445,12 +448,12 @@ void AFVTransformFromPixels(const float* JXL_RESTRICT pixels,
   coefficients[8] = (block00 + block01 - 2 * block10) * 0.25f;
 }
 
-HWY_MAYBE_UNUSED void TransformFromPixels(const AcStrategy::Type strategy,
+HWY_MAYBE_UNUSED void TransformFromPixels(const AcStrategyType strategy,
                                           const float* JXL_RESTRICT pixels,
                                           size_t pixels_stride,
                                           float* JXL_RESTRICT coefficients,
                                           float* JXL_RESTRICT scratch_space) {
-  using Type = AcStrategy::Type;
+  using Type = AcStrategyType;
   switch (strategy) {
     case Type::IDENTITY: {
       for (size_t y = 0; y < 2; y++) {
@@ -656,15 +659,13 @@ HWY_MAYBE_UNUSED void TransformFromPixels(const AcStrategy::Type strategy,
                                    scratch_space);
       break;
     }
-    case Type::kNumValidStrategies:
-      JXL_UNREACHABLE("Invalid strategy");
   }
 }
 
-HWY_MAYBE_UNUSED void DCFromLowestFrequencies(const AcStrategy::Type strategy,
+HWY_MAYBE_UNUSED void DCFromLowestFrequencies(const AcStrategyType strategy,
                                               const float* block, float* dc,
                                               size_t dc_stride) {
-  using Type = AcStrategy::Type;
+  using Type = AcStrategyType;
   switch (strategy) {
     case Type::DCT16X8: {
       ReinterpretingIDCT</*DCT_ROWS=*/2 * kBlockDim, /*DCT_COLS=*/kBlockDim,
@@ -786,8 +787,6 @@ HWY_MAYBE_UNUSED void DCFromLowestFrequencies(const AcStrategy::Type strategy,
     case Type::IDENTITY:
       dc[0] = block[0];
       break;
-    case Type::kNumValidStrategies:
-      JXL_UNREACHABLE("Invalid strategy");
   }
 }
 

--- a/lib/jxl/enc_transforms.cc
+++ b/lib/jxl/enc_transforms.cc
@@ -17,7 +17,7 @@ namespace jxl {
 
 #if HWY_ONCE
 HWY_EXPORT(TransformFromPixels);
-void TransformFromPixels(const AcStrategy::Type strategy,
+void TransformFromPixels(const AcStrategyType strategy,
                          const float* JXL_RESTRICT pixels, size_t pixels_stride,
                          float* JXL_RESTRICT coefficients,
                          float* scratch_space) {
@@ -26,7 +26,7 @@ void TransformFromPixels(const AcStrategy::Type strategy,
 }
 
 HWY_EXPORT(DCFromLowestFrequencies);
-void DCFromLowestFrequencies(AcStrategy::Type strategy, const float* block,
+void DCFromLowestFrequencies(AcStrategyType strategy, const float* block,
                              float* dc, size_t dc_stride) {
   HWY_DYNAMIC_DISPATCH(DCFromLowestFrequencies)(strategy, block, dc, dc_stride);
 }

--- a/lib/jxl/enc_transforms.h
+++ b/lib/jxl/enc_transforms.h
@@ -8,20 +8,22 @@
 
 // Facade for (non-inlined) integral transforms.
 
-#include <stddef.h>
+#include <cstddef>
+#include <cstdint>
 
-#include "lib/jxl/ac_strategy.h"
 #include "lib/jxl/base/compiler_specific.h"
 
 namespace jxl {
 
-void TransformFromPixels(AcStrategy::Type strategy,
+enum class AcStrategyType : uint32_t;
+
+void TransformFromPixels(AcStrategyType strategy,
                          const float* JXL_RESTRICT pixels, size_t pixels_stride,
                          float* JXL_RESTRICT coefficients,
                          float* JXL_RESTRICT scratch_space);
 
 // Equivalent of the above for DC image.
-void DCFromLowestFrequencies(AcStrategy::Type strategy, const float* block,
+void DCFromLowestFrequencies(AcStrategyType strategy, const float* block,
                              float* dc, size_t dc_stride);
 
 void AFVDCT4x4(const float* JXL_RESTRICT pixels, float* JXL_RESTRICT coeffs);

--- a/lib/jxl/encode.cc
+++ b/lib/jxl/encode.cc
@@ -742,7 +742,7 @@ jxl::Status JxlEncoderStruct::ProcessOneEnqueuedInput() {
     if (metadata.m.color_encoding.WantICC()) {
       if (!jxl::WriteICC(
               jxl::Span<const uint8_t>(metadata.m.color_encoding.ICC()),
-              &writer, jxl::kLayerHeader, aux_out)) {
+              &writer, jxl::LayerType::Header, aux_out)) {
         return JXL_API_ERROR(this, JXL_ENC_ERR_GENERIC,
                              "Failed to write ICC profile");
       }
@@ -751,7 +751,7 @@ jxl::Status JxlEncoderStruct::ProcessOneEnqueuedInput() {
 
     jxl::BitWriter::Allotment allotment(&writer, 8);
     writer.ZeroPadToByte();
-    allotment.ReclaimAndCharge(&writer, jxl::kLayerHeader, aux_out);
+    allotment.ReclaimAndCharge(&writer, jxl::LayerType::Header, aux_out);
 
     header_bytes = std::move(writer).TakeBytes();
 
@@ -2661,7 +2661,9 @@ JXL_EXPORT void JxlEncoderSetDebugImageCallback(
 }
 
 JXL_EXPORT JxlEncoderStats* JxlEncoderStatsCreate() {
-  return new JxlEncoderStats();
+  JxlEncoderStats* result = new JxlEncoderStats();
+  result->aux_out = jxl::make_unique<jxl::AuxOut>();
+  return result;
 }
 
 JXL_EXPORT void JxlEncoderStatsDestroy(JxlEncoderStats* stats) { delete stats; }
@@ -2669,44 +2671,44 @@ JXL_EXPORT void JxlEncoderStatsDestroy(JxlEncoderStats* stats) { delete stats; }
 JXL_EXPORT void JxlEncoderCollectStats(JxlEncoderFrameSettings* frame_settings,
                                        JxlEncoderStats* stats) {
   if (!stats) return;
-  frame_settings->values.aux_out = &stats->aux_out;
+  frame_settings->values.aux_out = stats->aux_out.get();
 }
 
 JXL_EXPORT size_t JxlEncoderStatsGet(const JxlEncoderStats* stats,
                                      JxlEncoderStatsKey key) {
   if (!stats) return 0;
-  const jxl::AuxOut& aux_out = stats->aux_out;
+  const jxl::AuxOut& aux_out = *stats->aux_out;
   switch (key) {
     case JXL_ENC_STAT_HEADER_BITS:
-      return aux_out.layers[jxl::kLayerHeader].total_bits;
+      return aux_out.layer(jxl::LayerType::Header).total_bits;
     case JXL_ENC_STAT_TOC_BITS:
-      return aux_out.layers[jxl::kLayerTOC].total_bits;
+      return aux_out.layer(jxl::LayerType::Toc).total_bits;
     case JXL_ENC_STAT_DICTIONARY_BITS:
-      return aux_out.layers[jxl::kLayerDictionary].total_bits;
+      return aux_out.layer(jxl::LayerType::Dictionary).total_bits;
     case JXL_ENC_STAT_SPLINES_BITS:
-      return aux_out.layers[jxl::kLayerSplines].total_bits;
+      return aux_out.layer(jxl::LayerType::Splines).total_bits;
     case JXL_ENC_STAT_NOISE_BITS:
-      return aux_out.layers[jxl::kLayerNoise].total_bits;
+      return aux_out.layer(jxl::LayerType::Noise).total_bits;
     case JXL_ENC_STAT_QUANT_BITS:
-      return aux_out.layers[jxl::kLayerQuant].total_bits;
+      return aux_out.layer(jxl::LayerType::Quant).total_bits;
     case JXL_ENC_STAT_MODULAR_TREE_BITS:
-      return aux_out.layers[jxl::kLayerModularTree].total_bits;
+      return aux_out.layer(jxl::LayerType::ModularTree).total_bits;
     case JXL_ENC_STAT_MODULAR_GLOBAL_BITS:
-      return aux_out.layers[jxl::kLayerModularGlobal].total_bits;
+      return aux_out.layer(jxl::LayerType::ModularGlobal).total_bits;
     case JXL_ENC_STAT_DC_BITS:
-      return aux_out.layers[jxl::kLayerDC].total_bits;
+      return aux_out.layer(jxl::LayerType::Dc).total_bits;
     case JXL_ENC_STAT_MODULAR_DC_GROUP_BITS:
-      return aux_out.layers[jxl::kLayerModularDcGroup].total_bits;
+      return aux_out.layer(jxl::LayerType::ModularDcGroup).total_bits;
     case JXL_ENC_STAT_CONTROL_FIELDS_BITS:
-      return aux_out.layers[jxl::kLayerControlFields].total_bits;
+      return aux_out.layer(jxl::LayerType::ControlFields).total_bits;
     case JXL_ENC_STAT_COEF_ORDER_BITS:
-      return aux_out.layers[jxl::kLayerOrder].total_bits;
+      return aux_out.layer(jxl::LayerType::Order).total_bits;
     case JXL_ENC_STAT_AC_HISTOGRAM_BITS:
-      return aux_out.layers[jxl::kLayerAC].total_bits;
+      return aux_out.layer(jxl::LayerType::Ac).total_bits;
     case JXL_ENC_STAT_AC_BITS:
-      return aux_out.layers[jxl::kLayerACTokens].total_bits;
+      return aux_out.layer(jxl::LayerType::AcTokens).total_bits;
     case JXL_ENC_STAT_MODULAR_AC_GROUP_BITS:
-      return aux_out.layers[jxl::kLayerModularAcGroup].total_bits;
+      return aux_out.layer(jxl::LayerType::ModularAcGroup).total_bits;
     case JXL_ENC_STAT_NUM_SMALL_BLOCKS:
       return aux_out.num_small_blocks;
     case JXL_ENC_STAT_NUM_DCT4X8_BLOCKS:
@@ -2737,5 +2739,5 @@ JXL_EXPORT size_t JxlEncoderStatsGet(const JxlEncoderStats* stats,
 JXL_EXPORT void JxlEncoderStatsMerge(JxlEncoderStats* stats,
                                      const JxlEncoderStats* other) {
   if (!stats || !other) return;
-  stats->aux_out.Assimilate(other->aux_out);
+  stats->aux_out->Assimilate(*other->aux_out);
 }

--- a/lib/jxl/encode_internal.h
+++ b/lib/jxl/encode_internal.h
@@ -30,7 +30,6 @@
 #include "lib/jxl/base/compiler_specific.h"
 #include "lib/jxl/base/data_parallel.h"
 #include "lib/jxl/base/status.h"
-#include "lib/jxl/enc_aux_out.h"
 #include "lib/jxl/enc_fast_lossless.h"
 #include "lib/jxl/enc_params.h"
 #include "lib/jxl/image_metadata.h"
@@ -675,7 +674,7 @@ struct JxlEncoderFrameSettingsStruct {
 };
 
 struct JxlEncoderStatsStruct {
-  jxl::AuxOut aux_out;
+  std::unique_ptr<jxl::AuxOut> aux_out;
 };
 
 #endif  // LIB_JXL_ENCODE_INTERNAL_H_

--- a/lib/jxl/fast_math_test.cc
+++ b/lib/jxl/fast_math_test.cc
@@ -192,8 +192,9 @@ HWY_NOINLINE void TestFastXYB() {
         for (int y = 0; y < kChunk; y++) {
           const float* xyba[4] = {xyb.PlaneRow(0, y), xyb.PlaneRow(1, y),
                                   xyb.PlaneRow(2, y), nullptr};
-          jxl::HWY_NAMESPACE::FastXYBTosRGB8(
-              xyba, roundtrip.data() + 3 * xyb.xsize() * y, false, xyb.xsize());
+          JXL_CHECK(jxl::HWY_NAMESPACE::FastXYBTosRGB8(
+              xyba, roundtrip.data() + 3 * xyb.xsize() * y, false,
+              xyb.xsize()));
         }
         for (int ir = 0; ir < kChunk; ir++) {
           for (int ig = 0; ig < kChunk; ig++) {

--- a/lib/jxl/fields.cc
+++ b/lib/jxl/fields.cc
@@ -414,19 +414,19 @@ class CanEncodeVisitor : public VisitorBase {
 void Bundle::Init(Fields* fields) {
   InitVisitor visitor;
   if (!visitor.Visit(fields)) {
-    JXL_UNREACHABLE("Init should never fail");
+    JXL_DEBUG_ABORT("Init should never fail");
   }
 }
 void Bundle::SetDefault(Fields* fields) {
   SetDefaultVisitor visitor;
   if (!visitor.Visit(fields)) {
-    JXL_UNREACHABLE("SetDefault should never fail");
+    JXL_DEBUG_ABORT("SetDefault should never fail");
   }
 }
 bool Bundle::AllDefault(const Fields& fields) {
   AllDefaultVisitor visitor;
   if (!visitor.VisitConst(fields)) {
-    JXL_UNREACHABLE("AllDefault should never fail");
+    JXL_DEBUG_ABORT("AllDefault should never fail");
   }
   return visitor.AllDefault();
 }

--- a/lib/jxl/fields.h
+++ b/lib/jxl/fields.h
@@ -21,6 +21,7 @@
 namespace jxl {
 
 struct AuxOut;
+enum class LayerType : uint8_t;
 struct BitWriter;
 
 // Integer coders: BitsCoder (raw), U32Coder (table), U64Coder (varint).
@@ -182,8 +183,8 @@ Status Read(BitReader* reader, Fields* JXL_RESTRICT fields);
 // this.
 bool CanRead(BitReader* reader, Fields* JXL_RESTRICT fields);
 
-Status Write(const Fields& fields, BitWriter* JXL_RESTRICT writer, size_t layer,
-             AuxOut* aux_out);
+Status Write(const Fields& fields, BitWriter* JXL_RESTRICT writer,
+             LayerType layer, AuxOut* aux_out);
 }  // namespace Bundle
 
 // Different subclasses of Visitor are passed to implementations of Fields

--- a/lib/jxl/frame_header.cc
+++ b/lib/jxl/frame_header.cc
@@ -5,7 +5,10 @@
 
 #include "lib/jxl/frame_header.h"
 
+#if JXL_DEBUG_V_LEVEL >= 1
 #include <sstream>
+#include <string>
+#endif
 
 #include "lib/jxl/base/printf_macros.h"
 #include "lib/jxl/base/status.h"
@@ -27,7 +30,7 @@ static Status VisitBlendMode(Visitor* JXL_RESTRICT visitor,
       Val(static_cast<uint32_t>(BlendMode::kAdd)),
       Val(static_cast<uint32_t>(BlendMode::kBlend)), BitsOffset(2, 3),
       static_cast<uint32_t>(default_value), &encoded));
-  if (encoded > 4) {
+  if (encoded > static_cast<uint32_t>(BlendMode::kMul)) {
     return JXL_FAILURE("Invalid blend_mode");
   }
   *blend_mode = static_cast<BlendMode>(encoded);

--- a/lib/jxl/icc_codec_test.cc
+++ b/lib/jxl/icc_codec_test.cc
@@ -13,6 +13,7 @@
 #include "lib/jxl/base/span.h"
 #include "lib/jxl/color_encoding_internal.h"
 #include "lib/jxl/dec_bit_reader.h"
+#include "lib/jxl/enc_aux_out.h"
 #include "lib/jxl/enc_bit_writer.h"
 #include "lib/jxl/enc_icc_codec.h"
 #include "lib/jxl/test_memory_manager.h"
@@ -25,7 +26,8 @@ namespace {
 void TestProfile(const IccBytes& icc) {
   JxlMemoryManager* memory_manager = jxl::test::MemoryManager();
   BitWriter writer{memory_manager};
-  ASSERT_TRUE(WriteICC(Span<const uint8_t>(icc), &writer, 0, nullptr));
+  ASSERT_TRUE(WriteICC(Span<const uint8_t>(icc), &writer,
+                       jxl::LayerType::Header, nullptr));
   writer.ZeroPadToByte();
   std::vector<uint8_t> dec;
   BitReader reader(writer.GetSpan());

--- a/lib/jxl/image_bundle.cc
+++ b/lib/jxl/image_bundle.cc
@@ -31,14 +31,14 @@ void ImageBundle::SetFromImage(Image3F&& color,
   VerifySizes();
 }
 
-void ImageBundle::VerifyMetadata() const {
+Status ImageBundle::VerifyMetadata() const {
   JXL_CHECK(!c_current_.ICC().empty());
   JXL_CHECK(metadata_->color_encoding.IsGray() == IsGray());
 
   if (metadata_->HasAlpha() && alpha().xsize() == 0) {
-    JXL_UNREACHABLE("MD alpha_bits %u IB alpha %" PRIuS " x %" PRIuS "\n",
-                    metadata_->GetAlphaBits(), alpha().xsize(),
-                    alpha().ysize());
+    return JXL_UNREACHABLE(
+        "MD alpha_bits %u IB alpha %" PRIuS " x %" PRIuS "\n",
+        metadata_->GetAlphaBits(), alpha().xsize(), alpha().ysize());
   }
   const uint32_t alpha_bits = metadata_->GetAlphaBits();
   JXL_CHECK(alpha_bits <= 32);
@@ -46,6 +46,7 @@ void ImageBundle::VerifyMetadata() const {
   // metadata_->num_extra_channels may temporarily differ from
   // extra_channels_.size(), e.g. after SetAlpha. They are synced by the next
   // call to VisitFields.
+  return true;
 }
 
 void ImageBundle::VerifySizes() const {

--- a/lib/jxl/image_bundle.h
+++ b/lib/jxl/image_bundle.h
@@ -197,7 +197,7 @@ class ImageBundle {
 
   const ImageMetadata* metadata() const { return metadata_; }
 
-  void VerifyMetadata() const;
+  Status VerifyMetadata() const;
 
   void SetDecodedBytes(size_t decoded_bytes) { decoded_bytes_ = decoded_bytes; }
   size_t decoded_bytes() const { return decoded_bytes_; }

--- a/lib/jxl/image_bundle_test.cc
+++ b/lib/jxl/image_bundle_test.cc
@@ -29,9 +29,10 @@ TEST(ImageBundleTest, ExtraChannelName) {
   eci.type = ExtraChannel::kBlack;
   eci.name = "testK";
   metadata.extra_channel_info.push_back(std::move(eci));
-  ASSERT_TRUE(WriteImageMetadata(metadata, &writer, /*layer=*/0, &aux_out));
+  ASSERT_TRUE(
+      WriteImageMetadata(metadata, &writer, LayerType::Header, &aux_out));
   writer.ZeroPadToByte();
-  allotment.ReclaimAndCharge(&writer, /*layer=*/0, &aux_out);
+  allotment.ReclaimAndCharge(&writer, LayerType::Header, &aux_out);
 
   BitReader reader(writer.GetSpan());
   ImageMetadata metadata_out;

--- a/lib/jxl/image_metadata.h
+++ b/lib/jxl/image_metadata.h
@@ -10,9 +10,9 @@
 #define LIB_JXL_IMAGE_METADATA_H_
 
 #include <jxl/codestream_header.h>
-#include <stddef.h>
-#include <stdint.h>
 
+#include <cstddef>
+#include <cstdint>
 #include <string>
 #include <vector>
 
@@ -28,6 +28,7 @@
 namespace jxl {
 
 struct AuxOut;
+enum class LayerType : uint8_t;
 
 // EXIF orientation of the image. This field overrides any field present in
 // actual EXIF metadata. The value tells which transformation the decoder must
@@ -373,7 +374,7 @@ Status ReadImageMetadata(BitReader* JXL_RESTRICT reader,
                          ImageMetadata* JXL_RESTRICT metadata);
 
 Status WriteImageMetadata(const ImageMetadata& metadata,
-                          BitWriter* JXL_RESTRICT writer, size_t layer,
+                          BitWriter* JXL_RESTRICT writer, LayerType layer,
                           AuxOut* aux_out);
 
 // All metadata applicable to the entire codestream (dimensions, extra channels,

--- a/lib/jxl/jpeg/enc_jpeg_data.cc
+++ b/lib/jxl/jpeg/enc_jpeg_data.cc
@@ -9,8 +9,11 @@
 #include <jxl/memory_manager.h>
 #include <jxl/types.h>
 
+#include <cstdint>
+
 #include "lib/jxl/base/sanitizers.h"
 #include "lib/jxl/codec_in_out.h"
+#include "lib/jxl/enc_aux_out.h"
 #include "lib/jxl/enc_bit_writer.h"
 #include "lib/jxl/image_bundle.h"
 #include "lib/jxl/jpeg/enc_jpeg_data_reader.h"
@@ -330,7 +333,8 @@ Status EncodeJPEGData(JxlMemoryManager* memory_manager, JPEGData& jpeg_data,
   size_t brotli_capacity = BrotliEncoderMaxCompressedSize(total_data);
 
   BitWriter writer{memory_manager};
-  JXL_RETURN_IF_ERROR(Bundle::Write(jpeg_data, &writer, 0, nullptr));
+  JXL_RETURN_IF_ERROR(
+      Bundle::Write(jpeg_data, &writer, LayerType::Header, nullptr));
   writer.ZeroPadToByte();
   {
     PaddedBytes serialized_jpeg_data = std::move(writer).TakeBytes();

--- a/lib/jxl/jpeg/jpeg_data.h
+++ b/lib/jxl/jpeg/jpeg_data.h
@@ -174,7 +174,7 @@ struct JPEGData : public Fields {
   Status VisitFields(Visitor* visitor) override;
 #else
   Status VisitFields(Visitor* /* visitor */) override {
-    JXL_UNREACHABLE("JPEG transcoding support not enabled");
+    return JXL_UNREACHABLE("JPEG transcoding support not enabled");
   }
 #endif  // JPEGXL_ENABLE_TRANSCODE_JPEG
 
@@ -208,7 +208,7 @@ Status SetJPEGDataFromICC(const std::vector<uint8_t>& icc,
 #else
 static JXL_INLINE Status SetJPEGDataFromICC(
     const std::vector<uint8_t>& /* icc */, jpeg::JPEGData* /* jpeg_data */) {
-  JXL_UNREACHABLE("JPEG transcoding support not enabled");
+  return JXL_UNREACHABLE("JPEG transcoding support not enabled");
 }
 #endif  // JPEGXL_ENABLE_TRANSCODE_JPEG
 

--- a/lib/jxl/modular/encoding/enc_encoding.cc
+++ b/lib/jxl/modular/encoding/enc_encoding.cc
@@ -196,79 +196,87 @@ Status GatherTreeData(const Image &image, pixel_type chan, size_t group_id,
 }
 
 Tree PredefinedTree(ModularOptions::TreeKind tree_kind, size_t total_pixels) {
-  if (tree_kind == ModularOptions::TreeKind::kJpegTranscodeACMeta ||
-      tree_kind == ModularOptions::TreeKind::kTrivialTreeNoPredictor) {
-    // All the data is 0, so no need for a fancy tree.
-    return {PropertyDecisionNode::Leaf(Predictor::Zero)};
-  }
-  if (tree_kind == ModularOptions::TreeKind::kFalconACMeta) {
-    // All the data is 0 except the quant field. TODO(veluca): make that 0 too.
-    return {PropertyDecisionNode::Leaf(Predictor::Left)};
-  }
-  if (tree_kind == ModularOptions::TreeKind::kACMeta) {
-    // Small image.
-    if (total_pixels < 1024) {
+  switch (tree_kind) {
+    case ModularOptions::TreeKind::kJpegTranscodeACMeta:
+      // All the data is 0, so no need for a fancy tree.
+      return {PropertyDecisionNode::Leaf(Predictor::Zero)};
+    case ModularOptions::TreeKind::kTrivialTreeNoPredictor:
+      // All the data is 0, so no need for a fancy tree.
+      return {PropertyDecisionNode::Leaf(Predictor::Zero)};
+    case ModularOptions::TreeKind::kFalconACMeta:
+      // All the data is 0 except the quant field. TODO(veluca): make that 0
+      // too.
       return {PropertyDecisionNode::Leaf(Predictor::Left)};
+    case ModularOptions::TreeKind::kACMeta: {
+      // Small image.
+      if (total_pixels < 1024) {
+        return {PropertyDecisionNode::Leaf(Predictor::Left)};
+      }
+      Tree tree;
+      // 0: c > 1
+      tree.push_back(PropertyDecisionNode::Split(0, 1, 1));
+      // 1: c > 2
+      tree.push_back(PropertyDecisionNode::Split(0, 2, 3));
+      // 2: c > 0
+      tree.push_back(PropertyDecisionNode::Split(0, 0, 5));
+      // 3: EPF control field (all 0 or 4), top > 3
+      tree.push_back(PropertyDecisionNode::Split(6, 3, 21));
+      // 4: ACS+QF, y > 0
+      tree.push_back(PropertyDecisionNode::Split(2, 0, 7));
+      // 5: CfL x
+      tree.push_back(PropertyDecisionNode::Leaf(Predictor::Gradient));
+      // 6: CfL b
+      tree.push_back(PropertyDecisionNode::Leaf(Predictor::Gradient));
+      // 7: QF: split according to the left quant value.
+      tree.push_back(PropertyDecisionNode::Split(7, 5, 9));
+      // 8: ACS: split in 4 segments (8x8 from 0 to 3, large square 4-5, large
+      // rectangular 6-11, 8x8 12+), according to previous ACS value.
+      tree.push_back(PropertyDecisionNode::Split(7, 5, 15));
+      // QF
+      tree.push_back(PropertyDecisionNode::Split(7, 11, 11));
+      tree.push_back(PropertyDecisionNode::Split(7, 3, 13));
+      tree.push_back(PropertyDecisionNode::Leaf(Predictor::Left));
+      tree.push_back(PropertyDecisionNode::Leaf(Predictor::Left));
+      tree.push_back(PropertyDecisionNode::Leaf(Predictor::Left));
+      tree.push_back(PropertyDecisionNode::Leaf(Predictor::Left));
+      // ACS
+      tree.push_back(PropertyDecisionNode::Split(7, 11, 17));
+      tree.push_back(PropertyDecisionNode::Split(7, 3, 19));
+      tree.push_back(PropertyDecisionNode::Leaf(Predictor::Zero));
+      tree.push_back(PropertyDecisionNode::Leaf(Predictor::Zero));
+      tree.push_back(PropertyDecisionNode::Leaf(Predictor::Zero));
+      tree.push_back(PropertyDecisionNode::Leaf(Predictor::Zero));
+      // EPF, left > 3
+      tree.push_back(PropertyDecisionNode::Split(7, 3, 23));
+      tree.push_back(PropertyDecisionNode::Split(7, 3, 25));
+      tree.push_back(PropertyDecisionNode::Leaf(Predictor::Zero));
+      tree.push_back(PropertyDecisionNode::Leaf(Predictor::Zero));
+      tree.push_back(PropertyDecisionNode::Leaf(Predictor::Zero));
+      tree.push_back(PropertyDecisionNode::Leaf(Predictor::Zero));
+      return tree;
     }
-    Tree tree;
-    // 0: c > 1
-    tree.push_back(PropertyDecisionNode::Split(0, 1, 1));
-    // 1: c > 2
-    tree.push_back(PropertyDecisionNode::Split(0, 2, 3));
-    // 2: c > 0
-    tree.push_back(PropertyDecisionNode::Split(0, 0, 5));
-    // 3: EPF control field (all 0 or 4), top > 3
-    tree.push_back(PropertyDecisionNode::Split(6, 3, 21));
-    // 4: ACS+QF, y > 0
-    tree.push_back(PropertyDecisionNode::Split(2, 0, 7));
-    // 5: CfL x
-    tree.push_back(PropertyDecisionNode::Leaf(Predictor::Gradient));
-    // 6: CfL b
-    tree.push_back(PropertyDecisionNode::Leaf(Predictor::Gradient));
-    // 7: QF: split according to the left quant value.
-    tree.push_back(PropertyDecisionNode::Split(7, 5, 9));
-    // 8: ACS: split in 4 segments (8x8 from 0 to 3, large square 4-5, large
-    // rectangular 6-11, 8x8 12+), according to previous ACS value.
-    tree.push_back(PropertyDecisionNode::Split(7, 5, 15));
-    // QF
-    tree.push_back(PropertyDecisionNode::Split(7, 11, 11));
-    tree.push_back(PropertyDecisionNode::Split(7, 3, 13));
-    tree.push_back(PropertyDecisionNode::Leaf(Predictor::Left));
-    tree.push_back(PropertyDecisionNode::Leaf(Predictor::Left));
-    tree.push_back(PropertyDecisionNode::Leaf(Predictor::Left));
-    tree.push_back(PropertyDecisionNode::Leaf(Predictor::Left));
-    // ACS
-    tree.push_back(PropertyDecisionNode::Split(7, 11, 17));
-    tree.push_back(PropertyDecisionNode::Split(7, 3, 19));
-    tree.push_back(PropertyDecisionNode::Leaf(Predictor::Zero));
-    tree.push_back(PropertyDecisionNode::Leaf(Predictor::Zero));
-    tree.push_back(PropertyDecisionNode::Leaf(Predictor::Zero));
-    tree.push_back(PropertyDecisionNode::Leaf(Predictor::Zero));
-    // EPF, left > 3
-    tree.push_back(PropertyDecisionNode::Split(7, 3, 23));
-    tree.push_back(PropertyDecisionNode::Split(7, 3, 25));
-    tree.push_back(PropertyDecisionNode::Leaf(Predictor::Zero));
-    tree.push_back(PropertyDecisionNode::Leaf(Predictor::Zero));
-    tree.push_back(PropertyDecisionNode::Leaf(Predictor::Zero));
-    tree.push_back(PropertyDecisionNode::Leaf(Predictor::Zero));
-    return tree;
+    case ModularOptions::TreeKind::kWPFixedDC: {
+      std::vector<int32_t> cutoffs = {
+          -500, -392, -255, -191, -127, -95, -63, -47, -31, -23, -15,
+          -11,  -7,   -4,   -3,   -1,   0,   1,   3,   5,   7,   11,
+          15,   23,   31,   47,   63,   95,  127, 191, 255, 392, 500};
+      return MakeFixedTree(kWPProp, cutoffs, Predictor::Weighted, total_pixels);
+    }
+    case ModularOptions::TreeKind::kGradientFixedDC: {
+      std::vector<int32_t> cutoffs = {
+          -500, -392, -255, -191, -127, -95, -63, -47, -31, -23, -15,
+          -11,  -7,   -4,   -3,   -1,   0,   1,   3,   5,   7,   11,
+          15,   23,   31,   47,   63,   95,  127, 191, 255, 392, 500};
+      return MakeFixedTree(kGradientProp, cutoffs, Predictor::Gradient,
+                           total_pixels);
+    }
+    case ModularOptions::TreeKind::kLearn: {
+      JXL_DEBUG_ABORT("internal: kLearn is not predefined tree");
+      return {};
+    }
   }
-  if (tree_kind == ModularOptions::TreeKind::kWPFixedDC) {
-    std::vector<int32_t> cutoffs = {
-        -500, -392, -255, -191, -127, -95, -63, -47, -31, -23, -15,
-        -11,  -7,   -4,   -3,   -1,   0,   1,   3,   5,   7,   11,
-        15,   23,   31,   47,   63,   95,  127, 191, 255, 392, 500};
-    return MakeFixedTree(kWPProp, cutoffs, Predictor::Weighted, total_pixels);
-  }
-  if (tree_kind == ModularOptions::TreeKind::kGradientFixedDC) {
-    std::vector<int32_t> cutoffs = {
-        -500, -392, -255, -191, -127, -95, -63, -47, -31, -23, -15,
-        -11,  -7,   -4,   -3,   -1,   0,   1,   3,   5,   7,   11,
-        15,   23,   31,   47,   63,   95,  127, 191, 255, 392, 500};
-    return MakeFixedTree(kGradientProp, cutoffs, Predictor::Gradient,
-                         total_pixels);
-  }
-  JXL_UNREACHABLE("Unreachable");
+  JXL_DEBUG_ABORT("internal: unexpected TreeKind: %d",
+                  static_cast<int>(tree_kind));
   return {};
 }
 
@@ -529,7 +537,7 @@ Status EncodeModularChannelMAANS(const Image &image, pixel_type chan,
 }
 
 Status ModularEncode(const Image &image, const ModularOptions &options,
-                     BitWriter *writer, AuxOut *aux_out, size_t layer,
+                     BitWriter *writer, AuxOut *aux_out, LayerType layer,
                      size_t group_id, TreeSamples *tree_samples,
                      size_t *total_pixels, const Tree *tree,
                      GroupHeader *header, std::vector<Token> *tokens,
@@ -644,9 +652,9 @@ Status ModularEncode(const Image &image, const ModularOptions &options,
     // Write tree
     BuildAndEncodeHistograms(memory_manager, options.histogram_params,
                              kNumTreeContexts, tree_tokens, &code, &context_map,
-                             writer, kLayerModularTree, aux_out);
-    WriteTokens(tree_tokens[0], code, context_map, 0, writer, kLayerModularTree,
-                aux_out);
+                             writer, LayerType::ModularTree, aux_out);
+    WriteTokens(tree_tokens[0], code, context_map, 0, writer,
+                LayerType::ModularTree, aux_out);
   }
 
   size_t image_width = 0;
@@ -703,11 +711,11 @@ Status ModularEncode(const Image &image, const ModularOptions &options,
 }
 
 Status ModularGenericCompress(Image &image, const ModularOptions &opts,
-                              BitWriter *writer, AuxOut *aux_out, size_t layer,
-                              size_t group_id, TreeSamples *tree_samples,
-                              size_t *total_pixels, const Tree *tree,
-                              GroupHeader *header, std::vector<Token> *tokens,
-                              size_t *width) {
+                              BitWriter *writer, AuxOut *aux_out,
+                              LayerType layer, size_t group_id,
+                              TreeSamples *tree_samples, size_t *total_pixels,
+                              const Tree *tree, GroupHeader *header,
+                              std::vector<Token> *tokens, size_t *width) {
   if (image.w == 0 || image.h == 0) return true;
   ModularOptions options = opts;  // Make a copy to modify it.
 

--- a/lib/jxl/modular/encoding/enc_encoding.h
+++ b/lib/jxl/modular/encoding/enc_encoding.h
@@ -7,6 +7,7 @@
 #define LIB_JXL_MODULAR_ENCODING_ENC_ENCODING_H_
 
 #include <cstddef>
+#include <cstdint>
 #include <vector>
 
 #include "lib/jxl/base/status.h"
@@ -20,6 +21,7 @@
 namespace jxl {
 
 struct AuxOut;
+enum class LayerType : uint8_t;
 struct GroupHeader;
 
 Tree PredefinedTree(ModularOptions::TreeKind tree_kind, size_t total_pixels);
@@ -33,7 +35,8 @@ Tree LearnTree(TreeSamples &&tree_samples, size_t total_pixels,
 
 Status ModularGenericCompress(
     Image &image, const ModularOptions &opts, BitWriter *writer,
-    AuxOut *aux_out = nullptr, size_t layer = 0, size_t group_id = 0,
+    AuxOut *aux_out = nullptr, LayerType layer = static_cast<LayerType>(0),
+    size_t group_id = 0,
     // For gathering data for producing a global tree.
     TreeSamples *tree_samples = nullptr, size_t *total_pixels = nullptr,
     // For encoding with global tree.

--- a/lib/jxl/quant_weights.h
+++ b/lib/jxl/quant_weights.h
@@ -267,7 +267,7 @@ class QuantEncoding final : public QuantEncodingInternal {
   }
 
   // RAW, note that this one is not a constexpr one.
-  static QuantEncoding RAW(const std::vector<int>& qtable, int shift = 0) {
+  static QuantEncoding RAW(std::vector<int>&& qtable, int shift = 0) {
     QuantEncoding encoding(kQuantModeRAW);
     encoding.qraw.qtable = new std::vector<int>();
     *encoding.qraw.qtable = qtable;
@@ -306,59 +306,60 @@ const float kDCQuant[3] = {
 class ModularFrameEncoder;
 class ModularFrameDecoder;
 
+enum class QuantTable : size_t {
+  DCT = 0,
+  IDENTITY,
+  DCT2X2,
+  DCT4X4,
+  DCT16X16,
+  DCT32X32,
+  // DCT16X8
+  DCT8X16,
+  // DCT32X8
+  DCT8X32,
+  // DCT32X16
+  DCT16X32,
+  DCT4X8,
+  // DCT8X4
+  AFV0,
+  // AFV1
+  // AFV2
+  // AFV3
+  DCT64X64,
+  // DCT64X32,
+  DCT32X64,
+  DCT128X128,
+  // DCT128X64,
+  DCT64X128,
+  DCT256X256,
+  // DCT256X128,
+  DCT128X256
+};
+
+static constexpr uint8_t kNumQuantTables =
+    static_cast<uint8_t>(QuantTable::DCT128X256) + 1;
+
+static const std::array<QuantTable, AcStrategy::kNumValidStrategies>
+    kAcStrategyToQuantTableMap = {
+        QuantTable::DCT,        QuantTable::IDENTITY,   QuantTable::DCT2X2,
+        QuantTable::DCT4X4,     QuantTable::DCT16X16,   QuantTable::DCT32X32,
+        QuantTable::DCT8X16,    QuantTable::DCT8X16,    QuantTable::DCT8X32,
+        QuantTable::DCT8X32,    QuantTable::DCT16X32,   QuantTable::DCT16X32,
+        QuantTable::DCT4X8,     QuantTable::DCT4X8,     QuantTable::AFV0,
+        QuantTable::AFV0,       QuantTable::AFV0,       QuantTable::AFV0,
+        QuantTable::DCT64X64,   QuantTable::DCT32X64,   QuantTable::DCT32X64,
+        QuantTable::DCT128X128, QuantTable::DCT64X128,  QuantTable::DCT64X128,
+        QuantTable::DCT256X256, QuantTable::DCT128X256, QuantTable::DCT128X256,
+};
+
 class DequantMatrices {
  public:
-  enum QuantTable : size_t {
-    DCT = 0,
-    IDENTITY,
-    DCT2X2,
-    DCT4X4,
-    DCT16X16,
-    DCT32X32,
-    // DCT16X8
-    DCT8X16,
-    // DCT32X8
-    DCT8X32,
-    // DCT32X16
-    DCT16X32,
-    DCT4X8,
-    // DCT8X4
-    AFV0,
-    // AFV1
-    // AFV2
-    // AFV3
-    DCT64X64,
-    // DCT64X32,
-    DCT32X64,
-    DCT128X128,
-    // DCT128X64,
-    DCT64X128,
-    DCT256X256,
-    // DCT256X128,
-    DCT128X256,
-    kNum
-  };
-
-  static constexpr QuantTable kQuantTable[] = {
-      QuantTable::DCT,        QuantTable::IDENTITY,   QuantTable::DCT2X2,
-      QuantTable::DCT4X4,     QuantTable::DCT16X16,   QuantTable::DCT32X32,
-      QuantTable::DCT8X16,    QuantTable::DCT8X16,    QuantTable::DCT8X32,
-      QuantTable::DCT8X32,    QuantTable::DCT16X32,   QuantTable::DCT16X32,
-      QuantTable::DCT4X8,     QuantTable::DCT4X8,     QuantTable::AFV0,
-      QuantTable::AFV0,       QuantTable::AFV0,       QuantTable::AFV0,
-      QuantTable::DCT64X64,   QuantTable::DCT32X64,   QuantTable::DCT32X64,
-      QuantTable::DCT128X128, QuantTable::DCT64X128,  QuantTable::DCT64X128,
-      QuantTable::DCT256X256, QuantTable::DCT128X256, QuantTable::DCT128X256,
-  };
-  static_assert(AcStrategy::kNumValidStrategies ==
-                    sizeof(kQuantTable) / sizeof *kQuantTable,
-                "Update this array when adding or removing AC strategies.");
-
   DequantMatrices();
 
   static const QuantEncoding* Library();
 
-  typedef std::array<QuantEncodingInternal, kNumPredefinedTables * kNum>
+  typedef std::array<QuantEncodingInternal,
+                     kNumPredefinedTables * kNumQuantTables>
       DequantLibraryInternal;
   // Return the array of library kNumPredefinedTables QuantEncoding entries as
   // a constexpr array. Use Library() to obtain a pointer to the copy in the
@@ -366,16 +367,15 @@ class DequantMatrices {
   static DequantLibraryInternal LibraryInit();
 
   // Returns aligned memory.
-  JXL_INLINE const float* Matrix(size_t quant_kind, size_t c) const {
-    JXL_DASSERT(quant_kind < AcStrategy::kNumValidStrategies);
-    JXL_DASSERT((1 << quant_kind) & computed_mask_);
-    return &table_[table_offsets_[quant_kind * 3 + c]];
+  JXL_INLINE const float* Matrix(AcStrategyType quant_kind, size_t c) const {
+    JXL_DASSERT((1 << static_cast<uint32_t>(quant_kind)) & computed_mask_);
+    return &table_[table_offsets_[static_cast<size_t>(quant_kind) * 3 + c]];
   }
 
-  JXL_INLINE const float* InvMatrix(size_t quant_kind, size_t c) const {
-    JXL_DASSERT(quant_kind < AcStrategy::kNumValidStrategies);
-    JXL_DASSERT((1 << quant_kind) & computed_mask_);
-    return &inv_table_[table_offsets_[quant_kind * 3 + c]];
+  JXL_INLINE const float* InvMatrix(AcStrategyType quant_kind, size_t c) const {
+    size_t quant_table_idx = static_cast<uint32_t>(quant_kind);
+    JXL_DASSERT((1 << quant_table_idx) & computed_mask_);
+    return &inv_table_[table_offsets_[quant_table_idx * 3 + c]];
   }
 
   // DC quants are used in modular mode for XYB multipliers.
@@ -406,12 +406,12 @@ class DequantMatrices {
 
   static constexpr auto required_size_x =
       to_array<int>({1, 1, 1, 1, 2, 4, 1, 1, 2, 1, 1, 8, 4, 16, 8, 32, 16});
-  static_assert(kNum == required_size_x.size(),
+  static_assert(kNumQuantTables == required_size_x.size(),
                 "Update this array when adding or removing quant tables.");
 
   static constexpr auto required_size_y =
       to_array<int>({1, 1, 1, 1, 2, 4, 2, 4, 4, 1, 1, 8, 8, 16, 16, 32, 32});
-  static_assert(kNum == required_size_y.size(),
+  static_assert(kNumQuantTables == required_size_y.size(),
                 "Update this array when adding or removing quant tables.");
 
   // MUST be equal `sum(dot(required_size_x, required_size_y))`.

--- a/lib/jxl/quant_weights_test.cc
+++ b/lib/jxl/quant_weights_test.cc
@@ -68,7 +68,7 @@ TEST(QuantWeightsTest, DC) {
 }
 
 void RoundtripMatrices(const std::vector<QuantEncoding>& encodings) {
-  ASSERT_TRUE(encodings.size() == DequantMatrices::kNum);
+  ASSERT_TRUE(encodings.size() == kNumQuantTables);
   DequantMatrices mat;
   CodecMetadata metadata;
   FrameHeader frame_header(&metadata);
@@ -98,7 +98,7 @@ void RoundtripMatrices(const std::vector<QuantEncoding>& encodings) {
       EXPECT_FALSE(!d.qraw.qtable);
       EXPECT_EQ(e.qraw.qtable->size(), d.qraw.qtable->size());
       for (size_t j = 0; j < e.qraw.qtable->size(); j++) {
-        EXPECT_EQ((*e.qraw.qtable)[j], (*d.qraw.qtable)[j]);
+        EXPECT_EQ(e.qraw.qtable->at(j), d.qraw.qtable->at(j));
       }
       EXPECT_NEAR(e.qraw.qtable_den, d.qraw.qtable_den, 1e-7f);
     } else {
@@ -128,56 +128,49 @@ void RoundtripMatrices(const std::vector<QuantEncoding>& encodings) {
 }
 
 TEST(QuantWeightsTest, AllDefault) {
-  std::vector<QuantEncoding> encodings(DequantMatrices::kNum,
+  std::vector<QuantEncoding> encodings(kNumQuantTables,
                                        QuantEncoding::Library(0));
   RoundtripMatrices(encodings);
 }
 
-void TestSingleQuantMatrix(DequantMatrices::QuantTable kind) {
-  std::vector<QuantEncoding> encodings(DequantMatrices::kNum,
+void TestSingleQuantMatrix(QuantTable kind) {
+  std::vector<QuantEncoding> encodings(kNumQuantTables,
                                        QuantEncoding::Library(0));
-  encodings[kind] = DequantMatrices::Library()[kind];
+  size_t quant_table_idx = static_cast<size_t>(kind);
+  encodings[quant_table_idx] = DequantMatrices::Library()[quant_table_idx];
   RoundtripMatrices(encodings);
 }
 
 // Ensure we can reasonably represent default quant tables.
-TEST(QuantWeightsTest, DCT) { TestSingleQuantMatrix(DequantMatrices::DCT); }
+TEST(QuantWeightsTest, DCT) { TestSingleQuantMatrix(QuantTable::DCT); }
 TEST(QuantWeightsTest, IDENTITY) {
-  TestSingleQuantMatrix(DequantMatrices::IDENTITY);
+  TestSingleQuantMatrix(QuantTable::IDENTITY);
 }
-TEST(QuantWeightsTest, DCT2X2) {
-  TestSingleQuantMatrix(DequantMatrices::DCT2X2);
-}
-TEST(QuantWeightsTest, DCT4X4) {
-  TestSingleQuantMatrix(DequantMatrices::DCT4X4);
-}
+TEST(QuantWeightsTest, DCT2X2) { TestSingleQuantMatrix(QuantTable::DCT2X2); }
+TEST(QuantWeightsTest, DCT4X4) { TestSingleQuantMatrix(QuantTable::DCT4X4); }
 TEST(QuantWeightsTest, DCT16X16) {
-  TestSingleQuantMatrix(DequantMatrices::DCT16X16);
+  TestSingleQuantMatrix(QuantTable::DCT16X16);
 }
 TEST(QuantWeightsTest, DCT32X32) {
-  TestSingleQuantMatrix(DequantMatrices::DCT32X32);
+  TestSingleQuantMatrix(QuantTable::DCT32X32);
 }
-TEST(QuantWeightsTest, DCT8X16) {
-  TestSingleQuantMatrix(DequantMatrices::DCT8X16);
-}
-TEST(QuantWeightsTest, DCT8X32) {
-  TestSingleQuantMatrix(DequantMatrices::DCT8X32);
-}
+TEST(QuantWeightsTest, DCT8X16) { TestSingleQuantMatrix(QuantTable::DCT8X16); }
+TEST(QuantWeightsTest, DCT8X32) { TestSingleQuantMatrix(QuantTable::DCT8X32); }
 TEST(QuantWeightsTest, DCT16X32) {
-  TestSingleQuantMatrix(DequantMatrices::DCT16X32);
+  TestSingleQuantMatrix(QuantTable::DCT16X32);
 }
-TEST(QuantWeightsTest, DCT4X8) {
-  TestSingleQuantMatrix(DequantMatrices::DCT4X8);
-}
-TEST(QuantWeightsTest, AFV0) { TestSingleQuantMatrix(DequantMatrices::AFV0); }
+TEST(QuantWeightsTest, DCT4X8) { TestSingleQuantMatrix(QuantTable::DCT4X8); }
+TEST(QuantWeightsTest, AFV0) { TestSingleQuantMatrix(QuantTable::AFV0); }
 TEST(QuantWeightsTest, RAW) {
-  std::vector<QuantEncoding> encodings(DequantMatrices::kNum,
+  std::vector<QuantEncoding> encodings(kNumQuantTables,
                                        QuantEncoding::Library(0));
   std::vector<int> matrix(3 * 32 * 32);
   Rng rng(0);
   for (int& v : matrix) v = rng.UniformI(1, 256);
-  encodings[DequantMatrices::kQuantTable[AcStrategy::DCT32X32]] =
-      QuantEncoding::RAW(matrix, 2);
+  QuantTable quant_table =
+      kAcStrategyToQuantTableMap[static_cast<size_t>(AcStrategyType::DCT32X32)];
+  encodings[static_cast<size_t>(quant_table)] =
+      QuantEncoding::RAW(std::move(matrix), 2);
   RoundtripMatrices(encodings);
 }
 
@@ -191,7 +184,7 @@ TEST_P(QuantWeightsTargetTest, DCTUniform) {
                          {1.0f / kUniformQuant, 0},
                          {1.0f / kUniformQuant, 0}};
   DctQuantWeightParams dct_params(weights);
-  std::vector<QuantEncoding> encodings(DequantMatrices::kNum,
+  std::vector<QuantEncoding> encodings(kNumQuantTables,
                                        QuantEncoding::DCT(dct_params));
   DequantMatrices dequant_matrices;
   CodecMetadata metadata;
@@ -212,7 +205,7 @@ TEST_P(QuantWeightsTargetTest, DCTUniform) {
     HWY_ALIGN_MAX float pixels[64];
     std::iota(std::begin(pixels), std::end(pixels), 0);
     HWY_ALIGN_MAX float coeffs[64];
-    const AcStrategy::Type dct = AcStrategy::DCT;
+    const AcStrategyType dct = AcStrategyType::DCT;
     TransformFromPixels(dct, pixels, 8, coeffs, scratch_space);
     HWY_ALIGN_MAX double slow_coeffs[64];
     for (size_t i = 0; i < 64; i++) slow_coeffs[i] = pixels[i];
@@ -236,7 +229,7 @@ TEST_P(QuantWeightsTargetTest, DCTUniform) {
     HWY_ALIGN_MAX float pixels[64 * 4];
     std::iota(std::begin(pixels), std::end(pixels), 0);
     HWY_ALIGN_MAX float coeffs[64 * 4];
-    const AcStrategy::Type dct = AcStrategy::DCT16X16;
+    const AcStrategyType dct = AcStrategyType::DCT16X16;
     TransformFromPixels(dct, pixels, 16, coeffs, scratch_space);
     HWY_ALIGN_MAX double slow_coeffs[64 * 4];
     for (size_t i = 0; i < 64 * 4; i++) slow_coeffs[i] = pixels[i];
@@ -258,7 +251,8 @@ TEST_P(QuantWeightsTargetTest, DCTUniform) {
   // Check that all matrices have the same DC quantization, i.e. that they all
   // have the same scaling.
   for (size_t i = 0; i < AcStrategy::kNumValidStrategies; i++) {
-    EXPECT_NEAR(dequant_matrices.Matrix(i, 0)[0], kUniformQuant, 1e-6);
+    AcStrategyType kind = static_cast<AcStrategyType>(i);
+    EXPECT_NEAR(dequant_matrices.Matrix(kind, 0)[0], kUniformQuant, 1e-6);
   }
 }
 

--- a/lib/jxl/quantizer.h
+++ b/lib/jxl/quantizer.h
@@ -27,6 +27,8 @@
 
 namespace jxl {
 
+enum class AcStrategyType : uint32_t;
+
 static constexpr int kGlobalScaleDenom = 1 << 16;
 static constexpr int kGlobalScaleNumerator = 4096;
 
@@ -117,11 +119,13 @@ class Quantizer {
 
   void DumpQuantizationMap(const ImageI& raw_quant_field) const;
 
-  JXL_INLINE const float* DequantMatrix(size_t quant_kind, size_t c) const {
+  JXL_INLINE const float* DequantMatrix(AcStrategyType quant_kind,
+                                        size_t c) const {
     return dequant_->Matrix(quant_kind, c);
   }
 
-  JXL_INLINE const float* InvDequantMatrix(size_t quant_kind, size_t c) const {
+  JXL_INLINE const float* InvDequantMatrix(AcStrategyType quant_kind,
+                                           size_t c) const {
     return dequant_->InvMatrix(quant_kind, c);
   }
 

--- a/lib/jxl/quantizer_test.cc
+++ b/lib/jxl/quantizer_test.cc
@@ -12,6 +12,7 @@
 
 #include "lib/jxl/base/status.h"
 #include "lib/jxl/dec_bit_reader.h"
+#include "lib/jxl/enc_aux_out.h"
 #include "lib/jxl/enc_bit_writer.h"
 #include "lib/jxl/enc_fields.h"
 #include "lib/jxl/fields.h"
@@ -52,7 +53,8 @@ TEST(QuantizerTest, BitStreamRoundtripSameQuant) {
   quantizer1.SetQuant(0.17f, 0.17f, &raw_quant_field);
   BitWriter writer{memory_manager};
   QuantizerParams params = quantizer1.GetParams();
-  EXPECT_TRUE(WriteQuantizerParams(params, &writer, 0, nullptr));
+  EXPECT_TRUE(
+      WriteQuantizerParams(params, &writer, LayerType::Header, nullptr));
   writer.ZeroPadToByte();
   const size_t bits_written = writer.BitsWritten();
   Quantizer quantizer2(&dequant);
@@ -79,7 +81,8 @@ TEST(QuantizerTest, BitStreamRoundtripRandomQuant) {
   quantizer1.SetQuantField(quant_dc, qf, &raw_quant_field);
   BitWriter writer{memory_manager};
   QuantizerParams params = quantizer1.GetParams();
-  EXPECT_TRUE(WriteQuantizerParams(params, &writer, 0, nullptr));
+  EXPECT_TRUE(
+      WriteQuantizerParams(params, &writer, LayerType::Header, nullptr));
   writer.ZeroPadToByte();
   const size_t bits_written = writer.BitsWritten();
   Quantizer quantizer2(&dequant);

--- a/lib/jxl/render_pipeline/low_memory_render_pipeline.cc
+++ b/lib/jxl/render_pipeline/low_memory_render_pipeline.cc
@@ -305,7 +305,8 @@ Status LowMemoryRenderPipeline::Init() {
   }
   for (size_t i = first_image_dim_stage_; i < stages_.size(); i++) {
     if (stages_[i]->SwitchToImageDimensions()) {
-      JXL_UNREACHABLE("Cannot switch to image dimensions multiple times");
+      return JXL_UNREACHABLE(
+          "cannot switch to image dimensions multiple times");
     }
     std::vector<std::pair<size_t, size_t>> input_sizes(shifts.size());
     for (size_t c = 0; c < shifts.size(); c++) {

--- a/lib/jxl/render_pipeline/render_pipeline.cc
+++ b/lib/jxl/render_pipeline/render_pipeline.cc
@@ -18,9 +18,11 @@
 
 namespace jxl {
 
-void RenderPipeline::Builder::AddStage(
+Status RenderPipeline::Builder::AddStage(
     std::unique_ptr<RenderPipelineStage> stage) {
+  if (!stage) return JXL_FAILURE("internal: no stage to add");
   stages_.push_back(std::move(stage));
+  return true;
 }
 
 StatusOr<std::unique_ptr<RenderPipeline>> RenderPipeline::Builder::Finalize(

--- a/lib/jxl/render_pipeline/render_pipeline.h
+++ b/lib/jxl/render_pipeline/render_pipeline.h
@@ -68,7 +68,7 @@ class RenderPipeline {
 
     // Adds a stage to the pipeline. Must be called at least once; the last
     // added stage cannot have kInOut channels.
-    void AddStage(std::unique_ptr<RenderPipelineStage> stage);
+    Status AddStage(std::unique_ptr<RenderPipelineStage> stage);
 
     // Enables using the simple (i.e. non-memory-efficient) implementation of
     // the pipeline.

--- a/lib/jxl/render_pipeline/render_pipeline_test.cc
+++ b/lib/jxl/render_pipeline/render_pipeline_test.cc
@@ -98,7 +98,7 @@ Status DecodeFile(const Span<const uint8_t> file, bool use_slow_pipeline,
     if (!reader.AllReadsWithinBounds()) {
       return JXL_FAILURE("Reader out of bounds read.");
     }
-    io->CheckMetadata();
+    JXL_RETURN_IF_ERROR(io->CheckMetadata());
     // reader is closed here.
   }
   return ret;
@@ -107,9 +107,9 @@ Status DecodeFile(const Span<const uint8_t> file, bool use_slow_pipeline,
 TEST(RenderPipelineTest, Build) {
   JxlMemoryManager* memory_manager = jxl::test::MemoryManager();
   RenderPipeline::Builder builder(memory_manager, /*num_c=*/1);
-  builder.AddStage(jxl::make_unique<UpsampleXSlowStage>());
-  builder.AddStage(jxl::make_unique<UpsampleYSlowStage>());
-  builder.AddStage(jxl::make_unique<Check0FinalStage>());
+  ASSERT_TRUE(builder.AddStage(jxl::make_unique<UpsampleXSlowStage>()));
+  ASSERT_TRUE(builder.AddStage(jxl::make_unique<UpsampleYSlowStage>()));
+  ASSERT_TRUE(builder.AddStage(jxl::make_unique<Check0FinalStage>()));
   builder.UseSimpleImplementation();
   FrameDimensions frame_dimensions;
   frame_dimensions.Set(/*xsize=*/1024, /*ysize=*/1024, /*group_size_shift=*/0,
@@ -121,9 +121,9 @@ TEST(RenderPipelineTest, Build) {
 TEST(RenderPipelineTest, CallAllGroups) {
   JxlMemoryManager* memory_manager = jxl::test::MemoryManager();
   RenderPipeline::Builder builder(memory_manager, /*num_c=*/1);
-  builder.AddStage(jxl::make_unique<UpsampleXSlowStage>());
-  builder.AddStage(jxl::make_unique<UpsampleYSlowStage>());
-  builder.AddStage(jxl::make_unique<Check0FinalStage>());
+  ASSERT_TRUE(builder.AddStage(jxl::make_unique<UpsampleXSlowStage>()));
+  ASSERT_TRUE(builder.AddStage(jxl::make_unique<UpsampleYSlowStage>()));
+  ASSERT_TRUE(builder.AddStage(jxl::make_unique<Check0FinalStage>()));
   builder.UseSimpleImplementation();
   FrameDimensions frame_dimensions;
   frame_dimensions.Set(/*xsize=*/1024, /*ysize=*/1024, /*group_size_shift=*/0,
@@ -145,9 +145,9 @@ TEST(RenderPipelineTest, CallAllGroups) {
 TEST(RenderPipelineTest, BuildFast) {
   JxlMemoryManager* memory_manager = jxl::test::MemoryManager();
   RenderPipeline::Builder builder(memory_manager, /*num_c=*/1);
-  builder.AddStage(jxl::make_unique<UpsampleXSlowStage>());
-  builder.AddStage(jxl::make_unique<UpsampleYSlowStage>());
-  builder.AddStage(jxl::make_unique<Check0FinalStage>());
+  ASSERT_TRUE(builder.AddStage(jxl::make_unique<UpsampleXSlowStage>()));
+  ASSERT_TRUE(builder.AddStage(jxl::make_unique<UpsampleYSlowStage>()));
+  ASSERT_TRUE(builder.AddStage(jxl::make_unique<Check0FinalStage>()));
   FrameDimensions frame_dimensions;
   frame_dimensions.Set(/*xsize=*/1024, /*ysize=*/1024, /*group_size_shift=*/0,
                        /*max_hshift=*/0, /*max_vshift=*/0,
@@ -158,9 +158,9 @@ TEST(RenderPipelineTest, BuildFast) {
 TEST(RenderPipelineTest, CallAllGroupsFast) {
   JxlMemoryManager* memory_manager = jxl::test::MemoryManager();
   RenderPipeline::Builder builder(memory_manager, /*num_c=*/1);
-  builder.AddStage(jxl::make_unique<UpsampleXSlowStage>());
-  builder.AddStage(jxl::make_unique<UpsampleYSlowStage>());
-  builder.AddStage(jxl::make_unique<Check0FinalStage>());
+  ASSERT_TRUE(builder.AddStage(jxl::make_unique<UpsampleXSlowStage>()));
+  ASSERT_TRUE(builder.AddStage(jxl::make_unique<UpsampleYSlowStage>()));
+  ASSERT_TRUE(builder.AddStage(jxl::make_unique<Check0FinalStage>()));
   builder.UseSimpleImplementation();
   FrameDimensions frame_dimensions;
   frame_dimensions.Set(/*xsize=*/1024, /*ysize=*/1024, /*group_size_shift=*/0,

--- a/lib/jxl/render_pipeline/stage_blending.cc
+++ b/lib/jxl/render_pipeline/stage_blending.cc
@@ -105,10 +105,6 @@ class BlendingStage : public RenderPipelineStage {
           pb->mode = PatchBlendMode::kAlphaWeightedAddAbove;
           break;
         }
-        default: {
-          JXL_UNREACHABLE(
-              "Invalid blend mode");  // should have failed to decode
-        }
       }
     };
     make_blending(info_, blending_info_.data());

--- a/lib/jxl/render_pipeline/stage_epf.cc
+++ b/lib/jxl/render_pipeline/stage_epf.cc
@@ -6,6 +6,8 @@
 #include "lib/jxl/render_pipeline/stage_epf.h"
 
 #include "lib/jxl/base/common.h"
+#include "lib/jxl/base/compiler_specific.h"
+#include "lib/jxl/base/status.h"
 #include "lib/jxl/common.h"  // JXL_HIGH_PRECISION
 #include "lib/jxl/epf.h"
 
@@ -508,18 +510,19 @@ HWY_EXPORT(GetEPFStage2);
 
 std::unique_ptr<RenderPipelineStage> GetEPFStage(const LoopFilter& lf,
                                                  const ImageF& sigma,
-                                                 size_t epf_stage) {
+                                                 EpfStage epf_stage) {
   JXL_ASSERT(lf.epf_iters != 0);
   switch (epf_stage) {
-    case 0:
+    case EpfStage::Zero:
       return HWY_DYNAMIC_DISPATCH(GetEPFStage0)(lf, sigma);
-    case 1:
+    case EpfStage::One:
       return HWY_DYNAMIC_DISPATCH(GetEPFStage1)(lf, sigma);
-    case 2:
+    case EpfStage::Two:
       return HWY_DYNAMIC_DISPATCH(GetEPFStage2)(lf, sigma);
-    default:
-      JXL_UNREACHABLE("Invalid EPF stage");
   }
+  JXL_DEBUG_ABORT("internal: unexpected EpfStage: %d",
+                  static_cast<int>(epf_stage));
+  return nullptr;
 }
 
 }  // namespace jxl

--- a/lib/jxl/render_pipeline/stage_epf.h
+++ b/lib/jxl/render_pipeline/stage_epf.h
@@ -5,13 +5,9 @@
 
 #ifndef LIB_JXL_RENDER_PIPELINE_STAGE_EPF_H_
 #define LIB_JXL_RENDER_PIPELINE_STAGE_EPF_H_
-#include <math.h>
-#include <stdint.h>
-#include <stdio.h>
 
-#include <algorithm>
-#include <utility>
-#include <vector>
+#include <cstdint>
+#include <memory>
 
 #include "lib/jxl/image.h"
 #include "lib/jxl/loop_filter.h"
@@ -19,13 +15,15 @@
 
 namespace jxl {
 
+enum class EpfStage : uint8_t { Zero, One, Two };
+
 // Applies the `epf_stage`-th EPF step with the given settings and `sigma`.
 // `sigma` will be accessed with an offset of (kSigmaPadding, kSigmaPadding),
 // and should have (kSigmaBorder, kSigmaBorder) mirrored sigma values available
 // around the main image. See also filters.(h|cc)
 std::unique_ptr<RenderPipelineStage> GetEPFStage(const LoopFilter& lf,
                                                  const ImageF& sigma,
-                                                 size_t epf_stage);
+                                                 EpfStage epf_stage);
 }  // namespace jxl
 
 #endif  // LIB_JXL_RENDER_PIPELINE_STAGE_EPF_H_

--- a/lib/jxl/render_pipeline/stage_from_linear.cc
+++ b/lib/jxl/render_pipeline/stage_from_linear.cc
@@ -5,6 +5,8 @@
 
 #include "lib/jxl/render_pipeline/stage_from_linear.h"
 
+#include "lib/jxl/base/status.h"
+
 #undef HWY_TARGET_INCLUDE
 #define HWY_TARGET_INCLUDE "lib/jxl/render_pipeline/stage_from_linear.cc"
 #include <hwy/foreach_target.h>
@@ -172,7 +174,8 @@ std::unique_ptr<RenderPipelineStage> GetFromLinearStage(
         MakePerChannelOp(OpGamma{output_encoding_info.inverse_gamma}));
   } else {
     // This is a programming error.
-    JXL_UNREACHABLE("Invalid target encoding");
+    JXL_DEBUG_ABORT("Invalid target encoding");
+    return nullptr;
   }
 }
 

--- a/lib/jxl/render_pipeline/stage_upsampling.cc
+++ b/lib/jxl/render_pipeline/stage_upsampling.cc
@@ -87,6 +87,7 @@ class UpsamplingStage : public RenderPipelineStage {
  private:
   template <size_t N>
   JXL_INLINE float Kernel(size_t x, size_t y, ssize_t ix, ssize_t iy) const {
+    static_assert(N == 2 || N == 4 || N == 8, "N must be 2, 4, or 8");
     ix += 2;
     iy += 2;
     if (N == 2) {
@@ -102,7 +103,6 @@ class UpsamplingStage : public RenderPipelineStage {
                     [x % 8 < 4 ? x % 4 : 3 - x % 4][y % 8 < 4 ? iy : 4 - iy]
                     [x % 8 < 4 ? ix : 4 - ix];
     }
-    JXL_UNREACHABLE("Invalid upsample");
   }
 
   template <ssize_t N>

--- a/lib/jxl/render_pipeline/stage_xyb.cc
+++ b/lib/jxl/render_pipeline/stage_xyb.cc
@@ -144,9 +144,8 @@ class FastXYBStage : public RenderPipelineStage {
         GetInputRow(input_rows, 2, 0),
         has_alpha_ ? GetInputRow(input_rows, alpha_c_, 0) : nullptr};
     uint8_t* out_buf = rgb_ + stride_ * ypos + (rgba_ ? 4 : 3) * xpos;
-    FastXYBTosRGB8(xyba, out_buf, rgba_,
-                   xsize + xpos <= width_ ? xsize : width_ - xpos);
-    return true;
+    return FastXYBTosRGB8(xyba, out_buf, rgba_,
+                          xsize + xpos <= width_ ? xsize : width_ - xpos);
   }
 
   RenderPipelineChannelMode GetChannelMode(size_t c) const final {
@@ -173,7 +172,7 @@ class FastXYBStage : public RenderPipelineStage {
 std::unique_ptr<RenderPipelineStage> GetFastXYBTosRGB8Stage(
     uint8_t* rgb, size_t stride, size_t width, size_t height, bool rgba,
     bool has_alpha, size_t alpha_c) {
-  JXL_ASSERT(HasFastXYBTosRGB8());
+  if (!HasFastXYBTosRGB8()) return nullptr;
   return make_unique<FastXYBStage>(rgb, stride, width, height, rgba, has_alpha,
                                    alpha_c);
 }

--- a/lib/jxl/splines_test.cc
+++ b/lib/jxl/splines_test.cc
@@ -170,7 +170,8 @@ TEST(SplinesTest, Serialization) {
   }
 
   BitWriter writer{memory_manager};
-  EncodeSplines(splines, &writer, kLayerSplines, HistogramParams(), nullptr);
+  EncodeSplines(splines, &writer, LayerType::Splines, HistogramParams(),
+                nullptr);
   writer.ZeroPadToByte();
   const size_t bits_written = writer.BitsWritten();
 
@@ -235,7 +236,7 @@ TEST(SplinesTest, TooManySplinesTest) {
   Splines splines(kQuantizationAdjustment, std::move(quantized_splines),
                   std::move(starting_points));
   BitWriter writer{memory_manager};
-  EncodeSplines(splines, &writer, kLayerSplines,
+  EncodeSplines(splines, &writer, LayerType::Splines,
                 HistogramParams(SpeedTier::kFalcon, 1), nullptr);
   writer.ZeroPadToByte();
   // Re-read splines.

--- a/lib/jxl/toc_test.cc
+++ b/lib/jxl/toc_test.cc
@@ -64,7 +64,7 @@ void Roundtrip(size_t num_entries, bool permute, Rng* rng) {
     }
     writer->ZeroPadToByte();
     AuxOut aux_out;
-    allotment.ReclaimAndCharge(writer.get(), 0, &aux_out);
+    allotment.ReclaimAndCharge(writer.get(), LayerType::Header, &aux_out);
   }
 
   BitWriter writer{memory_manager};

--- a/tools/hdr/image_utils.h
+++ b/tools/hdr/image_utils.h
@@ -25,6 +25,7 @@
 #include "lib/extras/enc/pnm.h"
 #include "lib/extras/packed_image.h"
 #include "lib/extras/packed_image_convert.h"
+#include "lib/jxl/base/compiler_specific.h"
 #include "lib/jxl/base/status.h"
 #include "lib/jxl/codec_in_out.h"
 #include "lib/jxl/image_bundle.h"
@@ -32,7 +33,7 @@
 namespace jpegxl {
 namespace tools {
 
-static inline jxl::Status TransformCodecInOutTo(
+static JXL_MAYBE_UNUSED jxl::Status TransformCodecInOutTo(
     jxl::CodecInOut& io, const jxl::ColorEncoding& c_desired,
     jxl::ThreadPool* pool) {
   const JxlCmsInterface& cms = *JxlGetDefaultCms();
@@ -54,7 +55,7 @@ static inline jxl::Status Encode(const jxl::CodecInOut& io,
   bytes->clear();
   JXL_CHECK(!io.Main().c_current().ICC().empty());
   JXL_CHECK(!c_desired.ICC().empty());
-  io.CheckMetadata();
+  JXL_RETURN_IF_ERROR(io.CheckMetadata());
   if (io.Main().IsJPEG()) {
     JXL_WARNING("Writing JPEG data as pixels");
   }

--- a/tools/icc_codec_fuzzer.cc
+++ b/tools/icc_codec_fuzzer.cc
@@ -66,7 +66,7 @@ int DoTestOneInput(const uint8_t* data, size_t size) {
     BitWriter writer{memory_manager};
     // Writing should support any random bytestream so must succeed, make
     // fuzzer fail if not.
-    JXL_ASSERT(jxl::WriteICC(icc, &writer, 0, nullptr));
+    JXL_ASSERT(jxl::WriteICC(icc, &writer, jxl::LayerType::Header, nullptr));
   }
 #else  // JXL_ICC_FUZZER_SLOW_TEST
   if (read) {

--- a/tools/jxl_from_tree.cc
+++ b/tools/jxl_from_tree.cc
@@ -15,6 +15,7 @@
 #include <string>
 #include <unordered_map>
 
+#include "lib/jxl/base/status.h"
 #include "lib/jxl/codec_in_out.h"
 #include "lib/jxl/enc_cache.h"
 #include "lib/jxl/enc_fields.h"
@@ -493,7 +494,7 @@ int JxlFromTree(const char* in, const char* out, const char* tree_out) {
   cparams.custom_splines = SplinesFromSplineData(spline_data);
   PaddedBytes compressed{memory_manager};
 
-  io.CheckMetadata();
+  JXL_RETURN_IF_ERROR(io.CheckMetadata());
   BitWriter writer{memory_manager};
 
   std::unique_ptr<CodecMetadata> metadata = jxl::make_unique<CodecMetadata>();


### PR DESCRIPTION
Turn "unreachable" to Status; reduce number places where it is used; remove "count" member in enum-classes.

Drive-by: straighten includes, use more forwarding.
