### PR TITLE
Update search path for highway version

### DIFF
--- a/cmake/FindHWY.cmake
+++ b/cmake/FindHWY.cmake
@@ -20,9 +20,19 @@ find_library(HWY_LIBRARY
 )
 
 if (HWY_INCLUDE_DIR AND NOT HWY_VERSION)
-  if (EXISTS "${HWY_INCLUDE_DIR}/hwy/highway.h")
-    file(READ "${HWY_INCLUDE_DIR}/hwy/highway.h" HWY_VERSION_CONTENT)
+  # Version 1.2.0 moved versioning to base.h
+  if (EXISTS "${HWY_INCLUDE_DIR}/hwy/base.h")
+    file(READ "${HWY_INCLUDE_DIR}/hwy/base.h" HWY_VERSION_CONTENT)
+    string(FIND "${HWY_VERSION_CONTENT}" "#define HWY_MAJOR" _FOUND_VERSION)
+    if (_FOUND_VERSION EQUAL -1)
+      unset(HWY_VERSION_CONTENT)
+      if (EXISTS "${HWY_INCLUDE_DIR}/hwy/highway.h")
+        file(READ "${HWY_INCLUDE_DIR}/hwy/highway.h" HWY_VERSION_CONTENT)
+      endif ()
+    endif ()
+  endif ()
 
+  if (HWY_VERSION_CONTENT)
     string(REGEX MATCH "#define HWY_MAJOR +([0-9]+)" _sink "${HWY_VERSION_CONTENT}")
     set(HWY_VERSION_MAJOR "${CMAKE_MATCH_1}")
 


### PR DESCRIPTION
In version 1.2.0 of highway the defines used to determine the version moved from `highway.h` to `base.h`. See if the version is in `base.h` and if not look in `highway.h`.

<!-- Thank you for considering a contribution to `libjxl`! -->

### Description

Modified the `FindHWY.cmake` module to search for version numbers in `base.h` then `highway.h`. The change in highway occurred at https://github.com/google/highway/commit/1bf05d6884e538a01a7d4b4a106824c7b46c1dcc

### Pull Request Checklist

- [X] **CLA Signed**: Have you signed the [Contributor License Agreement](https://code.google.com/legal/individual-cla-v1.0.html) (individual or corporate, as appropriate)? Only contributions from signed contributors can be accepted.
- [X] **Authors**: Have you considered adding your name to the [AUTHORS](AUTHORS) file?
- [X] **Code Style**: Have you ensured your code adheres to the project's coding style guidelines? You can use `./ci.sh lint` for automatic code formatting.


Please review the full [contributing guidelines](https://github.com/libjxl/libjxl/blob/main/CONTRIBUTING.md) for more details.
