### PR TITLE
Allow to ask for memory with 0-side padding.

### DIFF
--- a/lib/jxl/image.cc
+++ b/lib/jxl/image.cc
@@ -76,7 +76,8 @@ PlaneBase::PlaneBase(const size_t xsize, const size_t ysize,
   JXL_ASSERT(sizeof_t == 1 || sizeof_t == 2 || sizeof_t == 4 || sizeof_t == 8);
 }
 
-Status PlaneBase::Allocate(JxlMemoryManager* memory_manager) {
+Status PlaneBase::Allocate(JxlMemoryManager* memory_manager,
+                           size_t pre_padding) {
   JXL_CHECK(bytes_.address<void>() == nullptr);
 
   // Dimensions can be zero, e.g. for lazily-allocated images. Only allocate
@@ -86,7 +87,8 @@ Status PlaneBase::Allocate(JxlMemoryManager* memory_manager) {
   }
 
   JXL_ASSIGN_OR_RETURN(
-      bytes_, AlignedMemory::Create(memory_manager, bytes_per_row_ * ysize_));
+      bytes_, AlignedMemory::Create(memory_manager, bytes_per_row_ * ysize_,
+                                    pre_padding * sizeof_t_));
 
   InitializePadding(*this, sizeof_t_);
 

--- a/lib/jxl/image.h
+++ b/lib/jxl/image.h
@@ -93,7 +93,7 @@ struct PlaneBase {
 
  protected:
   PlaneBase(size_t xsize, size_t ysize, size_t sizeof_t);
-  Status Allocate(JxlMemoryManager* memory_manager);
+  Status Allocate(JxlMemoryManager* memory_manager, size_t pre_padding);
 
   // Returns pointer to the start of a row.
   JXL_INLINE void* VoidRow(const size_t y) const {
@@ -151,9 +151,10 @@ class Plane : public detail::PlaneBase {
   Plane() = default;
 
   static StatusOr<Plane> Create(JxlMemoryManager* memory_manager,
-                                const size_t xsize, const size_t ysize) {
+                                const size_t xsize, const size_t ysize,
+                                const size_t pre_padding = 0) {
     Plane plane(xsize, ysize, sizeof(T));
-    JXL_RETURN_IF_ERROR(plane.Allocate(memory_manager));
+    JXL_RETURN_IF_ERROR(plane.Allocate(memory_manager, pre_padding));
     return plane;
   }
 

--- a/lib/jxl/memory_manager_internal.cc
+++ b/lib/jxl/memory_manager_internal.cc
@@ -90,9 +90,9 @@ size_t BytesPerRow(const size_t xsize, const size_t sizeof_t) {
 }
 
 StatusOr<AlignedMemory> AlignedMemory::Create(JxlMemoryManager* memory_manager,
-                                              size_t size) {
-  size_t allocation_size = size + memory_manager_internal::kAlias;
-  if (size > allocation_size) {
+                                              size_t size, size_t pre_padding) {
+  size_t allocation_size = size + pre_padding + memory_manager_internal::kAlias;
+  if (size > allocation_size || size + pre_padding > allocation_size) {
     return JXL_FAILURE("Requested allocation is too large");
   }
   JXL_CHECK(memory_manager);
@@ -101,10 +101,11 @@ StatusOr<AlignedMemory> AlignedMemory::Create(JxlMemoryManager* memory_manager,
   if (allocated == nullptr) {
     return JXL_FAILURE("Allocation failed");
   }
-  return AlignedMemory{memory_manager, allocated};
+  return AlignedMemory(memory_manager, allocated, pre_padding);
 }
 
-AlignedMemory::AlignedMemory(JxlMemoryManager* memory_manager, void* allocation)
+AlignedMemory::AlignedMemory(JxlMemoryManager* memory_manager, void* allocation,
+                             size_t pre_padding)
     : allocation_(allocation), memory_manager_(memory_manager) {
   // Congruence to `offset` (mod kAlias) reduces cache conflicts and load/store
   // stalls, especially with large allocations that would otherwise have similar
@@ -116,9 +117,10 @@ AlignedMemory::AlignedMemory(JxlMemoryManager* memory_manager, void* allocation)
   size_t offset = memory_manager_internal::kAlignment * group;
 
   // Actual allocation.
-  uintptr_t address = reinterpret_cast<uintptr_t>(allocation);
+  uintptr_t address = reinterpret_cast<uintptr_t>(allocation) + pre_padding;
 
-  // Aligned address, but might land before allocation (50%/50%).
+  // Aligned address, but might land before allocation (50%/50%) or not have
+  // enough pre-padding.
   uintptr_t aligned_address =
       (address & ~(memory_manager_internal::kAlias - 1)) + offset;
   if (aligned_address < address)

--- a/lib/jxl/memory_manager_internal.h
+++ b/lib/jxl/memory_manager_internal.h
@@ -104,7 +104,7 @@ class AlignedMemory {
   ~AlignedMemory();
 
   static StatusOr<AlignedMemory> Create(JxlMemoryManager* memory_manager,
-                                        size_t size);
+                                        size_t size, size_t pre_padding = 0);
 
   template <typename T>
   T* address() const {
@@ -117,7 +117,8 @@ class AlignedMemory {
   //               might be useful for resizeable containers (e.g. PaddedBytes)
 
  private:
-  AlignedMemory(JxlMemoryManager* memory_manager, void* allocation);
+  AlignedMemory(JxlMemoryManager* memory_manager, void* allocation,
+                size_t pre_padding);
 
   void* allocation_;
   JxlMemoryManager* memory_manager_;

--- a/lib/jxl/render_pipeline/low_memory_render_pipeline.cc
+++ b/lib/jxl/render_pipeline/low_memory_render_pipeline.cc
@@ -383,7 +383,8 @@ Status LowMemoryRenderPipeline::PrepareForThreadsInternal(size_t num,
           group_data_[t][c],
           ImageF::Create(memory_manager_,
                          GroupInputXSize(c) + group_data_x_border_ * 2,
-                         GroupInputYSize(c) + group_data_y_border_ * 2));
+                         GroupInputYSize(c) + group_data_y_border_ * 2,
+                         kRenderPipelineXOffset));
     }
   }
   // TODO(veluca): avoid reallocating buffers if not needed.


### PR DESCRIPTION
In the render pipeline, we promise 16 floats before the pointer passed to each stage to be readable.

Because of implementation details of the pre-memory-manager image allocation, that was always the case before. Once we started using the memory manager, this is no longer the case. This PR introduces the possibility to explicitly ask for such padding and uses it in the render pipeline.