### PR TITLE
Make -Werror optional

### DIFF
--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -406,7 +406,7 @@ endif()  # SANITIZER != "none"
 set_target_properties(libjxl_test PROPERTIES PREFIX "tests/")
 target_link_libraries(libjxl_test jxl)
 if (NOT MSVC)
-target_compile_options(libjxl_test PRIVATE -Wall -Wextra -Werror)
+target_compile_options(libjxl_test PRIVATE -Wall -Wextra)
 if(NOT WIN32)
   target_compile_options(libjxl_test PRIVATE -pedantic)
 endif()  # NOT WIN32


### PR DESCRIPTION
Fixes https://github.com/libjxl/libjxl/issues/2670

I think it is not necessary to explicitly add `-Werror` to the `libjxl_test` target, because Werror is enabled/disabled globally via:
```
  if (JPEGXL_WARNINGS_AS_ERRORS)
    add_compile_options(-Werror)
  endif ()
```