### PR TITLE
Made it possible to force usage of system JPEG libraries.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -86,7 +86,8 @@ else()
 endif()
 
 
-if(EXISTS "${PROJECT_SOURCE_DIR}/third_party/libjpeg-turbo/jconfig.h.in")
+find_package(JPEG)
+if(JPEG_FOUND OR EXISTS "${PROJECT_SOURCE_DIR}/third_party/libjpeg-turbo/jconfig.h.in")
   set(ENABLE_JPEGLI_DEFAULT YES)
 else()
   set(ENABLE_JPEGLI_DEFAULT NO)

--- a/debian/rules
+++ b/debian/rules
@@ -8,14 +8,11 @@ include /usr/share/dpkg/pkg-info.mk
 override_dh_auto_configure:
 	# TODO(deymo): Remove the DCMAKE_BUILD_TYPE once builds without NDEBUG
 	# are as useful as Release builds.
-        # TODO(szabadka) Re-enable jpegli after tests are fixed on Ubuntu 20.04,
-        # and debian:buster
 	dh_auto_configure -- \
 	  -DJPEGXL_VERSION=$(DEB_VERSION) \
 	  -DCMAKE_BUILD_TYPE=RelWithDebInfo \
 	  -DJPEGXL_FORCE_SYSTEM_GTEST=ON \
 	  -DJPEGXL_FORCE_SYSTEM_BROTLI=ON \
 	  -DJPEGXL_FORCE_SYSTEM_HWY=ON \
-	  -DJPEGXL_ENABLE_JPEGLI=OFF \
-	  -DJPEGXL_ENABLE_JPEGLI_LIBJPEG=OFF \
+	  -DJPEGXL_FORCE_SYSTEM_JPEG_TURBO=ON \
 	  -DJPEGXL_ENABLE_PLUGINS=ON

--- a/lib/jpegli.cmake
+++ b/lib/jpegli.cmake
@@ -23,12 +23,29 @@ elseif(JPEGLI_LIBJPEG_LIBRARY_SOVERSION STREQUAL "8")
   set(JPEG_LIB_VERSION 80)
 endif()
 
-configure_file(
-  ../third_party/libjpeg-turbo/jconfig.h.in include/jpegli/jconfig.h)
-configure_file(
-  ../third_party/libjpeg-turbo/jpeglib.h include/jpegli/jpeglib.h COPYONLY)
-configure_file(
-  ../third_party/libjpeg-turbo/jmorecfg.h include/jpegli/jmorecfg.h COPYONLY)
+# Force system dependencies.
+set(JPEGXL_FORCE_SYSTEM_JPEG_TURBO false CACHE BOOL
+	"Force using system installed jpegturbo instead of third_party/libjpeg-turbo source.")
+
+# libjpeg-turbo
+if (NOT EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/libjpeg-turbo/jpeglib.h" OR
+	JPEGXL_FORCE_SYSTEM_JPEG_TURBO)
+  if (NOT JPEG_FOUND)
+	message(FATAL_ERROR
+	     "JPEG not found, install libjpeg62-turbo and libjpeg62-turbo-dev or"
+		 " download libjpeg-turbo source to third_party/libjpeg-turbo from"
+		 " https://github.com/libjpeg-turbo/libjpeg-turbo. You can use"
+		 " ${PROJECT_SOURCE_DIR}/deps.sh to download this dependency.")
+  endif ()
+else ()
+  configure_file(
+    ../third_party/libjpeg-turbo/jconfig.h.in include/jpegli/jconfig.h)
+  configure_file(
+    ../third_party/libjpeg-turbo/jpeglib.h include/jpegli/jpeglib.h COPYONLY)
+  configure_file(
+    ../third_party/libjpeg-turbo/jmorecfg.h include/jpegli/jmorecfg.h COPYONLY)
+endif ()
+
 
 add_library(jpegli-static STATIC EXCLUDE_FROM_ALL "${JPEGXL_INTERNAL_JPEGLI_SOURCES}")
 target_compile_options(jpegli-static PRIVATE "${JPEGXL_INTERNAL_FLAGS}")
@@ -49,58 +66,57 @@ target_link_libraries(jpegli-static PUBLIC ${JPEGLI_INTERNAL_LIBS})
 # Tests for jpegli-static
 #
 
-find_package(JPEG)
 if(JPEG_FOUND AND BUILD_TESTING)
-# TODO(eustas): merge into jxl_tests.cmake?
-
-add_library(jpegli_libjpeg_util-obj OBJECT
-  ${JPEGXL_INTERNAL_JPEGLI_LIBJPEG_HELPER_FILES}
-)
-target_include_directories(jpegli_libjpeg_util-obj PRIVATE
-  "${PROJECT_SOURCE_DIR}"
-  "${JPEG_INCLUDE_DIRS}"
-)
-target_compile_options(jpegli_libjpeg_util-obj PRIVATE
-  "${JPEGXL_INTERNAL_FLAGS}" "${JPEGXL_COVERAGE_FLAGS}")
-
-# Individual test binaries:
-file(MAKE_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/tests)
-foreach (TESTFILE IN LISTS JPEGXL_INTERNAL_JPEGLI_TESTS)
-  # The TESTNAME is the name without the extension or directory.
-  get_filename_component(TESTNAME ${TESTFILE} NAME_WE)
-  add_executable(${TESTNAME} ${TESTFILE}
-    $<TARGET_OBJECTS:jpegli_libjpeg_util-obj>
-    ${JPEGXL_INTERNAL_JPEGLI_TESTLIB_FILES}
+  # TODO(eustas): merge into jxl_tests.cmake?
+  
+  add_library(jpegli_libjpeg_util-obj OBJECT
+    ${JPEGXL_INTERNAL_JPEGLI_LIBJPEG_HELPER_FILES}
   )
-  target_compile_options(${TESTNAME} PRIVATE
-    ${JPEGXL_INTERNAL_FLAGS}
-    # Add coverage flags to the test binary so code in the private headers of
-    # the library is also instrumented when running tests that execute it.
-    ${JPEGXL_COVERAGE_FLAGS}
-  )
-  target_compile_definitions(${TESTNAME} PRIVATE
-    -DTEST_DATA_PATH="${JPEGXL_TEST_DATA_PATH}")
-  target_include_directories(${TESTNAME} PRIVATE
+  target_include_directories(jpegli_libjpeg_util-obj PRIVATE
     "${PROJECT_SOURCE_DIR}"
-    "${CMAKE_CURRENT_SOURCE_DIR}/include"
-    "${CMAKE_CURRENT_BINARY_DIR}/include"
+    "${JPEG_INCLUDE_DIRS}"
   )
-  target_link_libraries(${TESTNAME}
-    hwy
-    jpegli-static
-    GTest::GTest
-    GTest::Main
-    ${JPEG_LIBRARIES}
-  )
-  set_target_properties(${TESTNAME} PROPERTIES LINK_FLAGS "${JPEGXL_COVERAGE_LINK_FLAGS}")
-  # Output test targets in the test directory.
-  set_target_properties(${TESTNAME} PROPERTIES PREFIX "tests/")
-  if (WIN32 AND CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
-    set_target_properties(${TESTNAME} PROPERTIES COMPILE_FLAGS "-Wno-error")
-  endif ()
-  # 240 seconds because some build types (e.g. coverage) can be quite slow.
-  gtest_discover_tests(${TESTNAME} DISCOVERY_TIMEOUT 240)
-endforeach ()
+  target_compile_options(jpegli_libjpeg_util-obj PRIVATE
+    "${JPEGXL_INTERNAL_FLAGS}" "${JPEGXL_COVERAGE_FLAGS}")
+  
+  # Individual test binaries:
+  file(MAKE_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/tests)
+  foreach (TESTFILE IN LISTS JPEGXL_INTERNAL_JPEGLI_TESTS)
+    # The TESTNAME is the name without the extension or directory.
+    get_filename_component(TESTNAME ${TESTFILE} NAME_WE)
+    add_executable(${TESTNAME} ${TESTFILE}
+      $<TARGET_OBJECTS:jpegli_libjpeg_util-obj>
+      ${JPEGXL_INTERNAL_JPEGLI_TESTLIB_FILES}
+    )
+    target_compile_options(${TESTNAME} PRIVATE
+      ${JPEGXL_INTERNAL_FLAGS}
+      # Add coverage flags to the test binary so code in the private headers of
+      # the library is also instrumented when running tests that execute it.
+      ${JPEGXL_COVERAGE_FLAGS}
+    )
+    target_compile_definitions(${TESTNAME} PRIVATE
+      -DTEST_DATA_PATH="${JPEGXL_TEST_DATA_PATH}")
+    target_include_directories(${TESTNAME} PRIVATE
+      "${PROJECT_SOURCE_DIR}"
+      "${CMAKE_CURRENT_SOURCE_DIR}/include"
+      "${CMAKE_CURRENT_BINARY_DIR}/include"
+    )
+    target_link_libraries(${TESTNAME}
+      hwy
+      jpegli-static
+      GTest::GTest
+      GTest::Main
+      ${JPEG_LIBRARIES}
+    )
+    set_target_properties(${TESTNAME} PROPERTIES LINK_FLAGS "${JPEGXL_COVERAGE_LINK_FLAGS}")
+    # Output test targets in the test directory.
+    set_target_properties(${TESTNAME} PROPERTIES PREFIX "tests/")
+    if (WIN32 AND CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
+      set_target_properties(${TESTNAME} PROPERTIES COMPILE_FLAGS "-Wno-error")
+    endif ()
+    # 240 seconds because some build types (e.g. coverage) can be quite slow.
+    gtest_discover_tests(${TESTNAME} DISCOVERY_TIMEOUT 240)
+  endforeach ()
 endif()
 
 #
@@ -108,51 +124,51 @@ endif()
 #
 
 if (JPEGXL_ENABLE_JPEGLI_LIBJPEG AND NOT APPLE AND NOT WIN32 AND NOT EMSCRIPTEN)
-add_library(jpegli-libjpeg-obj OBJECT "${JPEGXL_INTERNAL_JPEGLI_WRAPPER_SOURCES}")
-target_compile_options(jpegli-libjpeg-obj PRIVATE ${JPEGXL_INTERNAL_FLAGS})
-target_compile_options(jpegli-libjpeg-obj PUBLIC ${JPEGXL_COVERAGE_FLAGS})
-set_property(TARGET jpegli-libjpeg-obj PROPERTY POSITION_INDEPENDENT_CODE ON)
-target_include_directories(jpegli-libjpeg-obj PRIVATE
-  "$<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}>"
-  "$<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/include/jpegli>"
-)
-target_compile_definitions(jpegli-libjpeg-obj PUBLIC
-  ${JPEGLI_LIBJPEG_OBJ_COMPILE_DEFINITIONS}
-)
-set(JPEGLI_LIBJPEG_INTERNAL_OBJECTS $<TARGET_OBJECTS:jpegli-libjpeg-obj>)
-
-file(MAKE_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/jpegli)
-add_library(jpeg SHARED ${JPEGLI_LIBJPEG_INTERNAL_OBJECTS})
-target_link_libraries(jpeg PUBLIC ${JPEGXL_COVERAGE_FLAGS})
-target_link_libraries(jpeg PRIVATE jpegli-static)
-set_target_properties(jpeg PROPERTIES
-  VERSION ${JPEGLI_LIBJPEG_LIBRARY_VERSION}
-  SOVERSION ${JPEGLI_LIBJPEG_LIBRARY_SOVERSION}
-  LIBRARY_OUTPUT_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/jpegli"
-  RUNTIME_OUTPUT_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/jpegli")
-
-# Add a jpeg.version file as a version script to tag symbols with the
-# appropriate version number.
-set_target_properties(jpeg PROPERTIES
-  LINK_DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/jpegli/jpeg.version.${JPEGLI_LIBJPEG_LIBRARY_SOVERSION})
-set_property(TARGET jpeg APPEND_STRING PROPERTY
-  LINK_FLAGS " -Wl,--version-script=${CMAKE_CURRENT_SOURCE_DIR}/jpegli/jpeg.version.${JPEGLI_LIBJPEG_LIBRARY_SOVERSION}")
-
-if (JPEGXL_INSTALL_JPEGLI_LIBJPEG)
-  install(TARGETS jpeg
-    RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
-    LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
-    ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR})
-  install(
-    DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/include/jpegli/"
-    DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}")
-endif()
-
-# This hides the default visibility symbols from static libraries bundled into
-# the shared library. In particular this prevents exposing symbols from hwy
-# in the shared library.
-if(LINKER_SUPPORT_EXCLUDE_LIBS)
+  add_library(jpegli-libjpeg-obj OBJECT "${JPEGXL_INTERNAL_JPEGLI_WRAPPER_SOURCES}")
+  target_compile_options(jpegli-libjpeg-obj PRIVATE ${JPEGXL_INTERNAL_FLAGS})
+  target_compile_options(jpegli-libjpeg-obj PUBLIC ${JPEGXL_COVERAGE_FLAGS})
+  set_property(TARGET jpegli-libjpeg-obj PROPERTY POSITION_INDEPENDENT_CODE ON)
+  target_include_directories(jpegli-libjpeg-obj PRIVATE
+    "$<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}>"
+    "$<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/include/jpegli>"
+  )
+  target_compile_definitions(jpegli-libjpeg-obj PUBLIC
+    ${JPEGLI_LIBJPEG_OBJ_COMPILE_DEFINITIONS}
+  )
+  set(JPEGLI_LIBJPEG_INTERNAL_OBJECTS $<TARGET_OBJECTS:jpegli-libjpeg-obj>)
+  
+  file(MAKE_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/jpegli)
+  add_library(jpeg SHARED ${JPEGLI_LIBJPEG_INTERNAL_OBJECTS})
+  target_link_libraries(jpeg PUBLIC ${JPEGXL_COVERAGE_FLAGS})
+  target_link_libraries(jpeg PRIVATE jpegli-static)
+  set_target_properties(jpeg PROPERTIES
+    VERSION ${JPEGLI_LIBJPEG_LIBRARY_VERSION}
+    SOVERSION ${JPEGLI_LIBJPEG_LIBRARY_SOVERSION}
+    LIBRARY_OUTPUT_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/jpegli"
+    RUNTIME_OUTPUT_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/jpegli")
+  
+  # Add a jpeg.version file as a version script to tag symbols with the
+  # appropriate version number.
+  set_target_properties(jpeg PROPERTIES
+    LINK_DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/jpegli/jpeg.version.${JPEGLI_LIBJPEG_LIBRARY_SOVERSION})
   set_property(TARGET jpeg APPEND_STRING PROPERTY
-    LINK_FLAGS " ${LINKER_EXCLUDE_LIBS_FLAG}")
-endif()
+    LINK_FLAGS " -Wl,--version-script=${CMAKE_CURRENT_SOURCE_DIR}/jpegli/jpeg.version.${JPEGLI_LIBJPEG_LIBRARY_SOVERSION}")
+  
+  if (JPEGXL_INSTALL_JPEGLI_LIBJPEG)
+    install(TARGETS jpeg
+      RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+      LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+      ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR})
+    install(
+      DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/include/jpegli/"
+      DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}")
+  endif()
+  
+  # This hides the default visibility symbols from static libraries bundled into
+  # the shared library. In particular this prevents exposing symbols from hwy
+  # in the shared library.
+  if(LINKER_SUPPORT_EXCLUDE_LIBS)
+    set_property(TARGET jpeg APPEND_STRING PROPERTY
+      LINK_FLAGS " ${LINKER_EXCLUDE_LIBS_FLAG}")
+  endif()
 endif()


### PR DESCRIPTION
Also made the Debian build rule use it.

<!-- Thank you for considering a contribution to `libjxl`! -->

### Description

<!-- Please provide a brief description of the changes in this PR and any additional context (e.g., why these changes were made, related issues, etc.). -->

### Pull Request Checklist

- [x] **CLA Signed**: Have you signed the [Contributor License Agreement](https://code.google.com/legal/individual-cla-v1.0.html) (individual or corporate, as appropriate)? Only contributions from signed contributors can be accepted.
- [x] **Authors**: Have you considered adding your name to the [AUTHORS](AUTHORS) file?
- [x] **Code Style**: Have you ensured your code adheres to the project's coding style guidelines? You can use `./ci.sh lint` for automatic code formatting.


Please review the full [contributing guidelines](https://github.com/libjxl/libjxl/blob/main/CONTRIBUTING.md) for more details.
