### PR TITLE
Gimp plugin: fix loading files with named frames

### DIFF
--- a/plugins/gimp/file-jxl-load.cc
+++ b/plugins/gimp/file-jxl-load.cc
@@ -429,9 +429,9 @@ bool LoadJpegXlImage(const gchar *const filename, gint32 *const image_id) {
       }
       if (frame_header.name_length > 0) {
         frame_name.resize(frame_header.name_length + 1);
-        if (JXL_DEC_SUCCESS !=
-            JxlDecoderGetFrameName(dec.get(), frame_name.data(),
-                                   frame_name.size())) {
+        if (JXL_DEC_SUCCESS != JxlDecoderGetFrameName(dec.get(),
+                                                      frame_name.data(),
+                                                      frame_name.size())) {
           g_printerr(LOAD_PROC "Error: JxlDecoderGetFrameName failed");
           return false;
         }

--- a/plugins/gimp/file-jxl-load.cc
+++ b/plugins/gimp/file-jxl-load.cc
@@ -355,17 +355,9 @@ bool LoadJpegXlImage(const gchar *const filename, gint32 *const image_id) {
       if (layer_idx == 0 && !info.have_animation) {
         layer_name = g_strdup_printf("Background");
       } else {
-        const GString *blend_null_flag = g_string_new("");
-        const GString *blend_replace_flag = g_string_new(" (replace)");
-        const GString *blend_combine_flag = g_string_new(" (combine)");
-        const GString *blend;
-        if (blend_mode == JXL_BLEND_REPLACE) {
-          blend = blend_replace_flag;
-        } else if (blend_mode == JXL_BLEND_BLEND) {
-          blend = blend_combine_flag;
-        } else {
-          blend = blend_null_flag;
-        }
+        const char *blend = (blend_mode == JXL_BLEND_REPLACE) ? " (replace)"
+                            : (blend_mode == JXL_BLEND_BLEND) ? " (combine)"
+                                                              : "";
         char *temp_frame_name = nullptr;
         bool must_free_frame_name = false;
         if (frame_name.size() == 0) {
@@ -376,7 +368,7 @@ bool LoadJpegXlImage(const gchar *const filename, gint32 *const image_id) {
         }
         double fduration = frame_duration * 1000.f * tps_denom / tps_numerator;
         layer_name = g_strdup_printf("%s (%.15gms)%s", temp_frame_name,
-                                     fduration, blend->str);
+                                     fduration, blend);
         if (must_free_frame_name) free(temp_frame_name);
       }
       layer = gimp_layer_new(*image_id, layer_name, xsize, ysize, layer_type,


### PR DESCRIPTION
### Description
The Gimp plugin fails to load any image with a named frame...

```
file-jxl-loadError: JxlDecoderGetFrameName failed
```

...due to the name buffer being 1 byte too short.  This fixes it, and also makes sure the buffer is freed on return.

Drive-by: also avoid leaking the blend string(s), by not allocating them in the first place.

#### After the fix:
```
$ jxlinfo two_frames_with_names.jxl
JPEG XL animation, 32x32, (possibly) lossless, 8-bit RGB+Alpha
Color space: RGB, D65, sRGB primaries, sRGB transfer function, rendering intent: Relative
frame: full image size, duration: 1000.0 ms, name: "the first frame"
frame: 32x32 at position (10,20), duration: 1000.0 ms, name: "the second frame"
Animation length: 2.000 seconds (looping)
```

![image](https://github.com/user-attachments/assets/3d124c98-cfc7-48b6-b1c9-8cada7c3980c)


(Is the plugin here still going to be maintained now that Gimp has its own separate one?)


### Pull Request Checklist

- [x] **CLA Signed**: Have you signed the [Contributor License Agreement](https://code.google.com/legal/individual-cla-v1.0.html) (individual or corporate, as appropriate)? Only contributions from signed contributors can be accepted.
- [x] **Authors**: Have you considered adding your name to the [AUTHORS](AUTHORS) file?
- [x] **Code Style**: Have you ensured your code adheres to the project's coding style guidelines? You can use `./ci.sh lint` for automatic code formatting.


Please review the full [contributing guidelines](https://github.com/libjxl/libjxl/blob/main/CONTRIBUTING.md) for more details.
