### PR TITLE
fix e1 condition again

### DIFF
--- a/lib/jxl/encode.cc
+++ b/lib/jxl/encode.cc
@@ -2227,8 +2227,7 @@ static bool CanDoFastLossless(const JxlEncoderFrameSettings* frame_settings,
   // TODO(veluca): implement support for LSB-padded input in fast_lossless.
   if (frame_settings->values.image_bit_depth.type ==
           JxlBitDepthType::JXL_BIT_DEPTH_FROM_PIXEL_FORMAT &&
-      frame_settings->values.image_bit_depth.bits_per_sample !=
-          frame_settings->enc->metadata.m.bit_depth.bits_per_sample) {
+      frame_settings->enc->metadata.m.bit_depth.bits_per_sample % 8 != 0) {
     return false;
   }
   if (!frame_settings->values.frame_name.empty()) {


### PR DESCRIPTION
Fixes https://github.com/libjxl/libjxl/issues/3729

https://github.com/libjxl/libjxl/pull/3661 accidentally caused FastLossless to never be used on PNG input, since `frame_settings->values.image_bit_depth.bits_per_sample` is always 0 (it's a value that gets ignored and that doesn't get set).

So the test was wrong before because it always succeeded on PNG input (which was bad because it can cause wrong results, when using --override_bitdepth), but the fix was also wrong because it always failed on PNG input (which is slightly less bad but causes e1 to be slower than expected).

Now it should be OK :)

(on PPM input, there was no issue)