### PR TITLE
more bits and precision for small blue details

### DIFF
--- a/lib/jxl/decode_test.cc
+++ b/lib/jxl/decode_test.cc
@@ -2124,7 +2124,7 @@ TEST(DecodeTest, PixelTestOpaqueSrgbLossyNoise) {
         ButteraugliDistance(io0.frames, io1.frames, butteraugli_params,
                             *JxlGetDefaultCms(),
                             /*distmap=*/nullptr, nullptr),
-        1.9f);
+        1.4f);
 
     JxlDecoderDestroy(dec);
   }

--- a/lib/jxl/encode_test.cc
+++ b/lib/jxl/encode_test.cc
@@ -260,7 +260,7 @@ TEST(EncodeTest, EncoderResetTest) {
   JxlEncoderPtr enc = JxlEncoderMake(nullptr);
   EXPECT_NE(nullptr, enc.get());
   VerifyFrameEncoding(50, 200, enc.get(),
-                      JxlEncoderFrameSettingsCreate(enc.get(), nullptr), 4577,
+                      JxlEncoderFrameSettingsCreate(enc.get(), nullptr), 4599,
                       false);
   // Encoder should become reusable for a new image from scratch after using
   // reset.

--- a/tools/optimizer/simplex_fork.py
+++ b/tools/optimizer/simplex_fork.py
@@ -62,9 +62,9 @@ def EvalCacheForget():
 def RandomizedJxlCodecs():
   retval = []
   minval = 0.2
-  maxval = 9.3
+  maxval = 2.3
   rangeval = maxval/minval
-  steps = 13
+  steps = 3
   for i in range(steps):
     mul = minval * rangeval**(float(i)/(steps - 1))
     mul *= 0.99 + 0.05 * random.random()


### PR DESCRIPTION
https://github.com/libjxl/libjxl/issues/414

0.08 % win on BPP * pnorm

small improvement on 'blue eyes' problem, perhaps fixes 15 % of the issue

```
Before:

104 images
Encoding      kPixels    Bytes          BPP  E MP/s  D MP/s     Max norm  SSIMULACRA2   PSNR        pnorm       BPP*pnorm   QABPP   Bugs
----------------------------------------------------------------------------------------------------------------------------------------
jxl:d0.1        20315 17201092    6.7734912   0.877   9.400   0.27150021  95.71487004  56.45   0.09202106  0.623303827334   6.776      0
jxl:d0.5        20315  7097969    2.7950569   1.055  13.011   0.85951955  91.44716664  46.43   0.34549147  0.965668308615   2.933      0
jxl:d0.8        20315  5369188    2.1142929   0.956  11.795   1.10998495  88.84518826  44.43   0.46523179  0.983636297558   2.467      0
jxl:d1          20315  4609354    1.8150835   0.957  11.755   1.32312207  87.02710112  43.19   0.55369287  1.004998801648   2.498      0
jxl:d1.5        20315  3497308    1.3771791   0.973  12.325   1.85060044  82.81802614  41.06   0.75584793  1.040937996647   2.642      0
jxl:d2.0        20315  2843267    1.1196291   1.005  13.102   2.40395119  78.77733614  39.54   0.94515107  1.058218683138   2.837      0
jxl:d2.5        20315  2394141    0.9427711   0.991  12.787   2.84155832  74.93859331  38.34   1.12102822  1.056873038553   2.818      0
jxl:d3          20315  2085469    0.8212215   0.958  12.823   3.25793791  71.56263100  37.51   1.27936547  1.050642375921   2.805      0
jxl:d5          20315  1396755    0.5500179   0.971   8.710   4.59055175  60.06439983  35.22   1.80800716  0.994436210208   2.620      0
jxl:d10         20315   843717    0.3322411   0.961   9.378   7.66272179  38.38418527  32.45   2.92733228  0.972580081795   2.532      0
Aggregate:      20315  3347697    1.3182647   0.969  11.387   1.86034228  76.95794978  41.00   0.73239975  0.965496754517   2.939      0

After:

104 images
Encoding      kPixels    Bytes          BPP  E MP/s  D MP/s     Max norm  SSIMULACRA2   PSNR        pnorm       BPP*pnorm   QABPP   Bugs
----------------------------------------------------------------------------------------------------------------------------------------
jxl:d0.1        20315 17234055    6.7864714   0.910   9.788   0.26921220  95.72922587  56.47   0.09149990  0.620961464563   6.786      0
jxl:d0.5        20315  7112515    2.8007848   1.071  13.558   0.85998310  91.46395356  46.44   0.34487223  0.965912919133   2.941      0
jxl:d0.8        20315  5380024    2.1185600   0.980  12.654   1.10730124  88.87286260  44.43   0.46413467  0.983297134681   2.471      0
jxl:d1          20315  4616590    1.8179329   0.999  12.761   1.32266768  87.04284922  43.20   0.55278192  1.004920452626   2.499      0
jxl:d1.5        20315  3501542    1.3788464   1.002  12.879   1.84924045  82.85156040  41.07   0.75456129  1.040424113923   2.644      0
jxl:d2.0        20315  2846638    1.1209566   1.014  13.333   2.40151432  78.80988790  39.56   0.94325779  1.057351028760   2.835      0
jxl:d2.5        20315  2396802    0.9438190   1.026  12.919   2.82912128  74.97206547  38.37   1.11707140  1.054313198037   2.814      0
jxl:d3          20315  2085594    0.8212707   0.978  13.233   3.25567966  71.58518909  37.51   1.27852510  1.050015177507   2.801      0
jxl:d5          20315  1398149    0.5505668   0.990   9.120   4.58800935  60.07606195  35.23   1.80660922  0.994659027562   2.622      0
jxl:d10         20315   843981    0.3323451   0.982   9.968   7.68431602  38.42064210  32.46   2.92598859  0.972437834700   2.534      0
Aggregate:      20315  3351858    1.3199034   0.994  11.905   1.85750610  76.98242982  41.01   0.73089142  0.964706041010   2.941      0
```

<!-- Thank you for considering a contribution to `libjxl`! -->

### Description

<!-- Please provide a brief description of the changes in this PR and any additional context (e.g., why these changes were made, related issues, etc.). -->

### Pull Request Checklist

- [ ] **CLA Signed**: Have you signed the [Contributor License Agreement](https://code.google.com/legal/individual-cla-v1.0.html) (individual or corporate, as appropriate)? Only contributions from signed contributors can be accepted.
- [ ] **Authors**: Have you considered adding your name to the [AUTHORS](AUTHORS) file?
- [ ] **Code Style**: Have you ensured your code adheres to the project's coding style guidelines? You can use `./ci.sh lint` for automatic code formatting.


Please review the full [contributing guidelines](https://github.com/libjxl/libjxl/blob/main/CONTRIBUTING.md) for more details.
