### PR TITLE
tools/file_io.h: set binary mode for stdin and stdout on Windows

### DIFF
--- a/tools/file_io.h
+++ b/tools/file_io.h
@@ -19,6 +19,11 @@
 
 #include "lib/jxl/base/compiler_specific.h"
 
+#ifdef _WIN32
+#include <fcntl.h>
+#include <io.h>
+#endif
+
 namespace jpegxl {
 namespace tools {
 
@@ -34,11 +39,14 @@ class FileWrapper {
         close_on_delete_(pathname != "-") {
 #ifdef _WIN32
     struct __stat64 s = {};
-    const int err = _stat64(pathname.c_str(), &s);
+    int err = _stat64(pathname.c_str(), &s);
     const bool is_file = (s.st_mode & S_IFREG) != 0;
+    if (pathname == "-") {
+      err |= _setmode(_fileno(file_), _O_BINARY);
+    }
 #else
     struct stat s = {};
-    const int err = stat(pathname.c_str(), &s);
+    int err = stat(pathname.c_str(), &s);
     const bool is_file = S_ISREG(s.st_mode);
 #endif
     if (err == 0 && is_file) {


### PR DESCRIPTION
Windows stdin and stdout default to text mode, but they can be changed to binary mode with _setmode from <io.h>. This is relevant because text mode enables LF <-> CRLF translation, and binary mode disables it, and it needs to be disabled for image reading/writing. This is technically also true on Unix-like operating systems, but text and binary do the same thing on macOS, Linux, etc.

Fixes #542 