### PR TITLE
Expose a wrapper function instead of Allotment

### DIFF
--- a/lib/jxl/enc_group.cc
+++ b/lib/jxl/enc_group.cc
@@ -541,10 +541,11 @@ Status EncodeGroupTokenizedCoefficients(size_t group_idx, size_t pass_idx,
   size_t histo_selector_bits = CeilLog2Nonzero(num_histograms);
 
   if (histo_selector_bits != 0) {
-    BitWriter::Allotment allotment(writer, histo_selector_bits);
-    writer->Write(histo_selector_bits, histogram_idx);
     JXL_RETURN_IF_ERROR(
-        allotment.ReclaimAndCharge(writer, LayerType::Ac, aux_out));
+        writer->WithMaxBits(histo_selector_bits, LayerType::Ac, aux_out, [&] {
+          writer->Write(histo_selector_bits, histogram_idx);
+          return true;
+        }));
   }
   size_t context_offset =
       histogram_idx * enc_state.shared.block_ctx_map.NumACContexts();

--- a/lib/jxl/enc_icc_codec.cc
+++ b/lib/jxl/enc_icc_codec.cc
@@ -450,9 +450,9 @@ Status WriteICC(const Span<const uint8_t> icc, BitWriter* JXL_RESTRICT writer,
   PaddedBytes enc{memory_manager};
   JXL_RETURN_IF_ERROR(PredictICC(icc.data(), icc.size(), &enc));
   std::vector<std::vector<Token>> tokens(1);
-  BitWriter::Allotment allotment(writer, 128);
-  JXL_RETURN_IF_ERROR(U64Coder::Write(enc.size(), writer));
-  JXL_RETURN_IF_ERROR(allotment.ReclaimAndCharge(writer, layer, aux_out));
+  JXL_RETURN_IF_ERROR(writer->WithMaxBits(128, layer, aux_out, [&] {
+    return U64Coder::Write(enc.size(), writer);
+  }));
 
   for (size_t i = 0; i < enc.size(); i++) {
     tokens[0].emplace_back(

--- a/lib/jxl/enc_noise.cc
+++ b/lib/jxl/enc_noise.cc
@@ -359,12 +359,13 @@ Status EncodeNoise(const NoiseParams& noise_params, BitWriter* writer,
                    LayerType layer, AuxOut* aux_out) {
   JXL_ENSURE(noise_params.HasAny());
 
-  BitWriter::Allotment allotment(writer, NoiseParams::kNumNoisePoints * 16);
-  for (float i : noise_params.lut) {
-    JXL_RETURN_IF_ERROR(EncodeFloatParam(i, kNoisePrecision, writer));
-  }
-  JXL_RETURN_IF_ERROR(allotment.ReclaimAndCharge(writer, layer, aux_out));
-  return true;
+  return writer->WithMaxBits(
+      NoiseParams::kNumNoisePoints * 16, layer, aux_out, [&]() -> Status {
+        for (float i : noise_params.lut) {
+          JXL_RETURN_IF_ERROR(EncodeFloatParam(i, kNoisePrecision, writer));
+        }
+        return true;
+      });
 }
 
 }  // namespace jxl

--- a/lib/jxl/enc_toc.cc
+++ b/lib/jxl/enc_toc.cc
@@ -20,29 +20,29 @@ Status WriteGroupOffsets(
     const std::vector<std::unique_ptr<BitWriter>>& group_codes,
     const std::vector<coeff_order_t>& permutation,
     BitWriter* JXL_RESTRICT writer, AuxOut* aux_out) {
-  BitWriter::Allotment allotment(writer, MaxBits(group_codes.size()));
-  if (!permutation.empty() && !group_codes.empty()) {
-    // Don't write a permutation at all for an empty group_codes.
-    writer->Write(1, 1);  // permutation
-    JXL_ENSURE(permutation.size() == group_codes.size());
-    JXL_RETURN_IF_ERROR(EncodePermutation(permutation.data(), /*skip=*/0,
-                                          permutation.size(), writer,
-                                          LayerType::Header, aux_out));
+  return writer->WithMaxBits(
+      MaxBits(group_codes.size()), LayerType::Toc, aux_out, [&]() -> Status {
+        if (!permutation.empty() && !group_codes.empty()) {
+          // Don't write a permutation at all for an empty group_codes.
+          writer->Write(1, 1);  // permutation
+          JXL_ENSURE(permutation.size() == group_codes.size());
+          JXL_RETURN_IF_ERROR(EncodePermutation(permutation.data(), /*skip=*/0,
+                                                permutation.size(), writer,
+                                                LayerType::Header, aux_out));
 
-  } else {
-    writer->Write(1, 0);  // no permutation
-  }
-  writer->ZeroPadToByte();  // before TOC entries
+        } else {
+          writer->Write(1, 0);  // no permutation
+        }
+        writer->ZeroPadToByte();  // before TOC entries
 
-  for (const auto& bw : group_codes) {
-    JXL_ENSURE(bw->BitsWritten() % kBitsPerByte == 0);
-    const size_t group_size = bw->BitsWritten() / kBitsPerByte;
-    JXL_RETURN_IF_ERROR(U32Coder::Write(kTocDist, group_size, writer));
-  }
-  writer->ZeroPadToByte();  // before first group
-  JXL_RETURN_IF_ERROR(
-      allotment.ReclaimAndCharge(writer, LayerType::Toc, aux_out));
-  return true;
+        for (const auto& bw : group_codes) {
+          JXL_ENSURE(bw->BitsWritten() % kBitsPerByte == 0);
+          const size_t group_size = bw->BitsWritten() / kBitsPerByte;
+          JXL_RETURN_IF_ERROR(U32Coder::Write(kTocDist, group_size, writer));
+        }
+        writer->ZeroPadToByte();  // before first group
+        return true;
+      });
 }
 
 }  // namespace jxl

--- a/lib/jxl/encode.cc
+++ b/lib/jxl/encode.cc
@@ -785,10 +785,11 @@ jxl::Status JxlEncoderStruct::ProcessOneEnqueuedInput() {
     }
     // TODO(lode): preview should be added here if a preview image is added
 
-    jxl::BitWriter::Allotment allotment(&writer, 8);
-    writer.ZeroPadToByte();
     JXL_RETURN_IF_ERROR(
-        allotment.ReclaimAndCharge(&writer, jxl::LayerType::Header, aux_out));
+        writer.WithMaxBits(8, jxl::LayerType::Header, aux_out, [&] {
+          writer.ZeroPadToByte();
+          return true;
+        }));
 
     header_bytes = std::move(writer).TakeBytes();
 

--- a/lib/jxl/test_utils.cc
+++ b/lib/jxl/test_utils.cc
@@ -842,10 +842,11 @@ Status EncodeFile(const CompressParams& params, CodecInOut* io,
   }
 
   // Each frame should start on byte boundaries.
-  BitWriter::Allotment allotment(&writer, 8);
-  writer.ZeroPadToByte();
-  JXL_RETURN_IF_ERROR(allotment.ReclaimAndCharge(&writer, LayerType::Header,
-                                                 /* aux_out */ nullptr));
+  JXL_RETURN_IF_ERROR(
+      writer.WithMaxBits(8, LayerType::Header, /*aux_out=*/nullptr, [&] {
+        writer.ZeroPadToByte();
+        return true;
+      }));
 
   for (size_t i = 0; i < io->frames.size(); i++) {
     FrameInfo info;


### PR DESCRIPTION
This lets us detect and handle failure in initialisation without requiring that we make `Allotment` movable for use with `JXL_ASSIGN_OR_RETURN`.