### PR TITLE
encoding changes for more precise epf

### DIFF
--- a/lib/jxl/decode_test.cc
+++ b/lib/jxl/decode_test.cc
@@ -2074,7 +2074,7 @@ TEST(DecodeTest, PixelTestOpaqueSrgbLossy) {
         ButteraugliDistance(io0.frames, io1.frames, butteraugli_params,
                             *JxlGetDefaultCms(),
                             /*distmap=*/nullptr, nullptr),
-        0.65f);
+        0.6f);
 
     JxlDecoderDestroy(dec);
   }

--- a/lib/jxl/jxl_test.cc
+++ b/lib/jxl/jxl_test.cc
@@ -241,7 +241,7 @@ TEST(JxlTest, RoundtripOutOfOrderProcessingBorder) {
   cparams.AddOption(JXL_ENC_FRAME_SETTING_RESAMPLING, 2);
 
   PackedPixelFile ppf_out;
-  EXPECT_NEAR(Roundtrip(t.ppf(), cparams, {}, &pool, &ppf_out), 9747, 200);
+  EXPECT_NEAR(Roundtrip(t.ppf(), cparams, {}, &pool, &ppf_out), 9947, 200);
   EXPECT_LE(ButteraugliDistance(t.ppf(), ppf_out), 2.9);
 }
 
@@ -319,7 +319,7 @@ TEST(JxlTest, RoundtripMultiGroup) {
   };
 
   auto run_kitten = std::async(std::launch::async, test, SpeedTier::kKitten,
-                               1.0f, 63624u, 8.5);
+                               1.0f, 64624u, 8.5);
   auto run_wombat = std::async(std::launch::async, test, SpeedTier::kWombat,
                                2.0f, 38887u, 15.5);
 }
@@ -448,8 +448,8 @@ TEST(JxlTest, RoundtripDotsForceEpf) {
   cparams.AddOption(JXL_ENC_FRAME_SETTING_DOTS, 1);
 
   PackedPixelFile ppf_out;
-  EXPECT_NEAR(Roundtrip(t.ppf(), cparams, {}, pool.get(), &ppf_out), 40999,
-              300);
+  EXPECT_NEAR(Roundtrip(t.ppf(), cparams, {}, pool.get(), &ppf_out), 41777,
+              500);
   EXPECT_SLIGHTLY_BELOW(ComputeDistance2(t.ppf(), ppf_out), 18);
 }
 
@@ -1389,7 +1389,7 @@ TEST(JxlTest, RoundtripAnimationPatches) {
   PackedPixelFile ppf_out;
   // 40k with no patches, 27k with patch frames encoded multiple times.
   EXPECT_SLIGHTLY_BELOW(Roundtrip(t.ppf(), cparams, dparams, pool, &ppf_out),
-                        21113);
+                        21199);
   EXPECT_EQ(ppf_out.frames.size(), t.ppf().frames.size());
   // >10 with broken patches; not all patches are detected on borders.
   EXPECT_SLIGHTLY_BELOW(ButteraugliDistance(t.ppf(), ppf_out), 1.85);
@@ -1677,7 +1677,7 @@ TEST(JxlTest, RoundtripProgressive) {
   cparams.AddOption(JXL_ENC_FRAME_SETTING_RESPONSIVE, 1);
 
   PackedPixelFile ppf_out;
-  EXPECT_NEAR(Roundtrip(t.ppf(), cparams, {}, pool.get(), &ppf_out), 70544,
+  EXPECT_NEAR(Roundtrip(t.ppf(), cparams, {}, pool.get(), &ppf_out), 71544,
               750);
   EXPECT_SLIGHTLY_BELOW(ButteraugliDistance(t.ppf(), ppf_out), 1.4);
 }

--- a/tools/optimizer/simplex_fork.py
+++ b/tools/optimizer/simplex_fork.py
@@ -59,12 +59,16 @@ def EvalCacheForget():
   global eval_hash
   eval_hash = {}
 
+g_first_pnorm = None
+
 def RandomizedJxlCodecs():
+  global g_first_pnorm
+  g_first_pnorm = None
   retval = []
-  minval = 0.2
-  maxval = 2.3
+  minval = 1.0
+  maxval = 8.3
   rangeval = maxval/minval
-  steps = 3
+  steps = 5
   for i in range(steps):
     mul = minval * rangeval**(float(i)/(steps - 1))
     mul *= 0.99 + 0.05 * random.random()
@@ -88,6 +92,7 @@ def Eval(vec, binary_name, cached=True):
   global eval_hash
   global g_codecs
   global g_best_val
+  global g_first_pnorm
   key = ""
   # os.environ["BUTTERAUGLI_OPTIMIZE"] = "1"
   for i in range(300):
@@ -112,7 +117,7 @@ def Eval(vec, binary_name, cached=True):
 
   # process.wait()
   found_score = False
-  vec[0] = 1.0
+  vec[0] = 1e29
   dct2 = 0.0
   dct4 = 0.0
   dct16 = 0.0
@@ -121,17 +126,14 @@ def Eval(vec, binary_name, cached=True):
   for line in process.communicate(input=None)[0].splitlines():
     print("BE", line)
     sys.stdout.flush()
-    if line[0:3] == b'jxl':
-      bpp = line.split()[3]
-      dist_pnorm = line.split()[9]
-      dist_max = line.split()[6]
-      vec[0] *= float(dist_pnorm) * float(bpp) / 16.0
-      #vec[0] *= (float(dist_max) * float(bpp) / 16.0) ** 0.01
-      n += 1
+    if line[0:4] == b'Aggr':
+      bpppnorm = float(line.split()[10])
+      if g_first_pnorm == None:
+        g_first_pnorm = float(line.split()[9])
+      correctbpp = 1. + 10.0 * (float(line.split()[9]) - g_first_pnorm) ** 2
+
+      vec[0] = 1e-5 * bpppnorm * correctbpp
       found_score = True
-      distance = float(line.split()[0].split(b'd')[-1])
-      faultybpp = 1.0 + 0.43 * ((float(bpp) * distance ** 0.69) - 1.64) ** 2
-      vec[0] *= faultybpp
 
   print("eval: ", vec)
   if (vec[0] <= 0.0):
@@ -256,6 +258,7 @@ for restarts in range(99999):
 
   mulli = 0.1 + 15 * random.random()**2.0
   g_codecs = RandomizedJxlCodecs()
+  g_best_val = None # get a new best val
   print("\n\n\nRestart", restarts, "mulli", mulli)
   g_simplex.sort()
   best = g_simplex[0][:]


### PR DESCRIPTION
about 0.18 % improvement on image quality as measured by BPP*pnorm

```
Before:

104 images
Encoding      kPixels    Bytes          BPP  E MP/s  D MP/s     Max norm  SSIMULACRA2   PSNR        pnorm       BPP*pnorm   QABPP   Bugs
----------------------------------------------------------------------------------------------------------------------------------------
jxl:d0.1        20315 17234055    6.7864714   0.795   8.565   0.26921220  95.72922587  56.47   0.09149990  0.620961464563   6.786      0
jxl:d0.5        20315  7112515    2.8007848   0.940  12.078   0.85998310  91.46395356  46.44   0.34487223  0.965912919133   2.941      0
jxl:d0.8        20315  5380024    2.1185600   0.861  11.031   1.10730124  88.87286260  44.43   0.46413467  0.983297134681   2.471      0
jxl:d1          20315  4616590    1.8179329   0.861  11.503   1.32266768  87.04284922  43.20   0.55278192  1.004920452626   2.499      0
jxl:d1.5        20315  3501542    1.3788464   0.879  11.142   1.84924045  82.85156040  41.07   0.75456129  1.040424113923   2.644      0
jxl:d2.0        20315  2846638    1.1209566   0.881  11.101   2.40151432  78.80988790  39.56   0.94325779  1.057351028760   2.835      0
jxl:d2.5        20315  2396802    0.9438190   0.893  11.413   2.82912128  74.97206547  38.37   1.11707140  1.054313198037   2.814      0
jxl:d3          20315  2085594    0.8212707   0.870  11.541   3.25567966  71.58518909  37.51   1.27852510  1.050015177507   2.801      0
jxl:d5          20315  1398149    0.5505668   0.873   7.995   4.58800935  60.07606195  35.23   1.80660922  0.994659027562   2.622      0
jxl:d10         20315   843981    0.3323451   0.865   8.538   7.68431602  38.42064210  32.46   2.92598859  0.972437834700   2.534      0
Aggregate:      20315  3351858    1.3199034   0.871  10.385   1.85750610  76.98242982  41.01   0.73089142  0.964706041010   2.941      0

After:

104 images
Encoding      kPixels    Bytes          BPP  E MP/s  D MP/s     Max norm  SSIMULACRA2   PSNR        pnorm       BPP*pnorm   QABPP   Bugs
----------------------------------------------------------------------------------------------------------------------------------------
jxl:d0.1        20315 17266997    6.7994434   0.815   8.802   0.26883625  95.74016251  56.48   0.09126255  0.620534568214   6.799      0
jxl:d0.5        20315  7125011    2.8057055   0.962  12.895   0.85243631  91.45559592  46.45   0.34403907  0.965272309787   2.931      0
jxl:d0.8        20315  5394265    2.1241678   0.894  11.084   1.09960077  88.89451775  44.49   0.46027287  0.977696821726   2.466      0
jxl:d1          20315  4624207    1.8209324   0.892  11.385   1.31717842  87.04791994  43.25   0.54900805  0.999706533924   2.495      0
jxl:d1.5        20315  3504409    1.3799754   0.912  11.012   1.85527307  82.85677175  41.09   0.75216350  1.037967114212   2.655      0
jxl:d2.0        20315  2844789    1.1202285   0.923  11.199   2.40613996  78.78007662  39.57   0.94250548  1.055821484127   2.840      0
jxl:d2.5        20315  2393011    0.9423262   0.923  11.503   2.83238352  74.92339850  38.38   1.11739846  1.052953789398   2.809      0
jxl:d3          20315  2079292    0.8187891   0.891  11.957   3.25359934  71.51771710  37.50   1.28061805  1.048556056115   2.794      0
jxl:d5          20315  1395949    0.5497005   0.903   8.354   4.62224705  60.04091153  35.21   1.81152423  0.995795707602   2.640      0
jxl:d10         20315   842166    0.3316303   0.892   8.832   7.70488447  38.44032069  32.44   2.93156275  0.972195146095   2.540      0
Aggregate:      20315  3351787    1.3198755   0.900  10.601   1.85647607  76.96973923  41.02   0.72960225  0.962984133078   2.942      0
```

