### PR TITLE
Change order of color description enums to match order of stringified representation

### DIFF
--- a/lib/extras/dec/color_description.cc
+++ b/lib/extras/dec/color_description.cc
@@ -39,6 +39,13 @@ constexpr auto kJxlPrimariesNames =
                                       {"202", JXL_PRIMARIES_2100},
                                       {"DCI", JXL_PRIMARIES_P3}});
 
+constexpr auto kJxlRenderingIntentNames =
+    to_array<EnumName<JxlRenderingIntent>>(
+        {{"Per", JXL_RENDERING_INTENT_PERCEPTUAL},
+         {"Rel", JXL_RENDERING_INTENT_RELATIVE},
+         {"Sat", JXL_RENDERING_INTENT_SATURATION},
+         {"Abs", JXL_RENDERING_INTENT_ABSOLUTE}});
+
 constexpr auto kJxlTransferFunctionNames =
     to_array<EnumName<JxlTransferFunction>>(
         {{"709", JXL_TRANSFER_FUNCTION_709},
@@ -49,13 +56,6 @@ constexpr auto kJxlTransferFunctionNames =
          {"DCI", JXL_TRANSFER_FUNCTION_DCI},
          {"HLG", JXL_TRANSFER_FUNCTION_HLG},
          {"", JXL_TRANSFER_FUNCTION_GAMMA}});
-
-constexpr auto kJxlRenderingIntentNames =
-    to_array<EnumName<JxlRenderingIntent>>(
-        {{"Per", JXL_RENDERING_INTENT_PERCEPTUAL},
-         {"Rel", JXL_RENDERING_INTENT_RELATIVE},
-         {"Sat", JXL_RENDERING_INTENT_SATURATION},
-         {"Abs", JXL_RENDERING_INTENT_ABSOLUTE}});
 
 template <typename T, size_t N>
 Status ParseEnum(const std::string& token,


### PR DESCRIPTION
<!-- Thank you for considering a contribution to `libjxl`! -->

### Description

The 'color_space' string is in the order 'Color Space, White Point, Primaries, Intent, Transfer' however the enums are defined in a different order in the file. It's not really a big deal, but it makes it easier to read. 

### Pull Request Checklist

- [x] **CLA Signed**: Have you signed the [Contributor License Agreement](https://code.google.com/legal/individual-cla-v1.0.html) (individual or corporate, as appropriate)? Only contributions from signed contributors can be accepted.
- [x] **Authors**: Have you considered adding your name to the [AUTHORS](AUTHORS) file?
- [x] **Code Style**: Have you ensured your code adheres to the project's coding style guidelines? You can use `./ci.sh lint` for automatic code formatting.


Please review the full [contributing guidelines](https://github.com/libjxl/libjxl/blob/main/CONTRIBUTING.md) for more details.
