### PR TITLE
tools/benchmark_codec_avif.cc: restore compatability with libavif < 1

### DIFF
--- a/tools/benchmark/benchmark_codec_avif.cc
+++ b/tools/benchmark/benchmark_codec_avif.cc
@@ -125,8 +125,12 @@ Status SetUpAvifColor(const ColorEncoding& color, bool rgb,
   }
 
   if (need_icc) {
+#if AVIF_VERSION_MAJOR < 1
+    avifImageSetProfileICC(image, color.ICC().data(), color.ICC().size());
+#else
     JXL_RETURN_IF_AVIF_ERROR(
         avifImageSetProfileICC(image, color.ICC().data(), color.ICC().size()));
+#endif
   }
   return true;
 }
@@ -310,7 +314,11 @@ class AvifCodec : public ImageCodec {
         avifRGBImageSetDefaults(&rgb_image, image.get());
         rgb_image.format =
             ib.HasAlpha() ? AVIF_RGB_FORMAT_RGBA : AVIF_RGB_FORMAT_RGB;
+#if AVIF_VERSION_MAJOR < 1
+        avifRGBImageAllocatePixels(&rgb_image);
+#else
         JXL_RETURN_IF_AVIF_ERROR(avifRGBImageAllocatePixels(&rgb_image));
+#endif
         std::unique_ptr<avifRGBImage, void (*)(avifRGBImage*)> pixels_freer(
             &rgb_image, &avifRGBImageFreePixels);
         const double start_convert_image = jxl::Now();
@@ -379,7 +387,11 @@ class AvifCodec : public ImageCodec {
         avifRGBImageSetDefaults(&rgb_image, decoder->image);
         rgb_image.format =
             has_alpha ? AVIF_RGB_FORMAT_RGBA : AVIF_RGB_FORMAT_RGB;
+#if AVIF_VERSION_MAJOR < 1
+        avifRGBImageAllocatePixels(&rgb_image);
+#else
         JXL_RETURN_IF_AVIF_ERROR(avifRGBImageAllocatePixels(&rgb_image));
+#endif
         std::unique_ptr<avifRGBImage, void (*)(avifRGBImage*)> pixels_freer(
             &rgb_image, &avifRGBImageFreePixels);
         JXL_RETURN_IF_AVIF_ERROR(avifImageYUVToRGB(decoder->image, &rgb_image));


### PR DESCRIPTION
Fixes regression since 5df155d975bd8ecf091f2b808d41cdd1f37e09b8. This commit restores compatibility with these functions using libavif before major version 1, as they didn't return a result in those cases.

Fixes #3753.