### PR TITLE
Faster PNG compression

### DIFF
--- a/lib/extras/enc/apng.cc
+++ b/lib/extras/enc/apng.cc
@@ -380,6 +380,7 @@ Status APNGEncoder::EncodePackedPixelFileToAPNG(
 
     info_ptr = png_create_info_struct(png_ptr);
     if (!info_ptr) return JXL_FAILURE("Could not init png info struct");
+    png_set_compression_level(png_ptr, 3);
 
     png_set_write_fn(png_ptr, bytes, PngWrite, nullptr);
     png_set_flush(png_ptr, 0);

--- a/lib/extras/enc/apng.cc
+++ b/lib/extras/enc/apng.cc
@@ -380,7 +380,7 @@ Status APNGEncoder::EncodePackedPixelFileToAPNG(
 
     info_ptr = png_create_info_struct(png_ptr);
     if (!info_ptr) return JXL_FAILURE("Could not init png info struct");
-    png_set_compression_level(png_ptr, 3);
+    png_set_compression_level(png_ptr, 1);
 
     png_set_write_fn(png_ptr, bytes, PngWrite, nullptr);
     png_set_flush(png_ptr, 0);


### PR DESCRIPTION
I did the thing.

Lowers the zlib compression level from the default 6 to 1, to lessen the impact of PNG writing on JXL decoding tests.
This results in a 20% density decrease and a 73% speed increase of djxl when outputting to PNGs.