### PR TITLE
Fix jpg.cc for MinGW-w64

### DIFF
--- a/lib/extras/enc/jpg.cc
+++ b/lib/extras/enc/jpg.cc
@@ -273,7 +273,7 @@ Status EncodeWithLibJpeg(const PackedImage& image, const JxlBasicInfo& info,
   cinfo.err = jpeg_std_error(&jerr);
   jpeg_create_compress(&cinfo);
   unsigned char* buffer = nullptr;
-  unsigned long size = 0;  // NOLINT
+  size_t size = 0;  // NOLINT
   jpeg_mem_dest(&cinfo, &buffer, &size);
   cinfo.image_width = image.xsize;
   cinfo.image_height = image.ysize;

--- a/lib/extras/enc/jpg.cc
+++ b/lib/extras/enc/jpg.cc
@@ -273,7 +273,11 @@ Status EncodeWithLibJpeg(const PackedImage& image, const JxlBasicInfo& info,
   cinfo.err = jpeg_std_error(&jerr);
   jpeg_create_compress(&cinfo);
   unsigned char* buffer = nullptr;
-  size_t size = 0;  // NOLINT
+#ifdef LIBJPEG_TURBO_VERSION
+  unsigned long size = 0;  // NOLINT
+#else
+  size_t size = 0;         // NOLINT
+#endif
   jpeg_mem_dest(&cinfo, &buffer, &size);
   cinfo.image_width = image.xsize;
   cinfo.image_height = image.ysize;

--- a/lib/extras/enc/jpg.cc
+++ b/lib/extras/enc/jpg.cc
@@ -276,7 +276,7 @@ Status EncodeWithLibJpeg(const PackedImage& image, const JxlBasicInfo& info,
 #ifdef LIBJPEG_TURBO_VERSION
   unsigned long size = 0;  // NOLINT
 #else
-  size_t size = 0;         // NOLINT
+  size_t size = 0;  // NOLINT
 #endif
   jpeg_mem_dest(&cinfo, &buffer, &size);
   cinfo.image_width = image.xsize;


### PR DESCRIPTION
Fix the following error when building with MinGW-w64 and libjpeg instead of libjpeg-turbo:

```raw
lib/extras/enc/jpg.cc:277:34: error: cannot convert 'long unsigned int*' to 'size_t*' {aka 'long long unsigned int*'}
  277 |   jpeg_mem_dest(&cinfo, &buffer, &size);
      |                                  ^~~~~
      |                                  |
      |                                  long unsigned int*
```

<!-- Thank you for considering a contribution to `libjxl`! -->

### Description

<!-- Please provide a brief description of the changes in this PR and any additional context (e.g., why these changes were made, related issues, etc.). -->

### Pull Request Checklist

- [ ] **CLA Signed**: Have you signed the [Contributor License Agreement](https://code.google.com/legal/individual-cla-v1.0.html) (individual or corporate, as appropriate)? Only contributions from signed contributors can be accepted.
- [ ] **Authors**: Have you considered adding your name to the [AUTHORS](AUTHORS) file?
- [ ] **Code Style**: Have you ensured your code adheres to the project's coding style guidelines? You can use `./ci.sh lint` for automatic code formatting.


Please review the full [contributing guidelines](https://github.com/libjxl/libjxl/blob/main/CONTRIBUTING.md) for more details.
