### PR TITLE
re-activate streaming fuzzer for higher efforts

### DIFF
--- a/tools/streaming_fuzzer.cc
+++ b/tools/streaming_fuzzer.cc
@@ -51,7 +51,7 @@ struct FuzzSpec {
   };
 
   std::vector<IntOptionSpec> int_options = {
-      IntOptionSpec{JXL_ENC_FRAME_SETTING_EFFORT, 1, 7, 0},
+      IntOptionSpec{JXL_ENC_FRAME_SETTING_EFFORT, 1, 9, 0},
       IntOptionSpec{JXL_ENC_FRAME_SETTING_DECODING_SPEED, 0, 4, 0},
       IntOptionSpec{JXL_ENC_FRAME_SETTING_NOISE, -1, 1, 0},
       IntOptionSpec{JXL_ENC_FRAME_SETTING_DOTS, -1, 1, 0},
@@ -327,7 +327,19 @@ Status Run(const FuzzSpec& spec, TrackingMemoryManager& memory_manager) {
                        Decode(enc_streaming, memory_manager));
   Check(memory_manager.Reset());
 
-  Check(dec_default == dec_streaming);
+  if (spec.int_options[0].value <= 7) {
+    Check(dec_default == dec_streaming);
+  } else {
+    Check(dec_default.size() == dec_streaming.size());
+    float max_abs_diff = 0.0f;
+    for (size_t i = 0; i < dec_default.size(); ++i) {
+      float abs_diff = std::abs(dec_default[i] - dec_streaming[i]);
+      if (abs_diff > max_abs_diff) {
+        max_abs_diff = abs_diff;
+      }
+    }
+    Check(max_abs_diff <= 0.1f);
+  }
 
   return true;
 }


### PR DESCRIPTION
and only check approximate equality of pixels in those cases.
