### PR TITLE
fix cmake script for homebrew a2x

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -460,7 +460,7 @@ if(JPEGXL_ENABLE_MANPAGES)
   find_program(ASCIIDOC a2x)
   if(ASCIIDOC)
     file(STRINGS "${ASCIIDOC}" ASCIIDOC_SHEBANG LIMIT_COUNT 1)
-    if(ASCIIDOC_SHEBANG MATCHES "sh$" OR MINGW)
+    if(ASCIIDOC_SHEBANG MATCHES "sh$" OR ASCIIDOC_SHEBANG MATCHES "libexec/bin/python$" OR MINGW)
       set(ASCIIDOC_PY_FOUND ON)
       # Run the program directly and set ASCIIDOC as empty.
       set(ASCIIDOC_PY "${ASCIIDOC}")


### PR DESCRIPTION
I needed this to get it to work in my macos/homebrew environment. Without this, it would go into the MSYS2 branch where it doesn't call `a2x` directly but invokes the Python interpreter on it — except it doesn't use the right Python version for that, and it fails (while calling `a2x` directly works fine).