### PR TITLE
loop_filter.{c,h}: Use correct header for std::abs

### DIFF
--- a/lib/jxl/loop_filter.h
+++ b/lib/jxl/loop_filter.h
@@ -8,8 +8,9 @@
 
 // Parameters for loop filter(s), stored in each frame.
 
-#include <stddef.h>
-#include <stdint.h>
+#include <cmath>
+#include <cstddef>
+#include <cstdint>
 
 #include "lib/jxl/base/compiler_specific.h"
 #include "lib/jxl/base/status.h"


### PR DESCRIPTION
Floating-point overloads of `std::abs` come from `<cmath>`. Also use non-deprecated C++ forms of the other headers.

### Description

Without this, the build fails on at least macOS 10.15:
```
libjxl-0.11.0/lib/jxl/loop_filter.cc:31:11: error: call to 'abs' is ambiguous
      if (std::abs(1.0f + (gab_x_weight1 + gab_x_weight2) * 4) < 1e-8) {
          ^~~~~~~~
/Library/Developer/CommandLineTools/SDKs/MacOSX10.15.sdk/usr/include/stdlib.h:132:6: note: candidate function
int      abs(int) __pure2;
         ^
/Library/Developer/CommandLineTools/usr/bin/../include/c++/v1/stdlib.h:110:44: note: candidate function
inline _LIBCPP_INLINE_VISIBILITY long      abs(     long __x) _NOEXCEPT {return  labs(__x);}
                                           ^
/Library/Developer/CommandLineTools/usr/bin/../include/c++/v1/stdlib.h:112:44: note: candidate function
inline _LIBCPP_INLINE_VISIBILITY long long abs(long long __x) _NOEXCEPT {return llabs(__x);}
                                           ^
```

### Pull Request Checklist

- [x] **CLA Signed**: Have you signed the [Contributor License Agreement](https://code.google.com/legal/individual-cla-v1.0.html) (individual or corporate, as appropriate)? Only contributions from signed contributors can be accepted.
- [x] **Authors**: Have you considered adding your name to the [AUTHORS](AUTHORS) file?
- [x] **Code Style**: Have you ensured your code adheres to the project's coding style guidelines? You can use `./ci.sh lint` for automatic code formatting.
