### PR TITLE
Don't abort in the destructor of allotment if allocation failed

### DIFF
--- a/lib/jxl/enc_bit_writer.cc
+++ b/lib/jxl/enc_bit_writer.cc
@@ -34,7 +34,10 @@ Status BitWriter::Allotment::Init(BitWriter* JXL_RESTRICT writer) {
   prev_bits_written_ = writer->BitsWritten();
   const size_t prev_bytes = writer->storage_.size();
   const size_t next_bytes = DivCeil(max_bits_, kBitsPerByte);
-  JXL_RETURN_IF_ERROR(writer->storage_.resize(prev_bytes + next_bytes));
+  if (!writer->storage_.resize(prev_bytes + next_bytes)) {
+    called_ = true;
+    return false;
+  }
   parent_ = writer->current_allotment_;
   writer->current_allotment_ = this;
   return true;

--- a/tools/streaming_fuzzer.cc
+++ b/tools/streaming_fuzzer.cc
@@ -310,7 +310,7 @@ Status Run(const FuzzSpec& spec, TrackingMemoryManager& memory_manager) {
   std::vector<uint8_t> enc_streaming;
 
   const auto encode = [&]() -> Status {
-    // It is not clear, which approach eatc more memory.
+    // It is not clear, which approach eats more memory.
     JXL_ASSIGN_OR_RETURN(enc_default, Encode(spec, memory_manager, false));
     Check(memory_manager.Reset());
     JXL_ASSIGN_OR_RETURN(enc_streaming, Encode(spec, memory_manager, true));
@@ -320,7 +320,7 @@ Status Run(const FuzzSpec& spec, TrackingMemoryManager& memory_manager) {
   // It is fine, if encoder OOMs.
   if (!encode()) return true;
 
-  // It is NOT OK, it decoder OOMs - it should not consume more than encoder.
+  // It is NOT OK, if decoder OOMs - it should not consume more than encoder.
   JXL_ASSIGN_OR_RETURN(auto dec_default, Decode(enc_default, memory_manager));
   Check(memory_manager.Reset());
   JXL_ASSIGN_OR_RETURN(auto dec_streaming,


### PR DESCRIPTION
drive-by: some typos in streaming fuzzer
