### PR TITLE
tools/djxl_main.cc: fix typo in -s documentation

### DIFF
--- a/tools/djxl_main.cc
+++ b/tools/djxl_main.cc
@@ -110,7 +110,7 @@ struct DecompressArgs {
         &color_space, &ParseString, 1);
 
     cmdline->AddOptionValue('s', "downsampling", "1|2|4|8",
-                            "If the input JXL stream is contains hints for "
+                            "If the input JXL stream contains hints for "
                             "target downsampling ratios,\n"
                             "    only decode what is needed to produce an "
                             "image intended for this downsampling ratio.",


### PR DESCRIPTION
Fix a simple typo in the documentation for the downsampling argument.