### PR TITLE
Set `CMAKE_MSVC_RUNTIME_LIBRARY` again for MSVC+Clang+GNU static build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -231,6 +231,10 @@ if(JPEGXL_STATIC)
   # ourselves; for real use case we don't care about stdlib, as it is "granted",
   # so just linking all other libraries is fine.
   if (NOT MSVC)
+    # FIXME: For some reason, CMake generator doesn't work well
+	# with Clang GNU driver on MSVC. So, this variable needs to
+	# be set again. See issue #3855
+    set(CMAKE_MSVC_RUNTIME_LIBRARY MultiThreaded)
     string(APPEND CMAKE_EXE_LINKER_FLAGS " -static")
   endif()
   if ((NOT WIN32 AND NOT APPLE) OR CYGWIN OR MINGW)


### PR DESCRIPTION
<!-- Thank you for considering a contribution to `libjxl`! -->

### Description

Set `CMAKE_MSVC_RUNTIME_LIBRARY` again for MSVC+clang+GNU driver as a temporary workaround. Closes #3855.

### Pull Request Checklist

- [x] **CLA Signed**: Have you signed the [Contributor License Agreement](https://code.google.com/legal/individual-cla-v1.0.html) (individual or corporate, as appropriate)? Only contributions from signed contributors can be accepted.
- [ ] **Authors**: Have you considered adding your name to the [AUTHORS](AUTHORS) file?
- [ ] **Code Style**: Have you ensured your code adheres to the project's coding style guidelines? You can use `./ci.sh lint` for automatic code formatting.