### PR TITLE
Port the Huffman lookup table size fix from brunsli.

### DIFF
--- a/lib/jpegli/huffman.h
+++ b/lib/jpegli/huffman.h
@@ -15,10 +15,18 @@ namespace jpegli {
 
 constexpr int kJpegHuffmanRootTableBits = 8;
 // Maximum huffman lookup table size.
-// According to zlib/examples/enough.c, 758 entries are always enough for
-// an alphabet of 257 symbols (256 + 1 special symbol for the all 1s code) and
-// max bit length 16 if the root table has 8 bits.
-constexpr int kJpegHuffmanLutSize = 758;
+// Requirements: alphabet of 257 symbols (256 + 1 special symbol for the all 1s
+// code) and max bit length 16, the root table has 8 bits.
+// zlib/examples/enough.c works with an assumption that Huffman code is
+// "complete". Input JPEGs might have this assumption broken, hence the
+// following sum is used as estimate:
+//  + number of 1-st level cells
+//  + number of symbols
+//  + asymptotic amount of repeated 2nd level cells
+// The third number is 1 + 3 + ... + 255 i.e. it is assumed that sub-table of
+// each "size" might be almost completely be filled with repetitions.
+// Total sum is slightly less than 1024,...
+constexpr int kJpegHuffmanLutSize = 1024;
 
 struct HuffmanTableEntry {
   uint8_t bits;    // number of bits used for this symbol

--- a/lib/jxl/jpeg/enc_jpeg_huffman_decode.h
+++ b/lib/jxl/jpeg/enc_jpeg_huffman_decode.h
@@ -15,10 +15,18 @@ namespace jpeg {
 
 constexpr int kJpegHuffmanRootTableBits = 8;
 // Maximum huffman lookup table size.
-// According to zlib/examples/enough.c, 758 entries are always enough for
-// an alphabet of 257 symbols (256 + 1 special symbol for the all 1s code) and
-// max bit length 16 if the root table has 8 bits.
-constexpr int kJpegHuffmanLutSize = 758;
+// Requirements: alphabet of 257 symbols (256 + 1 special symbol for the all 1s
+// code) and max bit length 16, the root table has 8 bits.
+// zlib/examples/enough.c works with an assumption that Huffman code is
+// "complete". Input JPEGs might have this assumption broken, hence the
+// following sum is used as estimate:
+//  + number of 1-st level cells
+//  + number of symbols
+//  + asymptotic amount of repeated 2nd level cells
+// The third number is 1 + 3 + ... + 255 i.e. it is assumed that sub-table of
+// each "size" might be almost completely be filled with repetitions.
+// Total sum is slightly less than 1024,...
+constexpr int kJpegHuffmanLutSize = 1024;
 
 struct HuffmanTableEntry {
   // Initialize the value to an invalid symbol so that we can recognize it


### PR DESCRIPTION
See also: https://www.youtube.com/watch?v=_ACCK0AUQ8Q&t=696s
