### PR TITLE
Remove reference to imlib2-jxl plugin

### DIFF
--- a/doc/software_support.md
+++ b/doc/software_support.md
@@ -27,7 +27,7 @@ For all browsers and to track browsers progress see [Can I Use](https://caniuse.
 
 - [ImageMagick](https://imagemagick.org/): supported since 7.0.10-54
 - [libvips](https://libvips.github.io/libvips/): supported since 8.11
-- [Imlib2](https://github.com/alistair7/imlib2-jxl)
+- [Imlib2](https://docs.enlightenment.org/api/imlib2/html/)
 - [FFmpeg](https://github.com/FFmpeg/FFmpeg/search?q=jpeg-xl&type=commits)
 - [GDAL](https://gdal.org/drivers/raster/jpegxl.html): supported since 3.4.0 as a TIFF codec, and 3.6.0 as standalone format
 - [GraphicsMagick](http://www.graphicsmagick.org/NEWS.html#march-26-2022): supported since 1.3.38


### PR DESCRIPTION
### Description

Remove the reference to my imlib2 plugin, as imlib2 / Enlightenment has had built-in support JPEG XL for years now.

The only remaining selling point of the plugin was that it forced everything to decode to sRGB... which while obviously wrong, is arguably less wrong than what imlib2 itself does, which is ignore the color space completely.  But that's how all the imlib2 loaders behave, so I think most users will be OK with it :).


### Pull Request Checklist

- [x] **CLA Signed**: Have you signed the [Contributor License Agreement](https://code.google.com/legal/individual-cla-v1.0.html) (individual or corporate, as appropriate)? Only contributions from signed contributors can be accepted.
- [x] **Authors**: Have you considered adding your name to the [AUTHORS](AUTHORS) file?
- [x] **Code Style**: Have you ensured your code adheres to the project's coding style guidelines? You can use `./ci.sh lint` for automatic code formatting.
