### PR TITLE
Update documentation

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -57,6 +57,7 @@ estrogently <41487185+estrogently@users.noreply.github.com>
 Even Rouault <even.rouault@spatialys.com>
 Fred Brennan <copypaste@kittens.ph>
 Gerhard Huber <support@pl32.com>
+Galaxy4594 <164440799+Galaxy4594@users.noreply.github.com>
 gi-man
 Gilles Devillers (GilDev) <gildev@gmail.com>
 Heiko Becker <heirecka@exherbo.org>

--- a/doc/benchmarking.md
+++ b/doc/benchmarking.md
@@ -22,12 +22,11 @@ build/tools/benchmark_xl --input "/path/*.png" --codec jxl:wombat:d1,jxl:cheetah
 Multiple comma-separated codecs are allowed. The characters after : are
 parameters for the codec, separated by colons, in this case specifying maximum
 target psychovisual distances of 1 and 2 (higher implies lower quality) and
-the encoder effort (see below). Other common parameters are `r0.5` (target
-bitrate 0.5 bits per pixel) and `q92` (quality 92, on a scale of 0-100, where
-higher is better). The `jxl` codec supports the following additional parameters:
+the encoder effort (see below). Another common parameter is `q92` (quality 92, on a scale of 0-100, where
+higher is better). Quality is directly mapped to distance (quality 90 equals a distance of 1). The `jxl` codec supports the following additional parameters:
 
 Speed: `lightning`, `thunder`, `falcon`, `cheetah`, `hare`, `wombat`, `squirrel`,
-`kitten`, `tortoise` control the encoder effort in ascending order. This also
+`kitten`, `tortoise`, `glacier`, and `tectonic plate` control the encoder effort in ascending order. This also
 affects memory usage: using lower effort will typically reduce memory consumption
 during encoding.
 
@@ -43,6 +42,8 @@ during encoding.
     context clustering.
 *   `kitten` optimizes the adaptive quantization for a psychovisual metric.
 *   `tortoise` enables a more thorough adaptive quantization search.
+*   `glacier` disables chunked encoding and enables whole image optimizaions.
+*   `tectonic plate` exhaustively tries different glacier settings.
 
 Mode: JPEG XL has two modes. The default is Var-DCT mode, which is suitable for
 lossy compression. The other mode is Modular mode, which is suitable for lossless
@@ -65,18 +66,18 @@ Other arguments to benchmark_xl include:
 The benchmark output begins with a header:
 
 ```
-Compr              Input    Compr            Compr       Compr  Decomp  Butteraugli
-Method            Pixels     Size              BPP   #    MP/s    MP/s     Distance    Error p norm           BPP*pnorm   Errors
+Encoding    kPixels   Bytes  BPP    E MP/s    D MP/s    Max norm    SSIMULACRA2 PSNR    pnorm   BPP*pnorm   QABPP   Bugs
 ```
 
-`ComprMethod` lists each each comma-separated codec. `InputPixels` is the number
-of pixels in the input image. `ComprSize` is the codestream size in bytes and
-`ComprBPP` the bitrate. `Compr MP/s` and `Decomp MP/s` are the
+`Encoding` lists each each comma-separated codec. `kPixels` is the number
+of pixels in the input image. `Bytes` is the codestream size in bytes and
+`BPP` stands for Bits Per Pixel. `E MP/s` and `D MP/s` are the
 compress/decompress throughput, in units of Megapixels/second.
-`Butteraugli Distance` indicates the maximum psychovisual error in the decoded
-image (larger is worse). `Error p norm` is a similar summary of the psychovisual
+`Max norm` indicates the maximum psychovisual error in the decoded
+image (larger is worse). `pnorm` is a similar summary of the psychovisual
 error, but closer to an average, giving less weight to small low-quality
-regions. `BPP*pnorm` is the product of `ComprBPP` and `Error p norm`, which is a
-figure of merit for the codec (lower is better). `Errors` is nonzero if errors
-occurred while loading or encoding/decoding the image.
-
+regions. `SSIMULACRA2` is a modern psychovisal metric, the range is 100
+(lossless) to -∞. `PSNR` is a signal-to-noise ratio meausred in dB.
+`BPP*pnorm` is the product of `BPP` and `pnorm`, which is a figure of merit
+for the codec (lower is better). `Bugs` is nonzero if errors occurred
+while loading or encoding/decoding the image.

--- a/doc/benchmarking.md
+++ b/doc/benchmarking.md
@@ -66,5 +66,6 @@ error, but closer to an average, giving less weight to small low-quality
 regions. `SSIMULACRA2` is a modern psychovisal metric, the range is 100
 (lossless) to -∞. `PSNR` is a signal-to-noise ratio meausred in dB.
 `BPP*pnorm` is the product of `BPP` and `pnorm`, which is a figure of merit
-for the codec (lower is better). `Bugs` is nonzero if errors occurred
+for the codec (lower is better). `QABPP` is quality adjusted bits per pixel,
+which is represented as `BPP`*`Max norm`. `Bugs` is nonzero if errors occurred
 while loading or encoding/decoding the image.

--- a/doc/benchmarking.md
+++ b/doc/benchmarking.md
@@ -25,25 +25,12 @@ target psychovisual distances of 1 and 2 (higher implies lower quality) and
 the encoder effort (see below). Another common parameter is `q92` (quality 92, on a scale of 0-100, where
 higher is better). Quality is directly mapped to distance (quality 90 equals a distance of 1). The `jxl` codec supports the following additional parameters:
 
-Speed: `lightning`, `thunder`, `falcon`, `cheetah`, `hare`, `wombat`, `squirrel`,
-`kitten`, `tortoise`, `glacier`, and `tectonic plate` control the encoder effort in ascending order. This also
+Speeds: `lightning`, `thunder`, `falcon`, `cheetah`, `hare`, `wombat`, `squirrel`,
+`kitten`, `tortoise`, `glacier`, and `tectonic_plate` control the encoder effort in ascending order. This also
 affects memory usage: using lower effort will typically reduce memory consumption
 during encoding.
 
-*   `lightning` and `thunder` are fast modes useful for lossless mode (modular).
-*   `falcon` disables all of the following tools.
-*   `cheetah` enables coefficient reordering, context clustering, and heuristics
-    for selecting DCT sizes and quantization steps.
-*   `hare` enables Gaborish filtering, chroma from luma, and an initial estimate
-    of quantization steps.
-*   `wombat` enables error diffusion quantization and full DCT size selection
-    heuristics.
-*   `squirrel` (default) enables dots, patches, and spline detection, and full
-    context clustering.
-*   `kitten` optimizes the adaptive quantization for a psychovisual metric.
-*   `tortoise` enables a more thorough adaptive quantization search.
-*   `glacier` disables chunked encoding and enables whole image optimizaions.
-*   `tectonic plate` exhaustively tries different glacier settings.
+[Encode_effort.md](https://github.com/libjxl/libjxl/blob/main/doc/encode_effort.md) describes what the various effort settings do.
 
 Mode: JPEG XL has two modes. The default is Var-DCT mode, which is suitable for
 lossy compression. The other mode is Modular mode, which is suitable for lossless

--- a/doc/encode_effort.md
+++ b/doc/encode_effort.md
@@ -3,7 +3,7 @@
 Various trade-offs between encode speed and compression performance can be selected in libjxl. In `cjxl`, this is done via the `--effort` (`-e`) option.
 Higher effort means slower encoding; generally the higher the effort, the more coding tools are used, computationally more expensive heuristics are used,
 and more exhaustive search is performed. 
-Generally efforts range between `1` and `9`, but there is also `e10` you pass the flag `--allow_expert_options` (in combination with "lossless", i.e. `-d 0`). It is considered an expert option because it can be extremely slow.
+Generally, efforts range between `1` and `10`, but there is also `e11` if you pass the flag `--allow_expert_options` (in combination with "lossless", i.e. `-d 0`). It is considered an expert option because it can be extremely slow.
 
 
 For lossy compression, higher effort results in better visual quality at a given filesize, and also better
@@ -18,15 +18,17 @@ The following table describes what the various effort settings do:
 
 |Effort | Modular (lossless) | VarDCT (lossy) |
 |-------|--------------------|----------------|
-| e1 | fast-lossless, fixed YCoCg RCT, fixed ClampedGradient predictor, simple palette detection, no MA tree (one context for everything), Huffman, simple rle-only lz77 | |
-| e2 | global channel palette, fixed MA tree (context based on Gradient-error), ANS, otherwise same as e1 | |
-| e3 | same as e2 but fixed Weighted predictor and fixed MA tree with context based on WP-error | only 8x8, basically XYB jpeg with ANS |
+| e1 | fast-lossless, fixed YCoCg RCT, fixed ClampedGradient predictor, simple palette detection, no MA tree (one context for everything), Huffman, simple rle-only lz77 | only 8x8, basically XYB jpeg with ANS |
+| e2 | global channel palette, fixed MA tree (context based on Gradient-error), ANS, otherwise same as e1 | same as e1 |
+| e3 | same as e2 but fixed Weighted predictor and fixed MA tree with context based on WP-error | e2 + better ANS |
 | e4 | try both ClampedGradient and Weighted predictor, learned MA tree, global palette | simple variable blocks heuristics, adaptive quantization, coefficient reordering |
 | e5 | e4 + patches, local palette / local channel palette, different local RCTs | e4 + gabor-like transform, chroma from luma |
 | e6 | e5 + more RCTs and MA tree properties | e5 + error diffusion, full variable blocks heuristics |
 | e7 | e6 + more RCTs and MA tree properties | e6 + patches (including dots) |
 | e8 | e7 + more RCTs, MA tree properties and Weighted predictor parameters | e7 + Butteraugli iterations for adaptive quantization |
 | e9 | e8 + more RCTs, MA tree properties and Weighted predictor parameters, try all predictors | e8 + more Butteraugli iterations |
-| e10 | e9 + previous-channel MA tree properties, different group dimensions, exhaustively try various e9 options | |
+| e10* | e9 + global MA tree + other whole image optimizaions | e9 + I don't know |
+| e11* | e10 + previous-channel MA tree properties, different group dimensions, exhaustively try various e10 options | N/A |
 
+__*For efforts 10 and higher, streaming encoding is disabled. This is a significant performance hit for larger images.__<br>
 For the entropy coding (context clustering, lz77 search, hybriduint configuration): slower/more exhaustive search as effort goes up.

--- a/doc/encode_effort.md
+++ b/doc/encode_effort.md
@@ -25,10 +25,9 @@ The following table describes what the various effort settings do:
 | e5 | e4 + patches, local palette / local channel palette, different local RCTs | e4 + gabor-like transform, chroma from luma |
 | e6 | e5 + more RCTs and MA tree properties | e5 + error diffusion, full variable blocks heuristics |
 | e7 | e6 + more RCTs and MA tree properties | e6 + patches (including dots) |
-| e8 | e7 + more RCTs, MA tree properties and Weighted predictor parameters | e7 + Butteraugli iterations for adaptive quantization |
-| e9 | e8 + more RCTs, MA tree properties and Weighted predictor parameters, try all predictors | e8 + more Butteraugli iterations |
-| e10* | e9 + global MA tree + other whole image optimizaions | e9 + I don't know |
-| e11* | e10 + previous-channel MA tree properties, different group dimensions, exhaustively try various e10 options | N/A |
+| e8 | e7 + more RCTs, MA tree properties and Weighted predictor parameters | e7 + Butteraugli iterations for adaptive quantization and disables chunked encoding |
+| e9 | e8 + more RCTs, MA tree properties, and Gradient/Weighted predictors | e8 + more Butteraugli iterations |
+| e10 | e9 + global MA tree, try all predictors, and disables chunked encoding | e9 + more thorough adaptive quantization |
+| e11 | e10 + previous-channel MA tree properties, different group dimensions, and try multiple e10 configurations | N/A |
 
-__*For efforts 10 and higher, streaming encoding is disabled. This is a significant performance hit for larger images.__<br>
-For the entropy coding (context clustering, lz77 search, hybriduint configuration): slower/more exhaustive search as effort goes up.
+For VarDCT, chunked encoding is disable at distances >=3. Chunked encoding is also disabled when `--patches=1`.<br>For the entropy coding (context clustering, lz77 search, hybriduint configuration): slower/more exhaustive search as effort goes up.

--- a/doc/encode_effort.md
+++ b/doc/encode_effort.md
@@ -30,4 +30,4 @@ The following table describes what the various effort settings do:
 | e10 | e9 + global MA tree, try all predictors, and disables chunked encoding | e9 + more thorough adaptive quantization |
 | e11 | e10 + previous-channel MA tree properties, different group dimensions, and try multiple e10 configurations | N/A |
 
-For VarDCT, chunked encoding is disable at distances >=3. Chunked encoding is also disabled when `--patches=1`.<br>For the entropy coding (context clustering, lz77 search, hybriduint configuration): slower/more exhaustive search as effort goes up.
+For VarDCT, chunked encoding is disabled at distances >=3. Chunked encoding is also disabled when `--patches=1`.<br>For the entropy coding (context clustering, lz77 search, hybriduint configuration): slower/more exhaustive search as effort goes up.

--- a/doc/encode_effort.md
+++ b/doc/encode_effort.md
@@ -25,9 +25,25 @@ The following table describes what the various effort settings do:
 | e5 | e4 + patches, local palette / local channel palette, different local RCTs | e4 + gabor-like transform, chroma from luma |
 | e6 | e5 + more RCTs and MA tree properties | e5 + error diffusion, full variable blocks heuristics |
 | e7 | e6 + more RCTs and MA tree properties | e6 + patches (including dots) |
-| e8 | e7 + more RCTs, MA tree properties, and Weighted predictor parameters | e7 + Butteraugli iterations for adaptive quantization and disables chunked encoding |
-| e9 | e8 + more RCTs, MA tree properties, and Weighted predictor parameters | e8 + more Butteraugli iterations |
+| e8 | e7 + more RCTs, MA tree properties, and Weighted predictor parameters | e7 + Butteraugli iterations for adaptive quantization |
+| e9 | e8 + more RCTs, MA tree properties, and Weighted predictor parameters | e8 + more Butteraugli iterations and disables chunked encoding |
 | e10 | e9 + global MA tree, try all predictors, and disables chunked encoding | e9 + more thorough adaptive quantization |
 | e11 | e10 + previous-channel MA tree properties, different group dimensions, and try multiple e10 configurations | N/A |
 
-For VarDCT, chunked encoding is disabled at distances >=3. Chunked encoding is also disabled when `--patches=1`.<br>For the entropy coding (context clustering, lz77 search, hybriduint configuration): slower/more exhaustive search as effort goes up.
+For the entropy coding (context clustering, lz77 search, hybriduint configuration): slower/more exhaustive search as effort goes up.
+
+<u>Chunked encoding is also disabled under these circumstances:</u>
+* When the image is smaller than 2048x2048.
+* Lossless Jpeg transcoding.
+* VarDCT at distances ≥20.
+* Effort 7 VarDCT at distances ≥3.0.
+* Effort 8 VarDCT at distances >0.5.
+* Lossy Modular.
+* When using any of these flags:
+  * `--patches=1`
+  * `--progressive_dc >0`
+  * `-p`
+  * `-d 0` and `-R 1`
+  * `--noise=1`
+  * `--resampling >1`
+  * `--disable_perceptual_optimizations`

--- a/doc/encode_effort.md
+++ b/doc/encode_effort.md
@@ -25,8 +25,8 @@ The following table describes what the various effort settings do:
 | e5 | e4 + patches, local palette / local channel palette, different local RCTs | e4 + gabor-like transform, chroma from luma |
 | e6 | e5 + more RCTs and MA tree properties | e5 + error diffusion, full variable blocks heuristics |
 | e7 | e6 + more RCTs and MA tree properties | e6 + patches (including dots) |
-| e8 | e7 + more RCTs, MA tree properties and Weighted predictor parameters | e7 + Butteraugli iterations for adaptive quantization and disables chunked encoding |
-| e9 | e8 + more RCTs, MA tree properties, and Gradient/Weighted predictors | e8 + more Butteraugli iterations |
+| e8 | e7 + more RCTs, MA tree properties, and Weighted predictor parameters | e7 + Butteraugli iterations for adaptive quantization and disables chunked encoding |
+| e9 | e8 + more RCTs, MA tree properties, and Weighted predictor parameters | e8 + more Butteraugli iterations |
 | e10 | e9 + global MA tree, try all predictors, and disables chunked encoding | e9 + more thorough adaptive quantization |
 | e11 | e10 + previous-channel MA tree properties, different group dimensions, and try multiple e10 configurations | N/A |
 


### PR DESCRIPTION
### Description
This should resolve #3517 and resolve #3904.
I updated benchmarking.md and encode_effort.md because effort 10 became effort 11 since libjxl 0.10. I also tweaked the wording to make it flow better.

### Things of note
~I updated all areas except VarDCT effort 10, I do not know what it does besides disabling chunked encoding. The header section in benchmarking.md has the `QABPP` category. I don't know what this acronym stands for (Quality Averaged Bits Per Pixel)?~
Edit: With some help all information gaps have been filled. :)

### Pull Request Checklist

- [x] **CLA Signed**: Have you signed the [Contributor License Agreement](https://code.google.com/legal/individual-cla-v1.0.html) (individual or corporate, as appropriate)? Only contributions from signed contributors can be accepted.
- [x] **Authors**: Have you considered adding your name to the [AUTHORS](AUTHORS) file?
- [x] **Code Style**: Have you ensured your code adheres to the project's coding style guidelines? You can use `./ci.sh lint` for automatic code formatting.

Please review the full [contributing guidelines](https://github.com/libjxl/libjxl/blob/main/CONTRIBUTING.md) for more details.