### PR TITLE
Disable cross-clang32 build

### DIFF
--- a/.github/workflows/build_test_md.yml
+++ b/.github/workflows/build_test_md.yml
@@ -51,7 +51,7 @@ jobs:
       matrix:
           include:
            - msystem: clang64
-           - msystem: clang32
+           # - msystem: clang32
     runs-on: ubuntu-latest
     steps:
       - name: Harden Runner

--- a/.github/workflows/build_test_msys2.yml
+++ b/.github/workflows/build_test_msys2.yml
@@ -39,8 +39,11 @@ jobs:
              - ButteraugliTest.Lossless
              - ButteraugliTest.Distmap
            disable_benchmark: true
-         - msystem: clang32
-           disable_benchmark: true
+         # "Legacy" toolchains are being "phased-out":
+         # https://www.msys2.org/news/#2023-12-13-starting-to-drop-some-32-bit-packages
+         # clang32 is already missing required "gtest" and "libavif"
+         # - msystem: clang32
+         #   disable_benchmark: true
 
     defaults:
       run:


### PR DESCRIPTION
Likely forever (with MSYS2 toolchain); perhaps we will get some other alternatives in the future.
