### PR TITLE
Make 0px channels eligible for "stop" check

### DIFF
--- a/lib/jxl/enc_modular.cc
+++ b/lib/jxl/enc_modular.cc
@@ -1031,6 +1031,7 @@ Status ModularFrameEncoder::ComputeEncodingData(
       if (fc.w > frame_dim_.group_dim || fc.h > frame_dim_.group_dim) break;
     }
     for (; ch < full_image.channel.size(); ch++) {
+      // TODO(eustas): shrink / assign channel to keep size consistency
       full_image.channel[ch].plane = ImageI();
     }
   }

--- a/lib/jxl/modular/encoding/enc_encoding.cc
+++ b/lib/jxl/modular/encoding/enc_encoding.cc
@@ -617,13 +617,13 @@ Status ModularEncode(const Image &image, const ModularOptions &options,
           options.max_property_values);
     }
     for (size_t i = 0; i < nb_channels; i++) {
-      if (!image.channel[i].w || !image.channel[i].h) {
-        continue;  // skip empty channels
-      }
       if (i >= image.nb_meta_channels &&
           (image.channel[i].w > options.max_chan_size ||
            image.channel[i].h > options.max_chan_size)) {
         break;
+      }
+      if (!image.channel[i].w || !image.channel[i].h) {
+        continue;  // skip empty channels
       }
       JXL_RETURN_IF_ERROR(GatherTreeData(
           image, i, group_id, header->wp_header, options,
@@ -694,13 +694,13 @@ Status ModularEncode(const Image &image, const ModularOptions &options,
     tokens->resize(pos + total_tokens);
     Token *tokenp = tokens->data() + pos;
     for (size_t i = 0; i < nb_channels; i++) {
-      if (!image.channel[i].w || !image.channel[i].h) {
-        continue;  // skip empty channels
-      }
       if (i >= image.nb_meta_channels &&
           (image.channel[i].w > options.max_chan_size ||
            image.channel[i].h > options.max_chan_size)) {
         break;
+      }
+      if (!image.channel[i].w || !image.channel[i].h) {
+        continue;  // skip empty channels
       }
       JXL_RETURN_IF_ERROR(EncodeModularChannelMAANS(
           image, i, header->wp_header, *tree, &tokenp, aux_out, group_id,

--- a/lib/jxl/modular/encoding/enc_ma.cc
+++ b/lib/jxl/modular/encoding/enc_ma.cc
@@ -935,13 +935,13 @@ void CollectPixelSamples(const Image &image, const ModularOptions &options,
   size_t total_pixels = 0;
   std::vector<size_t> channel_ids;
   for (size_t i = 0; i < image.channel.size(); i++) {
-    if (image.channel[i].w <= 1 || image.channel[i].h == 0) {
-      continue;  // skip empty or width-1 channels.
-    }
     if (i >= image.nb_meta_channels &&
         (image.channel[i].w > options.max_chan_size ||
          image.channel[i].h > options.max_chan_size)) {
       break;
+    }
+    if (image.channel[i].w <= 1 || image.channel[i].h == 0) {
+      continue;  // skip empty or width-1 channels.
     }
     channel_ids.push_back(i);
     group_pixel_count[group_id] += image.channel[i].w * image.channel[i].h;

--- a/lib/jxl/modular/encoding/encoding.cc
+++ b/lib/jxl/modular/encoding/encoding.cc
@@ -566,12 +566,12 @@ Status ModularDecode(BitReader *br, Image &image, GroupHeader &header,
   size_t distance_multiplier = 0;
   for (size_t i = 0; i < nb_channels; i++) {
     Channel &channel = image.channel[i];
-    if (!channel.w || !channel.h) {
-      continue;  // skip empty channels
-    }
     if (i >= image.nb_meta_channels && (channel.w > options->max_chan_size ||
                                         channel.h > options->max_chan_size)) {
       break;
+    }
+    if (!channel.w || !channel.h) {
+      continue;  // skip empty channels
     }
     if (channel.w > distance_multiplier) {
       distance_multiplier = channel.w;
@@ -631,13 +631,13 @@ Status ModularDecode(BitReader *br, Image &image, GroupHeader &header,
   uint32_t fl_v = 0;
   for (; next_channel < nb_channels; next_channel++) {
     Channel &channel = image.channel[next_channel];
-    if (!channel.w || !channel.h) {
-      continue;  // skip empty channels
-    }
     if (next_channel >= image.nb_meta_channels &&
         (channel.w > options->max_chan_size ||
          channel.h > options->max_chan_size)) {
       break;
+    }
+    if (!channel.w || !channel.h) {
+      continue;  // skip empty channels
     }
     JXL_RETURN_IF_ERROR(DecodeModularChannelMAANS(
         br, &reader, *context_map, *tree, header.wp_header, next_channel,


### PR DESCRIPTION
Before this PR 0px channels were "skipped" before the check. In some cases 1xK and Kx1 images are squeezed (for 420 subsampling) and thus 0xK / Kx0 channels appear.