### PR TITLE
PNG: write cLLI instead of cLLi, per recent update

### DIFF
--- a/lib/extras/enc/apng.cc
+++ b/lib/extras/enc/apng.cc
@@ -272,12 +272,12 @@ void MaybeAddCLLi(const JxlColorEncoding& c_enc, const float intensity_target,
   png_save_uint_32(chunk_data, max_content_light_level);
   // Leave MaxFALL set to 0.
   png_unknown_chunk chunk;
-  memcpy(chunk.name, "cLLi", 5);
+  memcpy(chunk.name, "cLLI", 5);
   chunk.data = chunk_data;
   chunk.size = sizeof chunk_data;
   chunk.location = PNG_HAVE_IHDR;
   png_set_keep_unknown_chunks(png_ptr, PNG_HANDLE_CHUNK_ALWAYS,
-                              reinterpret_cast<const png_byte*>("cLLi"), 1);
+                              reinterpret_cast<const png_byte*>("cLLI"), 1);
   png_set_unknown_chunks(png_ptr, info_ptr, &chunk, 1);
 }
 


### PR DESCRIPTION
https://w3c.github.io/png/#cLLI-chunk

Reading remains to be updated. (We might want to read both?)