### PR TITLE
Make gcov parser "suspicious_hits" a warning, not error

### DIFF
--- a/ci.sh
+++ b/ci.sh
@@ -522,6 +522,7 @@ cmd_coverage_report() {
   local gcovr_args=(
     -r "${real_build_dir}"
     --gcov-executable "${LLVM_COV} gcov"
+    --gcov-ignore-parse-errors suspicious_hits.warn_once_per_file
     # Only print coverage information for the libjxl directories. The rest
     # is not part of the code under test.
     --filter '.*jxl/.*'


### PR DESCRIPTION
That is gcov issue we can not work around.
