### PR TITLE
Fix some clang-tidy findings

### DIFF
--- a/lib/jxl/enc_frame.cc
+++ b/lib/jxl/enc_frame.cc
@@ -768,6 +768,7 @@ Status ComputeJPEGTranscodingData(const jpeg::JPEGData& jpeg_data,
       JpegOrder(frame_header.color_transform, jpeg_data.components.size() == 1);
 
   std::vector<int> qt(192);
+  std::array<int32_t, 3> qt_dc;
   for (size_t c = 0; c < 3; c++) {
     size_t jpeg_c = jpeg_c_map[c];
     const int32_t* quant =
@@ -780,6 +781,7 @@ Status ComputeJPEGTranscodingData(const jpeg::JPEGData& jpeg_data,
         qt[c * 64 + 8 * x + y] = quant[8 * y + x];
       }
     }
+    qt_dc[c] = qt[c * 64];
   }
   JXL_RETURN_IF_ERROR(DequantMatricesSetCustomDC(
       memory_manager, &shared.matrices, dcquantization));
@@ -956,7 +958,7 @@ Status ComputeJPEGTranscodingData(const jpeg::JPEGData& jpeg_data,
           if (DCzero) {
             idc = inputjpeg[base];
           } else {
-            idc = inputjpeg[base] + 1024 / qt[c * 64];
+            idc = inputjpeg[base] + 1024 / qt_dc[c];
           }
           dc_counts[c][std::min(static_cast<uint32_t>(idc + 1024),
                                 static_cast<uint32_t>(2047))]++;

--- a/lib/jxl/render_pipeline/render_pipeline_test.cc
+++ b/lib/jxl/render_pipeline/render_pipeline_test.cc
@@ -112,7 +112,8 @@ TEST(RenderPipelineTest, Build) {
   ASSERT_TRUE(builder.AddStage(jxl::make_unique<Check0FinalStage>()));
   builder.UseSimpleImplementation();
   FrameDimensions frame_dimensions;
-  frame_dimensions.Set(/*xsize=*/1024, /*ysize=*/1024, /*group_size_shift=*/0,
+  frame_dimensions.Set(/*xsize_px=*/1024, /*ysize_px=*/1024,
+                       /*group_size_shift=*/0,
                        /*max_hshift=*/0, /*max_vshift=*/0,
                        /*modular_mode=*/false, /*upsampling=*/1);
   JXL_TEST_ASSIGN_OR_DIE(auto pipeline,
@@ -128,7 +129,8 @@ TEST(RenderPipelineTest, CallAllGroups) {
   ASSERT_TRUE(builder.AddStage(jxl::make_unique<Check0FinalStage>()));
   builder.UseSimpleImplementation();
   FrameDimensions frame_dimensions;
-  frame_dimensions.Set(/*xsize=*/1024, /*ysize=*/1024, /*group_size_shift=*/0,
+  frame_dimensions.Set(/*xsize_px=*/1024, /*ysize_px=*/1024,
+                       /*group_size_shift=*/0,
                        /*max_hshift=*/0, /*max_vshift=*/0,
                        /*modular_mode=*/false, /*upsampling=*/1);
   JXL_TEST_ASSIGN_OR_DIE(auto pipeline,
@@ -152,7 +154,8 @@ TEST(RenderPipelineTest, BuildFast) {
   ASSERT_TRUE(builder.AddStage(jxl::make_unique<UpsampleYSlowStage>()));
   ASSERT_TRUE(builder.AddStage(jxl::make_unique<Check0FinalStage>()));
   FrameDimensions frame_dimensions;
-  frame_dimensions.Set(/*xsize=*/1024, /*ysize=*/1024, /*group_size_shift=*/0,
+  frame_dimensions.Set(/*xsize_px=*/1024, /*ysize_px=*/1024,
+                       /*group_size_shift=*/0,
                        /*max_hshift=*/0, /*max_vshift=*/0,
                        /*modular_mode=*/false, /*upsampling=*/1);
   JXL_TEST_ASSIGN_OR_DIE(auto pipeline,
@@ -168,7 +171,8 @@ TEST(RenderPipelineTest, CallAllGroupsFast) {
   ASSERT_TRUE(builder.AddStage(jxl::make_unique<Check0FinalStage>()));
   builder.UseSimpleImplementation();
   FrameDimensions frame_dimensions;
-  frame_dimensions.Set(/*xsize=*/1024, /*ysize=*/1024, /*group_size_shift=*/0,
+  frame_dimensions.Set(/*xsize_px=*/1024, /*ysize_px=*/1024,
+                       /*group_size_shift=*/0,
                        /*max_hshift=*/0, /*max_vshift=*/0,
                        /*modular_mode=*/false, /*upsampling=*/1);
   JXL_TEST_ASSIGN_OR_DIE(auto pipeline,

--- a/lib/jxl/tf_gbench.cc
+++ b/lib/jxl/tf_gbench.cc
@@ -26,6 +26,7 @@ namespace {
   auto sum2 = Zero(d);                                              \
   auto sum3 = Zero(d);                                              \
   for (auto _ : state) {                                            \
+    (void)_;                                                        \
     auto x = Set(d, 1e-5);                                          \
     auto v1 = Set(d, 1e-5);                                         \
     auto v2 = Set(d, 1.1e-5);                                       \
@@ -50,6 +51,7 @@ namespace {
   float sum2 = 0;                                            \
   float sum3 = 0;                                            \
   for (auto _ : state) {                                     \
+    (void)_;                                                 \
     float x = 1e-5;                                          \
     float v1 = 1e-5;                                         \
     float v2 = 1.1e-5;                                       \

--- a/tools/gauss_blur_gbench.cc
+++ b/tools/gauss_blur_gbench.cc
@@ -45,6 +45,7 @@ void BM_GaussBlur1d(benchmark::State& state) {
                      "Failed to allocate image.");
   const auto rg = CreateRecursiveGaussian(sigma);
   for (auto _ : state) {
+    (void)_;
     FastGaussian1D(rg, length, in.Row(0), out.Row(0));
     // Prevent optimizing out
     BM_CHECK(std::abs(out.ConstRow(0)[length / 2] - expected) / expected <
@@ -71,6 +72,7 @@ void BM_GaussBlur2d(benchmark::State& state) {
                      "Failed to allocate image.");
   const auto rg = CreateRecursiveGaussian(sigma);
   for (auto _ : state) {
+    (void)_;
     BM_CHECK(FastGaussian(
         memory_manager, rg, in.xsize(), in.ysize(),
         [&](size_t y) { return in.ConstRow(y); },


### PR DESCRIPTION
Most notably: use-after-move
