### PR TITLE
add decode option to set leniency

### DIFF
--- a/lib/extras/dec/jxl.cc
+++ b/lib/extras/dec/jxl.cc
@@ -227,6 +227,10 @@ bool DecodeImageJXL(const uint8_t* bytes, size_t bytes_size,
       fprintf(stderr, "JxlDecoderSetDecompressBoxes failed\n");
       return false;
     }
+    if (JXL_DEC_SUCCESS != JxlDecoderSetLeniency(dec, dparams.leniency)) {
+      fprintf(stderr, "JxlDecoderSetLeniency failed\n");
+      return false;
+    }
   }
   if (JXL_DEC_SUCCESS != JxlDecoderSetInput(dec, bytes, bytes_size)) {
     fprintf(stderr, "Decoder failed to set input\n");

--- a/lib/extras/dec/jxl.h
+++ b/lib/extras/dec/jxl.h
@@ -46,6 +46,9 @@ struct JXLDecompressParams {
   // Whether truncated input should be treated as an error.
   bool allow_partial_input = false;
 
+  // How lenient to be when input is corrupt.
+  int leniency = 0;
+
   // How many passes to decode at most. By default, decode everything.
   uint32_t max_passes = std::numeric_limits<uint32_t>::max();
 

--- a/lib/include/jxl/decode.h
+++ b/lib/include/jxl/decode.h
@@ -474,6 +474,24 @@ JXL_EXPORT size_t JxlDecoderSizeHintBasicInfo(const JxlDecoder* dec);
 JXL_EXPORT JxlDecoderStatus JxlDecoderSubscribeEvents(JxlDecoder* dec,
                                                       int events_wanted);
 
+/** Configure how strict or lenient the decoder is when the input bitstream
+ * is technically non-conforming, truncated or corrupt.
+ * By default, the value is 0. Higher values mean more leniency, lower values
+ * mean stricter.
+ * Currently supported values are:
+ * -2: fully check bitstream conformance including value range (not implemented)
+ * -1: check signaled level limitations, error on corruption (not implemented)
+ * 0 (default): check Main profile Level 10 limitations, error on corruption
+ * 1: recover HF corruption, error on other corruption
+ * 2: recover all recoverable corruption, error on non-recoverable corruption
+ *
+ * @param dec decoder object
+ * @param leniency amount of leniency regarding invalid input
+ * @return ::JXL_DEC_SUCCESS if no error, ::JXL_DEC_ERROR otherwise.
+ */
+JXL_EXPORT JxlDecoderStatus JxlDecoderSetLeniency(JxlDecoder* dec,
+                                                  int leniency);
+
 /** Enables or disables preserving of as-in-bitstream pixeldata
  * orientation. Some images are encoded with an Orientation tag
  * indicating that the decoder must perform a rotation and/or

--- a/lib/jxl/dec_cache.h
+++ b/lib/jxl/dec_cache.h
@@ -119,6 +119,8 @@ struct PassesDecoderState {
   // output.
   bool unpremul_alpha;
 
+  int leniency = 0;
+
   // The render pipeline will apply this orientation to bring the image to the
   // intended display orientation.
   Orientation undo_orientation;

--- a/lib/jxl/dec_frame.h
+++ b/lib/jxl/dec_frame.h
@@ -54,6 +54,7 @@ class FrameDecoder {
 
   void SetRenderSpotcolors(bool rsc) { render_spotcolors_ = rsc; }
   void SetCoalescing(bool c) { coalescing_ = c; }
+  void SetLeniency(int l) { leniency_ = l; }
 
   // Read FrameHeader and table of contents from the given BitReader.
   Status InitFrame(BitReader* JXL_RESTRICT br, ImageBundle* decoded,
@@ -195,6 +196,7 @@ class FrameDecoder {
                       bool unpremul_alpha, bool undo_orientation) const {
     dec_state_->width = xsize;
     dec_state_->height = ysize;
+    dec_state_->leniency = leniency_;
     dec_state_->main_output.format = format;
     dec_state_->main_output.bits_per_sample = bits_per_sample;
     dec_state_->main_output.callback = pixel_callback;
@@ -310,6 +312,7 @@ class FrameDecoder {
   ModularFrameDecoder modular_frame_decoder_;
   bool render_spotcolors_ = true;
   bool coalescing_ = true;
+  int leniency_ = 0;
 
   std::vector<uint8_t> processed_section_;
   std::vector<uint8_t> decoded_passes_per_ac_group_;

--- a/tools/djxl_main.cc
+++ b/tools/djxl_main.cc
@@ -120,6 +120,13 @@ struct DecompressArgs {
                            "Allow decoding of truncated files.",
                            &allow_partial_files, &SetBooleanTrue, 1);
 
+    cmdline->AddOptionValue(
+        '\0', "leniency", "N",
+        "Set decoder leniency/strictness. Default is 0. Lower values are "
+        "stricter, higher values more lenient. Can be used to recover an image "
+        "from a corrupt bitstream.",
+        &leniency, &ParseSigned, 1);
+
     if (jxl::extras::GetJPEGEncoder()) {
       cmdline->AddOptionFlag(
           'j', "pixels_to_jpeg",
@@ -246,6 +253,7 @@ struct DecompressArgs {
   std::string color_space;
   uint32_t downsampling = 0;
   bool allow_partial_files = false;
+  int leniency = 0;
   bool pixels_to_jpeg = false;
   size_t jpeg_quality = 95;
   bool use_sjpeg = false;
@@ -384,6 +392,7 @@ bool DecompressJxlToPackedPixelFile(
   dparams.runner = JxlThreadParallelRunner;
   dparams.runner_opaque = runner;
   dparams.allow_partial_input = args.allow_partial_files;
+  dparams.leniency = args.leniency;
   if (args.bits_per_sample == 0) {
     dparams.output_bitdepth.type = JXL_BIT_DEPTH_FROM_CODESTREAM;
   } else if (args.bits_per_sample > 0) {


### PR DESCRIPTION
This allows decoding (some) corrupt bitstreams. Fixes #3712.

Does not catch all kinds of corruptions yet, nor does it handle them in the best possible way, but it's a start.

The function `JxlDecoderSetLeniency()` is added, as well as the corresponding `djxl` option `--leniency=N`.
Default leniency is zero which does not change any behavior.

Leniency 1:
Corrupted HF sections are replaced with LF only (in case of VarDCT) or zeroes (in case of Modular).
This is a reasonable "graceful degradation": in case of lossy (VarDCT or Modular) it means the corrupt region becomes blurry; in case of lossless it means the corrupt region becomes black.

Leniency 2:
On top of leniency 1, also continue if LF sections are corrupt (corresponding to 2048x2048 pixels).
Corrupted LF sections are just turned entirely black.

This creates a basic mechanism for some amount of error recovery; instead of just returning an error when a bitstream is corrupt, you can now get a reasonable image.

TODO: better handle multi-pass and multi-frame.

Negative leniency (not implemented yet) can be useful if we want to have a way to be "stricter than default".

E.g. we currently don't check value ranges / integer overflows in places where checking would cause a slowdown (e.g. checking that modular data remains in int16 / int32 range, etc) so libjxl does decode some invalid codestreams without complaining. Having a way to validate codestreams would be nice, but it's probably best to keep that a non-default option since it will cause slowdown. Also I think we currently only check level 10 limits but not level 5 ones. Anyway: negative leniency is not implemented yet but it could be another use of this decode option besides positive leniency to handle corrupt bitstreams.
