### PR TITLE
Fix description of the box size field

### DIFF
--- a/lib/include/jxl/encode.h
+++ b/lib/include/jxl/encode.h
@@ -1004,8 +1004,9 @@ JXL_EXPORT JxlEncoderStatus JxlEncoderSetExtraChannelBuffer(
  * case metadata cannot be added.
  *
  * Each box generally has the following byte structure in the file:
- * - 4 bytes: box size including box header (Big endian. If set to 0, an
- *   8-byte 64-bit size follows instead).
+ * - 4 bytes: box size including box header (Big endian. If set to 1, an
+ *   8-byte 64-bit size follows instead. If set to 0, the box extends to the
+ *   end of the file.)
  * - 4 bytes: type, e.g. "JXL " for the signature box, "jxlc" for a codestream
  *   box.
  * - N bytes: box contents.


### PR DESCRIPTION
### Description

Fixes the description of how extended box size is signaled in the container format.  Just a comment fix - the code in encode.cc and decode.cc already behaves correctly.

### Pull Request Checklist

- [x] **CLA Signed**: Have you signed the [Contributor License Agreement](https://code.google.com/legal/individual-cla-v1.0.html) (individual or corporate, as appropriate)? Only contributions from signed contributors can be accepted.
- [x] **Authors**: Have you considered adding your name to the [AUTHORS](AUTHORS) file?
- [x] **Code Style**: Have you ensured your code adheres to the project's coding style guidelines? You can use `./ci.sh lint` for automatic code formatting.


Please review the full [contributing guidelines](https://github.com/libjxl/libjxl/blob/main/CONTRIBUTING.md) for more details.
