### PR TITLE
Fix to build static linked binaries on macOS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -254,7 +254,7 @@ if(JPEGXL_STATIC)
   # Clang developers say that in case to use "static" we have to build stdlib
   # ourselves; for real use case we don't care about stdlib, as it is "granted",
   # so just linking all other libraries is fine.
-  if (NOT MSVC)
+  if (NOT MSVC AND NOT APPLE)
     string(APPEND CMAKE_EXE_LINKER_FLAGS " -static")
   endif()
   if ((NOT WIN32 AND NOT APPLE) OR CYGWIN OR MINGW)

--- a/third_party/CMakeLists.txt
+++ b/third_party/CMakeLists.txt
@@ -135,6 +135,8 @@ elseif (JPEGXL_BUNDLE_LIBPNG)
     message(FATAL_ERROR "Please run ${PROJECT_SOURCE_DIR}/deps.sh to fetch the "
             "build dependencies.")
   endif()
+  file(COPY "${CMAKE_CURRENT_SOURCE_DIR}/libpng/scripts/pnglibconf.h.prebuilt" DESTINATION "${CMAKE_CURRENT_SOURCE_DIR}/libpng")
+  file(RENAME "${CMAKE_CURRENT_SOURCE_DIR}/libpng/pnglibconf.h.prebuilt" "${CMAKE_CURRENT_SOURCE_DIR}/libpng/pnglibconf.h")
   add_subdirectory(zlib)
   set(PNG_STATIC ON CACHE BOOL "")
   set(PNG_EXECUTABLES OFF CACHE BOOL "")


### PR DESCRIPTION
This PR enables building statically linked binaries on macOS.

When attempting to build statically linked binaries with Apple's C++ compiler, the -static flag causes an error due to the absence of static versions of libc++ and libSystem. 

omiting this flag, will build everything statically linked, with these two system libraries remaining dynamically linked—which is absolutely fine.

Additionally, the changes include copying pnglibconf.h.prebuild to libpngconf.h to resolve build dependencies when compiling lib/extras/dec/apng.cc or lib/extras/enc/apng.cc



