### PR TITLE
Fix pixbufloader test

### DIFF
--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -192,6 +192,7 @@ jobs:
           libwebp-dev \
           ninja-build \
           pkg-config \
+          xdg-utils \
           xvfb \
           ${{ matrix.apt_pkgs }} \
         #

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -92,6 +92,7 @@ jobs:
             libwebp-dev \
             ninja-build \
             pkg-config \
+            xdg-utils \
             xvfb \
             ${{ matrix.apt_pkgs }} \
           #

--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -107,6 +107,7 @@ jobs:
           libwebp-dev \
           ninja-build \
           pkg-config \
+          xdg-utils \
           xvfb \
           ${{ matrix.apt_pkgs }} \
         #

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -66,6 +66,7 @@ jobs:
           libwebp-dev \
           ninja-build \
           pkg-config \
+          xdg-utils \
         #
         echo "CC=clang" >> $GITHUB_ENV
         echo "CXX=clang++" >> $GITHUB_ENV

--- a/plugins/gdk-pixbuf/CMakeLists.txt
+++ b/plugins/gdk-pixbuf/CMakeLists.txt
@@ -44,9 +44,10 @@ if(BUILD_TESTING AND NOT CMAKE_CROSSCOMPILING)
     add_executable(pixbufloader_test pixbufloader_test.cc)
     target_link_libraries(pixbufloader_test PkgConfig::Gdk)
 
-    find_program (XDG_MIME_PROGRAM xdg-mime)
+    find_program(XDG_MIME_PROGRAM xdg-mime)
     if (NOT XDG_MIME_PROGRAM)
-      message(FATAL "xdg-mime is required for testing pixbufloader")
+      message(WARNING "xdg-mime is required for testing pixbufloader; consider installing xdg-utils package")
+      return()
     endif()
 
     # Create a mime cache for test.


### PR DESCRIPTION
Before it was breaking build too late (because message parameter should have been FATAL_ERROR, not FATAL).

Now it skips test if required binary is not found.

Instead fix all packages list to contain xdg-utils.
