### PR TITLE
Do not use CodecInOut in (core) libjxl

### DIFF
--- a/lib/extras/codec.cc
+++ b/lib/extras/codec.cc
@@ -11,6 +11,7 @@
 #include <string>
 #include <vector>
 
+#include "lib/extras/codec_in_out.h"
 #include "lib/extras/dec/color_hints.h"
 #include "lib/extras/dec/decode.h"
 #include "lib/extras/enc/apng.h"
@@ -24,7 +25,6 @@
 #include "lib/jxl/base/data_parallel.h"
 #include "lib/jxl/base/span.h"
 #include "lib/jxl/base/status.h"
-#include "lib/jxl/codec_in_out.h"
 
 namespace jxl {
 namespace {

--- a/lib/extras/codec.h
+++ b/lib/extras/codec.h
@@ -12,6 +12,7 @@
 #include <string>
 #include <vector>
 
+#include "lib/extras/codec_in_out.h"
 #include "lib/extras/dec/color_hints.h"
 #include "lib/extras/dec/decode.h"
 #include "lib/extras/packed_image.h"
@@ -19,7 +20,6 @@
 #include "lib/jxl/base/data_parallel.h"
 #include "lib/jxl/base/span.h"
 #include "lib/jxl/base/status.h"
-#include "lib/jxl/codec_in_out.h"
 
 namespace jxl {
 

--- a/lib/extras/codec_in_out.h
+++ b/lib/extras/codec_in_out.h
@@ -11,7 +11,6 @@
 #include <jxl/memory_manager.h>
 
 #include <cstddef>
-#include <cstdint>
 #include <utility>
 #include <vector>
 
@@ -20,18 +19,10 @@
 #include "lib/jxl/headers.h"
 #include "lib/jxl/image.h"
 #include "lib/jxl/image_bundle.h"
+#include "lib/jxl/image_metadata.h"
 #include "lib/jxl/luminance.h"
 
 namespace jxl {
-
-// Optional text/EXIF metadata.
-struct Blobs {
-  std::vector<uint8_t> exif;
-  std::vector<uint8_t> iptc;
-  std::vector<uint8_t> jhgm;
-  std::vector<uint8_t> jumbf;
-  std::vector<uint8_t> xmp;
-};
 
 // Holds a preview, a main image or one or more frames, plus the inputs/outputs
 // to/from decoding/encoding.
@@ -106,8 +97,6 @@ class CodecInOut {
   // Metadata stored into / retrieved from bitstreams.
 
   JxlMemoryManager* memory_manager;
-
-  Blobs blobs;
 
   CodecMetadata metadata;  // applies to preview and all frames
 

--- a/lib/extras/packed_image_convert.cc
+++ b/lib/extras/packed_image_convert.cc
@@ -15,13 +15,14 @@
 #include <cstdio>
 #include <utility>
 
+#include "lib/extras/codec_in_out.h"
 #include "lib/extras/packed_image.h"
 #include "lib/jxl/base/data_parallel.h"
 #include "lib/jxl/base/rect.h"
 #include "lib/jxl/base/span.h"
 #include "lib/jxl/base/status.h"
-#include "lib/jxl/codec_in_out.h"
 #include "lib/jxl/color_encoding_internal.h"
+#include "lib/jxl/dec_cache.h"
 #include "lib/jxl/dec_external_image.h"
 #include "lib/jxl/enc_external_image.h"
 #include "lib/jxl/enc_image_bundle.h"
@@ -157,13 +158,6 @@ Status ConvertPackedPixelFileToCodecInOut(const PackedPixelFile& ppf,
       return JXL_FAILURE("Failed to serialize ICC");
     }
   }
-
-  // Convert the extra blobs
-  io->blobs.exif = ppf.metadata.exif;
-  io->blobs.iptc = ppf.metadata.iptc;
-  io->blobs.jhgm = ppf.metadata.jhgm;
-  io->blobs.jumbf = ppf.metadata.jumbf;
-  io->blobs.xmp = ppf.metadata.xmp;
 
   // Append all other extra channels.
   for (const auto& info : ppf.extra_channels_info) {
@@ -306,12 +300,6 @@ Status ConvertCodecInOutToPackedPixelFile(const CodecInOut& io,
                           : PackedPixelFile::kColorEncodingIsPrimary;
   ppf->color_encoding = c_desired.ToExternal();
 
-  // Convert the extra blobs
-  ppf->metadata.exif = io.blobs.exif;
-  ppf->metadata.iptc = io.blobs.iptc;
-  ppf->metadata.jhgm = io.blobs.jhgm;
-  ppf->metadata.jumbf = io.blobs.jumbf;
-  ppf->metadata.xmp = io.blobs.xmp;
   const bool float_out = pixel_format.data_type == JXL_TYPE_FLOAT ||
                          pixel_format.data_type == JXL_TYPE_FLOAT16;
   // Convert the pixels

--- a/lib/extras/packed_image_convert.h
+++ b/lib/extras/packed_image_convert.h
@@ -11,10 +11,10 @@
 
 #include <jxl/types.h>
 
+#include "lib/extras/codec_in_out.h"
 #include "lib/extras/packed_image.h"
 #include "lib/jxl/base/data_parallel.h"
 #include "lib/jxl/base/status.h"
-#include "lib/jxl/codec_in_out.h"
 #include "lib/jxl/color_encoding_internal.h"
 #include "lib/jxl/image.h"
 

--- a/lib/extras/tone_mapping.cc
+++ b/lib/extras/tone_mapping.cc
@@ -9,11 +9,11 @@
 #include <cstdint>
 #include <utility>
 
+#include "lib/extras/codec_in_out.h"
 #include "lib/jxl/base/compiler_specific.h"
 #include "lib/jxl/base/data_parallel.h"
 #include "lib/jxl/base/matrix_ops.h"
 #include "lib/jxl/base/status.h"
-#include "lib/jxl/codec_in_out.h"
 #include "lib/jxl/color_encoding_internal.h"
 
 #undef HWY_TARGET_INCLUDE

--- a/lib/extras/tone_mapping.h
+++ b/lib/extras/tone_mapping.h
@@ -8,9 +8,9 @@
 
 #include <utility>
 
+#include "lib/extras/codec_in_out.h"
 #include "lib/jxl/base/data_parallel.h"
 #include "lib/jxl/base/status.h"
-#include "lib/jxl/codec_in_out.h"
 
 namespace jxl {
 

--- a/lib/extras/tone_mapping_gbench.cc
+++ b/lib/extras/tone_mapping_gbench.cc
@@ -8,10 +8,10 @@
 #include <utility>
 
 #include "benchmark/benchmark.h"
+#include "lib/extras/codec_in_out.h"
 #include "lib/extras/tone_mapping.h"
 #include "lib/jxl/base/common.h"
 #include "lib/jxl/base/status.h"
-#include "lib/jxl/codec_in_out.h"
 #include "lib/jxl/color_encoding_internal.h"
 #include "lib/jxl/image.h"
 #include "lib/jxl/image_ops.h"

--- a/lib/jxl/decode_test.cc
+++ b/lib/jxl/decode_test.cc
@@ -23,6 +23,7 @@
 #include <cstdio>
 #include <cstdlib>
 #include <cstring>
+#include <memory>
 #include <ostream>
 #include <set>
 #include <sstream>
@@ -256,7 +257,7 @@ std::vector<uint8_t> CreateTestJXLCodestream(
   EXPECT_TRUE(ConvertFromExternal(pixels, xsize, ysize, color_encoding,
                                   /*bits_per_sample=*/16, format,
                                   /* pool */ nullptr, &io->Main()));
-  std::vector<uint8_t> jpeg_data;
+  std::vector<uint8_t> encoded_jpeg_bytes;
   if (params.jpeg_codestream != nullptr) {
     if (jxl::extras::CanDecode(jxl::extras::Codec::kJPG)) {
       std::vector<uint8_t> jpeg_bytes;
@@ -276,10 +277,13 @@ std::vector<uint8_t> CreateTestJXLCodestream(
       EXPECT_TRUE(encoder->Encode(ppf, &encoded, nullptr));
       jpeg_bytes = encoded.bitstreams[0];
       Bytes(jpeg_bytes).AppendTo(*params.jpeg_codestream);
-      EXPECT_TRUE(jxl::jpeg::DecodeImageJPG(
-          jxl::Bytes(jpeg_bytes.data(), jpeg_bytes.size()), io.get()));
+      JXL_TEST_ASSIGN_OR_DIE(
+          std::unique_ptr<jxl::jpeg::JPEGData> jpeg_data,
+          jxl::jpeg::ParseJPG(memory_manager, jxl::Bytes(jpeg_bytes)));
+      EXPECT_TRUE(
+          jxl::test::JpegDataToCodecInOut(std::move(jpeg_data), io.get()));
       EXPECT_TRUE(EncodeJPEGData(memory_manager, *io->Main().jpeg_data,
-                                 &jpeg_data, params.cparams));
+                                 &encoded_jpeg_bytes, params.cparams));
       io->metadata.m.xyb_encoded = false;
     } else {
       ADD_FAILURE();
@@ -325,9 +329,9 @@ std::vector<uint8_t> CreateTestJXLCodestream(
       std::vector<uint8_t> c;
       Bytes(header).AppendTo(c);
       if (params.jpeg_codestream != nullptr) {
-        jxl::AppendBoxHeader(jxl::MakeBoxType("jbrd"), jpeg_data.size(), false,
-                             &c);
-        Bytes(jpeg_data).AppendTo(c);
+        jxl::AppendBoxHeader(jxl::MakeBoxType("jbrd"),
+                             encoded_jpeg_bytes.size(), false, &c);
+        Bytes(encoded_jpeg_bytes).AppendTo(c);
       }
       uint32_t jxlp_index = 0;
       if (add_container == kCSBF_Multi_First_Empty) {
@@ -404,9 +408,9 @@ std::vector<uint8_t> CreateTestJXLCodestream(
       std::vector<uint8_t> c;
       Bytes(header).AppendTo(c);
       if (params.jpeg_codestream != nullptr) {
-        jxl::AppendBoxHeader(jxl::MakeBoxType("jbrd"), jpeg_data.size(), false,
-                             &c);
-        Bytes(jpeg_data).AppendTo(c);
+        jxl::AppendBoxHeader(jxl::MakeBoxType("jbrd"),
+                             encoded_jpeg_bytes.size(), false, &c);
+        Bytes(encoded_jpeg_bytes).AppendTo(c);
       }
       if (add_container == kCSBF_Brob_Exif) {
         Bytes(box_brob_exif, box_brob_exif_size).AppendTo(c);
@@ -4988,7 +4992,10 @@ JXL_TRANSCODE_JPEG_TEST(DecodeTest, JPEGReconstructionTest) {
   const std::string jpeg_path = "jxl/flower/flower.png.im_q85_420.jpg";
   const std::vector<uint8_t> orig = jxl::test::ReadTestData(jpeg_path);
   auto orig_io = jxl::make_unique<jxl::CodecInOut>(memory_manager);
-  ASSERT_TRUE(jxl::jpeg::DecodeImageJPG(jxl::Bytes(orig), orig_io.get()));
+  JXL_TEST_ASSIGN_OR_DIE(std::unique_ptr<jxl::jpeg::JPEGData> jpeg_data,
+                         jxl::jpeg::ParseJPG(memory_manager, jxl::Bytes(orig)));
+  ASSERT_TRUE(
+      jxl::test::JpegDataToCodecInOut(std::move(jpeg_data), orig_io.get()));
   jxl::jpeg::JPEGData jpeg_data_copy = *orig_io->Main().jpeg_data;
   orig_io->metadata.m.xyb_encoded = false;
   jxl::BitWriter writer{memory_manager};
@@ -5002,14 +5009,14 @@ JXL_TRANSCODE_JPEG_TEST(DecodeTest, JPEGReconstructionTest) {
                                /*pool=*/nullptr, &writer,
                                /*aux_out=*/nullptr));
 
-  std::vector<uint8_t> jpeg_data;
-  ASSERT_TRUE(
-      EncodeJPEGData(memory_manager, jpeg_data_copy, &jpeg_data, cparams));
+  std::vector<uint8_t> encoded_jpeg_data;
+  ASSERT_TRUE(EncodeJPEGData(memory_manager, jpeg_data_copy, &encoded_jpeg_data,
+                             cparams));
   std::vector<uint8_t> container;
   jxl::Bytes(jxl::kContainerHeader).AppendTo(container);
-  jxl::AppendBoxHeader(jxl::MakeBoxType("jbrd"), jpeg_data.size(), false,
-                       &container);
-  jxl::Bytes(jpeg_data).AppendTo(container);
+  jxl::AppendBoxHeader(jxl::MakeBoxType("jbrd"), encoded_jpeg_data.size(),
+                       false, &container);
+  jxl::Bytes(encoded_jpeg_data).AppendTo(container);
   jxl::AppendBoxHeader(jxl::MakeBoxType("jxlc"), 0, true, &container);
   jxl::PaddedBytes codestream = std::move(writer).TakeBytes();
   jxl::Bytes(codestream).AppendTo(container);

--- a/lib/jxl/enc_bit_writer_test.cc
+++ b/lib/jxl/enc_bit_writer_test.cc
@@ -34,7 +34,7 @@ struct BitPatch {
 TEST(BitWriterTest, RandomSequence) {
   JxlMemoryManager* memory_manager = jxl::test::MemoryManager();
 
-  auto mt = std::make_unique<std::mt19937>(42);
+  auto mt = jxl::make_unique<std::mt19937>(42);
   std::uniform_int_distribution<> num_bits_dist(1, BitWriter::kMaxBitsPerCall);
   constexpr size_t kNumSequences = 1024 * 1024;
   std::vector<BitPatch> content;

--- a/lib/jxl/encode.cc
+++ b/lib/jxl/encode.cc
@@ -5,6 +5,7 @@
 
 #include <brotli/encode.h>
 #include <jxl/cms.h>
+#include <jxl/cms_interface.h>
 #include <jxl/codestream_header.h>
 #include <jxl/color_encoding.h>
 #include <jxl/encode.h>
@@ -35,7 +36,7 @@
 #include "lib/jxl/base/sanitizers.h"
 #include "lib/jxl/base/span.h"
 #include "lib/jxl/base/status.h"
-#include "lib/jxl/codec_in_out.h"
+#include "lib/jxl/cms/color_encoding_cms.h"
 #include "lib/jxl/color_encoding_internal.h"
 #include "lib/jxl/common.h"
 #include "lib/jxl/enc_aux_out.h"
@@ -50,6 +51,7 @@
 #include "lib/jxl/frame_header.h"
 #include "lib/jxl/image_metadata.h"
 #include "lib/jxl/jpeg/enc_jpeg_data.h"
+#include "lib/jxl/jpeg/jpeg_data.h"
 #include "lib/jxl/luminance.h"
 #include "lib/jxl/memory_manager_internal.h"
 #include "lib/jxl/modular/options.h"
@@ -798,9 +800,8 @@ jxl::Status JxlEncoderStruct::ProcessOneEnqueuedInput() {
     }
     // Only send ICC (at least several hundred bytes) if fields aren't enough.
     if (metadata.m.color_encoding.WantICC()) {
-      if (!jxl::WriteICC(
-              jxl::Span<const uint8_t>(metadata.m.color_encoding.ICC()),
-              &writer, jxl::LayerType::Header, aux_out)) {
+      if (!jxl::WriteICC(jxl::Bytes(metadata.m.color_encoding.ICC()), &writer,
+                         jxl::LayerType::Header, aux_out)) {
         return JXL_API_ERROR(this, JXL_ENC_ERR_GENERIC,
                              "Failed to write ICC profile");
       }
@@ -2105,21 +2106,27 @@ JxlEncoderStatus GetCurrentDimensions(
 JxlEncoderStatus JxlEncoderAddJPEGFrame(
     const JxlEncoderFrameSettings* frame_settings, const uint8_t* buffer,
     size_t size) {
+  JxlMemoryManager* memory_manager = &frame_settings->enc->memory_manager;
   if (frame_settings->enc->frames_closed) {
     return JXL_API_ERROR(frame_settings->enc, JXL_ENC_ERR_API_USAGE,
                          "Frame input is already closed");
   }
 
-  jxl::CodecInOut io{&frame_settings->enc->memory_manager};
-  if (!jxl::jpeg::DecodeImageJPG(jxl::Bytes(buffer, size), &io)) {
+  std::unique_ptr<jxl::jpeg::JPEGData> jpeg_data;
+  auto decode_jpg = [&]() -> jxl::Status {
+    JXL_ASSIGN_OR_RETURN(
+        jpeg_data,
+        jxl::jpeg::ParseJPG(memory_manager, jxl::Bytes(buffer, size)));
+    return true;
+  };
+  if (!decode_jpg()) {
     return JXL_API_ERROR(frame_settings->enc, JXL_ENC_ERR_BAD_INPUT,
                          "Error during decode of input JPEG");
   }
 
   if (!frame_settings->enc->color_encoding_set) {
     if (!SetColorEncodingFromJpegData(
-            *io.Main().jpeg_data,
-            &frame_settings->enc->metadata.m.color_encoding)) {
+            *jpeg_data, &frame_settings->enc->metadata.m.color_encoding)) {
       return JXL_API_ERROR(
           frame_settings->enc, JXL_ENC_ERR_BAD_INPUT,
           "Error decoding the ICC profile embedded in the input JPEG");
@@ -2130,8 +2137,8 @@ JxlEncoderStatus JxlEncoderAddJPEGFrame(
   if (!frame_settings->enc->basic_info_set) {
     JxlBasicInfo basic_info;
     JxlEncoderInitBasicInfo(&basic_info);
-    basic_info.xsize = io.Main().jpeg_data->width;
-    basic_info.ysize = io.Main().jpeg_data->height;
+    basic_info.xsize = jpeg_data->width;
+    basic_info.ysize = jpeg_data->height;
     basic_info.uses_original_profile = JXL_TRUE;
     if (JxlEncoderSetBasicInfo(frame_settings->enc, &basic_info) !=
         JXL_ENC_SUCCESS) {
@@ -2146,8 +2153,8 @@ JxlEncoderStatus JxlEncoderAddJPEGFrame(
     return JXL_API_ERROR(frame_settings->enc, JXL_ENC_ERR_GENERIC,
                          "bad dimensions");
   }
-  if (xsize != static_cast<size_t>(io.Main().jpeg_data->width) ||
-      ysize != static_cast<size_t>(io.Main().jpeg_data->height)) {
+  if (xsize != static_cast<size_t>(jpeg_data->width) ||
+      ysize != static_cast<size_t>(jpeg_data->height)) {
     return JXL_API_ERROR(frame_settings->enc, JXL_ENC_ERR_GENERIC,
                          "JPEG dimensions don't match frame dimensions");
   }
@@ -2156,14 +2163,21 @@ JxlEncoderStatus JxlEncoderAddJPEGFrame(
     return JXL_API_ERROR(frame_settings->enc, JXL_ENC_ERR_API_USAGE,
                          "Can't XYB encode a lossless JPEG");
   }
-  if (!io.blobs.exif.empty()) {
+
+  jxl::jpeg::Blobs blobs;
+  if (!SetBlobsFromJpegData(*jpeg_data, &blobs)) {
+    return JXL_API_ERROR(frame_settings->enc, JXL_ENC_ERR_BAD_INPUT,
+                         "Error during parsing of input JPEG blobs");
+  }
+
+  if (!blobs.exif.empty()) {
     JxlOrientation orientation = static_cast<JxlOrientation>(
         frame_settings->enc->metadata.m.orientation);
-    jxl::InterpretExif(io.blobs.exif, &orientation);
+    jxl::InterpretExif(blobs.exif, &orientation);
     frame_settings->enc->metadata.m.orientation = orientation;
   }
-  if (!io.blobs.exif.empty() && frame_settings->values.cparams.jpeg_keep_exif) {
-    size_t exif_size = io.blobs.exif.size();
+  if (!blobs.exif.empty() && frame_settings->values.cparams.jpeg_keep_exif) {
+    size_t exif_size = blobs.exif.size();
     // Exif data in JPEG is limited to 64k
     if (exif_size > 0xFFFF) {
       return JXL_API_ERROR(frame_settings->enc, JXL_ENC_ERR_GENERIC,
@@ -2171,24 +2185,22 @@ JxlEncoderStatus JxlEncoderAddJPEGFrame(
     }
     exif_size += 4;  // prefix 4 zero bytes for tiff offset
     std::vector<uint8_t> exif(exif_size);
-    memcpy(exif.data() + 4, io.blobs.exif.data(), io.blobs.exif.size());
+    memcpy(exif.data() + 4, blobs.exif.data(), blobs.exif.size());
     JxlEncoderUseBoxes(frame_settings->enc);
     JxlEncoderAddBox(
         frame_settings->enc, "Exif", exif.data(), exif_size,
         TO_JXL_BOOL(frame_settings->values.cparams.jpeg_compress_boxes));
   }
-  if (!io.blobs.xmp.empty() && frame_settings->values.cparams.jpeg_keep_xmp) {
+  if (!blobs.xmp.empty() && frame_settings->values.cparams.jpeg_keep_xmp) {
     JxlEncoderUseBoxes(frame_settings->enc);
     JxlEncoderAddBox(
-        frame_settings->enc, "xml ", io.blobs.xmp.data(), io.blobs.xmp.size(),
+        frame_settings->enc, "xml ", blobs.xmp.data(), blobs.xmp.size(),
         TO_JXL_BOOL(frame_settings->values.cparams.jpeg_compress_boxes));
   }
-  if (!io.blobs.jumbf.empty() &&
-      frame_settings->values.cparams.jpeg_keep_jumbf) {
+  if (!blobs.jumbf.empty() && frame_settings->values.cparams.jpeg_keep_jumbf) {
     JxlEncoderUseBoxes(frame_settings->enc);
     JxlEncoderAddBox(
-        frame_settings->enc, "jumb", io.blobs.jumbf.data(),
-        io.blobs.jumbf.size(),
+        frame_settings->enc, "jumb", blobs.jumbf.data(), blobs.jumbf.size(),
         TO_JXL_BOOL(frame_settings->values.cparams.jpeg_compress_boxes));
   }
   if (frame_settings->enc->store_jpeg_metadata) {
@@ -2198,21 +2210,20 @@ JxlEncoderStatus JxlEncoderAddJPEGFrame(
                            "Need to preserve EXIF and XMP to allow JPEG "
                            "bitstream reconstruction");
     }
-    jxl::jpeg::JPEGData data_in = *io.Main().jpeg_data;
-    std::vector<uint8_t> jpeg_data;
+    std::vector<uint8_t> jpeg_metadata;
     if (!jxl::jpeg::EncodeJPEGData(&frame_settings->enc->memory_manager,
-                                   data_in, &jpeg_data,
+                                   *jpeg_data, &jpeg_metadata,
                                    frame_settings->values.cparams)) {
       return JXL_API_ERROR(
           frame_settings->enc, JXL_ENC_ERR_JBRD,
           "JPEG bitstream reconstruction data cannot be encoded");
     }
-    frame_settings->enc->jpeg_metadata = jpeg_data;
+    frame_settings->enc->jpeg_metadata = jpeg_metadata;
   }
 
   jxl::JxlEncoderChunkedFrameAdapter frame_data(
       xsize, ysize, frame_settings->enc->metadata.m.num_extra_channels);
-  frame_data.SetJPEGData(std::move(io.Main().jpeg_data));
+  frame_data.SetJPEGData(std::move(jpeg_data));
 
   auto queued_frame = jxl::MemoryManagerMakeUnique<jxl::JxlEncoderQueuedFrame>(
       &frame_settings->enc->memory_manager,

--- a/lib/jxl/gradient_test.cc
+++ b/lib/jxl/gradient_test.cc
@@ -13,12 +13,12 @@
 #include <utility>
 #include <vector>
 
+#include "lib/extras/codec_in_out.h"
 #include "lib/extras/dec/jxl.h"
 #include "lib/jxl/base/common.h"
 #include "lib/jxl/base/compiler_specific.h"
 #include "lib/jxl/base/data_parallel.h"
 #include "lib/jxl/base/span.h"
-#include "lib/jxl/codec_in_out.h"
 #include "lib/jxl/color_encoding_internal.h"
 #include "lib/jxl/common.h"  // SpeedTier
 #include "lib/jxl/enc_params.h"

--- a/lib/jxl/jpeg/enc_jpeg_data.h
+++ b/lib/jxl/jpeg/enc_jpeg_data.h
@@ -9,6 +9,7 @@
 #include <jxl/memory_manager.h>
 
 #include <cstdint>
+#include <memory>
 #include <vector>
 
 #include "lib/jxl/base/span.h"
@@ -20,9 +21,17 @@
 
 namespace jxl {
 
-class CodecInOut;
-
 namespace jpeg {
+
+// Optional text/EXIF metadata.
+struct Blobs {
+  std::vector<uint8_t> exif;
+  std::vector<uint8_t> iptc;
+  std::vector<uint8_t> jhgm;
+  std::vector<uint8_t> jumbf;
+  std::vector<uint8_t> xmp;
+};
+
 Status EncodeJPEGData(JxlMemoryManager* memory_manager, JPEGData& jpeg_data,
                       std::vector<uint8_t>* bytes,
                       const CompressParams& cparams);
@@ -35,10 +44,12 @@ Status SetColorTransformFromJpegData(const JPEGData& jpg,
                                      ColorTransform* color_transform);
 
 /**
- * Decodes bytes containing JPEG codestream into a CodecInOut as coefficients
- * only, for lossless JPEG transcoding.
+ * Decodes bytes containing JPEG codestream as coefficients only,
+ * for lossless JPEG transcoding.
  */
-Status DecodeImageJPG(Span<const uint8_t> bytes, CodecInOut* io);
+StatusOr<std::unique_ptr<JPEGData>> ParseJPG(JxlMemoryManager* memory_manager,
+                                             Bytes bytes);
+Status SetBlobsFromJpegData(const jpeg::JPEGData& jpeg_data, Blobs* blobs);
 
 }  // namespace jpeg
 }  // namespace jxl

--- a/lib/jxl/jxl_test.cc
+++ b/lib/jxl/jxl_test.cc
@@ -23,6 +23,7 @@
 #include <vector>
 
 #include "lib/extras/codec.h"
+#include "lib/extras/codec_in_out.h"
 #include "lib/extras/dec/decode.h"
 #include "lib/extras/enc/encode.h"
 #include "lib/extras/enc/jxl.h"
@@ -33,7 +34,6 @@
 #include "lib/jxl/base/data_parallel.h"
 #include "lib/jxl/base/span.h"
 #include "lib/jxl/base/status.h"
-#include "lib/jxl/codec_in_out.h"
 #include "lib/jxl/color_encoding_internal.h"
 #include "lib/jxl/common.h"  // JXL_HIGH_PRECISION
 #include "lib/jxl/enc_params.h"

--- a/lib/jxl/modular_test.cc
+++ b/lib/jxl/modular_test.cc
@@ -18,6 +18,7 @@
 #include <vector>
 
 #include "lib/extras/codec.h"
+#include "lib/extras/codec_in_out.h"
 #include "lib/extras/dec/decode.h"
 #include "lib/extras/dec/jxl.h"
 #include "lib/extras/enc/jxl.h"
@@ -28,7 +29,6 @@
 #include "lib/jxl/base/random.h"
 #include "lib/jxl/base/span.h"
 #include "lib/jxl/base/status.h"
-#include "lib/jxl/codec_in_out.h"
 #include "lib/jxl/color_encoding_internal.h"
 #include "lib/jxl/common.h"
 #include "lib/jxl/dec_bit_reader.h"

--- a/lib/jxl/passes_test.cc
+++ b/lib/jxl/passes_test.cc
@@ -15,6 +15,7 @@
 #include <vector>
 
 #include "lib/extras/codec.h"
+#include "lib/extras/codec_in_out.h"
 #include "lib/extras/dec/jxl.h"
 #include "lib/jxl/base/common.h"
 #include "lib/jxl/base/data_parallel.h"
@@ -22,7 +23,6 @@
 #include "lib/jxl/base/rect.h"
 #include "lib/jxl/base/span.h"
 #include "lib/jxl/base/status.h"
-#include "lib/jxl/codec_in_out.h"
 #include "lib/jxl/common.h"
 #include "lib/jxl/enc_params.h"
 #include "lib/jxl/image.h"

--- a/lib/jxl/preview_test.cc
+++ b/lib/jxl/preview_test.cc
@@ -12,9 +12,9 @@
 #include <vector>
 
 #include "lib/extras/codec.h"
+#include "lib/extras/codec_in_out.h"
 #include "lib/extras/dec/jxl.h"
 #include "lib/jxl/base/span.h"
-#include "lib/jxl/codec_in_out.h"
 #include "lib/jxl/common.h"
 #include "lib/jxl/enc_params.h"
 #include "lib/jxl/headers.h"

--- a/lib/jxl/render_pipeline/render_pipeline_test.cc
+++ b/lib/jxl/render_pipeline/render_pipeline_test.cc
@@ -12,6 +12,7 @@
 #include <cctype>
 #include <cstdint>
 #include <cstdio>
+#include <memory>
 #include <ostream>
 #include <sstream>
 #include <string>
@@ -41,6 +42,7 @@
 #include "lib/jxl/image_ops.h"
 #include "lib/jxl/image_test_utils.h"
 #include "lib/jxl/jpeg/enc_jpeg_data.h"
+#include "lib/jxl/jpeg/jpeg_data.h"
 #include "lib/jxl/render_pipeline/test_render_pipeline_stages.h"
 #include "lib/jxl/splines.h"
 #include "lib/jxl/test_memory_manager.h"
@@ -230,7 +232,10 @@ TEST_P(RenderPipelineTestParam, PipelineTest) {
 
   auto io = jxl::make_unique<CodecInOut>(memory_manager);
   if (config.jpeg_transcode) {
-    ASSERT_TRUE(jpeg::DecodeImageJPG(Bytes(orig), io.get()));
+    JXL_TEST_ASSIGN_OR_DIE(std::unique_ptr<jxl::jpeg::JPEGData> jpeg_data,
+                           jpeg::ParseJPG(memory_manager, Bytes(orig)));
+    ASSERT_TRUE(
+        jxl::test::JpegDataToCodecInOut(std::move(jpeg_data), io.get()));
   } else {
     ASSERT_TRUE(SetFromBytes(Bytes(orig), io.get(), &pool));
   }

--- a/lib/jxl/test_utils.h
+++ b/lib/jxl/test_utils.h
@@ -24,7 +24,8 @@
 #include <string>
 #include <vector>
 
-#include "lib/extras/dec/decode.h"  // for TEST_LIBJPEG_SUPPORT
+#include "lib/extras/codec_in_out.h"
+#include "lib/extras/dec/decode.h"  // IWYU pragma: keep TEST_LIBJPEG_SUPPORT
 #include "lib/extras/dec/jxl.h"
 #include "lib/extras/enc/jxl.h"
 #include "lib/extras/packed_image.h"
@@ -34,12 +35,12 @@
 #include "lib/jxl/base/span.h"
 #include "lib/jxl/base/status.h"
 #include "lib/jxl/butteraugli/butteraugli.h"
-#include "lib/jxl/codec_in_out.h"
 #include "lib/jxl/color_encoding_internal.h"
 #include "lib/jxl/dec_bit_reader.h"
 #include "lib/jxl/enc_params.h"
 #include "lib/jxl/image.h"
 #include "lib/jxl/image_bundle.h"
+#include "lib/jxl/jpeg/jpeg_data.h"
 
 // TODO(eustas): rewrite
 #define TEST_LIBJPEG_SUPPORT()                                              \
@@ -242,6 +243,9 @@ Status EncodeFile(const CompressParams& params, CodecInOut* io,
                   std::vector<uint8_t>* compressed, ThreadPool* pool = nullptr);
 
 constexpr const char* BoolToCStr(bool b) { return b ? "true" : "false"; }
+
+Status JpegDataToCodecInOut(std::unique_ptr<jxl::jpeg::JPEGData>&& data,
+                            CodecInOut* io);
 
 }  // namespace test
 

--- a/lib/jxl_lists.bzl
+++ b/lib/jxl_lists.bzl
@@ -136,7 +136,6 @@ libjxl_dec_sources = [
     "jxl/blending.h",
     "jxl/chroma_from_luma.cc",
     "jxl/chroma_from_luma.h",
-    "jxl/codec_in_out.h",
     "jxl/coeff_order.cc",
     "jxl/coeff_order.h",
     "jxl/coeff_order_fwd.h",
@@ -412,6 +411,7 @@ libjxl_enc_sources = [
 libjxl_extras_for_tools_sources = [
     "extras/codec.cc",
     "extras/codec.h",
+    "extras/codec_in_out.h",
     "extras/hlg.cc",
     "extras/hlg.h",
     "extras/metrics.cc",

--- a/lib/jxl_lists.cmake
+++ b/lib/jxl_lists.cmake
@@ -133,7 +133,6 @@ set(JPEGXL_INTERNAL_DEC_SOURCES
   jxl/blending.h
   jxl/chroma_from_luma.cc
   jxl/chroma_from_luma.h
-  jxl/codec_in_out.h
   jxl/coeff_order.cc
   jxl/coeff_order.h
   jxl/coeff_order_fwd.h
@@ -409,6 +408,7 @@ set(JPEGXL_INTERNAL_ENC_SOURCES
 set(JPEGXL_INTERNAL_EXTRAS_FOR_TOOLS_SOURCES
   extras/codec.cc
   extras/codec.h
+  extras/codec_in_out.h
   extras/hlg.cc
   extras/hlg.h
   extras/metrics.cc

--- a/lib/lib.gni
+++ b/lib/lib.gni
@@ -134,7 +134,6 @@ libjxl_dec_sources = [
     "jxl/blending.h",
     "jxl/chroma_from_luma.cc",
     "jxl/chroma_from_luma.h",
-    "jxl/codec_in_out.h",
     "jxl/coeff_order.cc",
     "jxl/coeff_order.h",
     "jxl/coeff_order_fwd.h",
@@ -410,6 +409,7 @@ libjxl_enc_sources = [
 libjxl_extras_for_tools_sources = [
     "extras/codec.cc",
     "extras/codec.h",
+    "extras/codec_in_out.h",
     "extras/hlg.cc",
     "extras/hlg.h",
     "extras/metrics.cc",

--- a/tools/benchmark/benchmark_codec.h
+++ b/tools/benchmark/benchmark_codec.h
@@ -13,10 +13,10 @@
 #include <string>
 #include <vector>
 
+#include "lib/extras/codec_in_out.h"
 #include "lib/extras/packed_image.h"
 #include "lib/jxl/base/span.h"
 #include "lib/jxl/base/status.h"
-#include "lib/jxl/codec_in_out.h"
 #include "tools/benchmark/benchmark_args.h"
 #include "tools/benchmark/benchmark_stats.h"
 #include "tools/speed_stats.h"

--- a/tools/benchmark/benchmark_codec_avif.cc
+++ b/tools/benchmark/benchmark_codec_avif.cc
@@ -19,13 +19,13 @@
 #include <utility>
 #include <vector>
 
+#include "lib/extras/codec_in_out.h"
 #include "lib/extras/packed_image_convert.h"
 #include "lib/extras/time.h"
 #include "lib/jxl/base/common.h"
 #include "lib/jxl/base/data_parallel.h"
 #include "lib/jxl/base/span.h"
 #include "lib/jxl/base/status.h"
-#include "lib/jxl/codec_in_out.h"
 #include "lib/jxl/color_encoding_internal.h"
 #include "lib/jxl/dec_external_image.h"
 #include "lib/jxl/enc_external_image.h"

--- a/tools/benchmark/benchmark_xl.cc
+++ b/tools/benchmark/benchmark_xl.cc
@@ -24,6 +24,7 @@
 #include <vector>
 
 #include "lib/extras/codec.h"
+#include "lib/extras/codec_in_out.h"
 #include "lib/extras/dec/color_hints.h"
 #include "lib/extras/dec/decode.h"
 #include "lib/extras/enc/apng.h"
@@ -38,7 +39,6 @@
 #include "lib/jxl/base/span.h"
 #include "lib/jxl/base/status.h"
 #include "lib/jxl/butteraugli/butteraugli.h"
-#include "lib/jxl/codec_in_out.h"
 #include "lib/jxl/color_encoding_internal.h"
 #include "lib/jxl/enc_butteraugli_comparator.h"
 #include "lib/jxl/enc_comparator.h"

--- a/tools/butteraugli_main.cc
+++ b/tools/butteraugli_main.cc
@@ -15,6 +15,7 @@
 #include <vector>
 
 #include "lib/extras/codec.h"
+#include "lib/extras/codec_in_out.h"
 #include "lib/extras/dec/color_hints.h"
 #include "lib/extras/metrics.h"
 #include "lib/extras/packed_image.h"
@@ -24,7 +25,6 @@
 #include "lib/jxl/base/span.h"
 #include "lib/jxl/base/status.h"
 #include "lib/jxl/butteraugli/butteraugli.h"
-#include "lib/jxl/codec_in_out.h"
 #include "lib/jxl/color_encoding_internal.h"
 #include "lib/jxl/enc_butteraugli_comparator.h"
 #include "lib/jxl/enc_comparator.h"

--- a/tools/djxl_fuzzer.cc
+++ b/tools/djxl_fuzzer.cc
@@ -22,6 +22,7 @@
 #include <random>
 #include <vector>
 
+#include "lib/jxl/base/common.h"
 #include "lib/jxl/base/compiler_specific.h"
 #include "lib/jxl/fuzztest.h"
 #include "tools/tracking_memory_manager.h"
@@ -90,7 +91,7 @@ bool DecodeJpegXl(const uint8_t* jxl, size_t size,
       std::min<size_t>(2, JxlThreadParallelRunnerDefaultNumWorkerThreads());
   auto runner = JxlThreadParallelRunnerMake(memory_manager, num_threads);
 
-  auto mt = std::make_unique<std::mt19937>(spec.random_seed);
+  auto mt = jxl::make_unique<std::mt19937>(spec.random_seed);
   std::exponential_distribution<> dis_streaming(kStreamingTargetNumberOfChunks);
 
   auto dec = JxlDecoderMake(memory_manager);

--- a/tools/hdr/display_to_hlg.cc
+++ b/tools/hdr/display_to_hlg.cc
@@ -9,11 +9,11 @@
 #include <vector>
 
 #include "lib/extras/codec.h"
+#include "lib/extras/codec_in_out.h"
 #include "lib/extras/hlg.h"
 #include "lib/extras/tone_mapping.h"
 #include "lib/jxl/base/common.h"
 #include "lib/jxl/base/span.h"
-#include "lib/jxl/codec_in_out.h"
 #include "lib/jxl/color_encoding_internal.h"
 #include "tools/cmdline.h"
 #include "tools/file_io.h"

--- a/tools/hdr/exr_to_pq.cc
+++ b/tools/hdr/exr_to_pq.cc
@@ -10,6 +10,7 @@
 #include <cstring>
 #include <vector>
 
+#include "lib/extras/codec_in_out.h"
 #include "lib/extras/dec/decode.h"
 #include "lib/extras/packed_image.h"
 #include "lib/extras/packed_image_convert.h"
@@ -18,7 +19,6 @@
 #include "lib/jxl/base/matrix_ops.h"
 #include "lib/jxl/base/span.h"
 #include "lib/jxl/cms/jxl_cms_internal.h"
-#include "lib/jxl/codec_in_out.h"
 #include "lib/jxl/color_encoding_internal.h"
 #include "lib/jxl/image_bundle.h"
 #include "lib/jxl/image_ops.h"

--- a/tools/hdr/image_utils.h
+++ b/tools/hdr/image_utils.h
@@ -17,6 +17,7 @@
 #include <string>
 #include <vector>
 
+#include "lib/extras/codec_in_out.h"
 #include "lib/extras/dec/decode.h"  // Codec enum
 #include "lib/extras/enc/apng.h"
 #include "lib/extras/enc/encode.h"
@@ -29,7 +30,6 @@
 #include "lib/jxl/base/compiler_specific.h"
 #include "lib/jxl/base/data_parallel.h"
 #include "lib/jxl/base/status.h"
-#include "lib/jxl/codec_in_out.h"
 #include "lib/jxl/color_encoding_internal.h"
 #include "lib/jxl/image_bundle.h"
 

--- a/tools/hdr/local_tone_map.cc
+++ b/tools/hdr/local_tone_map.cc
@@ -13,6 +13,7 @@
 #include <utility>
 #include <vector>
 
+#include "lib/extras/codec_in_out.h"
 #include "lib/extras/dec/color_hints.h"
 #include "lib/extras/packed_image.h"
 #include "lib/jxl/base/common.h"
@@ -21,7 +22,6 @@
 #include "lib/jxl/base/rect.h"
 #include "lib/jxl/base/span.h"
 #include "lib/jxl/base/status.h"
-#include "lib/jxl/codec_in_out.h"
 #include "lib/jxl/color_encoding_internal.h"
 #include "lib/jxl/image.h"
 #include "lib/jxl/image_ops.h"

--- a/tools/hdr/pq_to_hlg.cc
+++ b/tools/hdr/pq_to_hlg.cc
@@ -9,12 +9,12 @@
 #include <vector>
 
 #include "lib/extras/codec.h"
+#include "lib/extras/codec_in_out.h"
 #include "lib/extras/dec/color_hints.h"
 #include "lib/extras/hlg.h"
 #include "lib/extras/tone_mapping.h"
 #include "lib/jxl/base/common.h"
 #include "lib/jxl/base/span.h"
-#include "lib/jxl/codec_in_out.h"
 #include "lib/jxl/color_encoding_internal.h"
 #include "tools/cmdline.h"
 #include "tools/file_io.h"

--- a/tools/hdr/render_hlg.cc
+++ b/tools/hdr/render_hlg.cc
@@ -9,13 +9,13 @@
 #include <vector>
 
 #include "lib/extras/codec.h"
+#include "lib/extras/codec_in_out.h"
 #include "lib/extras/dec/color_hints.h"
 #include "lib/extras/hlg.h"
 #include "lib/extras/tone_mapping.h"
 #include "lib/jxl/base/common.h"
 #include "lib/jxl/base/span.h"
 #include "lib/jxl/cms/color_encoding_cms.h"
-#include "lib/jxl/codec_in_out.h"
 #include "lib/jxl/color_encoding_internal.h"
 #include "tools/cmdline.h"
 #include "tools/file_io.h"

--- a/tools/hdr/texture_to_cube.cc
+++ b/tools/hdr/texture_to_cube.cc
@@ -10,10 +10,10 @@
 #include <vector>
 
 #include "lib/extras/codec.h"
+#include "lib/extras/codec_in_out.h"
 #include "lib/jxl/base/common.h"
 #include "lib/jxl/base/compiler_specific.h"
 #include "lib/jxl/base/span.h"
-#include "lib/jxl/codec_in_out.h"
 #include "lib/jxl/image_bundle.h"
 #include "tools/cmdline.h"
 #include "tools/file_io.h"

--- a/tools/hdr/tone_map.cc
+++ b/tools/hdr/tone_map.cc
@@ -9,13 +9,13 @@
 #include <vector>
 
 #include "lib/extras/codec.h"
+#include "lib/extras/codec_in_out.h"
 #include "lib/extras/dec/color_hints.h"
 #include "lib/extras/dec/decode.h"
 #include "lib/extras/tone_mapping.h"
 #include "lib/jxl/base/common.h"
 #include "lib/jxl/base/span.h"
 #include "lib/jxl/cms/color_encoding_cms.h"
-#include "lib/jxl/codec_in_out.h"
 #include "lib/jxl/color_encoding_internal.h"
 #include "tools/cmdline.h"
 #include "tools/file_io.h"

--- a/tools/icc_simplify.cc
+++ b/tools/icc_simplify.cc
@@ -12,10 +12,10 @@
 #include <vector>
 
 #include "lib/extras/codec.h"
+#include "lib/extras/codec_in_out.h"
 #include "lib/extras/dec/color_description.h"
 #include "lib/jxl/base/common.h"
 #include "lib/jxl/base/span.h"
-#include "lib/jxl/codec_in_out.h"
 #include "lib/jxl/color_encoding_internal.h"
 #include "tools/cmdline.h"
 #include "tools/file_io.h"

--- a/tools/jxl_from_tree.cc
+++ b/tools/jxl_from_tree.cc
@@ -20,10 +20,10 @@
 #include <utility>
 #include <vector>
 
+#include "lib/extras/codec_in_out.h"
 #include "lib/jxl/base/common.h"
 #include "lib/jxl/base/override.h"
 #include "lib/jxl/base/status.h"
-#include "lib/jxl/codec_in_out.h"
 #include "lib/jxl/color_encoding_internal.h"
 #include "lib/jxl/enc_bit_writer.h"
 #include "lib/jxl/enc_cache.h"

--- a/tools/set_from_bytes_fuzzer.cc
+++ b/tools/set_from_bytes_fuzzer.cc
@@ -10,12 +10,12 @@
 #include <vector>
 
 #include "lib/extras/codec.h"
+#include "lib/extras/codec_in_out.h"
 #include "lib/extras/size_constraints.h"
 #include "lib/jxl/base/common.h"
 #include "lib/jxl/base/compiler_specific.h"
 #include "lib/jxl/base/span.h"
 #include "lib/jxl/base/status.h"
-#include "lib/jxl/codec_in_out.h"
 #include "lib/jxl/fuzztest.h"
 #include "tools/thread_pool_internal.h"
 #include "tools/tracking_memory_manager.h"

--- a/tools/ssimulacra2_main.cc
+++ b/tools/ssimulacra2_main.cc
@@ -12,10 +12,10 @@
 #include <vector>
 
 #include "lib/extras/codec.h"
+#include "lib/extras/codec_in_out.h"
 #include "lib/jxl/base/common.h"
 #include "lib/jxl/base/span.h"
 #include "lib/jxl/base/status.h"
-#include "lib/jxl/codec_in_out.h"
 #include "tools/file_io.h"
 #include "tools/no_memory_manager.h"
 #include "tools/ssimulacra2.h"

--- a/tools/ssimulacra_main.cc
+++ b/tools/ssimulacra_main.cc
@@ -17,10 +17,10 @@
 // #include "lib/jxl/base/span.h"
 #include <jxl/cms.h>
 
+#include "lib/extras/codec_in_out.h"
 #include "lib/jxl/base/common.h"
 #include "lib/jxl/base/span.h"
 #include "lib/jxl/base/status.h"
-#include "lib/jxl/codec_in_out.h"
 #include "lib/jxl/color_encoding_internal.h"
 #include "lib/jxl/image.h"
 #include "lib/jxl/image_bundle.h"


### PR DESCRIPTION
This helps to avoid unnecessary Image3F allocation when transcoding

While it would be great to remove CodecInOut completely, currently it is moved to extras/ (and lost "blobs" member)
