### PR TITLE
Fix/extend conformance pipeline

### DIFF
--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -54,15 +54,16 @@ jobs:
         ${{ github.workspace }}/conformance/scripts/download_and_symlink.sh
 
   build:
-    name: Conformance Build ${{ matrix.name }}
+    name: CfB ${{ matrix.name }}
     if: ${{ !contains(github.event.pull_request.labels.*.name, 'CI:none') }}
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os || 'ubuntu-latest' }}
     strategy:
       fail-fast: false
       matrix:
         include:
           - name: AVX3
             cflags: -DHWY_DISABLED_TARGETS=HWY_AVX3-1
+            cmake_args: -DJPEGXL_ENABLE_AVX512=ON
           - name: AVX2
             cflags: -DHWY_DISABLED_TARGETS=HWY_AVX2-1
           - name: SSE4
@@ -76,6 +77,8 @@ jobs:
           - name: SCALAR_ASAN
             cflags: -DHWY_COMPILE_ONLY_SCALAR=1
             build_type: asan
+          - name: SVE2_128
+            os: ubuntu-24.04-arm
     env:
       CCACHE_DIR: ${{ github.workspace }}/.ccache
     steps:
@@ -115,12 +118,13 @@ jobs:
         mkdir -p ${CCACHE_DIR}
         echo "max_size = 200M" > ${CCACHE_DIR}/ccache.conf
         CC=clang CXX=clang++ CMAKE_FLAGS="${{ matrix.cflags }}" \
-        SKIP_TEST=1 TARGETS=tools/djxl \
+        SKIP_TEST=1 TARGETS="hwy_list_targets tools/djxl" \
         ./ci.sh ${{ matrix.build_type || 'release' }} \
           -DJPEGXL_FORCE_SYSTEM_BROTLI=ON \
           -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
           -DCMAKE_C_COMPILER_LAUNCHER=ccache \
-          -DBUILD_TESTING=OFF
+          -DBUILD_TESTING=OFF \
+          ${{ matrix.cmake_args }}
         # Flatten the artifacts directory structure
         cp tools/conformance/conformance.py build/tools/conformance
         cp tools/conformance/lcms2.py build/tools/conformance
@@ -141,16 +145,33 @@ jobs:
     - name: ccache stats
       run: ccache --show-stats
 
-  run:
-    name: Conformance Test ${{ matrix.name }} on ${{ matrix.target }}
+  test:
+    name: CfT ${{ matrix.name }} / ${{ matrix.target }}
     if: ${{ !contains(github.event.pull_request.labels.*.name, 'CI:none') }}
     needs: [warmup, build]
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os || 'ubuntu-latest' }}
     strategy:
       fail-fast: false
       matrix:
-        name: [main_level5, main_level10]
-        target: [AVX3, AVX2, SSE4, SSSE3, EMU128, SCALAR, SCALAR_ASAN]
+        name: [level5, level10]
+        target: [AVX3, AVX2, SSE4, SSSE3, EMU128, SCALAR, SCALAR_ASAN, SVE2_128]
+        include:
+          - name: level5
+            target: AVX3
+            sde_id: '813591'
+            sde_version: 9.33.0-2024-01-07
+            emulator: 'sde/sde64 -spr --'
+          - name: level10
+            target: AVX3
+            sde_id: '813591'
+            sde_version: 9.33.0-2024-01-07
+            emulator: 'sde/sde64 -spr --'
+          - name: level5
+            target: SVE2_128
+            os: ubuntu-24.04-arm
+          - name: level10
+            target: SVE2_128
+            os: ubuntu-24.04-arm
     steps:
     - name: Harden Runner
       uses: step-security/harden-runner@cb605e52c26070c328afc4562f0b4ada7618a84e # v2.10.4
@@ -167,6 +188,25 @@ jobs:
     - name: Install deps
       run: |
         sudo ./tools/scripts/install_deps.sh conformance
+
+    - name: Cache SDE
+      if: ${{ matrix.sde_id }}
+      uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
+      with:
+        path: ${{ github.workspace }}/sde
+        key: sde-${{ matrix.sde_id }}
+    - name: Download SDE ${{ matrix.sde_version }}
+      if: ${{ matrix.sde_id }}
+      run: |
+        mkdir -p sde
+        cd sde
+        SDE_ARCHIVE=sde.tar.xz
+        if [ ! -f "${SDE_ARCHIVE}" ]; then
+          curl -L --show-error -o "${SDE_ARCHIVE}" \
+            https://downloadmirror.intel.com/${{ matrix.sde_id }}/sde-external-${{ matrix.sde_version }}-lin.tar.xz
+        fi
+        tar --strip-components=1 -xJf "${SDE_ARCHIVE}"
+        cd ..
 
     - name: Checkout the conformance source
       uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -192,6 +232,13 @@ jobs:
         ln -s libjxl_cms.so.${{ env.LIBJXL_VERSION }} libjxl_cms.so.${{ env.LIBJXL_ABI_VERSION }}
         ln -s libjxl_threads.so.${{ env.LIBJXL_VERSION }} libjxl_threads.so.${{ env.LIBJXL_ABI_VERSION }}
         export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:`pwd`
-        python conformance.py \
+        ${{ matrix.emulator }} `pwd`/djxl -V | tee djxl_version.txt
+        TARGET=${{ matrix.target }}
+        if [[ $TARGET == *_ASAN ]]; then
+          grep -q ' ASAN ' djxl_version.txt || exit 1
+          TARGET=${TARGET%_ASAN}
+        fi
+        grep -q _${TARGET}_ djxl_version.txt || exit 1
+        ${{ matrix.emulator }} python conformance.py \
           --decoder=`pwd`/djxl \
-          --corpus=`pwd`/conformance/testcases/${{ matrix.name }}.txt
+          --corpus=`pwd`/conformance/testcases/main_${{ matrix.name }}.txt

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -54,7 +54,7 @@ else ()
     # NB: use `-Rpass-analysis=stack-frame-layout -g` for investigation.
     # TODO(eustas): tighten
     if (CMAKE_CXX_COMPILER_ID MATCHES "Clang")
-      list(APPEND JPEGXL_INTERNAL_FLAGS -Wframe-larger-than=4608)
+      list(APPEND JPEGXL_INTERNAL_FLAGS -Wframe-larger-than=5632)
     elseif (CMAKE_CXX_COMPILER_ID MATCHES "GNU" AND CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL 14.0)
       list(APPEND JPEGXL_INTERNAL_FLAGS -Wframe-larger-than=5120)
     endif()

--- a/tools/codec_config.cc
+++ b/tools/codec_config.cc
@@ -7,6 +7,7 @@
 
 #include <cstdint>
 #include <cstdio>
+#include <hwy/per_target.h>
 #include <hwy/targets.h>
 #include <string>
 
@@ -32,23 +33,36 @@ std::string CodecConfigString(uint32_t lib_version) {
   }
 
 #if defined(ADDRESS_SANITIZER)
-  config += " asan ";
+  config += " ASAN ";
 #elif defined(MEMORY_SANITIZER)
-  config += " msan ";
+  config += " MSAN ";
 #elif defined(THREAD_SANITIZER)
-  config += " tsan ";
+  config += " TSAN ";
 #else
 #endif
 
-  bool saw_target = false;
+  int64_t current = hwy::DispatchedTarget();
+  bool seen_current = false;
+  bool seen_target = false;
   config += "[";
-  for (const uint32_t target : hwy::SupportedAndGeneratedTargets()) {
-    config += hwy::TargetName(target);
+  for (const int64_t target : hwy::SupportedAndGeneratedTargets()) {
+    if (target == current) {
+      config += '_';
+      config += hwy::TargetName(target);
+      config += '_';
+      seen_current = true;
+    } else {
+      config += hwy::TargetName(target);
+    }
     config += ',';
-    saw_target = true;
+    seen_target = true;
   }
-  if (!saw_target) {
+  if (!seen_target) {
     config += "no targets found,";
+  } else if (!seen_current) {
+    config += "unsupported but chosen: ";
+    config += hwy::TargetName(current);
+    config += ',';
   }
   config.resize(config.size() - 1);  // remove trailing comma
   config += "]";


### PR DESCRIPTION
Add target traceability for conformance tests.

Fix: run AVX3 in Intel SDE; otherwise GitHub does not guarantee
(currently guarantees not) to run on CPU with AVX3.
Good news: AVX3 actually passes conformance test.

Add SVE2_128 build test.
Bad news: `noise` test fails (RSME is too large)