### PR TITLE
Fix for RLE encoding

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -63,6 +63,7 @@ gi-man
 Gilles Devillers (GilDev) <gildev@gmail.com>
 Heiko Becker <heirecka@exherbo.org>
 Ivan Kokorev
+Ivan Siutsou (Melirius) <melirius@gmail.com>
 Jim Robinson <jimbo2150@gmail.com>
 John Platts <john_platts@hotmail.com>
 Jonathan Brown (Jonnyawsom3) <jonathanbr30@gmail.com>

--- a/lib/jxl/decode_test.cc
+++ b/lib/jxl/decode_test.cc
@@ -1531,7 +1531,7 @@ std::ostream& operator<<(std::ostream& os, const PixelTestConfig& c) {
   }
   if (c.preview_mode == jxl::kSmallPreview) os << "Preview";
   if (c.preview_mode == jxl::kBigPreview) os << "BigPreview";
-  if (c.add_intrinsic_size) os << "IntrinicSize";
+  if (c.add_intrinsic_size) os << "IntrinsicSize";
   if (c.use_callback) os << "Callback";
   if (c.set_buffer_early) os << "EarlyBuffer";
   if (c.use_resizable_runner) os << "ResizableRunner";

--- a/lib/jxl/enc_ans.cc
+++ b/lib/jxl/enc_ans.cc
@@ -294,7 +294,7 @@ bool EncodeCounts(const ANSHistBin* counts, const int alphabet_size,
       if (counts[i] != counts[last] || i + 1 == alphabet_size ||
           (i - last) >= 255 || i == omit_pos || i == omit_pos + 1) {
         same[last] = (i - last);
-        last = i + 1;
+        last = i;
       }
     }
 

--- a/lib/jxl/jxl_test.cc
+++ b/lib/jxl/jxl_test.cc
@@ -1081,7 +1081,7 @@ JXL_SLOW_TEST(JxlTest, RoundtripLossless8) {
   dparams.accepted_formats.push_back(t.ppf().frames[0].color.format);
 
   PackedPixelFile ppf_out;
-  EXPECT_EQ(Roundtrip(t.ppf(), cparams, dparams, pool.get(), &ppf_out), 223058);
+  EXPECT_EQ(Roundtrip(t.ppf(), cparams, dparams, pool.get(), &ppf_out), 223053);
   EXPECT_EQ(ComputeDistance2(t.ppf(), ppf_out), 0.0);
 }
 
@@ -1100,7 +1100,7 @@ JXL_SLOW_TEST(JxlTest, RoundtripLossless8ThunderGradient) {
   dparams.accepted_formats.push_back(t.ppf().frames[0].color.format);
 
   PackedPixelFile ppf_out;
-  EXPECT_EQ(Roundtrip(t.ppf(), cparams, dparams, pool.get(), &ppf_out), 261684);
+  EXPECT_EQ(Roundtrip(t.ppf(), cparams, dparams, pool.get(), &ppf_out), 261683);
   EXPECT_EQ(ComputeDistance2(t.ppf(), ppf_out), 0.0);
 }
 
@@ -1138,7 +1138,7 @@ JXL_SLOW_TEST(JxlTest, RoundtripLossless8Falcon) {
   dparams.accepted_formats.push_back(t.ppf().frames[0].color.format);
 
   PackedPixelFile ppf_out;
-  EXPECT_EQ(Roundtrip(t.ppf(), cparams, dparams, pool.get(), &ppf_out), 230766);
+  EXPECT_EQ(Roundtrip(t.ppf(), cparams, dparams, pool.get(), &ppf_out), 230762);
   EXPECT_EQ(ComputeDistance2(t.ppf(), ppf_out), 0.0);
 }
 
@@ -1158,7 +1158,7 @@ TEST(JxlTest, RoundtripLossless8Alpha) {
   dparams.accepted_formats.push_back(t.ppf().frames[0].color.format);
 
   PackedPixelFile ppf_out;
-  EXPECT_EQ(Roundtrip(t.ppf(), cparams, dparams, pool, &ppf_out), 251470);
+  EXPECT_EQ(Roundtrip(t.ppf(), cparams, dparams, pool, &ppf_out), 251465);
   EXPECT_EQ(ComputeDistance2(t.ppf(), ppf_out), 0.0);
   EXPECT_EQ(ppf_out.info.alpha_bits, 8);
   EXPECT_TRUE(test::SameAlpha(t.ppf(), ppf_out));
@@ -1332,7 +1332,7 @@ TEST(JxlTest, RoundtripLossless8Gray) {
   dparams.accepted_formats.push_back(t.ppf().frames[0].color.format);
 
   PackedPixelFile ppf_out;
-  EXPECT_EQ(Roundtrip(t.ppf(), cparams, dparams, pool, &ppf_out), 92185);
+  EXPECT_EQ(Roundtrip(t.ppf(), cparams, dparams, pool, &ppf_out), 92179);
   EXPECT_EQ(ComputeDistance2(t.ppf(), ppf_out), 0.0);
   EXPECT_EQ(ppf_out.color_encoding.color_space, JXL_COLOR_SPACE_GRAY);
   EXPECT_EQ(ppf_out.info.bits_per_sample, 8);


### PR DESCRIPTION
### Description

RLE encoding procedure has a bug that skips one symbol after each run. It provides still valid results for encoding further, just some unnecessary additional run stops appear in the sequence, reducing the ability to compress histogram. This fix corrects "off-by-1" bug and provides then slightly better compression: that is why hardcoded sizes of output in several tests are corrected down as well.

Example: 
```
{12, 12, 13, 14, 15, 15, 15, 15, 7, 8, 6} histogram
{2,  0,  0,  1,  0,  3,  0,  0,  0, 1, 1} current same with +1
{2,  0,  1,  1,  4,  0,  0,  0,  1, 1, 1} correct same without +1
```
### Pull Request Checklist

- [x] **CLA Signed**: Have you signed the [Contributor License Agreement](https://code.google.com/legal/individual-cla-v1.0.html) (individual or corporate, as appropriate)? Only contributions from signed contributors can be accepted.
- [x] **Authors**: Have you considered adding your name to the [AUTHORS](AUTHORS) file?
- [x] **Code Style**: Have you ensured your code adheres to the project's coding style guidelines? You can use `./ci.sh lint` for automatic code formatting.