### PR TITLE
Make WASM CI non-fail-fast

### DIFF
--- a/.github/workflows/build_test_md.yml
+++ b/.github/workflows/build_test_md.yml
@@ -25,6 +25,7 @@ jobs:
     if: ${{ !contains(github.event.pull_request.labels.*.name, 'CI:none') }}
     # Include all names of required jobs here
     strategy:
+      fail-fast: false
       matrix:
         include:
           - name: release
@@ -48,6 +49,7 @@ jobs:
     if: ${{ !contains(github.event.pull_request.labels.*.name, 'CI:none') }}
     # Include all msystem of required jobs here
     strategy:
+      fail-fast: false
       matrix:
           include:
            - msystem: clang64

--- a/.github/workflows/build_test_wasm.yml
+++ b/.github/workflows/build_test_wasm.yml
@@ -34,6 +34,7 @@ jobs:
       NODE_VERSION: 21
 
     strategy:
+      fail-fast: false
       matrix:
         include:
           - variant: scalar

--- a/.github/workflows/test_new_highway.yml
+++ b/.github/workflows/test_new_highway.yml
@@ -20,6 +20,7 @@ jobs:
     if: github.repository_owner == 'libjxl'
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         include:
           - branch: 'test_highway'


### PR DESCRIPTION
That will help gathering more statistics on mysterious failures

Drive-by: make all CI non-fail-fast; that won't waste much resources, but will make reports more consistent (i.e. no more confusion between failed and cancelled because other job failed)
