### PR TITLE
slight improvement in jpeg recompression

### DIFF
--- a/lib/jxl/jxl_test.cc
+++ b/lib/jxl/jxl_test.cc
@@ -1472,7 +1472,7 @@ JXL_TRANSCODE_JPEG_TEST(JxlTest, RoundtripJpegRecompression444) {
   const std::vector<uint8_t> orig =
       ReadTestData("jxl/flower/flower.png.im_q85_444.jpg");
   // JPEG size is 696,659 bytes.
-  EXPECT_NEAR(RoundtripJpeg(orig, pool.get()), 568891u, 20);
+  EXPECT_NEAR(RoundtripJpeg(orig, pool.get()), 569190u, 20);
 }
 
 JXL_TRANSCODE_JPEG_TEST(JxlTest, RoundtripJpegRecompressionToPixels) {
@@ -1549,7 +1549,7 @@ JXL_TRANSCODE_JPEG_TEST(JxlTest, RoundtripJpegRecompressionGray) {
   const std::vector<uint8_t> orig =
       ReadTestData("jxl/flower/flower.png.im_q85_gray.jpg");
   // JPEG size is 456,528 bytes.
-  EXPECT_NEAR(RoundtripJpeg(orig, pool.get()), 387496u, 200);
+  EXPECT_NEAR(RoundtripJpeg(orig, pool.get()), 386602u, 200);
 }
 
 JXL_TRANSCODE_JPEG_TEST(JxlTest, RoundtripJpegRecompression420) {
@@ -1557,7 +1557,7 @@ JXL_TRANSCODE_JPEG_TEST(JxlTest, RoundtripJpegRecompression420) {
   const std::vector<uint8_t> orig =
       ReadTestData("jxl/flower/flower.png.im_q85_420.jpg");
   // JPEG size is 546,797 bytes.
-  EXPECT_NEAR(RoundtripJpeg(orig, pool.get()), 455510u, 20);
+  EXPECT_NEAR(RoundtripJpeg(orig, pool.get()), 455855u, 20);
 }
 
 JXL_TRANSCODE_JPEG_TEST(JxlTest, RoundtripJpegRecompressionLumaSubsample) {
@@ -1565,7 +1565,7 @@ JXL_TRANSCODE_JPEG_TEST(JxlTest, RoundtripJpegRecompressionLumaSubsample) {
   const std::vector<uint8_t> orig =
       ReadTestData("jxl/flower/flower.png.im_q85_luma_subsample.jpg");
   // JPEG size is 400,724 bytes.
-  EXPECT_NEAR(RoundtripJpeg(orig, pool.get()), 325310u, 20);
+  EXPECT_NEAR(RoundtripJpeg(orig, pool.get()), 324345u, 20);
 }
 
 JXL_TRANSCODE_JPEG_TEST(JxlTest, RoundtripJpegRecompression444wh12) {
@@ -1574,7 +1574,7 @@ JXL_TRANSCODE_JPEG_TEST(JxlTest, RoundtripJpegRecompression444wh12) {
   const std::vector<uint8_t> orig =
       ReadTestData("jxl/flower/flower.png.im_q85_444_1x2.jpg");
   // JPEG size is 703,874 bytes.
-  EXPECT_NEAR(RoundtripJpeg(orig, pool.get()), 569630u, 20);
+  EXPECT_NEAR(RoundtripJpeg(orig, pool.get()), 569982u, 20);
 }
 
 JXL_TRANSCODE_JPEG_TEST(JxlTest, RoundtripJpegRecompression422) {
@@ -1582,7 +1582,7 @@ JXL_TRANSCODE_JPEG_TEST(JxlTest, RoundtripJpegRecompression422) {
   const std::vector<uint8_t> orig =
       ReadTestData("jxl/flower/flower.png.im_q85_422.jpg");
   // JPEG size is 522,057 bytes.
-  EXPECT_NEAR(RoundtripJpeg(orig, pool.get()), 499236u, 20);
+  EXPECT_NEAR(RoundtripJpeg(orig, pool.get()), 499694u, 20);
 }
 
 JXL_TRANSCODE_JPEG_TEST(JxlTest, RoundtripJpegRecompression440) {
@@ -1590,7 +1590,7 @@ JXL_TRANSCODE_JPEG_TEST(JxlTest, RoundtripJpegRecompression440) {
   const std::vector<uint8_t> orig =
       ReadTestData("jxl/flower/flower.png.im_q85_440.jpg");
   // JPEG size is 603,623 bytes.
-  EXPECT_NEAR(RoundtripJpeg(orig, pool.get()), 501101u, 20);
+  EXPECT_NEAR(RoundtripJpeg(orig, pool.get()), 501538u, 20);
 }
 
 JXL_TRANSCODE_JPEG_TEST(JxlTest, RoundtripJpegRecompressionAsymmetric) {
@@ -1600,7 +1600,7 @@ JXL_TRANSCODE_JPEG_TEST(JxlTest, RoundtripJpegRecompressionAsymmetric) {
   const std::vector<uint8_t> orig =
       ReadTestData("jxl/flower/flower.png.im_q85_asymmetric.jpg");
   // JPEG size is 604,601 bytes.
-  EXPECT_NEAR(RoundtripJpeg(orig, pool.get()), 500548u, 20);
+  EXPECT_NEAR(RoundtripJpeg(orig, pool.get()), 501005u, 20);
 }
 
 JXL_TRANSCODE_JPEG_TEST(JxlTest, RoundtripJpegRecompression420Progr) {
@@ -1608,7 +1608,7 @@ JXL_TRANSCODE_JPEG_TEST(JxlTest, RoundtripJpegRecompression420Progr) {
   const std::vector<uint8_t> orig =
       ReadTestData("jxl/flower/flower.png.im_q85_420_progr.jpg");
   // JPEG size is 522,057 bytes.
-  EXPECT_NEAR(RoundtripJpeg(orig, pool.get()), 455454u, 20);
+  EXPECT_NEAR(RoundtripJpeg(orig, pool.get()), 455794u, 20);
 }
 
 JXL_TRANSCODE_JPEG_TEST(JxlTest, RoundtripJpegRecompressionMetadata) {
@@ -1676,7 +1676,7 @@ JXL_TRANSCODE_JPEG_TEST(JxlTest, RoundtripJpegRecompressionRestarts) {
   const std::vector<uint8_t> orig =
       ReadTestData("jxl/jpeg_reconstruction/bicycles_restarts.jpg");
   // JPEG size is 87478 bytes
-  EXPECT_NEAR(RoundtripJpeg(orig, pool.get()), 76054u, 30);
+  EXPECT_NEAR(RoundtripJpeg(orig, pool.get()), 76023u, 30);
 }
 
 JXL_TRANSCODE_JPEG_TEST(JxlTest, RoundtripJpegRecompressionOrientationICC) {


### PR DESCRIPTION
Changes the AC context modeling used when recompressing JPEGs.
Previous model: each DC  component was split into up to 3 equal buckets, and then luma AC used 3x3=9 contexts based on chroma DC while chroma AC used 3 contexts (shared between Cb and Cr) based on luma DC.
New model: only care about luma DC, split it in up to 4 buckets, and use up to 4 contexts per component (not shared between Cb and Cr).

This results in 0.1 - 0.2% better compression overall, depending on quality and image size. For larger images at higher quality, the improvement can be up  to 0.3 - 0.4 %; for smaller images the improvement is smaller (0.05 % or so).

Also the improvement seems to be a bit larger for jpegli encoded images than for libjpeg-turbo encoded images, which is nice because the amount of saving from recompression is in general lower for (already well-optimized) jpegli images than for (not very optimized) libjpeg-turbo images.

Your mileage may vary on individual images, I only looked at corpus totals.

### Detailed results:

corpus  | jpeg encoder | q setting | chroma | jpeg corpus size | jxl before | jxl after | improvement | saving before | saving after
-- | -- | -- | -- | -- | -- | -- | -- | -- | --
imagecompression.info | libjpeg-turbo | q30 | 4:4:4 | 11027077 | 7511255 | 7504575 | 0.09% | 31.88% | 31.94%
  | libjpeg-turbo | q50 | 4:4:4 | 15787104 | 11846444 | 11809831 | 0.31% | 24.96% | 25.19%
  | libjpeg-turbo | q60 | 4:4:4 | 18540959 | 14242903 | 14199379 | 0.31% | 23.18% | 23.42%
  | libjpeg-turbo | q70 | 4:4:4 | 22798622 | 17870310 | 17817181 | 0.30% | 21.62% | 21.85%
  | libjpeg-turbo | q80 | 4:4:4 | 30277359 | 24083456 | 23988861 | 0.39% | 20.46% | 20.77%
  | libjpeg-turbo | q90 | 4:4:4 | 49169245 | 39177048 | 39045153 | 0.34% | 20.32% | 20.59%
  | libjpeg-turbo | q92 | 4:4:4 | 56139556 | 44712883 | 44574988 | 0.31% | 20.35% | 20.60%
  | libjpeg-turbo | q95 | 4:4:4 | 78390474 | 61858309 | 61709516 | 0.24% | 21.09% | 21.28%
  | libjpeg-turbo | q98 | 4:4:4 | 131489557 | 104079893 | 103803199 | 0.27% | 20.85% | 21.06%
  | libjpeg-turbo | q30 | 4:2:0 | 8114783 | 5820965 | 5822602 | -0.03% | 28.27% | 28.25%
  | libjpeg-turbo | q50 | 4:2:0 | 11455694 | 8808743 | 8787137 | 0.25% | 23.11% | 23.29%
  | libjpeg-turbo | q60 | 4:2:0 | 13305148 | 10430588 | 10403268 | 0.26% | 21.60% | 21.81%
  | libjpeg-turbo | q70 | 4:2:0 | 16216874 | 12934404 | 12904083 | 0.23% | 20.24% | 20.43%
  | libjpeg-turbo | q80 | 4:2:0 | 21027815 | 17038360 | 16984104 | 0.32% | 18.97% | 19.23%
  | libjpeg-turbo | q90 | 4:2:0 | 33122078 | 26922783 | 26846704 | 0.28% | 18.72% | 18.95%
  | libjpeg-turbo | q92 | 4:2:0 | 37246951 | 30288385 | 30206284 | 0.27% | 18.68% | 18.90%
  | libjpeg-turbo | q95 | 4:2:0 | 51554277 | 41410234 | 41318467 | 0.22% | 19.68% | 19.85%
  | libjpeg-turbo | q98 | 4:2:0 | 80005173 | 65176598 | 65007740 | 0.26% | 18.53% | 18.75%
  | jpegli | q20 | 4:4:4 | 6682018 | 5311538 | 5310922 | 0.01% | 20.51% | 20.52%
  | jpegli | q50 | 4:4:4 | 10081076 | 8342875 | 8334325 | 0.10% | 17.24% | 17.33%
  | jpegli | q70 | 4:4:4 | 13609164 | 11513487 | 11490369 | 0.20% | 15.40% | 15.57%
  | jpegli | q80 | 4:4:4 | 17498075 | 15008162 | 14976391 | 0.21% | 14.23% | 14.41%
  | jpegli | q90 | 4:4:4 | 29156021 | 25522507 | 25431665 | 0.36% | 12.46% | 12.77%
  | jpegli | q92 | 4:4:4 | 34997571 | 30803078 | 30690148 | 0.37% | 11.99% | 12.31%
  | jpegli | q95 | 4:4:4 | 48533994 | 43066455 | 42890784 | 0.41% | 11.27% | 11.63%
  | jpegli | q98 | 4:4:4 | 83188536 | 74272353 | 73934719 | 0.45% | 10.72% | 11.12%
CfP Class A 8-bit | jpegli | q20 | 4:4:4 | 8510656 | 6927220 | 6937517 | -0.15% | 18.61% | 18.48%
  | jpegli | q50 | 4:4:4 | 12802858 | 10769156 | 10756154 | 0.12% | 15.88% | 15.99%
  | jpegli | q70 | 4:4:4 | 17056871 | 14590820 | 14559437 | 0.22% | 14.46% | 14.64%
  | jpegli | q80 | 4:4:4 | 21250924 | 18401662 | 18354072 | 0.26% | 13.41% | 13.63%
  | jpegli | q90 | 4:4:4 | 32633134 | 28801769 | 28717507 | 0.29% | 11.74% | 12.00%
  | jpegli | q92 | 4:4:4 | 38091940 | 33786314 | 33687699 | 0.29% | 11.30% | 11.56%
  | jpegli | q95 | 4:4:4 | 50486870 | 45147549 | 45009311 | 0.31% | 10.58% | 10.85%
  | jpegli | q98 | 4:4:4 | 81331127 | 73008983 | 72740731 | 0.37% | 10.23% | 10.56%
  | libjpeg-turbo | q30 | 4:4:4 | 12970005 | 9191054 | 9210498 | -0.21% | 29.14% | 28.99%
  | libjpeg-turbo | q50 | 4:4:4 | 17547226 | 13394824 | 13387581 | 0.05% | 23.66% | 23.71%
  | libjpeg-turbo | q60 | 4:4:4 | 20137541 | 15687152 | 15679491 | 0.05% | 22.10% | 22.14%
  | libjpeg-turbo | q70 | 4:4:4 | 24202500 | 19197989 | 19189707 | 0.04% | 20.68% | 20.71%
  | libjpeg-turbo | q80 | 4:4:4 | 31302553 | 25145547 | 25113791 | 0.13% | 19.67% | 19.77%
  | libjpeg-turbo | q90 | 4:4:4 | 49227679 | 39436079 | 39368899 | 0.17% | 19.89% | 20.03%
  | libjpeg-turbo | q92 | 4:4:4 | 55742847 | 44617563 | 44545739 | 0.16% | 19.96% | 20.09%
  | libjpeg-turbo | q95 | 4:4:4 | 76250578 | 60389904 | 60310387 | 0.13% | 20.80% | 20.91%
  | libjpeg-turbo | q98 | 4:4:4 | 121947268 | 96986990 | 96832191 | 0.16% | 20.47% | 20.60%
subset1 | jpegli | q20 | 4:4:4 | 3330271 | 2815891 | 2811586 | 0.15% | 15.45% | 15.57%
  | jpegli | q50 | 4:4:4 | 5288141 | 4597966 | 4592622 | 0.12% | 13.05% | 13.15%
  | jpegli | q70 | 4:4:4 | 7340099 | 6482235 | 6474381 | 0.12% | 11.69% | 11.79%
  | jpegli | q80 | 4:4:4 | 9285266 | 8277071 | 8267478 | 0.12% | 10.86% | 10.96%
  | jpegli | q90 | 4:4:4 | 13928323 | 12589598 | 12575421 | 0.11% | 9.61% | 9.71%
  | jpegli | q92 | 4:4:4 | 15973597 | 14478620 | 14462854 | 0.11% | 9.36% | 9.46%
  | jpegli | q95 | 4:4:4 | 20510021 | 18720852 | 18700872 | 0.11% | 8.72% | 8.82%
  | jpegli | q98 | 4:4:4 | 31665928 | 29041149 | 28977738 | 0.22% | 8.29% | 8.49%
subset1 | libjpeg-turbo | q30 | 4:4:4 | 5144520 | 3832104 | 3829803 | 0.06% | 25.51% | 25.56%
  | libjpeg-turbo | q50 | 4:4:4 | 7022349 | 5553575 | 5548810 | 0.09% | 20.92% | 20.98%
  | libjpeg-turbo | q60 | 4:4:4 | 8064122 | 6482590 | 6478147 | 0.07% | 19.61% | 19.67%
  | libjpeg-turbo | q70 | 4:4:4 | 9680706 | 7891098 | 7886166 | 0.06% | 18.49% | 18.54%
  | libjpeg-turbo | q80 | 4:4:4 | 12465663 | 10270361 | 10264286 | 0.06% | 17.61% | 17.66%
  | libjpeg-turbo | q90 | 4:4:4 | 19184949 | 15766524 | 15763787 | 0.02% | 17.82% | 17.83%
  | libjpeg-turbo | q92 | 4:4:4 | 21547808 | 17691660 | 17692219 | 0.00% | 17.90% | 17.89%
  | libjpeg-turbo | q95 | 4:4:4 | 28979663 | 23462371 | 23461663 | 0.00% | 19.04% | 19.04%
  | libjpeg-turbo | q98 | 4:4:4 | 46529091 | 37509677 | 37523917 | -0.04% | 19.38% | 19.35%
Average | libjpeg-turbo |   |   |   |   |   | 0.16% | 21.25% | 21.38%
Average | jpegli |   |   |   |   |   | 0.20% | 12.79% | 12.97%

