### PR TITLE
Draft: Fix for handling total_pixels

### DIFF
--- a/lib/jxl/modular/encoding/enc_encoding.cc
+++ b/lib/jxl/modular/encoding/enc_encoding.cc
@@ -589,17 +589,6 @@ Status ModularEncode(const Image &image, const ModularOptions &options,
   TreeSamples tree_samples_storage;
   size_t total_pixels_storage = 0;
   if (!total_pixels) total_pixels = &total_pixels_storage;
-  if (*total_pixels == 0) {
-    for (size_t i = 0; i < nb_channels; i++) {
-      if (i >= image.nb_meta_channels &&
-          (image.channel[i].w > options.max_chan_size ||
-           image.channel[i].h > options.max_chan_size)) {
-        break;
-      }
-      *total_pixels += image.channel[i].w * image.channel[i].h;
-    }
-    *total_pixels = std::max<size_t>(*total_pixels, 1);
-  }
   // If there's no tree, compute one (or gather data to).
   if (tree == nullptr &&
       options.tree_kind == ModularOptions::TreeKind::kLearn) {
@@ -647,6 +636,7 @@ Status ModularEncode(const Image &image, const ModularOptions &options,
     EntropyEncodingData code;
     std::vector<uint8_t> context_map;
 
+    *total_pixels = std::max<size_t>(*total_pixels, 1);
     std::vector<std::vector<Token>> tree_tokens(1);
     if (options.tree_kind == ModularOptions::TreeKind::kLearn) {
       JXL_ASSIGN_OR_RETURN(


### PR DESCRIPTION
### Description

Handling of the number of pixels in `ModularEncode` functions is strange: being applied to a sequence of stream images like in `ModularFrameEncoder::ComputeTree` or to an individual image like in other cases, it overestimates the number of pixels processed due to special treatment of `*total_pixels == 0` case.

If initially `total_pixels = 0` then we have after the function `total_pixels = 2 * (number of pixels in the image)` increased by this part and `GatherTreeData` , in any other case we have `total_pixels += (number of pixels in the image)` increased by `GatherTreeData` (modulo edge cases).

It looks like that the intention was to not allow zero in the number of pixels as it crashes `LearnTree` function. However, it can be done in a more straightforward way without pixel number overestimation. 

In my testing the proposed change also leads to a slightly better compression, of the order of $6\times10^{-3}$ %. However, some of the tests are failing due to increase of the file size, so I mark this as draft before I can find out the cause.

### Pull Request Checklist

- [x] **CLA Signed**: Have you signed the [Contributor License Agreement](https://code.google.com/legal/individual-cla-v1.0.html) (individual or corporate, as appropriate)? Only contributions from signed contributors can be accepted.
- [x] **Authors**: Have you considered adding your name to the [AUTHORS](AUTHORS) file?
- [x] **Code Style**: Have you ensured your code adheres to the project's coding style guidelines? You can use `./ci.sh lint` for automatic code formatting.
