### PR TITLE
fix test that was broken by #4111

### DIFF
--- a/lib/jxl/decode_test.cc
+++ b/lib/jxl/decode_test.cc
@@ -1673,7 +1673,7 @@ TEST(DecodeTest, PixelTestWithICCProfileLossy) {
       ButteraugliDistance(io0->frames, io1->frames, butteraugli_params,
                           *JxlGetDefaultCms(),
                           /*distmap=*/nullptr, nullptr),
-      1.00f);
+      1.1f);
 
   JxlDecoderDestroy(dec);
 }


### PR DESCRIPTION
In #4111, changes to GetSomeTestImage() cause test images to change which means some of the thresholds have to be adjusted.