### PR TITLE
fix jxl_from_tree

### DIFF
--- a/tools/jxl_from_tree.cc
+++ b/tools/jxl_from_tree.cc
@@ -487,6 +487,7 @@ bool ParseNode(F& tok, Tree& tree, SplineData& spline_data,
   cparams.ec_resampling = 1;
   cparams.modular_group_size_shift = 3;
   cparams.colorspace = 0;
+  cparams.buffering = 0;
   JxlMemoryManager* memory_manager = jpegxl::tools::NoMemoryManager();
   auto io = jxl::make_unique<CodecInOut>(memory_manager);
   io->metadata.m.modular_16_bit_buffer_sufficient = false;


### PR DESCRIPTION
For larger images (more than one LF group) the buffering-by-default was messing stuff up.