### PR TITLE
Resampling tweaks and updated docs

### DIFF
--- a/doc/encode_effort.md
+++ b/doc/encode_effort.md
@@ -26,18 +26,18 @@ The following table describes what the various effort settings do:
 | e6 | e5 + more RCTs and MA tree properties | e5 + error diffusion, full variable blocks heuristics |
 | e7 | e6 + more RCTs and MA tree properties | e6 + patches (including dots) |
 | e8 | e7 + more RCTs, MA tree properties, and Weighted predictor parameters | e7 + Butteraugli iterations for adaptive quantization |
-| e9 | e8 + more RCTs, MA tree properties, and Weighted predictor parameters | e8 + more Butteraugli iterations and disables chunked encoding |
-| e10 | e9 + global MA tree, try all predictors, and disables chunked encoding | e9 + more thorough adaptive quantization |
-| e11 | e10 + previous-channel MA tree properties, different group dimensions, and try multiple e10 configurations | N/A |
+| e9 | e8 + more RCTs, MA tree properties, and Weighted predictor parameters | e8 + more Butteraugli iterations |
+| e10 | e9 + global MA tree, try all predictors, and disables chunked encoding | e9 + more thorough adaptive quantization and disables chunked encoding |
+| e11 | e10 + previous-channel MA tree properties, different group dimensions, and try multiple e10 configurations | e10 + iterative downsampling for high distance values |
 
 For the entropy coding (context clustering, lz77 search, hybriduint configuration): slower/more exhaustive search as effort goes up.
 
 <u>Chunked encoding is also disabled under these circumstances:</u>
 * When the image is smaller than 2048x2048.
 * Lossless Jpeg transcoding.
-* VarDCT at distances ≥20.
 * Effort 7 VarDCT at distances ≥3.0.
 * Effort 8 VarDCT at distances >0.5.
+* Effort 11 VarDCT with --resampling 2.
 * Lossy Modular.
 * When using any of these flags:
   * `--patches=1`
@@ -45,5 +45,4 @@ For the entropy coding (context clustering, lz77 search, hybriduint configuratio
   * `-p`
   * `-d 0` and `-R 1`
   * `--noise=1`
-  * `--resampling >1`
   * `--disable_perceptual_optimizations`

--- a/doc/encode_effort.md
+++ b/doc/encode_effort.md
@@ -37,7 +37,6 @@ For the entropy coding (context clustering, lz77 search, hybriduint configuratio
 * Lossless Jpeg transcoding.
 * Effort 7 VarDCT at distances ≥3.0.
 * Effort 8 VarDCT at distances >0.5.
-* Effort 11 VarDCT with --resampling 2.
 * Lossy Modular.
 * When using any of these flags:
   * `--patches=1`

--- a/doc/encode_effort.md
+++ b/doc/encode_effort.md
@@ -45,4 +45,5 @@ For the entropy coding (context clustering, lz77 search, hybriduint configuratio
   * `-p`
   * `-d 0` and `-R 1`
   * `--noise=1`
+  * `--resampling >1`
   * `--disable_perceptual_optimizations`

--- a/doc/encode_effort.md
+++ b/doc/encode_effort.md
@@ -21,8 +21,8 @@ The following table describes what the various effort settings do:
 | e1 | fast-lossless, fixed YCoCg RCT, fixed ClampedGradient predictor, simple palette detection, no MA tree (one context for everything), Huffman, simple rle-only lz77 | only 8x8, basically XYB jpeg with ANS |
 | e2 | global channel palette, fixed MA tree (context based on Gradient-error), ANS, otherwise same as e1 | same as e1 |
 | e3 | same as e2 but fixed Weighted predictor and fixed MA tree with context based on WP-error | e2 + better ANS |
-| e4 | try both ClampedGradient and Weighted predictor, learned MA tree, global palette | simple variable blocks heuristics, adaptive quantization, coefficient reordering |
-| e5 | e4 + patches, local palette / local channel palette, different local RCTs | e4 + gabor-like transform, chroma from luma |
+| e4 | try both ClampedGradient and Weighted predictor, learned MA tree, global palette | coefficient reordering |
+| e5 | e4 + patches, local palette / local channel palette, different local RCTs | e4 + simple variable blocks heuristics, adaptive quantization, gabor-like transform, chroma from luma |
 | e6 | e5 + more RCTs and MA tree properties | e5 + error diffusion, full variable blocks heuristics |
 | e7 | e6 + more RCTs and MA tree properties | e6 + patches (including dots) |
 | e8 | e7 + more RCTs, MA tree properties, and Weighted predictor parameters | e7 + Butteraugli iterations for adaptive quantization |

--- a/doc/encode_effort.md
+++ b/doc/encode_effort.md
@@ -3,7 +3,7 @@
 Various trade-offs between encode speed and compression performance can be selected in libjxl. In `cjxl`, this is done via the `--effort` (`-e`) option.
 Higher effort means slower encoding; generally the higher the effort, the more coding tools are used, computationally more expensive heuristics are used,
 and more exhaustive search is performed. 
-Generally, efforts range between `1` and `10`, but there is also `e11` if you pass the flag `--allow_expert_options` (in combination with "lossless", i.e. `-d 0`). It is considered an expert option because it can be extremely slow.
+Generally, efforts range between `1` and `10`, but there is also `e11` if you pass the flag `--allow_expert_options`. It is considered an expert option because it can be extremely slow.
 
 
 For lossy compression, higher effort results in better visual quality at a given filesize, and also better

--- a/doc/encode_effort.md
+++ b/doc/encode_effort.md
@@ -36,7 +36,7 @@ For the entropy coding (context clustering, lz77 search, hybriduint configuratio
 * When the image is smaller than 2048x2048.
 * Lossless Jpeg transcoding.
 * Effort 7 VarDCT at distances ≥3.0.
-* Effort 8 VarDCT at distances >0.5.
+* Efforts 8 & 9 VarDCT at distances >0.5.
 * Lossy Modular.
 * When using any of these flags:
   * `--patches=1`

--- a/lib/jxl/common.h
+++ b/lib/jxl/common.h
@@ -49,10 +49,9 @@ enum class SpeedTier {
   // Turns on error diffusion and full AC strategy heuristics. Equivalent to
   // "fast" mode.
   kWombat = 4,
-  // Turns on gaborish by default, non-default cmap, initial quant field.
+  // Turns on simple heuristics for AC strategy, quant field, gaborish by default, non-default cmap, initial quant field, non-default CFL.
   kHare = 5,
-  // Turns on simple heuristics for AC strategy, quant field, and clustering;
-  // also enables coefficient reordering.
+  // Turns on clustering and enables coefficient reordering.
   kCheetah = 6,
   // Turns off most encoder features. Does context clustering.
   // Modular: uses fixed tree with Weighted predictor.

--- a/lib/jxl/enc_ac_strategy.cc
+++ b/lib/jxl/enc_ac_strategy.cc
@@ -1125,7 +1125,7 @@ Status AcStrategyHeuristics::ProcessRect(const Rect& rect,
                                          const ColorCorrelationMap& cmap,
                                          AcStrategyImage* ac_strategy,
                                          size_t thread) {
-  // In Falcon mode, use DCT8 everywhere and uniform quantization.
+  // In Cheetah mode, use DCT8 everywhere and uniform quantization.
   if (cparams.speed_tier >= SpeedTier::kCheetah) {
     ac_strategy->FillDCT8(rect);
     return true;

--- a/lib/jxl/enc_frame.cc
+++ b/lib/jxl/enc_frame.cc
@@ -107,10 +107,10 @@ Status ParamsPostInit(CompressParams* p) {
     // most photographic images, with an adjusted butteraugli score chosen to
     // give roughly the same amount of bits per pixel.
     if (!p->already_downsampled && p->butteraugli_distance >= 10) {
-      // TODO(Jonnyawsom3): Explore 4x4 resampling at distance 25. Results are
-      // inconsistent and images under 4K become far too blurry.
+      // TODO(Jonnyawsom3): Explore 4x4 resampling at distance 25. Lower bpp
+      // but results are inconsistent and images under 4K become far too blurry.
       p->resampling = 2;
-      p->butteraugli_distance = 2.5 + ((p->butteraugli_distance - 10) * 0.25);
+      p->butteraugli_distance = p->butteraugli_distance * 0.25;
     }
   }
   if (p->ec_resampling <= 0) {

--- a/lib/jxl/enc_frame.cc
+++ b/lib/jxl/enc_frame.cc
@@ -716,10 +716,10 @@ Status DownsampleColorChannels(const CompressParams& cparams,
     // CustomTransformData
     if (cparams.speed_tier == SpeedTier::kTectonicPlate) {
       // TODO(Jonnyawsom3): DownsampleImage2_Iterative is currently a 2x
-      // slowdown on Glacier and 3x memory increase for Squirrel due
-      // to chunked encoding. Until optimized, enabled only for TectonicPlate.
-      // Downsampling is only active at high distances by default, 
-      // making improvements negligible. Explore separate flag for distance.
+      // slowdown on Glacier and 3x memory increase for Squirrel.
+      // Until optimized, enabled only for TectonicPlate. Downsampling is
+      // only active at high distances by default anyway, making improvements
+      // negligible. Explore separate flag for explicit distance setting.
       JXL_RETURN_IF_ERROR(DownsampleImage2_Iterative(opsin));
     } else {
       JXL_RETURN_IF_ERROR(DownsampleImage2_Sharper(opsin));

--- a/lib/jxl/enc_frame.cc
+++ b/lib/jxl/enc_frame.cc
@@ -710,9 +710,10 @@ Status DownsampleColorChannels(const CompressParams& cparams,
     // TODO(lode): use the regular DownsampleImage, or adapt to the custom
     // coefficients, if there is are custom upscaling coefficients in
     // CustomTransformData
-    if (cparams.speed_tier <= SpeedTier::kTectonicPlate) {
+    if (cparams.speed_tier == SpeedTier::kTectonicPlate) {
       // TODO(Jonnyawsom3): DownsampleImage2_Iterative is currently a 2x
-      // slowdown on Glacier, therefore enabled only for TectonicPlate.
+      // slowdown on Glacier and 3x memory increase for Squirrel due
+      // to chunked encoding, so enabled only for TectonicPlate.
       JXL_RETURN_IF_ERROR(DownsampleImage2_Iterative(opsin));
     } else {
       JXL_RETURN_IF_ERROR(DownsampleImage2_Sharper(opsin));

--- a/lib/jxl/enc_frame.cc
+++ b/lib/jxl/enc_frame.cc
@@ -110,7 +110,9 @@ Status ParamsPostInit(CompressParams* p) {
       // TODO(Jonnyawsom3): Explore 4x4 resampling at distance 25. Lower bpp
       // but results are inconsistent and images under 4K become far too blurry.
       p->resampling = 2;
-      p->butteraugli_distance = p->butteraugli_distance * 0.25;
+      // Adding 0.25 balances photo with non-photo, shifting towards lower bpp
+      // to avoid large overshoot while maintaining quality equal to before.
+      p->butteraugli_distance = (p->butteraugli_distance * 0.25) + 0.25;
     }
   }
   if (p->ec_resampling <= 0) {

--- a/lib/jxl/enc_frame.cc
+++ b/lib/jxl/enc_frame.cc
@@ -717,7 +717,7 @@ Status DownsampleColorChannels(const CompressParams& cparams,
       // slowdown on Glacier and 3x memory increase for Squirrel due
       // to chunked encoding. Until optimized, enabled only for TectonicPlate.
       // Downsampling is only active at high distances by default, 
-      // making improvements negligable. Explore seperate flag for distance.
+      // making improvements negligible. Explore separate flag for distance.
       JXL_RETURN_IF_ERROR(DownsampleImage2_Iterative(opsin));
     } else {
       JXL_RETURN_IF_ERROR(DownsampleImage2_Sharper(opsin));

--- a/lib/jxl/enc_frame.cc
+++ b/lib/jxl/enc_frame.cc
@@ -106,9 +106,11 @@ Status ParamsPostInit(CompressParams* p) {
     // For very low bit rates, using 2x2 resampling gives better results on
     // most photographic images, with an adjusted butteraugli score chosen to
     // give roughly the same amount of bits per pixel.
-    if (!p->already_downsampled && p->butteraugli_distance >= 20) {
+    if (!p->already_downsampled && p->butteraugli_distance >= 10) {
+      // TODO(Jonnyawsom3): Explore 4x4 resampling at distance 25. Results are
+      // inconsistent and images under 4K become far too blurry.
       p->resampling = 2;
-      p->butteraugli_distance = 6 + ((p->butteraugli_distance - 20) * 0.25);
+      p->butteraugli_distance = 2.5 + ((p->butteraugli_distance - 10) * 0.25);
     }
   }
   if (p->ec_resampling <= 0) {
@@ -713,7 +715,9 @@ Status DownsampleColorChannels(const CompressParams& cparams,
     if (cparams.speed_tier == SpeedTier::kTectonicPlate) {
       // TODO(Jonnyawsom3): DownsampleImage2_Iterative is currently a 2x
       // slowdown on Glacier and 3x memory increase for Squirrel due
-      // to chunked encoding, so enabled only for TectonicPlate.
+      // to chunked encoding. Until optimized, enabled only for TectonicPlate.
+      // Downsampling is only active at high distances by default, 
+      // making improvements negligable. Explore seperate flag for distance.
       JXL_RETURN_IF_ERROR(DownsampleImage2_Iterative(opsin));
     } else {
       JXL_RETURN_IF_ERROR(DownsampleImage2_Sharper(opsin));

--- a/lib/jxl/enc_frame.cc
+++ b/lib/jxl/enc_frame.cc
@@ -710,10 +710,9 @@ Status DownsampleColorChannels(const CompressParams& cparams,
     // TODO(lode): use the regular DownsampleImage, or adapt to the custom
     // coefficients, if there is are custom upscaling coefficients in
     // CustomTransformData
-    if (cparams.speed_tier <= SpeedTier::kSquirrel) {
-      // TODO(lode): DownsampleImage2_Iterative is currently too slow to
-      // be used for squirrel, make it faster, and / or enable it only for
-      // kitten.
+    if (cparams.speed_tier <= SpeedTier::kTectonicPlate) {
+      // TODO(Jonnyawsom3): DownsampleImage2_Iterative is currently a 2x
+      // slowdown on Glacier, therefore enabled only for TectonicPlate.
       JXL_RETURN_IF_ERROR(DownsampleImage2_Iterative(opsin));
     } else {
       JXL_RETURN_IF_ERROR(DownsampleImage2_Sharper(opsin));


### PR DESCRIPTION
### Description

This PR lowers the threshold for resampling to be enabled during lossy encoding, now using 2x2 resampling at distance 10 and up, with a tweaked equation to closer match the non-resampled bpp. It varies by image content, but on average ssimulacra2 scores were 10 points higher at a lower or equal bpp, with most score regressions looking better after visual inspection.

I encountered one image that was using 50% higher bpp with resampling than without, causing a jump in image quality at distance 10, but I think butteraugli was undershooting without due to the extremely low image quality otherwise. I tested 4x4 resampling at distance 25, and while promising, the results were far too blurry on anything below 4K, and results were highly inconsistent between images.

It also moves the extremely slow iterative downsampling algorithm to effort 11, speeding up the default effort 7 by 3-10x with a significant reduction in memory due to chunked encoding being re-enabled. Effort 10 should be around 2x faster from my testing too, hence choosing to move it to effort 11 since lossy did nothing different before.

Documentation has been updated and incorrect/outdated comments fixed too.

Overall, distances above 10 should have improved image quality and/or bpp, with distances above 20 having higher bpp to match no resampling and marginally better quality. Images were also tested with version 0.8 due to quality regressions since, but the relative improvements are consistent across encoder changes.

Current Distance 10 (SSIMULACRA2: 25.41)
![image](https://github.com/user-attachments/assets/407546c5-a0fe-4963-9d30-760d98ea9e82)
New Resampled Distance 10 (SSIMULACRA2: 32.18)
![image](https://github.com/user-attachments/assets/92c454d6-4890-464f-99dd-97fbfe9852e7)


### Pull Request Checklist

- [x] **CLA Signed**: Have you signed the [Contributor License Agreement](https://code.google.com/legal/individual-cla-v1.0.html) (individual or corporate, as appropriate)? Only contributions from signed contributors can be accepted.
- [x] **Authors**: Have you considered adding your name to the [AUTHORS](AUTHORS) file?
- [x] **Code Style**: Have you ensured your code adheres to the project's coding style guidelines? You can use `./ci.sh lint` for automatic code formatting.


Please review the full [contributing guidelines](https://github.com/libjxl/libjxl/blob/main/CONTRIBUTING.md) for more details.
