### PR TITLE
Remove useless asserts

### DIFF
--- a/lib/jxl/base/rect.h
+++ b/lib/jxl/base/rect.h
@@ -74,31 +74,26 @@ class RectT {
 
   template <template <class> class P, typename V>
   V* Row(P<V>* image, size_t y) const {
-    JXL_DASSERT(y + y0_ >= 0);
     return image->Row(y + y0_) + x0_;
   }
 
   template <template <class> class P, typename V>
   const V* Row(const P<V>* image, size_t y) const {
-    JXL_DASSERT(y + y0_ >= 0);
     return image->Row(y + y0_) + x0_;
   }
 
   template <template <class> class MP, typename V>
   V* PlaneRow(MP<V>* image, const size_t c, size_t y) const {
-    JXL_DASSERT(y + y0_ >= 0);
     return image->PlaneRow(c, y + y0_) + x0_;
   }
 
   template <template <class> class P, typename V>
   const V* ConstRow(const P<V>& image, size_t y) const {
-    JXL_DASSERT(y + y0_ >= 0);
     return image.ConstRow(y + y0_) + x0_;
   }
 
   template <template <class> class MP, typename V>
   const V* ConstPlaneRow(const MP<V>& image, size_t c, size_t y) const {
-    JXL_DASSERT(y + y0_ >= 0);
     return image.ConstPlaneRow(c, y + y0_) + x0_;
   }
 


### PR DESCRIPTION
### Description

Here the asserts are useless: two `size_t`  added cannot give you a negative number. And being applied to other cases of usage appears to be the same: `size_t` as large unsigned forces promotion of other number to unsigned too.

### Pull Request Checklist

- [x] **CLA Signed**: Have you signed the [Contributor License Agreement](https://code.google.com/legal/individual-cla-v1.0.html) (individual or corporate, as appropriate)? Only contributions from signed contributors can be accepted.
- [x] **Authors**: Have you considered adding your name to the [AUTHORS](AUTHORS) file?
- [x] **Code Style**: Have you ensured your code adheres to the project's coding style guidelines? You can use `./ci.sh lint` for automatic code formatting.