### PR TITLE
Simpler SplitTreeSamples

### DIFF
--- a/lib/jxl/modular/encoding/enc_ma.h
+++ b/lib/jxl/modular/encoding/enc_ma.h
@@ -96,10 +96,6 @@ struct TreeSamples {
   // Swaps samples in position a and b. Does nothing if a == b.
   void Swap(size_t a, size_t b);
 
-  // Cycles samples: a -> b -> c -> a. We assume a <= b <= c, so that we can
-  // just call Swap(a, b) if b==c.
-  void ThreeShuffle(size_t a, size_t b, size_t c);
-
  private:
   // TODO(veluca): as the total number of properties and predictors are known
   // before adding any samples, it might be better to interleave predictors,


### PR DESCRIPTION
### Description

As we know exact value of property to split tree samples on, `SplitTreeSamples` function can be simplified (with slight performance improvement). `ThreeShuffle` method then becomes unused and was removed.

### Pull Request Checklist

- [x] **CLA Signed**: Have you signed the [Contributor License Agreement](https://code.google.com/legal/individual-cla-v1.0.html) (individual or corporate, as appropriate)? Only contributions from signed contributors can be accepted.
- [x] **Authors**: Have you considered adding your name to the [AUTHORS](AUTHORS) file?
- [x] **Code Style**: Have you ensured your code adheres to the project's coding style guidelines? You can use `./ci.sh lint` for automatic code formatting.