### PR TITLE
Fix ineffciency in quantize histogram

### DIFF
--- a/lib/jxl/enc_ans.cc
+++ b/lib/jxl/enc_ans.cc
@@ -160,6 +160,9 @@ bool RebalanceHistogram(const float* targets, int max_symbol,
       if (target >= count + 0.5f * inc && count + inc < table_size) {
         count += inc;
       }
+      if (target < count - 0.5f * inc && count - inc > 0) {
+        count -= inc;
+      }
       sum += count;
       counts[n] = count;
       const int count_log = FloorLog2Nonzero(count);

--- a/lib/jxl/jxl_test.cc
+++ b/lib/jxl/jxl_test.cc
@@ -925,7 +925,7 @@ TEST(JxlTest, RoundtripAlphaPremultiplied) {
 
   std::vector<uint8_t> compressed;
   EXPECT_TRUE(test::EncodeFile(cparams, io.get(), &compressed));
-  EXPECT_LE(compressed.size(), 18000u);
+  EXPECT_LE(compressed.size(), 18313u);
 
   for (bool use_image_callback : {false, true}) {
     for (bool unpremul_alpha : {false, true}) {
@@ -1081,7 +1081,7 @@ JXL_SLOW_TEST(JxlTest, RoundtripLossless8) {
   dparams.accepted_formats.push_back(t.ppf().frames[0].color.format);
 
   PackedPixelFile ppf_out;
-  EXPECT_EQ(Roundtrip(t.ppf(), cparams, dparams, pool.get(), &ppf_out), 223044);
+  EXPECT_EQ(Roundtrip(t.ppf(), cparams, dparams, pool.get(), &ppf_out), 223047);
   EXPECT_EQ(ComputeDistance2(t.ppf(), ppf_out), 0.0);
 }
 
@@ -1158,7 +1158,7 @@ TEST(JxlTest, RoundtripLossless8Alpha) {
   dparams.accepted_formats.push_back(t.ppf().frames[0].color.format);
 
   PackedPixelFile ppf_out;
-  EXPECT_EQ(Roundtrip(t.ppf(), cparams, dparams, pool, &ppf_out), 251456);
+  EXPECT_EQ(Roundtrip(t.ppf(), cparams, dparams, pool, &ppf_out), 251466);
   EXPECT_EQ(ComputeDistance2(t.ppf(), ppf_out), 0.0);
   EXPECT_EQ(ppf_out.info.alpha_bits, 8);
   EXPECT_TRUE(test::SameAlpha(t.ppf(), ppf_out));
@@ -1197,7 +1197,7 @@ TEST(JxlTest, RoundtripLossless16Alpha) {
 
   PackedPixelFile ppf_out;
   // TODO(szabadka) Investigate big size difference on i686
-  EXPECT_NEAR(Roundtrip(t.ppf(), cparams, dparams, pool, &ppf_out), 4665, 100);
+  EXPECT_NEAR(Roundtrip(t.ppf(), cparams, dparams, pool, &ppf_out), 4906, 100);
   EXPECT_EQ(ComputeDistance2(t.ppf(), ppf_out), 0.0);
   EXPECT_EQ(ppf_out.info.alpha_bits, 16);
   EXPECT_TRUE(test::SameAlpha(t.ppf(), ppf_out));
@@ -1236,7 +1236,7 @@ TEST(JxlTest, RoundtripLossless16AlphaNotMisdetectedAs8Bit) {
   dparams.accepted_formats.push_back(t.ppf().frames[0].color.format);
 
   PackedPixelFile ppf_out;
-  EXPECT_NEAR(Roundtrip(t.ppf(), cparams, dparams, pool, &ppf_out), 280, 50);
+  EXPECT_NEAR(Roundtrip(t.ppf(), cparams, dparams, pool, &ppf_out), 331, 50);
   EXPECT_EQ(ComputeDistance2(t.ppf(), ppf_out), 0.0);
   EXPECT_EQ(ppf_out.info.bits_per_sample, 16);
   EXPECT_EQ(ppf_out.info.alpha_bits, 16);
@@ -1332,7 +1332,7 @@ TEST(JxlTest, RoundtripLossless8Gray) {
   dparams.accepted_formats.push_back(t.ppf().frames[0].color.format);
 
   PackedPixelFile ppf_out;
-  EXPECT_EQ(Roundtrip(t.ppf(), cparams, dparams, pool, &ppf_out), 92179);
+  EXPECT_EQ(Roundtrip(t.ppf(), cparams, dparams, pool, &ppf_out), 92859);
   EXPECT_EQ(ComputeDistance2(t.ppf(), ppf_out), 0.0);
   EXPECT_EQ(ppf_out.color_encoding.color_space, JXL_COLOR_SPACE_GRAY);
   EXPECT_EQ(ppf_out.info.bits_per_sample, 8);

--- a/lib/jxl/modular/encoding/enc_ma.cc
+++ b/lib/jxl/modular/encoding/enc_ma.cc
@@ -748,6 +748,7 @@ std::vector<int32_t> QuantizeHistogram(const std::vector<uint32_t> &histogram,
       thresholds.push_back(i);
       while (cumsum > threshold * sum / num_chunks) threshold++;
     }
+    if (cumsum == sum) break;
   }
   return thresholds;
 }

--- a/lib/jxl/modular/encoding/enc_ma.cc
+++ b/lib/jxl/modular/encoding/enc_ma.cc
@@ -735,21 +735,24 @@ void TreeSamples::ThreeShuffle(size_t a, size_t b, size_t c) {
 namespace {
 std::vector<int32_t> QuantizeHistogram(const std::vector<uint32_t> &histogram,
                                        size_t num_chunks) {
-  if (histogram.empty()) return {};
+  if (histogram.empty() || num_chunks == 0) return {};
+  uint64_t sum = std::accumulate(histogram.begin(), histogram.end(), 0LU);
+  if (sum == 0) return {};
   // TODO(veluca): selecting distinct quantiles is likely not the best
   // way to go about this.
   std::vector<int32_t> thresholds;
-  uint64_t sum = std::accumulate(histogram.begin(), histogram.end(), 0LU);
   uint64_t cumsum = 0;
   uint64_t threshold = 1;
-  for (size_t i = 0; i + 1 < histogram.size(); i++) {
+  for (size_t i = 0; i < histogram.size(); i++) {
     cumsum += histogram[i];
-    if (cumsum >= threshold * sum / num_chunks) {
+    if (cumsum * num_chunks >= threshold * sum) {
       thresholds.push_back(i);
-      while (cumsum > threshold * sum / num_chunks) threshold++;
+      while (cumsum * num_chunks >= threshold * sum) threshold++;
     }
-    if (cumsum == sum) break;
   }
+  JXL_DASSERT(thresholds.size() <= num_chunks);
+  // last value collects all histogram and is not really a threshold
+  thresholds.resize(thresholds.size() - 1);
   return thresholds;
 }
 
@@ -914,6 +917,7 @@ void TreeSamples::PreQuantizeProperties(
                  compact_properties[i][mapped]) {
         mapped++;
       }
+      JXL_DASSERT(mapped < 256);
       // property_mapping[i] of a value V is `mapped` if
       // compact_properties[i][mapped] <= j and
       // compact_properties[i][mapped-1] > j


### PR DESCRIPTION
### Description

Histogram quantization function `QuantizeHistogram` has a deficiency that generates runs of false thresholds for zeros in histogram when `cumsum == threshold * sum / num_chunks`. As a result it can provide `thresholds` vectors much longer than supposed `num_chunks` , especially if histogram has a long zero-tail (can be verified by putting assert there on tests). Such vectors mess up with `property_mapping` providing not only much more buckets than intended, but also wrapping them out as `size_t mapped` is saved into `uint8_t`.

This PR fixes the problem. Some sizes in the tests get up as the number of buckets decreases to prescribed values.

The fix uncovered also a problem in the second `RebalanceHistogram` approach, that can fail on nearly-flat histograms with many sub-1 entries in targets (can be verified by `QuantWeightsTest.RAW` excluding changes in [lib/jxl/enc_ans.cc](https://github.com/libjxl/libjxl/compare/main...Melirius:Fix-ineffciency-in-QuantizeHistogram?expand=1#diff-eae1dcaff25053843308883e33aff691cb95c69e78af1909f1695a1cdd73d4fa)). Allowing also rounding down from targets, this case can be covered.

### Pull Request Checklist

- [x] **CLA Signed**: Have you signed the [Contributor License Agreement](https://code.google.com/legal/individual-cla-v1.0.html) (individual or corporate, as appropriate)? Only contributions from signed contributors can be accepted.
- [x] **Authors**: Have you considered adding your name to the [AUTHORS](AUTHORS) file?
- [x] **Code Style**: Have you ensured your code adheres to the project's coding style guidelines? You can use `./ci.sh lint` for automatic code formatting.