### PR TITLE
remove Ubuntu 20.04

### DIFF
--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -124,17 +124,26 @@ jobs:
             cc: gcc
             cxx: g++
           - name: release:gcc-old
-            os: ubuntu-22.04
+            os: ubuntu-24.04
             mode: release
             cc: gcc
             cxx: g++
-          # Builds with old clang in release mode
+          - name: release:gcc-old-old
+            os: ubuntu-22.04
+            mode: release
+            cc: gcc
+            cxx: g++          # Builds with old clang in release mode
           - name: release:clang-old
+            os: ubuntu-24.04
+            mode: release
+            cc: clang
+            cxx: clang++
+          - name: release:clang-old-old
             os: ubuntu-22.04
             mode: release
             cc: clang
             cxx: clang++
-          - name: release:osx
+         - name: release:osx
             os: macos-latest
             mode: release
             cmake_args: >-

--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -128,19 +128,9 @@ jobs:
             mode: release
             cc: gcc
             cxx: g++
-          - name: release:gcc-old-old
-            os: ubuntu-20.04
-            mode: release
-            cc: gcc
-            cxx: g++
           # Builds with old clang in release mode
           - name: release:clang-old
             os: ubuntu-22.04
-            mode: release
-            cc: clang
-            cxx: clang++
-          - name: release:clang-old-old
-            os: ubuntu-20.04
             mode: release
             cc: clang
             cxx: clang++

--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -132,7 +132,8 @@ jobs:
             os: ubuntu-22.04
             mode: release
             cc: gcc
-            cxx: g++          # Builds with old clang in release mode
+            cxx: g++
+          # Builds with old clang in release mode
           - name: release:clang-old
             os: ubuntu-24.04
             mode: release

--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -143,7 +143,7 @@ jobs:
             mode: release
             cc: clang
             cxx: clang++
-         - name: release:osx
+          - name: release:osx
             os: macos-latest
             mode: release
             cmake_args: >-


### PR DESCRIPTION
This runner was retired yesterday:
```
This is a scheduled Ubuntu 20.04 retirement. Ubuntu 20.04 LTS runner will be removed on 2025-04-15. For more details, see https://github.com/actions/runner-images/issues/11101
```