### PR TITLE
Adobe98

### DIFF
--- a/lib/extras/dec/color_description.cc
+++ b/lib/extras/dec/color_description.cc
@@ -224,9 +224,9 @@ Status ParseTransferFunction(Tokenizer* tokenizer, JxlColorEncoding* c) {
 Status ParseDescription(const std::string& description, JxlColorEncoding* c) {
   *c = {};
   if (description == "sRGB") {
-    return ParseDescription("RGB_D65_SRG_Per_SRG", c);
+    return ParseDescription("RGB_D65_SRG_Rel_SRG", c);
   } else if (description == "DisplayP3") {
-    return ParseDescription("RGB_D65_DCI_Per_SRG", c);
+    return ParseDescription("RGB_D65_DCI_Rel_SRG", c);
   } else if (description == "Adobe98") {
     return ParseDescription("RGB_D65_Ado_Rel_Ado", c);
   } else if (description == "Rec2100PQ") {

--- a/lib/extras/dec/color_description.cc
+++ b/lib/extras/dec/color_description.cc
@@ -160,6 +160,16 @@ Status ParsePrimaries(Tokenizer* tokenizer, JxlColorEncoding* c) {
   std::string str;
   JXL_RETURN_IF_ERROR(tokenizer->Next(&str));
   if (ParseEnum(str, kJxlPrimariesNames, &c->primaries)) return true;
+  if (str == "Ado") {
+    c->primaries_red_xy[0] = 0.6400;
+    c->primaries_red_xy[1] = 0.3300;
+    c->primaries_green_xy[0] = 0.2100;
+    c->primaries_green_xy[1] = 0.7100;
+    c->primaries_blue_xy[0] = 0.1500;
+    c->primaries_blue_xy[1] = 0.0600;
+    c->primaries = JXL_PRIMARIES_CUSTOM;
+    return true;
+  }
 
   Tokenizer xy_tokenizer(&str, ';');
   JXL_RETURN_IF_ERROR(ParseDouble(&xy_tokenizer, c->primaries_red_xy + 0));
@@ -195,7 +205,11 @@ Status ParseTransferFunction(Tokenizer* tokenizer, JxlColorEncoding* c) {
   if (ParseEnum(str, kJxlTransferFunctionNames, &c->transfer_function)) {
     return true;
   }
-
+  if (str == "Ado") {
+    c->transfer_function = JXL_TRANSFER_FUNCTION_GAMMA;
+    c->gamma = 256.0/563.0;
+    return true;
+  }
   if (str[0] == 'g') {
     JXL_RETURN_IF_ERROR(ParseDouble(str.substr(1), &c->gamma));
     c->transfer_function = JXL_TRANSFER_FUNCTION_GAMMA;
@@ -210,29 +224,15 @@ Status ParseTransferFunction(Tokenizer* tokenizer, JxlColorEncoding* c) {
 Status ParseDescription(const std::string& description, JxlColorEncoding* c) {
   *c = {};
   if (description == "sRGB") {
-    c->color_space = JXL_COLOR_SPACE_RGB;
-    c->white_point = JXL_WHITE_POINT_D65;
-    c->primaries = JXL_PRIMARIES_SRGB;
-    c->transfer_function = JXL_TRANSFER_FUNCTION_SRGB;
-    c->rendering_intent = JXL_RENDERING_INTENT_PERCEPTUAL;
+    return ParseDescription("RGB_D65_SRG_Per_SRG", c);
   } else if (description == "DisplayP3") {
-    c->color_space = JXL_COLOR_SPACE_RGB;
-    c->white_point = JXL_WHITE_POINT_D65;
-    c->primaries = JXL_PRIMARIES_P3;
-    c->transfer_function = JXL_TRANSFER_FUNCTION_SRGB;
-    c->rendering_intent = JXL_RENDERING_INTENT_PERCEPTUAL;
+    return ParseDescription("RGB_D65_DCI_Per_SRG", c);
+  } else if (description == "Adobe98") {
+    return ParseDescription("RGB_D65_Ado_Rel_Ado", c);
   } else if (description == "Rec2100PQ") {
-    c->color_space = JXL_COLOR_SPACE_RGB;
-    c->white_point = JXL_WHITE_POINT_D65;
-    c->primaries = JXL_PRIMARIES_2100;
-    c->transfer_function = JXL_TRANSFER_FUNCTION_PQ;
-    c->rendering_intent = JXL_RENDERING_INTENT_RELATIVE;
+    return ParseDescription("RGB_D65_202_Rel_PeQ", c);
   } else if (description == "Rec2100HLG") {
-    c->color_space = JXL_COLOR_SPACE_RGB;
-    c->white_point = JXL_WHITE_POINT_D65;
-    c->primaries = JXL_PRIMARIES_2100;
-    c->transfer_function = JXL_TRANSFER_FUNCTION_HLG;
-    c->rendering_intent = JXL_RENDERING_INTENT_RELATIVE;
+    return ParseDescription("RGB_D65_202_Rel_HLG", c);
   } else {
     Tokenizer tokenizer(&description, '_');
     JXL_RETURN_IF_ERROR(ParseColorSpace(&tokenizer, c));

--- a/tools/cjxl_main.cc
+++ b/tools/cjxl_main.cc
@@ -213,7 +213,7 @@ struct CompressArgs {
         "rendering intent\n"
         "      -x color_space=RGB_D65_202_Rel_PeQ is Rec.2100 PQ with relative "
         "rendering intent\n"
-        "    Shorthands: sRGB, DisplayP3, Rec2100PQ, Rec2100HLG\n"
+        "    Shorthands: sRGB, DisplayP3, Adobe98, Rec2100PQ, Rec2100HLG\n"
         "    The key 'icc_pathname' refers to a binary file containing an ICC "
         "profile.\n"
         "    The keys 'exif', 'xmp', and 'jumbf' refer to a binary file "

--- a/tools/jxlinfo.c
+++ b/tools/jxlinfo.c
@@ -39,12 +39,12 @@ static void PrintColorEncoding(const JxlColorEncoding* color_encoding) {
     if ((*color_encoding).primaries == JXL_PRIMARIES_CUSTOM) {
       printf(": red(x=%f,y=%f),", (*color_encoding).primaries_red_xy[0],
              (*color_encoding).primaries_red_xy[1]);
-      printf("  green(x=%f,y=%f),", (*color_encoding).primaries_green_xy[0],
+      printf(" green(x=%f,y=%f),", (*color_encoding).primaries_green_xy[0],
              (*color_encoding).primaries_green_xy[1]);
-      printf("  blue(x=%f,y=%f)", (*color_encoding).primaries_blue_xy[0],
+      printf(" blue(x=%f,y=%f)", (*color_encoding).primaries_blue_xy[0],
              (*color_encoding).primaries_blue_xy[1]);
-    } else
-      printf(", ");
+    }
+    printf(", ");
   }
   if ((*color_encoding).transfer_function == JXL_TRANSFER_FUNCTION_GAMMA) {
     printf("gamma(%f) transfer function, ", (*color_encoding).gamma);


### PR DESCRIPTION
Should fix https://github.com/libjxl/libjxl/issues/4187

Adds `Ado` keywords in color description strings, as well as a shorthand "`Adobe98`".

Flyby: simplify the code for the shorthands, tweak jxlinfo layout for custom primaries.