### PR TITLE
Refactor: Code separation

### DIFF
--- a/lib/jxl/enc_ans.cc
+++ b/lib/jxl/enc_ans.cc
@@ -32,6 +32,7 @@
 #include "lib/jxl/enc_context_map.h"
 #include "lib/jxl/enc_fields.h"
 #include "lib/jxl/enc_huffman.h"
+#include "lib/jxl/enc_lz77.h"
 #include "lib/jxl/enc_params.h"
 #include "lib/jxl/fields.h"
 
@@ -45,11 +46,6 @@ constexpr
     bool ans_fuzzer_friendly_ = false;
 
 const int kMaxNumSymbolsForSmallCode = 2;
-
-struct SizeWriter {
-  size_t size = 0;
-  void Write(size_t num, size_t bits) { size += num; }
-};
 
 template <typename Writer>
 void StoreVarLenUint8(size_t n, Writer* writer) {
@@ -619,11 +615,11 @@ StatusOr<float> Histogram::ANSPopulationCost() const {
 
 // Returns an estimate or exact cost of encoding this histogram and the
 // corresponding data.
-StatusOr<size_t> BuildAndStoreANSEncodingData(
+StatusOr<size_t> EntropyEncodingData::BuildAndStoreANSEncodingData(
     JxlMemoryManager* memory_manager,
     HistogramParams::ANSHistogramStrategy ans_histogram_strategy,
-    const Histogram& histogram, size_t log_alpha_size, bool use_prefix_code,
-    ANSEncSymbolInfo* info, BitWriter* writer) {
+    const Histogram& histogram, size_t log_alpha_size, BitWriter* writer) {
+  ANSEncSymbolInfo* info = encoding_info.back().data();
   size_t size = histogram.alphabet_size();
   if (use_prefix_code) {
     size_t cost = 0;
@@ -675,57 +671,38 @@ StatusOr<size_t> BuildAndStoreANSEncodingData(
   return static_cast<size_t>(ceilf(normalized.Cost()));
 }
 
-template <typename Writer>
-void EncodeUintConfig(const HybridUintConfig uint_config, Writer* writer,
-                      size_t log_alpha_size) {
-  writer->Write(CeilLog2Nonzero(log_alpha_size + 1),
-                uint_config.split_exponent);
-  if (uint_config.split_exponent == log_alpha_size) {
-    return;  // msb/lsb don't matter.
-  }
-  size_t nbits = CeilLog2Nonzero(uint_config.split_exponent + 1);
-  writer->Write(nbits, uint_config.msb_in_token);
-  nbits = CeilLog2Nonzero(uint_config.split_exponent -
-                          uint_config.msb_in_token + 1);
-  writer->Write(nbits, uint_config.lsb_in_token);
-}
-template <typename Writer>
-void EncodeUintConfigs(const std::vector<HybridUintConfig>& uint_config,
-                       Writer* writer, size_t log_alpha_size) {
-  // TODO(veluca): RLE?
-  for (const auto& cfg : uint_config) {
-    EncodeUintConfig(cfg, writer, log_alpha_size);
-  }
-}
-template void EncodeUintConfigs(const std::vector<HybridUintConfig>&,
-                                BitWriter*, size_t);
-
 namespace {
+
+Histogram HistogramFromSymbolInfo(
+    const std::vector<ANSEncSymbolInfo>& encoding_info, bool use_prefix_code) {
+  Histogram histo;
+  histo.counts_.resize(DivCeil(encoding_info.size(), Histogram::kRounding) *
+                       Histogram::kRounding);
+  histo.total_count_ = 0;
+  for (size_t i = 0; i < encoding_info.size(); ++i) {
+    const ANSEncSymbolInfo& info = encoding_info[i];
+    int count = use_prefix_code
+                    ? (info.depth ? (1u << (PREFIX_MAX_BITS - info.depth)) : 0)
+                    : info.freq_;
+    histo.counts_[i] = count;
+    histo.total_count_ += count;
+  }
+  return histo;
+}
 
 Status ChooseUintConfigs(const HistogramParams& params,
                          const std::vector<std::vector<Token>>& tokens,
                          const std::vector<uint8_t>& context_map,
                          std::vector<Histogram>* clustered_histograms,
                          EntropyEncodingData* codes, size_t* log_alpha_size) {
-  codes->uint_config.resize(clustered_histograms->size());
-  if (params.uint_method == HistogramParams::HybridUintMethod::kNone) {
+  codes->uint_config.assign(clustered_histograms->size(), params.UintConfig());
+  // If the uint config is fixed, just use it.
+  if (params.uint_method != HistogramParams::HybridUintMethod::kBest &&
+      params.uint_method != HistogramParams::HybridUintMethod::kFast) {
     return true;
   }
-  if (params.uint_method == HistogramParams::HybridUintMethod::k000) {
-    codes->uint_config.clear();
-    codes->uint_config.resize(clustered_histograms->size(),
-                              HybridUintConfig(0, 0, 0));
-    return true;
-  }
-  if (params.uint_method == HistogramParams::HybridUintMethod::kContextMap) {
-    codes->uint_config.clear();
-    codes->uint_config.resize(clustered_histograms->size(),
-                              HybridUintConfig(2, 0, 1));
-    return true;
-  }
-
-  // If the uint config is adaptive, just stick with the default in streaming
-  // mode.
+  // Even if the uint config is adaptive, just stick with the default in
+  // streaming mode.
   if (params.streaming_mode) {
     return true;
   }
@@ -837,835 +814,157 @@ Status ChooseUintConfigs(const HistogramParams& params,
   return true;
 }
 
-Histogram HistogramFromSymbolInfo(
-    const std::vector<ANSEncSymbolInfo>& encoding_info, bool use_prefix_code) {
-  Histogram histo;
-  histo.counts_.resize(DivCeil(encoding_info.size(), Histogram::kRounding) *
-                       Histogram::kRounding);
-  histo.total_count_ = 0;
-  for (size_t i = 0; i < encoding_info.size(); ++i) {
-    const ANSEncSymbolInfo& info = encoding_info[i];
-    int count = use_prefix_code
-                    ? (info.depth ? (1u << (PREFIX_MAX_BITS - info.depth)) : 0)
-                    : info.freq_;
-    histo.counts_[i] = count;
-    histo.total_count_ += count;
+}  // namespace
+
+// NOTE: `layer` is only for clustered_entropy; caller does ReclaimAndCharge.
+// Returns cost (in bits).
+StatusOr<size_t> EntropyEncodingData::BuildAndStoreEntropyCodes(
+    JxlMemoryManager* memory_manager, const HistogramParams& params,
+    const std::vector<std::vector<Token>>& tokens,
+    const HistogramBuilder* builder, std::vector<uint8_t>* context_map,
+    BitWriter* writer, LayerType layer, AuxOut* aux_out) {
+  const size_t prev_histograms = encoding_info.size();
+  std::vector<Histogram> clustered_histograms;
+  for (size_t i = 0; i < prev_histograms; ++i) {
+    clustered_histograms.push_back(
+        HistogramFromSymbolInfo(encoding_info[i], use_prefix_code));
   }
-  return histo;
-}
-
-class HistogramBuilder {
- public:
-  explicit HistogramBuilder(const size_t num_contexts)
-      : histograms_(num_contexts) {}
-
-  void VisitSymbol(int symbol, size_t histo_idx) {
-    JXL_DASSERT(histo_idx < histograms_.size());
-    histograms_[histo_idx].Add(symbol);
-  }
-
-  // NOTE: `layer` is only for clustered_entropy; caller does ReclaimAndCharge.
-  // Returns cost (in bits).
-  StatusOr<size_t> BuildAndStoreEntropyCodes(
-      JxlMemoryManager* memory_manager, const HistogramParams& params,
-      const std::vector<std::vector<Token>>& tokens, EntropyEncodingData* codes,
-      std::vector<uint8_t>* context_map, BitWriter* writer, LayerType layer,
-      AuxOut* aux_out) const {
-    const size_t prev_histograms = codes->encoding_info.size();
-    std::vector<Histogram> clustered_histograms;
-    for (size_t i = 0; i < prev_histograms; ++i) {
-      clustered_histograms.push_back(HistogramFromSymbolInfo(
-          codes->encoding_info[i], codes->use_prefix_code));
+  size_t context_offset = context_map->size();
+  context_map->resize(context_offset + builder->histograms_.size());
+  if (builder->histograms_.size() > 1) {
+    if (!ans_fuzzer_friendly_) {
+      std::vector<uint32_t> histogram_symbols;
+      JXL_RETURN_IF_ERROR(
+          ClusterHistograms(params, builder->histograms_, kClustersLimit,
+                            &clustered_histograms, &histogram_symbols));
+      for (size_t c = 0; c < builder->histograms_.size(); ++c) {
+        (*context_map)[context_offset + c] =
+            static_cast<uint8_t>(histogram_symbols[c]);
+      }
+    } else {
+      JXL_ENSURE(encoding_info.empty());
+      fill(context_map->begin(), context_map->end(), 0);
+      size_t max_symbol = 0;
+      for (const Histogram& h : builder->histograms_) {
+        max_symbol = std::max(h.counts_.size(), max_symbol);
+      }
+      size_t num_symbols = 1 << CeilLog2Nonzero(max_symbol + 1);
+      clustered_histograms.resize(1);
+      clustered_histograms[0].Clear();
+      for (size_t i = 0; i < num_symbols; i++) {
+        clustered_histograms[0].Add(i);
+      }
     }
-    size_t context_offset = context_map->size();
-    context_map->resize(context_offset + histograms_.size());
-    if (histograms_.size() > 1) {
-      if (!ans_fuzzer_friendly_) {
-        std::vector<uint32_t> histogram_symbols;
-        JXL_RETURN_IF_ERROR(
-            ClusterHistograms(params, histograms_, kClustersLimit,
-                              &clustered_histograms, &histogram_symbols));
-        for (size_t c = 0; c < histograms_.size(); ++c) {
-          (*context_map)[context_offset + c] =
-              static_cast<uint8_t>(histogram_symbols[c]);
-        }
+    if (writer != nullptr) {
+      JXL_RETURN_IF_ERROR(EncodeContextMap(
+          *context_map, clustered_histograms.size(), writer, layer, aux_out));
+    }
+  } else {
+    JXL_ENSURE(encoding_info.empty());
+    clustered_histograms.push_back(builder->histograms_[0]);
+  }
+  if (aux_out != nullptr) {
+    for (size_t i = prev_histograms; i < clustered_histograms.size(); ++i) {
+      aux_out->layer(layer).clustered_entropy +=
+          clustered_histograms[i].ShannonEntropy();
+    }
+  }
+  size_t log_alpha_size = lz77.enabled ? 8 : 7;  // Sane default.
+  if (ans_fuzzer_friendly_) {
+    uint_config.clear();
+    uint_config.resize(1, HybridUintConfig(7, 0, 0));
+  } else {
+    JXL_RETURN_IF_ERROR(ChooseUintConfigs(params, tokens, *context_map,
+                                          &clustered_histograms, this,
+                                          &log_alpha_size));
+  }
+  if (log_alpha_size < 5) log_alpha_size = 5;
+  if (params.streaming_mode) {
+    // TODO(szabadka) Figure out if we can use lower values here.
+    log_alpha_size = 8;
+  }
+  SizeWriter size_writer;  // Used if writer == nullptr to estimate costs.
+  size_t cost = 1;
+  if (writer) writer->Write(1, TO_JXL_BOOL(use_prefix_code));
+
+  if (use_prefix_code) {
+    log_alpha_size = PREFIX_MAX_BITS;
+  } else {
+    cost += 2;
+  }
+  if (writer == nullptr) {
+    EncodeUintConfigs(uint_config, &size_writer, log_alpha_size);
+  } else {
+    if (!use_prefix_code) writer->Write(2, log_alpha_size - 5);
+    EncodeUintConfigs(uint_config, writer, log_alpha_size);
+  }
+  if (use_prefix_code) {
+    for (const auto& histo : clustered_histograms) {
+      size_t alphabet_size = std::max(size_t(1), histo.alphabet_size());
+      if (writer) {
+        StoreVarLenUint16(alphabet_size - 1, writer);
       } else {
-        JXL_ENSURE(codes->encoding_info.empty());
-        fill(context_map->begin(), context_map->end(), 0);
-        size_t max_symbol = 0;
-        for (const Histogram& h : histograms_) {
-          max_symbol = std::max(h.counts_.size(), max_symbol);
-        }
-        size_t num_symbols = 1 << CeilLog2Nonzero(max_symbol + 1);
-        clustered_histograms.resize(1);
-        clustered_histograms[0].Clear();
-        for (size_t i = 0; i < num_symbols; i++) {
-          clustered_histograms[0].Add(i);
-        }
-      }
-      if (writer != nullptr) {
-        JXL_RETURN_IF_ERROR(EncodeContextMap(
-            *context_map, clustered_histograms.size(), writer, layer, aux_out));
-      }
-    } else {
-      JXL_ENSURE(codes->encoding_info.empty());
-      clustered_histograms.push_back(histograms_[0]);
-    }
-    if (aux_out != nullptr) {
-      for (size_t i = prev_histograms; i < clustered_histograms.size(); ++i) {
-        aux_out->layer(layer).clustered_entropy +=
-            clustered_histograms[i].ShannonEntropy();
+        StoreVarLenUint16(alphabet_size - 1, &size_writer);
       }
     }
-    size_t log_alpha_size = codes->lz77.enabled ? 8 : 7;  // Sane default.
-    if (ans_fuzzer_friendly_) {
-      codes->uint_config.clear();
-      codes->uint_config.resize(1, HybridUintConfig(7, 0, 0));
+  }
+  cost += size_writer.size;
+  for (size_t c = prev_histograms; c < clustered_histograms.size(); ++c) {
+    size_t alphabet_size = clustered_histograms[c].alphabet_size();
+    encoding_info.emplace_back();
+    encoding_info.back().resize(alphabet_size);
+    BitWriter* histo_writer = writer;
+    if (params.streaming_mode) {
+      encoded_histograms.emplace_back(memory_manager);
+      histo_writer = &encoded_histograms.back();
+    }
+    const auto& body = [&]() -> Status {
+      JXL_ASSIGN_OR_RETURN(
+          size_t ans_cost,
+          BuildAndStoreANSEncodingData(
+              memory_manager, params.ans_histogram_strategy,
+              clustered_histograms[c], log_alpha_size, histo_writer));
+      cost += ans_cost;
+      return true;
+    };
+    if (histo_writer) {
+      JXL_RETURN_IF_ERROR(histo_writer->WithMaxBits(
+          256 + alphabet_size * 24, layer, aux_out, body,
+          /*finished_histogram=*/true));
     } else {
-      JXL_RETURN_IF_ERROR(ChooseUintConfigs(params, tokens, *context_map,
-                                            &clustered_histograms, codes,
-                                            &log_alpha_size));
+      JXL_RETURN_IF_ERROR(body());
     }
     if (params.streaming_mode) {
-      // TODO(szabadka) Figure out if we can use lower values here.
-      log_alpha_size = 8;
-    }
-    SizeWriter size_writer;  // Used if writer == nullptr to estimate costs.
-    size_t cost = 1;
-    if (writer) writer->Write(1, TO_JXL_BOOL(codes->use_prefix_code));
-
-    if (codes->use_prefix_code) {
-      log_alpha_size = PREFIX_MAX_BITS;
-    } else {
-      cost += 2;
-    }
-    if (writer == nullptr) {
-      EncodeUintConfigs(codes->uint_config, &size_writer, log_alpha_size);
-    } else {
-      if (!codes->use_prefix_code) writer->Write(2, log_alpha_size - 5);
-      EncodeUintConfigs(codes->uint_config, writer, log_alpha_size);
-    }
-    if (codes->use_prefix_code) {
-      for (const auto& histo : clustered_histograms) {
-        size_t alphabet_size = std::max(size_t(1), histo.alphabet_size());
-        if (writer) {
-          StoreVarLenUint16(alphabet_size - 1, writer);
-        } else {
-          StoreVarLenUint16(alphabet_size - 1, &size_writer);
-        }
-      }
-    }
-    cost += size_writer.size;
-    for (size_t c = prev_histograms; c < clustered_histograms.size(); ++c) {
-      size_t alphabet_size = clustered_histograms[c].alphabet_size();
-      codes->encoding_info.emplace_back();
-      codes->encoding_info.back().resize(alphabet_size);
-      BitWriter* histo_writer = writer;
-      if (params.streaming_mode) {
-        codes->encoded_histograms.emplace_back(memory_manager);
-        histo_writer = &codes->encoded_histograms.back();
-      }
-      const auto& body = [&]() -> Status {
-        JXL_ASSIGN_OR_RETURN(
-            size_t ans_cost,
-            BuildAndStoreANSEncodingData(
-                memory_manager, params.ans_histogram_strategy,
-                clustered_histograms[c], log_alpha_size, codes->use_prefix_code,
-                codes->encoding_info.back().data(), histo_writer));
-        cost += ans_cost;
-        return true;
-      };
-      if (histo_writer) {
-        JXL_RETURN_IF_ERROR(histo_writer->WithMaxBits(
-            256 + alphabet_size * 24, layer, aux_out, body,
-            /*finished_histogram=*/true));
-      } else {
-        JXL_RETURN_IF_ERROR(body());
-      }
-      if (params.streaming_mode) {
-        JXL_RETURN_IF_ERROR(writer->AppendUnaligned(*histo_writer));
-      }
-    }
-    return cost;
-  }
-
-  const Histogram& Histo(size_t i) const { return histograms_[i]; }
-
- private:
-  std::vector<Histogram> histograms_;
-};
-
-class SymbolCostEstimator {
- public:
-  SymbolCostEstimator(size_t num_contexts, bool force_huffman,
-                      const std::vector<std::vector<Token>>& tokens,
-                      const LZ77Params& lz77) {
-    HistogramBuilder builder(num_contexts);
-    // Build histograms for estimating lz77 savings.
-    HybridUintConfig uint_config;
-    for (const auto& stream : tokens) {
-      for (const auto& token : stream) {
-        uint32_t tok, nbits, bits;
-        (token.is_lz77_length ? lz77.length_uint_config : uint_config)
-            .Encode(token.value, &tok, &nbits, &bits);
-        tok += token.is_lz77_length ? lz77.min_symbol : 0;
-        builder.VisitSymbol(tok, token.context);
-      }
-    }
-    max_alphabet_size_ = 0;
-    for (size_t i = 0; i < num_contexts; i++) {
-      max_alphabet_size_ =
-          std::max(max_alphabet_size_, builder.Histo(i).counts_.size());
-    }
-    bits_.resize(num_contexts * max_alphabet_size_);
-    // TODO(veluca): SIMD?
-    add_symbol_cost_.resize(num_contexts);
-    for (size_t i = 0; i < num_contexts; i++) {
-      float inv_total = 1.0f / (builder.Histo(i).total_count_ + 1e-8f);
-      float total_cost = 0;
-      for (size_t j = 0; j < builder.Histo(i).counts_.size(); j++) {
-        size_t cnt = builder.Histo(i).counts_[j];
-        float cost = 0;
-        if (cnt != 0 && cnt != builder.Histo(i).total_count_) {
-          cost = -FastLog2f(cnt * inv_total);
-          if (force_huffman) cost = std::ceil(cost);
-        } else if (cnt == 0) {
-          cost = ANS_LOG_TAB_SIZE;  // Highest possible cost.
-        }
-        bits_[i * max_alphabet_size_ + j] = cost;
-        total_cost += cost * builder.Histo(i).counts_[j];
-      }
-      // Penalty for adding a lz77 symbol to this contest (only used for static
-      // cost model). Higher penalty for contexts that have a very low
-      // per-symbol entropy.
-      add_symbol_cost_[i] = std::max(0.0f, 6.0f - total_cost * inv_total);
+      JXL_RETURN_IF_ERROR(writer->AppendUnaligned(*histo_writer));
     }
   }
-  float Bits(size_t ctx, size_t sym) const {
-    return bits_[ctx * max_alphabet_size_ + sym];
-  }
-  float LenCost(size_t ctx, size_t len, const LZ77Params& lz77) const {
-    uint32_t nbits, bits, tok;
-    lz77.length_uint_config.Encode(len, &tok, &nbits, &bits);
-    tok += lz77.min_symbol;
-    return nbits + Bits(ctx, tok);
-  }
-  float DistCost(size_t len, const LZ77Params& lz77) const {
-    uint32_t nbits, bits, tok;
-    HybridUintConfig().Encode(len, &tok, &nbits, &bits);
-    return nbits + Bits(lz77.nonserialized_distance_context, tok);
-  }
-  float AddSymbolCost(size_t idx) const { return add_symbol_cost_[idx]; }
-
- private:
-  size_t max_alphabet_size_;
-  std::vector<float> bits_;
-  std::vector<float> add_symbol_cost_;
-};
-
-void ApplyLZ77_RLE(const HistogramParams& params, size_t num_contexts,
-                   const std::vector<std::vector<Token>>& tokens,
-                   LZ77Params& lz77,
-                   std::vector<std::vector<Token>>& tokens_lz77) {
-  // TODO(veluca): tune heuristics here.
-  SymbolCostEstimator sce(num_contexts, params.force_huffman, tokens, lz77);
-  float bit_decrease = 0;
-  size_t total_symbols = 0;
-  tokens_lz77.resize(tokens.size());
-  std::vector<float> sym_cost;
-  HybridUintConfig uint_config;
-  for (size_t stream = 0; stream < tokens.size(); stream++) {
-    size_t distance_multiplier =
-        params.image_widths.size() > stream ? params.image_widths[stream] : 0;
-    const auto& in = tokens[stream];
-    auto& out = tokens_lz77[stream];
-    total_symbols += in.size();
-    // Cumulative sum of bit costs.
-    sym_cost.resize(in.size() + 1);
-    for (size_t i = 0; i < in.size(); i++) {
-      uint32_t tok, nbits, unused_bits;
-      uint_config.Encode(in[i].value, &tok, &nbits, &unused_bits);
-      sym_cost[i + 1] = sce.Bits(in[i].context, tok) + nbits + sym_cost[i];
-    }
-    out.reserve(in.size());
-    for (size_t i = 0; i < in.size(); i++) {
-      size_t num_to_copy = 0;
-      size_t distance_symbol = 0;  // 1 for RLE.
-      if (distance_multiplier != 0) {
-        distance_symbol = 1;  // Special distance 1 if enabled.
-        JXL_DASSERT(kSpecialDistances[1][0] == 1);
-        JXL_DASSERT(kSpecialDistances[1][1] == 0);
-      }
-      if (i > 0) {
-        for (; i + num_to_copy < in.size(); num_to_copy++) {
-          if (in[i + num_to_copy].value != in[i - 1].value) {
-            break;
-          }
-        }
-      }
-      if (num_to_copy == 0) {
-        out.push_back(in[i]);
-        continue;
-      }
-      float cost = sym_cost[i + num_to_copy] - sym_cost[i];
-      // This subtraction might overflow, but that's OK.
-      size_t lz77_len = num_to_copy - lz77.min_length;
-      float lz77_cost = num_to_copy >= lz77.min_length
-                            ? CeilLog2Nonzero(lz77_len + 1) + 1
-                            : 0;
-      if (num_to_copy < lz77.min_length || cost <= lz77_cost) {
-        for (size_t j = 0; j < num_to_copy; j++) {
-          out.push_back(in[i + j]);
-        }
-        i += num_to_copy - 1;
-        continue;
-      }
-      // Output the LZ77 length
-      out.emplace_back(in[i].context, lz77_len);
-      out.back().is_lz77_length = true;
-      i += num_to_copy - 1;
-      bit_decrease += cost - lz77_cost;
-      // Output the LZ77 copy distance.
-      out.emplace_back(lz77.nonserialized_distance_context, distance_symbol);
-    }
-  }
-
-  if (bit_decrease > total_symbols * 0.2 + 16) {
-    lz77.enabled = true;
-  }
+  return cost;
 }
 
-// Hash chain for LZ77 matching
-struct HashChain {
-  size_t size_;
-  std::vector<uint32_t> data_;
-
-  unsigned hash_num_values_ = 32768;
-  unsigned hash_mask_ = hash_num_values_ - 1;
-  unsigned hash_shift_ = 5;
-
-  std::vector<int> head;
-  std::vector<uint32_t> chain;
-  std::vector<int> val;
-
-  // Speed up repetitions of zero
-  std::vector<int> headz;
-  std::vector<uint32_t> chainz;
-  std::vector<uint32_t> zeros;
-  uint32_t numzeros = 0;
-
-  size_t window_size_;
-  size_t window_mask_;
-  size_t min_length_;
-  size_t max_length_;
-
-  // Map of special distance codes.
-  std::unordered_map<int, int> special_dist_table_;
-  size_t num_special_distances_ = 0;
-
-  uint32_t maxchainlength = 256;  // window_size_ to allow all
-
-  HashChain(const Token* data, size_t size, size_t window_size,
-            size_t min_length, size_t max_length, size_t distance_multiplier)
-      : size_(size),
-        window_size_(window_size),
-        window_mask_(window_size - 1),
-        min_length_(min_length),
-        max_length_(max_length) {
-    data_.resize(size);
-    for (size_t i = 0; i < size; i++) {
-      data_[i] = data[i].value;
-    }
-
-    head.resize(hash_num_values_, -1);
-    val.resize(window_size_, -1);
-    chain.resize(window_size_);
-    for (uint32_t i = 0; i < window_size_; ++i) {
-      chain[i] = i;  // same value as index indicates uninitialized
-    }
-
-    zeros.resize(window_size_);
-    headz.resize(window_size_ + 1, -1);
-    chainz.resize(window_size_);
-    for (uint32_t i = 0; i < window_size_; ++i) {
-      chainz[i] = i;
-    }
-    // Translate distance to special distance code.
-    if (distance_multiplier) {
-      // Count down, so if due to small distance multiplier multiple distances
-      // map to the same code, the smallest code will be used in the end.
-      for (int i = kNumSpecialDistances - 1; i >= 0; --i) {
-        special_dist_table_[SpecialDistance(i, distance_multiplier)] = i;
-      }
-      num_special_distances_ = kNumSpecialDistances;
-    }
+template <typename Writer>
+void EncodeUintConfig(const HybridUintConfig uint_config, Writer* writer,
+                      size_t log_alpha_size) {
+  writer->Write(CeilLog2Nonzero(log_alpha_size + 1),
+                uint_config.split_exponent);
+  if (uint_config.split_exponent == log_alpha_size) {
+    return;  // msb/lsb don't matter.
   }
-
-  uint32_t GetHash(size_t pos) const {
-    uint32_t result = 0;
-    if (pos + 2 < size_) {
-      // TODO(lode): take the MSB's of the uint32_t values into account as well,
-      // given that the hash code itself is less than 32 bits.
-      result ^= static_cast<uint32_t>(data_[pos + 0] << 0u);
-      result ^= static_cast<uint32_t>(data_[pos + 1] << hash_shift_);
-      result ^= static_cast<uint32_t>(data_[pos + 2] << (hash_shift_ * 2));
-    } else {
-      // No need to compute hash of last 2 bytes, the length 2 is too short.
-      return 0;
-    }
-    return result & hash_mask_;
-  }
-
-  uint32_t CountZeros(size_t pos, uint32_t prevzeros) const {
-    size_t end = pos + window_size_;
-    if (end > size_) end = size_;
-    if (prevzeros > 0) {
-      if (prevzeros >= window_mask_ && data_[end - 1] == 0 &&
-          end == pos + window_size_) {
-        return prevzeros;
-      } else {
-        return prevzeros - 1;
-      }
-    }
-    uint32_t num = 0;
-    while (pos + num < end && data_[pos + num] == 0) num++;
-    return num;
-  }
-
-  void Update(size_t pos) {
-    uint32_t hashval = GetHash(pos);
-    uint32_t wpos = pos & window_mask_;
-
-    val[wpos] = static_cast<int>(hashval);
-    if (head[hashval] != -1) chain[wpos] = head[hashval];
-    head[hashval] = wpos;
-
-    if (pos > 0 && data_[pos] != data_[pos - 1]) numzeros = 0;
-    numzeros = CountZeros(pos, numzeros);
-
-    zeros[wpos] = numzeros;
-    if (headz[numzeros] != -1) chainz[wpos] = headz[numzeros];
-    headz[numzeros] = wpos;
-  }
-
-  void Update(size_t pos, size_t len) {
-    for (size_t i = 0; i < len; i++) {
-      Update(pos + i);
-    }
-  }
-
-  template <typename CB>
-  void FindMatches(size_t pos, int max_dist, const CB& found_match) const {
-    uint32_t wpos = pos & window_mask_;
-    uint32_t hashval = GetHash(pos);
-    uint32_t hashpos = chain[wpos];
-
-    int prev_dist = 0;
-    int end = std::min<int>(pos + max_length_, size_);
-    uint32_t chainlength = 0;
-    uint32_t best_len = 0;
-    for (;;) {
-      int dist = (hashpos <= wpos) ? (wpos - hashpos)
-                                   : (wpos - hashpos + window_mask_ + 1);
-      if (dist < prev_dist) break;
-      prev_dist = dist;
-      uint32_t len = 0;
-      if (dist > 0) {
-        int i = pos;
-        int j = pos - dist;
-        if (numzeros > 3) {
-          int r = std::min<int>(numzeros - 1, zeros[hashpos]);
-          if (i + r >= end) r = end - i - 1;
-          i += r;
-          j += r;
-        }
-        while (i < end && data_[i] == data_[j]) {
-          i++;
-          j++;
-        }
-        len = i - pos;
-        // This can trigger even if the new length is slightly smaller than the
-        // best length, because it is possible for a slightly cheaper distance
-        // symbol to occur.
-        if (len >= min_length_ && len + 2 >= best_len) {
-          auto it = special_dist_table_.find(dist);
-          int dist_symbol = (it == special_dist_table_.end())
-                                ? (num_special_distances_ + dist - 1)
-                                : it->second;
-          found_match(len, dist_symbol);
-          if (len > best_len) best_len = len;
-        }
-      }
-
-      chainlength++;
-      if (chainlength >= maxchainlength) break;
-
-      if (numzeros >= 3 && len > numzeros) {
-        if (hashpos == chainz[hashpos]) break;
-        hashpos = chainz[hashpos];
-        if (zeros[hashpos] != numzeros) break;
-      } else {
-        if (hashpos == chain[hashpos]) break;
-        hashpos = chain[hashpos];
-        if (val[hashpos] != static_cast<int>(hashval)) {
-          // outdated hash value
-          break;
-        }
-      }
-    }
-  }
-  void FindMatch(size_t pos, int max_dist, size_t* result_dist_symbol,
-                 size_t* result_len) const {
-    *result_dist_symbol = 0;
-    *result_len = 1;
-    FindMatches(pos, max_dist, [&](size_t len, size_t dist_symbol) {
-      if (len > *result_len ||
-          (len == *result_len && *result_dist_symbol > dist_symbol)) {
-        *result_len = len;
-        *result_dist_symbol = dist_symbol;
-      }
-    });
-  }
-};
-
-float LenCost(size_t len) {
-  uint32_t nbits, bits, tok;
-  HybridUintConfig(1, 0, 0).Encode(len, &tok, &nbits, &bits);
-  constexpr float kCostTable[] = {
-      2.797667318563126,  3.213177690381199,  2.5706009246743737,
-      2.408392498667534,  2.829649191872326,  3.3923087753324577,
-      4.029267451554331,  4.415576699706408,  4.509357574741465,
-      9.21481543803004,   10.020590190114898, 11.858671627804766,
-      12.45853300490526,  11.713105831990857, 12.561996324849314,
-      13.775477692278367, 13.174027068768641,
-  };
-  size_t table_size = sizeof kCostTable / sizeof *kCostTable;
-  if (tok >= table_size) tok = table_size - 1;
-  return kCostTable[tok] + nbits;
+  size_t nbits = CeilLog2Nonzero(uint_config.split_exponent + 1);
+  writer->Write(nbits, uint_config.msb_in_token);
+  nbits = CeilLog2Nonzero(uint_config.split_exponent -
+                          uint_config.msb_in_token + 1);
+  writer->Write(nbits, uint_config.lsb_in_token);
 }
-
-// TODO(veluca): this does not take into account usage or non-usage of distance
-// multipliers.
-float DistCost(size_t dist) {
-  uint32_t nbits, bits, tok;
-  HybridUintConfig(7, 0, 0).Encode(dist, &tok, &nbits, &bits);
-  constexpr float kCostTable[] = {
-      6.368282626312716,  5.680793277090298,  8.347404197105247,
-      7.641619201599141,  6.914328374119438,  7.959808291537444,
-      8.70023120759855,   8.71378518934703,   9.379132523982769,
-      9.110472749092708,  9.159029569270908,  9.430936766731973,
-      7.278284055315169,  7.8278514904267755, 10.026641158289236,
-      9.976049229827066,  9.64351607048908,   9.563403863480442,
-      10.171474111762747, 10.45950155077234,  9.994813912104219,
-      10.322524683741156, 8.465808729388186,  8.756254166066853,
-      10.160930174662234, 10.247329273413435, 10.04090403724809,
-      10.129398517544082, 9.342311691539546,  9.07608009102374,
-      10.104799540677513, 10.378079384990906, 10.165828974075072,
-      10.337595322341553, 7.940557464567944,  10.575665823319431,
-      11.023344321751955, 10.736144698831827, 11.118277044595054,
-      7.468468230648442,  10.738305230932939, 10.906980780216568,
-      10.163468216353817, 10.17805759656433,  11.167283670483565,
-      11.147050200274544, 10.517921919244333, 10.651764778156886,
-      10.17074446448919,  11.217636876224745, 11.261630721139484,
-      11.403140815247259, 10.892472096873417, 11.1859607804481,
-      8.017346947551262,  7.895143720278828,  11.036577113822025,
-      11.170562110315794, 10.326988722591086, 10.40872184751056,
-      11.213498225466386, 11.30580635516863,  10.672272515665442,
-      10.768069466228063, 11.145257364153565, 11.64668307145549,
-      10.593156194627339, 11.207499484844943, 10.767517766396908,
-      10.826629811407042, 10.737764794499988, 10.6200448518045,
-      10.191315385198092, 8.468384171390085,  11.731295299170432,
-      11.824619886654398, 10.41518844301179,  10.16310536548649,
-      10.539423685097576, 10.495136599328031, 10.469112847728267,
-      11.72057686174922,  10.910326337834674, 11.378921834673758,
-      11.847759036098536, 11.92071647623854,  10.810628276345282,
-      11.008601085273893, 11.910326337834674, 11.949212023423133,
-      11.298614839104337, 11.611603659010392, 10.472930394619985,
-      11.835564720850282, 11.523267392285337, 12.01055816679611,
-      8.413029688994023,  11.895784139536406, 11.984679534970505,
-      11.220654278717394, 11.716311684833672, 10.61036646226114,
-      10.89849965960364,  10.203762898863669, 10.997560826267238,
-      11.484217379438984, 11.792836176993665, 12.24310468755171,
-      11.464858097919262, 12.212747017409377, 11.425595666074955,
-      11.572048533398757, 12.742093965163013, 11.381874288645637,
-      12.191870445817015, 11.683156920035426, 11.152442115262197,
-      11.90303691580457,  11.653292787169159, 11.938615382266098,
-      16.970641701570223, 16.853602280380002, 17.26240782594733,
-      16.644655390108507, 17.14310889757499,  16.910935455445955,
-      17.505678976959697, 17.213498225466388, 2.4162310293553024,
-      3.494587244462329,  3.5258600986408344, 3.4959806589517095,
-      3.098390886949687,  3.343454654302911,  3.588847442290287,
-      4.14614790111827,   5.152948641990529,  7.433696808092598,
-      9.716311684833672,
-  };
-  size_t table_size = sizeof kCostTable / sizeof *kCostTable;
-  if (tok >= table_size) tok = table_size - 1;
-  return kCostTable[tok] + nbits;
-}
-
-void ApplyLZ77_LZ77(const HistogramParams& params, size_t num_contexts,
-                    const std::vector<std::vector<Token>>& tokens,
-                    LZ77Params& lz77,
-                    std::vector<std::vector<Token>>& tokens_lz77) {
-  // TODO(veluca): tune heuristics here.
-  SymbolCostEstimator sce(num_contexts, params.force_huffman, tokens, lz77);
-  float bit_decrease = 0;
-  size_t total_symbols = 0;
-  tokens_lz77.resize(tokens.size());
-  HybridUintConfig uint_config;
-  std::vector<float> sym_cost;
-  for (size_t stream = 0; stream < tokens.size(); stream++) {
-    size_t distance_multiplier =
-        params.image_widths.size() > stream ? params.image_widths[stream] : 0;
-    const auto& in = tokens[stream];
-    auto& out = tokens_lz77[stream];
-    total_symbols += in.size();
-    // Cumulative sum of bit costs.
-    sym_cost.resize(in.size() + 1);
-    for (size_t i = 0; i < in.size(); i++) {
-      uint32_t tok, nbits, unused_bits;
-      uint_config.Encode(in[i].value, &tok, &nbits, &unused_bits);
-      sym_cost[i + 1] = sce.Bits(in[i].context, tok) + nbits + sym_cost[i];
-    }
-
-    out.reserve(in.size());
-    size_t max_distance = in.size();
-    size_t min_length = lz77.min_length;
-    JXL_DASSERT(min_length >= 3);
-    size_t max_length = in.size();
-
-    // Use next power of two as window size.
-    size_t window_size = 1;
-    while (window_size < max_distance && window_size < kWindowSize) {
-      window_size <<= 1;
-    }
-
-    HashChain chain(in.data(), in.size(), window_size, min_length, max_length,
-                    distance_multiplier);
-    size_t len;
-    size_t dist_symbol;
-
-    const size_t max_lazy_match_len = 256;  // 0 to disable lazy matching
-
-    // Whether the next symbol was already updated (to test lazy matching)
-    bool already_updated = false;
-    for (size_t i = 0; i < in.size(); i++) {
-      out.push_back(in[i]);
-      if (!already_updated) chain.Update(i);
-      already_updated = false;
-      chain.FindMatch(i, max_distance, &dist_symbol, &len);
-      if (len >= min_length) {
-        if (len < max_lazy_match_len && i + 1 < in.size()) {
-          // Try length at next symbol lazy matching
-          chain.Update(i + 1);
-          already_updated = true;
-          size_t len2, dist_symbol2;
-          chain.FindMatch(i + 1, max_distance, &dist_symbol2, &len2);
-          if (len2 > len) {
-            // Use the lazy match. Add literal, and use the next length starting
-            // from the next byte.
-            ++i;
-            already_updated = false;
-            len = len2;
-            dist_symbol = dist_symbol2;
-            out.push_back(in[i]);
-          }
-        }
-
-        float cost = sym_cost[i + len] - sym_cost[i];
-        size_t lz77_len = len - lz77.min_length;
-        float lz77_cost = LenCost(lz77_len) + DistCost(dist_symbol) +
-                          sce.AddSymbolCost(out.back().context);
-
-        if (lz77_cost <= cost) {
-          out.back().value = len - min_length;
-          out.back().is_lz77_length = true;
-          out.emplace_back(lz77.nonserialized_distance_context, dist_symbol);
-          bit_decrease += cost - lz77_cost;
-        } else {
-          // LZ77 match ignored, and symbol already pushed. Push all other
-          // symbols and skip.
-          for (size_t j = 1; j < len; j++) {
-            out.push_back(in[i + j]);
-          }
-        }
-
-        if (already_updated) {
-          chain.Update(i + 2, len - 2);
-          already_updated = false;
-        } else {
-          chain.Update(i + 1, len - 1);
-        }
-        i += len - 1;
-      } else {
-        // Literal, already pushed
-      }
-    }
-  }
-
-  if (bit_decrease > total_symbols * 0.2 + 16) {
-    lz77.enabled = true;
+template <typename Writer>
+void EncodeUintConfigs(const std::vector<HybridUintConfig>& uint_config,
+                       Writer* writer, size_t log_alpha_size) {
+  // TODO(veluca): RLE?
+  for (const auto& cfg : uint_config) {
+    EncodeUintConfig(cfg, writer, log_alpha_size);
   }
 }
-
-void ApplyLZ77_Optimal(const HistogramParams& params, size_t num_contexts,
-                       const std::vector<std::vector<Token>>& tokens,
-                       LZ77Params& lz77,
-                       std::vector<std::vector<Token>>& tokens_lz77) {
-  std::vector<std::vector<Token>> tokens_for_cost_estimate;
-  ApplyLZ77_LZ77(params, num_contexts, tokens, lz77, tokens_for_cost_estimate);
-  // If greedy-LZ77 does not give better compression than no-lz77, no reason to
-  // run the optimal matching.
-  if (!lz77.enabled) return;
-  SymbolCostEstimator sce(num_contexts + 1, params.force_huffman,
-                          tokens_for_cost_estimate, lz77);
-  tokens_lz77.resize(tokens.size());
-  HybridUintConfig uint_config;
-  std::vector<float> sym_cost;
-  std::vector<uint32_t> dist_symbols;
-  for (size_t stream = 0; stream < tokens.size(); stream++) {
-    size_t distance_multiplier =
-        params.image_widths.size() > stream ? params.image_widths[stream] : 0;
-    const auto& in = tokens[stream];
-    auto& out = tokens_lz77[stream];
-    // Cumulative sum of bit costs.
-    sym_cost.resize(in.size() + 1);
-    for (size_t i = 0; i < in.size(); i++) {
-      uint32_t tok, nbits, unused_bits;
-      uint_config.Encode(in[i].value, &tok, &nbits, &unused_bits);
-      sym_cost[i + 1] = sce.Bits(in[i].context, tok) + nbits + sym_cost[i];
-    }
-
-    out.reserve(in.size());
-    size_t max_distance = in.size();
-    size_t min_length = lz77.min_length;
-    JXL_DASSERT(min_length >= 3);
-    size_t max_length = in.size();
-
-    // Use next power of two as window size.
-    size_t window_size = 1;
-    while (window_size < max_distance && window_size < kWindowSize) {
-      window_size <<= 1;
-    }
-
-    HashChain chain(in.data(), in.size(), window_size, min_length, max_length,
-                    distance_multiplier);
-
-    struct MatchInfo {
-      uint32_t len;
-      uint32_t dist_symbol;
-      uint32_t ctx;
-      float total_cost = std::numeric_limits<float>::max();
-    };
-    // Total cost to encode the first N symbols.
-    std::vector<MatchInfo> prefix_costs(in.size() + 1);
-    prefix_costs[0].total_cost = 0;
-
-    size_t rle_length = 0;
-    size_t skip_lz77 = 0;
-    for (size_t i = 0; i < in.size(); i++) {
-      chain.Update(i);
-      float lit_cost =
-          prefix_costs[i].total_cost + sym_cost[i + 1] - sym_cost[i];
-      if (prefix_costs[i + 1].total_cost > lit_cost) {
-        prefix_costs[i + 1].dist_symbol = 0;
-        prefix_costs[i + 1].len = 1;
-        prefix_costs[i + 1].ctx = in[i].context;
-        prefix_costs[i + 1].total_cost = lit_cost;
-      }
-      if (skip_lz77 > 0) {
-        skip_lz77--;
-        continue;
-      }
-      dist_symbols.clear();
-      chain.FindMatches(i, max_distance,
-                        [&dist_symbols](size_t len, size_t dist_symbol) {
-                          if (dist_symbols.size() <= len) {
-                            dist_symbols.resize(len + 1, dist_symbol);
-                          }
-                          if (dist_symbol < dist_symbols[len]) {
-                            dist_symbols[len] = dist_symbol;
-                          }
-                        });
-      if (dist_symbols.size() <= min_length) continue;
-      {
-        size_t best_cost = dist_symbols.back();
-        for (size_t j = dist_symbols.size() - 1; j >= min_length; j--) {
-          if (dist_symbols[j] < best_cost) {
-            best_cost = dist_symbols[j];
-          }
-          dist_symbols[j] = best_cost;
-        }
-      }
-      for (size_t j = min_length; j < dist_symbols.size(); j++) {
-        // Cost model that uses results from lazy LZ77.
-        float lz77_cost = sce.LenCost(in[i].context, j - min_length, lz77) +
-                          sce.DistCost(dist_symbols[j], lz77);
-        float cost = prefix_costs[i].total_cost + lz77_cost;
-        if (prefix_costs[i + j].total_cost > cost) {
-          prefix_costs[i + j].len = j;
-          prefix_costs[i + j].dist_symbol = dist_symbols[j] + 1;
-          prefix_costs[i + j].ctx = in[i].context;
-          prefix_costs[i + j].total_cost = cost;
-        }
-      }
-      // We are in a RLE sequence: skip all the symbols except the first 8 and
-      // the last 8. This avoid quadratic costs for sequences with long runs of
-      // the same symbol.
-      if ((dist_symbols.back() == 0 && distance_multiplier == 0) ||
-          (dist_symbols.back() == 1 && distance_multiplier != 0)) {
-        rle_length++;
-      } else {
-        rle_length = 0;
-      }
-      if (rle_length >= 8 && dist_symbols.size() > 9) {
-        skip_lz77 = dist_symbols.size() - 10;
-        rle_length = 0;
-      }
-    }
-    size_t pos = in.size();
-    while (pos > 0) {
-      bool is_lz77_length = prefix_costs[pos].dist_symbol != 0;
-      if (is_lz77_length) {
-        size_t dist_symbol = prefix_costs[pos].dist_symbol - 1;
-        out.emplace_back(lz77.nonserialized_distance_context, dist_symbol);
-      }
-      size_t val = is_lz77_length ? prefix_costs[pos].len - min_length
-                                  : in[pos - 1].value;
-      out.emplace_back(prefix_costs[pos].ctx, val);
-      out.back().is_lz77_length = is_lz77_length;
-      pos -= prefix_costs[pos].len;
-    }
-    std::reverse(out.begin(), out.end());
-  }
-}
-
-void ApplyLZ77(const HistogramParams& params, size_t num_contexts,
-               const std::vector<std::vector<Token>>& tokens, LZ77Params& lz77,
-               std::vector<std::vector<Token>>& tokens_lz77) {
-  if (params.initialize_global_state) {
-    lz77.enabled = false;
-  }
-  if (params.force_huffman) {
-    lz77.min_symbol = std::min(PREFIX_MAX_ALPHABET_SIZE - 32, 512);
-  } else {
-    lz77.min_symbol = 224;
-  }
-  switch (params.lz77_method) {
-    case HistogramParams::LZ77Method::kNone:
-      return;
-    case HistogramParams::LZ77Method::kRLE:
-      ApplyLZ77_RLE(params, num_contexts, tokens, lz77, tokens_lz77);
-      return;
-    case HistogramParams::LZ77Method::kLZ77:
-      ApplyLZ77_LZ77(params, num_contexts, tokens, lz77, tokens_lz77);
-      return;
-    case HistogramParams::LZ77Method::kOptimal:
-      ApplyLZ77_Optimal(params, num_contexts, tokens, lz77, tokens_lz77);
-      return;
-  }
-}
-}  // namespace
+template void EncodeUintConfigs(const std::vector<HybridUintConfig>&,
+                                BitWriter*, size_t);
 
 Status EncodeHistograms(const std::vector<uint8_t>& context_map,
                         const EntropyEncodingData& codes, BitWriter* writer,
@@ -1707,15 +1006,19 @@ StatusOr<size_t> BuildAndEncodeHistograms(
     size_t num_contexts, std::vector<std::vector<Token>>& tokens,
     EntropyEncodingData* codes, std::vector<uint8_t>* context_map,
     BitWriter* writer, LayerType layer, AuxOut* aux_out) {
-  size_t cost = 0;
+  // TODO(Ivan): presumably not needed - default
+  // if (params.initialize_global_state) codes->lz77.enabled = false;
   codes->lz77.nonserialized_distance_context = num_contexts;
-  std::vector<std::vector<Token>> tokens_lz77;
-  ApplyLZ77(params, num_contexts, tokens, codes->lz77, tokens_lz77);
+  codes->lz77.min_symbol = params.force_huffman ? 512 : 224;
+  std::vector<std::vector<Token>> tokens_lz77 =
+      ApplyLZ77(params, num_contexts, tokens, codes->lz77);
+  if (!tokens_lz77.empty()) codes->lz77.enabled = true;
   if (ans_fuzzer_friendly_) {
     codes->lz77.length_uint_config = HybridUintConfig(10, 0, 0);
     codes->lz77.min_symbol = 2048;
   }
 
+  size_t cost = 0;
   const size_t max_contexts = std::min(num_contexts, kClustersLimit);
   const auto& body = [&]() -> Status {
     if (writer) {
@@ -1743,14 +1046,7 @@ StatusOr<size_t> BuildAndEncodeHistograms(
     size_t total_tokens = 0;
     // Build histograms.
     HistogramBuilder builder(num_contexts);
-    HybridUintConfig uint_config;  //  Default config for clustering.
-    // Unless we are using the kContextMap histogram option.
-    if (params.uint_method == HistogramParams::HybridUintMethod::kContextMap) {
-      uint_config = HybridUintConfig(2, 0, 1);
-    }
-    if (params.uint_method == HistogramParams::HybridUintMethod::k000) {
-      uint_config = HybridUintConfig(0, 0, 0);
-    }
+    HybridUintConfig uint_config = params.UintConfig();
     if (ans_fuzzer_friendly_) {
       uint_config = HybridUintConfig(10, 0, 0);
     }
@@ -1826,21 +1122,20 @@ StatusOr<size_t> BuildAndEncodeHistograms(
           [&]() -> Status {
             JXL_ASSIGN_OR_RETURN(
                 size_t ans_cost,
-                BuildAndStoreANSEncodingData(
+                codes->BuildAndStoreANSEncodingData(
                     memory_manager, params.ans_histogram_strategy,
-                    Histogram::Flat(alphabet_size, ANS_TAB_SIZE), log_alpha_size,
-                    codes->use_prefix_code, codes->encoding_info.back().data(),
-                    histo_writer));
+                    Histogram::Flat(alphabet_size, ANS_TAB_SIZE),
+                    log_alpha_size, histo_writer));
             (void)ans_cost;
             return true;
           }));
     }
 
     // Encode histograms.
-    JXL_ASSIGN_OR_RETURN(
-        size_t entropy_bits,
-        builder.BuildAndStoreEntropyCodes(memory_manager, params, tokens, codes,
-                                          context_map, writer, layer, aux_out));
+    JXL_ASSIGN_OR_RETURN(size_t entropy_bits,
+                         codes->BuildAndStoreEntropyCodes(
+                             memory_manager, params, tokens, &builder,
+                             context_map, writer, layer, aux_out));
     cost += entropy_bits;
     return true;
   };

--- a/lib/jxl/enc_ans.h
+++ b/lib/jxl/enc_ans.h
@@ -78,14 +78,6 @@ class ANSCoder {
 
 static const int kNumFixedHistograms = 1;
 
-struct EntropyEncodingData {
-  std::vector<std::vector<ANSEncSymbolInfo>> encoding_info;
-  bool use_prefix_code;
-  std::vector<HybridUintConfig> uint_config;
-  LZ77Params lz77;
-  std::vector<BitWriter> encoded_histograms;
-};
-
 // Integer to be encoded by an entropy coder, either ANS or Huffman.
 struct Token {
   Token() = default;
@@ -94,6 +86,49 @@ struct Token {
   uint32_t is_lz77_length : 1;
   uint32_t context : 31;
   uint32_t value;
+};
+
+struct SizeWriter {
+  size_t size = 0;
+  void Write(size_t num, size_t bits) { size += num; }
+};
+
+class HistogramBuilder {
+ public:
+  explicit HistogramBuilder(const size_t num_contexts)
+      : histograms_(num_contexts) {}
+
+  void VisitSymbol(int symbol, size_t histo_idx) {
+    JXL_DASSERT(histo_idx < histograms_.size());
+    histograms_[histo_idx].Add(symbol);
+  }
+
+  const Histogram& Histo(size_t i) const { return histograms_[i]; }
+  size_t HistoNum() const { return histograms_.size(); }
+
+  friend struct EntropyEncodingData;
+
+ protected:
+  std::vector<Histogram> histograms_;
+};
+
+struct EntropyEncodingData {
+  std::vector<std::vector<ANSEncSymbolInfo>> encoding_info;
+  bool use_prefix_code;
+  std::vector<HybridUintConfig> uint_config;
+  LZ77Params lz77;
+  std::vector<BitWriter> encoded_histograms;
+
+  StatusOr<size_t> BuildAndStoreEntropyCodes(
+      JxlMemoryManager* memory_manager, const HistogramParams& params,
+      const std::vector<std::vector<Token>>& tokens,
+      const HistogramBuilder* builder, std::vector<uint8_t>* context_map,
+      BitWriter* writer, LayerType layer, AuxOut* aux_out);
+
+  StatusOr<size_t> BuildAndStoreANSEncodingData(
+      JxlMemoryManager* memory_manager,
+      HistogramParams::ANSHistogramStrategy ans_histogram_strategy,
+      const Histogram& histogram, size_t log_alpha_size, BitWriter* writer);
 };
 
 // Writes the context map to the bitstream and concatenates the individual

--- a/lib/jxl/enc_ans_params.h
+++ b/lib/jxl/enc_ans_params.h
@@ -15,6 +15,7 @@
 
 #include "lib/jxl/ans_common.h"
 #include "lib/jxl/common.h"
+#include "lib/jxl/dec_ans.h"
 
 namespace jxl {
 
@@ -74,6 +75,17 @@ struct HistogramParams {
   static HistogramParams ForModular(
       const CompressParams& cparams,
       const std::vector<uint8_t>& extra_dc_precision, bool streaming_mode);
+
+  HybridUintConfig UintConfig() const {
+    if (uint_method == HistogramParams::HybridUintMethod::kContextMap) {
+      return HybridUintConfig(2, 0, 1);
+    }
+    if (uint_method == HistogramParams::HybridUintMethod::k000) {
+      return HybridUintConfig(0, 0, 0);
+    }
+    // Default config for clustering.
+    return HybridUintConfig();
+  }
 
   ClusteringType clustering = ClusteringType::kBest;
   HybridUintMethod uint_method = HybridUintMethod::kBest;

--- a/lib/jxl/enc_lz77.cc
+++ b/lib/jxl/enc_lz77.cc
@@ -1,0 +1,700 @@
+// Copyright (c) the JPEG XL Project Authors. All rights reserved.
+//
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+#include "lib/jxl/enc_lz77.h"
+
+#include <jxl/memory_manager.h>
+#include <jxl/types.h>
+
+#include <algorithm>
+#include <cmath>
+#include <cstddef>
+#include <cstdint>
+#include <limits>
+#include <unordered_map>
+#include <utility>
+#include <vector>
+
+#include "lib/jxl/ans_common.h"
+#include "lib/jxl/ans_params.h"
+#include "lib/jxl/base/bits.h"
+#include "lib/jxl/base/common.h"
+#include "lib/jxl/base/compiler_specific.h"
+#include "lib/jxl/base/fast_math-inl.h"
+#include "lib/jxl/base/status.h"
+#include "lib/jxl/common.h"
+#include "lib/jxl/dec_ans.h"
+#include "lib/jxl/enc_ans_params.h"
+#include "lib/jxl/enc_aux_out.h"
+#include "lib/jxl/enc_cluster.h"
+#include "lib/jxl/enc_context_map.h"
+#include "lib/jxl/enc_fields.h"
+#include "lib/jxl/enc_huffman.h"
+#include "lib/jxl/enc_params.h"
+#include "lib/jxl/fields.h"
+
+namespace jxl {
+
+class SymbolCostEstimator {
+ public:
+  SymbolCostEstimator(size_t num_contexts, bool force_huffman,
+                      const std::vector<std::vector<Token>>& tokens,
+                      const LZ77Params& lz77) {
+    HistogramBuilder builder(num_contexts);
+    // Build histograms for estimating lz77 savings.
+    HybridUintConfig uint_config;
+    for (const auto& stream : tokens) {
+      for (const auto& token : stream) {
+        uint32_t tok, nbits, bits;
+        (token.is_lz77_length ? lz77.length_uint_config : uint_config)
+            .Encode(token.value, &tok, &nbits, &bits);
+        tok += token.is_lz77_length ? lz77.min_symbol : 0;
+        builder.VisitSymbol(tok, token.context);
+      }
+    }
+    max_alphabet_size_ = 0;
+    for (size_t i = 0; i < num_contexts; i++) {
+      max_alphabet_size_ =
+          std::max(max_alphabet_size_, builder.Histo(i).counts_.size());
+    }
+    bits_.resize(num_contexts * max_alphabet_size_);
+    // TODO(veluca): SIMD?
+    add_symbol_cost_.resize(num_contexts);
+    for (size_t i = 0; i < num_contexts; i++) {
+      float inv_total = 1.0f / (builder.Histo(i).total_count_ + 1e-8f);
+      float total_cost = 0;
+      for (size_t j = 0; j < builder.Histo(i).counts_.size(); j++) {
+        size_t cnt = builder.Histo(i).counts_[j];
+        float cost = 0;
+        if (cnt != 0 && cnt != builder.Histo(i).total_count_) {
+          cost = -FastLog2f(cnt * inv_total);
+          if (force_huffman) cost = std::ceil(cost);
+        } else if (cnt == 0) {
+          cost = ANS_LOG_TAB_SIZE;  // Highest possible cost.
+        }
+        bits_[i * max_alphabet_size_ + j] = cost;
+        total_cost += cost * builder.Histo(i).counts_[j];
+      }
+      // Penalty for adding a lz77 symbol to this contest (only used for static
+      // cost model). Higher penalty for contexts that have a very low
+      // per-symbol entropy.
+      add_symbol_cost_[i] = std::max(0.0f, 6.0f - total_cost * inv_total);
+    }
+  }
+  float Bits(size_t ctx, size_t sym) const {
+    return bits_[ctx * max_alphabet_size_ + sym];
+  }
+  float LenCost(size_t ctx, size_t len, const LZ77Params& lz77) const {
+    uint32_t nbits, bits, tok;
+    lz77.length_uint_config.Encode(len, &tok, &nbits, &bits);
+    tok += lz77.min_symbol;
+    return nbits + Bits(ctx, tok);
+  }
+  float DistCost(size_t len, const LZ77Params& lz77) const {
+    uint32_t nbits, bits, tok;
+    HybridUintConfig().Encode(len, &tok, &nbits, &bits);
+    return nbits + Bits(lz77.nonserialized_distance_context, tok);
+  }
+  float AddSymbolCost(size_t idx) const { return add_symbol_cost_[idx]; }
+
+ private:
+  size_t max_alphabet_size_;
+  std::vector<float> bits_;
+  std::vector<float> add_symbol_cost_;
+};
+
+std::vector<std::vector<Token>> ApplyLZ77_RLE(
+    const HistogramParams& params, size_t num_contexts,
+    const std::vector<std::vector<Token>>& tokens, const LZ77Params& lz77) {
+  std::vector<std::vector<Token>> tokens_lz77(tokens.size());
+  // TODO(veluca): tune heuristics here.
+  SymbolCostEstimator sce(num_contexts, params.force_huffman, tokens, lz77);
+  float bit_decrease = 0;
+  size_t total_symbols = 0;
+  std::vector<float> sym_cost;
+  HybridUintConfig uint_config;
+  for (size_t stream = 0; stream < tokens.size(); stream++) {
+    size_t distance_multiplier =
+        params.image_widths.size() > stream ? params.image_widths[stream] : 0;
+    const auto& in = tokens[stream];
+    auto& out = tokens_lz77[stream];
+    total_symbols += in.size();
+    // Cumulative sum of bit costs.
+    sym_cost.resize(in.size() + 1);
+    for (size_t i = 0; i < in.size(); i++) {
+      uint32_t tok, nbits, unused_bits;
+      uint_config.Encode(in[i].value, &tok, &nbits, &unused_bits);
+      sym_cost[i + 1] = sce.Bits(in[i].context, tok) + nbits + sym_cost[i];
+    }
+    out.reserve(in.size());
+    for (size_t i = 0; i < in.size(); i++) {
+      size_t num_to_copy = 0;
+      size_t distance_symbol = 0;  // 1 for RLE.
+      if (distance_multiplier != 0) {
+        distance_symbol = 1;  // Special distance 1 if enabled.
+        JXL_DASSERT(kSpecialDistances[1][0] == 1);
+        JXL_DASSERT(kSpecialDistances[1][1] == 0);
+      }
+      if (i > 0) {
+        for (; i + num_to_copy < in.size(); num_to_copy++) {
+          if (in[i + num_to_copy].value != in[i - 1].value) {
+            break;
+          }
+        }
+      }
+      if (num_to_copy == 0) {
+        out.push_back(in[i]);
+        continue;
+      }
+      float cost = sym_cost[i + num_to_copy] - sym_cost[i];
+      // This subtraction might overflow, but that's OK.
+      size_t lz77_len = num_to_copy - lz77.min_length;
+      float lz77_cost = num_to_copy >= lz77.min_length
+                            ? CeilLog2Nonzero(lz77_len + 1) + 1
+                            : 0;
+      if (num_to_copy < lz77.min_length || cost <= lz77_cost) {
+        for (size_t j = 0; j < num_to_copy; j++) {
+          out.push_back(in[i + j]);
+        }
+        i += num_to_copy - 1;
+        continue;
+      }
+      // Output the LZ77 length
+      out.emplace_back(in[i].context, lz77_len);
+      out.back().is_lz77_length = true;
+      i += num_to_copy - 1;
+      bit_decrease += cost - lz77_cost;
+      // Output the LZ77 copy distance.
+      out.emplace_back(lz77.nonserialized_distance_context, distance_symbol);
+    }
+  }
+
+  if (bit_decrease > total_symbols * 0.2 + 16) {
+    return tokens_lz77;
+  }
+  return {};
+}
+
+// Hash chain for LZ77 matching
+struct HashChain {
+  size_t size_;
+  std::vector<uint32_t> data_;
+
+  unsigned hash_num_values_ = 32768;
+  unsigned hash_mask_ = hash_num_values_ - 1;
+  unsigned hash_shift_ = 5;
+
+  std::vector<int> head;
+  std::vector<uint32_t> chain;
+  std::vector<int> val;
+
+  // Speed up repetitions of zero
+  std::vector<int> headz;
+  std::vector<uint32_t> chainz;
+  std::vector<uint32_t> zeros;
+  uint32_t numzeros = 0;
+
+  size_t window_size_;
+  size_t window_mask_;
+  size_t min_length_;
+  size_t max_length_;
+
+  // Map of special distance codes.
+  std::unordered_map<int, int> special_dist_table_;
+  size_t num_special_distances_ = 0;
+
+  uint32_t maxchainlength = 256;  // window_size_ to allow all
+
+  HashChain(const Token* data, size_t size, size_t window_size,
+            size_t min_length, size_t max_length, size_t distance_multiplier)
+      : size_(size),
+        window_size_(window_size),
+        window_mask_(window_size - 1),
+        min_length_(min_length),
+        max_length_(max_length) {
+    data_.resize(size);
+    for (size_t i = 0; i < size; i++) {
+      data_[i] = data[i].value;
+    }
+
+    head.resize(hash_num_values_, -1);
+    val.resize(window_size_, -1);
+    chain.resize(window_size_);
+    for (uint32_t i = 0; i < window_size_; ++i) {
+      chain[i] = i;  // same value as index indicates uninitialized
+    }
+
+    zeros.resize(window_size_);
+    headz.resize(window_size_ + 1, -1);
+    chainz.resize(window_size_);
+    for (uint32_t i = 0; i < window_size_; ++i) {
+      chainz[i] = i;
+    }
+    // Translate distance to special distance code.
+    if (distance_multiplier) {
+      // Count down, so if due to small distance multiplier multiple distances
+      // map to the same code, the smallest code will be used in the end.
+      for (int i = kNumSpecialDistances - 1; i >= 0; --i) {
+        special_dist_table_[SpecialDistance(i, distance_multiplier)] = i;
+      }
+      num_special_distances_ = kNumSpecialDistances;
+    }
+  }
+
+  uint32_t GetHash(size_t pos) const {
+    uint32_t result = 0;
+    if (pos + 2 < size_) {
+      // TODO(lode): take the MSB's of the uint32_t values into account as well,
+      // given that the hash code itself is less than 32 bits.
+      result ^= static_cast<uint32_t>(data_[pos + 0] << 0u);
+      result ^= static_cast<uint32_t>(data_[pos + 1] << hash_shift_);
+      result ^= static_cast<uint32_t>(data_[pos + 2] << (hash_shift_ * 2));
+    } else {
+      // No need to compute hash of last 2 bytes, the length 2 is too short.
+      return 0;
+    }
+    return result & hash_mask_;
+  }
+
+  uint32_t CountZeros(size_t pos, uint32_t prevzeros) const {
+    size_t end = pos + window_size_;
+    if (end > size_) end = size_;
+    if (prevzeros > 0) {
+      if (prevzeros >= window_mask_ && data_[end - 1] == 0 &&
+          end == pos + window_size_) {
+        return prevzeros;
+      } else {
+        return prevzeros - 1;
+      }
+    }
+    uint32_t num = 0;
+    while (pos + num < end && data_[pos + num] == 0) num++;
+    return num;
+  }
+
+  void Update(size_t pos) {
+    uint32_t hashval = GetHash(pos);
+    uint32_t wpos = pos & window_mask_;
+
+    val[wpos] = static_cast<int>(hashval);
+    if (head[hashval] != -1) chain[wpos] = head[hashval];
+    head[hashval] = wpos;
+
+    if (pos > 0 && data_[pos] != data_[pos - 1]) numzeros = 0;
+    numzeros = CountZeros(pos, numzeros);
+
+    zeros[wpos] = numzeros;
+    if (headz[numzeros] != -1) chainz[wpos] = headz[numzeros];
+    headz[numzeros] = wpos;
+  }
+
+  void Update(size_t pos, size_t len) {
+    for (size_t i = 0; i < len; i++) {
+      Update(pos + i);
+    }
+  }
+
+  template <typename CB>
+  void FindMatches(size_t pos, int max_dist, const CB& found_match) const {
+    uint32_t wpos = pos & window_mask_;
+    uint32_t hashval = GetHash(pos);
+    uint32_t hashpos = chain[wpos];
+
+    int prev_dist = 0;
+    int end = std::min<int>(pos + max_length_, size_);
+    uint32_t chainlength = 0;
+    uint32_t best_len = 0;
+    for (;;) {
+      int dist = (hashpos <= wpos) ? (wpos - hashpos)
+                                   : (wpos - hashpos + window_mask_ + 1);
+      if (dist < prev_dist) break;
+      prev_dist = dist;
+      uint32_t len = 0;
+      if (dist > 0) {
+        int i = pos;
+        int j = pos - dist;
+        if (numzeros > 3) {
+          int r = std::min<int>(numzeros - 1, zeros[hashpos]);
+          if (i + r >= end) r = end - i - 1;
+          i += r;
+          j += r;
+        }
+        while (i < end && data_[i] == data_[j]) {
+          i++;
+          j++;
+        }
+        len = i - pos;
+        // This can trigger even if the new length is slightly smaller than the
+        // best length, because it is possible for a slightly cheaper distance
+        // symbol to occur.
+        if (len >= min_length_ && len + 2 >= best_len) {
+          auto it = special_dist_table_.find(dist);
+          int dist_symbol = (it == special_dist_table_.end())
+                                ? (num_special_distances_ + dist - 1)
+                                : it->second;
+          found_match(len, dist_symbol);
+          if (len > best_len) best_len = len;
+        }
+      }
+
+      chainlength++;
+      if (chainlength >= maxchainlength) break;
+
+      if (numzeros >= 3 && len > numzeros) {
+        if (hashpos == chainz[hashpos]) break;
+        hashpos = chainz[hashpos];
+        if (zeros[hashpos] != numzeros) break;
+      } else {
+        if (hashpos == chain[hashpos]) break;
+        hashpos = chain[hashpos];
+        if (val[hashpos] != static_cast<int>(hashval)) {
+          // outdated hash value
+          break;
+        }
+      }
+    }
+  }
+  void FindMatch(size_t pos, int max_dist, size_t* result_dist_symbol,
+                 size_t* result_len) const {
+    *result_dist_symbol = 0;
+    *result_len = 1;
+    FindMatches(pos, max_dist, [&](size_t len, size_t dist_symbol) {
+      if (len > *result_len ||
+          (len == *result_len && *result_dist_symbol > dist_symbol)) {
+        *result_len = len;
+        *result_dist_symbol = dist_symbol;
+      }
+    });
+  }
+};
+
+float LenCost(size_t len) {
+  uint32_t nbits, bits, tok;
+  HybridUintConfig(1, 0, 0).Encode(len, &tok, &nbits, &bits);
+  constexpr float kCostTable[] = {
+      2.797667318563126,  3.213177690381199,  2.5706009246743737,
+      2.408392498667534,  2.829649191872326,  3.3923087753324577,
+      4.029267451554331,  4.415576699706408,  4.509357574741465,
+      9.21481543803004,   10.020590190114898, 11.858671627804766,
+      12.45853300490526,  11.713105831990857, 12.561996324849314,
+      13.775477692278367, 13.174027068768641,
+  };
+  size_t table_size = sizeof kCostTable / sizeof *kCostTable;
+  if (tok >= table_size) tok = table_size - 1;
+  return kCostTable[tok] + nbits;
+}
+
+// TODO(veluca): this does not take into account usage or non-usage of distance
+// multipliers.
+float DistCost(size_t dist) {
+  uint32_t nbits, bits, tok;
+  HybridUintConfig(7, 0, 0).Encode(dist, &tok, &nbits, &bits);
+  constexpr float kCostTable[] = {
+      6.368282626312716,  5.680793277090298,  8.347404197105247,
+      7.641619201599141,  6.914328374119438,  7.959808291537444,
+      8.70023120759855,   8.71378518934703,   9.379132523982769,
+      9.110472749092708,  9.159029569270908,  9.430936766731973,
+      7.278284055315169,  7.8278514904267755, 10.026641158289236,
+      9.976049229827066,  9.64351607048908,   9.563403863480442,
+      10.171474111762747, 10.45950155077234,  9.994813912104219,
+      10.322524683741156, 8.465808729388186,  8.756254166066853,
+      10.160930174662234, 10.247329273413435, 10.04090403724809,
+      10.129398517544082, 9.342311691539546,  9.07608009102374,
+      10.104799540677513, 10.378079384990906, 10.165828974075072,
+      10.337595322341553, 7.940557464567944,  10.575665823319431,
+      11.023344321751955, 10.736144698831827, 11.118277044595054,
+      7.468468230648442,  10.738305230932939, 10.906980780216568,
+      10.163468216353817, 10.17805759656433,  11.167283670483565,
+      11.147050200274544, 10.517921919244333, 10.651764778156886,
+      10.17074446448919,  11.217636876224745, 11.261630721139484,
+      11.403140815247259, 10.892472096873417, 11.1859607804481,
+      8.017346947551262,  7.895143720278828,  11.036577113822025,
+      11.170562110315794, 10.326988722591086, 10.40872184751056,
+      11.213498225466386, 11.30580635516863,  10.672272515665442,
+      10.768069466228063, 11.145257364153565, 11.64668307145549,
+      10.593156194627339, 11.207499484844943, 10.767517766396908,
+      10.826629811407042, 10.737764794499988, 10.6200448518045,
+      10.191315385198092, 8.468384171390085,  11.731295299170432,
+      11.824619886654398, 10.41518844301179,  10.16310536548649,
+      10.539423685097576, 10.495136599328031, 10.469112847728267,
+      11.72057686174922,  10.910326337834674, 11.378921834673758,
+      11.847759036098536, 11.92071647623854,  10.810628276345282,
+      11.008601085273893, 11.910326337834674, 11.949212023423133,
+      11.298614839104337, 11.611603659010392, 10.472930394619985,
+      11.835564720850282, 11.523267392285337, 12.01055816679611,
+      8.413029688994023,  11.895784139536406, 11.984679534970505,
+      11.220654278717394, 11.716311684833672, 10.61036646226114,
+      10.89849965960364,  10.203762898863669, 10.997560826267238,
+      11.484217379438984, 11.792836176993665, 12.24310468755171,
+      11.464858097919262, 12.212747017409377, 11.425595666074955,
+      11.572048533398757, 12.742093965163013, 11.381874288645637,
+      12.191870445817015, 11.683156920035426, 11.152442115262197,
+      11.90303691580457,  11.653292787169159, 11.938615382266098,
+      16.970641701570223, 16.853602280380002, 17.26240782594733,
+      16.644655390108507, 17.14310889757499,  16.910935455445955,
+      17.505678976959697, 17.213498225466388, 2.4162310293553024,
+      3.494587244462329,  3.5258600986408344, 3.4959806589517095,
+      3.098390886949687,  3.343454654302911,  3.588847442290287,
+      4.14614790111827,   5.152948641990529,  7.433696808092598,
+      9.716311684833672,
+  };
+  size_t table_size = sizeof kCostTable / sizeof *kCostTable;
+  if (tok >= table_size) tok = table_size - 1;
+  return kCostTable[tok] + nbits;
+}
+
+std::vector<std::vector<Token>> ApplyLZ77_LZ77(
+    const HistogramParams& params, size_t num_contexts,
+    const std::vector<std::vector<Token>>& tokens, const LZ77Params& lz77) {
+  std::vector<std::vector<Token>> tokens_lz77(tokens.size());
+  // TODO(veluca): tune heuristics here.
+  SymbolCostEstimator sce(num_contexts, params.force_huffman, tokens, lz77);
+  float bit_decrease = 0;
+  size_t total_symbols = 0;
+  HybridUintConfig uint_config;
+  std::vector<float> sym_cost;
+  for (size_t stream = 0; stream < tokens.size(); stream++) {
+    size_t distance_multiplier =
+        params.image_widths.size() > stream ? params.image_widths[stream] : 0;
+    const auto& in = tokens[stream];
+    auto& out = tokens_lz77[stream];
+    total_symbols += in.size();
+    // Cumulative sum of bit costs.
+    sym_cost.resize(in.size() + 1);
+    for (size_t i = 0; i < in.size(); i++) {
+      uint32_t tok, nbits, unused_bits;
+      uint_config.Encode(in[i].value, &tok, &nbits, &unused_bits);
+      sym_cost[i + 1] = sce.Bits(in[i].context, tok) + nbits + sym_cost[i];
+    }
+
+    out.reserve(in.size());
+    size_t max_distance = in.size();
+    size_t min_length = lz77.min_length;
+    JXL_DASSERT(min_length >= 3);
+    size_t max_length = in.size();
+
+    // Use next power of two as window size.
+    size_t window_size = 1;
+    while (window_size < max_distance && window_size < kWindowSize) {
+      window_size <<= 1;
+    }
+
+    HashChain chain(in.data(), in.size(), window_size, min_length, max_length,
+                    distance_multiplier);
+    size_t len;
+    size_t dist_symbol;
+
+    const size_t max_lazy_match_len = 256;  // 0 to disable lazy matching
+
+    // Whether the next symbol was already updated (to test lazy matching)
+    bool already_updated = false;
+    for (size_t i = 0; i < in.size(); i++) {
+      out.push_back(in[i]);
+      if (!already_updated) chain.Update(i);
+      already_updated = false;
+      chain.FindMatch(i, max_distance, &dist_symbol, &len);
+      if (len >= min_length) {
+        if (len < max_lazy_match_len && i + 1 < in.size()) {
+          // Try length at next symbol lazy matching
+          chain.Update(i + 1);
+          already_updated = true;
+          size_t len2, dist_symbol2;
+          chain.FindMatch(i + 1, max_distance, &dist_symbol2, &len2);
+          if (len2 > len) {
+            // Use the lazy match. Add literal, and use the next length starting
+            // from the next byte.
+            ++i;
+            already_updated = false;
+            len = len2;
+            dist_symbol = dist_symbol2;
+            out.push_back(in[i]);
+          }
+        }
+
+        float cost = sym_cost[i + len] - sym_cost[i];
+        size_t lz77_len = len - lz77.min_length;
+        float lz77_cost = LenCost(lz77_len) + DistCost(dist_symbol) +
+                          sce.AddSymbolCost(out.back().context);
+
+        if (lz77_cost <= cost) {
+          out.back().value = len - min_length;
+          out.back().is_lz77_length = true;
+          out.emplace_back(lz77.nonserialized_distance_context, dist_symbol);
+          bit_decrease += cost - lz77_cost;
+        } else {
+          // LZ77 match ignored, and symbol already pushed. Push all other
+          // symbols and skip.
+          for (size_t j = 1; j < len; j++) {
+            out.push_back(in[i + j]);
+          }
+        }
+
+        if (already_updated) {
+          chain.Update(i + 2, len - 2);
+          already_updated = false;
+        } else {
+          chain.Update(i + 1, len - 1);
+        }
+        i += len - 1;
+      } else {
+        // Literal, already pushed
+      }
+    }
+  }
+
+  if (bit_decrease > total_symbols * 0.2 + 16) {
+    return tokens_lz77;
+  }
+  return {};
+}
+
+std::vector<std::vector<Token>> ApplyLZ77_Optimal(
+    const HistogramParams& params, size_t num_contexts,
+    const std::vector<std::vector<Token>>& tokens, const LZ77Params& lz77) {
+  std::vector<std::vector<Token>> tokens_for_cost_estimate =
+      ApplyLZ77_LZ77(params, num_contexts, tokens, lz77);
+  // If greedy-LZ77 does not give better compression than no-lz77, no reason to
+  // run the optimal matching.
+  if (tokens_for_cost_estimate.empty()) return {};
+  SymbolCostEstimator sce(num_contexts + 1, params.force_huffman,
+                          tokens_for_cost_estimate, lz77);
+  std::vector<std::vector<Token>> tokens_lz77(tokens.size());
+  HybridUintConfig uint_config;
+  std::vector<float> sym_cost;
+  std::vector<uint32_t> dist_symbols;
+  for (size_t stream = 0; stream < tokens.size(); stream++) {
+    size_t distance_multiplier =
+        params.image_widths.size() > stream ? params.image_widths[stream] : 0;
+    const auto& in = tokens[stream];
+    auto& out = tokens_lz77[stream];
+    // Cumulative sum of bit costs.
+    sym_cost.resize(in.size() + 1);
+    for (size_t i = 0; i < in.size(); i++) {
+      uint32_t tok, nbits, unused_bits;
+      uint_config.Encode(in[i].value, &tok, &nbits, &unused_bits);
+      sym_cost[i + 1] = sce.Bits(in[i].context, tok) + nbits + sym_cost[i];
+    }
+
+    out.reserve(in.size());
+    size_t max_distance = in.size();
+    size_t min_length = lz77.min_length;
+    JXL_DASSERT(min_length >= 3);
+    size_t max_length = in.size();
+
+    // Use next power of two as window size.
+    size_t window_size = 1;
+    while (window_size < max_distance && window_size < kWindowSize) {
+      window_size <<= 1;
+    }
+
+    HashChain chain(in.data(), in.size(), window_size, min_length, max_length,
+                    distance_multiplier);
+
+    struct MatchInfo {
+      uint32_t len;
+      uint32_t dist_symbol;
+      uint32_t ctx;
+      float total_cost = std::numeric_limits<float>::max();
+    };
+    // Total cost to encode the first N symbols.
+    std::vector<MatchInfo> prefix_costs(in.size() + 1);
+    prefix_costs[0].total_cost = 0;
+
+    size_t rle_length = 0;
+    size_t skip_lz77 = 0;
+    for (size_t i = 0; i < in.size(); i++) {
+      chain.Update(i);
+      float lit_cost =
+          prefix_costs[i].total_cost + sym_cost[i + 1] - sym_cost[i];
+      if (prefix_costs[i + 1].total_cost > lit_cost) {
+        prefix_costs[i + 1].dist_symbol = 0;
+        prefix_costs[i + 1].len = 1;
+        prefix_costs[i + 1].ctx = in[i].context;
+        prefix_costs[i + 1].total_cost = lit_cost;
+      }
+      if (skip_lz77 > 0) {
+        skip_lz77--;
+        continue;
+      }
+      dist_symbols.clear();
+      chain.FindMatches(i, max_distance,
+                        [&dist_symbols](size_t len, size_t dist_symbol) {
+                          if (dist_symbols.size() <= len) {
+                            dist_symbols.resize(len + 1, dist_symbol);
+                          }
+                          if (dist_symbol < dist_symbols[len]) {
+                            dist_symbols[len] = dist_symbol;
+                          }
+                        });
+      if (dist_symbols.size() <= min_length) continue;
+      {
+        size_t best_cost = dist_symbols.back();
+        for (size_t j = dist_symbols.size() - 1; j >= min_length; j--) {
+          if (dist_symbols[j] < best_cost) {
+            best_cost = dist_symbols[j];
+          }
+          dist_symbols[j] = best_cost;
+        }
+      }
+      for (size_t j = min_length; j < dist_symbols.size(); j++) {
+        // Cost model that uses results from lazy LZ77.
+        float lz77_cost = sce.LenCost(in[i].context, j - min_length, lz77) +
+                          sce.DistCost(dist_symbols[j], lz77);
+        float cost = prefix_costs[i].total_cost + lz77_cost;
+        if (prefix_costs[i + j].total_cost > cost) {
+          prefix_costs[i + j].len = j;
+          prefix_costs[i + j].dist_symbol = dist_symbols[j] + 1;
+          prefix_costs[i + j].ctx = in[i].context;
+          prefix_costs[i + j].total_cost = cost;
+        }
+      }
+      // We are in a RLE sequence: skip all the symbols except the first 8 and
+      // the last 8. This avoid quadratic costs for sequences with long runs of
+      // the same symbol.
+      if ((dist_symbols.back() == 0 && distance_multiplier == 0) ||
+          (dist_symbols.back() == 1 && distance_multiplier != 0)) {
+        rle_length++;
+      } else {
+        rle_length = 0;
+      }
+      if (rle_length >= 8 && dist_symbols.size() > 9) {
+        skip_lz77 = dist_symbols.size() - 10;
+        rle_length = 0;
+      }
+    }
+    size_t pos = in.size();
+    while (pos > 0) {
+      bool is_lz77_length = prefix_costs[pos].dist_symbol != 0;
+      if (is_lz77_length) {
+        size_t dist_symbol = prefix_costs[pos].dist_symbol - 1;
+        out.emplace_back(lz77.nonserialized_distance_context, dist_symbol);
+      }
+      size_t val = is_lz77_length ? prefix_costs[pos].len - min_length
+                                  : in[pos - 1].value;
+      out.emplace_back(prefix_costs[pos].ctx, val);
+      out.back().is_lz77_length = is_lz77_length;
+      pos -= prefix_costs[pos].len;
+    }
+    std::reverse(out.begin(), out.end());
+  }
+  return tokens_lz77;
+}
+
+std::vector<std::vector<Token>> ApplyLZ77(
+    const HistogramParams& params, size_t num_contexts,
+    const std::vector<std::vector<Token>>& tokens, const LZ77Params& lz77) {
+  switch (params.lz77_method) {
+    case HistogramParams::LZ77Method::kRLE:
+      return ApplyLZ77_RLE(params, num_contexts, tokens, lz77);
+    case HistogramParams::LZ77Method::kLZ77:
+      return ApplyLZ77_LZ77(params, num_contexts, tokens, lz77);
+    case HistogramParams::LZ77Method::kOptimal:
+      return ApplyLZ77_Optimal(params, num_contexts, tokens, lz77);
+    default:
+      return {};
+  }
+}
+
+}  // namespace jxl

--- a/lib/jxl/enc_lz77.h
+++ b/lib/jxl/enc_lz77.h
@@ -1,0 +1,27 @@
+// Copyright (c) the JPEG XL Project Authors. All rights reserved.
+//
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+#ifndef LIB_JXL_ENC_LZ77_H_
+#define LIB_JXL_ENC_LZ77_H_
+
+// Library to encode the ANS population counts to the bit-stream and encode
+// symbols based on the respective distributions.
+
+#include <cstdint>
+#include <vector>
+
+#include "lib/jxl/dec_ans.h"
+#include "lib/jxl/enc_ans.h"
+#include "lib/jxl/enc_ans_params.h"
+
+namespace jxl {
+
+std::vector<std::vector<Token>> ApplyLZ77(
+    const HistogramParams& params, size_t num_contexts,
+    const std::vector<std::vector<Token>>& tokens, const LZ77Params& lz77);
+
+}  // namespace jxl
+
+#endif  // LIB_JXL_ENC_LZ77_H_

--- a/lib/jxl_lists.bzl
+++ b/lib/jxl_lists.bzl
@@ -361,6 +361,8 @@ libjxl_enc_sources = [
     "jxl/enc_image_bundle.h",
     "jxl/enc_linalg.cc",
     "jxl/enc_linalg.h",
+    "jxl/enc_lz77.cc",
+    "jxl/enc_lz77.h",
     "jxl/enc_modular.cc",
     "jxl/enc_modular.h",
     "jxl/enc_noise.cc",

--- a/lib/jxl_lists.cmake
+++ b/lib/jxl_lists.cmake
@@ -358,6 +358,8 @@ set(JPEGXL_INTERNAL_ENC_SOURCES
   jxl/enc_image_bundle.h
   jxl/enc_linalg.cc
   jxl/enc_linalg.h
+  jxl/enc_lz77.cc
+  jxl/enc_lz77.h
   jxl/enc_modular.cc
   jxl/enc_modular.h
   jxl/enc_noise.cc

--- a/lib/lib.gni
+++ b/lib/lib.gni
@@ -359,6 +359,8 @@ libjxl_enc_sources = [
     "jxl/enc_image_bundle.h",
     "jxl/enc_linalg.cc",
     "jxl/enc_linalg.h",
+    "jxl/enc_lz77.cc",
+    "jxl/enc_lz77.h",
     "jxl/enc_modular.cc",
     "jxl/enc_modular.h",
     "jxl/enc_noise.cc",


### PR DESCRIPTION
### Description

Reducing complexity and compilation unit sizes I separated lz77-related part into another file+header, introduced derivation of default `UintConfig` from `HistogramParams`, and moved `BuildAndStoreEntropyCodes` and `BuildAndStoreANSEncodingData` that extensively use fields of `EntropyEncodingData` into its members.

### Pull Request Checklist

- [x] **CLA Signed**: Have you signed the [Contributor License Agreement](https://code.google.com/legal/individual-cla-v1.0.html) (individual or corporate, as appropriate)? Only contributions from signed contributors can be accepted.
- [x] **Authors**: Have you considered adding your name to the [AUTHORS](AUTHORS) file?
- [x] **Code Style**: Have you ensured your code adheres to the project's coding style guidelines? You can use `./ci.sh lint` for automatic code formatting.