### PR TITLE
Refactor: Interfaces clearing

### DIFF
--- a/lib/jxl/ans_test.cc
+++ b/lib/jxl/ans_test.cc
@@ -37,7 +37,6 @@ void RoundtripTestcase(int n_histograms, int alphabet_size,
     return true;
   }));
 
-  std::vector<uint8_t> context_map;
   EntropyEncodingData codes;
   std::vector<std::vector<Token>> input_values_vec;
   input_values_vec.push_back(input_values);
@@ -45,10 +44,10 @@ void RoundtripTestcase(int n_histograms, int alphabet_size,
   JXL_TEST_ASSIGN_OR_DIE(
       size_t cost,
       BuildAndEncodeHistograms(memory_manager, HistogramParams(), n_histograms,
-                               input_values_vec, &codes, &context_map, &writer,
+                               input_values_vec, &codes, &writer,
                                LayerType::Header, nullptr));
   (void)cost;
-  ASSERT_TRUE(WriteTokens(input_values_vec[0], codes, context_map, 0, &writer,
+  ASSERT_TRUE(WriteTokens(input_values_vec[0], codes, 0, &writer,
                           LayerType::Header, nullptr));
 
   // Magic bytes + padding
@@ -68,7 +67,7 @@ void RoundtripTestcase(int n_histograms, int alphabet_size,
   ANSCode decoded_codes;
   ASSERT_TRUE(DecodeHistograms(memory_manager, &br, n_histograms,
                                &decoded_codes, &dec_context_map));
-  ASSERT_EQ(dec_context_map, context_map);
+  ASSERT_EQ(dec_context_map, codes.context_map);
   JXL_TEST_ASSIGN_OR_DIE(ANSSymbolReader reader,
                          ANSSymbolReader::Create(&decoded_codes, &br));
 
@@ -216,7 +215,6 @@ void TestCheckpointing(bool ans, bool lz77) {
     input_values[0].emplace_back(0, i % 4);
   }
 
-  std::vector<uint8_t> context_map;
   EntropyEncodingData codes;
   HistogramParams params;
   params.lz77_method = lz77 ? HistogramParams::LZ77Method::kLZ77
@@ -227,12 +225,12 @@ void TestCheckpointing(bool ans, bool lz77) {
   {
     auto input_values_copy = input_values;
     JXL_TEST_ASSIGN_OR_DIE(
-        size_t cost, BuildAndEncodeHistograms(
-                         memory_manager, params, 1, input_values_copy, &codes,
-                         &context_map, &writer, LayerType::Header, nullptr));
+        size_t cost,
+        BuildAndEncodeHistograms(memory_manager, params, 1, input_values_copy,
+                                 &codes, &writer, LayerType::Header, nullptr));
     (void)cost;
-    ASSERT_TRUE(WriteTokens(input_values_copy[0], codes, context_map, 0,
-                            &writer, LayerType::Header, nullptr));
+    ASSERT_TRUE(WriteTokens(input_values_copy[0], codes, 0, &writer,
+                            LayerType::Header, nullptr));
     writer.ZeroPadToByte();
   }
 
@@ -247,7 +245,7 @@ void TestCheckpointing(bool ans, bool lz77) {
     ANSCode decoded_codes;
     ASSERT_TRUE(DecodeHistograms(memory_manager, &br, 1, &decoded_codes,
                                  &dec_context_map));
-    ASSERT_EQ(dec_context_map, context_map);
+    ASSERT_EQ(dec_context_map, codes.context_map);
     JXL_TEST_ASSIGN_OR_DIE(ANSSymbolReader reader,
                            ANSSymbolReader::Create(&decoded_codes, &br));
 

--- a/lib/jxl/enc_ans.cc
+++ b/lib/jxl/enc_ans.cc
@@ -93,7 +93,7 @@ class ANSEncodingHistogram {
       result.num_symbols_ = result.alphabet_size_;
       result.counts_ = CreateFlatHistogram(result.alphabet_size_, ANS_TAB_SIZE);
       // in this case length can be non-suitable for SIMD - fix it
-      result.counts_.resize(histo.counts_.size());
+      result.counts_.resize(histo.counts.size());
       SizeWriter writer;
       JXL_RETURN_IF_ERROR(result.Encode(&writer));
       result.cost_ = writer.size + EstimateDataBitsFlat(histo);
@@ -107,7 +107,7 @@ class ANSEncodingHistogram {
 
     size_t symbol_count = 0;
     for (size_t n = 0; n < result.alphabet_size_; ++n) {
-      if (histo.counts_[n] > 0) {
+      if (histo.counts[n] > 0) {
         if (symbol_count < kMaxNumSymbolsForSmallCode) {
           result.symbols_[symbol_count] = n;
         }
@@ -118,7 +118,7 @@ class ANSEncodingHistogram {
     if (symbol_count == 1) {
       // Single-bin histogram
       result.method_ = 1;
-      result.counts_ = histo.counts_;
+      result.counts_ = histo.counts;
       result.counts_[result.symbols_[0]] = ANS_TAB_SIZE;
       SizeWriter writer;
       JXL_RETURN_IF_ERROR(result.Encode(&writer));
@@ -164,14 +164,14 @@ class ANSEncodingHistogram {
 
     // Sanity check
 #if JXL_IS_DEBUG_BUILD
-    JXL_ENSURE(histo.counts_.size() == result.counts_.size());
+    JXL_ENSURE(histo.counts.size() == result.counts_.size());
     ANSHistBin total = 0;  // Used only in assert.
     for (size_t i = 0; i < result.alphabet_size_; ++i) {
       JXL_ENSURE(result.counts_[i] >= 0);
       // For non-flat histogram values should be zero or non-zero simultaneously
       // for the same symbol in both initial and normalized histograms.
       JXL_ENSURE(result.method_ == 0 ||
-                 (histo.counts_[i] > 0) == (result.counts_[i] > 0));
+                 (histo.counts[i] > 0) == (result.counts_[i] > 0));
       // Check accuracy of the histogram values
       if (result.method_ > 0 && result.counts_[i] > 0 &&
           i != result.omit_pos_) {
@@ -185,10 +185,10 @@ class ANSEncodingHistogram {
       total += result.counts_[i];
     }
     for (size_t i = result.alphabet_size_; i < result.counts_.size(); ++i) {
-      JXL_ENSURE(histo.counts_[i] == 0);
+      JXL_ENSURE(histo.counts[i] == 0);
       JXL_ENSURE(result.counts_[i] == 0);
     }
-    JXL_ENSURE((histo.total_count_ == 0) || (total == ANS_TAB_SIZE));
+    JXL_ENSURE((histo.total_count == 0) || (total == ANS_TAB_SIZE));
 #endif
     return result;
   }
@@ -360,15 +360,15 @@ class ANSEncodingHistogram {
     int64_t sum = 0;
     for (size_t i = 0; i < alphabet_size_; ++i) {
       // += histogram[i] * -log(counts[i]/total_counts)
-      sum += histo.counts_[i] * int64_t{lg2[counts_[i]]};
+      sum += histo.counts[i] * int64_t{lg2[counts_[i]]};
     }
-    return (histo.total_count_ - ldexpf(sum, -31)) * ANS_LOG_TAB_SIZE;
+    return (histo.total_count - ldexpf(sum, -31)) * ANS_LOG_TAB_SIZE;
   }
 
   static float EstimateDataBitsFlat(const Histogram& histo) {
     size_t len = histo.alphabet_size();
     int64_t flat_bits = int64_t{lg2[len]} * ANS_LOG_TAB_SIZE;
-    return ldexpf(histo.total_count_ * flat_bits, -31);
+    return ldexpf(histo.total_count * flat_bits, -31);
   }
 
   struct CountsEntropy {
@@ -445,13 +445,13 @@ class ANSEncodingHistogram {
     std::vector<EntropyDelta> bins;
     bins.reserve(256);
 
-    double norm = double{table_size} / histo.total_count_;
+    double norm = double{table_size} / histo.total_count;
 
     size_t remainder_pos = 0;  // highest balancing bin in the histogram
     int64_t max_freq = 0;
     ANSHistBin rest = table_size;  // reserve of histogram counts to distribute
     for (size_t n = 0; n < alphabet_size_; ++n) {
-      ANSHistBin freq = histo.counts_[n];
+      ANSHistBin freq = histo.counts[n];
       if (freq > max_freq) {
         remainder_pos = n;
         max_freq = freq;
@@ -604,7 +604,7 @@ const AEH::CountsArray AEH::allowed_counts = [] {
 }  // namespace
 
 StatusOr<float> Histogram::ANSPopulationCost() const {
-  if (counts_.size() > ANS_MAX_ALPHABET_SIZE) {
+  if (counts.size() > ANS_MAX_ALPHABET_SIZE) {
     return std::numeric_limits<float>::max();
   }
   JXL_ASSIGN_OR_RETURN(
@@ -619,7 +619,7 @@ StatusOr<float> Histogram::ANSPopulationCost() const {
 StatusOr<size_t> EntropyEncodingData::BuildAndStoreANSEncodingData(
     JxlMemoryManager* memory_manager,
     HistogramParams::ANSHistogramStrategy ans_histogram_strategy,
-    const Histogram& histogram, size_t log_alpha_size, BitWriter* writer) {
+    const Histogram& histogram, BitWriter* writer) {
   ANSEncSymbolInfo* info = encoding_info.back().data();
   size_t size = histogram.alphabet_size();
   if (use_prefix_code) {
@@ -627,8 +627,8 @@ StatusOr<size_t> EntropyEncodingData::BuildAndStoreANSEncodingData(
     if (size <= 1) return 0;
     std::vector<uint32_t> histo(size);
     for (size_t i = 0; i < size; i++) {
-      JXL_ENSURE(histogram.counts_[i] >= 0);
-      histo[i] = histogram.counts_[i];
+      JXL_ENSURE(histogram.counts[i] >= 0);
+      histo[i] = histogram.counts[i];
     }
     std::vector<uint8_t> depths(size);
     std::vector<uint16_t> bits(size);
@@ -677,26 +677,44 @@ namespace {
 Histogram HistogramFromSymbolInfo(
     const std::vector<ANSEncSymbolInfo>& encoding_info, bool use_prefix_code) {
   Histogram histo;
-  histo.counts_.resize(DivCeil(encoding_info.size(), Histogram::kRounding) *
-                       Histogram::kRounding);
-  histo.total_count_ = 0;
+  histo.counts.resize(DivCeil(encoding_info.size(), Histogram::kRounding) *
+                      Histogram::kRounding);
+  histo.total_count = 0;
   for (size_t i = 0; i < encoding_info.size(); ++i) {
     const ANSEncSymbolInfo& info = encoding_info[i];
     int count = use_prefix_code
                     ? (info.depth ? (1u << (PREFIX_MAX_BITS - info.depth)) : 0)
                     : info.freq_;
-    histo.counts_[i] = count;
-    histo.total_count_ += count;
+    histo.counts[i] = count;
+    histo.total_count += count;
   }
   return histo;
 }
 
-Status ChooseUintConfigs(const HistogramParams& params,
-                         const std::vector<std::vector<Token>>& tokens,
-                         const std::vector<uint8_t>& context_map,
-                         std::vector<Histogram>* clustered_histograms,
-                         EntropyEncodingData* codes, size_t* log_alpha_size) {
-  codes->uint_config.assign(clustered_histograms->size(), params.UintConfig());
+}  // namespace
+
+Status EntropyEncodingData::ChooseUintConfigs(
+    const HistogramParams& params,
+    const std::vector<std::vector<Token>>& tokens,
+    std::vector<Histogram>& clustered_histograms) {
+  // Set sane default `log_alpha_size`.
+  if (use_prefix_code) {
+    log_alpha_size = PREFIX_MAX_BITS;
+  } else if (params.streaming_mode) {
+    // TODO(szabadka) Figure out if we can use lower values here.
+    log_alpha_size = 8;
+  } else if (lz77.enabled) {
+    log_alpha_size = 8;
+  } else {
+    log_alpha_size = 7;
+  }
+
+  if (ans_fuzzer_friendly_) {
+    uint_config.assign(1, HybridUintConfig(7, 0, 0));
+    return true;
+  }
+
+  uint_config.assign(clustered_histograms.size(), params.UintConfig());
   // If the uint config is fixed, just use it.
   if (params.uint_method != HistogramParams::HybridUintMethod::kBest &&
       params.uint_method != HistogramParams::HybridUintMethod::kFast) {
@@ -747,18 +765,18 @@ Status ChooseUintConfigs(const HistogramParams& params,
     };
   }
 
-  std::vector<float> costs(clustered_histograms->size(),
+  std::vector<float> costs(clustered_histograms.size(),
                            std::numeric_limits<float>::max());
-  std::vector<uint32_t> extra_bits(clustered_histograms->size());
-  std::vector<uint8_t> is_valid(clustered_histograms->size());
+  std::vector<uint32_t> extra_bits(clustered_histograms.size());
+  std::vector<uint8_t> is_valid(clustered_histograms.size());
   // Wider histograms are assigned max cost in PopulationCost anyway
   // and therefore will not be used
-  constexpr size_t max_alpha = ANS_MAX_ALPHABET_SIZE;
+  size_t max_alpha = ANS_MAX_ALPHABET_SIZE;
   for (HybridUintConfig cfg : configs) {
     std::fill(is_valid.begin(), is_valid.end(), true);
     std::fill(extra_bits.begin(), extra_bits.end(), 0);
 
-    for (auto& histo : *clustered_histograms) {
+    for (auto& histo : clustered_histograms) {
       histo.Clear();
     }
     for (const auto& stream : tokens) {
@@ -766,88 +784,93 @@ Status ChooseUintConfigs(const HistogramParams& params,
         // TODO(veluca): do not ignore lz77 commands.
         if (token.is_lz77_length) continue;
         size_t histo = context_map[token.context];
+        if (!is_valid[histo]) continue;
         uint32_t tok, nbits, bits;
         cfg.Encode(token.value, &tok, &nbits, &bits);
-        if (tok >= max_alpha ||
-            (codes->lz77.enabled && tok >= codes->lz77.min_symbol)) {
+        if (tok >= max_alpha || (lz77.enabled && tok >= lz77.min_symbol)) {
           is_valid[histo] = JXL_FALSE;
           continue;
         }
         extra_bits[histo] += nbits;
-        (*clustered_histograms)[histo].Add(tok);
+        clustered_histograms[histo].Add(tok);
       }
     }
 
-    for (size_t i = 0; i < clustered_histograms->size(); i++) {
+    for (size_t i = 0; i < clustered_histograms.size(); i++) {
       if (!is_valid[i]) continue;
       JXL_ASSIGN_OR_RETURN(float cost,
-                           (*clustered_histograms)[i].ANSPopulationCost());
+                           clustered_histograms[i].ANSPopulationCost());
       cost += extra_bits[i];
       // add signaling cost of the hybriduintconfig itself
       cost += CeilLog2Nonzero(cfg.split_exponent + 1);
       cost += CeilLog2Nonzero(cfg.split_exponent - cfg.msb_in_token + 1);
       if (cost < costs[i]) {
-        codes->uint_config[i] = cfg;
+        uint_config[i] = cfg;
         costs[i] = cost;
       }
     }
   }
 
   // Rebuild histograms.
-  for (auto& histo : *clustered_histograms) {
+  for (auto& histo : clustered_histograms) {
     histo.Clear();
   }
-  *log_alpha_size = 5;
+  // `log_alpha_size - 5` is encoded in the header, so min is 5.
+  size_t log_size = 5;
   for (const auto& stream : tokens) {
     for (const auto& token : stream) {
       uint32_t tok, nbits, bits;
       size_t histo = context_map[token.context];
-      (token.is_lz77_length ? codes->lz77.length_uint_config
-                            : codes->uint_config[histo])
+      (token.is_lz77_length ? lz77.length_uint_config : uint_config[histo])
           .Encode(token.value, &tok, &nbits, &bits);
-      tok += token.is_lz77_length ? codes->lz77.min_symbol : 0;
-      (*clustered_histograms)[histo].Add(tok);
-      while (tok >= (1u << *log_alpha_size)) (*log_alpha_size)++;
+      tok += token.is_lz77_length ? lz77.min_symbol : 0;
+      clustered_histograms[histo].Add(tok);
+      while (tok >= (1u << log_size)) ++log_size;
     }
   }
-  size_t max_log_alpha_size = codes->use_prefix_code ? PREFIX_MAX_BITS : 8;
-  JXL_ENSURE(*log_alpha_size <= max_log_alpha_size);
+  size_t max_log_alpha_size = use_prefix_code ? PREFIX_MAX_BITS : 8;
+  JXL_ENSURE(log_size <= max_log_alpha_size);
+
+  if (use_prefix_code) {
+    log_alpha_size = PREFIX_MAX_BITS;
+  } else {
+    log_alpha_size = log_size;
+  }
+
   return true;
 }
-
-}  // namespace
 
 // NOTE: `layer` is only for clustered_entropy; caller does ReclaimAndCharge.
 // Returns cost (in bits).
 StatusOr<size_t> EntropyEncodingData::BuildAndStoreEntropyCodes(
     JxlMemoryManager* memory_manager, const HistogramParams& params,
     const std::vector<std::vector<Token>>& tokens,
-    const HistogramBuilder* builder, std::vector<uint8_t>* context_map,
-    BitWriter* writer, LayerType layer, AuxOut* aux_out) {
+    const std::vector<Histogram>& builder, BitWriter* writer, LayerType layer,
+    AuxOut* aux_out) {
   const size_t prev_histograms = encoding_info.size();
   std::vector<Histogram> clustered_histograms;
   for (size_t i = 0; i < prev_histograms; ++i) {
     clustered_histograms.push_back(
         HistogramFromSymbolInfo(encoding_info[i], use_prefix_code));
   }
-  size_t context_offset = context_map->size();
-  context_map->resize(context_offset + builder->histograms_.size());
-  if (builder->histograms_.size() > 1) {
+  size_t context_offset = context_map.size();
+  context_map.resize(context_offset + builder.size());
+  if (builder.size() > 1) {
     if (!ans_fuzzer_friendly_) {
       std::vector<uint32_t> histogram_symbols;
-      JXL_RETURN_IF_ERROR(
-          ClusterHistograms(params, builder->histograms_, kClustersLimit,
-                            &clustered_histograms, &histogram_symbols));
-      for (size_t c = 0; c < builder->histograms_.size(); ++c) {
-        (*context_map)[context_offset + c] =
+      JXL_RETURN_IF_ERROR(ClusterHistograms(params, builder, kClustersLimit,
+                                            &clustered_histograms,
+                                            &histogram_symbols));
+      for (size_t c = 0; c < builder.size(); ++c) {
+        context_map[context_offset + c] =
             static_cast<uint8_t>(histogram_symbols[c]);
       }
     } else {
       JXL_ENSURE(encoding_info.empty());
-      fill(context_map->begin(), context_map->end(), 0);
+      fill(context_map.begin(), context_map.end(), 0);
       size_t max_symbol = 0;
-      for (const Histogram& h : builder->histograms_) {
-        max_symbol = std::max(h.counts_.size(), max_symbol);
+      for (const Histogram& h : builder) {
+        max_symbol = std::max(h.counts.size(), max_symbol);
       }
       size_t num_symbols = 1 << CeilLog2Nonzero(max_symbol + 1);
       clustered_histograms.resize(1);
@@ -858,11 +881,11 @@ StatusOr<size_t> EntropyEncodingData::BuildAndStoreEntropyCodes(
     }
     if (writer != nullptr) {
       JXL_RETURN_IF_ERROR(EncodeContextMap(
-          *context_map, clustered_histograms.size(), writer, layer, aux_out));
+          context_map, clustered_histograms.size(), writer, layer, aux_out));
     }
   } else {
     JXL_ENSURE(encoding_info.empty());
-    clustered_histograms.push_back(builder->histograms_[0]);
+    clustered_histograms.push_back(builder[0]);
   }
   if (aux_out != nullptr) {
     for (size_t i = prev_histograms; i < clustered_histograms.size(); ++i) {
@@ -870,29 +893,13 @@ StatusOr<size_t> EntropyEncodingData::BuildAndStoreEntropyCodes(
           clustered_histograms[i].ShannonEntropy();
     }
   }
-  size_t log_alpha_size = lz77.enabled ? 8 : 7;  // Sane default.
-  if (ans_fuzzer_friendly_) {
-    uint_config.clear();
-    uint_config.resize(1, HybridUintConfig(7, 0, 0));
-  } else {
-    JXL_RETURN_IF_ERROR(ChooseUintConfigs(params, tokens, *context_map,
-                                          &clustered_histograms, this,
-                                          &log_alpha_size));
-  }
-  if (log_alpha_size < 5) log_alpha_size = 5;
-  if (params.streaming_mode) {
-    // TODO(szabadka) Figure out if we can use lower values here.
-    log_alpha_size = 8;
-  }
-  SizeWriter size_writer;  // Used if writer == nullptr to estimate costs.
-  size_t cost = 1;
-  if (writer) writer->Write(1, TO_JXL_BOOL(use_prefix_code));
 
-  if (use_prefix_code) {
-    log_alpha_size = PREFIX_MAX_BITS;
-  } else {
-    cost += 2;
-  }
+  JXL_RETURN_IF_ERROR(ChooseUintConfigs(params, tokens, clustered_histograms));
+
+  SizeWriter size_writer;  // Used if writer == nullptr to estimate costs.
+  size_t cost = use_prefix_code ? 1 : 3;
+
+  if (writer) writer->Write(1, TO_JXL_BOOL(use_prefix_code));
   if (writer == nullptr) {
     EncodeUintConfigs(uint_config, &size_writer, log_alpha_size);
   } else {
@@ -920,11 +927,10 @@ StatusOr<size_t> EntropyEncodingData::BuildAndStoreEntropyCodes(
       histo_writer = &encoded_histograms.back();
     }
     const auto& body = [&]() -> Status {
-      JXL_ASSIGN_OR_RETURN(
-          size_t ans_cost,
-          BuildAndStoreANSEncodingData(
-              memory_manager, params.ans_histogram_strategy,
-              clustered_histograms[c], log_alpha_size, histo_writer));
+      JXL_ASSIGN_OR_RETURN(size_t ans_cost,
+                           BuildAndStoreANSEncodingData(
+                               memory_manager, params.ans_histogram_strategy,
+                               clustered_histograms[c], histo_writer));
       cost += ans_cost;
       return true;
     };
@@ -967,8 +973,7 @@ void EncodeUintConfigs(const std::vector<HybridUintConfig>& uint_config,
 template void EncodeUintConfigs(const std::vector<HybridUintConfig>&,
                                 BitWriter*, size_t);
 
-Status EncodeHistograms(const std::vector<uint8_t>& context_map,
-                        const EntropyEncodingData& codes, BitWriter* writer,
+Status EncodeHistograms(const EntropyEncodingData& codes, BitWriter* writer,
                         LayerType layer, AuxOut* aux_out) {
   return writer->WithMaxBits(
       128 + kClustersLimit * 136, layer, aux_out,
@@ -978,8 +983,9 @@ Status EncodeHistograms(const std::vector<uint8_t>& context_map,
           EncodeUintConfig(codes.lz77.length_uint_config, writer,
                            /*log_alpha_size=*/8);
         }
-        JXL_RETURN_IF_ERROR(EncodeContextMap(
-            context_map, codes.encoding_info.size(), writer, layer, aux_out));
+        JXL_RETURN_IF_ERROR(EncodeContextMap(codes.context_map,
+                                             codes.encoding_info.size(), writer,
+                                             layer, aux_out));
         writer->Write(1, TO_JXL_BOOL(codes.use_prefix_code));
         size_t log_alpha_size = 8;
         if (codes.use_prefix_code) {
@@ -1005,8 +1011,8 @@ Status EncodeHistograms(const std::vector<uint8_t>& context_map,
 StatusOr<size_t> BuildAndEncodeHistograms(
     JxlMemoryManager* memory_manager, const HistogramParams& params,
     size_t num_contexts, std::vector<std::vector<Token>>& tokens,
-    EntropyEncodingData* codes, std::vector<uint8_t>* context_map,
-    BitWriter* writer, LayerType layer, AuxOut* aux_out) {
+    EntropyEncodingData* codes, BitWriter* writer, LayerType layer,
+    AuxOut* aux_out) {
   // TODO(Ivan): presumably not needed - default
   // if (params.initialize_global_state) codes->lz77.enabled = false;
   codes->lz77.nonserialized_distance_context = num_contexts;
@@ -1046,7 +1052,7 @@ StatusOr<size_t> BuildAndEncodeHistograms(
     }
     size_t total_tokens = 0;
     // Build histograms.
-    HistogramBuilder builder(num_contexts);
+    std::vector<Histogram> builder(num_contexts);
     HybridUintConfig uint_config = params.UintConfig();
     if (ans_fuzzer_friendly_) {
       uint_config = HybridUintConfig(10, 0, 0);
@@ -1059,21 +1065,23 @@ StatusOr<size_t> BuildAndEncodeHistograms(
           (token.is_lz77_length ? codes->lz77.length_uint_config : uint_config)
               .Encode(token.value, &tok, &nbits, &bits);
           tok += token.is_lz77_length ? codes->lz77.min_symbol : 0;
-          builder.VisitSymbol(tok, token.context);
+          JXL_DASSERT(token.context < num_contexts);
+          builder[token.context].Add(tok);
         }
       } else if (num_contexts == 1) {
         for (const auto& token : stream) {
           total_tokens++;
           uint32_t tok, nbits, bits;
           uint_config.Encode(token.value, &tok, &nbits, &bits);
-          builder.VisitSymbol(tok, /*token.context=*/0);
+          builder[0].Add(tok);
         }
       } else {
         for (const auto& token : stream) {
           total_tokens++;
           uint32_t tok, nbits, bits;
           uint_config.Encode(token.value, &tok, &nbits, &bits);
-          builder.VisitSymbol(tok, token.context);
+          JXL_DASSERT(token.context < num_contexts);
+          builder[token.context].Add(tok);
         }
       }
     }
@@ -1081,7 +1089,7 @@ StatusOr<size_t> BuildAndEncodeHistograms(
     if (params.add_missing_symbols) {
       for (size_t c = 0; c < num_contexts; ++c) {
         for (int symbol = 0; symbol < ANS_MAX_ALPHABET_SIZE; ++symbol) {
-          builder.VisitSymbol(symbol, c);
+          builder[c].Add(symbol);
         }
       }
     }
@@ -1094,7 +1102,7 @@ StatusOr<size_t> BuildAndEncodeHistograms(
       if (!use_prefix_code) {
         bool all_singleton = true;
         for (size_t i = 0; i < num_contexts; i++) {
-          if (builder.Histo(i).ShannonEntropy() >= 1e-5) {
+          if (builder[i].ShannonEntropy() >= 1e-5) {
             all_singleton = false;
           }
         }
@@ -1110,8 +1118,8 @@ StatusOr<size_t> BuildAndEncodeHistograms(
       // TODO(szabadka) Reduce alphabet size by choosing a non-default
       // uint_config.
       const size_t alphabet_size = ANS_MAX_ALPHABET_SIZE;
-      const size_t log_alpha_size = 8;
-      JXL_ENSURE(alphabet_size == 1u << log_alpha_size);
+      codes->log_alpha_size = 8;
+      JXL_ENSURE(alphabet_size == 1u << codes->log_alpha_size);
       static_assert(ANS_MAX_ALPHABET_SIZE <= ANS_TAB_SIZE,
                     "Alphabet does not fit table");
       codes->encoding_info.emplace_back();
@@ -1126,17 +1134,17 @@ StatusOr<size_t> BuildAndEncodeHistograms(
                 codes->BuildAndStoreANSEncodingData(
                     memory_manager, params.ans_histogram_strategy,
                     Histogram::Flat(alphabet_size, ANS_TAB_SIZE),
-                    log_alpha_size, histo_writer));
+                    histo_writer));
             (void)ans_cost;
             return true;
           }));
     }
 
     // Encode histograms.
-    JXL_ASSIGN_OR_RETURN(size_t entropy_bits,
-                         codes->BuildAndStoreEntropyCodes(
-                             memory_manager, params, tokens, &builder,
-                             context_map, writer, layer, aux_out));
+    JXL_ASSIGN_OR_RETURN(
+        size_t entropy_bits,
+        codes->BuildAndStoreEntropyCodes(memory_manager, params, tokens,
+                                         builder, writer, layer, aux_out));
     cost += entropy_bits;
     return true;
   };
@@ -1156,14 +1164,13 @@ StatusOr<size_t> BuildAndEncodeHistograms(
 }
 
 size_t WriteTokens(const std::vector<Token>& tokens,
-                   const EntropyEncodingData& codes,
-                   const std::vector<uint8_t>& context_map,
-                   size_t context_offset, BitWriter* writer) {
+                   const EntropyEncodingData& codes, size_t context_offset,
+                   BitWriter* writer) {
   size_t num_extra_bits = 0;
   if (codes.use_prefix_code) {
     for (const auto& token : tokens) {
       uint32_t tok, nbits, bits;
-      size_t histo = context_map[context_offset + token.context];
+      size_t histo = codes.context_map[context_offset + token.context];
       (token.is_lz77_length ? codes.lz77.length_uint_config
                             : codes.uint_config[histo])
           .Encode(token.value, &tok, &nbits, &bits);
@@ -1202,10 +1209,10 @@ size_t WriteTokens(const std::vector<Token>& tokens,
   };
   const int end = tokens.size();
   ANSCoder ans;
-  if (codes.lz77.enabled || context_map.size() > 1) {
+  if (codes.lz77.enabled || codes.context_map.size() > 1) {
     for (int i = end - 1; i >= 0; --i) {
       const Token token = tokens[i];
-      const uint8_t histo = context_map[context_offset + token.context];
+      const uint8_t histo = codes.context_map[context_offset + token.context];
       uint32_t tok, nbits, bits;
       (token.is_lz77_length ? codes.lz77.length_uint_config
                             : codes.uint_config[histo])
@@ -1243,15 +1250,13 @@ size_t WriteTokens(const std::vector<Token>& tokens,
 }
 
 Status WriteTokens(const std::vector<Token>& tokens,
-                   const EntropyEncodingData& codes,
-                   const std::vector<uint8_t>& context_map,
-                   size_t context_offset, BitWriter* writer, LayerType layer,
-                   AuxOut* aux_out) {
+                   const EntropyEncodingData& codes, size_t context_offset,
+                   BitWriter* writer, LayerType layer, AuxOut* aux_out) {
   // Theoretically, we could have 15 prefix code bits + 31 extra bits.
   return writer->WithMaxBits(
       46 * tokens.size() + 32 * 1024 * 4, layer, aux_out, [&] {
         size_t num_extra_bits =
-            WriteTokens(tokens, codes, context_map, context_offset, writer);
+            WriteTokens(tokens, codes, context_offset, writer);
         if (aux_out != nullptr) {
           aux_out->layer(layer).extra_bits += num_extra_bits;
         }

--- a/lib/jxl/enc_ans_params.h
+++ b/lib/jxl/enc_ans_params.h
@@ -101,38 +101,40 @@ struct HistogramParams {
 };
 
 struct Histogram {
+  Histogram(size_t length = 0) {
+    counts.resize(DivCeil(length, kRounding) * kRounding);
+  }
   // Create flat histogram
   static Histogram Flat(int length, int total_count) {
     Histogram flat;
-    flat.counts_ = CreateFlatHistogram(length, total_count);
-    flat.total_count_ = static_cast<size_t>(total_count);
-    flat.entropy_ = 0.0;
+    flat.counts = CreateFlatHistogram(length, total_count);
+    flat.total_count = static_cast<size_t>(total_count);
     return flat;
   }
   void Clear() {
-    counts_.clear();
-    total_count_ = 0;
-    entropy_ = 0.0;
+    counts.clear();
+    total_count = 0;
+    entropy = 0.0;
   }
   void Add(size_t symbol) {
-    if (counts_.size() <= symbol) {
-      counts_.resize(DivCeil(symbol + 1, kRounding) * kRounding);
+    if (counts.size() <= symbol) {
+      counts.resize(DivCeil(symbol + 1, kRounding) * kRounding);
     }
-    ++counts_[symbol];
-    ++total_count_;
+    ++counts[symbol];
+    ++total_count;
   }
   void AddHistogram(const Histogram& other) {
-    if (other.counts_.size() > counts_.size()) {
-      counts_.resize(other.counts_.size());
+    if (other.counts.size() > counts.size()) {
+      counts.resize(other.counts.size());
     }
-    for (size_t i = 0; i < other.counts_.size(); ++i) {
-      counts_[i] += other.counts_[i];
+    for (size_t i = 0; i < other.counts.size(); ++i) {
+      counts[i] += other.counts[i];
     }
-    total_count_ += other.total_count_;
+    total_count += other.total_count;
   }
   size_t alphabet_size() const {
-    for (int i = counts_.size() - 1; i >= 0; --i) {
-      if (counts_[i] > 0) {
+    for (int i = counts.size() - 1; i >= 0; --i) {
+      if (counts[i] > 0) {
         return i + 1;
       }
     }
@@ -145,9 +147,9 @@ struct Histogram {
 
   float ShannonEntropy() const;
 
-  std::vector<ANSHistBin> counts_;
-  size_t total_count_ = 0;
-  mutable float entropy_ = 0;  // WARNING: not kept up-to-date.
+  std::vector<ANSHistBin> counts;
+  size_t total_count = 0;
+  mutable float entropy = 0;  // WARNING: not kept up-to-date.
   static constexpr size_t kRounding = 8;
 };
 

--- a/lib/jxl/enc_cluster.cc
+++ b/lib/jxl/enc_cluster.cc
@@ -52,15 +52,15 @@ void HistogramEntropy(const Histogram& a) {
   const HWY_CAPPED(int32_t, Histogram::kRounding) di;
 
   const auto inv_tot = Set(df, 1.0f / a.total_count);
-  auto entropylanes = Zero(df);
+  auto entropy_lanes = Zero(df);
   auto total = Set(df, a.total_count);
 
   for (size_t i = 0; i < a.counts.size(); i += Lanes(di)) {
     const auto counts = LoadU(di, &a.counts[i]);
-    entropylanes =
-        Add(entropylanes, Entropy(ConvertTo(df, counts), inv_tot, total));
+    entropy_lanes =
+        Add(entropy_lanes, Entropy(ConvertTo(df, counts), inv_tot, total));
   }
-  a.entropy += GetLane(SumOfLanes(df, entropylanes));
+  a.entropy += GetLane(SumOfLanes(df, entropy_lanes));
 }
 
 float HistogramDistance(const Histogram& a, const Histogram& b) {

--- a/lib/jxl/enc_cluster.cc
+++ b/lib/jxl/enc_cluster.cc
@@ -45,63 +45,63 @@ V Entropy(V count, V inv_total, V total) {
 }
 
 void HistogramEntropy(const Histogram& a) {
-  a.entropy_ = 0.0f;
-  if (a.total_count_ == 0) return;
+  a.entropy = 0.0f;
+  if (a.total_count == 0) return;
 
   const HWY_CAPPED(float, Histogram::kRounding) df;
   const HWY_CAPPED(int32_t, Histogram::kRounding) di;
 
-  const auto inv_tot = Set(df, 1.0f / a.total_count_);
-  auto entropy_lanes = Zero(df);
-  auto total = Set(df, a.total_count_);
+  const auto inv_tot = Set(df, 1.0f / a.total_count);
+  auto entropylanes = Zero(df);
+  auto total = Set(df, a.total_count);
 
-  for (size_t i = 0; i < a.counts_.size(); i += Lanes(di)) {
-    const auto counts = LoadU(di, &a.counts_[i]);
-    entropy_lanes =
-        Add(entropy_lanes, Entropy(ConvertTo(df, counts), inv_tot, total));
+  for (size_t i = 0; i < a.counts.size(); i += Lanes(di)) {
+    const auto counts = LoadU(di, &a.counts[i]);
+    entropylanes =
+        Add(entropylanes, Entropy(ConvertTo(df, counts), inv_tot, total));
   }
-  a.entropy_ += GetLane(SumOfLanes(df, entropy_lanes));
+  a.entropy += GetLane(SumOfLanes(df, entropylanes));
 }
 
 float HistogramDistance(const Histogram& a, const Histogram& b) {
-  if (a.total_count_ == 0 || b.total_count_ == 0) return 0;
+  if (a.total_count == 0 || b.total_count == 0) return 0;
 
   const HWY_CAPPED(float, Histogram::kRounding) df;
   const HWY_CAPPED(int32_t, Histogram::kRounding) di;
 
-  const auto inv_tot = Set(df, 1.0f / (a.total_count_ + b.total_count_));
+  const auto inv_tot = Set(df, 1.0f / (a.total_count + b.total_count));
   auto distance_lanes = Zero(df);
-  auto total = Set(df, a.total_count_ + b.total_count_);
+  auto total = Set(df, a.total_count + b.total_count);
 
-  for (size_t i = 0; i < std::max(a.counts_.size(), b.counts_.size());
+  for (size_t i = 0; i < std::max(a.counts.size(), b.counts.size());
        i += Lanes(di)) {
     const auto a_counts =
-        a.counts_.size() > i ? LoadU(di, &a.counts_[i]) : Zero(di);
+        a.counts.size() > i ? LoadU(di, &a.counts[i]) : Zero(di);
     const auto b_counts =
-        b.counts_.size() > i ? LoadU(di, &b.counts_[i]) : Zero(di);
+        b.counts.size() > i ? LoadU(di, &b.counts[i]) : Zero(di);
     const auto counts = ConvertTo(df, Add(a_counts, b_counts));
     distance_lanes = Add(distance_lanes, Entropy(counts, inv_tot, total));
   }
   const float total_distance = GetLane(SumOfLanes(df, distance_lanes));
-  return total_distance - a.entropy_ - b.entropy_;
+  return total_distance - a.entropy - b.entropy;
 }
 
 constexpr const float kInfinity = std::numeric_limits<float>::infinity();
 
 float HistogramKLDivergence(const Histogram& actual, const Histogram& coding) {
-  if (actual.total_count_ == 0) return 0;
-  if (coding.total_count_ == 0) return kInfinity;
+  if (actual.total_count == 0) return 0;
+  if (coding.total_count == 0) return kInfinity;
 
   const HWY_CAPPED(float, Histogram::kRounding) df;
   const HWY_CAPPED(int32_t, Histogram::kRounding) di;
 
-  const auto coding_inv = Set(df, 1.0f / coding.total_count_);
+  const auto coding_inv = Set(df, 1.0f / coding.total_count);
   auto cost_lanes = Zero(df);
 
-  for (size_t i = 0; i < actual.counts_.size(); i += Lanes(di)) {
-    const auto counts = LoadU(di, &actual.counts_[i]);
+  for (size_t i = 0; i < actual.counts.size(); i += Lanes(di)) {
+    const auto counts = LoadU(di, &actual.counts[i]);
     const auto coding_counts =
-        coding.counts_.size() > i ? LoadU(di, &coding.counts_[i]) : Zero(di);
+        coding.counts.size() > i ? LoadU(di, &coding.counts[i]) : Zero(di);
     const auto coding_probs = Mul(ConvertTo(df, coding_counts), coding_inv);
     const auto neg_coding_cost = BitCast(
         df,
@@ -112,7 +112,7 @@ float HistogramKLDivergence(const Histogram& actual, const Histogram& coding) {
     cost_lanes = NegMulAdd(ConvertTo(df, counts), neg_coding_cost, cost_lanes);
   }
   const float total_cost = GetLane(SumOfLanes(df, cost_lanes));
-  return total_cost - actual.entropy_;
+  return total_cost - actual.entropy;
 }
 
 // First step of a k-means clustering with a fancy distance metric.
@@ -127,13 +127,13 @@ Status FastClusterHistograms(const std::vector<Histogram>& in,
   std::vector<float> dists(in.size(), std::numeric_limits<float>::max());
   size_t largest_idx = 0;
   for (size_t i = 0; i < in.size(); i++) {
-    if (in[i].total_count_ == 0) {
+    if (in[i].total_count == 0) {
       (*histogram_symbols)[i] = 0;
       dists[i] = 0.0f;
       continue;
     }
     HistogramEntropy(in[i]);
-    if (in[i].total_count_ > in[largest_idx].total_count_) {
+    if (in[i].total_count > in[largest_idx].total_count) {
       largest_idx = i;
     }
   }
@@ -202,7 +202,7 @@ HWY_EXPORT(HistogramEntropy);       // Local function
 
 float Histogram::ShannonEntropy() const {
   HWY_DYNAMIC_DISPATCH(HistogramEntropy)(*this);
-  return entropy_;
+  return entropy;
 }
 
 namespace {
@@ -254,7 +254,7 @@ Status ClusterHistograms(const HistogramParams& params,
   if (prev_histograms == 0 &&
       params.clustering == HistogramParams::ClusteringType::kBest) {
     for (auto& histo : *out) {
-      JXL_ASSIGN_OR_RETURN(histo.entropy_, histo.ANSPopulationCost());
+      JXL_ASSIGN_OR_RETURN(histo.entropy, histo.ANSPopulationCost());
     }
     uint32_t next_version = 2;
     std::vector<uint32_t> version(out->size(), 1);
@@ -286,7 +286,7 @@ Status ClusterHistograms(const HistogramParams& params,
         histo.AddHistogram((*out)[i]);
         histo.AddHistogram((*out)[j]);
         JXL_ASSIGN_OR_RETURN(float cost, histo.ANSPopulationCost());
-        cost -= (*out)[i].entropy_ + (*out)[j].entropy_;
+        cost -= (*out)[i].entropy + (*out)[j].entropy;
         // Avoid enqueueing pairs that are not advantageous to merge.
         if (cost >= 0) continue;
         pairs_to_merge.push(
@@ -306,7 +306,7 @@ Status ClusterHistograms(const HistogramParams& params,
         continue;
       }
       (*out)[first].AddHistogram((*out)[second]);
-      JXL_ASSIGN_OR_RETURN((*out)[first].entropy_,
+      JXL_ASSIGN_OR_RETURN((*out)[first].entropy,
                            (*out)[first].ANSPopulationCost());
       for (uint32_t& item : renumbering) {
         if (item == second) {
@@ -322,7 +322,7 @@ Status ClusterHistograms(const HistogramParams& params,
         histo.AddHistogram((*out)[first]);
         histo.AddHistogram((*out)[j]);
         JXL_ASSIGN_OR_RETURN(float merge_cost, histo.ANSPopulationCost());
-        merge_cost -= (*out)[first].entropy_ + (*out)[j].entropy_;
+        merge_cost -= (*out)[first].entropy + (*out)[j].entropy;
         // Avoid enqueueing pairs that are not advantageous to merge.
         if (merge_cost >= 0) continue;
         pairs_to_merge.push(

--- a/lib/jxl/enc_coeff_order.cc
+++ b/lib/jxl/enc_coeff_order.cc
@@ -264,15 +264,13 @@ Status EncodePermutation(const coeff_order_t* JXL_RESTRICT order, size_t skip,
   JxlMemoryManager* memory_manager = writer->memory_manager();
   std::vector<std::vector<Token>> tokens(1);
   JXL_RETURN_IF_ERROR(TokenizePermutation(order, skip, size, tokens.data()));
-  std::vector<uint8_t> context_map;
   EntropyEncodingData codes;
   JXL_ASSIGN_OR_RETURN(
-      size_t cost, BuildAndEncodeHistograms(
-                       memory_manager, HistogramParams(), kPermutationContexts,
-                       tokens, &codes, &context_map, writer, layer, aux_out));
+      size_t cost, BuildAndEncodeHistograms(memory_manager, HistogramParams(),
+                                            kPermutationContexts, tokens,
+                                            &codes, writer, layer, aux_out));
   (void)cost;
-  JXL_RETURN_IF_ERROR(
-      WriteTokens(tokens[0], codes, context_map, 0, writer, layer, aux_out));
+  JXL_RETURN_IF_ERROR(WriteTokens(tokens[0], codes, 0, writer, layer, aux_out));
   return true;
 }
 
@@ -319,16 +317,14 @@ Status EncodeCoeffOrders(uint16_t used_orders,
   }
   // Do not write anything if no order is used.
   if (used_orders != 0) {
-    std::vector<uint8_t> context_map;
     EntropyEncodingData codes;
     JXL_ASSIGN_OR_RETURN(
-        size_t cost,
-        BuildAndEncodeHistograms(memory_manager, HistogramParams(),
-                                 kPermutationContexts, tokens, &codes,
-                                 &context_map, writer, layer, aux_out));
+        size_t cost, BuildAndEncodeHistograms(memory_manager, HistogramParams(),
+                                              kPermutationContexts, tokens,
+                                              &codes, writer, layer, aux_out));
     (void)cost;
     JXL_RETURN_IF_ERROR(
-        WriteTokens(tokens[0], codes, context_map, 0, writer, layer, aux_out));
+        WriteTokens(tokens[0], codes, 0, writer, layer, aux_out));
   }
   return true;
 }

--- a/lib/jxl/enc_context_map.cc
+++ b/lib/jxl/enc_context_map.cc
@@ -89,19 +89,17 @@ Status EncodeContextMap(const std::vector<uint8_t>& context_map,
   size_t mtf_cost;
   {
     EntropyEncodingData codes;
-    std::vector<uint8_t> sink_context_map;
-    JXL_ASSIGN_OR_RETURN(ans_cost, BuildAndEncodeHistograms(
-                                       memory_manager, params, 1, tokens,
-                                       &codes, &sink_context_map, nullptr,
-                                       LayerType::Header, /*aux_out*/ nullptr));
+    JXL_ASSIGN_OR_RETURN(
+        ans_cost, BuildAndEncodeHistograms(memory_manager, params, 1, tokens,
+                                           &codes, nullptr, LayerType::Header,
+                                           /*aux_out*/ nullptr));
   }
   {
     EntropyEncodingData codes;
-    std::vector<uint8_t> sink_context_map;
-    JXL_ASSIGN_OR_RETURN(mtf_cost, BuildAndEncodeHistograms(
-                                       memory_manager, params, 1, mtf_tokens,
-                                       &codes, &sink_context_map, nullptr,
-                                       LayerType::Header, /*aux_out*/ nullptr));
+    JXL_ASSIGN_OR_RETURN(
+        mtf_cost, BuildAndEncodeHistograms(
+                      memory_manager, params, 1, mtf_tokens, &codes, nullptr,
+                      LayerType::Header, /*aux_out*/ nullptr));
   }
   bool use_mtf = mtf_cost < ans_cost;
   // Rebuild token list.
@@ -128,13 +126,12 @@ Status EncodeContextMap(const std::vector<uint8_t>& context_map,
           writer->Write(1, 0);
           writer->Write(1, TO_JXL_BOOL(use_mtf));  // Use/don't use MTF.
           EntropyEncodingData codes;
-          std::vector<uint8_t> sink_context_map;
-          JXL_ASSIGN_OR_RETURN(size_t cost,
-                               BuildAndEncodeHistograms(
-                                   memory_manager, params, 1, tokens, &codes,
-                                   &sink_context_map, writer, layer, aux_out));
+          JXL_ASSIGN_OR_RETURN(
+              size_t cost,
+              BuildAndEncodeHistograms(memory_manager, params, 1, tokens,
+                                       &codes, writer, layer, aux_out));
           (void)cost;
-          WriteTokens(tokens[0], codes, sink_context_map, 0, writer);
+          WriteTokens(tokens[0], codes, 0, writer);
           return true;
         }));
   }

--- a/lib/jxl/enc_frame.cc
+++ b/lib/jxl/enc_frame.cc
@@ -1262,8 +1262,8 @@ Status EncodeGlobalACInfo(PassesEncoderState* enc_state, BitWriter* writer,
         BuildAndEncodeHistograms(
             memory_manager, hist_params,
             num_histogram_groups * shared.block_ctx_map.NumACContexts(),
-            enc_state->passes[i].ac_tokens, &enc_state->passes[i].codes,
-            &enc_state->passes[i].context_map, writer, LayerType::Ac, aux_out));
+            enc_state->passes[i].ac_tokens, &enc_state->passes[i].codes, writer,
+            LayerType::Ac, aux_out));
     (void)cost;
   }
 
@@ -1916,11 +1916,10 @@ Status OutputGroups(std::vector<std::unique_ptr<BitWriter>>&& group_codes,
   return true;
 }
 
-void RemoveUnusedHistograms(std::vector<uint8_t>& context_map,
-                            EntropyEncodingData& codes) {
+void RemoveUnusedHistograms(EntropyEncodingData& codes) {
   std::vector<int> remap(256, -1);
   std::vector<uint8_t> inv_remap;
-  for (uint8_t& context : context_map) {
+  for (uint8_t& context : codes.context_map) {
     const uint8_t histo_ix = context;
     if (remap[histo_ix] == -1) {
       remap[histo_ix] = inv_remap.size();
@@ -1931,6 +1930,7 @@ void RemoveUnusedHistograms(std::vector<uint8_t>& context_map,
   EntropyEncodingData new_codes;
   new_codes.use_prefix_code = codes.use_prefix_code;
   new_codes.lz77 = codes.lz77;
+  new_codes.context_map = std::move(codes.context_map);
   for (uint8_t histo_idx : inv_remap) {
     new_codes.encoding_info.emplace_back(
         std::move(codes.encoding_info[histo_idx]));
@@ -1974,10 +1974,8 @@ Status OutputAcGlobal(PassesEncoderState& enc_state,
                           &writer, LayerType::Order, aux_out));
     // Fix up context map and entropy codes to remove any fix histograms that
     // were not selected by clustering.
-    RemoveUnusedHistograms(enc_state.passes[i].context_map,
-                           enc_state.passes[i].codes);
-    JXL_RETURN_IF_ERROR(EncodeHistograms(enc_state.passes[i].context_map,
-                                         enc_state.passes[i].codes, &writer,
+    RemoveUnusedHistograms(enc_state.passes[i].codes);
+    JXL_RETURN_IF_ERROR(EncodeHistograms(enc_state.passes[i].codes, &writer,
                                          LayerType::Ac, aux_out));
   }
   JXL_RETURN_IF_ERROR(writer.WithMaxBits(8, LayerType::Ac, aux_out, [&] {

--- a/lib/jxl/enc_group.cc
+++ b/lib/jxl/enc_group.cc
@@ -561,10 +561,10 @@ Status EncodeGroupTokenizedCoefficients(size_t group_idx, size_t pass_idx,
   }
   size_t context_offset =
       histogram_idx * enc_state.shared.block_ctx_map.NumACContexts();
-  JXL_RETURN_IF_ERROR(WriteTokens(
-      enc_state.passes[pass_idx].ac_tokens[group_idx],
-      enc_state.passes[pass_idx].codes, enc_state.passes[pass_idx].context_map,
-      context_offset, writer, LayerType::AcTokens, aux_out));
+  JXL_RETURN_IF_ERROR(
+      WriteTokens(enc_state.passes[pass_idx].ac_tokens[group_idx],
+                  enc_state.passes[pass_idx].codes, context_offset, writer,
+                  LayerType::AcTokens, aux_out));
 
   return true;
 }

--- a/lib/jxl/enc_icc_codec.cc
+++ b/lib/jxl/enc_icc_codec.cc
@@ -472,15 +472,12 @@ Status WriteICC(const Span<const uint8_t> icc, BitWriter* JXL_RESTRICT writer,
   params.lz77_method = enc.size() < 4096 ? HistogramParams::LZ77Method::kOptimal
                                          : HistogramParams::LZ77Method::kLZ77;
   EntropyEncodingData code;
-  std::vector<uint8_t> context_map;
   params.force_huffman = true;
-  JXL_ASSIGN_OR_RETURN(
-      size_t cost,
-      BuildAndEncodeHistograms(memory_manager, params, kNumICCContexts, tokens,
-                               &code, &context_map, writer, layer, aux_out));
+  JXL_ASSIGN_OR_RETURN(size_t cost, BuildAndEncodeHistograms(
+                                        memory_manager, params, kNumICCContexts,
+                                        tokens, &code, writer, layer, aux_out));
   (void)cost;
-  JXL_RETURN_IF_ERROR(
-      WriteTokens(tokens[0], code, context_map, 0, writer, layer, aux_out));
+  JXL_RETURN_IF_ERROR(WriteTokens(tokens[0], code, 0, writer, layer, aux_out));
   return true;
 }
 

--- a/lib/jxl/enc_modular.cc
+++ b/lib/jxl/enc_modular.cc
@@ -1260,15 +1260,12 @@ Status ModularFrameEncoder::EncodeGlobalInfo(bool streaming_mode,
       HistogramParams::ForModular(cparams_, extra_dc_precision, streaming_mode);
   {
     EntropyEncodingData tree_code;
-    std::vector<uint8_t> tree_context_map;
     JXL_ASSIGN_OR_RETURN(
-        size_t cost,
-        BuildAndEncodeHistograms(memory_manager, params, kNumTreeContexts,
-                                 tree_tokens_, &tree_code, &tree_context_map,
-                                 writer, LayerType::ModularTree, aux_out));
+        size_t cost, BuildAndEncodeHistograms(
+                         memory_manager, params, kNumTreeContexts, tree_tokens_,
+                         &tree_code, writer, LayerType::ModularTree, aux_out));
     (void)cost;
-    JXL_RETURN_IF_ERROR(WriteTokens(tree_tokens_[0], tree_code,
-                                    tree_context_map, 0, writer,
+    JXL_RETURN_IF_ERROR(WriteTokens(tree_tokens_[0], tree_code, 0, writer,
                                     LayerType::ModularTree, aux_out));
   }
   params.streaming_mode = streaming_mode;
@@ -1276,10 +1273,9 @@ Status ModularFrameEncoder::EncodeGlobalInfo(bool streaming_mode,
   params.image_widths = image_widths_;
   // Write histograms.
   JXL_ASSIGN_OR_RETURN(
-      size_t cost,
-      BuildAndEncodeHistograms(memory_manager, params, (tree_.size() + 1) / 2,
-                               tokens_, &code_, &context_map_, writer,
-                               LayerType::ModularGlobal, aux_out));
+      size_t cost, BuildAndEncodeHistograms(
+                       memory_manager, params, (tree_.size() + 1) / 2, tokens_,
+                       &code_, writer, LayerType::ModularGlobal, aux_out));
   (void)cost;
   return true;
 }
@@ -1299,8 +1295,8 @@ Status ModularFrameEncoder::EncodeStream(BitWriter* writer, AuxOut* aux_out,
   } else {
     JXL_RETURN_IF_ERROR(
         Bundle::Write(stream_headers_[stream_id], writer, layer, aux_out));
-    JXL_RETURN_IF_ERROR(WriteTokens(tokens_[stream_id], code_, context_map_, 0,
-                                    writer, layer, aux_out));
+    JXL_RETURN_IF_ERROR(
+        WriteTokens(tokens_[stream_id], code_, 0, writer, layer, aux_out));
   }
   return true;
 }

--- a/lib/jxl/enc_patch_dictionary.cc
+++ b/lib/jxl/enc_patch_dictionary.cc
@@ -116,15 +116,12 @@ Status PatchDictionaryEncoder::Encode(const PatchDictionary& pdic,
   }
 
   EntropyEncodingData codes;
-  std::vector<uint8_t> context_map;
   JXL_ASSIGN_OR_RETURN(
-      size_t cost,
-      BuildAndEncodeHistograms(memory_manager, HistogramParams(),
-                               kNumPatchDictionaryContexts, tokens, &codes,
-                               &context_map, writer, layer, aux_out));
+      size_t cost, BuildAndEncodeHistograms(memory_manager, HistogramParams(),
+                                            kNumPatchDictionaryContexts, tokens,
+                                            &codes, writer, layer, aux_out));
   (void)cost;
-  JXL_RETURN_IF_ERROR(
-      WriteTokens(tokens[0], codes, context_map, 0, writer, layer, aux_out));
+  JXL_RETURN_IF_ERROR(WriteTokens(tokens[0], codes, 0, writer, layer, aux_out));
   return true;
 }
 

--- a/lib/jxl/enc_splines.cc
+++ b/lib/jxl/enc_splines.cc
@@ -86,15 +86,13 @@ Status EncodeSplines(const Splines& splines, BitWriter* writer,
   }
 
   EntropyEncodingData codes;
-  std::vector<uint8_t> context_map;
   JXL_ASSIGN_OR_RETURN(
       size_t cost,
       BuildAndEncodeHistograms(writer->memory_manager(), histogram_params,
-                               kNumSplineContexts, tokens, &codes, &context_map,
-                               writer, layer, aux_out));
+                               kNumSplineContexts, tokens, &codes, writer,
+                               layer, aux_out));
   (void)cost;
-  JXL_RETURN_IF_ERROR(
-      WriteTokens(tokens[0], codes, context_map, 0, writer, layer, aux_out));
+  JXL_RETURN_IF_ERROR(WriteTokens(tokens[0], codes, 0, writer, layer, aux_out));
   return true;
 }
 

--- a/lib/jxl/modular/encoding/enc_encoding.cc
+++ b/lib/jxl/modular/encoding/enc_encoding.cc
@@ -759,13 +759,12 @@ Status ModularGenericCompress(const Image &image, const ModularOptions &opts,
 
   // Write tree
   EntropyEncodingData code;
-  std::vector<uint8_t> context_map;
-  JXL_ASSIGN_OR_RETURN(size_t cost,
-                       BuildAndEncodeHistograms(
-                           memory_manager, options.histogram_params,
-                           kNumTreeContexts, tree_tokens, &code, &context_map,
-                           &writer, LayerType::ModularTree, aux_out));
-  JXL_RETURN_IF_ERROR(WriteTokens(tree_tokens[0], code, context_map, 0, &writer,
+  JXL_ASSIGN_OR_RETURN(
+      size_t cost,
+      BuildAndEncodeHistograms(memory_manager, options.histogram_params,
+                               kNumTreeContexts, tree_tokens, &code, &writer,
+                               LayerType::ModularTree, aux_out));
+  JXL_RETURN_IF_ERROR(WriteTokens(tree_tokens[0], code, 0, &writer,
                                   LayerType::ModularTree, aux_out));
 
   size_t image_width = 0;
@@ -777,16 +776,14 @@ Status ModularGenericCompress(const Image &image, const ModularOptions &opts,
 
   // Write data
   code = {};
-  context_map.clear();
   HistogramParams histo_params = options.histogram_params;
   histo_params.image_widths.push_back(image_width);
   JXL_ASSIGN_OR_RETURN(
       cost, BuildAndEncodeHistograms(memory_manager, histo_params,
                                      (tree.size() + 1) / 2, tokens, &code,
-                                     &context_map, &writer, layer, aux_out));
+                                     &writer, layer, aux_out));
   (void)cost;
-  JXL_RETURN_IF_ERROR(
-      WriteTokens(tokens[0], code, context_map, 0, &writer, layer, aux_out));
+  JXL_RETURN_IF_ERROR(WriteTokens(tokens[0], code, 0, &writer, layer, aux_out));
 
   bits = writer.BitsWritten() - bits;
   JXL_DEBUG_V(4,


### PR DESCRIPTION
### Description

I found out that `context_map`  is used almost exclusively with `EntropyEncodingData`, that allows to merge them.

In this PR I put `context_map` , `log_alpha_size` , and `ChooseUintConfigs` into `EntropyEncodingData`, rename `Histogram` fields per codestyle guide, remove `HistogramBuilder`, and move all `log_alpha_size`  handling into `EntropyEncodingData::ChooseUintConfigs`.

As a result `BuildAndEncodeHistograms` and `WriteTokens` interfaces and usage cleared a lot.

I'll prepare also another PR with corresponding changes on decoder side.

### Pull Request Checklist

- [x] **CLA Signed**: Have you signed the [Contributor License Agreement](https://code.google.com/legal/individual-cla-v1.0.html) (individual or corporate, as appropriate)? Only contributions from signed contributors can be accepted.
- [x] **Authors**: Have you considered adding your name to the [AUTHORS](AUTHORS) file?
- [x] **Code Style**: Have you ensured your code adheres to the project's coding style guidelines? You can use `./ci.sh lint` for automatic code formatting.