### PR TITLE
add copyright/license to example Dockerfile to stop bash_test from failing

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,3 +1,8 @@
+# Copyright (c) the JPEG XL Project Authors. All rights reserved.
+#
+# Use of this source code is governed by a BSD-style
+# license that can be found in the LICENSE file.
+
 FROM debian:stable
 
 RUN apt update


### PR DESCRIPTION
https://github.com/libjxl/libjxl/pull/4176 added a Dockerfile without the copyright/license blob, which makes bash_test fail.