### PR TITLE
try reducing workflow permissions from write to read

### DIFF
--- a/.github/workflows/gitlab_mirror.yml
+++ b/.github/workflows/gitlab_mirror.yml
@@ -3,7 +3,7 @@
 # Use of this source code is governed by a BSD-style
 # license that can be found in the LICENSE file.
 
-# Workflow for building and running tests.
+# Workflow for mirroring the github libjxl repo to the wg1 gitlab repo
 
 name: Mirror to GitLab
 
@@ -21,8 +21,6 @@ permissions:
 
 jobs:
   mirror:
-    permissions:
-      contents: write  # for Git to git push
     if: github.repository_owner == 'libjxl'
     runs-on: ubuntu-latest
 

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -28,7 +28,7 @@ on:
   workflow_dispatch:
 
 permissions:
-  contents: write
+  contents: read
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event_name }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -106,7 +106,9 @@ jobs:
 
     - name: Upload binaries to release
       if: github.event_name == 'release'
-      uses: AButler/upload-release-assets@3d6774fae0ed91407dc5ae29d576b166536d1777 # v3.0
+      permissions:
+        contents: write
+      uses: actions/upload-release-asset
       with:
         files: ${{ runner.workspace }}/jxl-linux-x86_64-static-${{ github.event.release.tag_name }}.tar.gz
         repo-token: ${{ secrets.GITHUB_TOKEN }}
@@ -233,7 +235,9 @@ jobs:
 
     - name: Upload binaries to release
       if: github.event_name == 'release'
-      uses: AButler/upload-release-assets@3d6774fae0ed91407dc5ae29d576b166536d1777 # v3.0
+      permissions:
+        contents: write
+      uses: actions/upload-release-asset
       with:
         files: ${{ steps.env.outputs.artifact_name }}-${{ github.event.release.tag_name }}.tar.gz
         repo-token: ${{ secrets.GITHUB_TOKEN }}
@@ -382,7 +386,9 @@ jobs:
 
     - name: Upload binaries to release
       if: github.event_name == 'release'
-      uses: AButler/upload-release-assets@3d6774fae0ed91407dc5ae29d576b166536d1777 # v3.0
+      permissions:
+        contents: write
+      uses: actions/upload-release-asset
       with:
         files: jxl-${{matrix.triplet}}.zip
         repo-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Not sure if these two workflows actually need `contents: write` permissions to do their thing.
If they do, then the permission should be at the lowest level where it is needed, not at the top-level like it is now.

See also: 
https://securityscorecards.dev/viewer/?uri=github.com/libjxl/libjxl
https://github.com/ossf/scorecard/blob/cd152cb6742c5b8f2f3d2b5193b41d9c50905198/docs/checks.md#token-permissions