### PR TITLE
faster decoding of d0 e1 images

### DIFF
--- a/lib/jxl/dec_huffman.cc
+++ b/lib/jxl/dec_huffman.cc
@@ -242,20 +242,4 @@ bool HuffmanDecodingData::ReadFromBitStream(size_t alphabet_size,
   return (table_size > 0);
 }
 
-// Decodes the next Huffman coded symbol from the bit-stream.
-uint16_t HuffmanDecodingData::ReadSymbol(BitReader* br) const {
-  size_t n_bits;
-  const HuffmanCode* table = table_.data();
-  table += br->PeekBits(kHuffmanTableBits);
-  n_bits = table->bits;
-  if (n_bits > kHuffmanTableBits) {
-    br->Consume(kHuffmanTableBits);
-    n_bits -= kHuffmanTableBits;
-    table += table->value;
-    table += br->PeekBits(n_bits);
-  }
-  br->Consume(table->bits);
-  return table->value;
-}
-
 }  // namespace jxl


### PR DESCRIPTION
Inlining the Huffman reading makes quite a difference in the fast path for d0 e1 decoding, at least on my laptop.

Before:
JPEG XL decoder v0.11.1 0.11.1 [NEON]
Decoded to pixels.
7216 x 5412,  geomean: 269.298 MP/s [230.95, 282.30], , 30 reps, 12 threads.

After:
JPEG XL decoder v0.12.0 d502d111 [_NEON_]
Decoded to pixels.
7216 x 5412,  geomean: 332.387 MP/s [285.23, 347.83], , 30 reps, 12 threads.
