### PR TITLE
Allow more use of LZ77

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Progressive VarDCT couldn't load progressively. (#4223)
   - Lossless Faster Decoding would create uncompressed files for levels 1 and 2,
     with levels 3 and 4 being slower instead of faster. (#4201)
+  - Density regression with Predictor Zero since v0.11. (#4225)
 
 ### Changed / clarified
   - Empty DHT markers are now valid for JPEG transcoding. (#2704)

--- a/lib/jxl/enc_ans.cc
+++ b/lib/jxl/enc_ans.cc
@@ -1302,7 +1302,7 @@ HistogramParams HistogramParams::ForModular(
     params.max_histograms = 12;
   }
   if ((cparams.decoding_speed_tier >= 3 ||
-  cparams_.options.predictor = Predictor::Zero) && cparams.modular_mode) {
+  cparams_.options.predictor == Predictor::Zero) && cparams.modular_mode) {
 	  params.lz77_method = cparams.speed_tier >= SpeedTier::kCheetah
 		  ? HistogramParams::LZ77Method::kRLE
 		  : cparams.speed_tier >= SpeedTier::kKitten

--- a/lib/jxl/enc_ans.cc
+++ b/lib/jxl/enc_ans.cc
@@ -1281,7 +1281,10 @@ HistogramParams HistogramParams::ForModular(
         cparams.speed_tier > SpeedTier::kThunder
             ? HistogramParams::ANSHistogramStrategy::kFast
             : HistogramParams::ANSHistogramStrategy::kApproximate;
-    params.lz77_method = HistogramParams::LZ77Method::kNone;
+	  params.lz77_method = cparams.modular_mode &&
+		  cparams.speed_tier <= SpeedTier::kHare
+		  ? HistogramParams::LZ77Method::kRLE
+		  : HistogramParams::LZ77Method::kNone;
     // Near-lossless DC, as well as modular mode, require choosing hybrid uint
     // more carefully.
     if ((!extra_dc_precision.empty() && extra_dc_precision[0] != 0) ||
@@ -1298,18 +1301,13 @@ HistogramParams HistogramParams::ForModular(
   if (cparams.decoding_speed_tier >= 2) {
     params.max_histograms = 12;
   }
-  if (cparams.decoding_speed_tier >= 3) {
-    if (cparams.modular_mode) {
-    params.lz77_method = cparams.speed_tier >= SpeedTier::kCheetah
-                             ? HistogramParams::LZ77Method::kRLE
-                         : cparams.speed_tier >= SpeedTier::kKitten
-                             ? HistogramParams::LZ77Method::kLZ77
-                             : HistogramParams::LZ77Method::kOptimal;
-    } else {
-	  params.lz77_method = HistogramParams::LZ77Method::kNone;
-	  // LZ77 significantly slows down encoding for VarDCT with
-	  // no benefit to density or decoding speed
-    }
+  if ((cparams.decoding_speed_tier >= 3 ||
+  cparams_.options.predictor = Predictor::Zero) && cparams.modular_mode) {
+	  params.lz77_method = cparams.speed_tier >= SpeedTier::kCheetah
+		  ? HistogramParams::LZ77Method::kRLE
+		  : cparams.speed_tier >= SpeedTier::kKitten
+		  ? HistogramParams::LZ77Method::kLZ77
+		  : HistogramParams::LZ77Method::kOptimal;
   }
   return params;
 }

--- a/lib/jxl/enc_ans.cc
+++ b/lib/jxl/enc_ans.cc
@@ -1302,7 +1302,7 @@ HistogramParams HistogramParams::ForModular(
     params.max_histograms = 12;
   }
   if ((cparams.decoding_speed_tier >= 3 ||
-  cparams_.options.predictor == Predictor::Zero) && cparams.modular_mode) {
+  cparams.options.predictor == Predictor::Zero) && cparams.modular_mode) {
 	  params.lz77_method = cparams.speed_tier >= SpeedTier::kCheetah
 		  ? HistogramParams::LZ77Method::kRLE
 		  : cparams.speed_tier >= SpeedTier::kKitten

--- a/lib/jxl/enc_icc_codec.cc
+++ b/lib/jxl/enc_icc_codec.cc
@@ -469,7 +469,7 @@ Status WriteICC(const Span<const uint8_t> icc, BitWriter* JXL_RESTRICT writer,
         enc[i]);
   }
   HistogramParams params;
-  params.lz77_method = enc.size() < 4096 ? HistogramParams::LZ77Method::kOptimal
+  params.lz77_method = enc.size() < 16384 ? HistogramParams::LZ77Method::kOptimal
                                          : HistogramParams::LZ77Method::kLZ77;
   EntropyEncodingData code;
   params.force_huffman = true;

--- a/lib/jxl/jxl_test.cc
+++ b/lib/jxl/jxl_test.cc
@@ -1082,7 +1082,7 @@ JXL_SLOW_TEST(JxlTest, RoundtripLossless8) {
 
   PackedPixelFile ppf_out;
   EXPECT_EQ(Roundtrip(t.ppf(), cparams, dparams, pool.get(), &ppf_out),
-            223033u);
+            222983u);
   EXPECT_EQ(ComputeDistance2(t.ppf(), ppf_out), 0.0);
 }
 
@@ -1102,7 +1102,7 @@ JXL_SLOW_TEST(JxlTest, RoundtripLossless8ThunderGradient) {
 
   PackedPixelFile ppf_out;
   EXPECT_EQ(Roundtrip(t.ppf(), cparams, dparams, pool.get(), &ppf_out),
-            261663u);
+            261613u);
   EXPECT_EQ(ComputeDistance2(t.ppf(), ppf_out), 0.0);
 }
 
@@ -1141,7 +1141,7 @@ JXL_SLOW_TEST(JxlTest, RoundtripLossless8Falcon) {
 
   PackedPixelFile ppf_out;
   EXPECT_EQ(Roundtrip(t.ppf(), cparams, dparams, pool.get(), &ppf_out),
-            230747u);
+            230697u);
   EXPECT_EQ(ComputeDistance2(t.ppf(), ppf_out), 0.0);
 }
 
@@ -1161,7 +1161,7 @@ TEST(JxlTest, RoundtripLossless8Alpha) {
   dparams.accepted_formats.push_back(t.ppf().frames[0].color.format);
 
   PackedPixelFile ppf_out;
-  EXPECT_EQ(Roundtrip(t.ppf(), cparams, dparams, pool, &ppf_out), 251451u);
+  EXPECT_EQ(Roundtrip(t.ppf(), cparams, dparams, pool, &ppf_out), 251400u);
   EXPECT_EQ(ComputeDistance2(t.ppf(), ppf_out), 0.0);
   EXPECT_EQ(ppf_out.info.alpha_bits, 8);
   EXPECT_TRUE(test::SameAlpha(t.ppf(), ppf_out));


### PR DESCRIPTION
Currently only Effort 8 uses LZ77 and Effort 9+ use LZ77-Optimal, causing a large difference between 7 and 8 when `-P 0` is used. This has been present since a regression in v0.11.

This PR enables RLE for Efforts 5-7, with Predictor Zero enabling RLE at Effort 1-4, LZ77 for Effort 5-8 and LZ77-Optimal for Effort 9+. ICC compression is also higher for profiles up to 16KiB in size. This results in roughly a 5% encoding speed penalty but up to **25,000x** smaller filesize, when using a solid color image with `cjxl -d 0 -P 0 -g 3`. [Test Image](https://github.com/user-attachments/assets/95fab318-d072-432d-a6fa-9c4076d06b16)

Main
```
JPEG XL encoder v0.12.0 5e1e5530 [_AVX2_,SSE4,SSE2]
Encoding [Modular, lossless, effort: 7]
Compressed to 12583.2 kB (6.000 bpp).
4096 x 4096,  6.958 MP/s [6.96, 6.96], , 1 reps, 16 threads.
```
PR
```
JPEG XL encoder v0.12.0 [_AVX2_,SSE4,SSE2]
Encoding [Modular, lossless, effort: 7]
Compressed to 479 bytes (0.000 bpp).
4096 x 4096,  7.064 MP/s [7.06, 7.06], , 1 reps, 16 threads.
```