### PR TITLE
lossless: finetune fast_decode_multiplier

### DIFF
--- a/lib/jxl/enc_modular.cc
+++ b/lib/jxl/enc_modular.cc
@@ -476,38 +476,43 @@ Status ModularFrameEncoder::Init(const FrameHeader& frame_header,
   // Progressive lossless only benefits from levels 2 and higher
   // Lower levels of faster decoding can outperform higher tiers
   // depending on the PC
-  if (cparams_.responsive == 1 && cparams_.IsLossless() && cparams_.decoding_speed_tier == 1) {
+  if (cparams_.responsive == 1 && cparams_.IsLossless() &&
+      cparams_.decoding_speed_tier == 1) {
     cparams_.decoding_speed_tier = 2;
   }
   if (cparams_.responsive == 1 && cparams_.IsLossless()) {
-      //RCT selection seems bugged with Squeeze, YCoCg works well.
-      if (cparams_.colorspace < 0) {
-          cparams_.colorspace = 6;
-      }
+    // RCT selection seems bugged with Squeeze, YCoCg works well.
+    if (cparams_.colorspace < 0) {
+      cparams_.colorspace = 6;
+    }
   }
 
   if (cparams_.ModularPartIsLossless()) {
     switch (cparams_.decoding_speed_tier) {
       case 0:
+        cparams_.options.fast_decode_multiplier = 1.001f;
         break;
-      case 1: // No Weighted predictor
+      case 1:  // No Weighted predictor
+        cparams_.options.fast_decode_multiplier = 1.005f;
         cparams_.options.wp_tree_mode = ModularOptions::TreeMode::kNoWP;
         break;
-      case 2: { // No Weighted predictor and Group size 0 defined in enc_frame.cc
+      case 2: {  // No Weighted predictor and Group size 0 defined in
+                 // enc_frame.cc
+        cparams_.options.fast_decode_multiplier = 1.015f;
         cparams_.options.wp_tree_mode = ModularOptions::TreeMode::kNoWP;
         break;
       }
-      case 3: { // Gradient only, Group size 0, and Fast MA tree
+      case 3: {  // Gradient only, Group size 0, and Fast MA tree
         cparams_.options.wp_tree_mode = ModularOptions::TreeMode::kGradientOnly;
         cparams_.options.predictor = Predictor::Gradient;
         break;
       }
-      default: { // Gradient only, Group size 0, and No MA tree
+      default: {  // Gradient only, Group size 0, and No MA tree
         cparams_.options.wp_tree_mode = ModularOptions::TreeMode::kGradientOnly;
         cparams_.options.predictor = Predictor::Gradient;
         cparams_.options.nb_repeats = 0;
-          // Disabling MA Trees sometimes doesn't increase decode speed
-          // depending on PC
+        // Disabling MA Trees sometimes doesn't increase decode speed
+        // depending on PC
         break;
       }
     }
@@ -528,7 +533,8 @@ Status ModularFrameEncoder::Init(const FrameHeader& frame_header,
   }
 
   cparams_.options.splitting_heuristics_node_threshold =
-      82 + 14 * static_cast<int>(cparams_.speed_tier);
+      75 + 14 * static_cast<int>(cparams_.speed_tier) +
+      10 * cparams_.decoding_speed_tier;
 
   {
     // Set properties.
@@ -619,9 +625,9 @@ Status ModularFrameEncoder::Init(const FrameHeader& frame_header,
       // multipliers in lossy mode.
       cparams_.options.predictor = Predictor::Variable;
     } else if (cparams_.responsive || cparams_.lossy_palette) {
-    // zero predictor for Squeeze residues and lossy palette indices
-    // TODO: Try adding 'Squeezed' predictor set, with the most
-    // common predictors used by Variable in squeezed images, including none.
+      // zero predictor for Squeeze residues and lossy palette indices
+      // TODO: Try adding 'Squeezed' predictor set, with the most
+      // common predictors used by Variable in squeezed images, including none.
       cparams_.options.predictor = Predictor::Zero;
     } else if (!cparams_.IsLossless()) {
       // If not responsive and lossy. TODO(veluca): use near_lossless instead?
@@ -636,7 +642,7 @@ Status ModularFrameEncoder::Init(const FrameHeader& frame_header,
       // just gradient predictor in thunder mode
       cparams_.options.predictor = Predictor::Gradient;
     }
-   } else {
+  } else {
     if (cparams_.lossy_palette) cparams_.options.predictor = Predictor::Zero;
   }
   if (!cparams_.ModularPartIsLossless()) {
@@ -1396,7 +1402,8 @@ Status ModularFrameEncoder::PrepareStreamParams(const Rect& rect,
         cparams.speed_tier < SpeedTier::kCheetah) {
       int max_bitdepth = 0, maxval = 0;  // don't care about that here
       float channel_color_percent = 0;
-      if (!(cparams.responsive && (cparams.decoding_speed_tier >= 1 || cparams.IsLossless()))) {
+      if (!(cparams.responsive &&
+            (cparams.decoding_speed_tier >= 1 || cparams.IsLossless()))) {
         channel_color_percent = cparams.channel_colors_percent;
       }
       try_palettes(gi, max_bitdepth, maxval, cparams, channel_color_percent);
@@ -1413,7 +1420,7 @@ Status ModularFrameEncoder::PrepareStreamParams(const Rect& rect,
     Transform sg(TransformId::kRCT);
     sg.begin_c = gi.nb_meta_channels;
     size_t nb_rcts_to_try = 0;
-      switch (cparams.speed_tier) {
+    switch (cparams.speed_tier) {
       case SpeedTier::kLightning:
       case SpeedTier::kThunder:
       case SpeedTier::kFalcon:

--- a/lib/jxl/jxl_test.cc
+++ b/lib/jxl/jxl_test.cc
@@ -1082,7 +1082,7 @@ JXL_SLOW_TEST(JxlTest, RoundtripLossless8) {
 
   PackedPixelFile ppf_out;
   EXPECT_EQ(Roundtrip(t.ppf(), cparams, dparams, pool.get(), &ppf_out),
-            222983u);
+            222764u);
   EXPECT_EQ(ComputeDistance2(t.ppf(), ppf_out), 0.0);
 }
 
@@ -1161,7 +1161,7 @@ TEST(JxlTest, RoundtripLossless8Alpha) {
   dparams.accepted_formats.push_back(t.ppf().frames[0].color.format);
 
   PackedPixelFile ppf_out;
-  EXPECT_EQ(Roundtrip(t.ppf(), cparams, dparams, pool, &ppf_out), 251400u);
+  EXPECT_EQ(Roundtrip(t.ppf(), cparams, dparams, pool, &ppf_out), 250568u);
   EXPECT_EQ(ComputeDistance2(t.ppf(), ppf_out), 0.0);
   EXPECT_EQ(ppf_out.info.alpha_bits, 8);
   EXPECT_TRUE(test::SameAlpha(t.ppf(), ppf_out));
@@ -1335,7 +1335,7 @@ TEST(JxlTest, RoundtripLossless8Gray) {
   dparams.accepted_formats.push_back(t.ppf().frames[0].color.format);
 
   PackedPixelFile ppf_out;
-  EXPECT_EQ(Roundtrip(t.ppf(), cparams, dparams, pool, &ppf_out), 92842u);
+  EXPECT_EQ(Roundtrip(t.ppf(), cparams, dparams, pool, &ppf_out), 92600u);
   EXPECT_EQ(ComputeDistance2(t.ppf(), ppf_out), 0.0);
   EXPECT_EQ(ppf_out.color_encoding.color_space, JXL_COLOR_SPACE_GRAY);
   EXPECT_EQ(ppf_out.info.bits_per_sample, 8);
@@ -1389,7 +1389,7 @@ TEST(JxlTest, RoundtripLosslessAnimation) {
 
   PackedPixelFile ppf_out;
   EXPECT_SLIGHTLY_BELOW(Roundtrip(t.ppf(), cparams, dparams, pool, &ppf_out),
-                        958);
+                        969);
 
   ASSERT_TRUE(t.CoalesceGIFAnimationWithAlpha());
   ASSERT_EQ(ppf_out.frames.size(), t.ppf().frames.size());

--- a/lib/jxl/jxl_test.cc
+++ b/lib/jxl/jxl_test.cc
@@ -1082,7 +1082,7 @@ JXL_SLOW_TEST(JxlTest, RoundtripLossless8) {
 
   PackedPixelFile ppf_out;
   EXPECT_EQ(Roundtrip(t.ppf(), cparams, dparams, pool.get(), &ppf_out),
-            222764u);
+            222714u);
   EXPECT_EQ(ComputeDistance2(t.ppf(), ppf_out), 0.0);
 }
 
@@ -1161,7 +1161,7 @@ TEST(JxlTest, RoundtripLossless8Alpha) {
   dparams.accepted_formats.push_back(t.ppf().frames[0].color.format);
 
   PackedPixelFile ppf_out;
-  EXPECT_EQ(Roundtrip(t.ppf(), cparams, dparams, pool, &ppf_out), 250568u);
+  EXPECT_EQ(Roundtrip(t.ppf(), cparams, dparams, pool, &ppf_out), 250517u);
   EXPECT_EQ(ComputeDistance2(t.ppf(), ppf_out), 0.0);
   EXPECT_EQ(ppf_out.info.alpha_bits, 8);
   EXPECT_TRUE(test::SameAlpha(t.ppf(), ppf_out));

--- a/lib/jxl/jxl_test.cc
+++ b/lib/jxl/jxl_test.cc
@@ -1418,7 +1418,7 @@ TEST(JxlTest, RoundtripAnimationPatches) {
   PackedPixelFile ppf_out;
   // 40k with no patches, 27k with patch frames encoded multiple times.
   EXPECT_SLIGHTLY_BELOW(Roundtrip(t.ppf(), cparams, dparams, pool, &ppf_out),
-                        21270u);
+                        21278u);
   EXPECT_EQ(ppf_out.frames.size(), t.ppf().frames.size());
   // >10 with broken patches; not all patches are detected on borders.
   EXPECT_SLIGHTLY_BELOW(ButteraugliDistance(t.ppf(), ppf_out), 1.85);


### PR DESCRIPTION
The parameter `fast_decode_multiplier` for modular tree learning (which penalizes use of the WP property and of non-static properties in MA tree decision nodes) was set to a fixed value of 1.01 regardless of decode speed tier. This PR changes the parameter depending on decode speed tier, making fd0 and fd1 decode a bit slower than before while improving density by 0.5% or so at default effort (on photographic images), and making fd2 decode a bit faster at the cost of 0.3% or so worse density at default effort (on photographic images). On non-photo images the impact is typically smaller. On individual images, your mileage may vary, as usual.

There is no effect on fd3 and fd4, nor on e1-e3, since they don't do any tree learning.

Before: (on the jyrki31 corpus)
```
31 images
Encoding                       kPixels    Bytes          BPP  E MP/s  D MP/s     Max norm  SSIMULACRA2   PSNR        pnorm       BPP*pnorm   QABPP   Bugs
---------------------------------------------------------------------------------------------------------------------------------------------------------
jxl:d0:4                         13270 17166585   10.3487591   4.190  52.092          nan 100.00000000  99.99   0.00000000  0.000000000000  10.349      0
jxl:d0:7                         13270 16722942   10.0813119   1.050  34.164          nan 100.00000000  99.99   0.00000000  0.000000000000  10.081      0
jxl:d0:9                         13270 16527177    9.9632963   0.217  33.494          nan 100.00000000  99.99   0.00000000  0.000000000000   9.963      0
jxl:d0:10                        13270 16452402    9.9182187   0.059  31.318          nan 100.00000000  99.99   0.00000000  0.000000000000   9.918      0
jxl:d0:4:faster_decoding=1       13270 18717166   11.2835163   9.189 118.330          nan 100.00000000  99.99   0.00000000  0.000000000000  11.284      0
jxl:d0:7:faster_decoding=1       13270 17091332   10.3033934   1.718  39.749          nan 100.00000000  99.99   0.00000000  0.000000000000  10.303      0
jxl:d0:9:faster_decoding=1       13270 16733587   10.0877292   0.253  37.039          nan 100.00000000  99.99   0.00000000  0.000000000000  10.088      0
jxl:d0:10:faster_decoding=1      13270 16580292    9.9953164   0.063  34.612          nan 100.00000000  99.99   0.00000000  0.000000000000   9.995      0
jxl:d0:4:faster_decoding=2       13270 18689410   11.2667838   9.331 158.741          nan 100.00000000  99.99   0.00000000  0.000000000000  11.267      0
jxl:d0:7:faster_decoding=2       13270 17349207   10.4588515   1.684  59.472          nan 100.00000000  99.99   0.00000000  0.000000000000  10.459      0
jxl:d0:9:faster_decoding=2       13270 17042518   10.2739662   0.361  51.153          nan 100.00000000  99.99   0.00000000  0.000000000000  10.274      0
jxl:d0:10:faster_decoding=2      13270 16860454   10.1642101   0.070  48.503          nan 100.00000000  99.99   0.00000000  0.000000000000  10.164      0
Aggregate:                       13270 17145823   10.3362429   0.649  50.322   0.00000000 100.00000000  99.99   0.00000000  0.000000000000  10.336      0
```


After:
```
31 images
Encoding                       kPixels    Bytes          BPP  E MP/s  D MP/s     Max norm  SSIMULACRA2   PSNR        pnorm       BPP*pnorm   QABPP   Bugs
---------------------------------------------------------------------------------------------------------------------------------------------------------
jxl:d0:4                         13270 17162582   10.3463459   4.269  50.644          nan 100.00000000  99.99   0.00000000  0.000000000000  10.346      0
jxl:d0:7                         13270 16638016   10.0301149   1.110  30.411          nan 100.00000000  99.99   0.00000000  0.000000000000  10.030      0
jxl:d0:9                         13270 16458308    9.9217791   0.223  27.523          nan 100.00000000  99.99   0.00000000  0.000000000000   9.922      0
jxl:d0:10                        13270 16449991    9.9167653   0.058  24.975          nan 100.00000000  99.99   0.00000000  0.000000000000   9.917      0
jxl:d0:4:faster_decoding=1       13270 18717146   11.2835043   9.303 117.184          nan 100.00000000  99.99   0.00000000  0.000000000000  11.284      0
jxl:d0:7:faster_decoding=1       13270 17027614   10.2649814   1.727  38.026          nan 100.00000000  99.99   0.00000000  0.000000000000  10.265      0
jxl:d0:9:faster_decoding=1       13270 16634165   10.0277933   0.252  33.415          nan 100.00000000  99.99   0.00000000  0.000000000000  10.028      0
jxl:d0:10:faster_decoding=1      13270 16532684    9.9666162   0.065  32.419          nan 100.00000000  99.99   0.00000000  0.000000000000   9.967      0
jxl:d0:4:faster_decoding=2       13270 18689459   11.2668134   9.239 164.631          nan 100.00000000  99.99   0.00000000  0.000000000000  11.267      0
jxl:d0:7:faster_decoding=2       13270 17398030   10.4882842   1.707  63.980          nan 100.00000000  99.99   0.00000000  0.000000000000  10.488      0
jxl:d0:9:faster_decoding=2       13270 17104565   10.3113708   0.370  58.642          nan 100.00000000  99.99   0.00000000  0.000000000000  10.311      0
jxl:d0:10:faster_decoding=2      13270 16892782   10.1836988   0.078  55.215          nan 100.00000000  99.99   0.00000000  0.000000000000  10.184      0
Aggregate:                       13270 17126038   10.3243156   0.664  48.615   0.00000000 100.00000000  99.99   0.00000000  0.000000000000  10.324      0
```
