### PR TITLE
Rerun failed tests in WASM CI

### DIFF
--- a/.github/workflows/build_test_wasm.yml
+++ b/.github/workflows/build_test_wasm.yml
@@ -124,4 +124,5 @@ jobs:
         (github.event_name == 'pull_request' &&
          contains(github.event.pull_request.labels.*.name, 'CI:full'))
       run: |
-        ./ci.sh test -E 'bash_test'
+        ./ci.sh test -E 'bash_test' || \
+          ./ci.sh test -E 'bash_test' --rerun-failed


### PR DESCRIPTION
Some WASM tests fail once in a while. Give them a second chance.
