### PR TITLE
ensure we stay within Level 5, also avoid "lossy d0"

### DIFF
--- a/lib/jxl/enc_cache.cc
+++ b/lib/jxl/enc_cache.cc
@@ -135,7 +135,7 @@ Status InitializePassesEncoder(const FrameHeader& frame_header,
           std::max(static_cast<int>(SpeedTier::kTortoise),
                    static_cast<int>(cparams.speed_tier) - 1));
       cparams.butteraugli_distance =
-          std::max(kMinButteraugliDistance,
+          std::max(kMinButteraugliDistance * 0.02f,
                    enc_state->cparams.butteraugli_distance * 0.02f);
     } else {
       cparams.max_error_mode = true;

--- a/lib/jxl/enc_frame.cc
+++ b/lib/jxl/enc_frame.cc
@@ -94,7 +94,7 @@ Status ParamsPostInit(CompressParams* p) {
   if (!p->manual_xyb_factors.empty() && p->manual_xyb_factors.size() != 3) {
     return JXL_FAILURE("Invalid number of XYB quantization factors");
   }
-  if (!p->modular_mode && p->butteraugli_distance == 0.0) {
+  if (!p->modular_mode && p->butteraugli_distance < kMinButteraugliDistance) {
     p->butteraugli_distance = kMinButteraugliDistance;
   }
   if (p->original_butteraugli_distance == -1.0) {
@@ -344,16 +344,18 @@ Status MakeFrameHeader(size_t xsize, size_t ysize,
     } else {
       frame_header->group_size_shift = cparams.modular_group_size_shift;
     }
-    if (cparams.modular_group_size_shift < 0 && cparams.decoding_speed_tier >= 2) {
-	  frame_header->group_size_shift = 0;
-	  // by default uses the smallest group size for faster decoding 2 and
-	  // higher, greatly speeds up decoding via multithreading at the cost
-	  // of density.
-    } if (cparams.modular_group_size_shift < 0 && cparams.decoding_speed_tier > 1 &&
-	       cparams.responsive == 1) {
-		frame_header->group_size_shift = 0;
-		// Force decoding speed to tier 2 for progressive lossless
-	 }
+    if (cparams.modular_group_size_shift < 0 &&
+        cparams.decoding_speed_tier >= 2) {
+      frame_header->group_size_shift = 0;
+      // by default uses the smallest group size for faster decoding 2 and
+      // higher, greatly speeds up decoding via multithreading at the cost
+      // of density.
+    }
+    if (cparams.modular_group_size_shift < 0 &&
+        cparams.decoding_speed_tier > 1 && cparams.responsive == 1) {
+      frame_header->group_size_shift = 0;
+      // Force decoding speed to tier 2 for progressive lossless
+    }
   }
 
   if (jpeg_data) {
@@ -1639,13 +1641,13 @@ Status ComputeEncodingData(
   }
 
   if (!enc_state.streaming_mode) {
-  // If checks pass here, a Global MA tree is used.
+    // If checks pass here, a Global MA tree is used.
     if (cparams.speed_tier < SpeedTier::kTortoise ||
         !cparams.ModularPartIsLossless() || cparams.lossy_palette ||
         (cparams.responsive == 1 && !cparams.IsLossless()) ||
-      // Allow Local trees for progressive lossless but not lossy.
-	(cparams.buffering && cparams.responsive < 0) ||
-	!cparams.custom_fixed_tree.empty()) {
+        // Allow Local trees for progressive lossless but not lossy.
+        (cparams.buffering && cparams.responsive < 0) ||
+        !cparams.custom_fixed_tree.empty()) {
       // Use local trees if doing lossless modular, unless at very slow speeds.
       JXL_RETURN_IF_ERROR(enc_modular.ComputeTree(pool));
       JXL_RETURN_IF_ERROR(enc_modular.ComputeTokens(pool));

--- a/lib/jxl/enc_frame.cc
+++ b/lib/jxl/enc_frame.cc
@@ -2488,7 +2488,7 @@ Status EncodeFrame(JxlMemoryManager* memory_manager,
     return JXL_FAILURE("Too many levels of progressive DC");
   }
 
-  if (cparams.butteraugli_distance != 0 &&
+  if (cparams.modular_mode == false &&
       cparams.butteraugli_distance < kMinButteraugliDistance) {
     return JXL_FAILURE("Butteraugli distance is too low (%f)",
                        cparams.butteraugli_distance);

--- a/lib/jxl/enc_params.h
+++ b/lib/jxl/enc_params.h
@@ -196,7 +196,9 @@ static constexpr float kMinButteraugliToSubtractOriginalPatches = 3.0f;
 static constexpr float kMinButteraugliForNoise = 99.0f;
 
 // Minimum butteraugli distance the encoder accepts.
-static constexpr float kMinButteraugliDistance = 0.001f;
+// Below d0.05 is not useful and risks going outside Level 5 limits
+// (in particular modular_16bit_buffers becomes an issue for DC)
+static constexpr float kMinButteraugliDistance = 0.05f;
 
 // Tile size for encoder-side processing. Must be equal to color tile dim in the
 // current implementation.

--- a/lib/jxl/encode.cc
+++ b/lib/jxl/encode.cc
@@ -1530,10 +1530,13 @@ JxlEncoderStatus JxlEncoderSetFrameDistance(
                          "Distance has to be in [0.0..25.0] (corresponding to "
                          "quality in [0.0..100.0])");
   }
-  if (distance > 0.f && distance < 0.01f) {
-    distance = 0.01f;
+  if (distance > 0.f && distance < jxl::kMinButteraugliDistance) {
+    distance = jxl::kMinButteraugliDistance;
   }
   frame_settings->values.cparams.butteraugli_distance = distance;
+  if (distance == 0.f) {
+    return JxlEncoderSetFrameLossless(frame_settings, JXL_TRUE);
+  }
   return JxlErrorOrStatus::Success();
 }
 

--- a/lib/jxl/jxl_test.cc
+++ b/lib/jxl/jxl_test.cc
@@ -1261,13 +1261,13 @@ TEST(JxlTest, RoundtripDots) {
   JXLCompressParams cparams;
   cparams.AddOption(JXL_ENC_FRAME_SETTING_EFFORT, 7);  // kSquirrel
   cparams.AddOption(JXL_ENC_FRAME_SETTING_DOTS, 1);
-  cparams.distance = 0.04;
+  cparams.distance = 0.05;
   extras::JXLDecompressParams dparams;
 
   PackedPixelFile ppf_out;
-  EXPECT_NEAR(Roundtrip(t.ppf(), cparams, dparams, pool, &ppf_out), 276166,
-              4000);
-  EXPECT_SLIGHTLY_BELOW(ButteraugliDistance(t.ppf(), ppf_out), 0.14);
+  EXPECT_NEAR(Roundtrip(t.ppf(), cparams, dparams, pool, &ppf_out), 245151,
+              3000);
+  EXPECT_SLIGHTLY_BELOW(ButteraugliDistance(t.ppf(), ppf_out), 0.16);
 }
 
 TEST(JxlTest, RoundtripDisablePerceptual) {
@@ -1708,8 +1708,8 @@ TEST(JxlTest, RoundtripProgressive) {
 
   PackedPixelFile ppf_out;
   EXPECT_NEAR(Roundtrip(t.ppf(), cparams, dparams, pool.get(), &ppf_out), 71544,
-              750);
-  EXPECT_SLIGHTLY_BELOW(ButteraugliDistance(t.ppf(), ppf_out), 1.4);
+              500);
+  EXPECT_SLIGHTLY_BELOW(ButteraugliDistance(t.ppf(), ppf_out), 1.3);
 }
 
 TEST(JxlTest, RoundtripProgressiveLevel2Slow) {

--- a/lib/jxl/jxl_test.cc
+++ b/lib/jxl/jxl_test.cc
@@ -1267,7 +1267,7 @@ TEST(JxlTest, RoundtripDots) {
   PackedPixelFile ppf_out;
   EXPECT_NEAR(Roundtrip(t.ppf(), cparams, dparams, pool, &ppf_out), 245151,
               3000);
-  EXPECT_SLIGHTLY_BELOW(ButteraugliDistance(t.ppf(), ppf_out), 0.16);
+  EXPECT_SLIGHTLY_BELOW(ButteraugliDistance(t.ppf(), ppf_out), 0.165);
 }
 
 TEST(JxlTest, RoundtripDisablePerceptual) {


### PR DESCRIPTION
Fixes https://github.com/libjxl/libjxl/issues/4234

After all, it was not modular mode + XYB that caused this (as I first thought), but bad API usage that ended up doing VarDCT at d0. The current code would translate that to d0.001, but that distance is too low: the DC quantization factors will be huge and the result is that the DC goes outside the `int16` range, which means it does not conform to Level 5 and we are producing technically invalid bitstreams since we don't set `modular_16bit_buffers` to false as we should.

While we could in principle go to arbitrarily low distances and just go outside Level 5, there is no real practical use for that so for now let's ignore that option.
This sets the minimum distance to 0.05 (instead of 0.001), which should be a safe limit to stay within Level 5.

Additionally, when setting the distance to 0 in the API, JxlEncoderSetFrameLossless will be called, which will result in JXL_API_ERROR in the example of https://github.com/libjxl/libjxl/issues/4234 (which it is; when doing lossless you cannot use XYB). That should help catch these cases of bad API usage where people are accidentally doing lossy when they really want to do lossless.