### PR TITLE
Group size selection cleanup and fix

### DIFF
--- a/lib/jxl/enc_frame.cc
+++ b/lib/jxl/enc_frame.cc
@@ -334,27 +334,24 @@ Status MakeFrameHeader(size_t xsize, size_t ysize,
   if (cparams.modular_mode) {
     frame_header->encoding = FrameEncoding::kModular;
     if (cparams.modular_group_size_shift == -1) {
-      frame_header->group_size_shift = 1;
+      // By default, use the smallest group size for faster decoding 2
+      // and higher. Greatly speeds up decoding via multithreading at
+      // the cost of density.
+      if (cparams.decoding_speed_tier >= 2 ||
+        // Force decoding speed to tier 2 for progressive lossless.
+        (cparams.decoding_speed_tier >= 1 && cparams.responsive == 1
+        && cparams.IsLossless())) {
+        frame_header->group_size_shift = 0;
       // no point using groups when only one group is full and the others are
       // less than half full: multithreading will not really help much, while
       // compression does suffer
-      if (xsize <= 400 && ysize <= 400) {
+      } else if (xsize <= 400 && ysize <= 400) {
         frame_header->group_size_shift = 2;
+      } else {
+        frame_header->group_size_shift = 1;
       }
     } else {
       frame_header->group_size_shift = cparams.modular_group_size_shift;
-    }
-    if (cparams.modular_group_size_shift < 0 &&
-        cparams.decoding_speed_tier >= 2) {
-      frame_header->group_size_shift = 0;
-      // by default uses the smallest group size for faster decoding 2 and
-      // higher, greatly speeds up decoding via multithreading at the cost
-      // of density.
-    }
-    if (cparams.modular_group_size_shift < 0 &&
-        cparams.decoding_speed_tier > 1 && cparams.responsive == 1) {
-      frame_header->group_size_shift = 0;
-      // Force decoding speed to tier 2 for progressive lossless
     }
   }
 


### PR DESCRIPTION
The check for progressive lossless with faster decoding was incorrectly `> 1` instead of `>= 1` and missing the lossless condition.
Also consolidated both if statements and moved them into the existing block.