### PR TITLE
Fix minor bug in tree construction

### DIFF
--- a/lib/jxl/jxl_test.cc
+++ b/lib/jxl/jxl_test.cc
@@ -1082,7 +1082,7 @@ JXL_SLOW_TEST(JxlTest, RoundtripLossless8) {
 
   PackedPixelFile ppf_out;
   EXPECT_EQ(Roundtrip(t.ppf(), cparams, dparams, pool.get(), &ppf_out),
-            222714u);
+            222547u);
   EXPECT_EQ(ComputeDistance2(t.ppf(), ppf_out), 0.0);
 }
 
@@ -1161,7 +1161,7 @@ TEST(JxlTest, RoundtripLossless8Alpha) {
   dparams.accepted_formats.push_back(t.ppf().frames[0].color.format);
 
   PackedPixelFile ppf_out;
-  EXPECT_EQ(Roundtrip(t.ppf(), cparams, dparams, pool, &ppf_out), 250517u);
+  EXPECT_EQ(Roundtrip(t.ppf(), cparams, dparams, pool, &ppf_out), 250392u);
   EXPECT_EQ(ComputeDistance2(t.ppf(), ppf_out), 0.0);
   EXPECT_EQ(ppf_out.info.alpha_bits, 8);
   EXPECT_TRUE(test::SameAlpha(t.ppf(), ppf_out));
@@ -1335,7 +1335,7 @@ TEST(JxlTest, RoundtripLossless8Gray) {
   dparams.accepted_formats.push_back(t.ppf().frames[0].color.format);
 
   PackedPixelFile ppf_out;
-  EXPECT_EQ(Roundtrip(t.ppf(), cparams, dparams, pool, &ppf_out), 92600u);
+  EXPECT_EQ(Roundtrip(t.ppf(), cparams, dparams, pool, &ppf_out), 92588u);
   EXPECT_EQ(ComputeDistance2(t.ppf(), ppf_out), 0.0);
   EXPECT_EQ(ppf_out.color_encoding.color_space, JXL_COLOR_SPACE_GRAY);
   EXPECT_EQ(ppf_out.info.bits_per_sample, 8);

--- a/lib/jxl/modular/encoding/enc_ma.cc
+++ b/lib/jxl/modular/encoding/enc_ma.cc
@@ -373,7 +373,7 @@ void FindBestSplit(TreeSamples &tree_samples, float threshold,
           bool zero_entropy_side = rcost == 0 || lcost == 0;
 
           SplitInfo &best_ref =
-              prop < kNumStaticProperties
+              tree_samples.PropertyFromIndex(prop) < kNumStaticProperties
                   ? (zero_entropy_side ? best_split_static_constant
                                        : best_split_static)
                   : (adds_wp ? best_split_nonstatic : best_split_nowp);


### PR DESCRIPTION
### Description

This PR fixes a minor bug in the tree construction where the property index (`prop` in range `[0, num_properties)`) is compared with a property "value" `kNumStaticProperties`. I believe this comparison should be made using `tree_samples.PropertyFromIndex(prop)` instead, which gets the enum value associated with the property index.

This bug only affects a very specific scenario when not both of the static properties are used.  As far as I can tell, this only occurs when there are few groups (see [relevant line](https://github.com/libjxl/libjxl/blob/77cd542df9714955e35e4b1515682da651157cc7/lib/jxl/enc_modular.cc#L553)).

It seems to improve compression slightly in those cases, and I had to update the test values as a result. To further demonstrate this, I've ran the changes on a few of the small PNGs in the testdata repository:

#### Before
```
$ for i in testdata/jxl/flower/flower_small*.png; do ./build/tools/cjxl --modular=1 --distance=0 --disable_output $i; done
JPEG XL encoder v0.12.0 6c270007 [_AVX2_,SSE4,SSE2]
Encoding [Modular, lossless, effort: 7]
Compressed to 204.9 kB (6.043 bpp).
510 x 532,  1.536 MP/s [1.54, 1.54], , 1 reps, 16 threads.
JPEG XL encoder v0.12.0 6c270007 [_AVX2_,SSE4,SSE2]
Encoding [Modular, lossless, effort: 7]
Compressed to 98173 bytes (2.895 bpp).
510 x 532,  3.332 MP/s [3.33, 3.33], , 1 reps, 16 threads.
JPEG XL encoder v0.12.0 6c270007 [_AVX2_,SSE4,SSE2]
Encoding [Modular, lossless, effort: 7]
Compressed to 330.7 kB (9.751 bpp).
510 x 532,  0.824 MP/s [0.82, 0.82], , 1 reps, 16 threads.
JPEG XL encoder v0.12.0 6c270007 [_AVX2_,SSE4,SSE2]
Encoding [Modular, lossless, effort: 7]
Compressed to 243.5 kB including container (7.180 bpp).
510 x 532,  1.118 MP/s [1.12, 1.12], , 1 reps, 16 threads.
```

#### After
```
$ for i in testdata/jxl/flower/flower_small*.png; do ./build/tools/cjxl --modular=1 --distance=0 --disable_output $i; done
JPEG XL encoder v0.12.0 6c270007 [_AVX2_,SSE4,SSE2]
Encoding [Modular, lossless, effort: 7]
Compressed to 204.8 kB (6.040 bpp).
510 x 532,  1.625 MP/s [1.63, 1.63], , 1 reps, 16 threads.
JPEG XL encoder v0.12.0 6c270007 [_AVX2_,SSE4,SSE2]
Encoding [Modular, lossless, effort: 7]
Compressed to 98158 bytes (2.894 bpp).
510 x 532,  3.768 MP/s [3.77, 3.77], , 1 reps, 16 threads.
JPEG XL encoder v0.12.0 6c270007 [_AVX2_,SSE4,SSE2]
Encoding [Modular, lossless, effort: 7]
Compressed to 330.2 kB (9.736 bpp).
510 x 532,  0.833 MP/s [0.83, 0.83], , 1 reps, 16 threads.
JPEG XL encoder v0.12.0 6c270007 [_AVX2_,SSE4,SSE2]
Encoding [Modular, lossless, effort: 7]
Compressed to 243.4 kB including container (7.177 bpp).
510 x 532,  1.149 MP/s [1.15, 1.15], , 1 reps, 16 threads.
```

If there is a bigger and more representative set of images I should run it on, please let me know.

### Pull Request Checklist

- [x] **CLA Signed**: Have you signed the [Contributor License Agreement](https://code.google.com/legal/individual-cla-v1.0.html) (individual or corporate, as appropriate)? Only contributions from signed contributors can be accepted.
- [x] **Authors**: Have you considered adding your name to the [AUTHORS](AUTHORS) file?
- [x] **Code Style**: Have you ensured your code adheres to the project's coding style guidelines? You can use `./ci.sh lint` for automatic code formatting.


Please review the full [contributing guidelines](https://github.com/libjxl/libjxl/blob/main/CONTRIBUTING.md) for more details.
