### PR TITLE
minor quality tweak

### DIFF
--- a/lib/jxl/decode_test.cc
+++ b/lib/jxl/decode_test.cc
@@ -1775,7 +1775,7 @@ TEST_P(DecodeAllEncodingsTest, PreserveOriginalProfileTest) {
   EXPECT_EQ(JXL_DEC_FULL_IMAGE, JxlDecoderProcessInput(dec));
   double dist = ButteraugliDistance(xsize, ysize, pixels, c_in, intensity_in,
                                     out, c_in, intensity_in);
-  EXPECT_LT(dist, 1.45);
+  EXPECT_LT(dist, 1.55);
   EXPECT_EQ(JXL_DEC_SUCCESS, JxlDecoderProcessInput(dec));
   JxlDecoderDestroy(dec);
 }

--- a/lib/jxl/enc_heuristics.cc
+++ b/lib/jxl/enc_heuristics.cc
@@ -942,9 +942,10 @@ Status ComputeARHeuristics(const FrameHeader& frame_header,
   }
   std::vector<std::vector<size_t>> histo(9, std::vector<size_t>(kNumEPFVals));
   std::vector<size_t> totals(9, 1);
-  const float c5 = 0.007620386618483585f;
-  const float c6 = 0.0083224805679680686f;
-  const float c7 = 0.99663939685686753;
+  static const float c5 = 0.008;
+  static const float c6 = 0.0082;
+  static const float c7 = 1.0;
+  const float favor_no_smoothing = c7 - c5 * clamped_butteraugli;
   for (size_t by = 0; by < frame_dim.ysize_blocks; by++) {
     uint8_t* JXL_RESTRICT out_row = epf_sharpness.Row(by);
     uint8_t* JXL_RESTRICT prev_row = epf_sharpness.Row(by > 0 ? by - 1 : 0);
@@ -958,7 +959,7 @@ Status ComputeARHeuristics(const FrameHeader& frame_header,
       for (uint8_t val : epf_steps) {
         float error = error_images[val].Row(by)[bx];
         if (val == 0) {
-          error *= c7 - c5 * clamped_butteraugli;
+	  error *= favor_no_smoothing;
         }
         if (error < best_error) {
           best_val = val;
@@ -980,7 +981,7 @@ Status ComputeARHeuristics(const FrameHeader& frame_header,
   }
   const float c1 = 0.059588212153340203f;
   const float c2 = 0.10599497107315753f;
-  const float c3base = 0.97;
+  const float c3base = 0.94;
   const float c3 = std::pow(c3base, clamped_butteraugli);
   const float c4 = 1.247544678665836f;
   const float context_weight = c1 + c2 * clamped_butteraugli;


### PR DESCRIPTION
slightly less smoothing

Before:

```
104 images
Encoding      kPixels    Bytes          BPP  E MP/s  D MP/s     Max norm  SSIMULACRA2   PSNR        pnorm       BPP*pnorm   QABPP   Bugs
----------------------------------------------------------------------------------------------------------------------------------------
jxl:d0.1        20315 17262519    6.7976800   0.820  10.092   0.26883791  95.73059523  56.48   0.09126293  0.620376202833   6.798      0
jxl:d0.5        20315  7123032    2.8049262   0.993  14.348   0.85243591  91.46139586  46.45   0.34404012  0.965007169526   2.930      0
jxl:d0.8        20315  5392600    2.1235122   0.904  12.586   1.09959988  88.89283658  44.49   0.46026238  0.977372768155   2.466      0
jxl:d1          20315  4622687    1.8203338   0.911  12.955   1.31731055  87.05243657  43.25   0.54900969  0.999380913021   2.494      0
jxl:d1.5        20315  3503298    1.3795379   0.920  12.898   1.85578124  82.86398021  41.09   0.75217760  1.037657496870   2.654      0
jxl:d2.0        20315  2843948    1.1198973   0.950  13.778   2.40613971  78.78082739  39.57   0.94249827  1.055501278446   2.839      0
jxl:d2.5        20315  2392108    0.9419706   0.953  13.522   2.83213812  74.91924987  38.38   1.11737462  1.052534008135   2.808      0
jxl:d3          20315  2078465    0.8184634   0.919  14.065   3.25330075  71.51579769  37.50   1.28061624  1.048137531087   2.793      0
jxl:d5          20315  1395228    0.5494165   0.943  10.255   4.62224637  60.04106135  35.21   1.81155925  0.995300621982   2.639      0
jxl:d10         20315   877901    0.3457022   1.612  21.278  13.42282233  30.14043889  30.85   4.60521593  1.592033097966   4.145      0
Aggregate:      20315  3364709    1.3249638   0.976  13.307   1.96248267  76.13986196  40.82   0.76331014  1.011358322004   3.089      0
```

After:

```
104 images
Encoding      kPixels    Bytes          BPP  E MP/s  D MP/s     Max norm  SSIMULACRA2   PSNR        pnorm       BPP*pnorm   QABPP   Bugs
----------------------------------------------------------------------------------------------------------------------------------------
jxl:d0.1        20315 17262519    6.7976800   0.810   9.780   0.26883791  95.73059523  56.48   0.09126293  0.620376202833   6.798      0
jxl:d0.5        20315  7123032    2.8049262   0.963  14.025   0.85243591  91.46139586  46.45   0.34404012  0.965007169526   2.930      0
jxl:d0.8        20315  5394253    2.1241631   0.891  12.904   1.09906342  88.90361674  44.49   0.46062210  0.978436469735   2.465      0
jxl:d1          20315  4625829    1.8215711   0.881  12.488   1.31395416  87.05752415  43.24   0.54946382  1.000887405527   2.490      0
jxl:d1.5        20315  3501953    1.3790082   0.912  13.026   1.84947477  82.86664293  41.07   0.75383494  1.039544599838   2.645      0
jxl:d2.0        20315  2843307    1.1196449   0.933  13.161   2.40059524  78.81268424  39.54   0.94475792  1.057793385159   2.839      0
jxl:d2.5        20315  2391784    0.9418430   0.958  13.710   2.82296911  74.98569784  38.35   1.12119079  1.055985680747   2.802      0
jxl:d3          20315  2078183    0.8183524   0.909  14.320   3.23661994  71.62407577  37.47   1.28531647  1.051841761253   2.778      0
jxl:d5          20315  1394013    0.5489381   0.924  11.729   4.58649234  60.14158061  35.12   1.82655919  1.002667930027   2.629      0
jxl:d10         20315   877709    0.3456266   1.562  19.977  13.42331189  30.13368811  30.85   4.60613867  1.592003837386   4.145      0
Aggregate:      20315  3364377    1.3248334   0.959  13.309   1.95760955  76.17175015  40.79   0.76497009  1.013457911576   3.084      0
```

Jyrki observed in manual verification very slightly better quality, some less oversmoothing.

<!-- Thank you for considering a contribution to `libjxl`! -->

### Description

<!-- Please provide a brief description of the changes in this PR and any additional context (e.g., why these changes were made, related issues, etc.). -->

### Pull Request Checklist

- [x] **CLA Signed**: Have you signed the [Contributor License Agreement](https://code.google.com/legal/individual-cla-v1.0.html) (individual or corporate, as appropriate)? Only contributions from signed contributors can be accepted.
- [x] **Authors**: Have you considered adding your name to the [AUTHORS](AUTHORS) file?
- [x] **Code Style**: Have you ensured your code adheres to the project's coding style guidelines? You can use `./ci.sh lint` for automatic code formatting.


Please review the full [contributing guidelines](https://github.com/libjxl/libjxl/blob/main/CONTRIBUTING.md) for more details.
