### PR TITLE
Revert #4242 and extend test to detect the problem

### DIFF
--- a/lib/jxl/splines.cc
+++ b/lib/jxl/splines.cc
@@ -79,7 +79,7 @@ float ContinuousIDCT(const Dct32& dct, const float t) {
 
 template <typename DF>
 void DrawSegment(DF df, const SplineSegment& segment, const bool add,
-                 const size_t y, const size_t x, const size_t row_x0, float* JXL_RESTRICT rows[3]) {
+                 const size_t y, const size_t x, float* JXL_RESTRICT rows[3]) {
   Rebind<int32_t, DF> di;
   const auto inv_sigma = Set(df, segment.inv_sigma);
   const auto half = Set(df, 0.5f);
@@ -98,8 +98,8 @@ void DrawSegment(DF df, const SplineSegment& segment, const bool add,
           Mul(one_dimensional_factor, one_dimensional_factor));
   for (size_t c = 0; c < 3; ++c) {
     const auto cm = Set(df, add ? segment.color[c] : -segment.color[c]);
-    const auto in = LoadU(df, rows[c] + x - row_x0);
-    StoreU(MulAdd(cm, local_intensity, in), df, rows[c] + x - row_x0);
+    const auto in = LoadU(df, rows[c] + x);
+    StoreU(MulAdd(cm, local_intensity, in), df, rows[c] + x);
   }
 }
 
@@ -112,10 +112,10 @@ void DrawSegment(const SplineSegment& segment, const bool add, const size_t y,
       x1, std::llround(segment.center_x + segment.maximum_distance) + 1);
   HWY_FULL(float) df;
   for (; x + static_cast<ssize_t>(Lanes(df)) <= x1; x += Lanes(df)) {
-    DrawSegment(df, segment, add, y, x, x0, rows);
+    DrawSegment(df, segment, add, y, x, rows);
   }
   for (; x < x1; ++x) {
-    DrawSegment(HWY_CAPPED(float, 1)(), segment, add, y, x, x0, rows);
+    DrawSegment(HWY_CAPPED(float, 1)(), segment, add, y, x, rows);
   }
 }
 

--- a/lib/jxl/splines_test.cc
+++ b/lib/jxl/splines_test.cc
@@ -288,56 +288,26 @@ TEST(SplinesTest, DuplicatePoints) {
                                            color_correlation));
 }
 
-TEST(SplinesTest, Drawing) {
+TEST(SplinesTest, Golden) {
   JxlMemoryManager* memory_manager = jxl::test::MemoryManager();
   auto io_expected = jxl::make_unique<jxl::CodecInOut>(memory_manager);
-  const std::vector<uint8_t> orig = ReadTestData("jxl/splines.pfm");
-  ASSERT_TRUE(SetFromBytes(Bytes(orig), io_expected.get(),
+  const std::vector<uint8_t> bytes_expected = ReadTestData("jxl/splines.png");
+  ASSERT_TRUE(SetFromBytes(Bytes(bytes_expected), io_expected.get(),
                            /*pool=*/nullptr));
-
-  std::vector<Spline::Point> control_points{{9, 54},  {118, 159}, {97, 3},
-                                            {10, 40}, {150, 25},  {120, 300}};
-  // Use values that survive quant/decorellation roundtrip.
-  const Spline spline{
-      control_points,
-      /*color_dct=*/
-      {Dct32{0.4989345073699951171875000f, 0.4997999966144561767578125f},
-       Dct32{0.4772970676422119140625000f, 0.f, 0.5250000357627868652343750f},
-       Dct32{-0.0176776945590972900390625f, 0.4900000095367431640625000f,
-             0.5250000357627868652343750f}},
-      /*sigma_dct=*/
-      {0.9427147507667541503906250f, 0.f, 0.f, 0.f, 0.f, 0.f, 0.f,
-       0.6665999889373779296875000f}};
-  std::vector<Spline> spline_data = {spline};
-  std::vector<QuantizedSpline> quantized_splines;
-  std::vector<Spline::Point> starting_points;
-  for (const Spline& ospline : spline_data) {
-    JXL_ASSIGN_OR_QUIT(
-        QuantizedSpline qspline,
-        QuantizedSpline::Create(ospline, kQuantizationAdjustment, kYToX, kYToB),
-        "Failed to create QuantizedSpline.");
-    quantized_splines.emplace_back(std::move(qspline));
-    starting_points.push_back(spline.control_points.front());
-  }
-  Splines splines(kQuantizationAdjustment, std::move(quantized_splines),
-                  std::move(starting_points));
-
-  JXL_TEST_ASSIGN_OR_DIE(Image3F image,
-                         Image3F::Create(memory_manager, 320, 320));
-  ZeroFillImage(&image);
-  ASSERT_TRUE(splines.InitializeDrawCache(image.xsize(), image.ysize(),
-                                          color_correlation));
-  splines.AddTo(&image, Rect(image));
-
   auto io_actual = jxl::make_unique<jxl::CodecInOut>(memory_manager);
-  JXL_TEST_ASSIGN_OR_DIE(Image3F image2,
-                         Image3F::Create(memory_manager, 320, 320));
-  ASSERT_TRUE(CopyImageTo(image, &image2));
-  ASSERT_TRUE(
-      io_actual->SetFromImage(std::move(image2), ColorEncoding::SRGB()));
-  ASSERT_TRUE(io_actual->frames[0].TransformTo(io_expected->Main().c_current(),
-                                               *JxlGetDefaultCms()));
+  // jxl/splines.jxl is produced from jxl/splines.tree
+  const std::vector<uint8_t> bytes_actual = ReadTestData("jxl/splines.jxl");
+  ASSERT_TRUE(test::DecodeFile({}, Bytes(bytes_actual), io_actual.get()));
 
+  // Clamp. There is slightly negative DC component in blue channel.
+  for (size_t c = 0; c < 3; ++c) {
+    for (size_t y = 0; y < io_actual->ysize(); ++y) {
+      float* const JXL_RESTRICT row = io_actual->Main().color()->PlaneRow(c, y);
+      for (size_t x = 0; x < io_actual->xsize(); ++x) {
+        row[x] = Clamp1(row[x], 0.f, 1.f);
+      }
+    }
+  }
   JXL_TEST_ASSERT_OK(VerifyRelativeError(*io_expected->Main().color(),
                                          *io_actual->Main().color(), 1e-2f,
                                          1e-1f, _));

--- a/plugins/gimp/file-jxl-load.cc
+++ b/plugins/gimp/file-jxl-load.cc
@@ -26,7 +26,7 @@
 namespace jxl {
 
 bool SetJpegXlOutBuffer(
-    std::unique_ptr<JxlDecoderStruct, JxlDecoderDestroyStruct> *dec,
+    std::unique_ptr<JxlDecoder, JxlDecoderDestroyStruct> *dec,
     JxlPixelFormat *format, size_t *buffer_size, gpointer *pixels_buffer_1) {
   if (JXL_DEC_SUCCESS !=
       JxlDecoderImageOutBufferSize(dec->get(), format, buffer_size)) {


### PR DESCRIPTION
Test is simplified: jxl crafting is covered by jxl_from_tree now

Drive-by: fix compilation problem in gimp plugin after #4243
