### PR TITLE
Make `-p` more progressive

### DIFF
--- a/tools/cjxl_main.cc
+++ b/tools/cjxl_main.cc
@@ -678,17 +678,6 @@ void SetDistanceFromFlags(CommandLineParser* cmdline, CompressArgs* args,
   params->alpha_distance = alpha_distance_set ? args->alpha_distance : 0;
 }
 
-// Set progressive options before processing flags
-if (args->progressive) {
-  args->qprogressive_ac = true;
-  if (args->progressive_dc = -1) {
-    args->progressive_dc = 1;
-  }
-  args->group_order = 1;
-  args->responsive = 1;
-  responsive_set = true;
-}
-
 void ProcessFlags(const jxl::extras::Codec codec,
                   const jxl::extras::PackedPixelFile& ppf,
                   const std::vector<uint8_t>* jpeg_bytes,
@@ -775,6 +764,19 @@ void ProcessFlags(const jxl::extras::Codec codec,
 
   SetDistanceFromFlags(cmdline, args, params, codec);
 
+  bool responsive_set = cmdline->GetOption(args->opt_responsive_id)->matched();
+  
+  // Set progressive options before processing flags
+  if (args->progressive) {
+    args->qprogressive_ac = true;
+    if (args->progressive_dc == -1) {
+      args->progressive_dc = 1;
+    }
+    args->group_order = jxl::Override::kOn;
+    args->responsive = 1;
+    responsive_set = true;
+  }
+
   if (args->group_order != jxl::Override::kOn &&
       (args->center_x != -1 || args->center_y != -1)) {
     std::cerr << "Invalid flag combination. Setting --center_x or --center_y "
@@ -799,8 +801,6 @@ void ProcessFlags(const jxl::extras::Codec codec,
               });
 
   // Progressive/responsive mode settings.
-  bool responsive_set = cmdline->GetOption(args->opt_responsive_id)->matched();
-
   ProcessFlag("progressive_dc", args->progressive_dc,
               JXL_ENC_FRAME_SETTING_PROGRESSIVE_DC, params,
               [](int64_t x) -> std::string {

--- a/tools/cjxl_main.cc
+++ b/tools/cjxl_main.cc
@@ -678,6 +678,17 @@ void SetDistanceFromFlags(CommandLineParser* cmdline, CompressArgs* args,
   params->alpha_distance = alpha_distance_set ? args->alpha_distance : 0;
 }
 
+// Set progressive options before processing flags
+if (args->progressive) {
+  args->qprogressive_ac = true;
+  if (args->progressive_dc = -1) {
+    args->progressive_dc = 1;
+  }
+  args->group_order = 1;
+  args->responsive = 1;
+  responsive_set = true;
+}
+
 void ProcessFlags(const jxl::extras::Codec codec,
                   const jxl::extras::PackedPixelFile& ppf,
                   const std::vector<uint8_t>* jpeg_bytes,
@@ -798,12 +809,7 @@ void ProcessFlags(const jxl::extras::Codec codec,
               });
   ProcessFlag("progressive_ac", static_cast<int64_t>(args->progressive_ac),
               JXL_ENC_FRAME_SETTING_PROGRESSIVE_AC, params);
-
-  if (args->progressive) {
-    args->qprogressive_ac = true;
-    args->responsive = 1;
-    responsive_set = true;
-  }
+  
   if (responsive_set) {
     ProcessFlag("responsive", args->responsive,
                 JXL_ENC_FRAME_SETTING_RESPONSIVE, params);


### PR DESCRIPTION
When the `-p` flag is used, this PR allows decoding full-frame images/previews from files as soon as 0.16% loaded instead of 16% (For a 4K image) and loads centre-first by default. This is at the cost of 25% slower encoding and 2% filesize increase on average (efforts 1 and 2 are 20% larger, effort 3 is 5% and 2% for all other effort levels).
Disabling patches improves speeds by up to 50% compared to main for effort 7, but could impact density when lots of matches are found.

This makes files futureproof for decoders and web usage in the future with minimal density impact, while also making sure the progressive flag meets expectations of using the format's capabilities. The encode speed penalty is quite severe, but can be reverted with `--progressive_dc 0` and only applies when progressive encoding is specifically requested anyway.