### PR TITLE
Specify types for arguments to disambiguate calls to pow()

### DIFF
--- a/lib/jxl/enc_ac_strategy.cc
+++ b/lib/jxl/enc_ac_strategy.cc
@@ -489,7 +489,7 @@ Status EstimateEntropy(const AcStrategy& acs, float entropy_mul, size_t x,
   }
   float loss_scalar =
       pow(GetLane(SumOfLanes(df8, loss)) / (num_blocks * kDCTBlockSize),
-          1.0 / 8.0) *
+          1.0f / 8.0f) *
       (num_blocks * kDCTBlockSize) / quant_norm16;
   entropy *= entropy_mul;
   entropy += config.info_loss_multiplier * loss_scalar;
@@ -572,7 +572,7 @@ Status FindBest8x8Transform(size_t x, size_t y, int encoding_speed_tier,
          tx.type == AcStrategyType::IDENTITY) &&
         butteraugli_target < 5.0) {
       static const float kFavor2X2AtHighQuality = 0.4;
-      float weight = pow((5.0f - butteraugli_target) / 5.0f, 2.0);
+      float weight = pow((5.0f - butteraugli_target) / 5.0f, 2.0f);
       entropy_mul -= kFavor2X2AtHighQuality * weight;
     }
     if ((tx.type != AcStrategyType::DCT && tx.type != AcStrategyType::DCT2X2 &&


### PR DESCRIPTION
### Description
Building libjxl with clang 18 on illumos was failing due to being unable to resolve the `std::pow` overloading:
```
lib/jxl/enc_ac_strategy.cc:572:22: error: call to 'pow' is ambiguous
  572 |       float weight = pow((5.0f - butteraugli_target) / 5.0f, 2.0);
      |                      ^~~
/usr/include/iso/math_iso.h:175:15: note: candidate function
  175 |         inline float pow(float __X, float __Y) { return __powf(__X, __Y); }
      |                      ^
/usr/include/iso/math_iso.h:177:15: note: candidate function
  177 |         inline float pow(float __X, int __Y) {
      |                      ^
/usr/include/iso/math_iso.h:76:15: note: candidate function
   76 | extern double pow(double, double);
      |               ^
```
Adding type declarations for the constant arguments addresses this.

### Pull Request Checklist

- [x] **CLA Signed**: Have you signed the [Contributor License Agreement](https://code.google.com/legal/individual-cla-v1.0.html) (individual or corporate, as appropriate)? Only contributions from signed contributors can be accepted.
- [x] **Authors**: Have you considered adding your name to the [AUTHORS](AUTHORS) file?
- [x] **Code Style**: Have you ensured your code adheres to the project's coding style guidelines? You can use `./ci.sh lint` for automatic code formatting.


Please review the full [contributing guidelines](https://github.com/libjxl/libjxl/blob/main/CONTRIBUTING.md) for more details.
