### PR TITLE
Fix streaming fuzzer encoder API usage.

### DIFF
--- a/lib/jxl/encode_test.cc
+++ b/lib/jxl/encode_test.cc
@@ -80,7 +80,7 @@ TEST(EncodeTest, AddFrameAfterCloseInputTest) {
   jxl::test::JxlBasicInfoSetFromPixelFormat(&basic_info, &pixel_format);
   basic_info.xsize = xsize;
   basic_info.ysize = ysize;
-  basic_info.uses_original_profile = 0;
+  basic_info.uses_original_profile = JXL_FALSE;
   EXPECT_EQ(JXL_ENC_SUCCESS, JxlEncoderSetCodestreamLevel(enc.get(), 10));
   EXPECT_EQ(JXL_ENC_SUCCESS, JxlEncoderSetBasicInfo(enc.get(), &basic_info));
   JxlColorEncoding color_encoding;
@@ -890,7 +890,7 @@ TEST(EncodeTest, CodestreamLevelTest) {
   jxl::test::JxlBasicInfoSetFromPixelFormat(&basic_info, &pixel_format);
   basic_info.xsize = xsize;
   basic_info.ysize = ysize;
-  basic_info.uses_original_profile = 0;
+  basic_info.uses_original_profile = JXL_FALSE;
 
   JxlEncoderPtr enc = JxlEncoderMake(nullptr);
   EXPECT_EQ(JXL_ENC_SUCCESS, JxlEncoderSetCodestreamLevel(enc.get(), 10));
@@ -1080,7 +1080,7 @@ TEST(EncodeTest, BasicInfoTest) {
   jxl::test::JxlBasicInfoSetFromPixelFormat(&basic_info, &pixel_format);
   basic_info.xsize = xsize;
   basic_info.ysize = ysize;
-  basic_info.uses_original_profile = 0;
+  basic_info.uses_original_profile = JXL_FALSE;
   basic_info.have_animation = 1;
   basic_info.intensity_target = 123.4;
   basic_info.min_nits = 5.0;

--- a/tools/streaming_fuzzer.cc
+++ b/tools/streaming_fuzzer.cc
@@ -128,20 +128,22 @@ struct FuzzSpec {
     spec.alpha = b1();
     spec.bit_depth = u8() % 16 + 1;
     // constants chosen so to cover the entire 0.01 - 25 range.
-    spec.distance = u8() % 2 ? 0.0 : 0.01 + 0.00038132 * u16();
-
-    Check(spec.float_options[2].flag ==
-          JXL_ENC_FRAME_SETTING_MODULAR_MA_TREE_LEARNING_PERCENT);
-    Check(spec.int_options[15].flag == JXL_ENC_FRAME_SETTING_COLOR_TRANSFORM);
-    if (spec.distance != 0 || spec.int_options[15].value == 0) {
-      spec.float_options[2].possible_values[1] = 1;
-    }
+    bool lossless = ((u8() % 2) == 1);
+    spec.distance = lossless ? 0.0 : 0.01 + 0.00038132 * u16();
 
     spec.num_threads = u8();
 
     for (auto& int_opt : spec.int_options) {
       int_opt.value = u8() % (int_opt.max - int_opt.min + 1) + int_opt.min;
     }
+
+    Check(spec.int_options[15].flag == JXL_ENC_FRAME_SETTING_COLOR_TRANSFORM);
+    if (!lossless || spec.int_options[15].value == 0) {
+      Check(spec.float_options[2].flag ==
+            JXL_ENC_FRAME_SETTING_MODULAR_MA_TREE_LEARNING_PERCENT);
+      spec.float_options[2].possible_values[1] = 1;
+    }
+
     for (auto& float_opt : spec.float_options) {
       float_opt.value = float_opt.possible_values[u8() % 4];
     }
@@ -155,7 +157,8 @@ struct FuzzSpec {
     }
 
     if (false) {
-      fprintf(stderr, "Image size: %d X %d\n", spec.xsize, spec.ysize);
+      fprintf(stderr, "Image size: %d X %d, d=%f\n", spec.xsize, spec.ysize,
+              spec.distance);
       for (auto& int_opt : spec.int_options) {
         fprintf(stderr, "%s = %d\n", int_opt.name.c_str(), int_opt.value);
       }
@@ -202,7 +205,8 @@ StatusOr<std::vector<uint8_t>> Encode(const FuzzSpec& spec,
   basic_info.xsize = spec.xsize;
   basic_info.ysize = spec.ysize;
   basic_info.bits_per_sample = spec.bit_depth;
-  basic_info.uses_original_profile = JXL_FALSE;
+  bool lossless = (spec.distance == 0.0f);
+  basic_info.uses_original_profile = TO_JXL_BOOL(lossless);
   uint32_t nchan = basic_info.num_color_channels;
   if (spec.alpha) {
     nchan += 1;


### PR DESCRIPTION
In case of lossless we have to set `uses_original_profile`.

Drive-by: `MODULAR_MA_TREE_LEARNING_PERCENT` was limited (effectively) unconditionally.
