### PR TITLE
Propagate memory manager and constraints to avoid fuzzer blowing on expected OOM / timeouts

### DIFF
--- a/lib/extras/codec.cc
+++ b/lib/extras/codec.cc
@@ -41,7 +41,8 @@ Status SetFromBytes(const Span<const uint8_t> bytes,
   if (bytes.size() < kMinBytes) return JXL_FAILURE("Too few bytes");
 
   extras::PackedPixelFile ppf;
-  if (extras::DecodeBytes(bytes, color_hints, &ppf, constraints, orig_codec)) {
+  if (extras::DecodeBytes(bytes, color_hints, &ppf, constraints, orig_codec,
+                          io->memory_manager)) {
     return ConvertPackedPixelFileToCodecInOut(ppf, pool, io);
   }
   return JXL_FAILURE("Codecs failed to decode");

--- a/lib/extras/dec/decode.h
+++ b/lib/extras/dec/decode.h
@@ -8,6 +8,8 @@
 
 // Facade for image decoders (PNG, PNM, ...).
 
+#include <jxl/memory_manager.h>
+
 #include <cstddef>
 #include <cstdint>
 #include <string>
@@ -51,7 +53,8 @@ Codec CodecFromPath(const std::string& path,
 Status DecodeBytes(Span<const uint8_t> bytes, const ColorHints& color_hints,
                    extras::PackedPixelFile* ppf,
                    const SizeConstraints* constraints = nullptr,
-                   Codec* orig_codec = nullptr);
+                   Codec* orig_codec = nullptr,
+                   JxlMemoryManager* memory_manager = nullptr);
 
 }  // namespace extras
 }  // namespace jxl

--- a/lib/extras/dec/exr.cc
+++ b/lib/extras/dec/exr.cc
@@ -161,6 +161,10 @@ Status DecodeImageEXR(Span<const uint8_t> bytes, const ColorHints& color_hints,
   ++image_size.x;
   ++image_size.y;
 
+  if (!VerifyDimensions<uint32_t>(constraints, image_size.x, image_size.y)) {
+    return JXL_FAILURE("image too big");
+  }
+
   ppf->info.xsize = image_size.x;
   ppf->info.ysize = image_size.y;
   ppf->info.num_color_channels = 3;

--- a/lib/extras/dec/jxl.h
+++ b/lib/extras/dec/jxl.h
@@ -18,6 +18,8 @@
 #include <string>
 #include <vector>
 
+#include "lib/extras/size_constraints.h"
+
 namespace jxl {
 namespace extras {
 
@@ -66,7 +68,8 @@ struct JXLDecompressParams {
 bool DecodeImageJXL(const uint8_t* bytes, size_t bytes_size,
                     const JXLDecompressParams& dparams, size_t* decoded_bytes,
                     PackedPixelFile* ppf,
-                    std::vector<uint8_t>* jpeg_bytes = nullptr);
+                    std::vector<uint8_t>* jpeg_bytes = nullptr,
+                    const SizeConstraints* constraints = nullptr);
 
 }  // namespace extras
 }  // namespace jxl


### PR DESCRIPTION
Propagate memory manager and constraints to avoid fuzzer blowing on expected OOM / timeouts