### PR TITLE
reduce long-distance color ringing (red-green)

### DIFF
--- a/lib/jxl/jxl_test.cc
+++ b/lib/jxl/jxl_test.cc
@@ -248,7 +248,7 @@ TEST(JxlTest, RoundtripOutOfOrderProcessingBorder) {
   extras::JXLDecompressParams dparams;
 
   PackedPixelFile ppf_out;
-  EXPECT_NEAR(Roundtrip(t.ppf(), cparams, dparams, &pool, &ppf_out), 9707, 200);
+  EXPECT_NEAR(Roundtrip(t.ppf(), cparams, dparams, &pool, &ppf_out), 9907, 200);
   EXPECT_LE(ButteraugliDistance(t.ppf(), ppf_out), 2.9);
 }
 
@@ -396,7 +396,7 @@ TEST(JxlTest, RoundtripLargeFast) {
 
   PackedPixelFile ppf_out;
   EXPECT_NEAR(Roundtrip(t.ppf(), cparams, dparams, pool.get(), &ppf_out),
-              503000, 12000);
+              508000, 12000);
   EXPECT_SLIGHTLY_BELOW(ComputeDistance2(t.ppf(), ppf_out), 78);
 }
 
@@ -447,7 +447,7 @@ TEST(JxlTest, RoundtripOutputColorSpace) {
   dparams.color_space = "RGB_D65_DCI_Rel_709";
   PackedPixelFile ppf_out;
   EXPECT_NEAR(Roundtrip(t.ppf(), cparams, dparams, pool.get(), &ppf_out),
-              503000, 12000);
+              513000, 12000);
   EXPECT_SLIGHTLY_BELOW(ComputeDistance2(t.ppf(), ppf_out), 78);
 }
 
@@ -984,7 +984,7 @@ TEST(JxlTest, RoundtripAlphaResampling) {
   extras::JXLDecompressParams dparams;
 
   PackedPixelFile ppf_out;
-  EXPECT_NEAR(Roundtrip(t.ppf(), cparams, dparams, pool, &ppf_out), 13600, 130);
+  EXPECT_NEAR(Roundtrip(t.ppf(), cparams, dparams, pool, &ppf_out), 13900, 130);
   EXPECT_SLIGHTLY_BELOW(ButteraugliDistance(t.ppf(), ppf_out), 5.0);
 }
 
@@ -1289,7 +1289,7 @@ TEST(JxlTest, RoundtripDisablePerceptual) {
 
   PackedPixelFile ppf_out;
 
-  size_t expected_size = 477778;
+  size_t expected_size = 487778;
   EXPECT_NEAR(Roundtrip(t.ppf(), cparams, dparams, pool, &ppf_out),
               expected_size, 4000);
   // TODO(veluca): figure out why we can't get below this value.
@@ -1728,7 +1728,7 @@ TEST(JxlTest, RoundtripProgressiveLevel2Slow) {
   extras::JXLDecompressParams dparams;
 
   PackedPixelFile ppf_out;
-  EXPECT_NEAR(Roundtrip(t.ppf(), cparams, dparams, pool.get(), &ppf_out), 76666,
+  EXPECT_NEAR(Roundtrip(t.ppf(), cparams, dparams, pool.get(), &ppf_out), 78765,
               1000);
   EXPECT_SLIGHTLY_BELOW(ButteraugliDistance(t.ppf(), ppf_out), 1.17);
 }


### PR DESCRIPTION
```
104 images
Encoding      kPixels    Bytes          BPP  E MP/s  D MP/s     Max norm  SSIMULACRA2   PSNR        pnorm       BPP*pnorm   QABPP   Bugs
----------------------------------------------------------------------------------------------------------------------------------------
jxl:d0.1        20315 17262466    6.7976592   0.679   8.830   0.26883791  95.73074691  56.48   0.09126293  0.620374290230   6.798      0
jxl:d0.5        20315  7123032    2.8049262   0.801  12.266   0.85243585  91.46070452  46.45   0.34404012  0.965007161729   2.930      0
jxl:d0.8        20315  5403007    2.1276103   0.734  11.521   1.09686460  88.90359100  44.49   0.45983938  0.978358992626   2.468      0
jxl:d1          20315  4635303    1.8253018   0.753  11.671   1.31577511  87.07023293  43.25   0.54844111  1.001070530531   2.498      0
jxl:d1.5        20315  3513931    1.3837250   0.756  11.537   1.85093001  82.88893748  41.10   0.75070347  1.038767140170   2.658      0
jxl:d2.0        20315  2859102    1.1258647   0.773  11.881   2.40013573  78.84458753  39.58   0.94033462  1.058689549653   2.846      0
jxl:d2.5        20315  2408997    0.9486212   0.775  12.377   2.81960073  75.01469481  38.38   1.11437995  1.057124403275   2.816      0
jxl:d3          20315  2095771    0.8252782   0.760  12.194   3.24199950  71.66443259  37.51   1.27622134  1.053237654190   2.804      0
jxl:d5          20315  1404963    0.5532500   0.746   7.634   4.57633364  60.27028294  35.22   1.80381263  0.997959369366   2.632      0
jxl:d10         20315   880459    0.3467095   1.246  14.891  13.41355010  30.10499975  30.85   4.60450961  1.596427023195   4.152      0
Aggregate:      20315  3377582    1.3300329   0.791  11.310   1.95712006  76.19532105  40.82   0.76203069  1.013525892559   3.093      0
```

```
104 images
Encoding      kPixels    Bytes          BPP  E MP/s  D MP/s     Max norm  SSIMULACRA2   PSNR        pnorm       BPP*pnorm   QABPP   Bugs
----------------------------------------------------------------------------------------------------------------------------------------
jxl:d0.1        20315 17287248    6.8074179   0.644   8.407   0.26423619  95.73744604  56.49   0.09050842  0.616128653680   6.807      0
jxl:d0.5        20315  7193703    2.8327553   0.740  11.241   0.83800207  91.55687831  46.50   0.33972124  0.962347115414   2.921      0
jxl:d0.8        20315  5467179    2.1528801   0.681  10.748   1.08576247  88.94532671  44.56   0.45793802  0.985885656319   2.486      0
jxl:d1          20315  4692728    1.8479148   0.700  11.049   1.29672978  87.13736097  43.31   0.54648373  1.009855352556   2.518      0
jxl:d1.5        20315  3540916    1.3943512   0.711  10.927   1.84600162  82.91555646  41.13   0.75199498  1.048545094769   2.718      0
jxl:d2.0        20315  2873357    1.1314781   0.724  11.201   2.37964086  78.90476128  39.62   0.94207176  1.065933533787   2.842      0
jxl:d2.5        20315  2416745    0.9516722   0.747  11.393   2.81124569  75.03990169  38.46   1.11627889  1.062331574243   2.798      0
jxl:d3          20315  2106559    0.8295263   0.712  11.918   3.23199288  71.72988692  37.58   1.27420462  1.056986282826   2.811      0
jxl:d5          20315  1412292    0.5561361   0.704   7.092   4.53990547  60.33989877  35.23   1.80481407  1.003722170893   2.628      0
jxl:d10         20315   885780    0.3488048   1.198  14.064  13.44679420  30.11382274  30.87   4.60981219  1.607924496323   4.207      0
Aggregate:      20315  3400499    1.3390576   0.745  10.640   1.94115403  76.24208399  40.86   0.76026013  1.018032100378   3.106      0
```

<!-- Thank you for considering a contribution to `libjxl`! -->

### Description

<!-- Please provide a brief description of the changes in this PR and any additional context (e.g., why these changes were made, related issues, etc.). -->

### Pull Request Checklist

- [ ] **CLA Signed**: Have you signed the [Contributor License Agreement](https://code.google.com/legal/individual-cla-v1.0.html) (individual or corporate, as appropriate)? Only contributions from signed contributors can be accepted.
- [ ] **Authors**: Have you considered adding your name to the [AUTHORS](AUTHORS) file?
- [ ] **Code Style**: Have you ensured your code adheres to the project's coding style guidelines? You can use `./ci.sh lint` for automatic code formatting.


Please review the full [contributing guidelines](https://github.com/libjxl/libjxl/blob/main/CONTRIBUTING.md) for more details.
