### PR TITLE
max blue/hf correction instead of multiplying them

### DIFF
--- a/lib/extras/dec/decode.cc
+++ b/lib/extras/dec/decode.cc
@@ -181,7 +181,6 @@ Status DecodeBytes(const Span<const uint8_t> bytes,
   return true;
 }
 
-
 template <size_t N, size_t L>
 bool CheckSignatures(const Span<const uint8_t>& bytes,
                      const std::array<std::array<uint8_t, L>, N>& signatures) {

--- a/lib/jxl/enc_ac_strategy.cc
+++ b/lib/jxl/enc_ac_strategy.cc
@@ -445,7 +445,9 @@ Status EstimateEntropy(const AcStrategy& acs, float entropy_mul, size_t x,
 
     {
       float masku_lut[3] = {
-	12.0, 0.0, 4.0,
+          12.0,
+          0.0,
+          4.0,
       };
       auto masku_off = Set(df8, masku_lut[c]);
       auto lossc = Zero(df8);
@@ -462,9 +464,9 @@ Status EstimateEntropy(const AcStrategy& acs, float entropy_mul, size_t x,
                                       ix * kBlockDim + dx);
               if (x + ix * 8 + dx + Lanes(df8) <= config.mask1x1_xsize) {
                 auto masku =
-		  Add(Load(df8, config.MaskingPtr1x1(x + ix * 8 + dx,
-						     y + iy * 8 + dy)),
-		      masku_off);
+                    Add(Load(df8, config.MaskingPtr1x1(x + ix * 8 + dx,
+                                                       y + iy * 8 + dy)),
+                        masku_off);
                 in = Mul(masku, in);
                 in = Mul(in, in);
                 in = Mul(in, in);

--- a/lib/jxl/jxl_test.cc
+++ b/lib/jxl/jxl_test.cc
@@ -145,7 +145,7 @@ TEST(JxlTest, RoundtripSmallD1) {
 
   {
     PackedPixelFile ppf_out;
-    EXPECT_NEAR(Roundtrip(t.ppf(), {}, {}, pool, &ppf_out), 723, 20);
+    EXPECT_NEAR(Roundtrip(t.ppf(), {}, {}, pool, &ppf_out), 747, 20);
     EXPECT_SLIGHTLY_BELOW(ButteraugliDistance(t.ppf(), ppf_out), 1.3);
     EXPECT_EQ(ppf_out.info.intensity_target, t.ppf().info.intensity_target);
   }
@@ -225,7 +225,7 @@ TEST(JxlTest, RoundtripOutOfOrderProcessing) {
   extras::JXLDecompressParams dparams;
 
   PackedPixelFile ppf_out;
-  EXPECT_NEAR(Roundtrip(t.ppf(), cparams, dparams, &pool, &ppf_out), 26933,
+  EXPECT_NEAR(Roundtrip(t.ppf(), cparams, dparams, &pool, &ppf_out), 23666,
               400);
   EXPECT_LE(ButteraugliDistance(t.ppf(), ppf_out), 1.35);
 }
@@ -248,7 +248,7 @@ TEST(JxlTest, RoundtripOutOfOrderProcessingBorder) {
   extras::JXLDecompressParams dparams;
 
   PackedPixelFile ppf_out;
-  EXPECT_NEAR(Roundtrip(t.ppf(), cparams, dparams, &pool, &ppf_out), 9907, 200);
+  EXPECT_NEAR(Roundtrip(t.ppf(), cparams, dparams, &pool, &ppf_out), 9479, 200);
   EXPECT_LE(ButteraugliDistance(t.ppf(), ppf_out), 2.9);
 }
 
@@ -330,9 +330,9 @@ TEST(JxlTest, RoundtripMultiGroup) {
   };
 
   auto run_kitten = std::async(std::launch::async, test, SpeedTier::kKitten,
-                               1.0f, 64624u, 8.5);
+                               1.0f, 58737u, 9.1);
   auto run_wombat = std::async(std::launch::async, test, SpeedTier::kWombat,
-                               2.0f, 39001u, 15.5);
+                               2.0f, 35561u, 16.5);
 }
 
 TEST(JxlTest, RoundtripRGBToGrayscale) {
@@ -396,7 +396,7 @@ TEST(JxlTest, RoundtripLargeFast) {
 
   PackedPixelFile ppf_out;
   EXPECT_NEAR(Roundtrip(t.ppf(), cparams, dparams, pool.get(), &ppf_out),
-              508000, 12000);
+              488000, 12000);
   EXPECT_SLIGHTLY_BELOW(ComputeDistance2(t.ppf(), ppf_out), 78);
 }
 
@@ -447,7 +447,7 @@ TEST(JxlTest, RoundtripOutputColorSpace) {
   dparams.color_space = "RGB_D65_DCI_Rel_709";
   PackedPixelFile ppf_out;
   EXPECT_NEAR(Roundtrip(t.ppf(), cparams, dparams, pool.get(), &ppf_out),
-              513000, 12000);
+              487000, 12000);
   EXPECT_SLIGHTLY_BELOW(ComputeDistance2(t.ppf(), ppf_out), 78);
 }
 
@@ -572,7 +572,7 @@ TEST(JxlTest, RoundtripNoGaborishNoAR) {
   extras::JXLDecompressParams dparams;
 
   PackedPixelFile ppf_out;
-  EXPECT_NEAR(Roundtrip(t.ppf(), cparams, dparams, pool, &ppf_out), 45241, 400);
+  EXPECT_NEAR(Roundtrip(t.ppf(), cparams, dparams, pool, &ppf_out), 44555, 400);
   EXPECT_SLIGHTLY_BELOW(ButteraugliDistance(t.ppf(), ppf_out), 1.55);
 }
 
@@ -646,7 +646,7 @@ TEST(JxlTest, RoundtripSmallPatches) {
   extras::JXLDecompressParams dparams;
 
   PackedPixelFile ppf_out;
-  EXPECT_NEAR(Roundtrip(t.ppf(), cparams, dparams, pool, &ppf_out), 486, 100);
+  EXPECT_NEAR(Roundtrip(t.ppf(), cparams, dparams, pool, &ppf_out), 363, 100);
   EXPECT_SLIGHTLY_BELOW(ButteraugliDistance(t.ppf(), ppf_out), 0.015f);
 }
 
@@ -836,7 +836,7 @@ TEST(JxlTest, RoundtripAlpha) {
           ButteraugliDistance(io->frames, io2->frames, ButteraugliParams(),
                               *JxlGetDefaultCms(),
                               /*distmap=*/nullptr),
-          1.11);
+          1.05);
     }
   }
 }
@@ -984,7 +984,7 @@ TEST(JxlTest, RoundtripAlphaResampling) {
   extras::JXLDecompressParams dparams;
 
   PackedPixelFile ppf_out;
-  EXPECT_NEAR(Roundtrip(t.ppf(), cparams, dparams, pool, &ppf_out), 13900, 130);
+  EXPECT_NEAR(Roundtrip(t.ppf(), cparams, dparams, pool, &ppf_out), 13730, 130);
   EXPECT_SLIGHTLY_BELOW(ButteraugliDistance(t.ppf(), ppf_out), 5.0);
 }
 
@@ -1024,7 +1024,7 @@ TEST(JxlTest, RoundtripAlphaNonMultipleOf8) {
 
   PackedPixelFile ppf_out;
   EXPECT_NEAR(Roundtrip(t.ppf(), {}, {}, pool, &ppf_out), 107, 10);
-  EXPECT_SLIGHTLY_BELOW(ButteraugliDistance(t.ppf(), ppf_out), 0.006);
+  EXPECT_SLIGHTLY_BELOW(ButteraugliDistance(t.ppf(), ppf_out), 0.007);
 }
 
 TEST(JxlTest, RoundtripAlpha16) {
@@ -1063,7 +1063,7 @@ TEST(JxlTest, RoundtripAlpha16) {
   PackedPixelFile ppf_out;
   // TODO(szabadka) Investigate big size difference on i686
   // This still keeps happening (2023-04-18).
-  EXPECT_NEAR(Roundtrip(t.ppf(), cparams, dparams, pool.get(), &ppf_out), 4013,
+  EXPECT_NEAR(Roundtrip(t.ppf(), cparams, dparams, pool.get(), &ppf_out), 3810,
               120);
   EXPECT_SLIGHTLY_BELOW(ButteraugliDistance(t.ppf(), ppf_out), 0.6);
 }
@@ -1265,7 +1265,7 @@ TEST(JxlTest, RoundtripDots) {
   extras::JXLDecompressParams dparams;
 
   PackedPixelFile ppf_out;
-  EXPECT_NEAR(Roundtrip(t.ppf(), cparams, dparams, pool, &ppf_out), 245151,
+  EXPECT_NEAR(Roundtrip(t.ppf(), cparams, dparams, pool, &ppf_out), 236173,
               3000);
   EXPECT_SLIGHTLY_BELOW(ButteraugliDistance(t.ppf(), ppf_out), 0.165);
 }
@@ -1357,7 +1357,7 @@ TEST(JxlTest, RoundtripAnimation) {
   dparams.accepted_formats.push_back(t.ppf().frames[0].color.format);
 
   PackedPixelFile ppf_out;
-  EXPECT_SLIGHTLY_BELOW(Roundtrip(t.ppf(), {}, dparams, pool, &ppf_out), 3370);
+  EXPECT_SLIGHTLY_BELOW(Roundtrip(t.ppf(), {}, dparams, pool, &ppf_out), 2666);
 
   ASSERT_TRUE(t.CoalesceGIFAnimationWithAlpha());
   ASSERT_EQ(ppf_out.frames.size(), t.ppf().frames.size());
@@ -1707,7 +1707,7 @@ TEST(JxlTest, RoundtripProgressive) {
   extras::JXLDecompressParams dparams;
 
   PackedPixelFile ppf_out;
-  EXPECT_NEAR(Roundtrip(t.ppf(), cparams, dparams, pool.get(), &ppf_out), 71544,
+  EXPECT_NEAR(Roundtrip(t.ppf(), cparams, dparams, pool.get(), &ppf_out), 65298,
               500);
   EXPECT_SLIGHTLY_BELOW(ButteraugliDistance(t.ppf(), ppf_out), 1.3);
 }
@@ -1728,9 +1728,9 @@ TEST(JxlTest, RoundtripProgressiveLevel2Slow) {
   extras::JXLDecompressParams dparams;
 
   PackedPixelFile ppf_out;
-  EXPECT_NEAR(Roundtrip(t.ppf(), cparams, dparams, pool.get(), &ppf_out), 78765,
+  EXPECT_NEAR(Roundtrip(t.ppf(), cparams, dparams, pool.get(), &ppf_out), 71969,
               1000);
-  EXPECT_SLIGHTLY_BELOW(ButteraugliDistance(t.ppf(), ppf_out), 1.17);
+  EXPECT_SLIGHTLY_BELOW(ButteraugliDistance(t.ppf(), ppf_out), 1.20);
 }
 
 TEST(JxlTest, RoundtripUnsignedCustomBitdepthLossless) {

--- a/lib/jxl/passes_test.cc
+++ b/lib/jxl/passes_test.cc
@@ -116,7 +116,7 @@ TEST(PassesTest, RoundtripMultiGroupPasses) {
   };
 
   auto run1 = std::async(std::launch::async, test, 1.0f, 0.25f);
-  auto run2 = std::async(std::launch::async, test, 2.0f, 0.0f);
+  auto run2 = std::async(std::launch::async, test, 2.1f, 0.0f);
 }
 
 TEST(PassesTest, RoundtripLargeFastPasses) {

--- a/tools/cjxl_main.cc
+++ b/tools/cjxl_main.cc
@@ -765,7 +765,7 @@ void ProcessFlags(const jxl::extras::Codec codec,
   SetDistanceFromFlags(cmdline, args, params, codec);
 
   bool responsive_set = cmdline->GetOption(args->opt_responsive_id)->matched();
-  
+
   // Set progressive options before processing flags
   if (args->progressive) {
     args->qprogressive_ac = true;
@@ -809,7 +809,7 @@ void ProcessFlags(const jxl::extras::Codec codec,
               });
   ProcessFlag("progressive_ac", static_cast<int64_t>(args->progressive_ac),
               JXL_ENC_FRAME_SETTING_PROGRESSIVE_AC, params);
-  
+
   if (responsive_set) {
     ProcessFlag("responsive", args->responsive,
                 JXL_ENC_FRAME_SETTING_RESPONSIVE, params);

--- a/tools/djxl_fuzzer.cc
+++ b/tools/djxl_fuzzer.cc
@@ -345,7 +345,8 @@ bool DecodeJpegXl(const uint8_t* jxl, size_t size,
         }
         decode_callback_data.xsize = frame_header.layer_info.xsize;
         decode_callback_data.ysize = frame_header.layer_info.ysize;
-        size_t num_pixels = static_cast<size_t>(frame_header.layer_info.xsize) * frame_header.layer_info.ysize;
+        size_t num_pixels = static_cast<size_t>(frame_header.layer_info.xsize) *
+                            frame_header.layer_info.ysize;
         if (num_pixels > max_pixels) return false;
         if (!spec.coalescing) {
           decode_callback_data.called_rows.clear();


### PR DESCRIPTION
improves:

0.17 on ssimulacra
~0.2 % on BPP * pnorm, but 1 % around distance 2.0

all metrics, manual viewing and logic about the algorithm improvement agree here

before
```
104 images
Encoding      kPixels    Bytes          BPP  E MP/s  D MP/s     Max norm  SSIMULACRA2   PSNR        pnorm       BPP*pnorm   QABPP   Bugs
----------------------------------------------------------------------------------------------------------------------------------------
jxl:d0.1        20315 17287248    6.8074179   0.652   8.511   0.26423619  95.73744604  56.49   0.09050842  0.616128653680   6.807      0
jxl:d0.5        20315  7193703    2.8327553   0.748  12.261   0.83800207  91.55687831  46.50   0.33972124  0.962347115414   2.921      0
jxl:d0.8        20315  5467179    2.1528801   0.700  10.896   1.08576247  88.94532671  44.56   0.45793802  0.985885656319   2.486      0
jxl:d1          20315  4692728    1.8479148   0.696  11.032   1.29672978  87.13736097  43.31   0.54648373  1.009855352556   2.518      0
jxl:d1.5        20315  3540916    1.3943512   0.721  10.384   1.84600162  82.91555646  41.13   0.75199498  1.048545094769   2.718      0
jxl:d2.0        20315  2873357    1.1314781   0.733  11.591   2.37964086  78.90476128  39.62   0.94207176  1.065933533787   2.842      0
jxl:d2.5        20315  2416745    0.9516722   0.740  12.135   2.81124569  75.03990169  38.46   1.11627889  1.062331574243   2.798      0
jxl:d3          20315  2106559    0.8295263   0.718  11.653   3.23199288  71.72988692  37.58   1.27420462  1.056986282826   2.811      0
jxl:d5          20315  1412292    0.5561361   0.712   7.578   4.53990547  60.33989877  35.23   1.80481407  1.003722170893   2.628      0
jxl:d10         20315   885780    0.3488048   1.218  14.880  13.44679420  30.11382274  30.87   4.60981219  1.607924496323   4.207      0
Aggregate:      20315  3400499    1.3390576   0.752  10.918   1.94115403  76.24208399  40.86   0.76026013  1.018032100378   3.106      0
```

after

```
104 images
Encoding      kPixels    Bytes          BPP  E MP/s  D MP/s     Max norm  SSIMULACRA2   PSNR        pnorm       BPP*pnorm   QABPP   Bugs
----------------------------------------------------------------------------------------------------------------------------------------
jxl:d0.1        20315 16928774    6.6662571   0.673   8.835   0.25709601  95.74008193  56.38   0.09404056  0.626898531148   6.666      0
jxl:d0.5        20315  7097246    2.7947722   0.781  12.922   0.83919270  91.59391026  46.52   0.34385431  0.960994456444   2.888      0
jxl:d0.8        20315  5425531    2.1364798   0.727  11.471   1.07087716  88.94574405  44.60   0.46210717  0.987282649907   2.426      0
jxl:d1          20315  4666804    1.8377063   0.735  11.723   1.29700776  87.13643847  43.36   0.54874848  1.008438546762   2.493      0
jxl:d1.5        20315  3535170    1.3920885   0.750  11.764   1.84916804  82.97981073  41.19   0.74676124  1.039557750548   2.668      0
jxl:d2.0        20315  2868008    1.1293717   0.758  12.247   2.33111245  79.01640376  39.69   0.93358090  1.054359861435   2.773      0
jxl:d2.5        20315  2424350    0.9546669   0.768  12.323   2.72540360  75.24313008  38.52   1.10495488  1.054863856950   2.717      0
jxl:d3          20315  2117569    0.8338619   0.748  12.828   3.17444505  72.00488841  37.67   1.25683719  1.048028618391   2.774      0
jxl:d5          20315  1415654    0.5574599   0.738   8.054   4.49675448  60.65340735  35.27   1.78974720  0.997712384624   2.604      0
jxl:d10         20315   899569    0.3542346   1.227  14.734  13.29089677  30.83041744  30.93   4.56538626  1.617217970039   4.179      0
Aggregate:      20315  3392026    1.3357211   0.780  11.529   1.91634235  76.41442325  40.91   0.76068214  1.016059179620   3.054      0
```
