### PR TITLE
minor improvement in BPP * pnorm

### DIFF
--- a/lib/jxl/enc_ac_strategy.cc
+++ b/lib/jxl/enc_ac_strategy.cc
@@ -889,7 +889,7 @@ Status ProcessRectACS(const CompressParams& cparams, const ACSConfig& config,
   // ringing next to sky etc. Optimization will find smaller numbers
   // and produce more ringing than is ideal. Larger numbers will
   // help stop ringing.
-  const float entropy_mul16X8 = 1.24;
+  const float entropy_mul16X8 = 1.21;
   const float entropy_mul16X16 = 1.34;
   const float entropy_mul16X32 = 1.49;
   const float entropy_mul32X32 = 1.48;

--- a/lib/jxl/jxl_test.cc
+++ b/lib/jxl/jxl_test.cc
@@ -302,7 +302,7 @@ TEST(JxlTest, RoundtripUnalignedD2) {
   extras::JXLDecompressParams dparams;
 
   PackedPixelFile ppf_out;
-  EXPECT_NEAR(Roundtrip(t.ppf(), cparams, dparams, pool, &ppf_out), 506, 30);
+  EXPECT_NEAR(Roundtrip(t.ppf(), cparams, dparams, pool, &ppf_out), 540, 37);
   EXPECT_SLIGHTLY_BELOW(ButteraugliDistance(t.ppf(), ppf_out), 1.72);
 }
 


### PR DESCRIPTION
seems to not look worse in manual viewing, and numbers suggest a 0.1 % improvement

before:
```
104 images
Encoding      kPixels    Bytes          BPP  E MP/s  D MP/s     Max norm  SSIMULACRA2   PSNR        pnorm       BPP*pnorm   QABPP   Bugs
----------------------------------------------------------------------------------------------------------------------------------------
jxl:d0.1        20315 16928774    6.6662571   0.654   8.619   0.25709601  95.74008193  56.38   0.09404056  0.626898531148   6.666      0
jxl:d0.5        20315  7097246    2.7947722   0.785  12.374   0.83919270  91.59391026  46.52   0.34385431  0.960994456444   2.888      0
jxl:d0.8        20315  5425531    2.1364798   0.710  11.153   1.07087716  88.94574405  44.60   0.46210717  0.987282649907   2.426      0
jxl:d1          20315  4666804    1.8377063   0.727  11.703   1.29700776  87.13643847  43.36   0.54874848  1.008438546762   2.493      0
jxl:d1.5        20315  3535170    1.3920885   0.739  11.908   1.84916804  82.97981073  41.19   0.74676124  1.039557750548   2.668      0
jxl:d2.0        20315  2868008    1.1293717   0.755  12.405   2.33111245  79.01640376  39.69   0.93358090  1.054359861435   2.773      0
jxl:d2.5        20315  2424350    0.9546669   0.753  12.490   2.72540360  75.24313008  38.52   1.10495488  1.054863856950   2.717      0
jxl:d3          20315  2117569    0.8338619   0.733  12.153   3.17444505  72.00488841  37.67   1.25683719  1.048028618391   2.774      0
jxl:d5          20315  1415654    0.5574599   0.732   7.948   4.49675448  60.65340735  35.27   1.78974720  0.997712384624   2.604      0
jxl:d10         20315   899569    0.3542346   1.228  15.008  13.29089677  30.83041744  30.93   4.56538626  1.617217970039   4.179      0
Aggregate:      20315  3392026    1.3357211   0.770  11.405   1.91634235  76.41442325  40.91   0.76068214  1.016059179620   3.054      0
```

after:
```
104 images
Encoding      kPixels    Bytes          BPP  E MP/s  D MP/s     Max norm  SSIMULACRA2   PSNR        pnorm       BPP*pnorm   QABPP   Bugs
----------------------------------------------------------------------------------------------------------------------------------------
jxl:d0.1        20315 16928997    6.6663449   0.720   9.695   0.25733609  95.73998625  56.38   0.09404859  0.626960304875   6.666      0
jxl:d0.5        20315  7094130    2.7935451   0.849  13.891   0.83891349  91.58925939  46.52   0.34389021  0.960672818245   2.886      0
jxl:d0.8        20315  5421471    2.1348811   0.784  12.431   1.07067609  88.93528878  44.60   0.46221525  0.986774604028   2.422      0
jxl:d1          20315  4661128    1.8354712   0.795  12.771   1.29805532  87.13484664  43.35   0.54900923  1.007690646825   2.492      0
jxl:d1.5        20315  3527538    1.3890832   0.800  12.216   1.84316500  82.97146880  41.18   0.74726132  1.038008129587   2.652      0
jxl:d2.0        20315  2860723    1.1265030   0.809  13.343   2.33560321  78.99089630  39.68   0.93447508  1.052688991359   2.767      0
jxl:d2.5        20315  2417329    0.9519022   0.837  13.304   2.72200245  75.22181458  38.51   1.10658068  1.053356538629   2.702      0
jxl:d3          20315  2111778    0.8315815   0.814  13.405   3.16400079  71.98223173  37.66   1.25817263  1.046273067644   2.758      0
jxl:d5          20315  1414744    0.5571016   0.797   8.343   4.48632781  60.63838877  35.26   1.79040022  0.997434836279   2.597      0
jxl:d10         20315   898551    0.3538338   1.314  15.930  13.30761446  30.78065039  30.92   4.56737416  1.616091225669   4.185      0
Aggregate:      20315  3387108    1.3337843   0.840  12.351   1.91524738  76.39848316  40.90   0.76112787  1.015180441748   3.047      0
```

<!-- Thank you for considering a contribution to `libjxl`! -->

### Description

<!-- Please provide a brief description of the changes in this PR and any additional context (e.g., why these changes were made, related issues, etc.). -->

### Pull Request Checklist

- [x] **CLA Signed**: Have you signed the [Contributor License Agreement](https://code.google.com/legal/individual-cla-v1.0.html) (individual or corporate, as appropriate)? Only contributions from signed contributors can be accepted.
- [x] **Authors**: Have you considered adding your name to the [AUTHORS](AUTHORS) file?
- [x] **Code Style**: Have you ensured your code adheres to the project's coding style guidelines? You can use `./ci.sh lint` for automatic code formatting.


Please review the full [contributing guidelines](https://github.com/libjxl/libjxl/blob/main/CONTRIBUTING.md) for more details.
