### PR TITLE
Allow "broken" HWY targets for testing and conformance.

### DIFF
--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -260,7 +260,7 @@ jobs:
         MODE="${{ matrix.mode }}"
         BUILD_TESTS=$([ "${WILL_TEST}" == "true" ] && echo "ON" || echo "OFF")
         [[ -n "${MODE}" ]] || MODE="${{ matrix.name }}"
-        SKIP_TEST=1 TARGETS=all CMAKE_CXX_FLAGS='${{ matrix.cxxflags }}' \
+        SKIP_TEST=1 TARGETS=all CMAKE_CXX_FLAGS='${{ matrix.cxxflags }}' CMAKE_FLAGS='-DHWY_BROKEN_TARGETS=0' \
         ./ci.sh ${MODE} \
           -DJPEGXL_FORCE_SYSTEM_BROTLI=ON \
           -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \

--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -129,7 +129,7 @@ jobs:
       run: |
         mkdir -p ${CCACHE_DIR}
         echo "max_size = 200M" > ${CCACHE_DIR}/ccache.conf
-        CC=clang CXX=clang++ CMAKE_FLAGS="${{ matrix.cflags }}" \
+        CC=clang CXX=clang++ CMAKE_FLAGS="${{ matrix.cflags }} -DHWY_BROKEN_TARGETS=0" \
         SKIP_TEST=1 TARGETS="hwy_list_targets tools/djxl" \
         ./ci.sh ${{ matrix.build_type || 'release' }} \
           -DJPEGXL_FORCE_SYSTEM_BROTLI=ON \


### PR DESCRIPTION
We are fine with HWY not always working, once it works for us.
