### PR TITLE
Fix decoder: some valid streams were undecodable.

### DIFF
--- a/lib/jxl/dec_ans.h
+++ b/lib/jxl/dec_ans.h
@@ -379,6 +379,8 @@ class ANSSymbolReader {
   bool IsSingleValueAndAdvance(size_t ctx, uint32_t* value, size_t count) {
     // TODO(veluca): No optimization for Huffman mode yet.
     if (use_prefix_code_) return false;
+    // TODO(eustas): Check if we could deal with copy tail as well.
+    if (num_to_copy_ != 0) return false;
     // TODO(eustas): propagate "degenerate_symbol" to simplify this method.
     const uint32_t res = state_ & (ANS_TAB_SIZE - 1u);
     const AliasTable::Entry* table = &alias_tables_[ctx << log_alpha_size_];


### PR DESCRIPTION
`IsSingleValueAndAdvance` assumes that LZ77 does not "mix" images, i.e. tail of copy does not span over beginning of degenerate image.
