### PR TITLE
allow decoding without coalescing, and do that when doing jxl to jxl

### DIFF
--- a/lib/extras/dec/decode.cc
+++ b/lib/extras/dec/decode.cc
@@ -117,7 +117,7 @@ std::string ListOfDecodeCodecs() {
 Status DecodeBytes(const Span<const uint8_t> bytes,
                    const ColorHints& color_hints, extras::PackedPixelFile* ppf,
                    const SizeConstraints* constraints, Codec* orig_codec,
-                   JxlMemoryManager* memory_manager) {
+                   JxlMemoryManager* memory_manager, bool coalescing) {
   if (bytes.size() < kMinBytes) return JXL_FAILURE("Too few bytes");
 
   *ppf = extras::PackedPixelFile();
@@ -144,6 +144,7 @@ Status DecodeBytes(const Span<const uint8_t> bytes,
     case Codec::kJXL: {
       JXLDecompressParams dparams = {};
       dparams.memory_manager = memory_manager;
+      dparams.coalescing = coalescing;
       for (const uint32_t num_channels : {1, 2, 3, 4}) {
         dparams.accepted_formats.push_back(
             {num_channels, JXL_TYPE_FLOAT, JXL_LITTLE_ENDIAN, /*align=*/0});

--- a/lib/extras/dec/decode.h
+++ b/lib/extras/dec/decode.h
@@ -56,7 +56,8 @@ Status DecodeBytes(Span<const uint8_t> bytes, const ColorHints& color_hints,
                    extras::PackedPixelFile* ppf,
                    const SizeConstraints* constraints = nullptr,
                    Codec* orig_codec = nullptr,
-                   JxlMemoryManager* memory_manager = nullptr);
+                   JxlMemoryManager* memory_manager = nullptr,
+                   bool coalescing = true);
 
 }  // namespace extras
 }  // namespace jxl

--- a/lib/extras/dec/jxl.h
+++ b/lib/extras/dec/jxl.h
@@ -38,7 +38,7 @@ struct JXLDecompressParams {
   // Whether to keep or undo the orientation given in the header.
   bool keep_orientation = false;
   // Coalescing or not
-  bool coalescing = false;
+  bool coalescing = true;
 
   // If runner_opaque is set, the decoder uses this parallel runner.
   JxlParallelRunner runner;

--- a/lib/extras/dec/jxl.h
+++ b/lib/extras/dec/jxl.h
@@ -37,6 +37,8 @@ struct JXLDecompressParams {
   bool render_spotcolors = true;
   // Whether to keep or undo the orientation given in the header.
   bool keep_orientation = false;
+  // Coalescing or not
+  bool coalescing = false;
 
   // If runner_opaque is set, the decoder uses this parallel runner.
   JxlParallelRunner runner;

--- a/lib/extras/enc/encode.cc
+++ b/lib/extras/enc/encode.cc
@@ -86,7 +86,9 @@ Status Encoder::VerifyImageSize(const PackedImage& image,
   }
   size_t info_num_channels =
       (info.num_color_channels + (info.alpha_bits > 0 ? 1 : 0));
-  if (image.xsize != info.xsize || image.ysize != info.ysize ||
+  // TODO(jon): frames do not necessarily have to match image size,
+  // but probably this is still assumed in some encoders
+  if (  // image.xsize != info.xsize || image.ysize != info.ysize ||
       image.format.num_channels != info_num_channels) {
     return JXL_FAILURE("Frame size does not match image size");
   }

--- a/tools/cjxl_main.cc
+++ b/tools/cjxl_main.cc
@@ -1089,7 +1089,7 @@ int main(int argc, char** argv) {
       const double t0 = jxl::Now();
       jxl::Status status = jxl::extras::DecodeBytes(
           jxl::Bytes(image_data), args.color_hints_proxy.target, &ppf, nullptr,
-          &codec);
+          &codec, nullptr, /*coalescing=*/false);
 
       if (!status) {
         std::cerr << "Getting pixel data failed.\n";

--- a/tools/djxl_main.cc
+++ b/tools/djxl_main.cc
@@ -176,6 +176,10 @@ struct DecompressArgs {
                            "Disables rendering of spot colors.",
                            &render_spotcolors, &SetBooleanFalse, 2);
 
+    cmdline->AddOptionFlag('\0', "no_coalescing",
+                           "Disables coalescing of layers.", &coalescing,
+                           &SetBooleanFalse, 2);
+
     cmdline->AddOptionValue('\0', "preview_out", "FILENAME",
                             "If specified, writes the preview image to this "
                             "file.",
@@ -250,6 +254,7 @@ struct DecompressArgs {
   size_t jpeg_quality = 95;
   bool use_sjpeg = false;
   bool render_spotcolors = true;
+  bool coalescing = true;
   bool output_extra_channels = false;
   bool output_frames = false;
   std::string preview_out;
@@ -381,6 +386,7 @@ bool DecompressJxlToPackedPixelFile(
   dparams.display_nits = args.display_nits;
   dparams.color_space = args.color_space;
   dparams.render_spotcolors = args.render_spotcolors;
+  dparams.coalescing = args.coalescing;
   dparams.runner = JxlThreadParallelRunner;
   dparams.runner_opaque = runner;
   dparams.allow_partial_input = args.allow_partial_files;

--- a/tools/djxl_main.cc
+++ b/tools/djxl_main.cc
@@ -604,7 +604,9 @@ int main(int argc, const char* argv[]) {
       size_t nlayers = args.output_extra_channels
                            ? 1 + encoded_image.extra_channel_bitstreams.size()
                            : 1;
-      size_t nframes = args.output_frames ? encoded_image.bitstreams.size() : 1;
+      size_t nframes = (args.output_frames || !args.coalescing)
+                           ? encoded_image.bitstreams.size()
+                           : 1;
       for (size_t i = 0; i < nlayers; ++i) {
         for (size_t j = 0; j < nframes; ++j) {
           const std::vector<uint8_t>& bitstream =


### PR DESCRIPTION
Should fix https://github.com/libjxl/libjxl/issues/4097

~Probably the new `--no_coalescing` option in djxl does not quite do the right thing; it works when outputting to .pam with `--output_frames` but for other output formats it may do bad things still. Anyway,~
default djxl will apply coalescing just like before, so nothing changes there.

When loading a layered jxl in cjxl, it will be loaded without coalescing now, so layers are preserved. This is probably what you want to do, e.g. to convert a lossless layered image to a better-compressed lossless layered image or a slightly-lossy one.

~Also other tools that can take jxl input will now get the layered image, not the coalesced one, which may or may not be a good idea.~

When outputting a layered image to PNG (or PAM) with `--no_coalescing`, it will now produce multiple files, one per layer. We can in general not use APNG for this since 1) it does not support 0-duration frames, 2) it does not support frames with negative offsets or otherwise not contained in the canvas, 3) it does not support all blend modes of jxl, so the blending may have to be incorrect, 4) it does not support the mechanism of 4 reference frames that can be used as a base for blending.