### PR TITLE
Comparison tool: don’t draw the left image if the cursor is to its left

### DIFF
--- a/tools/comparison_viewer/split_image_renderer.cc
+++ b/tools/comparison_viewer/split_image_renderer.cc
@@ -195,7 +195,9 @@ void SplitImageRenderer::paintEvent(QPaintEvent* const event) {
   QRectF rightRect = rightImage_.rect();
   rightRect.setLeft(middleRect.right());
 
-  painter.drawPixmap(QPointF(), leftImage_, leftRect);
+  if (leftRect.isValid()) {
+    painter.drawPixmap(QPointF(), leftImage_, leftRect);
+  }
   painter.drawPixmap(middleRect.topLeft() / devicePixelRatio(), middleImage_,
                      middleRect);
   painter.drawPixmap(rightRect.topLeft() / devicePixelRatio(), rightImage_,


### PR DESCRIPTION
`drawPixmap` with an empty rect appears to draw the entire image. If the left and right image are the same size (as should usually be the case) then the right image would then cover it anyway, but this avoids the appearance of a glitch otherwise.
