### PR TITLE
cjxl: EXR improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,6 @@ tools/conformance/__pycache__
 
 # Editor configuration
 *.code-workspace
+
+# macOS Finder state files
+.DS_Store

--- a/AUTHORS
+++ b/AUTHORS
@@ -40,6 +40,7 @@ Alistair Barrow
 Andrius Lukas Narbutas <andrius4669@gmail.com>
 Andrew Kaster <andrew@ladybird.org>
 Aous Naman <aous@unsw.edu.au>
+Aras Pranckevičius <aras@nesnausk.org>
 Artem Selishchev
 Aryan Pingle <realaryanpingle@gmail.com>
 Biswapriyo Nath <nathbappai@gmail.com>

--- a/lib/extras/dec/exr.cc
+++ b/lib/extras/dec/exr.cc
@@ -33,9 +33,10 @@ Status DecodeImageEXR(Span<const uint8_t> bytes, const ColorHints& color_hints,
 
 #else  // JPEGXL_ENABLE_EXR
 
+#include <ImfChannelList.h>
+#include <ImfFrameBuffer.h>
 #include <ImfIO.h>
-#include <ImfRgba.h>
-#include <ImfRgbaFile.h>
+#include <ImfInputFile.h>
 #include <ImfStandardAttributes.h>
 #include <OpenEXRConfig.h>
 #include <jxl/color_encoding.h>
@@ -45,6 +46,7 @@ Status DecodeImageEXR(Span<const uint8_t> bytes, const ColorHints& color_hints,
 #include <cstddef>
 #include <cstring>
 #include <memory>
+#include <set>
 #include <utility>
 #include <vector>
 
@@ -70,9 +72,6 @@ namespace OpenEXR = OPENEXR_IMF_NAMESPACE;
 // on macOS, where the definition for OpenEXR::Int64 was actually not equivalent
 // to uint64_t. This alternative should work in all cases.
 using ExrInt64 = decltype(std::declval<OpenEXR::IStream>().tellg());
-
-constexpr int kExrBitsPerSample = 16;
-constexpr int kExrAlphaBits = 16;
 
 class InMemoryIStream : public OpenEXR::IStream {
  public:
@@ -127,52 +126,109 @@ class InMemoryIStream : public OpenEXR::IStream {
 
 bool CanDecodeEXR() { return true; }
 
+static std::string FindColorLayerPrefix(const OpenEXR::ChannelList& channels) {
+  // check if just R,G,B channels exist; use those if present
+  if (channels.findChannel("R") != nullptr &&
+      channels.findChannel("G") != nullptr &&
+      channels.findChannel("B") != nullptr) {
+    return "";
+  }
+
+  // check channels for presence of R,G,B with common prefix ("layer name"),
+  // use the first one that is present
+  for (OpenEXR::ChannelList::ConstIterator it = channels.begin();
+       it != channels.end(); ++it) {
+    std::string name = it.name();
+    size_t dotIndex = name.rfind('.');
+    if (dotIndex == std::string::npos) continue;
+    std::string suffix = name.substr(dotIndex + 1);
+    if (suffix != "R" && suffix != "G" && suffix != "B") continue;
+    std::string prefix = name.substr(0, dotIndex + 1);
+    if (channels.findChannel((prefix + "R").c_str()) != nullptr &&
+        channels.findChannel((prefix + "G").c_str()) != nullptr &&
+        channels.findChannel((prefix + "B").c_str()) != nullptr) {
+      return prefix;
+    }
+  }
+
+  return "";
+}
+
 Status DecodeImageEXR(Span<const uint8_t> bytes, const ColorHints& color_hints,
                       PackedPixelFile* ppf,
                       const SizeConstraints* constraints) {
   InMemoryIStream is(bytes);
 
 #ifdef __EXCEPTIONS
-  std::unique_ptr<OpenEXR::RgbaInputFile> input_ptr;
+  std::unique_ptr<OpenEXR::InputFile> input_ptr;
   try {
-    input_ptr = jxl::make_unique<OpenEXR::RgbaInputFile>(is);
+    input_ptr = jxl::make_unique<OpenEXR::InputFile>(is);
   } catch (...) {
     // silently return false if it is not an EXR file
     return false;
   }
-  OpenEXR::RgbaInputFile& input = *input_ptr;
+  OpenEXR::InputFile& input = *input_ptr;
 #else
-  OpenEXR::RgbaInputFile input(is);
+  OpenEXR::InputFile input(is);
 #endif
 
-  if ((input.channels() & OpenEXR::RgbaChannels::WRITE_RGB) !=
-      OpenEXR::RgbaChannels::WRITE_RGB) {
-    return JXL_FAILURE("only RGB OpenEXR files are supported");
+  const OpenEXR::Header& header = input.header();
+  const OpenEXR::ChannelList& channels = header.channels();
+
+  // we don't support subsampled or UINT channels yet
+  // TODO: support common cases of subsampling (2x, 4x)
+  for (OpenEXR::ChannelList::ConstIterator it = channels.begin();
+       it != channels.end(); ++it) {
+    const OpenEXR::Channel& ch = it.channel();
+    if (ch.type == OpenEXR::UINT) {
+      return JXL_FAILURE("OpenEXR files with UINT channels are not supported");
+    }
+    if (ch.xSampling != 1 || ch.ySampling != 1) {
+      return JXL_FAILURE(
+          "OpenEXR files sub-sampled channels are not supported");
+    }
   }
-  const bool has_alpha = (input.channels() & OpenEXR::RgbaChannels::WRITE_A) ==
-                         OpenEXR::RgbaChannels::WRITE_A;
 
-  const float intensity_target = OpenEXR::hasWhiteLuminance(input.header())
-                                     ? OpenEXR::whiteLuminance(input.header())
-                                     : 0;
+  const std::string chPrefix = FindColorLayerPrefix(channels);
+  const std::string chNameR = chPrefix + "R";
+  const std::string chNameG = chPrefix + "G";
+  const std::string chNameB = chPrefix + "B";
+  const std::string chNameA = chPrefix + "A";
+  const OpenEXR::Channel* chR = channels.findChannel(chNameR.c_str());
+  const OpenEXR::Channel* chG = channels.findChannel(chNameG.c_str());
+  const OpenEXR::Channel* chB = channels.findChannel(chNameB.c_str());
+  const OpenEXR::Channel* chA = channels.findChannel(chNameA.c_str());
+  // If we don't have RGB (same type) channels, we'll treat the first
+  // channel as grayscale.
+  const bool has_rgb = chR != nullptr && chG != nullptr && chB != nullptr &&
+                       chR->type == chG->type && chR->type == chB->type;
+  const OpenEXR::Channel* chBase = has_rgb ? chR : &channels.begin().channel();
+  const std::string chNameBase = has_rgb ? chNameR : channels.begin().name();
 
-  auto image_size = input.displayWindow().size();
+  const bool has_alpha =
+      chA != nullptr && chA != chBase && chA->type == chBase->type;
+
+  const float intensity_target =
+      OpenEXR::hasWhiteLuminance(header) ? OpenEXR::whiteLuminance(header) : 0;
+
+  const Imath::Box2i displayWindow = header.displayWindow();
+  const Imath::Box2i dataWindow = header.dataWindow();
   // Size is computed as max - min, but both bounds are inclusive.
-  ++image_size.x;
-  ++image_size.y;
+  const int imageWidth = displayWindow.max.x - displayWindow.min.x + 1;
+  const int imageHeight = displayWindow.max.y - displayWindow.min.y + 1;
 
-  if (!VerifyDimensions<uint32_t>(constraints, image_size.x, image_size.y)) {
+  if (!VerifyDimensions<uint32_t>(constraints, imageWidth, imageHeight)) {
     return JXL_FAILURE("image too big");
   }
 
-  ppf->info.xsize = image_size.x;
-  ppf->info.ysize = image_size.y;
-  ppf->info.num_color_channels = 3;
+  ppf->info.xsize = imageWidth;
+  ppf->info.ysize = imageHeight;
+  ppf->info.num_color_channels = has_rgb ? 3 : 1;
 
   const JxlDataType data_type =
-      kExrBitsPerSample == 16 ? JXL_TYPE_FLOAT16 : JXL_TYPE_FLOAT;
+      chBase->type == OpenEXR::HALF ? JXL_TYPE_FLOAT16 : JXL_TYPE_FLOAT;
   const JxlPixelFormat format{
-      /*num_channels=*/3u + (has_alpha ? 1u : 0u),
+      /*num_channels=*/ppf->info.num_color_channels + (has_alpha ? 1u : 0u),
       /*data_type=*/data_type,
       /*endianness=*/JXL_NATIVE_ENDIAN,
       /*align=*/0,
@@ -180,61 +236,159 @@ Status DecodeImageEXR(Span<const uint8_t> bytes, const ColorHints& color_hints,
   ppf->frames.clear();
   // Allocates the frame buffer.
   {
-    JXL_ASSIGN_OR_RETURN(
-        PackedFrame frame,
-        PackedFrame::Create(image_size.x, image_size.y, format));
+    JXL_ASSIGN_OR_RETURN(PackedFrame frame,
+                         PackedFrame::Create(imageWidth, imageHeight, format));
     ppf->frames.emplace_back(std::move(frame));
   }
-  const auto& frame = ppf->frames.back();
+  auto& frame = ppf->frames.back();
 
-  const int row_size = input.dataWindow().size().x + 1;
+  // Allocate extra channel images
+  uint32_t extraCount = 0;
+  size_t extraPixelBytes = 0;
+  std::set<const OpenEXR::Channel*> extraChannels;
+  for (OpenEXR::ChannelList::ConstIterator it = channels.begin();
+       it != channels.end(); ++it) {
+    const std::string name = it.name();
+    if (has_rgb && (name == chNameR || name == chNameG || name == chNameB))
+      continue;
+    if (has_alpha && name == chNameA) continue;
+    if (name == chNameBase) continue;
+
+    const bool fp16 = it.channel().type == OpenEXR::HALF;
+    ++extraCount;
+    extraPixelBytes += fp16 ? 2 : 4;
+    extraChannels.insert(&it.channel());
+
+    const JxlPixelFormat ec_format{1, fp16 ? JXL_TYPE_FLOAT16 : JXL_TYPE_FLOAT,
+                                   JXL_NATIVE_ENDIAN, 0};
+    JXL_ASSIGN_OR_RETURN(
+        PackedImage ec,
+        PackedImage::Create(imageWidth, imageHeight, ec_format));
+    frame.extra_channels.emplace_back(std::move(ec));
+
+    PackedExtraChannel pec = {};
+    pec.ec_info.bits_per_sample = fp16 ? 16 : 32;
+    pec.ec_info.exponent_bits_per_sample = fp16 ? 5 : 8;
+    // TODO: detect channel types (depth etc.) based on naming convention
+    pec.ec_info.type = JXL_CHANNEL_OPTIONAL;
+    pec.name = name;
+    ppf->extra_channels_info.emplace_back(std::move(pec));
+  }
+  ppf->info.num_extra_channels = (has_alpha ? 1 : 0) + extraCount;
+
+  const int row_size = dataWindow.size().x + 1;
   // Number of rows to read at a time.
   // https://www.openexr.com/documentation/ReadingAndWritingImageFiles.pdf
   // recommends reading the whole file at once.
-  const int y_chunk_size = input.displayWindow().size().y + 1;
-  std::vector<OpenEXR::Rgba> input_rows(row_size * y_chunk_size);
-  for (int start_y =
-           std::max(input.dataWindow().min.y, input.displayWindow().min.y);
-       start_y <=
-       std::min(input.dataWindow().max.y, input.displayWindow().max.y);
+  const int y_chunk_size = displayWindow.size().y + 1;
+
+  const size_t colorChannelBytes = chBase->type == OpenEXR::HALF ? 2 : 4;
+  const size_t colorPixelBytes = colorChannelBytes * format.num_channels;
+  std::vector<char> input_rows(colorPixelBytes * row_size * y_chunk_size);
+  std::vector<char> input_extra_rows(extraPixelBytes * row_size * y_chunk_size);
+  for (int start_y = std::max(dataWindow.min.y, displayWindow.min.y);
+       start_y <= std::min(dataWindow.max.y, displayWindow.max.y);
        start_y += y_chunk_size) {
     // Inclusive.
-    const int end_y = std::min(
-        start_y + y_chunk_size - 1,
-        std::min(input.dataWindow().max.y, input.displayWindow().max.y));
-    input.setFrameBuffer(
-        input_rows.data() - input.dataWindow().min.x - start_y * row_size,
-        /*xStride=*/1, /*yStride=*/row_size);
+    const int end_y = std::min(start_y + y_chunk_size - 1,
+                               std::min(dataWindow.max.y, displayWindow.max.y));
+
+    // Setup framebuffer: color/grayscale
+    OpenEXR::FrameBuffer fb;
+    char* input_rows_ptr =
+        input_rows.data() -
+        (dataWindow.min.x + start_y * row_size) * colorPixelBytes;
+    if (has_rgb) {
+      fb.insert(
+          chNameR.c_str(),
+          OpenEXR::Slice(chR->type, input_rows_ptr + colorChannelBytes * 0,
+                         colorPixelBytes, colorPixelBytes * row_size));
+      fb.insert(
+          chNameG.c_str(),
+          OpenEXR::Slice(chG->type, input_rows_ptr + colorChannelBytes * 1,
+                         colorPixelBytes, colorPixelBytes * row_size));
+      fb.insert(
+          chNameB.c_str(),
+          OpenEXR::Slice(chB->type, input_rows_ptr + colorChannelBytes * 2,
+                         colorPixelBytes, colorPixelBytes * row_size));
+    } else {
+      fb.insert(
+          chNameBase.c_str(),
+          OpenEXR::Slice(chBase->type, input_rows_ptr + colorChannelBytes * 0,
+                         colorPixelBytes, colorPixelBytes * row_size));
+    }
+
+    // Setup framebuffer: alpha
+    if (has_alpha)
+      fb.insert(
+          chNameA.c_str(),
+          OpenEXR::Slice(chA->type,
+                         input_rows_ptr + colorChannelBytes * (has_rgb ? 3 : 1),
+                         colorPixelBytes, colorPixelBytes * row_size));
+
+    // Setup framebuffer: extra channels
+    char* extra_rows_ptr =
+        input_extra_rows.data() -
+        (dataWindow.min.x + start_y * row_size) * extraPixelBytes;
+    for (OpenEXR::ChannelList::ConstIterator it = channels.begin();
+         it != channels.end(); ++it) {
+      if (extraChannels.find(&it.channel()) == extraChannels.end()) {
+        continue;
+      }
+      const size_t size = it.channel().type == OpenEXR::HALF ? 2 : 4;
+      fb.insert(it.name(), OpenEXR::Slice(it.channel().type, extra_rows_ptr,
+                                          size, size * row_size));
+      extra_rows_ptr += size * row_size * (end_y - start_y + 1);
+    }
+
+    // Read EXR data
+    input.setFrameBuffer(fb);
     input.readPixels(start_y, end_y);
+
+    // Copy read data into the result image
     for (int exr_y = start_y; exr_y <= end_y; ++exr_y) {
-      const int image_y = exr_y - input.displayWindow().min.y;
-      const OpenEXR::Rgba* const JXL_RESTRICT input_row =
-          &input_rows[(exr_y - start_y) * row_size];
+      const int image_y = exr_y - displayWindow.min.y;
+      const char* const JXL_RESTRICT input_row =
+          &input_rows[(exr_y - start_y) * colorPixelBytes * row_size];
       uint8_t* row = static_cast<uint8_t*>(frame.color.pixels()) +
                      frame.color.stride * image_y;
-      const uint32_t pixel_size =
-          (3 + (has_alpha ? 1 : 0)) * kExrBitsPerSample / 8;
-      for (int exr_x =
-               std::max(input.dataWindow().min.x, input.displayWindow().min.x);
-           exr_x <=
-           std::min(input.dataWindow().max.x, input.displayWindow().max.x);
-           ++exr_x) {
-        const int image_x = exr_x - input.displayWindow().min.x;
-        // TODO(eustas): UB: OpenEXR::Rgba is not TriviallyCopyable
-        memcpy(row + image_x * pixel_size,
-               input_row + (exr_x - input.dataWindow().min.x), pixel_size);
+
+      const int exr_x1 = std::max(dataWindow.min.x, displayWindow.min.x);
+      const int exr_x2 = std::min(dataWindow.max.x, displayWindow.max.x);
+
+      const char* exr_ptr =
+          input_row + (exr_x1 - dataWindow.min.x) * colorPixelBytes;
+      uint8_t* image_ptr =
+          row + (exr_x1 - displayWindow.min.x) * colorPixelBytes;
+      memcpy(image_ptr, exr_ptr, (exr_x2 - exr_x1 + 1) * colorPixelBytes);
+
+      const char* JXL_RESTRICT input_ec_slice = input_extra_rows.data();
+      for (PackedImage& ec : frame.extra_channels) {
+        const char* const JXL_RESTRICT input_ec_row =
+            input_ec_slice + (exr_y - start_y) * ec.stride;
+        uint8_t* ec_row =
+            static_cast<uint8_t*>(ec.pixels()) + ec.stride * image_y;
+        input_ec_slice += ec.stride * (end_y - start_y + 1);
+
+        const char* exr_ec_ptr =
+            input_ec_row + (exr_x1 - dataWindow.min.x) * ec.pixel_stride();
+        uint8_t* image_ec_ptr =
+            ec_row + (exr_x1 - displayWindow.min.x) * ec.pixel_stride();
+        memcpy(image_ec_ptr, exr_ec_ptr,
+               (exr_x2 - exr_x1 + 1) * ec.pixel_stride());
       }
     }
   }
 
   ppf->color_encoding.transfer_function = JXL_TRANSFER_FUNCTION_LINEAR;
-  ppf->color_encoding.color_space = JXL_COLOR_SPACE_RGB;
+  ppf->color_encoding.color_space =
+      has_rgb ? JXL_COLOR_SPACE_RGB : JXL_COLOR_SPACE_GRAY;
   ppf->color_encoding.primaries = JXL_PRIMARIES_SRGB;
   ppf->color_encoding.white_point = JXL_WHITE_POINT_D65;
-  if (OpenEXR::hasChromaticities(input.header())) {
+  if (OpenEXR::hasChromaticities(header)) {
     ppf->color_encoding.primaries = JXL_PRIMARIES_CUSTOM;
     ppf->color_encoding.white_point = JXL_WHITE_POINT_CUSTOM;
-    const auto& chromaticities = OpenEXR::chromaticities(input.header());
+    const auto& chromaticities = OpenEXR::chromaticities(header);
     ppf->color_encoding.primaries_red_xy[0] = chromaticities.red.x;
     ppf->color_encoding.primaries_red_xy[1] = chromaticities.red.y;
     ppf->color_encoding.primaries_green_xy[0] = chromaticities.green.x;
@@ -246,11 +400,11 @@ Status DecodeImageEXR(Span<const uint8_t> bytes, const ColorHints& color_hints,
   }
 
   // EXR uses binary16 or binary32 floating point format.
-  ppf->info.bits_per_sample = kExrBitsPerSample;
-  ppf->info.exponent_bits_per_sample = kExrBitsPerSample == 16 ? 5 : 8;
+  ppf->info.bits_per_sample = chBase->type == OpenEXR::HALF ? 16 : 32;
+  ppf->info.exponent_bits_per_sample = chBase->type == OpenEXR::HALF ? 5 : 8;
   if (has_alpha) {
-    ppf->info.alpha_bits = kExrAlphaBits;
-    ppf->info.alpha_exponent_bits = ppf->info.exponent_bits_per_sample;
+    ppf->info.alpha_bits = chA->type == OpenEXR::HALF ? 16 : 32;
+    ppf->info.alpha_exponent_bits = chA->type == OpenEXR::HALF ? 5 : 8;
     ppf->info.alpha_premultiplied = JXL_TRUE;
   }
   ppf->info.intensity_target = intensity_target;

--- a/lib/extras/enc/jxl.cc
+++ b/lib/extras/enc/jxl.cc
@@ -348,12 +348,12 @@ bool EncodeImageJXL(const JXLCompressParams& params, const PackedPixelFile& ppf,
       }
       // Only set extra channel buffer if it is provided non-interleaved.
       for (size_t i = 0; i < pframe.extra_channels.size(); ++i) {
-        if (JXL_ENC_SUCCESS !=
-            JxlEncoderSetExtraChannelBuffer(settings, &ppixelformat,
-                                            pframe.extra_channels[i].pixels(),
-                                            pframe.extra_channels[i].stride *
-                                                pframe.extra_channels[i].ysize,
-                                            num_interleaved_alpha + i)) {
+        if (JXL_ENC_SUCCESS != JxlEncoderSetExtraChannelBuffer(
+                                   settings, &pframe.extra_channels[i].format,
+                                   pframe.extra_channels[i].pixels(),
+                                   pframe.extra_channels[i].stride *
+                                       pframe.extra_channels[i].ysize,
+                                   num_interleaved_alpha + i)) {
           fprintf(stderr, "JxlEncoderSetExtraChannelBuffer() failed.\n");
           return false;
         }


### PR DESCRIPTION
### Description

Improvements in handling EXR files when reading them in `cjxl`:
- No longer makes color channels always be FP16 (even for EXR files where they were FP32), fixing #465
- Support EXR files where color channel names are not strictly just `R`, `G`, `B` (`A`). Multi-layer files could have names like `Composite.Combined.R` etc. Now finds the first EXR "layer" (channel prefix ending with `.`) that contains channels `R`, `G`, `B` and uses that for color channels. Uses alpha with the same prefix.
- If no "color channels" are found, put first EXR channel as "grayscale", this makes it support luminance-only files like [Garden.exr](https://openexr.com/en/latest/test_images/LuminanceChroma/Garden.html) from EXR test suite.
- Read all other channels as "extra channels" to be encoded.
- Additionally, this fixes `EncodeImageJXL` to actually support per-channel pixel formats; previously it was using the same base color pixel format for all the extra channels.

This makes `cjxl` be able to read [Blender40.exr](https://aras-p.info/files/exr_files/Blender40.exr) (135MB) or [Blender41small.exr](https://aras-p.info/files/exr_files/Blender41small.exr) (3.3MB) with many channels.

**Issues I haven't figured out yet**:
- ~~When mixed channel precisions are used (e.g. Blender41small.exr above), the FP32 channels seem to get encoded as garbage with `cjxl -d 0 -e 2`. The data that ends up in corresponding `PackedImage` object of that channel seems to be correct, so something further down in the whole compression pipeline goes wrong?~~ _Fixed in EncodeImageJXL_.
- Extra channel names do not come through to JXL file. I am setting them in `PackedExtraChannel` but maybe that is not used further down?

### Pull Request Checklist

- [x] **CLA Signed**: Have you signed the [Contributor License Agreement](https://code.google.com/legal/individual-cla-v1.0.html) (individual or corporate, as appropriate)? Only contributions from signed contributors can be accepted.
- [x] **Authors**: Have you considered adding your name to the [AUTHORS](AUTHORS) file?
- [x] **Code Style**: Have you ensured your code adheres to the project's coding style guidelines? You can use `./ci.sh lint` for automatic code formatting.
