### PR TITLE
Remove libm dependency when building with MSVC

### DIFF
--- a/lib/jxl.cmake
+++ b/lib/jxl.cmake
@@ -269,12 +269,17 @@ install(TARGETS jxl
 set(JPEGXL_LIBRARY_REQUIRES
     "libhwy libbrotlienc libbrotlidec libjxl_cms")
 
+# MSVCRT bundles math functions so no explicit libm dependency is required
 if (BUILD_SHARED_LIBS)
   set(JPEGXL_REQUIRES_TYPE "Requires.private")
-  set(JPEGXL_PRIVATE_LIBS "-lm ${PKGCONFIG_CXX_LIB}")
+  if(NOT MSVC)
+    set(JPEGXL_PRIVATE_LIBS "-lm ${PKGCONFIG_CXX_LIB}")
+  endif()
 else()
   set(JPEGXL_REQUIRES_TYPE "Requires")
-  set(JPEGXL_PUBLIC_LIBS "-lm ${PKGCONFIG_CXX_LIB}")
+  if(NOT MSVC)
+    set(JPEGXL_PUBLIC_LIBS "-lm ${PKGCONFIG_CXX_LIB}")
+  endif()
 endif()
 
 configure_file("${CMAKE_CURRENT_SOURCE_DIR}/jxl/libjxl.pc.in"


### PR DESCRIPTION
<!-- Thank you for considering a contribution to `libjxl`! -->

### Description

See https://github.com/microsoft/vcpkg/pull/46177 for more context, but the vcpkg libjxl port was broken on MSVC due to consumers of the target attempting to link with `m.lib`, as libm is not a thing in MSVCRT. It was asked that my patch to the port also be upstreamed into libjxl itself.

### Pull Request Checklist

- [x] **CLA Signed**: Have you signed the [Contributor License Agreement](https://code.google.com/legal/individual-cla-v1.0.html) (individual or corporate, as appropriate)? Only contributions from signed contributors can be accepted.
- [x] **Authors**: Have you considered adding your name to the [AUTHORS](AUTHORS) file?
- [x] **Code Style**: Have you ensured your code adheres to the project's coding style guidelines? You can use `./ci.sh lint` for automatic code formatting.


Please review the full [contributing guidelines](https://github.com/libjxl/libjxl/blob/main/CONTRIBUTING.md) for more details.
