### PR TITLE
Image viewers: for jxl files, use Qt for color transforms instead of lcms2

### DIFF
--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -4,9 +4,11 @@
 # license that can be found in the LICENSE file.
 
 # ICC detection library used by the comparison and viewer tools.
+# We require Qt 6.8 for the various color management improvements introduced in that version.
+set(JPEGXL_QT_VERSION_REQUIRED 6.8)
 if(JPEGXL_ENABLE_VIEWERS)
 if(WIN32)
-  find_package(Qt6 QUIET COMPONENTS Widgets)
+  find_package(Qt6 "${JPEGXL_QT_VERSION_REQUIRED}" QUIET COMPONENTS Widgets)
   if (NOT Qt6_FOUND)
     message(WARNING "Qt6 was not found.")
   else()
@@ -22,7 +24,7 @@ if(WIN32)
     endif()  # JPEGXL_DEP_LICENSE_DIR
   endif()
 elseif(APPLE)
-  find_package(Qt6 QUIET COMPONENTS Widgets)
+  find_package(Qt6 "${JPEGXL_QT_VERSION_REQUIRED}" QUIET COMPONENTS Widgets)
   if (Qt6_FOUND)
     add_library(icc_detect STATIC EXCLUDE_FROM_ALL
       icc_detect/icc_detect_empty.cc
@@ -34,7 +36,7 @@ elseif(APPLE)
     message(WARNING "APPLE: Qt6 was not found.")
   endif()
 else()
-  find_package(Qt6 QUIET COMPONENTS Widgets)
+  find_package(Qt6 "${JPEGXL_QT_VERSION_REQUIRED}" QUIET COMPONENTS Widgets)
   find_package(ECM QUIET NO_MODULE)
   if (NOT Qt6_FOUND OR NOT ECM_FOUND)
     if (NOT Qt6_FOUND)

--- a/tools/comparison_viewer/CMakeLists.txt
+++ b/tools/comparison_viewer/CMakeLists.txt
@@ -24,16 +24,12 @@ add_library(image_loading STATIC
   image_loading.cc
   image_loading.h
 )
-target_include_directories(image_loading PRIVATE
-  $<TARGET_PROPERTY:lcms2,INCLUDE_DIRECTORIES>
-)
 target_link_libraries(image_loading PUBLIC
   Qt6::Widgets
   jxl-internal
   jxl_threads
   jxl_extras-internal
   jxl_tool
-  lcms2
 )
 
 add_executable(compare_codecs WIN32

--- a/tools/viewer/CMakeLists.txt
+++ b/tools/viewer/CMakeLists.txt
@@ -26,14 +26,10 @@ add_executable(viewer WIN32
   viewer_window.h
   viewer_window.ui
 )
-target_include_directories(viewer PRIVATE
-  $<TARGET_PROPERTY:lcms2,INCLUDE_DIRECTORIES>
-  "${PROJECT_SOURCE_DIR}"
-)
+target_include_directories(viewer PRIVATE "${PROJECT_SOURCE_DIR}")
 target_link_libraries(viewer
   Qt6::Widgets
   icc_detect
   jxl
   jxl_threads
-  lcms2
 )


### PR DESCRIPTION
Simpler and much faster (an image that took over 11 seconds to load on my machine now takes 850ms).