### PR TITLE
cjxl: set extra channel names

### DIFF
--- a/lib/extras/enc/jxl.cc
+++ b/lib/extras/enc/jxl.cc
@@ -90,6 +90,15 @@ bool SetupFrame(JxlEncoder* enc, JxlEncoderFrameSettings* settings,
         fprintf(stderr, "JxlEncoderSetExtraChannelInfo() failed.\n");
         return false;
       }
+      const auto& ec_name = ppf.extra_channels_info[i].name;
+      if (!ec_name.empty() && false) {
+        if (JXL_ENC_SUCCESS !=
+            JxlEncoderSetExtraChannelName(enc, num_interleaved_alpha + i,
+                                          ec_name.c_str(), ec_name.size())) {
+          fprintf(stderr, "JxlEncoderSetExtraChannelName() failed.\n");
+          return false;
+        }
+      }
     }
   }
   return true;

--- a/lib/extras/enc/jxl.cc
+++ b/lib/extras/enc/jxl.cc
@@ -91,7 +91,7 @@ bool SetupFrame(JxlEncoder* enc, JxlEncoderFrameSettings* settings,
         return false;
       }
       const auto& ec_name = ppf.extra_channels_info[i].name;
-      if (!ec_name.empty() && false) {
+      if (!ec_name.empty()) {
         if (JXL_ENC_SUCCESS !=
             JxlEncoderSetExtraChannelName(enc, num_interleaved_alpha + i,
                                           ec_name.c_str(), ec_name.size())) {


### PR DESCRIPTION
### Description

PackedExtraChannel name was being ignored when encoding JXL files, now it is set via JxlEncoderSetExtraChannelName. This makes cjxl preserve channel names coming from multi-layer EXR files better.

I noticed this while doing #4312 and a comment there said that fixing this issue separately is the way to go.

### Pull Request Checklist

- [x] **CLA Signed**: Have you signed the [Contributor License Agreement](https://code.google.com/legal/individual-cla-v1.0.html) (individual or corporate, as appropriate)? Only contributions from signed contributors can be accepted.
- [x] **Authors**: Have you considered adding your name to the [AUTHORS](AUTHORS) file?
- [x] **Code Style**: Have you ensured your code adheres to the project's coding style guidelines? You can use `./ci.sh lint` for automatic code formatting.
