### PR TITLE
Speedup uint-coding trial

### DIFF
--- a/lib/jxl/dec_ans.h
+++ b/lib/jxl/dec_ans.h
@@ -89,6 +89,8 @@ struct HybridUintConfig {
     }
   }
 
+  JXL_INLINE uint32_t LsbMask() const { return (1 << lsb_in_token) - 1; }
+
   explicit HybridUintConfig(uint32_t split_exponent = 4,
                             uint32_t msb_in_token = 2,
                             uint32_t lsb_in_token = 0)

--- a/lib/jxl/enc_ans.h
+++ b/lib/jxl/enc_ans.h
@@ -114,7 +114,8 @@ struct EntropyEncodingData {
       const Histogram& histogram, BitWriter* writer);
 
  private:
-  Status ChooseUintConfigs(const HistogramParams& params,
+  Status ChooseUintConfigs(JxlMemoryManager* memory_manager,
+                           const HistogramParams& params,
                            const std::vector<std::vector<Token>>& tokens,
                            std::vector<Histogram>& clustered_histograms);
 };

--- a/lib/jxl/enc_ans_simd.cc
+++ b/lib/jxl/enc_ans_simd.cc
@@ -1,0 +1,232 @@
+// Copyright (c) the JPEG XL Project Authors. All rights reserved.
+//
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+#include "lib/jxl/enc_ans_simd.h"
+
+#include <cstdint>
+
+#include "lib/jxl/base/status.h"
+#include "lib/jxl/dec_ans.h"
+#include "lib/jxl/memory_manager_internal.h"
+
+#undef HWY_TARGET_INCLUDE
+#define HWY_TARGET_INCLUDE "lib/jxl/enc_ans_simd.cc"
+#include <hwy/foreach_target.h>
+#include <hwy/highway.h>
+
+HWY_BEFORE_NAMESPACE();
+namespace jxl {
+namespace HWY_NAMESPACE {
+
+// These templates are not found via ADL.
+using hwy::HWY_NAMESPACE::Add;
+using hwy::HWY_NAMESPACE::And;
+using hwy::HWY_NAMESPACE::Ge;
+using hwy::HWY_NAMESPACE::GetLane;
+using hwy::HWY_NAMESPACE::IfThenElse;
+using hwy::HWY_NAMESPACE::IfThenElseZero;
+using hwy::HWY_NAMESPACE::Iota;
+using hwy::HWY_NAMESPACE::LoadU;
+using hwy::HWY_NAMESPACE::Lt;
+using hwy::HWY_NAMESPACE::Mul;
+using hwy::HWY_NAMESPACE::Or;
+using hwy::HWY_NAMESPACE::Set;
+using hwy::HWY_NAMESPACE::ShiftRight;
+using hwy::HWY_NAMESPACE::Store;
+using hwy::HWY_NAMESPACE::Sub;
+using hwy::HWY_NAMESPACE::Zero;
+
+template <size_t E, size_t M, size_t L>
+uint32_t EstimateTokenCostImpl(uint32_t* JXL_RESTRICT values, size_t len,
+                               uint32_t* JXL_RESTRICT out) {
+  const HWY_FULL(uint32_t) du;
+  const HWY_FULL(float) df;
+  const auto kZero = Zero(du);
+  const auto kSplit = Set(du, 1 << E);
+  const auto kExpOffset = Set(du, 127);
+  const auto kEBOffset = Set(du, 127 + M + L);
+  const auto kBase = Set(du, static_cast<uint32_t>((1 << E) - (E << (M + L))));
+  const auto kMulN = Set(du, 1 << (M + L));
+  const auto kMaskL = Set(du, (1 << L) - 1);
+  const auto kMaskM = Set(du, ((1 << M) - 1) << L);
+
+  auto extra_bits = kZero;
+  size_t last_full = Lanes(du) * (len / Lanes(du));
+  for (size_t i = 0; i < last_full; i += Lanes(du)) {
+    const auto val = LoadU(du, values + i);
+    const auto not_literal = Ge(val, kSplit);
+    const auto b = BitCast(du, ConvertTo(df, val));
+    const auto l = And(val, kMaskL);
+    const auto exp = ShiftRight<23>(b);
+    const auto n = Sub(exp, kExpOffset);
+    const auto eb = Sub(exp, kEBOffset);
+    const auto m = ShiftRight<23 - M - L>(b);
+    const auto a = Add(kBase, Mul(n, kMulN));
+    const auto d = And(m, kMaskM);
+    const auto eb_fixed = IfThenElseZero(not_literal, eb);
+    const auto c = Or(a, l);
+    extra_bits = Add(extra_bits, eb_fixed);
+    const auto t = Or(c, d);
+    const auto t_fixed = IfThenElse(not_literal, t, val);
+    Store(t_fixed, du, out + i);
+  }
+  if (last_full < len) {
+    const auto stop = Set(du, len);
+    const auto fence = Iota(du, last_full);
+    const auto take = Lt(fence, stop);
+    const auto val = LoadU(du, values + last_full);
+    const auto not_literal = Ge(val, kSplit);
+    const auto b = BitCast(du, ConvertTo(df, val));
+    const auto l = And(val, kMaskL);
+    const auto exp = ShiftRight<23>(b);
+    const auto n = Sub(exp, kExpOffset);
+    const auto eb = Sub(exp, kEBOffset);
+    const auto m = ShiftRight<23 - M - L>(b);
+    const auto a = Add(kBase, Mul(n, kMulN));
+    const auto d = And(m, kMaskM);
+    const auto eb_fixed = IfThenElseZero(not_literal, eb);
+    const auto eb_masked = IfThenElseZero(take, eb_fixed);
+    const auto c = Or(a, l);
+    extra_bits = Add(extra_bits, eb_masked);
+    const auto t = Or(c, d);
+    const auto t_fixed = IfThenElse(not_literal, t, val);
+    Store(t_fixed, du, out + last_full);
+  }
+  return GetLane(SumOfLanes(du, extra_bits));
+}
+
+uint32_t EstimateTokenCost(uint32_t* JXL_RESTRICT values, size_t len,
+                           HybridUintConfig cfg, AlignedMemory& tokens) {
+  uint32_t* JXL_RESTRICT out = tokens.address<uint32_t>();
+#if HWY_TARGET == HWY_SCALAR
+  uint32_t extra_bits = 0;
+  for (size_t i = 0; i < len; ++i) {
+    uint32_t v = values[i];
+    uint32_t tok, nbits, bits;
+    cfg.Encode(v, &tok, &nbits, &bits);
+    extra_bits += nbits;
+    out[i] = tok;
+  }
+  return extra_bits;
+#else
+  if (cfg.split_exponent == 0) {
+    return EstimateTokenCostImpl<0, 0, 0>(values, len, out);
+  } else if (cfg.split_exponent == 2) {
+    JXL_DASSERT((cfg.msb_in_token == 0) && (cfg.lsb_in_token == 1));
+    return EstimateTokenCostImpl<2, 0, 1>(values, len, out);
+  } else if (cfg.split_exponent == 3) {
+    if (cfg.msb_in_token == 1) {
+      if (cfg.lsb_in_token == 0) {
+        return EstimateTokenCostImpl<3, 1, 0>(values, len, out);
+      } else {
+        JXL_DASSERT(cfg.lsb_in_token == 2);
+        return EstimateTokenCostImpl<3, 1, 2>(values, len, out);
+      }
+    } else {
+      JXL_DASSERT(cfg.msb_in_token == 2);
+      if (cfg.lsb_in_token == 0) {
+        return EstimateTokenCostImpl<3, 2, 0>(values, len, out);
+      } else {
+        JXL_DASSERT(cfg.lsb_in_token == 1);
+        return EstimateTokenCostImpl<3, 2, 1>(values, len, out);
+      }
+    }
+  } else if (cfg.split_exponent == 4) {
+    if (cfg.msb_in_token == 1) {
+      if (cfg.lsb_in_token == 0) {
+        return EstimateTokenCostImpl<4, 1, 0>(values, len, out);
+      } else if (cfg.lsb_in_token == 2) {
+        return EstimateTokenCostImpl<4, 1, 2>(values, len, out);
+      } else {
+        JXL_DASSERT(cfg.lsb_in_token == 3);
+        return EstimateTokenCostImpl<4, 1, 3>(values, len, out);
+      }
+    } else {
+      JXL_DASSERT(cfg.msb_in_token == 2);
+      if (cfg.lsb_in_token == 0) {
+        return EstimateTokenCostImpl<4, 2, 0>(values, len, out);
+      } else if (cfg.lsb_in_token == 1) {
+        return EstimateTokenCostImpl<4, 2, 1>(values, len, out);
+      } else {
+        JXL_DASSERT(cfg.lsb_in_token == 2);
+        return EstimateTokenCostImpl<4, 2, 2>(values, len, out);
+      }
+    }
+  } else if (cfg.split_exponent == 5) {
+    if (cfg.msb_in_token == 1) {
+      if (cfg.lsb_in_token == 0) {
+        return EstimateTokenCostImpl<5, 1, 0>(values, len, out);
+      } else if (cfg.lsb_in_token == 2) {
+        return EstimateTokenCostImpl<5, 1, 2>(values, len, out);
+      } else {
+        JXL_DASSERT(cfg.lsb_in_token == 4);
+        return EstimateTokenCostImpl<5, 1, 4>(values, len, out);
+      }
+    } else {
+      JXL_DASSERT(cfg.msb_in_token == 2);
+      if (cfg.lsb_in_token == 0) {
+        return EstimateTokenCostImpl<5, 2, 0>(values, len, out);
+      } else if (cfg.lsb_in_token == 1) {
+        return EstimateTokenCostImpl<5, 2, 1>(values, len, out);
+      } else if (cfg.lsb_in_token == 2) {
+        return EstimateTokenCostImpl<5, 2, 2>(values, len, out);
+      } else {
+        JXL_DASSERT(cfg.lsb_in_token == 3);
+        return EstimateTokenCostImpl<5, 2, 3>(values, len, out);
+      }
+    }
+  } else if (cfg.split_exponent == 6) {
+    if (cfg.msb_in_token == 0) {
+      JXL_DASSERT(cfg.lsb_in_token == 0);
+      return EstimateTokenCostImpl<6, 0, 0>(values, len, out);
+    } else if (cfg.msb_in_token == 1) {
+      JXL_DASSERT(cfg.lsb_in_token == 5);
+      return EstimateTokenCostImpl<6, 1, 5>(values, len, out);
+    } else {
+      JXL_DASSERT(cfg.msb_in_token == 2);
+      JXL_DASSERT(cfg.lsb_in_token == 4);
+      return EstimateTokenCostImpl<6, 2, 4>(values, len, out);
+    }
+  } else if (cfg.split_exponent >= 7 && cfg.split_exponent <= 12) {
+    JXL_DASSERT(cfg.msb_in_token == 0);
+    JXL_DASSERT(cfg.lsb_in_token == 0);
+    if (cfg.split_exponent == 7) {
+      return EstimateTokenCostImpl<7, 0, 0>(values, len, out);
+    } else if (cfg.split_exponent == 8) {
+      return EstimateTokenCostImpl<8, 0, 0>(values, len, out);
+    } else if (cfg.split_exponent == 9) {
+      return EstimateTokenCostImpl<9, 0, 0>(values, len, out);
+    } else if (cfg.split_exponent == 10) {
+      return EstimateTokenCostImpl<10, 0, 0>(values, len, out);
+    } else if (cfg.split_exponent == 11) {
+      return EstimateTokenCostImpl<11, 0, 0>(values, len, out);
+    } else {
+      return EstimateTokenCostImpl<12, 0, 0>(values, len, out);
+    }
+  } else {
+    JXL_DASSERT(false);
+  }
+  return ~0;
+#endif
+}
+
+// NOLINTNEXTLINE(google-readability-namespace-comments)
+}  // namespace HWY_NAMESPACE
+}  // namespace jxl
+HWY_AFTER_NAMESPACE();
+
+#if HWY_ONCE
+namespace jxl {
+
+HWY_EXPORT(EstimateTokenCost);
+
+uint32_t EstimateTokenCost(uint32_t* JXL_RESTRICT values, size_t len,
+                           HybridUintConfig cfg, AlignedMemory& tokens) {
+  JXL_DASSERT(cfg.lsb_in_token + cfg.msb_in_token <= cfg.split_exponent);
+  return HWY_DYNAMIC_DISPATCH(EstimateTokenCost)(values, len, cfg, tokens);
+}
+
+}  // namespace jxl
+#endif

--- a/lib/jxl/enc_ans_simd.h
+++ b/lib/jxl/enc_ans_simd.h
@@ -1,0 +1,24 @@
+// Copyright (c) the JPEG XL Project Authors. All rights reserved.
+//
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+#ifndef LIB_JXL_ENC_ANS_SIMD_H_
+#define LIB_JXL_ENC_ANS_SIMD_H_
+
+#include <cstddef>
+#include <cstdint>
+
+#include "lib/jxl/base/compiler_specific.h"
+#include "lib/jxl/dec_ans.h"
+#include "lib/jxl/memory_manager_internal.h"
+
+namespace jxl {
+
+// Returns "extra_bits" sum and puts tokens into `tokens`.
+uint32_t EstimateTokenCost(uint32_t* JXL_RESTRICT values, size_t len,
+                           HybridUintConfig cfg, AlignedMemory& tokens);
+
+}  // namespace jxl
+
+#endif  // LIB_JXL_ENC_ANS_SIMD_H_

--- a/lib/jxl/simd_util.cc
+++ b/lib/jxl/simd_util.cc
@@ -16,9 +16,34 @@ HWY_BEFORE_NAMESPACE();
 namespace jxl {
 namespace HWY_NAMESPACE {
 
+using hwy::HWY_NAMESPACE::GetLane;
+using hwy::HWY_NAMESPACE::IfThenElseZero;
+using hwy::HWY_NAMESPACE::Iota;
+using hwy::HWY_NAMESPACE::LoadU;
+using hwy::HWY_NAMESPACE::Lt;
+using hwy::HWY_NAMESPACE::Max;
+using hwy::HWY_NAMESPACE::MaxOfLanes;
+using hwy::HWY_NAMESPACE::Set;
+
 size_t MaxVectorSize() {
   HWY_FULL(float) df;
   return Lanes(df) * sizeof(float);
+}
+
+uint32_t MaxValue(uint32_t* JXL_RESTRICT data, size_t len) {
+  HWY_FULL(uint32_t) du;
+  size_t last_full = Lanes(du) * (len / Lanes(du));
+  auto max = Set(du, 0);
+  for (size_t i = 0; i < last_full; i += Lanes(du)) {
+    max = Max(max, LoadU(du, data + i));
+  }
+  if (last_full < len) {
+    const auto stop = Set(du, len);
+    const auto fence = Iota(du, last_full);
+    const auto take = Lt(fence, stop);
+    max = Max(max, IfThenElseZero(take, LoadU(du, data + last_full)));
+  }
+  return GetLane(MaxOfLanes(du, max));
 }
 
 // NOLINTNEXTLINE(google-readability-namespace-comments)
@@ -30,12 +55,17 @@ HWY_AFTER_NAMESPACE();
 namespace jxl {
 
 HWY_EXPORT(MaxVectorSize);
+HWY_EXPORT(MaxValue);
 
 size_t MaxVectorSize() {
   // Ideally HWY framework should provide us this value.
   // Less than ideal is to check all available targets and choose maximal.
   // As for now, we just ask current active target, assuming it won't change.
   return HWY_DYNAMIC_DISPATCH(MaxVectorSize)();
+}
+
+uint32_t MaxValue(uint32_t* JXL_RESTRICT data, size_t len) {
+  return HWY_DYNAMIC_DISPATCH(MaxValue)(data, len);
 }
 
 }  // namespace jxl

--- a/lib/jxl/simd_util.h
+++ b/lib/jxl/simd_util.h
@@ -7,11 +7,16 @@
 #define LIB_JXL_SIMD_UTIL_H_
 
 #include <cstddef>
+#include <cstdint>
+
+#include "lib/jxl/base/compiler_specific.h"
 
 namespace jxl {
 
 // Maximal vector size in bytes.
 size_t MaxVectorSize();
+
+uint32_t MaxValue(uint32_t* JXL_RESTRICT data, size_t len);
 
 }  // namespace jxl
 

--- a/lib/jxl_lists.bzl
+++ b/lib/jxl_lists.bzl
@@ -309,6 +309,8 @@ libjxl_enc_sources = [
     "jxl/enc_ans.cc",
     "jxl/enc_ans.h",
     "jxl/enc_ans_params.h",
+    "jxl/enc_ans_simd.cc",
+    "jxl/enc_ans_simd.h",
     "jxl/enc_aux_out.cc",
     "jxl/enc_aux_out.h",
     "jxl/enc_bit_writer.cc",

--- a/lib/jxl_lists.cmake
+++ b/lib/jxl_lists.cmake
@@ -306,6 +306,8 @@ set(JPEGXL_INTERNAL_ENC_SOURCES
   jxl/enc_ans.cc
   jxl/enc_ans.h
   jxl/enc_ans_params.h
+  jxl/enc_ans_simd.cc
+  jxl/enc_ans_simd.h
   jxl/enc_aux_out.cc
   jxl/enc_aux_out.h
   jxl/enc_bit_writer.cc

--- a/lib/lib.gni
+++ b/lib/lib.gni
@@ -307,6 +307,8 @@ libjxl_enc_sources = [
     "jxl/enc_ans.cc",
     "jxl/enc_ans.h",
     "jxl/enc_ans_params.h",
+    "jxl/enc_ans_simd.cc",
+    "jxl/enc_ans_simd.h",
     "jxl/enc_aux_out.cc",
     "jxl/enc_aux_out.h",
     "jxl/enc_bit_writer.cc",


### PR DESCRIPTION
Unshuffle tokens, SIMDfy Encode, pre-stretch histograms.

`d0 m1 e8` becomes 1.17x faster
