### PR TITLE
Do not ignore rct_type=0

### DIFF
--- a/lib/jxl/enc_modular.cc
+++ b/lib/jxl/enc_modular.cc
@@ -1460,7 +1460,10 @@ Status ModularFrameEncoder::PrepareStreamParams(const Rect& rect,
       if (nb_rcts_to_try == 0) break;
       sg.rct_type = i;
       nb_rcts_to_try--;
-      if (do_transform(gi, sg, weighted::Header())) {
+      // no-op rct_type; use as baseline cost
+      if (i == 0) {
+        JXL_ASSIGN_OR_RETURN(best_cost, EstimateCost(gi));
+      } else if (do_transform(gi, sg, weighted::Header())) {
         JXL_ASSIGN_OR_RETURN(float cost, EstimateCost(gi));
         if (cost < best_cost) {
           best_rct = i;
@@ -1472,8 +1475,10 @@ Status ModularFrameEncoder::PrepareStreamParams(const Rect& rect,
       }
     }
     // Apply the best RCT to the image for future encoding.
-    sg.rct_type = best_rct;
-    do_transform(gi, sg, weighted::Header());
+    if (best_rct != 0) {
+      sg.rct_type = best_rct;
+      do_transform(gi, sg, weighted::Header());
+    }
   } else {
     // No need to try anything, just use the default options.
   }

--- a/lib/jxl/jxl_test.cc
+++ b/lib/jxl/jxl_test.cc
@@ -1083,7 +1083,7 @@ JXL_SLOW_TEST(JxlTest, RoundtripLossless8) {
   PackedPixelFile ppf_out;
   size_t compressed_size =
       Roundtrip(t.ppf(), cparams, dparams, pool.get(), &ppf_out);
-  EXPECT_EQ(compressed_size, 222547u);
+  EXPECT_EQ(compressed_size, 218429u);
   EXPECT_EQ(ComputeDistance2(t.ppf(), ppf_out), 0.0);
 }
 
@@ -1163,7 +1163,7 @@ TEST(JxlTest, RoundtripLossless8Alpha) {
 
   PackedPixelFile ppf_out;
   size_t compressed_size = Roundtrip(t.ppf(), cparams, dparams, pool, &ppf_out);
-  EXPECT_EQ(compressed_size, 250392u);
+  EXPECT_EQ(compressed_size, 246225u);
   EXPECT_EQ(ComputeDistance2(t.ppf(), ppf_out), 0.0);
   EXPECT_EQ(ppf_out.info.alpha_bits, 8);
   EXPECT_TRUE(test::SameAlpha(t.ppf(), ppf_out));
@@ -1202,7 +1202,8 @@ TEST(JxlTest, RoundtripLossless16Alpha) {
 
   PackedPixelFile ppf_out;
   // TODO(szabadka) Investigate big size difference on i686
-  EXPECT_NEAR(Roundtrip(t.ppf(), cparams, dparams, pool, &ppf_out), 4906, 100);
+  size_t compressed_size = Roundtrip(t.ppf(), cparams, dparams, pool, &ppf_out);
+  EXPECT_NEAR(compressed_size, 3477, 100);
   EXPECT_EQ(ComputeDistance2(t.ppf(), ppf_out), 0.0);
   EXPECT_EQ(ppf_out.info.alpha_bits, 16);
   EXPECT_TRUE(test::SameAlpha(t.ppf(), ppf_out));
@@ -1241,7 +1242,8 @@ TEST(JxlTest, RoundtripLossless16AlphaNotMisdetectedAs8Bit) {
   dparams.accepted_formats.push_back(t.ppf().frames[0].color.format);
 
   PackedPixelFile ppf_out;
-  EXPECT_NEAR(Roundtrip(t.ppf(), cparams, dparams, pool, &ppf_out), 331u, 100u);
+  size_t compressed_size = Roundtrip(t.ppf(), cparams, dparams, pool, &ppf_out);
+  EXPECT_NEAR(compressed_size, 1278u, 100u);
   EXPECT_EQ(ComputeDistance2(t.ppf(), ppf_out), 0.0);
   EXPECT_EQ(ppf_out.info.bits_per_sample, 16);
   EXPECT_EQ(ppf_out.info.alpha_bits, 16);


### PR DESCRIPTION
This improves density in relevant cases
