### PR TITLE
fix decoding jpeg images with ICC/XYB

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -56,6 +56,7 @@ Dirk Lemstra <dirk@lemstra.org>
 Dmitry Baryshev <dima8w@gmail.com>
 Don Olmstead <don.j.olmstead@gmail.com>
 Dong Xu <xdong181@gmail.com>
+Emre Akyüz <emreakyuz_2@hotmail.com>
 estrogently <41487185+estrogently@users.noreply.github.com>
 Even Rouault <even.rouault@spatialys.com>
 Fred Brennan <copypaste@kittens.ph>

--- a/lib/extras/dec/decode.cc
+++ b/lib/extras/dec/decode.cc
@@ -220,10 +220,11 @@ Codec DetectCodec(const Span<const uint8_t>& bytes) {
        {'P', '7'},
        {'P', 'F'},
        {'P', 'f'}}};
-  static const std::array<std::array<uint8_t, 4>, 4> kJpgSignatures = {{
+  static const std::array<std::array<uint8_t, 4>, 5> kJpgSignatures = {{
       {0xFF, 0xD8, 0xFF, 0xDB},
       {0xFF, 0xD8, 0xFF, 0xE0},
       {0xFF, 0xD8, 0xFF, 0xE1},
+      {0xFF, 0xD8, 0xFF, 0xE2},
       {0xFF, 0xD8, 0xFF, 0xEE},
   }};
   static const std::array<std::array<uint8_t, 9>, 1> kJxlBoxSignatures = {{


### PR DESCRIPTION
### Description

Currently, JPEG images with an APP2 marker/ICC profile (XYB for example) can not be decoded by SSIMULACRA2 or Butteraugli. The breaking commit is: #4268 

### Pull Request Checklist

- [X] **CLA Signed**: Have you signed the [Contributor License Agreement](https://code.google.com/legal/individual-cla-v1.0.html) (individual or corporate, as appropriate)? Only contributions from signed contributors can be accepted.
- [X] **Authors**: Have you considered adding your name to the [AUTHORS](AUTHORS) file?
- [X] **Code Style**: Have you ensured your code adheres to the project's coding style guidelines? You can use `./ci.sh lint` for automatic code formatting.
