### PR TITLE
Make VerifyDimensions always to some sanity check

### DIFF
--- a/lib/extras/size_constraints.h
+++ b/lib/extras/size_constraints.h
@@ -16,22 +16,24 @@ namespace jxl {
 struct SizeConstraints {
   // Upper limit on pixel dimensions/area, enforced by VerifyDimensions
   // (called from decoders). Fuzzers set smaller values to limit memory use.
-  uint32_t dec_max_xsize = 0xFFFFFFFFu;
-  uint32_t dec_max_ysize = 0xFFFFFFFFu;
-  uint64_t dec_max_pixels = 0xFFFFFFFFu;  // Might be up to ~0ull
+  // Default values correspond to JXL level 10.
+  uint32_t dec_max_xsize = 1u << 30;
+  uint32_t dec_max_ysize = 1u << 30;
+  uint64_t dec_max_pixels = static_cast<uint64_t>(1u) << 40;
 };
 
 template <typename T,
           class = typename std::enable_if<std::is_unsigned<T>::value>::type>
 Status VerifyDimensions(const SizeConstraints* constraints, T xs, T ys) {
-  if (!constraints) return true;
+  SizeConstraints limit = {};
+  if (constraints) limit = *constraints;
 
   if (xs == 0 || ys == 0) return JXL_FAILURE("Empty image.");
-  if (xs > constraints->dec_max_xsize) return JXL_FAILURE("Image too wide.");
-  if (ys > constraints->dec_max_ysize) return JXL_FAILURE("Image too tall.");
+  if (xs > limit.dec_max_xsize) return JXL_FAILURE("Image too wide.");
+  if (ys > limit.dec_max_ysize) return JXL_FAILURE("Image too tall.");
 
   const uint64_t num_pixels = static_cast<uint64_t>(xs) * ys;
-  if (num_pixels > constraints->dec_max_pixels) {
+  if (num_pixels > limit.dec_max_pixels) {
     return JXL_FAILURE("Image too big.");
   }
 


### PR DESCRIPTION
Defaults are lowered a bit, but main concern is to make sure that check is always applied. This guarantees that is decoder that checked x/y-size of size_t type can safely downcast them to uint32_t (used in PackedImage).
