### PR TITLE
Undisable trixie

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -120,10 +120,13 @@ jobs:
         - ubuntu:20.04
         - debian:bullseye
         - debian:bookworm
-        # GIMP-2 package is removed: https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1078402
-        # GIMP-3 package has incompatible API: https://github.com/libjxl/libjxl/issues/4037
-        # - debian:trixie
-        # - debian:sid
+        - debian:trixie
+        - debian:sid
+        include:
+          - os: debian:trixie
+            exclude_debian_packages: libjxl-gimp-plugin
+          - os: debian:sid
+            exclude_debian_packages: libjxl-gimp-plugin
 
     container:
       image: ${{ matrix.os }}
@@ -142,6 +145,7 @@ jobs:
           build-essential \
           devscripts \
           python3 \
+          sed \
         #
 
     - name: Calculate artifact suffix
@@ -203,7 +207,7 @@ jobs:
     - name: Build libjxl
       run: |
         apt build-dep -y .
-        ./ci.sh debian_build jpeg-xl
+        EXCLUDE_DEBIAN_PACKAGES="${{ matrix.exclude_debian_packages || '' }}" ./ci.sh debian_build jpeg-xl
 
     - name: Stats
       run: |

--- a/ci.sh
+++ b/ci.sh
@@ -42,6 +42,7 @@ fi
 POST_MESSAGE_ON_ERROR="${POST_MESSAGE_ON_ERROR:-1}"
 # By default, do a lightweight debian HWY package build.
 HWY_PKG_OPTIONS="${HWY_PKG_OPTIONS:---set-envvar=HWY_EXTRA_CONFIG=-DBUILD_TESTING=OFF -DHWY_ENABLE_EXAMPLES=OFF -DHWY_ENABLE_CONTRIB=OFF}"
+EXCLUDE_DEBIAN_PACKAGES="${EXCLUDE_DEBIAN_PACKAGES:-}"
 
 # Set default compilers to clang if not already set
 export CC=${CC:-clang}
@@ -1387,6 +1388,11 @@ build_debian_pkg() {
       ln -s "${srcdir}/$f" "${builddir}/$f"
     fi
   done
+  if [[ -n "${EXCLUDE_DEBIAN_PACKAGES}" ]]; then
+    # TODO(eustas): support comma-separated list
+    rm -f "${builddir}"/debian/${EXCLUDE_DEBIAN_PACKAGES}.install
+    sed -i "/Package: ${EXCLUDE_DEBIAN_PACKAGES}/,/\n/d" "${builddir}"/debian/control
+  fi
   (
     cd "${builddir}"
     debuild "${options}" -b -uc -us

--- a/debian/control
+++ b/debian/control
@@ -10,7 +10,7 @@ Build-Depends:
  libbrotli-dev,
  libgdk-pixbuf-2.0-dev | libgdk-pixbuf2.0-dev,
  libgif-dev,
- libgimp2.0-dev,
+ libgimp2.0-dev | base-files (>= 13.8),
  libgoogle-perftools-dev,
  libgtest-dev,
  libhwy-dev (>= 1.0.0),


### PR DESCRIPTION
Since Gimp3 has their own JXL plugin, we could just discontinue shipping ours (for distros that dropped Gimp2).