### PR TITLE
fix malformed expressions

### DIFF
--- a/third_party/skcms.cmake
+++ b/third_party/skcms.cmake
@@ -18,23 +18,31 @@ function(target_link_skcms TARGET_NAME)
     "${_sources_dir}/skcms.cc"
     "${_sources_dir}/src/skcms_TransformBaseline.cc"
   )
-
   if (CMAKE_CXX_COMPILER_ID MATCHES "GNU")
     set_source_files_properties("${_sources_dir}/src/skcms_TransformBaseline.cc"
       PROPERTIES COMPILE_OPTIONS "-Wno-maybe-uninitialized"
       TARGET_DIRECTORY ${TARGET_NAME}
     )
   endif()
-
+  
   if(CMAKE_SYSTEM_PROCESSOR MATCHES "x86_64" AND CMAKE_CXX_COMPILER_ID MATCHES "Clang")
-    set(_use_avx2 ${CXX_MAVX2_SUPPORTED} AND ${CXX_MF16C_SUPPORTED})
-    set(_use_avx512 ${CXX_MAVX512F_SUPPORTED} AND ${CXX_MAVX512DQ_SUPPORTED} AND ${CXX_MAVX512CD_SUPPORTED} AND ${CXX_MAVX512BW_SUPPORTED} AND ${CXX_MAVX512VL_SUPPORTED})
+    if(CXX_MAVX2_SUPPORTED AND CXX_MF16C_SUPPORTED)
+      set(_use_avx2 TRUE)
+    else()
+      set(_use_avx2 FALSE)
+    endif()
+    
+    if(CXX_MAVX512F_SUPPORTED AND CXX_MAVX512DQ_SUPPORTED AND CXX_MAVX512CD_SUPPORTED AND CXX_MAVX512BW_SUPPORTED AND CXX_MAVX512VL_SUPPORTED)
+      set(_use_avx512 TRUE)
+    else()
+      set(_use_avx512 FALSE)
+    endif()
   else()
-    set(_use_avx2 0)
-    set(_use_avx512 0)
+    set(_use_avx2 FALSE)
+    set(_use_avx512 FALSE)
   endif()
-
-  if(${_use_avx2})
+  
+  if(_use_avx2)
     list(APPEND _sources "${_sources_dir}/src/skcms_TransformHsw.cc")
     set_source_files_properties("${_sources_dir}/src/skcms_TransformHsw.cc"
       PROPERTIES COMPILE_OPTIONS "-march=x86-64;-mavx2;-mf16c"
@@ -43,7 +51,8 @@ function(target_link_skcms TARGET_NAME)
   else()
     target_compile_definitions(${TARGET_NAME} PRIVATE -DSKCMS_DISABLE_HSW)
   endif()
-  if(${_use_avx512})
+  
+  if(_use_avx512)
     list(APPEND _sources "${_sources_dir}/src/skcms_TransformSkx.cc")
     set_source_files_properties("${_sources_dir}/src/skcms_TransformSkx.cc"
       PROPERTIES COMPILE_OPTIONS "-march=x86-64;-mavx512f;-mavx512dq;-mavx512cd;-mavx512bw;-mavx512vl"
@@ -52,14 +61,14 @@ function(target_link_skcms TARGET_NAME)
   else()
     target_compile_definitions(${TARGET_NAME} PRIVATE -DSKCMS_DISABLE_SKX)
   endif()
-
-  target_sources(${TARGET_NAME} PRIVATE "${_sources}")
+  
+  target_sources(${TARGET_NAME} PRIVATE ${_sources})
   target_include_directories(${TARGET_NAME} PRIVATE "${PROJECT_SOURCE_DIR}/third_party/skcms/")
-
+  
   include(CheckCXXCompilerFlag)
   check_cxx_compiler_flag("-Wno-psabi" CXX_WPSABI_SUPPORTED)
   if(CXX_WPSABI_SUPPORTED)
-    set_source_files_properties("${_sources}"
+    set_source_files_properties(${_sources}
       PROPERTIES COMPILE_OPTIONS "-Wno-psabi"
       TARGET_DIRECTORY ${TARGET_NAME})
   endif()

--- a/third_party/skcms.cmake
+++ b/third_party/skcms.cmake
@@ -18,58 +18,56 @@ function(target_link_skcms TARGET_NAME)
     "${_sources_dir}/skcms.cc"
     "${_sources_dir}/src/skcms_TransformBaseline.cc"
   )
-  if (CMAKE_CXX_COMPILER_ID MATCHES "GNU")
-    set_source_files_properties("${_sources_dir}/src/skcms_TransformBaseline.cc"
-      PROPERTIES COMPILE_OPTIONS "-Wno-maybe-uninitialized"
+
+  # TODO(eustas): investigate if we need this.
+  set(_common_copts)
+  include(CheckCXXCompilerFlag)
+  check_cxx_compiler_flag("-Wno-psabi" CXX_WPSABI_SUPPORTED)
+  if (CXX_WPSABI_SUPPORTED)
+    set(_common_copts "-Wno-psabi")
+    set_source_files_properties(${_sources}
+      PROPERTIES COMPILE_OPTIONS "${_common_copts}"
       TARGET_DIRECTORY ${TARGET_NAME}
     )
   endif()
-  
-  if(CMAKE_SYSTEM_PROCESSOR MATCHES "x86_64" AND CMAKE_CXX_COMPILER_ID MATCHES "Clang")
-    if(CXX_MAVX2_SUPPORTED AND CXX_MF16C_SUPPORTED)
-      set(_use_avx2 TRUE)
-    else()
-      set(_use_avx2 FALSE)
-    endif()
-    
-    if(CXX_MAVX512F_SUPPORTED AND CXX_MAVX512DQ_SUPPORTED AND CXX_MAVX512CD_SUPPORTED AND CXX_MAVX512BW_SUPPORTED AND CXX_MAVX512VL_SUPPORTED)
-      set(_use_avx512 TRUE)
-    else()
-      set(_use_avx512 FALSE)
-    endif()
-  else()
-    set(_use_avx2 FALSE)
-    set(_use_avx512 FALSE)
+
+  if (CMAKE_CXX_COMPILER_ID MATCHES "GNU")
+    set_source_files_properties("${_sources_dir}/src/skcms_TransformBaseline.cc"
+      PROPERTIES COMPILE_OPTIONS "${_common_copts};-Wno-maybe-uninitialized"
+      TARGET_DIRECTORY ${TARGET_NAME}
+    )
   endif()
-  
-  if(_use_avx2)
+
+  set(_use_avx2 FALSE)
+  set(_use_avx512 FALSE)
+  if (CMAKE_SYSTEM_PROCESSOR MATCHES "x86_64" AND CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+    if (CXX_MAVX2_SUPPORTED AND CXX_MF16C_SUPPORTED)
+      set(_use_avx2 TRUE)
+    endif()
+    if (CXX_MAVX512F_SUPPORTED AND CXX_MAVX512DQ_SUPPORTED AND CXX_MAVX512CD_SUPPORTED} AND ${CXX_MAVX512BW_SUPPORTED} AND CXX_MAVX512VL_SUPPORTED)
+      set(_use_avx512 TRUE)
+    endif()
+  endif()
+
+  if (_use_avx2)
     list(APPEND _sources "${_sources_dir}/src/skcms_TransformHsw.cc")
     set_source_files_properties("${_sources_dir}/src/skcms_TransformHsw.cc"
-      PROPERTIES COMPILE_OPTIONS "-march=x86-64;-mavx2;-mf16c"
+      PROPERTIES COMPILE_OPTIONS "${_common_copts};-march=x86-64;-mavx2;-mf16c"
       TARGET_DIRECTORY ${TARGET_NAME}
     )
   else()
     target_compile_definitions(${TARGET_NAME} PRIVATE -DSKCMS_DISABLE_HSW)
   endif()
-  
-  if(_use_avx512)
+  if (_use_avx512)
     list(APPEND _sources "${_sources_dir}/src/skcms_TransformSkx.cc")
     set_source_files_properties("${_sources_dir}/src/skcms_TransformSkx.cc"
-      PROPERTIES COMPILE_OPTIONS "-march=x86-64;-mavx512f;-mavx512dq;-mavx512cd;-mavx512bw;-mavx512vl"
+      PROPERTIES COMPILE_OPTIONS "${_common_copts};-march=x86-64;-mavx512f;-mavx512dq;-mavx512cd;-mavx512bw;-mavx512vl"
       TARGET_DIRECTORY ${TARGET_NAME}
     )
   else()
     target_compile_definitions(${TARGET_NAME} PRIVATE -DSKCMS_DISABLE_SKX)
   endif()
-  
-  target_sources(${TARGET_NAME} PRIVATE ${_sources})
+
+  target_sources(${TARGET_NAME} PRIVATE "${_sources}")
   target_include_directories(${TARGET_NAME} PRIVATE "${PROJECT_SOURCE_DIR}/third_party/skcms/")
-  
-  include(CheckCXXCompilerFlag)
-  check_cxx_compiler_flag("-Wno-psabi" CXX_WPSABI_SUPPORTED)
-  if(CXX_WPSABI_SUPPORTED)
-    set_source_files_properties(${_sources}
-      PROPERTIES COMPILE_OPTIONS "-Wno-psabi"
-      TARGET_DIRECTORY ${TARGET_NAME})
-  endif()
 endfunction()


### PR DESCRIPTION
Fixes a CMake configuration error in `third_party/skcms.cmake` where malformed expressions caused build failures.

The original code attempted to combine boolean variables using `AND` directly in `set()` commands:

set(_use_avx2 ${CXX_MAVX2_SUPPORTED} AND ${CXX_MF16C_SUPPORTED})

When these variables were undefined/empty, this resulted in malformed if() statements like if(AND AND AND AND), causing
CMake Error at third_party/skcms.cmake:46 (if):
  if given arguments:
    "AND" "AND" "AND" "AND"
  Unknown arguments specified