### PR TITLE
Update Node to LTS (22)

### DIFF
--- a/.github/workflows/build_test_wasm.yml
+++ b/.github/workflows/build_test_wasm.yml
@@ -31,7 +31,8 @@ jobs:
       CCACHE_DIR: ${{ github.workspace }}/.ccache
       BUILD_TARGET: wasm32
       EM_VERSION: 3.1.51
-      NODE_VERSION: 21
+      # As of 28.08.2025 ubuntu-latest is 24.04; it is shipped with node 22.18
+      NODE_VERSION: 22
 
     strategy:
       fail-fast: false


### PR DESCRIPTION
It is shipped on ubuntu-latest, so install will not require download.
