### PR TITLE
Fix build on some systems

### DIFF
--- a/lib/extras/codec_test.cc
+++ b/lib/extras/codec_test.cc
@@ -281,7 +281,7 @@ void TestRoundTrip(const TestImageParams& params, ThreadPool* pool) {
   CreateTestImage(params, &ppf_in);
   EncodedImage encoded;
   ASSERT_TRUE(encoder->Encode(ppf_in, &encoded, pool));
-  ASSERT_EQ(encoded.bitstreams.size(), 1);
+  ASSERT_EQ(encoded.bitstreams.size(), 1u);
 
   PackedPixelFile ppf_out;
   ColorHints color_hints;
@@ -310,7 +310,7 @@ void TestRoundTrip(const TestImageParams& params, ThreadPool* pool) {
     EXPECT_EQ(ppf_in.icc, ppf_out.icc);
   }
 
-  ASSERT_EQ(ppf_out.frames.size(), 1);
+  ASSERT_EQ(ppf_out.frames.size(), 1u);
   const auto& frame_in = ppf_in.frames[0];
   const auto& frame_out = ppf_out.frames[0];
   VerifySameImage(frame_in.color, ppf_in.info.bits_per_sample, frame_out.color,
@@ -383,7 +383,7 @@ TEST(CodecTest, LosslessPNMRoundtrip) {
       auto encoder = Encoder::FromExtension(extension);
       ASSERT_TRUE(encoder.get());
       ASSERT_TRUE(encoder->Encode(ppf, &encoded, pool.get()));
-      ASSERT_EQ(encoded.bitstreams.size(), 1);
+      ASSERT_EQ(encoded.bitstreams.size(), 1u);
       ASSERT_EQ(orig.size(), encoded.bitstreams[0].size());
       EXPECT_EQ(0,
                 memcmp(orig.data(), encoded.bitstreams[0].data(), orig.size()));
@@ -486,14 +486,14 @@ TEST(CodecTest, EncodeToPNG) {
   EncodedImage encoded_png;
   ASSERT_TRUE(png_encoder->Encode(ppf, &encoded_png, pool));
   EXPECT_TRUE(encoded_png.icc.empty());
-  ASSERT_EQ(encoded_png.bitstreams.size(), 1);
+  ASSERT_EQ(encoded_png.bitstreams.size(), 1u);
 
   PackedPixelFile decoded_ppf;
   ASSERT_TRUE(extras::DecodeBytes(Bytes(encoded_png.bitstreams.front()),
                                   ColorHints(), &decoded_ppf));
 
   ASSERT_EQ(decoded_ppf.info.bits_per_sample, ppf.info.bits_per_sample);
-  ASSERT_EQ(decoded_ppf.frames.size(), 1);
+  ASSERT_EQ(decoded_ppf.frames.size(), 1u);
   VerifySameImage(ppf.frames[0].color, ppf.info.bits_per_sample,
                   decoded_ppf.frames[0].color,
                   decoded_ppf.info.bits_per_sample);

--- a/lib/extras/jpegli_test.cc
+++ b/lib/extras/jpegli_test.cc
@@ -108,7 +108,7 @@ TEST(JpegliTest, JpegliSRGBDecodeTest) {
   PackedPixelFile ppf0;
   ASSERT_TRUE(ReadTestImage(testimage, &ppf0));
   EXPECT_EQ("RGB_D65_SRG_Rel_SRG", Description(ppf0.color_encoding));
-  EXPECT_EQ(8, ppf0.info.bits_per_sample);
+  EXPECT_EQ(8u, ppf0.info.bits_per_sample);
 
   std::vector<uint8_t> compressed;
   ASSERT_TRUE(EncodeWithLibjpeg(ppf0, 90, &compressed));
@@ -127,7 +127,7 @@ TEST(JpegliTest, JpegliGrayscaleDecodeTest) {
   PackedPixelFile ppf0;
   ASSERT_TRUE(ReadTestImage(testimage, &ppf0));
   EXPECT_EQ("Gra_D65_Rel_SRG", Description(ppf0.color_encoding));
-  EXPECT_EQ(8, ppf0.info.bits_per_sample);
+  EXPECT_EQ(8u, ppf0.info.bits_per_sample);
 
   std::vector<uint8_t> compressed;
   ASSERT_TRUE(EncodeWithLibjpeg(ppf0, 90, &compressed));
@@ -146,7 +146,7 @@ TEST(JpegliTest, JpegliXYBEncodeTest) {
   PackedPixelFile ppf_in;
   ASSERT_TRUE(ReadTestImage(testimage, &ppf_in));
   EXPECT_EQ("RGB_D65_SRG_Rel_SRG", Description(ppf_in.color_encoding));
-  EXPECT_EQ(8, ppf_in.info.bits_per_sample);
+  EXPECT_EQ(8u, ppf_in.info.bits_per_sample);
 
   std::vector<uint8_t> compressed;
   JpegSettings settings;
@@ -196,7 +196,7 @@ TEST(JpegliTest, JpegliYUVEncodeTest) {
   PackedPixelFile ppf_in;
   ASSERT_TRUE(ReadTestImage(testimage, &ppf_in));
   EXPECT_EQ("RGB_D65_SRG_Rel_SRG", Description(ppf_in.color_encoding));
-  EXPECT_EQ(8, ppf_in.info.bits_per_sample);
+  EXPECT_EQ(8u, ppf_in.info.bits_per_sample);
 
   std::vector<uint8_t> compressed;
   JpegSettings settings;
@@ -215,7 +215,7 @@ TEST(JpegliTest, JpegliYUVChromaSubsamplingEncodeTest) {
   PackedPixelFile ppf_in;
   ASSERT_TRUE(ReadTestImage(testimage, &ppf_in));
   EXPECT_EQ("RGB_D65_SRG_Rel_SRG", Description(ppf_in.color_encoding));
-  EXPECT_EQ(8, ppf_in.info.bits_per_sample);
+  EXPECT_EQ(8u, ppf_in.info.bits_per_sample);
 
   std::vector<uint8_t> compressed;
   JpegSettings settings;
@@ -237,7 +237,7 @@ TEST(JpegliTest, JpegliYUVEncodeTestNoAq) {
   PackedPixelFile ppf_in;
   ASSERT_TRUE(ReadTestImage(testimage, &ppf_in));
   EXPECT_EQ("RGB_D65_SRG_Rel_SRG", Description(ppf_in.color_encoding));
-  EXPECT_EQ(8, ppf_in.info.bits_per_sample);
+  EXPECT_EQ(8u, ppf_in.info.bits_per_sample);
 
   std::vector<uint8_t> compressed;
   JpegSettings settings;
@@ -256,7 +256,7 @@ TEST(JpegliTest, JpegliHDRRoundtripTest) {
   PackedPixelFile ppf_in;
   ASSERT_TRUE(ReadTestImage(testimage, &ppf_in));
   EXPECT_EQ("Rec2100HLG", Description(ppf_in.color_encoding));
-  EXPECT_EQ(16, ppf_in.info.bits_per_sample);
+  EXPECT_EQ(16u, ppf_in.info.bits_per_sample);
 
   std::vector<uint8_t> compressed;
   JpegSettings settings;
@@ -276,7 +276,7 @@ TEST(JpegliTest, JpegliSetAppData) {
   PackedPixelFile ppf_in;
   ASSERT_TRUE(ReadTestImage(testimage, &ppf_in));
   EXPECT_EQ("RGB_D65_SRG_Rel_SRG", Description(ppf_in.color_encoding));
-  EXPECT_EQ(8, ppf_in.info.bits_per_sample);
+  EXPECT_EQ(8u, ppf_in.info.bits_per_sample);
 
   std::vector<uint8_t> compressed;
   JpegSettings settings;
@@ -342,7 +342,7 @@ TEST_P(JpegliColorQuantTestParam, JpegliColorQuantizeTest) {
   PackedPixelFile ppf0;
   ASSERT_TRUE(ReadTestImage(testimage, &ppf0));
   EXPECT_EQ("RGB_D65_SRG_Rel_SRG", Description(ppf0.color_encoding));
-  EXPECT_EQ(8, ppf0.info.bits_per_sample);
+  EXPECT_EQ(8u, ppf0.info.bits_per_sample);
 
   std::vector<uint8_t> compressed;
   ASSERT_TRUE(EncodeWithLibjpeg(ppf0, 90, &compressed));

--- a/lib/jpegli/decode_api_test.cc
+++ b/lib/jpegli/decode_api_test.cc
@@ -56,7 +56,7 @@ class SourceManager {
   }
 
   ~SourceManager() {
-    EXPECT_EQ(0, pub_.bytes_in_buffer);
+    EXPECT_EQ(0u, pub_.bytes_in_buffer);
     EXPECT_EQ(len_, pos_);
   }
 
@@ -121,7 +121,7 @@ uint8_t get_next_byte(j_decompress_ptr cinfo) {
 boolean test_marker_processor(j_decompress_ptr cinfo) {
   markers_seen[num_markers_seen] = cinfo->unread_marker;
   size_t marker_len = (get_next_byte(cinfo) << 8) + get_next_byte(cinfo);
-  EXPECT_EQ(2 + ((num_markers_seen + 2) % sizeof(kMarkerData)), marker_len);
+  EXPECT_EQ(2u + ((num_markers_seen + 2u) % sizeof(kMarkerData)), marker_len);
   if (marker_len > 2) {
     (*cinfo->src->skip_input_data)(cinfo, marker_len - 2);
   }
@@ -567,7 +567,7 @@ TEST(DecodeAPITest, AbbreviatedStreams) {
       return true;
     };
     EXPECT_TRUE(try_catch_block());
-    EXPECT_LT(data_stream_size, 50);
+    EXPECT_LT(data_stream_size, 50u);
     jpegli_destroy_compress(&cinfo);
   }
   {
@@ -579,16 +579,16 @@ TEST(DecodeAPITest, AbbreviatedStreams) {
       jpegli_read_header(&cinfo, FALSE);
       jpegli_mem_src(&cinfo, data_stream, data_stream_size);
       jpegli_read_header(&cinfo, TRUE);
-      EXPECT_EQ(1, cinfo.image_width);
-      EXPECT_EQ(1, cinfo.image_height);
+      EXPECT_EQ(1u, cinfo.image_width);
+      EXPECT_EQ(1u, cinfo.image_height);
       EXPECT_EQ(3, cinfo.num_components);
       jpegli_start_decompress(&cinfo);
       JSAMPLE image[3] = {0};
       JSAMPROW row[] = {image};
       jpegli_read_scanlines(&cinfo, row, 1);
-      EXPECT_EQ(0, image[0]);
-      EXPECT_EQ(0, image[1]);
-      EXPECT_EQ(0, image[2]);
+      EXPECT_EQ(0u, image[0]);
+      EXPECT_EQ(0u, image[1]);
+      EXPECT_EQ(0u, image[2]);
       jpegli_finish_decompress(&cinfo);
       return true;
     };

--- a/lib/jpegli/encode_api_test.cc
+++ b/lib/jpegli/encode_api_test.cc
@@ -281,18 +281,18 @@ TEST(EncodeAPITest, AbbreviatedStreams) {
       return true;
     };
     EXPECT_TRUE(try_catch_block());
-    EXPECT_LT(data_stream_size, 50);
+    EXPECT_LT(data_stream_size, 50u);
     jpegli_destroy_compress(&cinfo);
   }
   TestImage output;
   DecodeWithLibjpeg(CompressParams(), DecompressParams(), table_stream,
                     table_stream_size, data_stream, data_stream_size, &output);
-  EXPECT_EQ(1, output.xsize);
-  EXPECT_EQ(1, output.ysize);
-  EXPECT_EQ(3, output.components);
-  EXPECT_EQ(0, output.pixels[0]);
-  EXPECT_EQ(0, output.pixels[1]);
-  EXPECT_EQ(0, output.pixels[2]);
+  EXPECT_EQ(1u, output.xsize);
+  EXPECT_EQ(1u, output.ysize);
+  EXPECT_EQ(3u, output.components);
+  EXPECT_EQ(0u, output.pixels[0]);
+  EXPECT_EQ(0u, output.pixels[1]);
+  EXPECT_EQ(0u, output.pixels[2]);
   if (table_stream) free(table_stream);
   if (data_stream) free(data_stream);
 }

--- a/lib/jpegli/error_handling_test.cc
+++ b/lib/jpegli/error_handling_test.cc
@@ -46,10 +46,10 @@ TEST(EncoderErrorHandlingTest, MinimalSuccess) {
   TestImage output;
   DecodeWithLibjpeg(CompressParams(), DecompressParams(), nullptr, 0, buffer,
                     buffer_size, &output);
-  EXPECT_EQ(1, output.xsize);
-  EXPECT_EQ(1, output.ysize);
-  EXPECT_EQ(1, output.components);
-  EXPECT_EQ(0, output.pixels[0]);
+  EXPECT_EQ(1u, output.xsize);
+  EXPECT_EQ(1u, output.ysize);
+  EXPECT_EQ(1u, output.components);
+  EXPECT_EQ(0u, output.pixels[0]);
   if (buffer) free(buffer);
 }
 
@@ -1062,13 +1062,13 @@ TEST(DecoderErrorHandlingTest, MinimalSuccess) {
     jpegli_create_decompress(&cinfo);
     jpegli_mem_src(&cinfo, kCompressed0, kLen0);
     jpegli_read_header(&cinfo, TRUE);
-    EXPECT_EQ(1, cinfo.image_width);
-    EXPECT_EQ(1, cinfo.image_height);
+    EXPECT_EQ(1u, cinfo.image_width);
+    EXPECT_EQ(1u, cinfo.image_height);
     jpegli_start_decompress(&cinfo);
     JSAMPLE image[1];
     JSAMPROW row[] = {image};
     jpegli_read_scanlines(&cinfo, row, 1);
-    EXPECT_EQ(0, image[0]);
+    EXPECT_EQ(0u, image[0]);
     jpegli_finish_decompress(&cinfo);
     return true;
   };
@@ -1108,12 +1108,12 @@ TEST(DecoderErrorHandlingTest, NoStartDecompress) {
     jpegli_create_decompress(&cinfo);
     jpegli_mem_src(&cinfo, kCompressed0, kLen0);
     jpegli_read_header(&cinfo, TRUE);
-    EXPECT_EQ(1, cinfo.image_width);
-    EXPECT_EQ(1, cinfo.image_height);
+    EXPECT_EQ(1u, cinfo.image_width);
+    EXPECT_EQ(1u, cinfo.image_height);
     JSAMPLE image[1];
     JSAMPROW row[] = {image};
     jpegli_read_scanlines(&cinfo, row, 1);
-    EXPECT_EQ(0, image[0]);
+    EXPECT_EQ(0u, image[0]);
     jpegli_finish_decompress(&cinfo);
     return true;
   };
@@ -1128,8 +1128,8 @@ TEST(DecoderErrorHandlingTest, NoReadScanlines) {
     jpegli_create_decompress(&cinfo);
     jpegli_mem_src(&cinfo, kCompressed0, kLen0);
     jpegli_read_header(&cinfo, TRUE);
-    EXPECT_EQ(1, cinfo.image_width);
-    EXPECT_EQ(1, cinfo.image_height);
+    EXPECT_EQ(1u, cinfo.image_width);
+    EXPECT_EQ(1u, cinfo.image_height);
     jpegli_start_decompress(&cinfo);
     jpegli_finish_decompress(&cinfo);
     return true;

--- a/lib/jpegli/input_suspension_test.cc
+++ b/lib/jpegli/input_suspension_test.cc
@@ -47,7 +47,7 @@ struct SourceManager {
   }
 
   ~SourceManager() {
-    EXPECT_EQ(0, pub_.bytes_in_buffer);
+    EXPECT_EQ(0u, pub_.bytes_in_buffer);
     if (!is_partial_file_) {
       EXPECT_EQ(len_, pos_);
     }
@@ -121,7 +121,7 @@ boolean test_marker_processor(j_decompress_ptr cinfo) {
     return FALSE;
   }
   size_t marker_len = (get_next_byte(cinfo) << 8) + get_next_byte(cinfo);
-  EXPECT_EQ(2 + ((num_markers_seen + 2) % sizeof(kMarkerData)), marker_len);
+  EXPECT_EQ(2u + ((num_markers_seen + 2u) % sizeof(kMarkerData)), marker_len);
   if (marker_len > 2) {
     (*cinfo->src->skip_input_data)(cinfo, marker_len - 2);
   }
@@ -411,17 +411,18 @@ TEST_P(InputSuspensionTestParam, PreConsumeInputBuffered) {
       }
     }
 
+    size_t input_scan_number = cinfo.input_scan_number;
     EXPECT_TRUE(jpegli_input_complete(&cinfo));
-    EXPECT_EQ(output_progression1.size(), cinfo.input_scan_number);
+    EXPECT_EQ(output_progression1.size(), input_scan_number);
     EXPECT_EQ(0, cinfo.output_scan_number);
 
     EXPECT_TRUE(jpegli_start_output(&cinfo, cinfo.input_scan_number));
-    EXPECT_EQ(output_progression1.size(), cinfo.input_scan_number);
+    EXPECT_EQ(output_progression1.size(), input_scan_number);
     EXPECT_EQ(cinfo.output_scan_number, cinfo.input_scan_number);
 
     JPEGLI_TEST_ENSURE_TRUE(
         ReadOutputImage(dparams, &cinfo, nullptr, &output0));
-    EXPECT_EQ(output_progression1.size(), cinfo.input_scan_number);
+    EXPECT_EQ(output_progression1.size(), input_scan_number);
     EXPECT_EQ(cinfo.output_scan_number, cinfo.input_scan_number);
 
     EXPECT_TRUE(jpegli_finish_output(&cinfo));

--- a/lib/jxl.cmake
+++ b/lib/jxl.cmake
@@ -90,7 +90,7 @@ foreach(path ${JPEGXL_INTERNAL_PUBLIC_HEADERS})
 endforeach()
 
 add_library(jxl_base INTERFACE)
-target_include_directories(jxl_base SYSTEM BEFORE INTERFACE
+target_include_directories(jxl_base BEFORE INTERFACE
   "$<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/include>"
 )
 target_include_directories(jxl_base BEFORE INTERFACE

--- a/lib/jxl/blending_test.cc
+++ b/lib/jxl/blending_test.cc
@@ -29,7 +29,7 @@ TEST(BlendingTest, Crops) {
   extras::PackedPixelFile decoded;
   ASSERT_TRUE(DecodeImageJXL(compressed.data(), compressed.size(), dparams,
                              /*decoded_bytes=*/nullptr, &decoded));
-  ASSERT_EQ(decoded.frames.size(), 4);
+  ASSERT_EQ(decoded.frames.size(), 4u);
 
   int i = 0;
   for (auto&& decoded_frame : decoded.frames) {

--- a/lib/jxl/decode_test.cc
+++ b/lib/jxl/decode_test.cc
@@ -1962,8 +1962,6 @@ void DecodeImageWithColorEncoding(const std::vector<uint8_t>& compressed,
   EXPECT_EQ(JXL_DEC_BASIC_INFO, JxlDecoderProcessInput(dec));
   EXPECT_EQ(JXL_DEC_SUCCESS, JxlDecoderGetBasicInfo(dec, &info));
   EXPECT_EQ(JXL_DEC_COLOR_ENCODING, JxlDecoderProcessInput(dec));
-  // TODO(eustas): why unused?
-  std::string color_space_in = GetOrigProfile(dec);
   if (with_cms) {
     JxlDecoderSetCms(dec, *JxlGetDefaultCms());
     EXPECT_TRUE(color_encoding.CreateICC());
@@ -2213,7 +2211,7 @@ TEST(DecodeTest, ExtraBytesAfterCompressedStream) {
         /*use_resizable_runner=*/false, /*require_boxes=*/false,
         /*expect_success=*/true);
     size_t unconsumed_bytes = JxlDecoderReleaseInput(dec);
-    EXPECT_EQ(last_unknown_box_size + 3, unconsumed_bytes);
+    EXPECT_EQ(last_unknown_box_size + 3u, unconsumed_bytes);
     EXPECT_EQ(num_pixels * channels * 4, pixels2.size());
     JxlDecoderDestroy(dec);
   }
@@ -2248,8 +2246,8 @@ TEST(DecodeTest, ExtraBytesAfterCompressedStreamRequireBoxes) {
         /*use_callback=*/false, /*set_buffer_early=*/true,
         /*use_resizable_runner=*/false, /*require_boxes=*/true, expect_success);
     size_t unconsumed_bytes = JxlDecoderReleaseInput(dec);
-    EXPECT_EQ(3, unconsumed_bytes);
-    EXPECT_EQ(num_pixels * channels * 4, pixels2.size());
+    EXPECT_EQ(3u, unconsumed_bytes);
+    EXPECT_EQ(num_pixels * channels * 4u, pixels2.size());
     JxlDecoderDestroy(dec);
   }
 }
@@ -2297,11 +2295,11 @@ TEST(DecodeTest, ConcatenatedCompressedStreams) {
             /*use_callback=*/false, /*set_buffer_early=*/true,
             /*use_resizable_runner=*/false, /*require_boxes=*/true,
             expect_success);
-        EXPECT_EQ(num_pixels * channels * 4, pixels2.size());
+        EXPECT_EQ(num_pixels * channels * 4u, pixels2.size());
         remaining = JxlDecoderReleaseInput(dec);
         JxlDecoderDestroy(dec);
       }
-      EXPECT_EQ(0, remaining);
+      EXPECT_EQ(0u, remaining);
     }
   }
 }
@@ -2535,7 +2533,7 @@ TEST(DecodeTest, PreviewTest) {
     size_t ysize_preview = io0->Main().ysize();
     EXPECT_EQ(xsize_preview, info.preview.xsize);
     EXPECT_EQ(ysize_preview, info.preview.ysize);
-    EXPECT_EQ(xsize_preview * ysize_preview * 3, buffer_size);
+    EXPECT_EQ(xsize_preview * ysize_preview * 3u, buffer_size);
 
     EXPECT_EQ(JXL_DEC_NEED_PREVIEW_OUT_BUFFER, JxlDecoderProcessInput(dec));
 
@@ -2685,7 +2683,7 @@ TEST(DecodeTest, AnimationTest) {
     EXPECT_EQ(JXL_DEC_SUCCESS, JxlDecoderGetFrameName(dec, &name, 1));
     EXPECT_EQ(0, name);
 
-    EXPECT_EQ(i + 1 == num_frames, frame_header.is_last);
+    EXPECT_EQ(i + 1u == num_frames, frame_header.is_last);
 
     EXPECT_EQ(JXL_DEC_NEED_IMAGE_OUT_BUFFER, JxlDecoderProcessInput(dec));
 
@@ -2993,29 +2991,29 @@ TEST(DecodeTest, SkipCurrentFrameTest) {
     JxlFrameHeader frame_header;
     EXPECT_EQ(JXL_DEC_SUCCESS, JxlDecoderGetFrameHeader(dec, &frame_header));
     EXPECT_EQ(frame_durations[i], frame_header.duration);
-    EXPECT_EQ(i + 1 == num_frames, frame_header.is_last);
+    EXPECT_EQ(i + 1u == num_frames, frame_header.is_last);
     EXPECT_EQ(JXL_DEC_NEED_IMAGE_OUT_BUFFER, JxlDecoderProcessInput(dec));
     EXPECT_EQ(JXL_DEC_SUCCESS, JxlDecoderSetImageOutBuffer(
                                    dec, &format, pixels.data(), pixels.size()));
-    if (i == 2) {
+    if (i == 2u) {
       EXPECT_EQ(JXL_DEC_SUCCESS, JxlDecoderSkipCurrentFrame(dec));
       continue;
     }
     EXPECT_EQ(JXL_DEC_FRAME_PROGRESSION, JxlDecoderProcessInput(dec));
-    EXPECT_EQ(8, JxlDecoderGetIntendedDownsamplingRatio(dec));
-    if (i == 3) {
+    EXPECT_EQ(8u, JxlDecoderGetIntendedDownsamplingRatio(dec));
+    if (i == 3u) {
       EXPECT_EQ(JXL_DEC_SUCCESS, JxlDecoderSkipCurrentFrame(dec));
       continue;
     }
     EXPECT_EQ(JXL_DEC_FRAME_PROGRESSION, JxlDecoderProcessInput(dec));
-    EXPECT_EQ(4, JxlDecoderGetIntendedDownsamplingRatio(dec));
-    if (i == 4) {
+    EXPECT_EQ(4u, JxlDecoderGetIntendedDownsamplingRatio(dec));
+    if (i == 4u) {
       EXPECT_EQ(JXL_DEC_SUCCESS, JxlDecoderSkipCurrentFrame(dec));
       continue;
     }
     EXPECT_EQ(JXL_DEC_FRAME_PROGRESSION, JxlDecoderProcessInput(dec));
-    EXPECT_EQ(2, JxlDecoderGetIntendedDownsamplingRatio(dec));
-    if (i == 5) {
+    EXPECT_EQ(2u, JxlDecoderGetIntendedDownsamplingRatio(dec));
+    if (i == 5u) {
       EXPECT_EQ(JXL_DEC_SUCCESS, JxlDecoderSkipCurrentFrame(dec));
       continue;
     }
@@ -3113,7 +3111,7 @@ TEST(DecodeTest, SkipFrameTest) {
     EXPECT_EQ(JXL_DEC_SUCCESS, JxlDecoderGetFrameHeader(dec, &frame_header));
     EXPECT_EQ(frame_durations[i], frame_header.duration);
 
-    EXPECT_EQ(i + 1 == num_frames, frame_header.is_last);
+    EXPECT_EQ(i + 1u == num_frames, frame_header.is_last);
 
     EXPECT_EQ(JXL_DEC_NEED_IMAGE_OUT_BUFFER, JxlDecoderProcessInput(dec));
 
@@ -3150,7 +3148,7 @@ TEST(DecodeTest, SkipFrameTest) {
     EXPECT_EQ(JXL_DEC_SUCCESS, JxlDecoderGetFrameHeader(dec, &frame_header));
     EXPECT_EQ(frame_durations[i], frame_header.duration);
 
-    EXPECT_EQ(i + 1 == num_frames, frame_header.is_last);
+    EXPECT_EQ(i + 1u == num_frames, frame_header.is_last);
 
     EXPECT_EQ(JXL_DEC_NEED_IMAGE_OUT_BUFFER, JxlDecoderProcessInput(dec));
 
@@ -3293,7 +3291,7 @@ TEST(DecodeTest, SkipFrameWithBlendingTest) {
     EXPECT_EQ(JXL_DEC_SUCCESS, JxlDecoderGetFrameHeader(dec, &frame_header));
     EXPECT_EQ(frame_durations[i], frame_header.duration);
 
-    EXPECT_EQ(i + 1 == num_frames, frame_header.is_last);
+    EXPECT_EQ(i + 1u == num_frames, frame_header.is_last);
 
     EXPECT_EQ(JXL_DEC_NEED_IMAGE_OUT_BUFFER, JxlDecoderProcessInput(dec));
 
@@ -3328,7 +3326,7 @@ TEST(DecodeTest, SkipFrameWithBlendingTest) {
     EXPECT_EQ(JXL_DEC_SUCCESS, JxlDecoderGetFrameHeader(dec, &frame_header));
     EXPECT_EQ(frame_durations[i], frame_header.duration);
 
-    EXPECT_EQ(i + 1 == num_frames, frame_header.is_last);
+    EXPECT_EQ(i + 1u == num_frames, frame_header.is_last);
 
     EXPECT_EQ(JXL_DEC_NEED_IMAGE_OUT_BUFFER, JxlDecoderProcessInput(dec));
 
@@ -3365,7 +3363,7 @@ TEST(DecodeTest, SkipFrameWithBlendingTest) {
     EXPECT_EQ(JXL_DEC_SUCCESS, JxlDecoderGetFrameHeader(dec, &frame_header));
     EXPECT_EQ(frame_durations[i], frame_header.duration);
 
-    EXPECT_EQ(i + 1 == num_frames, frame_header.is_last);
+    EXPECT_EQ(i + 1u == num_frames, frame_header.is_last);
 
     EXPECT_EQ(JXL_DEC_NEED_IMAGE_OUT_BUFFER, JxlDecoderProcessInput(dec));
 
@@ -3490,9 +3488,9 @@ TEST(DecodeTest, SkipFrameWithAlphaBlendingTest) {
         EXPECT_EQ(JXL_DEC_SUCCESS,
                   JxlDecoderImageOutBufferSize(dec, &format, &buffer_size));
         if (coalescing) {
-          EXPECT_EQ(xsize * ysize * 8, buffer_size);
+          EXPECT_EQ(xsize * ysize * 8u, buffer_size);
         } else {
-          EXPECT_EQ(frame_xsize[i] * frame_ysize[i] * 8, buffer_size);
+          EXPECT_EQ(frame_xsize[i] * frame_ysize[i] * 8u, buffer_size);
         }
         frames[i].resize(buffer_size);
         EXPECT_EQ(JXL_DEC_SUCCESS,
@@ -3539,7 +3537,7 @@ TEST(DecodeTest, SkipFrameWithAlphaBlendingTest) {
       EXPECT_EQ((coalescing ? frame_durations_c[i] : frame_durations_nc[i]),
                 frame_header.duration);
 
-      EXPECT_EQ(i + 1 == num_frames, frame_header.is_last);
+      EXPECT_EQ(i + 1u == num_frames, frame_header.is_last);
 
       EXPECT_EQ(JXL_DEC_NEED_IMAGE_OUT_BUFFER, JxlDecoderProcessInput(dec));
 
@@ -3591,7 +3589,7 @@ TEST(DecodeTest, SkipFrameWithAlphaBlendingTest) {
       EXPECT_EQ((coalescing ? frame_durations_c[i] : frame_durations_nc[i]),
                 frame_header.duration);
 
-      EXPECT_EQ(i + 1 == num_frames + (coalescing ? 0 : 5),
+      EXPECT_EQ(i + 1u == num_frames + (coalescing ? 0u : 5u),
                 frame_header.is_last);
 
       EXPECT_EQ(JXL_DEC_NEED_IMAGE_OUT_BUFFER, JxlDecoderProcessInput(dec));
@@ -3609,10 +3607,12 @@ TEST(DecodeTest, SkipFrameWithAlphaBlendingTest) {
       } else {
         EXPECT_EQ(frame_header.layer_info.xsize, frame_xsize[i]);
         EXPECT_EQ(frame_header.layer_info.ysize, frame_ysize[i]);
-        EXPECT_EQ(frame_header.layer_info.crop_x0, frame_x0[i]);
-        EXPECT_EQ(frame_header.layer_info.crop_y0, frame_y0[i]);
+        EXPECT_EQ(frame_header.layer_info.crop_x0,
+                  static_cast<int32_t>(frame_x0[i]));
+        EXPECT_EQ(frame_header.layer_info.crop_y0,
+                  static_cast<int32_t>(frame_y0[i]));
         EXPECT_EQ(frame_header.layer_info.blend_info.blendmode,
-                  i != 12 + 5 && frame_header.duration != 0
+                  ((i != 17u) && (frame_header.duration != 0u))
                       ? 2
                       : 0);  // kBlend or the default kReplace
       }
@@ -3651,7 +3651,7 @@ TEST(DecodeTest, SkipFrameWithAlphaBlendingTest) {
       EXPECT_EQ((coalescing ? frame_durations_c[i] : frame_durations_nc[i]),
                 frame_header.duration);
 
-      EXPECT_EQ(i + 1 == num_frames + (coalescing ? 0 : 5),
+      EXPECT_EQ(i + 1u == num_frames + (coalescing ? 0u : 5u),
                 frame_header.is_last);
 
       EXPECT_EQ(JXL_DEC_NEED_IMAGE_OUT_BUFFER, JxlDecoderProcessInput(dec));
@@ -3751,10 +3751,10 @@ TEST(DecodeTest, OrientedCroppedFrameTest) {
           EXPECT_EQ(JXL_DEC_SUCCESS,
                     JxlDecoderImageOutBufferSize(dec, &format, &buffer_size));
           if (coalescing) {
-            EXPECT_EQ(xsize * ysize * 8, buffer_size);
+            EXPECT_EQ(xsize * ysize * 8u, buffer_size);
           } else {
             EXPECT_EQ(frame_header.layer_info.xsize *
-                          frame_header.layer_info.ysize * 8,
+                          frame_header.layer_info.ysize * 8u,
                       buffer_size);
           }
           frames[i].resize(buffer_size);
@@ -3838,7 +3838,7 @@ void AnalyzeCodestream(const std::vector<uint8_t>& data,
   std::vector<uint8_t> codestream;
   std::vector<std::pair<size_t, size_t>> breakpoints;
   bool codestream_end = false;
-  ASSERT_LE(2, data.size());
+  ASSERT_LE(2u, data.size());
   if (data[0] == 0xff && data[1] == 0x0a) {
     codestream = std::vector<uint8_t>(data.begin(), data.end());
     streampos->codestream_start = 0;
@@ -3846,7 +3846,7 @@ void AnalyzeCodestream(const std::vector<uint8_t>& data,
     const uint8_t* in = data.data();
     size_t pos = 0;
     while (pos < data.size()) {
-      ASSERT_LE(pos + 8, data.size());
+      ASSERT_LE(pos + 8u, data.size());
       streampos->box_start.push_back(pos);
       size_t box_size = LoadBE32(in + pos);
       if (box_size == 0) box_size = data.size() - pos;
@@ -3885,7 +3885,7 @@ void AnalyzeCodestream(const std::vector<uint8_t>& data,
   };
   // Analyze the unboxed codestream.
   jxl::BitReader br(jxl::Bytes(codestream.data(), codestream.size()));
-  ASSERT_EQ(br.ReadFixedBits<16>(), 0x0AFF);
+  ASSERT_EQ(br.ReadFixedBits<16>(), 0x0AFFu);
   auto metadata = jxl::make_unique<jxl::CodecMetadata>();
   ASSERT_TRUE(ReadSizeHeader(&br, &metadata->size));
   ASSERT_TRUE(ReadImageMetadata(&br, &metadata->m));
@@ -3922,7 +3922,7 @@ void AnalyzeCodestream(const std::vector<uint8_t>& data,
     ASSERT_TRUE(ReadGroupOffsets(memory_manager, toc_entries, &br,
                                  &section_offsets, &section_sizes,
                                  &groups_total_size));
-    EXPECT_EQ(br.TotalBitsConsumed() % jxl::kBitsPerByte, 0);
+    EXPECT_EQ(br.TotalBitsConsumed() % jxl::kBitsPerByte, 0u);
     size_t sections_start = br.TotalBitsConsumed() / jxl::kBitsPerByte;
     p.toc_end = add_offset(sections_start);
     for (size_t i = 0; i < toc_entries; ++i) {
@@ -3948,8 +3948,8 @@ void VerifyProgression(size_t xsize, size_t ysize, uint32_t num_channels,
                        const std::vector<uint8_t>& data,
                        std::vector<Breakpoint> breakpoints) {
   // Size large enough for multiple groups, required to have progressive stages.
-  ASSERT_LT(256, xsize);
-  ASSERT_LT(256, ysize);
+  ASSERT_LT(256u, xsize);
+  ASSERT_LT(256u, ysize);
   std::vector<uint8_t> pixels2;
   pixels2.resize(pixels.size());
   JxlPixelFormat format = {num_channels, JXL_TYPE_UINT16, JXL_BIG_ENDIAN, 0};
@@ -3957,14 +3957,15 @@ void VerifyProgression(size_t xsize, size_t ysize, uint32_t num_channels,
   EXPECT_EQ(JXL_DEC_SUCCESS,
             JxlDecoderSubscribeEvents(
                 dec, JXL_DEC_BASIC_INFO | JXL_DEC_FRAME | JXL_DEC_FULL_IMAGE));
-  int bp = 0;
+  size_t bp = 0;
   const uint8_t* next_in = data.data();
   size_t avail_in = breakpoints[bp].file_pos;
   EXPECT_EQ(JXL_DEC_SUCCESS, JxlDecoderSetInput(dec, next_in, avail_in));
   double prev_dist = 1.0;
   for (;;) {
     JxlDecoderStatus status = JxlDecoderProcessInput(dec);
-    printf("bp: %d  status: 0x%x\n", bp, static_cast<int>(status));
+    printf("bp: %d  status: 0x%x\n", static_cast<int>(bp),
+           static_cast<int>(status));
     if (status == JXL_DEC_BASIC_INFO) {
       JxlBasicInfo info;
       EXPECT_EQ(JXL_DEC_SUCCESS, JxlDecoderGetBasicInfo(dec, &info));
@@ -3982,7 +3983,7 @@ void VerifyProgression(size_t xsize, size_t ysize, uint32_t num_channels,
     } else if (status == JXL_DEC_FRAME) {
       // Nothing to do.
     } else if (status == JXL_DEC_SUCCESS) {
-      EXPECT_EQ(bp + 1, breakpoints.size());
+      EXPECT_EQ(bp + 1u, breakpoints.size());
       break;
     } else if (status == JXL_DEC_NEED_MORE_INPUT ||
                status == JXL_DEC_FULL_IMAGE) {
@@ -4002,10 +4003,11 @@ void VerifyProgression(size_t xsize, size_t ysize, uint32_t num_channels,
         }
       }
       if (status == JXL_DEC_FULL_IMAGE) {
-        EXPECT_EQ(bp + 1, breakpoints.size());
+        EXPECT_EQ(bp + 1u, breakpoints.size());
         continue;
       }
-      ASSERT_LT(++bp, breakpoints.size());
+      bp++;
+      ASSERT_LT(bp, breakpoints.size());
       next_in += avail_in - JxlDecoderReleaseInput(dec);
       avail_in = breakpoints[bp].file_pos - (next_in - data.data());
       EXPECT_EQ(JXL_DEC_SUCCESS, JxlDecoderSetInput(dec, next_in, avail_in));
@@ -4033,8 +4035,8 @@ TEST(DecodeTest, ProgressionTest) {
   AnalyzeCodestream(data, &streampos);
   const std::vector<FramePositions>& fp = streampos.frames;
   // We have preview, dc frame and regular frame.
-  EXPECT_EQ(3, fp.size());
-  EXPECT_EQ(7, fp[2].section_end.size());
+  EXPECT_EQ(3u, fp.size());
+  EXPECT_EQ(7u, fp[2].section_end.size());
   EXPECT_EQ(data.size(), fp[2].section_end[6]);
   std::vector<Breakpoint> breakpoints{
       {fp[0].frame_start, NO_FLUSH},           // headers
@@ -4070,8 +4072,8 @@ TEST(DecodeTest, ProgressionTestLosslessAlpha) {
   AnalyzeCodestream(data, &streampos);
   const std::vector<FramePositions>& fp = streampos.frames;
   // We have preview, dc frame and regular frame.
-  EXPECT_EQ(1, fp.size());
-  EXPECT_EQ(7, fp[0].section_end.size());
+  EXPECT_EQ(1u, fp.size());
+  EXPECT_EQ(7u, fp[0].section_end.size());
   EXPECT_EQ(data.size(), fp[0].section_end[6]);
   std::vector<Breakpoint> breakpoints{
       {fp[0].frame_start, NO_FLUSH},           // headers
@@ -4117,7 +4119,7 @@ TEST(DecodeTest, InputHandlingTestOneShot) {
     AnalyzeCodestream(data, &streampos);
     const std::vector<FramePositions>& fp = streampos.frames;
     // We have preview, dc frame and regular frame.
-    EXPECT_EQ(3, fp.size());
+    EXPECT_EQ(3u, fp.size());
 
     std::vector<uint8_t> pixels2;
     pixels2.resize(pixels.size());
@@ -4212,8 +4214,8 @@ JXL_TRANSCODE_JPEG_TEST(DecodeTest, InputHandlingTestJPEGOneshot) {
     AnalyzeCodestream(data, &streampos);
     const std::vector<FramePositions>& fp = streampos.frames;
     // We have preview and regular frame.
-    EXPECT_EQ(2, fp.size());
-    EXPECT_LT(0, streampos.jbrd_end);
+    EXPECT_EQ(2u, fp.size());
+    EXPECT_LT(0u, streampos.jbrd_end);
 
     std::vector<uint8_t> pixels2;
     pixels2.resize(pixels.size());
@@ -4302,7 +4304,7 @@ TEST(DecodeTest, InputHandlingTestStreaming) {
     AnalyzeCodestream(data, &streampos);
     const std::vector<FramePositions>& fp = streampos.frames;
     // We have preview, dc frame and regular frame.
-    EXPECT_EQ(3, fp.size());
+    EXPECT_EQ(3u, fp.size());
     std::vector<uint8_t> pixels2;
     pixels2.resize(pixels.size());
     int events_wanted =
@@ -4359,12 +4361,12 @@ TEST(DecodeTest, InputHandlingTestStreaming) {
           EXPECT_EQ(file_pos, streampos.codestream_end);
           break;
         } else if (status == JXL_DEC_NEED_MORE_INPUT) {
-          EXPECT_LT(remaining, 12);
-          if ((i == kCSBF_None && file_pos >= 2) ||
+          EXPECT_LT(remaining, 12u);
+          if ((i == kCSBF_None && file_pos >= 2u) ||
               (box_index > 0 && box_index < streampos.box_start.size() &&
                file_pos >= streampos.box_start[box_index - 1] + 12 &&
                file_pos < streampos.box_start[box_index])) {
-            EXPECT_EQ(remaining, 0);
+            EXPECT_EQ(remaining, 0u);
           }
           if (file_pos == data.size()) break;
         } else if (status == JXL_DEC_BOX) {
@@ -4895,7 +4897,7 @@ TEST_P(DecodeProgressiveTest, ProgressiveEventTest) {
       if (expect_flush) {
         // Return a particular downsampling ratio only after the last
         // pass for that downsampling was processed.
-        int expected_downsampling_ratios[] = {8, 8, 4, 4, 2};
+        size_t expected_downsampling_ratios[] = {8u, 8u, 4u, 4u, 2u};
         for (int p = 0; p < kNumPasses; p = next_pass(p)) {
           EXPECT_EQ(JXL_DEC_FRAME_PROGRESSION, process_input());
           EXPECT_EQ(expected_downsampling_ratios[p],
@@ -4955,7 +4957,7 @@ void VerifyJPEGReconstruction(jxl::Span<const uint8_t> container,
   EXPECT_EQ(JXL_DEC_SUCCESS,
             JxlDecoderSetJPEGBuffer(dec.get(), reconstructed_buffer.data(),
                                     reconstructed_buffer.size()));
-  size_t used = 0;
+  size_t used = 0u;
   JxlDecoderStatus process_result = JXL_DEC_JPEG_NEED_MORE_OUTPUT;
   while (process_result == JXL_DEC_JPEG_NEED_MORE_OUTPUT) {
     used = reconstructed_buffer.size() - JxlDecoderReleaseJPEGBuffer(dec.get());
@@ -5114,25 +5116,25 @@ TEST(DecodeTest, ExtendedBoxSizeTest) {
   EXPECT_EQ(JXL_DEC_SUCCESS, JxlDecoderGetBoxType(dec, type, JXL_FALSE));
   EXPECT_TRUE(BoxTypeEquals("JXL ", type));
   EXPECT_EQ(JXL_DEC_SUCCESS, JxlDecoderGetBoxSizeRaw(dec, &box_size));
-  EXPECT_EQ(12, box_size);
+  EXPECT_EQ(12u, box_size);
   EXPECT_EQ(JXL_DEC_SUCCESS, JxlDecoderGetBoxSizeContents(dec, &contents_size));
   EXPECT_EQ(contents_size + 8, box_size);
   EXPECT_EQ(JXL_DEC_BOX, JxlDecoderProcessInput(dec));
   EXPECT_EQ(JXL_DEC_SUCCESS, JxlDecoderGetBoxType(dec, type, JXL_FALSE));
   EXPECT_TRUE(BoxTypeEquals("ftyp", type));
   EXPECT_EQ(JXL_DEC_SUCCESS, JxlDecoderGetBoxSizeRaw(dec, &box_size));
-  EXPECT_EQ(20, box_size);
+  EXPECT_EQ(20u, box_size);
   EXPECT_EQ(JXL_DEC_SUCCESS, JxlDecoderGetBoxSizeContents(dec, &contents_size));
-  EXPECT_EQ(contents_size + 8, box_size);
+  EXPECT_EQ(contents_size + 8u, box_size);
   EXPECT_EQ(JXL_DEC_BOX, JxlDecoderProcessInput(dec));
   EXPECT_EQ(JXL_DEC_SUCCESS, JxlDecoderGetBoxType(dec, type, JXL_FALSE));
   EXPECT_TRUE(BoxTypeEquals("jxlc", type));
   EXPECT_EQ(JXL_DEC_SUCCESS, JxlDecoderGetBoxSizeRaw(dec, &box_size));
-  EXPECT_EQ(72, box_size);
+  EXPECT_EQ(72u, box_size);
   EXPECT_EQ(JXL_DEC_SUCCESS, JxlDecoderGetBoxSizeContents(dec, &contents_size));
   // This is an extended box, hence the difference between `box_size` and
   // `contents_size` is 16.
-  EXPECT_EQ(contents_size + 8 + 8, box_size);
+  EXPECT_EQ(contents_size + 8u + 8u, box_size);
 
   JxlDecoderDestroy(dec);
 }
@@ -5180,12 +5182,12 @@ JXL_BOXES_TEST(DecodeTest, BoxTest) {
       EXPECT_EQ(expected_box_sizes[i], box_size);
       EXPECT_EQ(JXL_DEC_SUCCESS,
                 JxlDecoderGetBoxSizeContents(dec, &contents_size));
-      EXPECT_EQ(contents_size + 8, box_size);
+      EXPECT_EQ(contents_size + 8u, box_size);
     }
 
     if (expected_release_size > 0) {
       EXPECT_EQ(expected_release_size, JxlDecoderReleaseBoxBuffer(dec));
-      expected_release_size = 0;
+      expected_release_size = 0u;
     }
 
     if (type[0] == 'u' && type[1] == 'n' && type[2] == 'k') {
@@ -5274,7 +5276,7 @@ JXL_BOXES_TEST(DecodeTest, ExifBrobBoxTest) {
           seen_brob_end = true;
           size_t remaining = JxlDecoderReleaseBoxBuffer(dec);
           box_num_output = box_buffer.size() - remaining;
-          EXPECT_EQ(box_num_output, box_brob_exif_size - 8);
+          EXPECT_EQ(box_num_output, box_brob_exif_size - 8u);
           EXPECT_EQ(
               0, memcmp(box_buffer.data(), box_brob_exif + 8, box_num_output));
           box_buffer.clear();
@@ -5450,7 +5452,7 @@ JXL_BOXES_TEST(DecodeTest, PartialCodestreamBoxTest) {
         if (!box_buffer.empty()) {
           size_t remaining = JxlDecoderReleaseBoxBuffer(dec);
           box_num_output = box_buffer.size() - remaining;
-          EXPECT_GE(box_num_output, 4);
+          EXPECT_GE(box_num_output, 4u);
           // Do not insert the first 4 bytes, which are not part of the
           // codestream, but the partial codestream box index
           extracted_codestream.insert(extracted_codestream.end(),
@@ -5480,7 +5482,7 @@ JXL_BOXES_TEST(DecodeTest, PartialCodestreamBoxTest) {
     }
 
     // The test file created with kCSBF_Multi is expected to have 4 jxlp boxes.
-    EXPECT_EQ(4, num_jxlp);
+    EXPECT_EQ(4u, num_jxlp);
 
     EXPECT_EQ(0u, jxl::test::ComparePixels(pixels.data(), pixels2.data(), xsize,
                                            ysize, format_orig, format_orig));
@@ -5542,7 +5544,7 @@ JXL_BOXES_TEST(DecodeTest, PartialCodestreamBoxTest) {
       }
     }
 
-    EXPECT_EQ(0, num_boxes);  // The data does not use the container format.
+    EXPECT_EQ(0u, num_boxes);  // The data does not use the container format.
     EXPECT_EQ(0u, jxl::test::ComparePixels(pixels.data(), pixels2.data(), xsize,
                                            ysize, format_orig, format_orig));
 
@@ -5659,17 +5661,17 @@ TEST(DecodeTest, SpotColorTest) {
           // if spot color isn't rendered, main image should be as we made it
           // (red and blue are all zeroes)
 
-          EXPECT_EQ(rowm[x * 3 + 0], 0);
-          EXPECT_EQ(rowm[x * 3 + 1], (x + y > 255 ? 255 : x + y));
-          EXPECT_EQ(rowm[x * 3 + 2], 0);
+          EXPECT_EQ(rowm[x * 3 + 0], 0u);
+          EXPECT_EQ(rowm[x * 3 + 1], (x + y > 255u ? 255u : x + y));
+          EXPECT_EQ(rowm[x * 3 + 2], 0u);
         }
         if (render_spot) {
           // if spot color is rendered, expect red and blue to look like the
           // spot color channel
-          EXPECT_LT(abs(rowm[x * 3 + 0] - (rows[x] * 0.25f)), 1);
-          EXPECT_LT(abs(rowm[x * 3 + 2] - (rows[x] * 0.5f)), 1);
+          EXPECT_LT(abs(rowm[x * 3 + 0] - (rows[x] * 0.25f)), 1.0f);
+          EXPECT_LT(abs(rowm[x * 3 + 2] - (rows[x] * 0.5f)), 1.0f);
         }
-        EXPECT_EQ(rows[x], ((x ^ y) & 255));
+        EXPECT_EQ(rows[x], ((x ^ y) & 255u));
       }
     }
   }

--- a/lib/jxl/enc_bit_writer_test.cc
+++ b/lib/jxl/enc_bit_writer_test.cc
@@ -14,7 +14,6 @@
 #include <vector>
 
 #include "lib/jxl/base/common.h"
-#include "lib/jxl/base/compiler_specific.h"
 #include "lib/jxl/base/status.h"
 #include "lib/jxl/dec_bit_reader.h"
 #include "lib/jxl/enc_aux_out.h"
@@ -68,7 +67,7 @@ TEST(BitWriterTest, RandomSequence) {
   }
   EXPECT_TRUE(reader.JumpToByteBoundary());
   EXPECT_TRUE(reader.Close());
-  EXPECT_EQ(num_mismatches, 0);
+  EXPECT_EQ(num_mismatches, 0u);
 }
 
 }  // namespace

--- a/lib/jxl/encode_test.cc
+++ b/lib/jxl/encode_test.cc
@@ -516,7 +516,7 @@ TEST(EncodeTest, FrameSettingsTest) {
             frame_settings, JXL_ENC_FRAME_SETTING_GROUP_ORDER_CENTER_X, 5));
     VerifyFrameEncoding(enc.get(), frame_settings);
     EXPECT_EQ(true, enc->last_used_cparams.centerfirst);
-    EXPECT_EQ(5, enc->last_used_cparams.center_x);
+    EXPECT_EQ(5u, enc->last_used_cparams.center_x);
   }
 
   {
@@ -1469,7 +1469,7 @@ JXL_BOXES_TEST_P(EncodeBoxTest, BoxTest) {
     if (status == JXL_DEC_ERROR) {
       FAIL();
     } else if (status == JXL_DEC_SUCCESS) {
-      EXPECT_EQ(0, JxlDecoderReleaseBoxBuffer(dec.get()));
+      EXPECT_EQ(0u, JxlDecoderReleaseBoxBuffer(dec.get()));
       break;
     } else if (status == JXL_DEC_FRAME) {
       post_frame = true;
@@ -1477,7 +1477,7 @@ JXL_BOXES_TEST_P(EncodeBoxTest, BoxTest) {
       // Since we gave the exif/xml box output buffer of the exact known
       // correct size, 0 bytes should be released. Same when no buffer was
       // set.
-      EXPECT_EQ(0, JxlDecoderReleaseBoxBuffer(dec.get()));
+      EXPECT_EQ(0u, JxlDecoderReleaseBoxBuffer(dec.get()));
       JxlBoxType type;
       EXPECT_EQ(JXL_DEC_SUCCESS, JxlDecoderGetBoxType(dec.get(), type, true));
       if (memcmp(type, "Exif", 4) == 0) {

--- a/lib/jxl/jxl_test.cc
+++ b/lib/jxl/jxl_test.cc
@@ -975,7 +975,7 @@ TEST(JxlTest, RoundtripAlphaResampling) {
   TestImage t;
   ASSERT_TRUE(t.DecodeFromBytes(orig));
   t.ClearMetadata();
-  ASSERT_NE(t.ppf().info.xsize, 0);
+  ASSERT_NE(t.ppf().info.xsize, 0u);
   ASSERT_TRUE(t.ppf().info.alpha_bits > 0);
 
   JXLCompressParams cparams;
@@ -997,7 +997,7 @@ TEST(JxlTest, RoundtripAlphaResamplingOnlyAlpha) {
   TestImage t;
   ASSERT_TRUE(t.DecodeFromBytes(orig));
   t.ClearMetadata();
-  ASSERT_NE(t.ppf().info.xsize, 0);
+  ASSERT_NE(t.ppf().info.xsize, 0u);
   ASSERT_TRUE(t.ppf().info.alpha_bits > 0);
 
   JXLCompressParams cparams;
@@ -1020,7 +1020,7 @@ TEST(JxlTest, RoundtripAlphaNonMultipleOf8) {
   ASSERT_TRUE(t.DecodeFromBytes(orig));
   t.ClearMetadata();
   ASSERT_TRUE(t.SetDimensions(12, 12));
-  ASSERT_NE(t.ppf().info.xsize, 0);
+  ASSERT_NE(t.ppf().info.xsize, 0u);
   ASSERT_TRUE(t.ppf().info.alpha_bits > 0);
   EXPECT_EQ(t.ppf().frames[0].color.format.data_type, JXL_TYPE_UINT8);
 
@@ -1053,8 +1053,8 @@ TEST(JxlTest, RoundtripAlpha16) {
     }
   }
 
-  ASSERT_NE(t.ppf().info.xsize, 0);
-  ASSERT_EQ(t.ppf().info.alpha_bits, 16);
+  ASSERT_NE(t.ppf().info.xsize, 0u);
+  ASSERT_EQ(t.ppf().info.alpha_bits, 16u);
 
   JXLCompressParams cparams;
   cparams.AddOption(JXL_ENC_FRAME_SETTING_EFFORT, 6);  // kWombat
@@ -1155,7 +1155,7 @@ TEST(JxlTest, RoundtripLossless8Alpha) {
   TestImage t;
   ASSERT_TRUE(t.DecodeFromBytes(orig));
   t.ClearMetadata();
-  ASSERT_EQ(t.ppf().info.alpha_bits, 8);
+  ASSERT_EQ(t.ppf().info.alpha_bits, 8u);
   EXPECT_EQ(t.ppf().frames[0].color.format.data_type, JXL_TYPE_UINT8);
 
   JXLCompressParams cparams = test::CompressParamsForLossless();
@@ -1167,7 +1167,7 @@ TEST(JxlTest, RoundtripLossless8Alpha) {
   size_t compressed_size = Roundtrip(t.ppf(), cparams, dparams, pool, &ppf_out);
   EXPECT_EQ(compressed_size, 246225u);
   EXPECT_EQ(ComputeDistance2(t.ppf(), ppf_out), 0.0);
-  EXPECT_EQ(ppf_out.info.alpha_bits, 8);
+  EXPECT_EQ(ppf_out.info.alpha_bits, 8u);
   EXPECT_TRUE(test::SameAlpha(t.ppf(), ppf_out));
 }
 
@@ -1194,8 +1194,8 @@ TEST(JxlTest, RoundtripLossless16Alpha) {
       ASSERT_TRUE(frame.SetValue(y, x, 3, g * mul));
     }
   }
-  ASSERT_EQ(t.ppf().info.bits_per_sample, 16);
-  ASSERT_EQ(t.ppf().info.alpha_bits, 16);
+  ASSERT_EQ(t.ppf().info.bits_per_sample, 16u);
+  ASSERT_EQ(t.ppf().info.alpha_bits, 16u);
 
   JXLCompressParams cparams = test::CompressParamsForLossless();
 
@@ -1205,9 +1205,9 @@ TEST(JxlTest, RoundtripLossless16Alpha) {
   PackedPixelFile ppf_out;
   // TODO(szabadka) Investigate big size difference on i686
   size_t compressed_size = Roundtrip(t.ppf(), cparams, dparams, pool, &ppf_out);
-  EXPECT_NEAR(compressed_size, 3477, 100);
+  EXPECT_NEAR(compressed_size, 3477u, 100u);
   EXPECT_EQ(ComputeDistance2(t.ppf(), ppf_out), 0.0);
-  EXPECT_EQ(ppf_out.info.alpha_bits, 16);
+  EXPECT_EQ(ppf_out.info.alpha_bits, 16u);
   EXPECT_TRUE(test::SameAlpha(t.ppf(), ppf_out));
 }
 
@@ -1235,8 +1235,8 @@ TEST(JxlTest, RoundtripLossless16AlphaNotMisdetectedAs8Bit) {
       ASSERT_TRUE(frame.SetValue(y, x, 3, g * mul));
     }
   }
-  ASSERT_EQ(t.ppf().info.bits_per_sample, 16);
-  ASSERT_EQ(t.ppf().info.alpha_bits, 16);
+  ASSERT_EQ(t.ppf().info.bits_per_sample, 16u);
+  ASSERT_EQ(t.ppf().info.alpha_bits, 16u);
 
   JXLCompressParams cparams = test::CompressParamsForLossless();
 
@@ -1247,8 +1247,8 @@ TEST(JxlTest, RoundtripLossless16AlphaNotMisdetectedAs8Bit) {
   size_t compressed_size = Roundtrip(t.ppf(), cparams, dparams, pool, &ppf_out);
   EXPECT_NEAR(compressed_size, 1278u, 100u);
   EXPECT_EQ(ComputeDistance2(t.ppf(), ppf_out), 0.0);
-  EXPECT_EQ(ppf_out.info.bits_per_sample, 16);
-  EXPECT_EQ(ppf_out.info.alpha_bits, 16);
+  EXPECT_EQ(ppf_out.info.bits_per_sample, 16u);
+  EXPECT_EQ(ppf_out.info.alpha_bits, 16u);
   EXPECT_TRUE(test::SameAlpha(t.ppf(), ppf_out));
 }
 
@@ -1259,8 +1259,8 @@ TEST(JxlTest, RoundtripDots) {
   TestImage t;
   ASSERT_TRUE(t.DecodeFromBytes(orig));
   t.ClearMetadata();
-  ASSERT_NE(t.ppf().info.xsize, 0);
-  EXPECT_EQ(t.ppf().info.bits_per_sample, 8);
+  ASSERT_NE(t.ppf().info.xsize, 0u);
+  EXPECT_EQ(t.ppf().info.bits_per_sample, 8u);
   EXPECT_EQ(t.ppf().color_encoding.transfer_function,
             JXL_TRANSFER_FUNCTION_SRGB);
 
@@ -1271,8 +1271,8 @@ TEST(JxlTest, RoundtripDots) {
   extras::JXLDecompressParams dparams;
 
   PackedPixelFile ppf_out;
-  EXPECT_NEAR(Roundtrip(t.ppf(), cparams, dparams, pool, &ppf_out), 236173,
-              3000);
+  EXPECT_NEAR(Roundtrip(t.ppf(), cparams, dparams, pool, &ppf_out), 236173u,
+              3000u);
   EXPECT_SLIGHTLY_BELOW(ButteraugliDistance(t.ppf(), ppf_out), 0.165);
 }
 
@@ -1282,8 +1282,8 @@ TEST(JxlTest, RoundtripDisablePerceptual) {
   TestImage t;
   ASSERT_TRUE(t.DecodeFromBytes(orig));
   t.ClearMetadata();
-  ASSERT_NE(t.ppf().info.xsize, 0);
-  EXPECT_EQ(t.ppf().info.bits_per_sample, 8);
+  ASSERT_NE(t.ppf().info.xsize, 0u);
+  EXPECT_EQ(t.ppf().info.bits_per_sample, 8u);
   EXPECT_EQ(t.ppf().color_encoding.transfer_function,
             JXL_TRANSFER_FUNCTION_SRGB);
 
@@ -1309,8 +1309,8 @@ TEST(JxlTest, RoundtripNoise) {
   TestImage t;
   ASSERT_TRUE(t.DecodeFromBytes(orig));
   t.ClearMetadata();
-  ASSERT_NE(t.ppf().info.xsize, 0);
-  EXPECT_EQ(t.ppf().info.bits_per_sample, 8);
+  ASSERT_NE(t.ppf().info.xsize, 0u);
+  EXPECT_EQ(t.ppf().info.bits_per_sample, 8u);
   EXPECT_EQ(t.ppf().color_encoding.transfer_function,
             JXL_TRANSFER_FUNCTION_SRGB);
 
@@ -1333,7 +1333,7 @@ TEST(JxlTest, RoundtripLossless8Gray) {
   ASSERT_TRUE(t.DecodeFromBytes(orig));
   t.ClearMetadata();
   EXPECT_EQ(t.ppf().color_encoding.color_space, JXL_COLOR_SPACE_GRAY);
-  EXPECT_EQ(t.ppf().info.bits_per_sample, 8);
+  EXPECT_EQ(t.ppf().info.bits_per_sample, 8u);
 
   JXLCompressParams cparams = test::CompressParamsForLossless();
 
@@ -1344,7 +1344,7 @@ TEST(JxlTest, RoundtripLossless8Gray) {
   EXPECT_EQ(Roundtrip(t.ppf(), cparams, dparams, pool, &ppf_out), 92588u);
   EXPECT_EQ(ComputeDistance2(t.ppf(), ppf_out), 0.0);
   EXPECT_EQ(ppf_out.color_encoding.color_space, JXL_COLOR_SPACE_GRAY);
-  EXPECT_EQ(ppf_out.info.bits_per_sample, 8);
+  EXPECT_EQ(ppf_out.info.bits_per_sample, 8u);
 }
 
 TEST(JxlTest, RoundtripAnimation) {
@@ -1357,7 +1357,7 @@ TEST(JxlTest, RoundtripAnimation) {
   TestImage t;
   ASSERT_TRUE(t.DecodeFromBytes(orig));
   t.ClearMetadata();
-  EXPECT_EQ(4, t.ppf().frames.size());
+  EXPECT_EQ(4u, t.ppf().frames.size());
 
   JXLDecompressParams dparams;
   dparams.accepted_formats.push_back(t.ppf().frames[0].color.format);
@@ -1386,7 +1386,7 @@ TEST(JxlTest, RoundtripLosslessAnimation) {
   TestImage t;
   ASSERT_TRUE(t.DecodeFromBytes(orig));
   t.ClearMetadata();
-  EXPECT_EQ(4, t.ppf().frames.size());
+  EXPECT_EQ(4u, t.ppf().frames.size());
 
   JXLCompressParams cparams = test::CompressParamsForLossless();
 
@@ -1395,7 +1395,7 @@ TEST(JxlTest, RoundtripLosslessAnimation) {
 
   PackedPixelFile ppf_out;
   EXPECT_SLIGHTLY_BELOW(Roundtrip(t.ppf(), cparams, dparams, pool, &ppf_out),
-                        969);
+                        969u);
 
   ASSERT_TRUE(t.CoalesceGIFAnimationWithAlpha());
   ASSERT_EQ(ppf_out.frames.size(), t.ppf().frames.size());
@@ -1520,7 +1520,7 @@ JXL_TRANSCODE_JPEG_TEST(JxlTest,
   ASSERT_TRUE(t.DecodeFromBytes(orig));
 
   JXLDecompressParams dparams;
-  dparams.max_downsampling = 8;
+  dparams.max_downsampling = 8u;
 
   PackedPixelFile ppf_out;
   RoundtripJpegToPixels(orig, dparams, pool.get(), &ppf_out);
@@ -1599,7 +1599,7 @@ JXL_TRANSCODE_JPEG_TEST(JxlTest, RoundtripJpegRecompression440) {
   const std::vector<uint8_t> orig =
       ReadTestData("jxl/flower/flower.png.im_q85_440.jpg");
   // JPEG size is 603,623 bytes.
-  EXPECT_NEAR(RoundtripJpeg(orig, pool.get()), 501617u, 20);
+  EXPECT_NEAR(RoundtripJpeg(orig, pool.get()), 501617u, 20u);
 }
 
 JXL_TRANSCODE_JPEG_TEST(JxlTest, RoundtripJpegRecompressionAsymmetric) {
@@ -1609,7 +1609,7 @@ JXL_TRANSCODE_JPEG_TEST(JxlTest, RoundtripJpegRecompressionAsymmetric) {
   const std::vector<uint8_t> orig =
       ReadTestData("jxl/flower/flower.png.im_q85_asymmetric.jpg");
   // JPEG size is 604,601 bytes.
-  EXPECT_NEAR(RoundtripJpeg(orig, pool.get()), 500974u, 20);
+  EXPECT_NEAR(RoundtripJpeg(orig, pool.get()), 500974u, 20u);
 }
 
 JXL_TRANSCODE_JPEG_TEST(JxlTest, RoundtripJpegRecompression420Progr) {
@@ -1617,7 +1617,7 @@ JXL_TRANSCODE_JPEG_TEST(JxlTest, RoundtripJpegRecompression420Progr) {
   const std::vector<uint8_t> orig =
       ReadTestData("jxl/flower/flower.png.im_q85_420_progr.jpg");
   // JPEG size is 522,057 bytes.
-  EXPECT_NEAR(RoundtripJpeg(orig, pool.get()), 456037u, 20);
+  EXPECT_NEAR(RoundtripJpeg(orig, pool.get()), 456037u, 20u);
 }
 
 JXL_TRANSCODE_JPEG_TEST(JxlTest, RoundtripJpegRecompressionMetadata) {
@@ -1626,12 +1626,13 @@ JXL_TRANSCODE_JPEG_TEST(JxlTest, RoundtripJpegRecompressionMetadata) {
       ReadTestData("jxl/jpeg_reconstruction/1x1_exif_xmp.jpg");
   // JPEG size is 4290 bytes
   // 1370 on 386, so higher margin.
-  EXPECT_NEAR(RoundtripJpeg(orig, pool.get()), 1334u, 100);
+  EXPECT_NEAR(RoundtripJpeg(orig, pool.get()), 1334u, 100u);
 }
 
 JXL_TRANSCODE_JPEG_TEST(JxlTest, RoundtripJpegRecompressionEmptyExif) {
   ThreadPoolForTests pool(8);
   const std::vector<uint8_t> orig = {
+      /* clang-format off */
       // SOI
       0xff, 0xd8,  //
       // APP1
@@ -1676,8 +1677,9 @@ JXL_TRANSCODE_JPEG_TEST(JxlTest, RoundtripJpegRecompressionEmptyExif) {
       0xfc, 0xaa, 0xaf,  //
       // EOI
       0xff, 0xd9,  //
+      /* clang-format on */
   };
-  EXPECT_NEAR(RoundtripJpeg(orig, pool.get()), 466u, 100);
+  EXPECT_NEAR(RoundtripJpeg(orig, pool.get()), 466u, 100u);
 }
 
 JXL_TRANSCODE_JPEG_TEST(JxlTest, RoundtripJpegRecompressionRestarts) {
@@ -1685,7 +1687,7 @@ JXL_TRANSCODE_JPEG_TEST(JxlTest, RoundtripJpegRecompressionRestarts) {
   const std::vector<uint8_t> orig =
       ReadTestData("jxl/jpeg_reconstruction/bicycles_restarts.jpg");
   // JPEG size is 87478 bytes
-  EXPECT_NEAR(RoundtripJpeg(orig, pool.get()), 76010u, 30);
+  EXPECT_NEAR(RoundtripJpeg(orig, pool.get()), 76010u, 30u);
 }
 
 JXL_TRANSCODE_JPEG_TEST(JxlTest, RoundtripJpegRecompressionOrientationICC) {
@@ -1693,7 +1695,7 @@ JXL_TRANSCODE_JPEG_TEST(JxlTest, RoundtripJpegRecompressionOrientationICC) {
   const std::vector<uint8_t> orig =
       ReadTestData("jxl/jpeg_reconstruction/sideways_bench.jpg");
   // JPEG size is 15252 bytes
-  EXPECT_NEAR(RoundtripJpeg(orig, pool.get()), 12000u, 470);
+  EXPECT_NEAR(RoundtripJpeg(orig, pool.get()), 12000u, 470u);
   // TODO(jon): investigate why 'Cross-compiling i686-linux-gnu' produces a
   // larger result
 }
@@ -1713,8 +1715,8 @@ TEST(JxlTest, RoundtripProgressive) {
   extras::JXLDecompressParams dparams;
 
   PackedPixelFile ppf_out;
-  EXPECT_NEAR(Roundtrip(t.ppf(), cparams, dparams, pool.get(), &ppf_out), 68606,
-              500);
+  EXPECT_NEAR(Roundtrip(t.ppf(), cparams, dparams, pool.get(), &ppf_out),
+              68606u, 500u);
   EXPECT_SLIGHTLY_BELOW(ButteraugliDistance(t.ppf(), ppf_out), 1.2);
 }
 
@@ -1724,7 +1726,7 @@ TEST(JxlTest, RoundtripProgressiveLevel2Slow) {
   TestImage t;
   ASSERT_TRUE(t.DecodeFromBytes(orig));
   t.ClearMetadata();
-  ASSERT_TRUE(t.SetDimensions(600, 1024));
+  ASSERT_TRUE(t.SetDimensions(600u, 1024u));
 
   JXLCompressParams cparams;
   cparams.AddOption(JXL_ENC_FRAME_SETTING_EFFORT, 9);  // kTortoise
@@ -1749,7 +1751,7 @@ TEST(JxlTest, RoundtripUnsignedCustomBitdepthLossless) {
                num_channels, bitdepth,
                endianness == JXL_LITTLE_ENDIAN ? "little" : "big");
         TestImage t;
-        ASSERT_TRUE(t.SetDimensions(256, 256));
+        ASSERT_TRUE(t.SetDimensions(256u, 256u));
         ASSERT_TRUE(t.SetChannels(num_channels));
         t.SetAllBitDepths(bitdepth).SetEndianness(endianness);
         JXL_TEST_ASSIGN_OR_DIE(auto frame, t.AddFrame());
@@ -1802,7 +1804,7 @@ TEST(JxlTest, LosslessPNMRoundtrip) {
       auto encoder = extras::Encoder::FromExtension(extension);
       ASSERT_TRUE(encoder.get());
       ASSERT_TRUE(encoder->Encode(ppf_out, &encoded, nullptr));
-      ASSERT_EQ(encoded.bitstreams.size(), 1);
+      ASSERT_EQ(encoded.bitstreams.size(), 1u);
       ASSERT_EQ(orig.size(), encoded.bitstreams[0].size());
       EXPECT_EQ(0,
                 memcmp(orig.data(), encoded.bitstreams[0].data(), orig.size()));

--- a/lib/jxl/modular_test.cc
+++ b/lib/jxl/modular_test.cc
@@ -115,7 +115,7 @@ void TestLarge(size_t dim, size_t co_dim, size_t group_size_shift) {
     extras::PackedPixelFile ppf_out;
     size_t compressed_size =
         Roundtrip(t.ppf(), cparams, dparams, nullptr, &ppf_out);
-    EXPECT_LE(compressed_size, 16384);
+    EXPECT_LE(compressed_size, 16384u);
   }
 }
 
@@ -437,7 +437,7 @@ TEST_P(ModularTestParam, RoundtripLossless) {
       }
     }
   }
-  EXPECT_EQ(different, 0);
+  EXPECT_EQ(different, 0u);
 }
 
 TEST(ModularTest, RoundtripLosslessCustomFloat) {
@@ -568,7 +568,7 @@ TEST(ModularTest, PredictorIntegerOverflow) {
   params.accepted_formats.push_back({1, JXL_TYPE_FLOAT, JXL_NATIVE_ENDIAN, 0});
   EXPECT_TRUE(DecodeImageJXL(compressed.data(), compressed.size(), params,
                              nullptr, &ppf));
-  ASSERT_EQ(1, ppf.frames.size());
+  ASSERT_EQ(1u, ppf.frames.size());
   const auto& img = ppf.frames[0].color;
   const auto* pixels = reinterpret_cast<const float*>(img.pixels());
   EXPECT_EQ(-1.0f, pixels[0]);
@@ -619,7 +619,7 @@ TEST(ModularTest, UnsqueezeIntegerOverflow) {
   params.accepted_formats.push_back({1, JXL_TYPE_FLOAT, JXL_NATIVE_ENDIAN, 0});
   EXPECT_TRUE(DecodeImageJXL(compressed.data(), compressed.size(), params,
                              nullptr, &ppf));
-  ASSERT_EQ(1, ppf.frames.size());
+  ASSERT_EQ(1u, ppf.frames.size());
   const auto& img = ppf.frames[0].color;
   const float* pixels = reinterpret_cast<const float*>(img.pixels());
   for (size_t x = 0; x < xsize; ++x) {

--- a/lib/jxl/passes_test.cc
+++ b/lib/jxl/passes_test.cc
@@ -75,7 +75,7 @@ TEST(PassesTest, RoundtripSmallPasses) {
 
   PackedPixelFile ppf2;
   size_t compressed_size = Roundtrip(ppf, cparams, {}, pool, &ppf2);
-  EXPECT_LE(compressed_size, 5600);
+  EXPECT_LE(compressed_size, 5600u);
   EXPECT_SLIGHTLY_BELOW(ButteraugliDistance(ppf, ppf2, pool), 1.0);
 }
 
@@ -91,7 +91,7 @@ TEST(PassesTest, RoundtripUnalignedPasses) {
 
   PackedPixelFile ppf2;
   size_t compressed_size = Roundtrip(ppf, cparams, {}, pool, &ppf2);
-  EXPECT_LE(compressed_size, 5200);
+  EXPECT_LE(compressed_size, 5200u);
 
   EXPECT_SLIGHTLY_BELOW(ButteraugliDistance(ppf, ppf2, pool), 1.72);
 }
@@ -420,7 +420,7 @@ TEST(PassesTest, RoundtripSmallNoGaborishPasses) {
 
   PackedPixelFile ppf2;
   size_t compressed_size = Roundtrip(ppf, cparams, {}, pool, &ppf2);
-  EXPECT_LE(compressed_size, 5700);
+  EXPECT_LE(compressed_size, 5700u);
 
   EXPECT_SLIGHTLY_BELOW(ButteraugliDistance(ppf, ppf2, pool), 1.0);
 }

--- a/lib/jxl/render_pipeline/render_pipeline_test.cc
+++ b/lib/jxl/render_pipeline/render_pipeline_test.cc
@@ -146,7 +146,7 @@ TEST(RenderPipelineTest, CallAllGroups) {
     ASSERT_TRUE(input_buffers.Done());
   }
 
-  EXPECT_EQ(pipeline->PassesWithAllInput(), 1);
+  EXPECT_EQ(pipeline->PassesWithAllInput(), 1u);
 }
 
 TEST(RenderPipelineTest, BuildFast) {
@@ -188,7 +188,7 @@ TEST(RenderPipelineTest, CallAllGroupsFast) {
     ASSERT_TRUE(input_buffers.Done());
   }
 
-  EXPECT_EQ(pipeline->PassesWithAllInput(), 1);
+  EXPECT_EQ(pipeline->PassesWithAllInput(), 1u);
 }
 
 struct RenderPipelineTestInputSettings {

--- a/lib/threads/thread_parallel_runner_test.cc
+++ b/lib/threads/thread_parallel_runner_test.cc
@@ -60,8 +60,8 @@ TEST(ThreadParallelRunnerTest, TestPool) {
 
 // Verify "thread" parameter when processing few tasks.
 TEST(ThreadParallelRunnerTest, TestSmallAssignments) {
-  const int kMaxThreads = 8;
-  for (int num_threads = 1; num_threads <= kMaxThreads; ++num_threads) {
+  const size_t kMaxThreads = 8u;
+  for (size_t num_threads = 1; num_threads <= kMaxThreads; ++num_threads) {
     ThreadPoolForTests pool(num_threads);
 
     // (Avoid mutex because it may perturb the worker thread scheduling)
@@ -71,7 +71,7 @@ TEST(ThreadParallelRunnerTest, TestSmallAssignments) {
                              const int task, const int thread) -> jxl::Status {
       num_calls.fetch_add(1, std::memory_order_relaxed);
 
-      EXPECT_LT(thread, num_threads);
+      EXPECT_LT(static_cast<size_t>(thread), num_threads);
       uint64_t bits = id_bits.load(std::memory_order_relaxed);
       while (!id_bits.compare_exchange_weak(bits, bits | (1ULL << thread))) {
         // lock-free retry-loop
@@ -84,7 +84,7 @@ TEST(ThreadParallelRunnerTest, TestSmallAssignments) {
     // Correct number of tasks.
     EXPECT_EQ(num_threads, num_calls.load());
 
-    const int num_participants = PopulationCount(id_bits.load());
+    const size_t num_participants = PopulationCount(id_bits.load());
     // Can't expect equality because other workers may have woken up too late.
     EXPECT_LE(num_participants, num_threads);
   }


### PR DESCRIPTION
"SYSTEM" includes get special treatment when Clang rewrites command line for AppleClang.
It seems that without that option all works fine on other systems.

Drive-by: fix specific warnings/errors.