### PR TITLE
Fix "unable to find library -lpthread" error on Android

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -325,7 +325,8 @@ if(JPEGXL_STATIC)
     link_libraries(-Wl,-Bstatic -lstdc++ -lpthread -Wl,-Bdynamic)
   elseif(CMAKE_USE_PTHREADS_INIT)
     # "whole-archive" is not supported on OSX.
-    if (NOT APPLE)
+    # On Android, libc (bionic) has pthreads built-in.
+    if (NOT APPLE AND NOT ANDROID)
       # Set pthreads as a whole-archive, otherwise weak symbols in the static
       # libraries will discard pthreads symbols leading to segmentation fault at
       # runtime.


### PR DESCRIPTION
<!-- Thank you for considering a contribution to `libjxl`! -->

### Description

Without this PR. Android build fails with `unable to find library -lpthread`.

This is because of this cmake statement:

```
set_target_properties(Threads::Threads PROPERTIES
         INTERFACE_LINK_LIBRARIES
             "-Wl,--whole-archive;-lpthread;-Wl,--no-whole-archive")
```

Android’s libc (bionic) has pthreads built-in. Trying to force `-lpthread` with `--whole-archive` can break build on Android, because there’s no libpthread.a in the NDK (threads are provided by libc).

### Pull Request Checklist

- [ ] **CLA Signed**: Have you signed the [Contributor License Agreement](https://code.google.com/legal/individual-cla-v1.0.html) (individual or corporate, as appropriate)? Only contributions from signed contributors can be accepted.
- [ ] **Authors**: Have you considered adding your name to the [AUTHORS](AUTHORS) file?
- [ ] **Code Style**: Have you ensured your code adheres to the project's coding style guidelines? You can use `./ci.sh lint` for automatic code formatting.


Please review the full [contributing guidelines](https://github.com/libjxl/libjxl/blob/main/CONTRIBUTING.md) for more details.
