### PR TITLE
Exclude optional types

### DIFF
--- a/lib/jpegli/common_internal.h
+++ b/lib/jpegli/common_internal.h
@@ -14,7 +14,6 @@
 
 #include "lib/jpegli/memory_manager.h"
 #include "lib/jpegli/simd.h"
-#include "lib/jxl/base/compiler_specific.h"  // for ssize_t
 
 namespace jpegli {
 
@@ -104,7 +103,7 @@ class RowBuffer {
     data_ = ::jpegli::Allocate<T>(cinfo, ysize_ * stride_, JPOOL_IMAGE_ALIGNED);
   }
 
-  T* Row(ssize_t y) const {
+  T* Row(ptrdiff_t y) const {
     return &data_[((ysize_ + y) % ysize_) * stride_ + offset_];
   }
 
@@ -123,12 +122,12 @@ class RowBuffer {
     }
   }
 
-  void CopyRow(ssize_t dst_row, ssize_t src_row, int border) {
+  void CopyRow(ptrdiff_t dst_row, ptrdiff_t src_row, int border) {
     memcpy(Row(dst_row) - border, Row(src_row) - border,
            (xsize_ + 2 * border) * sizeof(T));
   }
 
-  void FillRow(ssize_t y, T val, size_t len) {
+  void FillRow(ptrdiff_t y, T val, size_t len) {
     T* row = Row(y);
     for (size_t x = 0; x < len; ++x) {
       row[x] = val;

--- a/lib/jpegli/downsample.cc
+++ b/lib/jpegli/downsample.cc
@@ -322,9 +322,9 @@ void ApplyInputSmoothing(j_compress_ptr cinfo) {
   const float kW1 = cinfo->smoothing_factor / 1024.0;
   const float kW0 = 1.0f - 8.0f * kW1;
   const size_t iMCU_height = DCTSIZE * cinfo->max_v_samp_factor;
-  const ssize_t y0 = m->next_iMCU_row * iMCU_height;
-  const ssize_t y1 = y0 + iMCU_height;
-  const ssize_t xsize_padded = m->xsize_blocks * DCTSIZE;
+  const ptrdiff_t y0 = m->next_iMCU_row * iMCU_height;
+  const ptrdiff_t y1 = y0 + iMCU_height;
+  const ptrdiff_t xsize_padded = m->xsize_blocks * DCTSIZE;
   for (int c = 0; c < cinfo->num_components; c++) {
     auto& input = m->input_buffer[c];
     auto& output = *m->smooth_input[c];
@@ -336,12 +336,12 @@ void ApplyInputSmoothing(j_compress_ptr cinfo) {
       input.CopyRow(last_row + 1, last_row, 1);
     }
     // TODO(szabadka) SIMDify this.
-    for (ssize_t y = y0; y < y1; ++y) {
+    for (ptrdiff_t y = y0; y < y1; ++y) {
       const float* row_t = input.Row(y - 1);
       const float* row_m = input.Row(y);
       const float* row_b = input.Row(y + 1);
       float* row_out = output.Row(y);
-      for (ssize_t x = 0; x < xsize_padded; ++x) {
+      for (ptrdiff_t x = 0; x < xsize_padded; ++x) {
         float val_tl = row_t[x - 1];
         float val_tm = row_t[x];
         float val_tr = row_t[x + 1];

--- a/lib/jxl/base/compiler_specific.h
+++ b/lib/jxl/base/compiler_specific.h
@@ -95,11 +95,6 @@
 #define JXL_UNLIKELY(expr) __builtin_expect(!!(expr), 0)
 #endif
 
-#if JXL_COMPILER_MSVC
-#include <stdint.h>
-using ssize_t = intptr_t;
-#endif
-
 // Returns a void* pointer which the compiler then assumes is N-byte aligned.
 // Example: float* JXL_RESTRICT aligned = (float*)JXL_ASSUME_ALIGNED(in, 32);
 //

--- a/lib/jxl/base/printf_macros.h
+++ b/lib/jxl/base/printf_macros.h
@@ -10,7 +10,7 @@
 // library since those may unconditionally define these, depending on the
 // platform.
 
-// PRIuS and PRIdS macros to print size_t and ssize_t respectively.
+// PRIuS and PRIdS macros to print size_t and ptrdiff_t respectively.
 #if !defined(PRIdS)
 #if defined(_WIN64)
 #define PRIdS "lld"

--- a/lib/jxl/base/sanitizers.h
+++ b/lib/jxl/base/sanitizers.h
@@ -121,7 +121,7 @@ static JXL_INLINE JXL_MAYBE_UNUSED void PrintImageUninitialized(
     std::vector<PixelSegment> segments_;
     // Row number of the first row in the range of rows that have |segments| as
     // the undefined segments.
-    ssize_t start_y_ = -1;
+    ptrdiff_t start_y_ = -1;
   } rows_merger;
 
   class SegmentsMerger {
@@ -142,7 +142,7 @@ static JXL_INLINE JXL_MAYBE_UNUSED void PrintImageUninitialized(
     SegmentsMerger seg_merger;
     size_t x = 0;
     while (x < im.xsize()) {
-      intptr_t ret =
+      ptrdiff_t ret =
           __msan_test_shadow(row + x, (im.xsize() - x) * sizeof(row[0]));
       if (ret < 0) break;
       size_t next_x = x + ret / sizeof(row[0]);
@@ -165,7 +165,7 @@ static JXL_INLINE JXL_MAYBE_UNUSED void CheckImageInitialized(
   JXL_DASSERT(r.y0() + r.ysize() <= im.ysize());
   for (size_t y = r.y0(); y < r.y0() + r.ysize(); y++) {
     const auto* row = im.Row(y);
-    intptr_t ret = __msan_test_shadow(row + r.x0(), sizeof(*row) * r.xsize());
+    ptrdiff_t ret = __msan_test_shadow(row + r.x0(), sizeof(*row) * r.xsize());
     if (ret != -1) {
       JXL_DEBUG(
           1,

--- a/lib/jxl/butteraugli/butteraugli.cc
+++ b/lib/jxl/butteraugli/butteraugli.cc
@@ -577,8 +577,8 @@ BUTTERAUGLI_INLINE V Sum(V a, V b, V c, V d, V e, V f, V g, V h, V i) {
 
 template <class D>
 Vec<D> MaltaUnit(MaltaTagLF /*tag*/, const D df,
-                 const float* BUTTERAUGLI_RESTRICT d, const intptr_t xs) {
-  const intptr_t xs3 = 3 * xs;
+                 const float* BUTTERAUGLI_RESTRICT d, const ptrdiff_t xs) {
+  const ptrdiff_t xs3 = 3 * xs;
 
   const auto center = LoadU(df, d);
 
@@ -751,8 +751,8 @@ Vec<D> MaltaUnit(MaltaTagLF /*tag*/, const D df,
 
 template <class D>
 Vec<D> MaltaUnit(MaltaTag /*tag*/, const D df,
-                 const float* BUTTERAUGLI_RESTRICT d, const intptr_t xs) {
-  const intptr_t xs3 = 3 * xs;
+                 const float* BUTTERAUGLI_RESTRICT d, const ptrdiff_t xs) {
+  const ptrdiff_t xs3 = 3 * xs;
 
   const auto center = LoadU(df, d);
 
@@ -1052,7 +1052,7 @@ static Status MaltaDiffMapT(const Tag tag, const ImageF& lum0,
 
   const HWY_FULL(float) df;
   const size_t aligned_x = std::max(static_cast<size_t>(4), Lanes(df));
-  const intptr_t stride = diffs->PixelsPerRow();
+  const ptrdiff_t stride = diffs->PixelsPerRow();
 
   // Middle
   for (; y0 < ysize_ - 4; ++y0) {

--- a/lib/jxl/convolve_symmetric5.cc
+++ b/lib/jxl/convolve_symmetric5.cc
@@ -161,7 +161,7 @@ Status Symmetric5(const ImageF& in, const Rect& in_rect,
     const int64_t riy = task;
     const int64_t iy = in_rect.y0() + riy;
 
-    if (iy < 2 || iy >= static_cast<ssize_t>(in.ysize()) - 2) {
+    if (iy < 2 || iy >= static_cast<ptrdiff_t>(in.ysize()) - 2) {
       Symmetric5Row<WrapMirror>(in, in_rect, iy, weights,
                                 out_rect.Row(out, riy));
     } else {

--- a/lib/jxl/dec_group.cc
+++ b/lib/jxl/dec_group.cc
@@ -520,8 +520,8 @@ Status DecodeACVarBlock(size_t ctx_offset, size_t log2_covered_blocks,
     // signed integer to avoid undefined behavior of shifting negative numbers.
     const size_t magnitude = u_coeff >> 1;
     const size_t neg_sign = (~u_coeff) & 1;
-    const intptr_t coeff =
-        static_cast<intptr_t>((magnitude ^ (neg_sign - 1)) << shift);
+    const ptrdiff_t coeff =
+        static_cast<ptrdiff_t>((magnitude ^ (neg_sign - 1)) << shift);
     if (ac_type == ACType::k16) {
       block.ptr16[order[k]] += coeff;
     } else {
@@ -770,9 +770,9 @@ Status DecodeGroup(const FrameHeader& frame_header,
       RenderPipelineStage::RowInfo output_rows(1, std::vector<float*>(8));
       for (size_t y = src_rect.y0(); y < src_rect.y0() + src_rect.ysize();
            y++) {
-        for (ssize_t iy = 0; iy < 5; iy++) {
+        for (ptrdiff_t iy = 0; iy < 5; iy++) {
           input_rows[0][iy] = group_dec_cache->dc_buffer.Row(
-              Mirror(static_cast<ssize_t>(y) + iy - 2,
+              Mirror(static_cast<ptrdiff_t>(y) + iy - 2,
                      dec_state->shared->dc->Plane(c).ysize() >> vs) +
               2 - src_rect.y0());
         }

--- a/lib/jxl/dec_patch_dictionary.cc
+++ b/lib/jxl/dec_patch_dictionary.cc
@@ -13,7 +13,6 @@
 #include <utility>
 #include <vector>
 
-#include "lib/jxl/base/compiler_specific.h"  // ssize_t
 #include "lib/jxl/base/printf_macros.h"
 #include "lib/jxl/base/status.h"
 #include "lib/jxl/blending.h"
@@ -108,14 +107,14 @@ Status PatchDictionary::Decode(JxlMemoryManager* memory_manager, BitReader* br,
         pos.x = read_num(kPatchPositionContext);
         pos.y = read_num(kPatchPositionContext);
       } else {
-        ssize_t deltax = UnpackSigned(read_num(kPatchOffsetContext));
+        ptrdiff_t deltax = UnpackSigned(read_num(kPatchOffsetContext));
         if (deltax < 0 && static_cast<size_t>(-deltax) > positions_.back().x) {
           return JXL_FAILURE("Invalid patch: negative x coordinate (%" PRIuS
                              " base x %" PRIdS " delta x)",
                              positions_.back().x, deltax);
         }
         pos.x = positions_.back().x + deltax;
-        ssize_t deltay = UnpackSigned(read_num(kPatchOffsetContext));
+        ptrdiff_t deltay = UnpackSigned(read_num(kPatchOffsetContext));
         if (deltay < 0 && static_cast<size_t>(-deltay) > positions_.back().y) {
           return JXL_FAILURE("Invalid patch: negative y coordinate (%" PRIuS
                              " base y %" PRIdS " delta y)",
@@ -255,8 +254,8 @@ void PatchDictionary::ComputePatchTree() {
     // Fill in sorted_patches_y0_ and sorted_patches_y1_ for the current node.
     node.num = right_start - left_end;
     node.start = sorted_patches_y0_.size();
-    for (ssize_t i = static_cast<ssize_t>(right_start) - 1;
-         i >= static_cast<ssize_t>(left_end); --i) {
+    for (ptrdiff_t i = static_cast<ptrdiff_t>(right_start) - 1;
+         i >= static_cast<ptrdiff_t>(left_end); --i) {
       sorted_patches_y1_.emplace_back(intervals[i].y1, intervals[i].idx);
     }
     sort_by_y0(left_end, right_start);
@@ -287,8 +286,8 @@ std::vector<size_t> PatchDictionary::GetPatchesForRow(size_t y) const {
   std::vector<size_t> result;
   if (y < num_patches_.size() && num_patches_[y] > 0) {
     result.reserve(num_patches_[y]);
-    for (ssize_t tree_idx = 0; tree_idx != -1;) {
-      JXL_DASSERT(tree_idx < static_cast<ssize_t>(patch_tree_.size()));
+    for (ptrdiff_t tree_idx = 0; tree_idx != -1;) {
+      JXL_DASSERT(tree_idx < static_cast<ptrdiff_t>(patch_tree_.size()));
       const auto& node = patch_tree_[tree_idx];
       if (y <= node.y_center) {
         for (size_t i = 0; i < node.num; ++i) {

--- a/lib/jxl/dec_patch_dictionary.h
+++ b/lib/jxl/dec_patch_dictionary.h
@@ -18,7 +18,6 @@
 #include <utility>
 #include <vector>
 
-#include "lib/jxl/base/compiler_specific.h"  // ssize_t
 #include "lib/jxl/base/status.h"
 #include "lib/jxl/dec_bit_reader.h"
 #include "lib/jxl/image_bundle.h"
@@ -146,8 +145,8 @@ class PatchDictionary {
 
   // Interval tree on the y coordinates of the patches.
   struct PatchTreeNode {
-    ssize_t left_child;
-    ssize_t right_child;
+    ptrdiff_t left_child;
+    ptrdiff_t right_child;
     size_t y_center;
     // Range of patches in sorted_patches_y0_ and sorted_patches_y1_ that
     // contain the row y_center.

--- a/lib/jxl/enc_entropy_coder.cc
+++ b/lib/jxl/enc_entropy_coder.cc
@@ -9,7 +9,6 @@
 #include <cstdint>
 #include <vector>
 
-#include "lib/jxl/base/compiler_specific.h"  // ssize_t
 #include "lib/jxl/base/rect.h"
 #include "lib/jxl/enc_ans.h"
 #include "lib/jxl/frame_dimensions.h"
@@ -226,7 +225,7 @@ Status TokenizeCoefficients(const coeff_order_t* JXL_RESTRICT orders,
         const size_t histo_offset =
             block_ctx_map.ZeroDensityContextsOffset(block_ctx);
         // Skip LLF.
-        size_t prev = (nzeros > static_cast<ssize_t>(size / 16) ? 0 : 1);
+        size_t prev = (nzeros > static_cast<ptrdiff_t>(size / 16) ? 0 : 1);
         for (size_t k = covered_blocks; k < size && nzeros != 0; ++k) {
           int32_t coeff = block[order[k]];
           size_t ctx =

--- a/lib/jxl/enc_fast_lossless.cc
+++ b/lib/jxl/enc_fast_lossless.cc
@@ -19,11 +19,7 @@
 
 #include "lib/jxl/enc_fast_lossless.h"
 
-#if FJXL_STANDALONE
-#if defined(_MSC_VER)
-using ssize_t = intptr_t;
-#endif
-#else  // FJXL_STANDALONE
+#if !FJXL_STANDALONE
 #include "lib/jxl/encode_internal.h"
 #endif  // FJXL_STANDALONE
 
@@ -3416,7 +3412,7 @@ void ProcessImageArea(const unsigned char* rgba, size_t x0, size_t y0,
   constexpr size_t kAlignPixels = kAlign / sizeof(pixel_t);
 
   auto align = [=](pixel_t* ptr) {
-    size_t offset = reinterpret_cast<uintptr_t>(ptr) % kAlign;
+    size_t offset = reinterpret_cast<size_t>(ptr) % kAlign;
     if (offset) {
       ptr += offset / sizeof(pixel_t);
     }
@@ -3875,8 +3871,8 @@ JxlFastLosslessFrameState* LLPrepare(JxlChunkedFrameInputSource input,
         input.get_color_channel_data_at(input.opaque, x0, y0, xs, ys, &stride);
     auto rgba = reinterpret_cast<const unsigned char*>(buffer);
     int y_begin_group =
-        std::max<ssize_t>(
-            0, static_cast<ssize_t>(ys) - static_cast<ssize_t>(num_rows)) /
+        std::max<ptrdiff_t>(
+            0, static_cast<ptrdiff_t>(ys) - static_cast<ptrdiff_t>(num_rows)) /
         2;
     int y_count = std::min<int>(num_rows, ys - y_begin_group);
     int x_max = xs / kChunkSize * kChunkSize;

--- a/lib/jxl/enc_modular.cc
+++ b/lib/jxl/enc_modular.cc
@@ -248,7 +248,7 @@ float EstimateWPCost(const Image& img, size_t i) {
   weighted::Header wp_header;
   PredictorMode(i, &wp_header);
   for (const Channel& ch : img.channel) {
-    const intptr_t onerow = ch.plane.PixelsPerRow();
+    const ptrdiff_t onerow = ch.plane.PixelsPerRow();
     weighted::State wp_state(wp_header, ch.w, ch.h);
     Properties properties(1);
     for (size_t y = 0; y < ch.h; y++) {

--- a/lib/jxl/enc_modular_simd.cc
+++ b/lib/jxl/enc_modular_simd.cc
@@ -65,7 +65,7 @@ StatusOr<float> EstimateCost(const Image& img) {
   constexpr size_t nc = sizeof(cutoffs) / sizeof(*cutoffs) + 1;
   Histogram histo[nc] = {};
   for (const Channel& ch : img.channel) {
-    const intptr_t onerow = ch.plane.PixelsPerRow();
+    const ptrdiff_t onerow = ch.plane.PixelsPerRow();
     for (size_t y = 0; y < ch.h; y++) {
       const pixel_type* JXL_RESTRICT r = ch.Row(y);
       for (size_t x = 0; x < ch.w; x++) {

--- a/lib/jxl/enc_noise.cc
+++ b/lib/jxl/enc_noise.cc
@@ -275,10 +275,10 @@ std::vector<NoiseLevel> GetNoiseLevel(
           for (size_t x_bl = 0; x_bl < block_s; ++x_bl) {
             float filtered_value = 0;
             for (int y_f = -1 * filt_size; y_f <= filt_size; ++y_f) {
-              if ((static_cast<ssize_t>(y_bl) + y_f) >= 0 &&
+              if ((static_cast<ptrdiff_t>(y_bl) + y_f) >= 0 &&
                   (y_bl + y_f) < block_s) {
                 for (int x_f = -1 * filt_size; x_f <= filt_size; ++x_f) {
-                  if ((static_cast<ssize_t>(x_bl) + x_f) >= 0 &&
+                  if ((static_cast<ptrdiff_t>(x_bl) + x_f) >= 0 &&
                       (x_bl + x_f) < block_s) {
                     filtered_value +=
                         0.5f *
@@ -295,7 +295,7 @@ std::vector<NoiseLevel> GetNoiseLevel(
                 }
               } else {
                 for (int x_f = -1 * filt_size; x_f <= filt_size; ++x_f) {
-                  if ((static_cast<ssize_t>(x_bl) + x_f) >= 0 &&
+                  if ((static_cast<ptrdiff_t>(x_bl) + x_f) >= 0 &&
                       (x_bl + x_f) < block_s) {
                     filtered_value +=
                         0.5f *

--- a/lib/jxl/image.h
+++ b/lib/jxl/image.h
@@ -174,8 +174,8 @@ class Plane : public detail::PlaneBase {
   // Returns number of pixels (some of which are padding) per row. Useful for
   // computing other rows via pointer arithmetic. WARNING: this must
   // NOT be used to determine xsize.
-  JXL_INLINE intptr_t PixelsPerRow() const {
-    return static_cast<intptr_t>(bytes_per_row_ / sizeof(T));
+  JXL_INLINE ptrdiff_t PixelsPerRow() const {
+    return static_cast<ptrdiff_t>(bytes_per_row_ / sizeof(T));
   }
 
  private:
@@ -304,7 +304,7 @@ class Image3 {
   // Returns number of pixels (some of which are padding) per row. Useful for
   // computing other rows via pointer arithmetic. WARNING: this must NOT be used
   // to determine xsize.
-  JXL_INLINE intptr_t PixelsPerRow() const { return planes_[0].PixelsPerRow(); }
+  JXL_INLINE ptrdiff_t PixelsPerRow() const { return planes_[0].PixelsPerRow(); }
 
  private:
   Image3(PlaneT&& plane0, PlaneT&& plane1, PlaneT&& plane2) {

--- a/lib/jxl/image_test_utils.h
+++ b/lib/jxl/image_test_utils.h
@@ -69,24 +69,24 @@ template <typename T>
 bool VerifyRelativeError(const Plane<T>& expected, const Plane<T>& actual,
                          const double threshold_l1,
                          const double threshold_relative,
-                         std::stringstream& failures, const intptr_t border = 0,
+                         std::stringstream& failures, const ptrdiff_t border = 0,
                          const int c = 0) {
   if (!SameSize(expected, actual)) {
     failures << "size mismatch\n";
     return false;
   }
-  const intptr_t xsize = expected.xsize();
-  const intptr_t ysize = expected.ysize();
+  const ptrdiff_t xsize = expected.xsize();
+  const ptrdiff_t ysize = expected.ysize();
 
   // Max over current scanline to give a better idea whether there are
   // systematic errors or just one outlier. Invalid if negative.
   double max_l1 = -1;
   double max_relative = -1;
   bool any_bad = false;
-  for (intptr_t y = border; y < ysize - border; ++y) {
+  for (ptrdiff_t y = border; y < ysize - border; ++y) {
     const T* const JXL_RESTRICT row_expected = expected.Row(y);
     const T* const JXL_RESTRICT row_actual = actual.Row(y);
-    for (intptr_t x = border; x < xsize - border; ++x) {
+    for (ptrdiff_t x = border; x < xsize - border; ++x) {
       const double l1 = std::abs(row_expected[x] - row_actual[x]);
 
       // Cannot compute relative, only check/update L1.
@@ -119,23 +119,23 @@ bool VerifyRelativeError(const Plane<T>& expected, const Plane<T>& actual,
             max_l1, max_relative, threshold_l1, threshold_relative);
   }
   // Dump the expected image and actual image if the region is small enough.
-  const intptr_t kMaxTestDumpSize = 16;
+  const ptrdiff_t kMaxTestDumpSize = 16;
   if (xsize <= kMaxTestDumpSize + 2 * border &&
       ysize <= kMaxTestDumpSize + 2 * border) {
     fprintf(stderr, "Expected image:\n");
-    for (intptr_t y = border; y < ysize - border; ++y) {
+    for (ptrdiff_t y = border; y < ysize - border; ++y) {
       const T* const JXL_RESTRICT row_expected = expected.Row(y);
-      for (intptr_t x = border; x < xsize - border; ++x) {
+      for (ptrdiff_t x = border; x < xsize - border; ++x) {
         fprintf(stderr, "%10lf ", static_cast<double>(row_expected[x]));
       }
       fprintf(stderr, "\n");
     }
 
     fprintf(stderr, "Actual image:\n");
-    for (intptr_t y = border; y < ysize - border; ++y) {
+    for (ptrdiff_t y = border; y < ysize - border; ++y) {
       const T* const JXL_RESTRICT row_expected = expected.Row(y);
       const T* const JXL_RESTRICT row_actual = actual.Row(y);
-      for (intptr_t x = border; x < xsize - border; ++x) {
+      for (ptrdiff_t x = border; x < xsize - border; ++x) {
         const double l1 = std::abs(row_expected[x] - row_actual[x]);
 
         bool bad = l1 > threshold_l1;
@@ -155,11 +155,11 @@ bool VerifyRelativeError(const Plane<T>& expected, const Plane<T>& actual,
   }
 
   // Find first failing x for further debugging.
-  for (intptr_t y = border; y < ysize - border; ++y) {
+  for (ptrdiff_t y = border; y < ysize - border; ++y) {
     const T* const JXL_RESTRICT row_expected = expected.Row(y);
     const T* const JXL_RESTRICT row_actual = actual.Row(y);
 
-    for (intptr_t x = border; x < xsize - border; ++x) {
+    for (ptrdiff_t x = border; x < xsize - border; ++x) {
       const double l1 = std::abs(row_expected[x] - row_actual[x]);
 
       bool bad = l1 > threshold_l1;
@@ -185,7 +185,7 @@ bool VerifyRelativeError(const Image3<T>& expected, const Image3<T>& actual,
                          const float threshold_l1,
                          const float threshold_relative,
                          std::stringstream& failures,
-                         const intptr_t border = 0) {
+                         const ptrdiff_t border = 0) {
   for (size_t c = 0; c < 3; ++c) {
     bool ok = VerifyRelativeError(expected.Plane(c), actual.Plane(c),
                                   threshold_l1, threshold_relative, failures,

--- a/lib/jxl/modular/encoding/context_predict.h
+++ b/lib/jxl/modular/encoding/context_predict.h
@@ -385,7 +385,7 @@ inline void PrecomputeReferences(const Channel &ch, size_t y,
   ZeroFillImage(&references->plane);
   uint32_t offset = 0;
   size_t num_extra_props = references->w;
-  intptr_t onerow = references->plane.PixelsPerRow();
+  ptrdiff_t onerow = references->plane.PixelsPerRow();
   for (int32_t j = static_cast<int32_t>(i) - 1;
        j >= 0 && offset < num_extra_props; j--) {
     if (image.channel[j].w != image.channel[i].w ||
@@ -485,7 +485,7 @@ JXL_INLINE pixel_type_w PredictOne(Predictor p, pixel_type_w left,
 template <int mode>
 JXL_INLINE PredictionResult Predict(
     Properties *p, size_t w, const pixel_type *JXL_RESTRICT pp,
-    const intptr_t onerow, const size_t x, const size_t y, Predictor predictor,
+    const ptrdiff_t onerow, const size_t x, const size_t y, Predictor predictor,
     const MATreeLookup *lookup, const Channel *references,
     weighted::State *wp_state, pixel_type_w *predictions) {
   // We start in position 3 because of 2 static properties + y.
@@ -563,7 +563,7 @@ JXL_INLINE PredictionResult Predict(
 
 inline PredictionResult PredictNoTreeNoWP(size_t w,
                                           const pixel_type *JXL_RESTRICT pp,
-                                          const intptr_t onerow, const int x,
+                                          const ptrdiff_t onerow, const int x,
                                           const int y, Predictor predictor) {
   return detail::Predict</*mode=*/0>(
       /*p=*/nullptr, w, pp, onerow, x, y, predictor, /*lookup=*/nullptr,
@@ -572,7 +572,7 @@ inline PredictionResult PredictNoTreeNoWP(size_t w,
 
 inline PredictionResult PredictNoTreeWP(size_t w,
                                         const pixel_type *JXL_RESTRICT pp,
-                                        const intptr_t onerow, const int x,
+                                        const ptrdiff_t onerow, const int x,
                                         const int y, Predictor predictor,
                                         weighted::State *wp_state) {
   return detail::Predict<detail::kUseWP>(
@@ -582,7 +582,7 @@ inline PredictionResult PredictNoTreeWP(size_t w,
 
 inline PredictionResult PredictTreeNoWP(Properties *p, size_t w,
                                         const pixel_type *JXL_RESTRICT pp,
-                                        const intptr_t onerow, const int x,
+                                        const ptrdiff_t onerow, const int x,
                                         const int y,
                                         const MATreeLookup &tree_lookup,
                                         const Channel &references) {
@@ -593,7 +593,7 @@ inline PredictionResult PredictTreeNoWP(Properties *p, size_t w,
 // Only use for y > 1, x > 1, x < w-2, and empty references
 JXL_INLINE PredictionResult
 PredictTreeNoWPNEC(Properties *p, size_t w, const pixel_type *JXL_RESTRICT pp,
-                   const intptr_t onerow, const int x, const int y,
+                   const ptrdiff_t onerow, const int x, const int y,
                    const MATreeLookup &tree_lookup, const Channel &references) {
   return detail::Predict<detail::kUseTree | detail::kNoEdgeCases>(
       p, w, pp, onerow, x, y, Predictor::Zero, &tree_lookup, &references,
@@ -602,7 +602,7 @@ PredictTreeNoWPNEC(Properties *p, size_t w, const pixel_type *JXL_RESTRICT pp,
 
 inline PredictionResult PredictTreeWP(Properties *p, size_t w,
                                       const pixel_type *JXL_RESTRICT pp,
-                                      const intptr_t onerow, const int x,
+                                      const ptrdiff_t onerow, const int x,
                                       const int y,
                                       const MATreeLookup &tree_lookup,
                                       const Channel &references,
@@ -613,7 +613,7 @@ inline PredictionResult PredictTreeWP(Properties *p, size_t w,
 }
 JXL_INLINE PredictionResult PredictTreeWPNEC(Properties *p, size_t w,
                                              const pixel_type *JXL_RESTRICT pp,
-                                             const intptr_t onerow, const int x,
+                                             const ptrdiff_t onerow, const int x,
                                              const int y,
                                              const MATreeLookup &tree_lookup,
                                              const Channel &references,
@@ -626,7 +626,7 @@ JXL_INLINE PredictionResult PredictTreeWPNEC(Properties *p, size_t w,
 
 inline PredictionResult PredictLearn(Properties *p, size_t w,
                                      const pixel_type *JXL_RESTRICT pp,
-                                     const intptr_t onerow, const int x,
+                                     const ptrdiff_t onerow, const int x,
                                      const int y, Predictor predictor,
                                      const Channel &references,
                                      weighted::State *wp_state) {
@@ -637,7 +637,7 @@ inline PredictionResult PredictLearn(Properties *p, size_t w,
 
 inline void PredictLearnAll(Properties *p, size_t w,
                             const pixel_type *JXL_RESTRICT pp,
-                            const intptr_t onerow, const int x, const int y,
+                            const ptrdiff_t onerow, const int x, const int y,
                             const Channel &references,
                             weighted::State *wp_state,
                             pixel_type_w *predictions) {
@@ -648,7 +648,7 @@ inline void PredictLearnAll(Properties *p, size_t w,
 }
 inline PredictionResult PredictLearnNEC(Properties *p, size_t w,
                                         const pixel_type *JXL_RESTRICT pp,
-                                        const intptr_t onerow, const int x,
+                                        const ptrdiff_t onerow, const int x,
                                         const int y, Predictor predictor,
                                         const Channel &references,
                                         weighted::State *wp_state) {
@@ -660,7 +660,7 @@ inline PredictionResult PredictLearnNEC(Properties *p, size_t w,
 
 inline void PredictLearnAllNEC(Properties *p, size_t w,
                                const pixel_type *JXL_RESTRICT pp,
-                               const intptr_t onerow, const int x, const int y,
+                               const ptrdiff_t onerow, const int x, const int y,
                                const Channel &references,
                                weighted::State *wp_state,
                                pixel_type_w *predictions) {
@@ -671,7 +671,7 @@ inline void PredictLearnAllNEC(Properties *p, size_t w,
 }
 
 inline void PredictAllNoWP(size_t w, const pixel_type *JXL_RESTRICT pp,
-                           const intptr_t onerow, const int x, const int y,
+                           const ptrdiff_t onerow, const int x, const int y,
                            pixel_type_w *predictions) {
   detail::Predict<detail::kAllPredictions>(
       /*p=*/nullptr, w, pp, onerow, x, y, Predictor::Zero,

--- a/lib/jxl/modular/encoding/enc_encoding.cc
+++ b/lib/jxl/modular/encoding/enc_encoding.cc
@@ -138,7 +138,7 @@ Status GatherTreeData(const Image &image, pixel_type chan, size_t group_id,
     return (bits >> 32) <= threshold;
   };
 
-  const intptr_t onerow = channel.plane.PixelsPerRow();
+  const ptrdiff_t onerow = channel.plane.PixelsPerRow();
   JXL_ASSIGN_OR_RETURN(
       Channel references,
       Channel::Create(memory_manager, properties.size() - kNumNonrefProperties,
@@ -283,7 +283,7 @@ Status EncodeModularChannelMAANS(const Image &image, pixel_type chan,
       FillImage(static_cast<float>(PredictorColor(Predictor::Weighted)[c]),
                 &predictor_img.Plane(c));
     }
-    const intptr_t onerow = channel.plane.PixelsPerRow();
+    const ptrdiff_t onerow = channel.plane.PixelsPerRow();
     weighted::State wp_state(wp_header, channel.w, channel.h);
     Properties properties(1);
     for (size_t y = 0; y < channel.h; y++) {
@@ -315,7 +315,7 @@ Status EncodeModularChannelMAANS(const Image &image, pixel_type chan,
       FillImage(static_cast<float>(PredictorColor(Predictor::Gradient)[c]),
                 &predictor_img.Plane(c));
     }
-    const intptr_t onerow = channel.plane.PixelsPerRow();
+    const ptrdiff_t onerow = channel.plane.PixelsPerRow();
     for (size_t y = 0; y < channel.h; y++) {
       const pixel_type *JXL_RESTRICT r = channel.Row(y);
       for (size_t x = 0; x < channel.w; x++) {
@@ -332,7 +332,7 @@ Status EncodeModularChannelMAANS(const Image &image, pixel_type chan,
       FillImage(static_cast<float>(PredictorColor(Predictor::Gradient)[c]),
                 &predictor_img.Plane(c));
     }
-    const intptr_t onerow = channel.plane.PixelsPerRow();
+    const ptrdiff_t onerow = channel.plane.PixelsPerRow();
     for (size_t y = 0; y < channel.h; y++) {
       const pixel_type *JXL_RESTRICT r = channel.Row(y);
       for (size_t x = 0; x < channel.w; x++) {
@@ -373,7 +373,7 @@ Status EncodeModularChannelMAANS(const Image &image, pixel_type chan,
     }
     uint32_t mul_shift =
         FloorLog2Nonzero(static_cast<uint32_t>(tree[0].multiplier));
-    const intptr_t onerow = channel.plane.PixelsPerRow();
+    const ptrdiff_t onerow = channel.plane.PixelsPerRow();
     for (size_t y = 0; y < channel.h; y++) {
       const pixel_type *JXL_RESTRICT r = channel.Row(y);
       for (size_t x = 0; x < channel.w; x++) {
@@ -386,7 +386,7 @@ Status EncodeModularChannelMAANS(const Image &image, pixel_type chan,
     }
 
   } else if (!use_wp && !skip_encoder_fast_path) {
-    const intptr_t onerow = channel.plane.PixelsPerRow();
+    const ptrdiff_t onerow = channel.plane.PixelsPerRow();
     Properties properties(num_props);
     JXL_ASSIGN_OR_RETURN(
         Channel references,
@@ -417,7 +417,7 @@ Status EncodeModularChannelMAANS(const Image &image, pixel_type chan,
       }
     }
   } else {
-    const intptr_t onerow = channel.plane.PixelsPerRow();
+    const ptrdiff_t onerow = channel.plane.PixelsPerRow();
     Properties properties(num_props);
     JXL_ASSIGN_OR_RETURN(
         Channel references,

--- a/lib/jxl/modular/encoding/encoding.cc
+++ b/lib/jxl/modular/encoding/encoding.cc
@@ -271,7 +271,7 @@ Status DecodeModularChannelMAANS(BitReader *br, ANSSymbolReader *reader,
     } else if (predictor == Predictor::Gradient && offset == 0 &&
                multiplier == 1) {
       JXL_DEBUG_V(8, "Gradient very fast track.");
-      const intptr_t onerow = channel.plane.PixelsPerRow();
+      const ptrdiff_t onerow = channel.plane.PixelsPerRow();
       for (size_t y = 0; y < channel.h; y++) {
         pixel_type *JXL_RESTRICT r = channel.Row(y);
         for (size_t x = 0; x < channel.w; x++) {
@@ -299,7 +299,7 @@ Status DecodeModularChannelMAANS(BitReader *br, ANSSymbolReader *reader,
 
   if (is_gradient_only) {
     JXL_DEBUG_V(8, "Gradient fast track.");
-    const intptr_t onerow = channel.plane.PixelsPerRow();
+    const ptrdiff_t onerow = channel.plane.PixelsPerRow();
     for (size_t y = 0; y < channel.h; y++) {
       pixel_type *JXL_RESTRICT r = channel.Row(y);
       for (size_t x = 0; x < channel.w; x++) {
@@ -384,7 +384,7 @@ Status DecodeModularChannelMAANS(BitReader *br, ANSSymbolReader *reader,
     JXL_DEBUG_V(8, "Slow track.");
     MATreeLookup tree_lookup(tree);
     Properties properties = Properties(num_props);
-    const intptr_t onerow = channel.plane.PixelsPerRow();
+    const ptrdiff_t onerow = channel.plane.PixelsPerRow();
     JXL_ASSIGN_OR_RETURN(
         Channel references,
         Channel::Create(memory_manager,
@@ -433,7 +433,7 @@ Status DecodeModularChannelMAANS(BitReader *br, ANSSymbolReader *reader,
     JXL_DEBUG_V(8, "Slowest track.");
     MATreeLookup tree_lookup(tree);
     Properties properties = Properties(num_props);
-    const intptr_t onerow = channel.plane.PixelsPerRow();
+    const ptrdiff_t onerow = channel.plane.PixelsPerRow();
     JXL_ASSIGN_OR_RETURN(
         Channel references,
         Channel::Create(memory_manager,

--- a/lib/jxl/modular/options.h
+++ b/lib/jxl/modular/options.h
@@ -11,7 +11,6 @@
 #include <cstdint>
 #include <vector>
 
-#include "lib/jxl/base/compiler_specific.h"  // ssize_t
 #include "lib/jxl/enc_ans_params.h"
 
 namespace jxl {
@@ -47,7 +46,7 @@ constexpr size_t kNumModularPredictors =
 constexpr size_t kNumModularEncoderPredictors =
     static_cast<size_t>(Predictor::Variable) + 1;
 
-static constexpr ssize_t kNumStaticProperties = 2;  // channel, group_id.
+static constexpr ptrdiff_t kNumStaticProperties = 2;  // channel, group_id.
 
 using StaticPropRange =
     std::array<std::array<uint32_t, 2>, kNumStaticProperties>;

--- a/lib/jxl/modular/transform/enc_palette.cc
+++ b/lib/jxl/modular/transform/enc_palette.cc
@@ -405,8 +405,8 @@ Status FwdPaletteIteration(Image &input, uint32_t begin_c, uint32_t end_c,
   pch.hshift = -1;
   pch.vshift = -1;
   pixel_type *JXL_RESTRICT p_palette = pch.Row(0);
-  intptr_t onerow = pch.plane.PixelsPerRow();
-  intptr_t onerow_image = input.channel[begin_c].plane.PixelsPerRow();
+  ptrdiff_t onerow = pch.plane.PixelsPerRow();
+  ptrdiff_t onerow_image = input.channel[begin_c].plane.PixelsPerRow();
   const int bit_depth = std::min(input.bitdepth, 24);
 
   if (lossy) {

--- a/lib/jxl/modular/transform/enc_squeeze.cc
+++ b/lib/jxl/modular/transform/enc_squeeze.cc
@@ -91,7 +91,7 @@ Status FwdVSqueeze(Image &input, int c, int rc) {
   chout.component = chin.component;
   chout_residual.component = chin.component;
 
-  intptr_t onerow_in = chin.plane.PixelsPerRow();
+  ptrdiff_t onerow_in = chin.plane.PixelsPerRow();
   for (size_t y = 0; y < chout_residual.h; y++) {
     const pixel_type *JXL_RESTRICT p_in = chin.Row(y * 2);
     pixel_type *JXL_RESTRICT p_out = chout.Row(y);
@@ -113,7 +113,7 @@ Status FwdVSqueeze(Image &input, int c, int rc) {
         next_avg = p_in[x + 2 * onerow_in];
       }
       pixel_type top =
-          (y > 0 ? p_in[static_cast<ssize_t>(x) - onerow_in] : avg);
+          (y > 0 ? p_in[static_cast<ptrdiff_t>(x) - onerow_in] : avg);
       pixel_type tendency = SmoothTendency(top, avg, next_avg);
 
       p_res[x] = diff - tendency;

--- a/lib/jxl/modular/transform/palette.cc
+++ b/lib/jxl/modular/transform/palette.cc
@@ -48,8 +48,8 @@ Status InvPalette(Image &input, uint32_t begin_c, uint32_t nb_colors,
   }
   const Channel &palette = input.channel[0];
   const pixel_type *JXL_RESTRICT p_palette = input.channel[0].Row(0);
-  intptr_t onerow = input.channel[0].plane.PixelsPerRow();
-  intptr_t onerow_image = input.channel[c0].plane.PixelsPerRow();
+  ptrdiff_t onerow = input.channel[0].plane.PixelsPerRow();
+  ptrdiff_t onerow_image = input.channel[c0].plane.PixelsPerRow();
   const int bit_depth = std::min(input.bitdepth, 24);
 
   if (w == 0) {

--- a/lib/jxl/modular/transform/squeeze.cc
+++ b/lib/jxl/modular/transform/squeeze.cc
@@ -185,9 +185,9 @@ Status InvHSqueeze(Image &input, uint32_t c, uint32_t rc, ThreadPool *pool) {
     size_t x = 0;
 
 #if HWY_TARGET != HWY_SCALAR
-    intptr_t onerow_in = chin.plane.PixelsPerRow();
-    intptr_t onerow_inr = chin_residual.plane.PixelsPerRow();
-    intptr_t onerow_out = chout.plane.PixelsPerRow();
+    ptrdiff_t onerow_in = chin.plane.PixelsPerRow();
+    ptrdiff_t onerow_inr = chin_residual.plane.PixelsPerRow();
+    ptrdiff_t onerow_out = chout.plane.PixelsPerRow();
     const pixel_type *JXL_RESTRICT p_residual = chin_residual.Row(y0);
     const pixel_type *JXL_RESTRICT p_avg = chin.Row(y0);
     pixel_type *JXL_RESTRICT p_out = chout.Row(y0);

--- a/lib/jxl/render_pipeline/simple_render_pipeline.cc
+++ b/lib/jxl/render_pipeline/simple_render_pipeline.cc
@@ -15,7 +15,6 @@
 
 #include "lib/jxl/base/bits.h"
 #include "lib/jxl/base/common.h"
-#include "lib/jxl/base/compiler_specific.h"  // ssize_t
 #include "lib/jxl/base/rect.h"
 #include "lib/jxl/base/sanitizers.h"
 #include "lib/jxl/base/status.h"
@@ -137,7 +136,7 @@ Status SimpleRenderPipeline::ProcessBuffers(size_t group_id, size_t thread_id) {
         float* row = get_row(c, y);
         for (size_t ix = 0; ix < stage->settings_.border_x; ix++) {
           *(row - ix - 1) =
-              row[Mirror(-static_cast<ssize_t>(ix) - 1, input_sizes[c].first)];
+              row[Mirror(-static_cast<ptrdiff_t>(ix) - 1, input_sizes[c].first)];
         }
         for (size_t ix = 0; ix < stage->settings_.border_x; ix++) {
           *(row + ix + input_sizes[c].first) =
@@ -147,7 +146,7 @@ Status SimpleRenderPipeline::ProcessBuffers(size_t group_id, size_t thread_id) {
       // Vertical mirroring.
       for (int y = 0; y < static_cast<int>(stage->settings_.border_y); y++) {
         memcpy(get_row(c, -y - 1) - stage->settings_.border_x,
-               get_row(c, Mirror(-static_cast<ssize_t>(y) - 1,
+               get_row(c, Mirror(-static_cast<ptrdiff_t>(y) - 1,
                                  input_sizes[c].second)) -
                    stage->settings_.border_x,
                sizeof(float) *
@@ -260,8 +259,8 @@ Status SimpleRenderPipeline::ProcessBuffers(size_t group_id, size_t thread_id) {
         // background that won't be occluded.
         stage->ProcessPaddingRow(output_rows, image_xsize, 0, y);
       }
-      ssize_t x0 = frame_origin.x0;
-      ssize_t y0 = frame_origin.y0;
+      ptrdiff_t x0 = frame_origin.x0;
+      ptrdiff_t y0 = frame_origin.y0;
       size_t x0_fg = 0;
       size_t y0_fg = 0;
       if (x0 < 0) {

--- a/lib/jxl/render_pipeline/stage_blending.cc
+++ b/lib/jxl/render_pipeline/stage_blending.cc
@@ -14,7 +14,6 @@
 #include <vector>
 
 #include "lib/jxl/base/common.h"
-#include "lib/jxl/base/compiler_specific.h"  // ssize_t
 #include "lib/jxl/base/status.h"
 #include "lib/jxl/color_encoding_internal.h"
 #include "lib/jxl/dec_cache.h"
@@ -138,12 +137,12 @@ class BlendingStage : public RenderPipelineStage {
     JXL_ENSURE(initialized_);
     JxlMemoryManager* memory_manager = state_.memory_manager;
     const FrameOrigin& frame_origin = frame_header_.frame_origin;
-    ssize_t bg_xpos = frame_origin.x0 + static_cast<ssize_t>(xpos);
-    ssize_t bg_ypos = frame_origin.y0 + static_cast<ssize_t>(ypos);
+    ptrdiff_t bg_xpos = frame_origin.x0 + static_cast<ptrdiff_t>(xpos);
+    ptrdiff_t bg_ypos = frame_origin.y0 + static_cast<ptrdiff_t>(ypos);
     int offset = 0;
-    if (bg_xpos + static_cast<ssize_t>(xsize) <= 0 ||
-        frame_origin.x0 >= static_cast<ssize_t>(image_xsize_) || bg_ypos < 0 ||
-        bg_ypos >= static_cast<ssize_t>(image_ysize_)) {
+    if (bg_xpos + static_cast<ptrdiff_t>(xsize) <= 0 ||
+        frame_origin.x0 >= static_cast<ptrdiff_t>(image_xsize_) || bg_ypos < 0 ||
+        bg_ypos >= static_cast<ptrdiff_t>(image_ysize_)) {
       // TODO(eustas): or fail?
       return true;
     }
@@ -154,7 +153,7 @@ class BlendingStage : public RenderPipelineStage {
     }
     if (bg_xpos + xsize > image_xsize_) {
       xsize =
-          std::max<ssize_t>(0, static_cast<ssize_t>(image_xsize_) - bg_xpos);
+          std::max<ptrdiff_t>(0, static_cast<ptrdiff_t>(image_xsize_) - bg_xpos);
     }
     std::vector<const float*> bg_row_ptrs_(input_rows.size());
     std::vector<float*> fg_row_ptrs_(input_rows.size());

--- a/lib/jxl/render_pipeline/stage_chroma_upsampling.cc
+++ b/lib/jxl/render_pipeline/stage_chroma_upsampling.cc
@@ -9,7 +9,6 @@
 #include <memory>
 
 #include "lib/jxl/base/common.h"
-#include "lib/jxl/base/compiler_specific.h"  // ssize_t
 #include "lib/jxl/base/status.h"
 #include "lib/jxl/render_pipeline/render_pipeline_stage.h"
 
@@ -44,7 +43,7 @@ class HorizontalChromaUpsamplingStage : public RenderPipelineStage {
     auto onefour = Set(df, 0.25f);
     const float* row_in = GetInputRow(input_rows, c_, 0);
     float* row_out = GetOutputRow(output_rows, c_, 0);
-    for (ssize_t x = -xextra; x < static_cast<ssize_t>(xsize + xextra);
+    for (ptrdiff_t x = -xextra; x < static_cast<ptrdiff_t>(xsize + xextra);
          x += Lanes(df)) {
       auto current = Mul(LoadU(df, row_in + x), threefour);
       auto prev = LoadU(df, row_in + x - 1);
@@ -86,7 +85,7 @@ class VerticalChromaUpsamplingStage : public RenderPipelineStage {
     const float* row_bot = GetInputRow(input_rows, c_, 1);
     float* row_out0 = GetOutputRow(output_rows, c_, 0);
     float* row_out1 = GetOutputRow(output_rows, c_, 1);
-    for (ssize_t x = -xextra; x < static_cast<ssize_t>(xsize + xextra);
+    for (ptrdiff_t x = -xextra; x < static_cast<ptrdiff_t>(xsize + xextra);
          x += Lanes(df)) {
       auto it = LoadU(df, row_top + x);
       auto im = LoadU(df, row_mid + x);

--- a/lib/jxl/render_pipeline/stage_epf.cc
+++ b/lib/jxl/render_pipeline/stage_epf.cc
@@ -11,7 +11,6 @@
 #include <utility>
 
 #include "lib/jxl/base/common.h"
-#include "lib/jxl/base/compiler_specific.h"  // ssize_t
 #include "lib/jxl/base/status.h"
 #include "lib/jxl/common.h"  // JXL_HIGH_PRECISION
 #include "lib/jxl/dec_cache.h"
@@ -60,7 +59,7 @@ class EPF0Stage : public RenderPipelineStage {
         sigma_(&sigma) {}
 
   template <bool aligned>
-  JXL_INLINE void AddPixel(int row, float* JXL_RESTRICT rows[3][7], ssize_t x,
+  JXL_INLINE void AddPixel(int row, float* JXL_RESTRICT rows[3][7], ptrdiff_t x,
                            Vec<DF> sad, Vec<DF> inv_sigma,
                            Vec<DF>* JXL_RESTRICT X, Vec<DF>* JXL_RESTRICT Y,
                            Vec<DF>* JXL_RESTRICT B,
@@ -111,7 +110,7 @@ class EPF0Stage : public RenderPipelineStage {
             ? sad_mul_border
             : sad_mul_center;
 
-    for (ssize_t x = -xextra; x < static_cast<ssize_t>(xsize + xextra);
+    for (ptrdiff_t x = -xextra; x < static_cast<ptrdiff_t>(xsize + xextra);
          x += Lanes(df)) {
       size_t bx = (x + xpos + kSigmaPadding * kBlockDim) / kBlockDim;
       size_t ix = (x + xpos) % kBlockDim;
@@ -199,7 +198,7 @@ class EPF1Stage : public RenderPipelineStage {
         sigma_(&sigma) {}
 
   template <bool aligned>
-  JXL_INLINE void AddPixel(int row, float* JXL_RESTRICT rows[3][5], ssize_t x,
+  JXL_INLINE void AddPixel(int row, float* JXL_RESTRICT rows[3][5], ptrdiff_t x,
                            Vec<DF> sad, Vec<DF> inv_sigma,
                            Vec<DF>* JXL_RESTRICT X, Vec<DF>* JXL_RESTRICT Y,
                            Vec<DF>* JXL_RESTRICT B,
@@ -246,7 +245,7 @@ class EPF1Stage : public RenderPipelineStage {
             ? sad_mul_border
             : sad_mul_center;
 
-    for (ssize_t x = -xextra; x < static_cast<ssize_t>(xsize + xextra);
+    for (ptrdiff_t x = -xextra; x < static_cast<ptrdiff_t>(xsize + xextra);
          x += Lanes(df)) {
       size_t bx = (x + xpos + kSigmaPadding * kBlockDim) / kBlockDim;
       size_t ix = (x + xpos) % kBlockDim;
@@ -380,7 +379,7 @@ class EPF2Stage : public RenderPipelineStage {
         sigma_(&sigma) {}
 
   template <bool aligned>
-  JXL_INLINE void AddPixel(int row, float* JXL_RESTRICT rows[3][3], ssize_t x,
+  JXL_INLINE void AddPixel(int row, float* JXL_RESTRICT rows[3][3], ptrdiff_t x,
                            Vec<DF> rx, Vec<DF> ry, Vec<DF> rb,
                            Vec<DF> inv_sigma, Vec<DF>* JXL_RESTRICT X,
                            Vec<DF>* JXL_RESTRICT Y, Vec<DF>* JXL_RESTRICT B,
@@ -432,7 +431,7 @@ class EPF2Stage : public RenderPipelineStage {
             ? sad_mul_border
             : sad_mul_center;
 
-    for (ssize_t x = -xextra; x < static_cast<ssize_t>(xsize + xextra);
+    for (ptrdiff_t x = -xextra; x < static_cast<ptrdiff_t>(xsize + xextra);
          x += Lanes(df)) {
       size_t bx = (x + xpos + kSigmaPadding * kBlockDim) / kBlockDim;
       size_t ix = (x + xpos) % kBlockDim;

--- a/lib/jxl/render_pipeline/stage_from_linear.cc
+++ b/lib/jxl/render_pipeline/stage_from_linear.cc
@@ -10,7 +10,6 @@
 #include <memory>
 
 #include "lib/jxl/base/common.h"
-#include "lib/jxl/base/compiler_specific.h"
 #include "lib/jxl/base/status.h"
 #include "lib/jxl/dec_xyb.h"
 #include "lib/jxl/render_pipeline/render_pipeline_stage.h"
@@ -125,7 +124,7 @@ class FromLinearStage : public RenderPipelineStage {
     msan::UnpoisonMemory(row0 + xsize, sizeof(float) * (xsize_v - xsize));
     msan::UnpoisonMemory(row1 + xsize, sizeof(float) * (xsize_v - xsize));
     msan::UnpoisonMemory(row2 + xsize, sizeof(float) * (xsize_v - xsize));
-    for (ssize_t x = -xextra; x < static_cast<ssize_t>(xsize + xextra);
+    for (ptrdiff_t x = -xextra; x < static_cast<ptrdiff_t>(xsize + xextra);
          x += Lanes(d)) {
       auto r = LoadU(d, row0 + x);
       auto g = LoadU(d, row1 + x);

--- a/lib/jxl/render_pipeline/stage_gaborish.cc
+++ b/lib/jxl/render_pipeline/stage_gaborish.cc
@@ -9,7 +9,6 @@
 #include <memory>
 
 #include "lib/jxl/base/common.h"
-#include "lib/jxl/base/compiler_specific.h"  // ssize_t
 #include "lib/jxl/base/status.h"
 #include "lib/jxl/loop_filter.h"
 #include "lib/jxl/render_pipeline/render_pipeline_stage.h"
@@ -74,8 +73,8 @@ class GaborishStage : public RenderPipelineStage {
 #endif
       // Since GetInputRow(input_rows, c, {-1, 0, 1}) is aligned, rounding
       // xextra up to Lanes(d) doesn't access anything problematic.
-      for (ssize_t x = -RoundUpTo(xextra, Lanes(d));
-           x < static_cast<ssize_t>(xsize + xextra); x += Lanes(d)) {
+      for (ptrdiff_t x = -RoundUpTo(xextra, Lanes(d));
+           x < static_cast<ptrdiff_t>(xsize + xextra); x += Lanes(d)) {
         const auto t = LoadMaybeU(d, row_t + x);
         const auto tl = LoadU(d, row_t + x - 1);
         const auto tr = LoadU(d, row_t + x + 1);

--- a/lib/jxl/render_pipeline/stage_noise.cc
+++ b/lib/jxl/render_pipeline/stage_noise.cc
@@ -12,7 +12,6 @@
 #include <memory>
 
 #include "lib/jxl/base/common.h"
-#include "lib/jxl/base/compiler_specific.h"
 #include "lib/jxl/base/sanitizers.h"
 #include "lib/jxl/base/status.h"
 #include "lib/jxl/chroma_from_luma.h"
@@ -270,12 +269,12 @@ class ConvolveNoiseStage : public RenderPipelineStage {
         rows[i] = GetInputRow(input_rows, c, i - 2);
       }
       float* JXL_RESTRICT row_out = GetOutputRow(output_rows, c, 0);
-      for (ssize_t x = -RoundUpTo(xextra, Lanes(d));
-           x < static_cast<ssize_t>(xsize + xextra); x += Lanes(d)) {
+      for (ptrdiff_t x = -RoundUpTo(xextra, Lanes(d));
+           x < static_cast<ptrdiff_t>(xsize + xextra); x += Lanes(d)) {
         const auto p00 = LoadU(d, rows[2] + x);
         auto others = Zero(d);
         // TODO(eustas): sum loaded values to reduce the calculation chain
-        for (ssize_t i = -2; i <= 2; i++) {
+        for (ptrdiff_t i = -2; i <= 2; i++) {
           others = Add(others, LoadU(d, rows[0] + x + i));
           others = Add(others, LoadU(d, rows[1] + x + i));
           others = Add(others, LoadU(d, rows[3] + x + i));

--- a/lib/jxl/render_pipeline/stage_spot.cc
+++ b/lib/jxl/render_pipeline/stage_spot.cc
@@ -10,7 +10,6 @@
 #include <memory>
 
 #include "lib/jxl/base/common.h"
-#include "lib/jxl/base/compiler_specific.h"
 #include "lib/jxl/base/status.h"
 #include "lib/jxl/render_pipeline/render_pipeline_stage.h"
 
@@ -30,7 +29,7 @@ class SpotColorStage : public RenderPipelineStage {
     for (size_t c = 0; c < 3; c++) {
       float* JXL_RESTRICT p = GetInputRow(input_rows, c, 0);
       const float* JXL_RESTRICT s = GetInputRow(input_rows, spot_c_, 0);
-      for (ssize_t x = -xextra; x < static_cast<ssize_t>(xsize + xextra); x++) {
+      for (ptrdiff_t x = -xextra; x < static_cast<ptrdiff_t>(xsize + xextra); x++) {
         float mix = scale * s[x];
         p[x] = mix * spot_color_[c] + (1.0f - mix) * p[x];
       }

--- a/lib/jxl/render_pipeline/stage_to_linear.cc
+++ b/lib/jxl/render_pipeline/stage_to_linear.cc
@@ -10,7 +10,6 @@
 #include <memory>
 
 #include "lib/jxl/base/common.h"
-#include "lib/jxl/base/compiler_specific.h"
 #include "lib/jxl/base/sanitizers.h"
 #include "lib/jxl/base/status.h"
 #include "lib/jxl/dec_xyb.h"
@@ -129,7 +128,7 @@ class ToLinearStage : public RenderPipelineStage {
     msan::UnpoisonMemory(row0 + xsize, sizeof(float) * (xsize_v - xsize));
     msan::UnpoisonMemory(row1 + xsize, sizeof(float) * (xsize_v - xsize));
     msan::UnpoisonMemory(row2 + xsize, sizeof(float) * (xsize_v - xsize));
-    for (ssize_t x = -xextra; x < static_cast<ssize_t>(xsize + xextra);
+    for (ptrdiff_t x = -xextra; x < static_cast<ptrdiff_t>(xsize + xextra);
          x += Lanes(d)) {
       auto r = LoadU(d, row0 + x);
       auto g = LoadU(d, row1 + x);

--- a/lib/jxl/render_pipeline/stage_tone_mapping.cc
+++ b/lib/jxl/render_pipeline/stage_tone_mapping.cc
@@ -10,7 +10,6 @@
 #include <utility>
 
 #include "lib/jxl/base/common.h"
-#include "lib/jxl/base/compiler_specific.h"  // ssize_t
 #include "lib/jxl/base/sanitizers.h"
 #include "lib/jxl/base/status.h"
 #include "lib/jxl/cms/tone_mapping.h"
@@ -83,7 +82,7 @@ class ToneMappingStage : public RenderPipelineStage {
     msan::UnpoisonMemory(row0 + xsize, sizeof(float) * (xsize_v - xsize));
     msan::UnpoisonMemory(row1 + xsize, sizeof(float) * (xsize_v - xsize));
     msan::UnpoisonMemory(row2 + xsize, sizeof(float) * (xsize_v - xsize));
-    for (ssize_t x = -xextra; x < static_cast<ssize_t>(xsize + xextra);
+    for (ptrdiff_t x = -xextra; x < static_cast<ptrdiff_t>(xsize + xextra);
          x += Lanes(d)) {
       auto r = LoadU(d, row0 + x);
       auto g = LoadU(d, row1 + x);

--- a/lib/jxl/render_pipeline/stage_upsampling.cc
+++ b/lib/jxl/render_pipeline/stage_upsampling.cc
@@ -12,7 +12,6 @@
 #include <memory>
 
 #include "lib/jxl/base/common.h"
-#include "lib/jxl/base/compiler_specific.h"  // ssize_t
 #include "lib/jxl/base/sanitizers.h"
 #include "lib/jxl/base/status.h"
 #include "lib/jxl/image_metadata.h"
@@ -88,7 +87,7 @@ class UpsamplingStage : public RenderPipelineStage {
     size_t shift = settings_.shift_x;
     size_t N = 1 << shift;
     const size_t xsize_v = RoundUpTo(xsize, Lanes(df));
-    for (ssize_t iy = -2; iy <= 2; iy++) {
+    for (ptrdiff_t iy = -2; iy <= 2; iy++) {
       msan::UnpoisonMemory(GetInputRow(input_rows, c_, iy) + xsize + 2,
                            sizeof(float) * (xsize_v - xsize));
     }
@@ -200,7 +199,7 @@ class UpsamplingStage : public RenderPipelineStage {
     }
   }
 
-  template <ssize_t N>
+  template <ptrdiff_t N>
   void ProcessRowImpl(const RowInfo& input_rows, const RowInfo& output_rows,
                       size_t x0, size_t len, size_t thread_id) const {
     constexpr HWY_FULL(float) df;
@@ -229,8 +228,8 @@ class UpsamplingStage : public RenderPipelineStage {
     float* JXL_RESTRICT mins = temp_[2][thread_id].address<float>();
     float* JXL_RESTRICT maxs = temp_[0][thread_id].address<float>();
     std::array<float*, 25> input;
-    for (ssize_t iy = -2; iy <= 2; ++iy) {
-      for (ssize_t ix = -2; ix <= 2; ++ix) {
+    for (ptrdiff_t iy = -2; iy <= 2; ++iy) {
+      for (ptrdiff_t ix = -2; ix <= 2; ++ix) {
         input[5 * (iy + 2) + (ix + 2)] = GetInputRow(input_rows, c_, iy) + ix;
       }
     }

--- a/lib/jxl/render_pipeline/stage_xyb.cc
+++ b/lib/jxl/render_pipeline/stage_xyb.cc
@@ -10,7 +10,6 @@
 #include <memory>
 
 #include "lib/jxl/base/common.h"
-#include "lib/jxl/base/compiler_specific.h"
 #include "lib/jxl/base/sanitizers.h"
 #include "lib/jxl/base/status.h"
 #include "lib/jxl/color_encoding_internal.h"
@@ -62,7 +61,7 @@ class XYBStage : public RenderPipelineStage {
       const auto offset_x = Set(d, jxl::cms::kScaledXYBOffset[0]);
       const auto offset_y = Set(d, jxl::cms::kScaledXYBOffset[1]);
       const auto offset_bmy = Set(d, jxl::cms::kScaledXYBOffset[2]);
-      for (ssize_t x = -xextra; x < static_cast<ssize_t>(xsize + xextra);
+      for (ptrdiff_t x = -xextra; x < static_cast<ptrdiff_t>(xsize + xextra);
            x += Lanes(d)) {
         const auto in_x = LoadU(d, row0 + x);
         const auto in_y = LoadU(d, row1 + x);
@@ -75,7 +74,7 @@ class XYBStage : public RenderPipelineStage {
         StoreU(out_b, d, row2 + x);
       }
     } else {
-      for (ssize_t x = -xextra; x < static_cast<ssize_t>(xsize + xextra);
+      for (ptrdiff_t x = -xextra; x < static_cast<ptrdiff_t>(xsize + xextra);
            x += Lanes(d)) {
         const auto in_opsin_x = LoadU(d, row0 + x);
         const auto in_opsin_y = LoadU(d, row1 + x);

--- a/lib/jxl/splines.cc
+++ b/lib/jxl/splines.cc
@@ -19,7 +19,6 @@
 
 #include "lib/jxl/base/bits.h"
 #include "lib/jxl/base/common.h"
-#include "lib/jxl/base/compiler_specific.h"  // ssize_t
 #include "lib/jxl/base/printf_macros.h"
 #include "lib/jxl/base/rect.h"
 #include "lib/jxl/base/status.h"
@@ -108,13 +107,13 @@ void DrawSegment(DF df, const SplineSegment& segment, const bool add,
 void DrawSegment(const SplineSegment& segment, const bool add, const size_t y,
                  const size_t x0, const size_t x1,
                  float* JXL_RESTRICT rows[3]) {
-  ssize_t start = std::llround(segment.center_x - segment.maximum_distance);
-  ssize_t end = std::llround(segment.center_x + segment.maximum_distance);
-  if (end < static_cast<ssize_t>(x0) || start >= static_cast<ssize_t>(x1)) {
+  ptrdiff_t start = std::llround(segment.center_x - segment.maximum_distance);
+  ptrdiff_t end = std::llround(segment.center_x + segment.maximum_distance);
+  if (end < static_cast<ptrdiff_t>(x0) || start >= static_cast<ptrdiff_t>(x1)) {
     return;  // span does not intersect scan
   }
-  size_t span_x0 = std::max<ssize_t>(x0, start) - x0;
-  size_t span_x1 = std::min<ssize_t>(x1, end + 1) - x0;  // exclusive
+  size_t span_x0 = std::max<ptrdiff_t>(x0, start) - x0;
+  size_t span_x1 = std::min<ptrdiff_t>(x1, end + 1) - x0;  // exclusive
   HWY_FULL(float) df;
   size_t x = span_x0;
   for (; x + Lanes(df) <= span_x1; x += Lanes(df)) {
@@ -157,10 +156,10 @@ void ComputeSegments(const Spline::Point& center, const float intensity,
   segment.inv_sigma = 1.0f / sigma;
   segment.sigma_over_4_times_intensity = .25f * sigma * intensity;
   segment.maximum_distance = maximum_distance;
-  ssize_t y0 = std::llround(center.y - maximum_distance);
-  ssize_t y1 =
+  ptrdiff_t y0 = std::llround(center.y - maximum_distance);
+  ptrdiff_t y1 =
       std::llround(center.y + maximum_distance) + 1;  // one-past-the-end
-  for (ssize_t y = std::max<ssize_t>(y0, 0); y < y1; y++) {
+  for (ptrdiff_t y = std::max<ptrdiff_t>(y0, 0); y < y1; y++) {
     segments_by_y.emplace_back(y, segments.size());
   }
   segments.push_back(segment);

--- a/lib/jxl/test_image.cc
+++ b/lib/jxl/test_image.cc
@@ -23,7 +23,6 @@
 #include "lib/extras/dec/decode.h"
 #include "lib/extras/packed_image.h"
 #include "lib/jxl/base/byte_order.h"
-#include "lib/jxl/base/compiler_specific.h"  // ssize_t
 #include "lib/jxl/base/random.h"
 #include "lib/jxl/base/span.h"
 #include "lib/jxl/base/status.h"
@@ -418,12 +417,12 @@ StatusOr<TestImage::Frame> TestImage::AddFrame() {
 }
 
 void TestImage::CropLayerInfo(size_t xsize, size_t ysize, JxlLayerInfo* info) {
-  if (info->crop_x0 < static_cast<ssize_t>(xsize)) {
+  if (info->crop_x0 < static_cast<ptrdiff_t>(xsize)) {
     info->xsize = std::min<size_t>(info->xsize, xsize - info->crop_x0);
   } else {
     info->xsize = 0;
   }
-  if (info->crop_y0 < static_cast<ssize_t>(ysize)) {
+  if (info->crop_y0 < static_cast<ptrdiff_t>(ysize)) {
     info->ysize = std::min<size_t>(info->ysize, ysize - info->crop_y0);
   } else {
     info->ysize = 0;

--- a/tools/gauss_blur_test.cc
+++ b/tools/gauss_blur_test.cc
@@ -571,9 +571,9 @@ TEST(GaussBlurTest, TestSign) {
   const size_t xtest = xsize / 2;
   const size_t ytest = ysize / 2;
 
-  for (intptr_t dy = -16; dy <= 16; ++dy) {
+  for (ptrdiff_t dy = -16; dy <= 16; ++dy) {
     float* row = in.Row(ytest + dy);
-    for (intptr_t dx = -16; dx <= 16; ++dx)
+    for (ptrdiff_t dx = -16; dx <= 16; ++dx)
       row[xtest + dx] = center[(dy + 16) * 33 + (dx + 16)];
   }
 

--- a/tools/hdr/local_tone_map.cc
+++ b/tools/hdr/local_tone_map.cc
@@ -115,15 +115,15 @@ StatusOr<ImageF> Upsample(const ImageF& image, ThreadPool* pool) {
   JXL_ASSIGN_OR_RETURN(ImageF upsampled_horizontally,
                        ImageF::Create(jpegxl::tools::NoMemoryManager(),
                                       2 * image.xsize(), image.ysize()));
-  const auto BoundX = [&image](ssize_t x) {
-    return Clamp1<ssize_t>(x, 0, image.xsize() - 1);
+  const auto BoundX = [&image](ptrdiff_t x) {
+    return Clamp1<ptrdiff_t>(x, 0, image.xsize() - 1);
   };
   const auto process_row_h = [&](const int32_t y,
                                  const int32_t /*thread_id*/) -> Status {
     const float* const JXL_RESTRICT in_row = image.ConstRow(y);
     float* const JXL_RESTRICT out_row = upsampled_horizontally.Row(y);
 
-    for (ssize_t x = 0; x < static_cast<ssize_t>(image.xsize()); ++x) {
+    for (ptrdiff_t x = 0; x < static_cast<ptrdiff_t>(image.xsize()); ++x) {
       out_row[2 * x] = in_row[x];
       out_row[2 * x + 1] =
           0.5625f * (in_row[x] + in_row[BoundX(x + 1)]) -
@@ -138,8 +138,8 @@ StatusOr<ImageF> Upsample(const ImageF& image, ThreadPool* pool) {
   JXL_ASSIGN_OR_RETURN(ImageF upsampled,
                        ImageF::Create(jpegxl::tools::NoMemoryManager(),
                                       2 * image.xsize(), 2 * image.ysize()));
-  const auto BoundY = [&image](ssize_t y) {
-    return Clamp1<ssize_t>(y, 0, image.ysize() - 1);
+  const auto BoundY = [&image](ptrdiff_t y) {
+    return Clamp1<ptrdiff_t>(y, 0, image.ysize() - 1);
   };
   const auto process_row_v = [&](const int32_t y,
                                  const int32_t /*thread_id*/) -> Status {
@@ -154,8 +154,8 @@ StatusOr<ImageF> Upsample(const ImageF& image, ThreadPool* pool) {
         upsampled.Row(2 * y + 1),
     };
 
-    for (ssize_t x = 0;
-         x < static_cast<ssize_t>(upsampled_horizontally.xsize());
+    for (ptrdiff_t x = 0;
+         x < static_cast<ptrdiff_t>(upsampled_horizontally.xsize());
          x += Lanes(df)) {
       Store(Load(df, in_rows[1] + x), df, out_rows[0] + x);
       Store(MulAdd(Set(df, 0.5625f),


### PR DESCRIPTION
### Description

Unfortunately, types `intptr_t` and `ssize_t` are optional in C++, so this PR converts them into standard `ptrdif_t`.

### Pull Request Checklist

- [x] **CLA Signed**: Have you signed the [Contributor License Agreement](https://code.google.com/legal/individual-cla-v1.0.html) (individual or corporate, as appropriate)? Only contributions from signed contributors can be accepted.
- [x] **Authors**: Have you considered adding your name to the [AUTHORS](AUTHORS) file?
- [x] **Code Style**: Have you ensured your code adheres to the project's coding style guidelines? You can use `./ci.sh lint` for automatic code formatting.