### PR TITLE
Change default color decoding from LinearSRGB to SRGB

### DIFF
--- a/lib/jxl/dec_xyb.h
+++ b/lib/jxl/dec_xyb.h
@@ -68,7 +68,7 @@ struct OutputEncodingInfo {
   bool cms_set = false;
   JxlCmsInterface color_management_system;
 
-  Status SetFromMetadata(const CodecMetadata& metadata, bool is_float_output = true);
+  Status SetFromMetadata(const CodecMetadata& metadata);
   Status MaybeSetColorEncoding(const ColorEncoding& c_desired);
 
  private:

--- a/lib/jxl/decode.cc
+++ b/lib/jxl/decode.cc
@@ -679,32 +679,6 @@ bool CheckSizeLimit(JxlDecoder* dec, size_t xsize, size_t ysize) {
   return true;
 }
 
-JxlDecoderStatus UpdateOutputEncoding(JxlDecoder* dec) {
-  if (!dec->passes_state) return JXL_DEC_SUCCESS;
-
-  // Default to Float (Linear) if the user hasn't specified a buffer yet.
-  bool is_float = true;
-
-  // If the user has already set the output buffer, check the format.
-  if (dec->image_out_buffer_set) {
-    if (dec->image_out_format.data_type == JXL_TYPE_UINT8 ||
-        dec->image_out_format.data_type == JXL_TYPE_UINT16) {
-      is_float = false;
-    }
-  }
-
-  // Pass the flag to the modified SetFromMetadata
-  JXL_API_RETURN_IF_ERROR(
-      dec->passes_state->output_encoding_info.SetFromMetadata(dec->metadata, is_float));
-
-  // Restore intensity target if custom
-  if (dec->desired_intensity_target > 0) {
-    dec->passes_state->output_encoding_info.desired_intensity_target =
-        dec->desired_intensity_target;
-  }
-  return JXL_DEC_SUCCESS;
-}
-
 }  // namespace
 
 // Resets the state that must be reset for both Rewind and Reset
@@ -2479,8 +2453,6 @@ JxlDecoderStatus JxlDecoderSetImageOutBuffer(JxlDecoder* dec,
   dec->image_out_size = size;
   dec->image_out_format = *format;
 
-  return UpdateOutputEncoding(dec);
-
   return JXL_DEC_SUCCESS;
 }
 
@@ -2577,8 +2549,6 @@ JxlDecoderStatus JxlDecoderSetMultithreadedImageOutCallback(
   dec->image_out_destroy_callback = destroy_callback;
   dec->image_out_init_opaque = init_opaque;
   dec->image_out_format = *format;
-
-  return UpdateOutputEncoding(dec);
 
   return JXL_DEC_SUCCESS;
 }
@@ -2880,6 +2850,5 @@ JxlDecoderStatus JxlDecoderSetImageOutBitDepth(JxlDecoder* dec,
   JXL_API_RETURN_IF_ERROR(
       VerifyOutputBitDepth(*bit_depth, dec->metadata.m, dec->image_out_format));
   dec->image_out_bit_depth = *bit_depth;
-  return UpdateOutputEncoding(dec);
   return JXL_DEC_SUCCESS;
 }


### PR DESCRIPTION
Basically, it changes the default transfer curve from Linear to sRGB since that's what's usually expected of image viewers and is implied by the docs.

The dithering when decoding to 8-bit was masking the banding, but it's still quite visible since 8-bit linear is quite bad.
![all-fixed-now](https://raw.githubusercontent.com/Galaxy4594/jxl-comp/refs/heads/main/im/all-fixed-now.webp)

Fixes #2289
It also addresses these as well:
Fixes #2147
Fixes #4307
Fixes #4511
