### PR TITLE
examples: require CMake 3.16

### DIFF
--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -5,7 +5,7 @@
 
 # Example project using libjxl.
 
-cmake_minimum_required(VERSION 3.10)
+cmake_minimum_required(VERSION 3.16)
 
 project(SAMPLE_LIBJXL LANGUAGES C CXX)
 


### PR DESCRIPTION
Fix for Gentoo QA Notice https://bugs.gentoo.org/964598

I think it is OK to require cmake 3.16 here in examples, because the root CMakeLists.txt from the repo requires 3.16 too.