### PR TITLE
cjxl: preserve frame names from input

### DIFF
--- a/lib/extras/enc/jxl.cc
+++ b/lib/extras/enc/jxl.cc
@@ -58,12 +58,14 @@ bool SetupFrame(JxlEncoder* enc, JxlEncoderFrameSettings* settings,
   if (!SetFrameOptions(params.options, frame_index, &option_idx, settings)) {
     return false;
   }
-  const auto& frame_name = ppf.frames[frame_index].name;
-  if (!frame_name.empty()) {
-    if (JXL_ENC_SUCCESS !=
-        JxlEncoderSetFrameName(settings, frame_name.c_str())) {
-      fprintf(stderr, "JxlEncoderSetFrameName() failed.\n");
-      return false;
+  if (frame_index < ppf.frames.size()) {
+    const auto& frame_name = ppf.frames[frame_index].name;
+    if (!frame_name.empty()) {
+      if (JXL_ENC_SUCCESS !=
+          JxlEncoderSetFrameName(settings, frame_name.c_str())) {
+        fprintf(stderr, "JxlEncoderSetFrameName() failed.\n");
+        return false;
+      }
     }
   }
   if (num_alpha_channels > 0) {


### PR DESCRIPTION
Pass frame names to the encoder when converting JXL -> JXL.

Fixes #4556

Testing with multi-layer, multi-frame:

```
$ jxlinfo original.jxl
JPEG XL animation, 1x1, (possibly) lossless, 1-bit Grayscale
Color space: Grayscale, D65, sRGB transfer function, rendering intent: Relative
layer: full image size, duration: 0.0 ms, name: "background"
frame: full image size, duration: 1000.0 ms, name: "foreground"
frame: full image size, duration: 1000.0 ms
frame: full image size, duration: 1000.0 ms, name: "frame3"
Animation length: 3.000 seconds (looping)

$ ./cjxl -d 0 -e 1 original.jxl converted.jxl
JPEG XL encoder v0.12.0 53042ec5 [_AVX2_,SSE4,SSE2] {Clang 18.1.3}
Encoding [Modular, lossless, effort: 1]
Compressed to 232 bytes (464.000 bpp/frame).
1 x 1, 0.000 MP/s, 8 threads.

$ jxlinfo converted.jxl
JPEG XL animation, 1x1, (possibly) lossless, 1-bit Grayscale
Color space: 328-byte ICC profile, CMM type: "jxl ", color space: "GRAY", rendering intent: 1
layer: full image size, duration: 0.0 ms, name: "background"
frame: full image size, duration: 1000.0 ms, name: "foreground"
frame: full image size, duration: 1000.0 ms
frame: full image size, duration: 1000.0 ms, name: "frame3"
Animation length: 3.000 seconds (looping)
```


### Pull Request Checklist

- [x] **CLA Signed**: Have you signed the [Contributor License Agreement](https://code.google.com/legal/individual-cla-v1.0.html) (individual or corporate, as appropriate)? Only contributions from signed contributors can be accepted.
- [x] **Authors**: Have you considered adding your name to the [AUTHORS](AUTHORS) file?
- [x] **Code Style**: Have you ensured your code adheres to the project's coding style guidelines? You can use `./ci.sh lint` for automatic code formatting.