### PR TITLE
Enforce minimum GIF delay for parity with web browsers

### DIFF
--- a/lib/extras/dec/gif.cc
+++ b/lib/extras/dec/gif.cc
@@ -213,6 +213,16 @@ Status DecodeImageGIF(Span<const uint8_t> bytes, const ColorHints& color_hints,
 
   bool replace = true;
   bool last_base_was_none = true;
+  bool follow_browser = true;
+  bool warn_gif_delay = true;
+  JXL_RETURN_IF_ERROR(color_hints.Foreach(
+      [&follow_browser](const std::string& key,
+                        const std::string& value) -> Status {
+        if (key == "gif_follow_browser") {
+          follow_browser = value != "0";
+        }
+        return true;
+      }));
   for (int i = 0; i < gif->ImageCount; ++i) {
     const SavedImage& image = gif->SavedImages[i];
     msan::UnpoisonMemory(image.RasterBits, sizeof(*image.RasterBits) *
@@ -285,7 +295,20 @@ Status DecodeImageGIF(Span<const uint8_t> bytes, const ColorHints& color_hints,
                         total_rect.xsize() == canvas.color.xsize &&
                         total_rect.ysize() == canvas.color.ysize;
     if (ppf->info.have_animation) {
-      frame->frame_info.duration = gcb.DelayTime;
+      // Enforce minimum GIF delay for parity with web browsers.
+      // See http://webkit.org/b/26455 for more information.
+      if (follow_browser && gcb.DelayTime <= 1) {
+        frame->frame_info.duration = 10;
+        if (warn_gif_delay) {
+          fprintf(stderr,
+                  "Warning: Frame delay is <= 10 ms; bumping to 100 ms to "
+                  "match browser behavior. Pass '-x gif_follow_browser=0' to "
+                  "keep the original delay.\n");
+          warn_gif_delay = false;
+        }
+      } else {
+        frame->frame_info.duration = gcb.DelayTime;
+      }
       frame->frame_info.layer_info.have_crop = static_cast<int>(!is_full_size);
       frame->frame_info.layer_info.crop_x0 = total_rect.x0();
       frame->frame_info.layer_info.crop_y0 = total_rect.y0();


### PR DESCRIPTION
### Description

Many GIFs are mistakenly created with <= 10 ms delays but are meant to be played at 100 ms, this PR enforces a minimum GIF delay to match the behavior of web browsers.
See http://webkit.org/b/26455 for details.

### Pull Request Checklist

- [x] **CLA Signed**: Have you signed the [Contributor License Agreement](https://code.google.com/legal/individual-cla-v1.0.html) (individual or corporate, as appropriate)? Only contributions from signed contributors can be accepted.
- [x] **Authors**: Have you considered adding your name to the [AUTHORS](AUTHORS) file?
- [x] **Code Style**: Have you ensured your code adheres to the project's coding style guidelines? You can use `./ci.sh lint` for automatic code formatting.
