### PR TITLE
Fix #4581: Avoid calling StartBox until the client has received JXL_DEC_BOX

### DIFF
--- a/lib/jxl/decode.cc
+++ b/lib/jxl/decode.cc
@@ -408,8 +408,10 @@ struct JxlDecoder {
 
   JxlBoxType box_type;
   JxlBoxType box_decoded_type;  // Underlying type for brob boxes
-  // Set to true right after a JXL_DEC_BOX event only.
+  // Set to true right after JXL_DEC_BOX or JXL_DEC_BOX_NEED_MORE_OUTPUT.
   bool box_event;
+  // Set to true right after a JXL_DEC_BOX event only.
+  bool new_box;
   bool decompress_boxes;
 
   bool box_out_buffer_set;
@@ -756,6 +758,7 @@ void JxlDecoderRewindDecodingState(JxlDecoder* dec) {
   memset(dec->box_type, 0, sizeof(dec->box_type));
   memset(dec->box_decoded_type, 0, sizeof(dec->box_decoded_type));
   dec->box_event = false;
+  dec->new_box = false;
   dec->box_stage = BoxStage::kHeader;
   dec->jxl_file_format_version = 0;
   dec->next_jxlp_index = 0;
@@ -1684,9 +1687,18 @@ static JxlDecoderStatus HandleBoxes(JxlDecoder* dec) {
         // continuing decoding past the box header; treat this as opting out
         // of box output for this box and disallow late buffer setup.
         dec->box_event = false;
+        dec->new_box = false;
       }
       if ((dec->events_wanted & JXL_DEC_BOX) &&
           dec->box_out_buffer_set_current_box) {
+        if (dec->new_box) {
+          bool decompress =
+              dec->decompress_boxes && memcmp(dec->box_type, "brob", 4) == 0;
+          dec->box_content_decoder.StartBox(decompress,
+                                            dec->box_contents_unbounded,
+                                            dec->box_contents_size);
+          dec->new_box = false;
+        }
         uint8_t* next_out = dec->box_out_buffer + dec->box_out_buffer_pos;
         size_t avail_out = dec->box_out_buffer_size - dec->box_out_buffer_pos;
 
@@ -1901,16 +1913,6 @@ static JxlDecoderStatus HandleBoxes(JxlDecoder* dec) {
           dec->recon_out_buffer_pos = 0;
         }
       }
-#endif
-#if JPEGXL_ENABLE_BOXES
-      if (dec->events_wanted & JXL_DEC_BOX) {
-        bool decompress =
-            dec->decompress_boxes && memcmp(dec->box_type, "brob", 4) == 0;
-        dec->box_content_decoder.StartBox(
-            decompress, dec->box_contents_unbounded, dec->box_contents_size);
-      }
-#endif
-#if JPEGXL_ENABLE_TRANSCODE_JPEG
       if (dec->store_exif == 1 || dec->store_xmp == 1) {
         bool brob = memcmp(dec->box_type, "brob", 4) == 0;
         dec->metadata_decoder.StartBox(brob, dec->box_contents_unbounded,
@@ -1942,6 +1944,7 @@ static JxlDecoderStatus HandleBoxes(JxlDecoder* dec) {
 
       if (dec->events_wanted & JXL_DEC_BOX) {
         dec->box_event = true;
+        dec->new_box = true;
         dec->box_out_buffer_set_current_box = false;
         return JXL_DEC_BOX;
       }

--- a/lib/jxl/decode_test.cc
+++ b/lib/jxl/decode_test.cc
@@ -113,6 +113,9 @@ enum CodeStreamBoxFormat {
   kCSBF_Multi_Last_Empty_Other,
   // Have a compressed exif box before a regular codestream box
   kCSBF_Brob_Exif,
+  // Multiple identical compressed exif boxes before and after a regular
+  // codestream box
+  kCSBF_Brob_Exif_Repeated,
   // Not a value but used for counting amount of enum entries
   kCSBF_NUM_ENTRIES,
 };
@@ -418,6 +421,9 @@ std::vector<uint8_t> CreateTestJXLCodestream(
       }
       if (add_container == kCSBF_Brob_Exif) {
         Bytes(box_brob_exif, box_brob_exif_size).AppendTo(c);
+      } else if (add_container == kCSBF_Brob_Exif_Repeated) {
+        Bytes(box_brob_exif, box_brob_exif_size).AppendTo(c);
+        Bytes(box_brob_exif, box_brob_exif_size).AppendTo(c);
       }
       AppendU32BE(add_container == kCSBF_Single_Zero_Terminated
                       ? 0
@@ -431,6 +437,8 @@ std::vector<uint8_t> CreateTestJXLCodestream(
       if (add_container == kCSBF_Single_Other) {
         AppendTestBox(unk1_box_type, unk1_box_contents, unk1_box_size, false,
                       &c);
+      } else if (add_container == kCSBF_Brob_Exif_Repeated) {
+        Bytes(box_brob_exif, box_brob_exif_size).AppendTo(c);
       }
       compressed.swap(c);
     }
@@ -2195,6 +2203,8 @@ TEST(DecodeTest, ExtraBytesAfterCompressedStream) {
       // If boxes are not required, the decoder won't consume the last empty
       // jxlp box.
       last_unknown_box_size = 12 + unk3_box_size + 8;
+    } else if (box_format == kCSBF_Brob_Exif_Repeated) {
+      last_unknown_box_size = box_brob_exif_size;
     }
     jxl::TestCodestreamParams params;
     params.box_format = box_format;
@@ -5436,6 +5446,119 @@ JXL_BOXES_TEST(DecodeTest, ExifBrobBoxTest) {
 
     EXPECT_EQ(true, seen_exif_begin);
     EXPECT_EQ(true, seen_exif_end);
+
+    JxlDecoderDestroy(dec);
+  }
+}
+
+JXL_BOXES_TEST(DecodeTest, DecompressBrobBoxTest) {
+  size_t xsize = 1;
+  size_t ysize = 1;
+  std::vector<uint8_t> pixels = jxl::test::GetSomeTestImage(xsize, ysize, 4, 0);
+  jxl::TestCodestreamParams params;
+  // Lossless to verify pixels exactly after roundtrip.
+  params.cparams.SetLossless();
+  params.box_format = kCSBF_Brob_Exif_Repeated;
+  params.add_icc_profile = true;
+  std::vector<uint8_t> compressed = jxl::CreateTestJXLCodestream(
+      jxl::Bytes(pixels.data(), pixels.size()), xsize, ysize, 4, params);
+
+  // Test selectively decompressing brob boxes
+  for (int streaming = 0; streaming < 2; ++streaming) {
+    JxlDecoder* dec = JxlDecoderCreate(nullptr);
+
+    EXPECT_EQ(JXL_DEC_SUCCESS, JxlDecoderSubscribeEvents(dec, JXL_DEC_BOX));
+    if (!streaming) {
+      EXPECT_EQ(JXL_DEC_SUCCESS,
+                JxlDecoderSetInput(dec, compressed.data(), compressed.size()));
+      JxlDecoderCloseInput(dec);
+    }
+    // for streaming input case
+    const uint8_t* next_in = compressed.data();
+    size_t avail_in = 0;
+    size_t total_in = 0;
+    size_t step_size = 64;
+
+    std::vector<uint8_t> box_buffer;
+    size_t box_num_output;
+    int exif_begin_count = 0;
+    int exif_end_count = 0;
+    bool decompress = false;
+
+    for (;;) {
+      JxlDecoderStatus status = JxlDecoderProcessInput(dec);
+      if (status == JXL_DEC_NEED_MORE_INPUT) {
+        if (streaming) {
+          size_t remaining = JxlDecoderReleaseInput(dec);
+          EXPECT_LE(remaining, avail_in);
+          next_in += avail_in - remaining;
+          avail_in = remaining;
+          size_t amount = step_size;
+          if (total_in + amount > compressed.size()) {
+            amount = compressed.size() - total_in;
+          }
+          avail_in += amount;
+          total_in += amount;
+          EXPECT_EQ(JXL_DEC_SUCCESS,
+                    JxlDecoderSetInput(dec, next_in, avail_in));
+          if (total_in == compressed.size()) JxlDecoderCloseInput(dec);
+        } else {
+          FAIL();
+          break;
+        }
+      } else if (status == JXL_DEC_BOX || status == JXL_DEC_SUCCESS) {
+        if (!box_buffer.empty()) {
+          EXPECT_LT(0, exif_begin_count);
+          ++exif_end_count;
+          size_t remaining = JxlDecoderReleaseBoxBuffer(dec);
+          box_num_output = box_buffer.size() - remaining;
+          // Expect that the output has the same size and contents as the
+          // compressed/uncompressed exif data. Only check contents if the sizes
+          // match to avoid comparing uninitialized memory in the test.
+          if (decompress) {
+            EXPECT_EQ(box_num_output, exif_uncompressed_size);
+            if (box_num_output == exif_uncompressed_size) {
+              EXPECT_EQ(0, memcmp(box_buffer.data(), exif_uncompressed,
+                                  exif_uncompressed_size));
+            }
+          } else {
+            EXPECT_EQ(box_num_output, box_brob_exif_size - 8u);
+            if (box_num_output == box_brob_exif_size - 8u) {
+              EXPECT_EQ(0, memcmp(box_buffer.data(), box_brob_exif + 8u,
+                                  box_num_output));
+            }
+          }
+          box_buffer.clear();
+        }
+        if (status == JXL_DEC_SUCCESS) break;
+        JxlBoxType type;
+        EXPECT_EQ(JXL_DEC_SUCCESS, JxlDecoderGetBoxType(dec, type, JXL_TRUE));
+        if (BoxTypeEquals("Exif", type)) {
+          ++exif_begin_count;
+          // There are 3 brob/Exif boxes in the input.
+          // Decompress only the second.
+          decompress = exif_begin_count == 2;
+          EXPECT_EQ(JXL_DEC_SUCCESS,
+                    JxlDecoderSetDecompressBoxes(
+                        dec, decompress ? JXL_TRUE : JXL_FALSE));
+          box_buffer.resize(8);
+          JxlDecoderSetBoxBuffer(dec, box_buffer.data(), box_buffer.size());
+        }
+      } else if (status == JXL_DEC_BOX_NEED_MORE_OUTPUT) {
+        size_t remaining = JxlDecoderReleaseBoxBuffer(dec);
+        box_num_output = box_buffer.size() - remaining;
+        box_buffer.resize(box_buffer.size() * 2);
+        JxlDecoderSetBoxBuffer(dec, box_buffer.data() + box_num_output,
+                               box_buffer.size() - box_num_output);
+      } else {
+        // We do not expect any other events or errors
+        FAIL();
+        break;
+      }
+    }
+
+    EXPECT_EQ(3, exif_begin_count);
+    EXPECT_EQ(3, exif_end_count);
 
     JxlDecoderDestroy(dec);
   }


### PR DESCRIPTION
### Description
Avoid calling StartBox until the client has received the JXL_DEC_BOX event, so they have a chance to call `JxlDecoderSetDecompressBoxes` and affect the behavior for the current box. 

Fixes #4581 

### Pull Request Checklist

- [x] **CLA Signed**: Have you signed the [Contributor License Agreement](https://code.google.com/legal/individual-cla-v1.0.html) (individual or corporate, as appropriate)? Only contributions from signed contributors can be accepted.
- [x] **Authors**: Have you considered adding your name to the [AUTHORS](AUTHORS) file?
- [x] **Code Style**: Have you ensured your code adheres to the project's coding style guidelines? You can use `./ci.sh lint` for automatic code formatting.


Please review the full [contributing guidelines](https://github.com/libjxl/libjxl/blob/main/CONTRIBUTING.md) for more details.
