### PR TITLE
Added support of debug libraries for hwy, brotli, and lcms2

### DIFF
--- a/cmake/FindBrotli.cmake
+++ b/cmake/FindBrotli.cmake
@@ -25,6 +25,11 @@ foreach(brlib IN ITEMS ${brlibs})
     HINTS ${PC_${BRPREFIX}_LIBDIR} ${PC_${BRPREFIX}_LIBRARY_DIRS}
   )
 
+  find_library(${BRPREFIX}_DEBUG_LIBRARY
+    NAMES ${${BRPREFIX}_DEBUG_NAMES} ${brlib}d
+    HINTS ${PC_${BRPREFIX}_LIBDIR} ${PC_${BRPREFIX}_LIBRARY_DIRS}
+  )
+
   if (${BRPREFIX}_LIBRARY AND NOT TARGET ${brlib})
     if(CMAKE_VERSION VERSION_LESS "3.13.5")
     add_library(${brlib} INTERFACE IMPORTED GLOBAL)
@@ -35,8 +40,15 @@ foreach(brlib IN ITEMS ${brlibs})
     add_library(${brlib} INTERFACE IMPORTED GLOBAL)
       target_include_directories(${brlib}
         INTERFACE ${BROTLI_INCLUDE_DIR})
-      target_link_libraries(${brlib}
-        INTERFACE ${${BRPREFIX}_LIBRARY})
+      if (${BRPREFIX}_DEBUG_LIBRARY)
+        target_link_libraries(${brlib}
+          INTERFACE debug ${${BRPREFIX}_DEBUG_LIBRARY})
+        target_link_libraries(${brlib}
+          INTERFACE optimized ${${BRPREFIX}_LIBRARY})
+      else()
+        target_link_libraries(${brlib}
+          INTERFACE ${${BRPREFIX}_LIBRARY})
+      endif()
       target_link_options(${brlib}
         INTERFACE ${PC_${BRPREFIX}_LDFLAGS_OTHER})
       target_compile_options(${brlib}

--- a/cmake/FindHWY.cmake
+++ b/cmake/FindHWY.cmake
@@ -19,6 +19,11 @@ find_library(HWY_LIBRARY
   HINTS ${PC_HWY_LIBDIR} ${PC_HWY_LIBRARY_DIRS}
 )
 
+find_library(HWY_DEBUG_LIBRARY
+  NAMES ${HWY_DEBUG_NAMES} hwyd
+  HINTS ${PC_HWY_LIBDIR} ${PC_HWY_LIBRARY_DIRS}
+)
+
 # If version not found using pkg-config, try extracting it from header files
 if (HWY_INCLUDE_DIR AND NOT HWY_VERSION)
   set(HWY_VERSION "")
@@ -62,7 +67,12 @@ if (HWY_LIBRARY AND NOT TARGET hwy)
     set_property(TARGET hwy PROPERTY INTERFACE_COMPILE_OPTIONS ${PC_HWY_CFLAGS_OTHER})
   else()
     target_include_directories(hwy INTERFACE ${HWY_INCLUDE_DIR})
-    target_link_libraries(hwy INTERFACE ${HWY_LIBRARY})
+    if (HWY_DEBUG_LIBRARY)
+        target_link_libraries(hwy INTERFACE debug ${HWY_DEBUG_LIBRARY})
+        target_link_libraries(hwy INTERFACE optimized ${HWY_LIBRARY})
+    else()
+        target_link_libraries(hwy INTERFACE ${HWY_LIBRARY})
+    endif()
     target_link_options(hwy INTERFACE ${PC_HWY_LDFLAGS_OTHER})
     target_compile_options(hwy INTERFACE ${PC_HWY_CFLAGS_OTHER})
   endif()

--- a/cmake/FindLCMS2.cmake
+++ b/cmake/FindLCMS2.cmake
@@ -19,6 +19,11 @@ find_library(LCMS2_LIBRARY
   HINTS ${PC_LCMS2_LIBDIR} ${PC_LCMS2_LIBRARY_DIRS}
 )
 
+find_library(LCMS2_DEBUG_LIBRARY
+  NAMES ${LCMS2_DEBUG_NAMES} lcms2d liblcms2d lcms-2d liblcms-2d
+  HINTS ${PC_LCMS2_LIBDIR} ${PC_LCMS2_LIBRARY_DIRS}
+)
+
 if (LCMS2_INCLUDE_DIR AND NOT LCMS_VERSION)
     file(READ ${LCMS2_INCLUDE_DIR}/lcms2.h LCMS2_VERSION_CONTENT)
     string(REGEX MATCH "#define[ \t]+LCMS_VERSION[ \t]+([0-9]+)[ \t]*\n" LCMS2_VERSION_MATCH ${LCMS2_VERSION_CONTENT})
@@ -45,7 +50,12 @@ if (LCMS2_LIBRARY AND NOT TARGET lcms2)
     set_property(TARGET lcms2 PROPERTY INTERFACE_COMPILE_OPTIONS ${PC_LCMS2_CFLAGS_OTHER})
   else()
     target_include_directories(lcms2 INTERFACE ${LCMS2_INCLUDE_DIR})
-    target_link_libraries(lcms2 INTERFACE ${LCMS2_LIBRARY})
+    if (LCMS2_DEBUG_LIBRARY)
+      target_link_libraries(lcms2 INTERFACE debug ${LCMS2_DEBUG_LIBRARY})
+      target_link_libraries(lcms2 INTERFACE optimized ${LCMS2_LIBRARY})
+    else()
+      target_link_libraries(lcms2 INTERFACE ${LCMS2_LIBRARY})
+    endif()
     target_link_options(lcms2 INTERFACE ${PC_LCMS2_LDFLAGS_OTHER})
     target_compile_options(lcms2 INTERFACE ${PC_LCMS2_CFLAGS_OTHER})
   endif()


### PR DESCRIPTION
### Description

Added support of multiconfig build in FindHWY.cmake, FindBrotli.cmake, FindLCMS2.cmake.
The current version looks only for one release library, so it is impossible to use in Visual Studio.

In this version FindHWY tries to find optional library `hwyd`. If it is found, then `target_link_libraries` is called with both `debug` and `optimized` libraries. If not found, then old behaviour is used. Same for brotli and LCMS2.

