### PR TITLE
CI: Replace retired macos-13 runner with macos-15-intel

### DIFF
--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -173,9 +173,9 @@ jobs:
             test_stack_limit: 128
             cmake_args: >-
               -DCMAKE_FIND_FRAMEWORK=NEVER
-          - name: debug:osx-13
-            # The last "free" X86 OSX runnde
-            os: macos-13
+          - name: debug:osx-15
+            # The last available x86_64 OSX runner
+            os: macos-15-intel
             mode: debug
             cmake_args: >-
               -DCMAKE_FIND_FRAMEWORK=NEVER


### PR DESCRIPTION
macos-13 was retired on December 4, 2025. Switch to macos-15-intel, the last supported Intel runner, available until August 2027.