### PR TITLE
Fix JXL primary color representation detection

### DIFF
--- a/lib/extras/dec/jxl.cc
+++ b/lib/extras/dec/jxl.cc
@@ -419,12 +419,13 @@ bool DecodeImageJXL(const uint8_t* bytes, size_t bytes_size,
           return false;
         }
       }
+      ppf->primary_color_representation =
+          PackedPixelFile::kColorEncodingIsPrimary;
       if (JXL_DEC_SUCCESS != JxlDecoderGetColorAsEncodedProfile(
                                  dec, target, &ppf->color_encoding)) {
         ppf->color_encoding.color_space = JXL_COLOR_SPACE_UNKNOWN;
+        ppf->primary_color_representation = PackedPixelFile::kIccIsPrimary;
       }
-      ppf->primary_color_representation =
-          PackedPixelFile::kColorEncodingIsPrimary;
 
       icc_size = 0;
       target = JXL_COLOR_PROFILE_TARGET_ORIGINAL;
@@ -440,7 +441,6 @@ bool DecodeImageJXL(const uint8_t* bytes, size_t bytes_size,
           fprintf(stderr, "JxlDecoderGetColorAsICCProfile failed\n");
           return false;
         }
-        ppf->primary_color_representation = PackedPixelFile::kIccIsPrimary;
       }
 
     } else if (status == JXL_DEC_FRAME) {


### PR DESCRIPTION
This partially reverts #3880 
I'm not sure what that PR was trying to fix.

Fixes #2581 again, Fixes #4608 