### PR TITLE
fix: heap buffer underflow in jpegli horizontal chroma upsampling

### DIFF
--- a/lib/jpegli/decode.cc
+++ b/lib/jpegli/decode.cc
@@ -534,12 +534,9 @@ void AllocateOutputBuffers(j_decompress_ptr cinfo) {
   }
   m->idct_scratch_ = Allocate<float>(cinfo, 5 * DCTSIZE2, JPOOL_IMAGE_ALIGNED);
   // Padding for horizontal chroma upsampling.
-  constexpr size_t kPaddingLeft = 64;
-  constexpr size_t kPaddingRight = 64;
-  m->upsample_scratch_ =
-      Allocate<float>(cinfo, output_stride + kPaddingLeft + kPaddingRight,
-                      JPOOL_IMAGE_ALIGNED) +
-      kPaddingLeft;
+  constexpr size_t kUpsamplePadding = 2 * HWY_ALIGNMENT / sizeof(float);
+  m->upsample_scratch_ = Allocate<float>(
+      cinfo, output_stride + kUpsamplePadding, JPOOL_IMAGE_ALIGNED);
   size_t bytes_per_sample = jpegli_bytes_per_sample(m->output_data_type_);
   size_t bytes_per_pixel = cinfo->out_color_components * bytes_per_sample;
   size_t scratch_stride = RoundUpTo(output_stride, HWY_ALIGNMENT);

--- a/lib/jpegli/render.cc
+++ b/lib/jpegli/render.cc
@@ -718,7 +718,8 @@ void ProcessOutput(j_decompress_ptr cinfo, size_t* num_output_rows,
             for (int yix = 0; yix < m->v_factor[c]; ++yix) {
               int row_ix = m->v_factor[c] * dy + yix;
               float* JXL_RESTRICT row = render_out->Row(row_ix);
-              float* JXL_RESTRICT tmp = m->upsample_scratch_;
+              float* JXL_RESTRICT tmp =
+                  m->upsample_scratch_ + HWY_ALIGNMENT / sizeof(float);
               if (cinfo->do_fancy_upsampling && m->h_factor[c] == 2) {
                 Upsample2Horizontal(row, tmp, output_width);
               } else {


### PR DESCRIPTION
### Description

Fix heap buffer underflow in jpegli horizontal chroma upsampling.

`Upsample2Horizontal()` writes `scratch_space[-1]` for boundary pixel replication. The `upsample_scratch_` buffer is allocated with 64-float left padding in its size, but the pointer is never advanced past it — so `scratch_space[-1]` writes 4 bytes before the allocation, corrupting `hwy::AllocateAlignedBytes` metadata.

Triggered by default (`do_fancy_upsampling=TRUE`) on any JPEG with horizontal chroma subsampling (4:2:0, 4:2:2).

**Fix:** Advance `upsample_scratch_` by `kPaddingLeft` after allocation, matching the offset pattern used by `RowBuffer::Row()`.
