### PR TITLE
Default to buffering level 2

### DIFF
--- a/lib/jxl/enc_frame.cc
+++ b/lib/jxl/enc_frame.cc
@@ -1791,7 +1791,7 @@ bool CanDoStreamingEncoding(const CompressParams& cparams,
   if (cparams.buffering == 0) {
     return false;
   }
-  if (cparams.buffering <= 1 && frame_data.xsize <= 2048 &&
+  if (cparams.buffering == 1 && frame_data.xsize <= 2048 &&
       frame_data.ysize <= 2048) {
     return false;
   }


### PR DESCRIPTION
Changes the default buffering level to 2, greatly speeding up common 720p and 1080p images, while allowing it to adapt based on group and image size instead of the fixed 2048x2048 limit.

Lossless Modular
| 720p | Main | PR |  Δ (%) |
|------|-------|----|--------|
| MP/s | 0.454 | 4.247 | +935 |
| Mem MiB | 79.22 | 67.55 | -15 |
| BPP | 6.656 | 6.708 | +0.8 |

| 1080p | Main | PR |  Δ (%) |
|------|-------|----|--------|
| MP/s | 0.398 | 4.788 | +1203 |
| Mem MiB | 167 | 113.1 | -32 |
| BPP | 6.254 | 6.293 | +0.6 |

Lossy VarDCT
| 720p | Main | PR |  Δ (%) |
|------|-------|----|--------|
| MP/s | 3.988 | 6.050 | +52 |
| Mem MiB | 86.03 | 80.16 | -6.8 |
| BPP | 1.194 | 1.205 | +0.9 |

| 1080p | Main | PR |  Δ (%) |
|------|-------|----|--------|
| MP/s | 4.788 | 7.025 | +47 |
| Mem MiB | 185 | 152.5 | -17.6 |
| BPP | 1.051 | 1.061 | +1 |

10x faster encoding for lossless and 1.5x for lossy with only 1% higher bpp.