### PR TITLE
Revise MA tree check to align with new buffering logic

### DIFF
--- a/lib/jxl/enc_frame.cc
+++ b/lib/jxl/enc_frame.cc
@@ -1670,6 +1670,7 @@ Status ComputeEncodingData(
         !cparams.ModularPartIsLossless() || cparams.lossy_palette ||
         (cparams.responsive == 1 && !cparams.IsLossless()) ||
         // Allow Local trees for progressive lossless but not lossy.
+        cparams.buffering == 0 || cparams.buffering == 1 ||
         !cparams.custom_fixed_tree.empty()) {
       // Use local trees if doing lossless modular, unless at very slow speeds.
       JXL_RETURN_IF_ERROR(enc_modular.ComputeTree(pool));


### PR DESCRIPTION
There is an inconsistency where `--buffering=0` and `--buffering=1` results in different image sizes. With the new buffering logic, level 0 uses local MA trees while level 1 uses global MA trees.

The updated logic fixes this:

--buffering=0: Always buffers the image and uses global MA trees.

--buffering=1: Preserves the legacy libjxl default behavior, from before #4634 (buffers and uses global MA trees only for images smaller than 2048x2048).