### PR TITLE
Fix GlobalMA Tree check

### DIFF
--- a/lib/jxl/enc_frame.cc
+++ b/lib/jxl/enc_frame.cc
@@ -1668,10 +1668,9 @@ Status ComputeEncodingData(
     // If checks pass here, a Global MA tree is used.
     if (cparams.speed_tier < SpeedTier::kTortoise ||
         !cparams.ModularPartIsLossless() || cparams.lossy_palette ||
-        (cparams.responsive == 1 && !cparams.IsLossless()) ||
         // Allow Local trees for progressive lossless but not lossy.
-        cparams.buffering == 0 || cparams.buffering == 1 ||
-        !cparams.custom_fixed_tree.empty()) {
+        (cparams.responsive == 1 && !cparams.IsLossless()) ||
+        cparams.buffering < 3 || !cparams.custom_fixed_tree.empty()) {
       // Use local trees if doing lossless modular, unless at very slow speeds.
       JXL_RETURN_IF_ERROR(enc_modular.ComputeTree(pool));
       JXL_RETURN_IF_ERROR(enc_modular.ComputeTokens(pool));


### PR DESCRIPTION
A follow-up to #4637. All tests now pass and `--buffering 0` forces global trees while `--buffering 3` forces local trees.

Previously buffering was always 1 with no way to change it via the CLI, causing the check to always pass true and be enabled by default. The previous PR enabled it only for 0 and 1, but now that 2 is the default it would return false and cause some odd behaviour.