### PR TITLE
jpegli: add overflow and OOM checks in memory destination growth

### DIFF
--- a/lib/jpegli/destination_manager.cc
+++ b/lib/jpegli/destination_manager.cc
@@ -67,8 +67,10 @@ struct MemoryDestinationManager {
 
   static boolean empty_output_buffer(j_compress_ptr cinfo) {
     auto* dest = reinterpret_cast<MemoryDestinationManager*>(cinfo->dest);
+    if (dest->buffer_size > (size_t)-1 / 2) return FALSE;
     uint8_t* next_buffer =
         reinterpret_cast<uint8_t*>(malloc(dest->buffer_size * 2));
+    if (next_buffer == nullptr) return FALSE;
     memcpy(next_buffer, dest->current_buffer, dest->buffer_size);
     if (dest->temp_buffer != nullptr) {
       free(dest->temp_buffer);


### PR DESCRIPTION
This change adds defensive overflow and out-of-memory checks in empty_output_buffer() when growing the in-memory destination buffer.

The buffer size is doubled using buffer_size * 2. On platforms where size_t may overflow, this multiplication could wrap around, resulting in an undersized allocation.

The patch adds:

A guard against buffer_size > SIZE_MAX / 2

A null check for malloc failure

This change does not alter behavior for valid inputs and only improves robustness in extreme edge cases.