### PR TITLE
jpegli: guard against size_t overflow in output pixel allocation (32-…

### DIFF
--- a/lib/jpegli/decode.cc
+++ b/lib/jpegli/decode.cc
@@ -419,8 +419,16 @@ bool IsInputReady(j_decompress_ptr cinfo) {
 bool ReadOutputPass(j_decompress_ptr cinfo) {
   jpeg_decomp_master* m = cinfo->master;
   if (!m->pixels_) {
+    if (cinfo->output_width != 0 &&
+        static_cast<size_t>(cinfo->out_color_components) >
+            SIZE_MAX / cinfo->output_width) {
+      JPEGLI_ERROR("Image dimensions too large");
+    }
     size_t stride =
         static_cast<size_t>(cinfo->out_color_components) * cinfo->output_width;
+    if (cinfo->output_height != 0 && stride > SIZE_MAX / cinfo->output_height) {
+      JPEGLI_ERROR("Image dimensions too large");
+    }
     size_t num_samples = cinfo->output_height * stride;
     m->pixels_ = Allocate<uint8_t>(cinfo, num_samples, JPOOL_IMAGE);
     m->scanlines_ =


### PR DESCRIPTION
This change adds defensive overflow checks in ReadOutputPass() before computing the output pixel buffer size.

On 32-bit platforms, the calculation:

num_samples = output_height * (out_color_components * output_width)

may overflow size_t when processing large JPEG dimensions (e.g., 65535 × 65535 with 4 components). This could result in an undersized allocation.

The patch adds division-based guards to ensure both intermediate and final size computations fit in size_t.

There is no behavior change on 64-bit platforms. This improves robustness and portability for 32-bit builds and other constrained targets.