### PR TITLE
Fix heap buffer overflow in UpsamplingStage temp buffer allocation

### DIFF
--- a/lib/jxl/render_pipeline/stage_upsampling.cc
+++ b/lib/jxl/render_pipeline/stage_upsampling.cc
@@ -127,7 +127,9 @@ class UpsamplingStage : public RenderPipelineStage {
   }
 
   Status PrepareForThreads(size_t num_threads) override {
-    size_t alloc_size = sizeof(float) * (kChunkSize + 4);
+    constexpr HWY_FULL(float) df;
+    size_t alloc_size =
+        sizeof(float) * (kChunkSize + std::max(size_t{4}, Lanes(df)));
     for (size_t i = 0; i < 3; ++i) {
       temp_[i].resize(num_threads);
       for (size_t t = 0; t < num_threads; ++t) {


### PR DESCRIPTION
### Description

Fix heap buffer overflow in `UpsamplingStage::PrepareForThreads`.

The temp buffers (`col_min`, `col_max`) used in `PreProcessRowImpl` were allocated as `kChunkSize + 4` floats (1028 elements). However, the SIMD loop that writes to these buffers iterates with bound `len + 4` and stride `Lanes(df)`:

```cpp
for (size_t x = 0; x < len + 4; x += Lanes(df)) {
    Store(min, df, col_min + x);
    Store(max, df, col_max + x);
}
```

When `len == kChunkSize` (1024) and `Lanes(df) >= 8` (AVX2/AVX-512), the last iteration starts at `x = 1024` and writes 8 or 16 floats, reaching up to index 1031 or 1039 — past the end of the 1028-element buffer.

**Fix:** Replace the hardcoded `+ 4` in the allocation with `+ Lanes(df)`, which correctly accounts for the SIMD width on every target. On SSE4 (4 lanes) the allocation size is unchanged. No hot-loop changes, no behavior change.

**Reproduction:** Build with ASAN, encode a ≥2048px-wide image using `cjxl -m 1 -g 3 --resampling=2 -e 1`, decode with `djxl` on an AVX2 machine.

### Pull Request Checklist

- [x] **CLA Signed**: Have you signed the [Contributor License Agreement](https://code.google.com/legal/individual-cla-v1.0.html) (individual or corporate, as appropriate)? Only contributions from signed contributors can be accepted.
- [ ] **Authors**: Have you considered adding your name to the [AUTHORS](AUTHORS) file?
- [x] **Code Style**: Have you ensured your code adheres to the project's coding style guidelines? You can use `./ci.sh lint` for automatic code formatting.
