### PR TITLE
Improve JPEG transcoding error reporting for JBRD failures

### DIFF
--- a/lib/extras/enc/jxl.cc
+++ b/lib/extras/enc/jxl.cc
@@ -232,10 +232,39 @@ bool EncodeImageJXL(const JXLCompressParams& params, const PackedPixelFile& ppf,
         fprintf(stderr,
                 "Error while decoding the JPEG image. It may be corrupt (e.g. "
                 "truncated) or of an unsupported type (e.g. CMYK).\n");
+      } else if (error == JXL_ENC_ERR_JBRD_TOO_MUCH_TAIL_DATA) {
+        fprintf(stderr,
+                "JPEG bitstream reconstruction data could not be created: "
+                "tail data is too large.\n"
+                "This can be fixed by removing trailing bytes after the JPEG "
+                "EOI marker.\n");
+        fprintf(stderr,
+                "Try using --allow_jpeg_reconstruction 0, to losslessly "
+                "recompress the JPEG image data without bitstream "
+                "reconstruction data.\n");
+      } else if (error == JXL_ENC_ERR_JBRD_TOO_MANY_RESET_POINTS) {
+        fprintf(stderr,
+                "JPEG bitstream reconstruction data could not be created: too "
+                "many reset points for JXL reconstruction format.\n"
+                "This limitation cannot be overcome while preserving exact "
+                "JPEG bitstream reconstruction.\n");
+        fprintf(stderr,
+                "Try using --allow_jpeg_reconstruction 0, to losslessly "
+                "recompress the JPEG image data without bitstream "
+                "reconstruction data.\n");
+      } else if (error == JXL_ENC_ERR_JBRD_TOO_MANY_MARKERS) {
+        fprintf(stderr,
+                "JPEG bitstream reconstruction data could not be created: too "
+                "many JPEG markers for JXL reconstruction format.\n"
+                "This limitation cannot be overcome while preserving exact "
+                "JPEG bitstream reconstruction.\n");
+        fprintf(stderr,
+                "Try using --allow_jpeg_reconstruction 0, to losslessly "
+                "recompress the JPEG image data without bitstream "
+                "reconstruction data.\n");
       } else if (error == JXL_ENC_ERR_JBRD) {
         fprintf(stderr,
-                "JPEG bitstream reconstruction data could not be created. "
-                "Possibly there is too much tail data.\n"
+                "JPEG bitstream reconstruction data could not be created.\n"
                 "Try using --allow_jpeg_reconstruction 0, to losslessly "
                 "recompress the JPEG image data without bitstream "
                 "reconstruction data.\n");

--- a/lib/include/jxl/encode.h
+++ b/lib/include/jxl/encode.h
@@ -103,6 +103,20 @@ typedef enum {
    */
   JXL_ENC_ERR_BAD_INPUT = 4,
 
+  /** JPEG bitstream reconstruction data contains too much tail data after EOI.
+    */
+  JXL_ENC_ERR_JBRD_TOO_MUCH_TAIL_DATA = 5,
+
+  /** JPEG bitstream reconstruction data has too many reset points to represent
+    *  in JXL reconstruction metadata.
+    */
+  JXL_ENC_ERR_JBRD_TOO_MANY_RESET_POINTS = 6,
+
+  /** JPEG bitstream reconstruction data has too many markers to represent in
+    *  JXL reconstruction metadata.
+    */
+  JXL_ENC_ERR_JBRD_TOO_MANY_MARKERS = 7,
+
   /** The encoder doesn't (yet) support this. Either no version of libjxl
    * supports this, and the API is used incorrectly, or the libjxl version
    * should have been checked before trying to do this.

--- a/lib/jxl/encode.cc
+++ b/lib/jxl/encode.cc
@@ -2107,6 +2107,9 @@ JxlEncoderStatus GetCurrentDimensions(
 }
 }  // namespace
 
+static JxlEncoderError GetJpegReconstructionError(
+    const jxl::jpeg::JPEGData& jpeg);
+
 JxlEncoderStatus JxlEncoderAddJPEGFrame(
     const JxlEncoderFrameSettings* frame_settings, const uint8_t* buffer,
     size_t size) {
@@ -2221,6 +2224,25 @@ JxlEncoderStatus JxlEncoderAddJPEGFrame(
                            "Need to preserve EXIF and XMP to allow JPEG "
                            "bitstream reconstruction");
     }
+    JxlEncoderError precheck_error = GetJpegReconstructionError(*jpeg_data);
+    if (precheck_error != JXL_ENC_ERR_OK) {
+      switch (precheck_error) {
+        case JXL_ENC_ERR_JBRD_TOO_MUCH_TAIL_DATA:
+          return JXL_API_ERROR(frame_settings->enc, precheck_error,
+                               "JPEG tail data is too large for "
+                               "reconstruction metadata");
+        case JXL_ENC_ERR_JBRD_TOO_MANY_RESET_POINTS:
+          return JXL_API_ERROR(frame_settings->enc, precheck_error,
+                               "Too many JPEG reset points for "
+                               "reconstruction metadata");
+        case JXL_ENC_ERR_JBRD_TOO_MANY_MARKERS:
+          return JXL_API_ERROR(frame_settings->enc, precheck_error,
+                               "Too many JPEG markers for reconstruction "
+                               "metadata");
+        default:
+          break;
+      }
+    }
     std::vector<uint8_t> jpeg_metadata;
     if (!jxl::jpeg::EncodeJPEGData(&frame_settings->enc->memory_manager,
                                    *jpeg_data, &jpeg_metadata,
@@ -2311,8 +2333,30 @@ static bool CanDoFastLossless(const JxlEncoderFrameSettings* frame_settings,
         has_alpha)) {
     return false;
   }
-
   return true;
+}
+
+static JxlEncoderError GetJpegReconstructionError(
+    const jxl::jpeg::JPEGData& jpeg) {
+  if (jpeg.tail_data.size() > 4260096) {
+    return JXL_ENC_ERR_JBRD_TOO_MUCH_TAIL_DATA;
+  }
+  if (jpeg.marker_order.size() > 16384) {
+    return JXL_ENC_ERR_JBRD_TOO_MANY_MARKERS;
+  }
+  for (const auto& scan : jpeg.scan_info) {
+    for (uint32_t block_idx : scan.reset_points) {
+      if (block_idx >= (3u << 26)) {
+        return JXL_ENC_ERR_JBRD_TOO_MANY_RESET_POINTS;
+      }
+    }
+    for (const auto& extra_zero_run : scan.extra_zero_runs) {
+      if (extra_zero_run.block_idx > (3u << 26)) {
+        return JXL_ENC_ERR_JBRD_TOO_MANY_RESET_POINTS;
+      }
+    }
+  }
+  return JXL_ENC_ERR_OK;
 }
 
 namespace {

--- a/lib/jxl/encode_test.cc
+++ b/lib/jxl/encode_test.cc
@@ -1003,6 +1003,23 @@ JXL_TRANSCODE_JPEG_TEST(EncodeTest, JPEGReconstructionTest) {
   EXPECT_EQ(0, memcmp(decoded_jpeg_bytes.data(), orig.data(), orig.size()));
 }
 
+JXL_TRANSCODE_JPEG_TEST(EncodeTest,
+                        JPEGReconstructionTailDataTooLargeErrorTest) {
+  const std::string jpeg_path = "jxl/flower/flower.png.im_q85_420.jpg";
+  std::vector<uint8_t> orig = jxl::test::ReadTestData(jpeg_path);
+  orig.resize(orig.size() + 4260097, 0);
+
+  JxlEncoderPtr enc = JxlEncoderMake(nullptr);
+  JxlEncoderFrameSettings* frame_settings =
+      JxlEncoderFrameSettingsCreate(enc.get(), nullptr);
+  ASSERT_NE(nullptr, frame_settings);
+
+  EXPECT_EQ(JXL_ENC_SUCCESS, JxlEncoderStoreJPEGMetadata(enc.get(), JXL_TRUE));
+  EXPECT_EQ(JXL_ENC_ERROR,
+            JxlEncoderAddJPEGFrame(frame_settings, orig.data(), orig.size()));
+  EXPECT_EQ(JXL_ENC_ERR_JBRD_TOO_MUCH_TAIL_DATA, JxlEncoderGetError(enc.get()));
+}
+
 JXL_TRANSCODE_JPEG_TEST(EncodeTest, ProgressiveJPEGReconstructionTest) {
   const std::string jpeg_path = "jxl/flower/flower.png.im_q85_420.jpg";
   const std::vector<uint8_t> orig = jxl::test::ReadTestData(jpeg_path);


### PR DESCRIPTION
Improve JPEG transcoding error reporting by returning more specific errors for common JBRD failure cases (e.g., excessive tail data, too many reset points, or markers).

https://github.com/libjxl/libjxl/issues/4309
