### PR TITLE
Write permuted_toc=0 bit if !streaming_output in streaming encoding

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -109,5 +109,6 @@ Vincent Torri <vincent.torri@gmail.com>
 Wonwoo Choi <chwo9843@gmail.com>
 xiota
 Yonatan Nebenzhal <yonatan.nebenzhl@gmail.com>
+yosh <yosh@unix.dog>
 Ziemowit Zabawa <ziemek.zabawa@outlook.com>
 源文雨 <41315874+fumiama@users.noreply.github.com>

--- a/lib/jxl/enc_frame.cc
+++ b/lib/jxl/enc_frame.cc
@@ -2115,6 +2115,8 @@ JXL_NOINLINE Status EncodeFrameStreaming(
               JXL_RETURN_IF_ERROR(EncodePermutation(
                   permutation.data(), /*skip=*/0, permutation.size(), &writer,
                   LayerType::Header, aux_out));
+            } else {
+              writer.Write(1, 0); // no permutation
             }
             writer.ZeroPadToByte();
             return true;


### PR DESCRIPTION
### Description

The cause of #4653 was due to the encoder not writing the permutation bit in this code path, causing padding bits to start one bit earlier than intended, which would cause incorrect padding if the padding just so happened to be called on the first bit of a byte boundary.

Since permutations aren't written in this code path, the `permutated_toc = 0` bit should be written as opposed to skipped entirely (F.3.1 in 18181-1).

This fixes #4653 for me & I tested on a few other images without any issue. 

### Pull Request Checklist

- [x] **CLA Signed**: Have you signed the [Contributor License Agreement](https://code.google.com/legal/individual-cla-v1.0.html) (individual or corporate, as appropriate)? Only contributions from signed contributors can be accepted.
- [x] **Authors**: Have you considered adding your name to the [AUTHORS](AUTHORS) file?
- [x] **Code Style**: Have you ensured your code adheres to the project's coding style guidelines? You can use `./ci.sh lint` for automatic code formatting.
