### PR TITLE
WIP: dec_group: SIMDify Transpose8x8InPlace

### DIFF
--- a/lib/jxl/dec_group.cc
+++ b/lib/jxl/dec_group.cc
@@ -51,6 +51,7 @@
 #include "lib/jxl/quant_weights.h"
 #include "lib/jxl/quantizer-inl.h"
 #include "lib/jxl/quantizer.h"
+#include "lib/jxl/simd_util-inl.h"
 
 #ifndef LIB_JXL_DEC_GROUP_CC
 #define LIB_JXL_DEC_GROUP_CC
@@ -91,6 +92,7 @@ using hwy::HWY_NAMESPACE::MaskFromVec;
 using hwy::HWY_NAMESPACE::Or;
 using hwy::HWY_NAMESPACE::Rebind;
 using hwy::HWY_NAMESPACE::ShiftRight;
+using hwy::HWY_NAMESPACE::Repartition;
 
 using D = HWY_FULL(float);
 using DU = HWY_FULL(uint32_t);
@@ -102,13 +104,16 @@ constexpr DI di;
 constexpr DI16 di16;
 constexpr DI16_FULL di16_full;
 
-// TODO(veluca): consider SIMDfying.
-void Transpose8x8InPlace(int32_t* JXL_RESTRICT block) {
+JXL_INLINE void Transpose8x8InPlace(int32_t* JXL_RESTRICT block) {
+#if HWY_TARGET != HWY_SCALAR
+  Transpose8x8BlockInPlace(block);
+#else
   for (size_t x = 0; x < 8; x++) {
     for (size_t y = x + 1; y < 8; y++) {
       std::swap(block[y * 8 + x], block[x * 8 + y]);
     }
   }
+#endif
 }
 
 template <ACType ac_type>

--- a/lib/jxl/simd_util-inl.h
+++ b/lib/jxl/simd_util-inl.h
@@ -315,6 +315,54 @@ JXL_INLINE void Transpose8x8Block(const int32_t* JXL_RESTRICT from,
   Store(i6, d, to + 6 * 8);
   Store(i7, d, to + 7 * 8);
 }
+
+JXL_INLINE void Transpose8x8BlockInPlace(int32_t* JXL_RESTRICT block) {
+  const HWY_CAPPED(int32_t, 8) d;
+  auto i0 = Load(d, block);
+  auto i1 = Load(d, block + 1 * 8);
+  auto i2 = Load(d, block + 2 * 8);
+  auto i3 = Load(d, block + 3 * 8);
+  auto i4 = Load(d, block + 4 * 8);
+  auto i5 = Load(d, block + 5 * 8);
+  auto i6 = Load(d, block + 6 * 8);
+  auto i7 = Load(d, block + 7 * 8);
+
+  const auto q0 = InterleaveLower(d, i0, i2);
+  const auto q1 = InterleaveLower(d, i1, i3);
+  const auto q2 = InterleaveUpper(d, i0, i2);
+  const auto q3 = InterleaveUpper(d, i1, i3);
+  const auto q4 = InterleaveLower(d, i4, i6);
+  const auto q5 = InterleaveLower(d, i5, i7);
+  const auto q6 = InterleaveUpper(d, i4, i6);
+  const auto q7 = InterleaveUpper(d, i5, i7);
+
+  const auto r0 = InterleaveLower(d, q0, q1);
+  const auto r1 = InterleaveUpper(d, q0, q1);
+  const auto r2 = InterleaveLower(d, q2, q3);
+  const auto r3 = InterleaveUpper(d, q2, q3);
+  const auto r4 = InterleaveLower(d, q4, q5);
+  const auto r5 = InterleaveUpper(d, q4, q5);
+  const auto r6 = InterleaveLower(d, q6, q7);
+  const auto r7 = InterleaveUpper(d, q6, q7);
+
+  i0 = ConcatLowerLower(d, r4, r0);
+  i1 = ConcatLowerLower(d, r5, r1);
+  i2 = ConcatLowerLower(d, r6, r2);
+  i3 = ConcatLowerLower(d, r7, r3);
+  i4 = ConcatUpperUpper(d, r4, r0);
+  i5 = ConcatUpperUpper(d, r5, r1);
+  i6 = ConcatUpperUpper(d, r6, r2);
+  i7 = ConcatUpperUpper(d, r7, r3);
+
+  Store(i0, d, block);
+  Store(i1, d, block + 1 * 8);
+  Store(i2, d, block + 2 * 8);
+  Store(i3, d, block + 3 * 8);
+  Store(i4, d, block + 4 * 8);
+  Store(i5, d, block + 5 * 8);
+  Store(i6, d, block + 6 * 8);
+  Store(i7, d, block + 7 * 8);
+}
 #elif HWY_TARGET != HWY_SCALAR
 JXL_INLINE void Transpose8x8Block(const int32_t* JXL_RESTRICT from,
                                   int32_t* JXL_RESTRICT to, size_t fromstride) {
@@ -338,6 +386,31 @@ JXL_INLINE void Transpose8x8Block(const int32_t* JXL_RESTRICT from,
       Store(r1, d, to + (1 + m) * 8 + n);
       Store(r2, d, to + (2 + m) * 8 + n);
       Store(r3, d, to + (3 + m) * 8 + n);
+    }
+  }
+}
+
+JXL_INLINE void Transpose8x8BlockInPlace(int32_t* JXL_RESTRICT block) {
+  const HWY_CAPPED(int32_t, 4) d;
+  for (size_t n = 0; n < 8; n += 4) {
+    for (size_t m = 0; m < 8; m += 4) {
+      auto p0 = Load(d, block + n * 8 + m);
+      auto p1 = Load(d, block + (n + 1) * 8 + m);
+      auto p2 = Load(d, block + (n + 2) * 8 + m);
+      auto p3 = Load(d, block + (n + 3) * 8 + m);
+      const auto q0 = InterleaveLower(d, p0, p2);
+      const auto q1 = InterleaveLower(d, p1, p3);
+      const auto q2 = InterleaveUpper(d, p0, p2);
+      const auto q3 = InterleaveUpper(d, p1, p3);
+
+      const auto r0 = InterleaveLower(d, q0, q1);
+      const auto r1 = InterleaveUpper(d, q0, q1);
+      const auto r2 = InterleaveLower(d, q2, q3);
+      const auto r3 = InterleaveUpper(d, q2, q3);
+      Store(r0, d, block + m * 8 + n);
+      Store(r1, d, block + (1 + m) * 8 + n);
+      Store(r2, d, block + (2 + m) * 8 + n);
+      Store(r3, d, block + (3 + m) * 8 + n);
     }
   }
 }


### PR DESCRIPTION
<!-- Thank you for considering a contribution to `libjxl`! -->

### Description

<!-- Please provide a brief description of the changes in this PR and any additional context (e.g., why these changes were made, related issues, etc.). -->

This WIP PR SIMDifies `Transpose8x8InPlace` in `lib/jxl/dec_group.cc` used when decoding JPEG XL's losslessly transcoded from JPEG. 

I adapted `Transpose8x8Block` from `simd_util-inl.h` for this purpose. I also left the scalar implementation in place as a fall back. However, at least on my CPU (Ryzen 7 4750U), it seems the SIMD version is not consistently faster even with `CMAKE_BUILD_TYPE=Release`. I'll clean the code up and probably do some more accurate benchmarks in the coming days, and try to optimize the implementation some more.

### Pull Request Checklist

- [ x] **CLA Signed**: Have you signed the [Contributor License Agreement](https://code.google.com/legal/individual-cla-v1.0.html) (individual or corporate, as appropriate)? Only contributions from signed contributors can be accepted.
- [ ] **Authors**: Have you considered adding your name to the [AUTHORS](AUTHORS) file?
- [ ] **Code Style**: Have you ensured your code adheres to the project's coding style guidelines? You can use `./ci.sh lint` for automatic code formatting.
