### PR TITLE
out-of-order jxlp boxes

### DIFF
--- a/lib/jxl/decode.cc
+++ b/lib/jxl/decode.cc
@@ -19,6 +19,7 @@
 #include <cstdint>
 #include <cstring>
 #include <functional>
+#include <map>
 #include <memory>
 #include <utility>
 #include <vector>
@@ -213,6 +214,7 @@ enum class BoxStage : uint32_t {
   kSkip,        // Box whose contents are skipped
   kCodestream,  // Handling codestream box contents, or non-container stream
   kPartialCodestream,  // Handling the extra header of partial codestream box
+  kBufferingJxlp,      // Reading an out-of-order jxlp box payload into buffer
   kJpegRecon,          // Handling jpeg reconstruction box
 };
 
@@ -538,6 +540,34 @@ struct JxlDecoder {
 
   BoxStage box_stage;
 
+  // ftyp minor-version: 0 = jxlp must be in order; 1 = OOO jxlp allowed.
+  uint32_t jxl_file_format_version;
+
+  // Counter of the next expected jxlp box; earlier-arriving boxes are buffered.
+  uint32_t next_jxlp_index;
+
+  // OOO jxlp payloads keyed by counter: (codestream bytes without 4-byte
+  // header, is_last).
+  std::map<uint32_t, std::pair<std::vector<uint8_t>, bool>> jxlp_ooo_buffer;
+
+  // Index and is_last flag of the jxlp box currently being buffered
+  // (valid only while box_stage == kBufferingJxlp).
+  uint32_t buffering_jxlp_index;
+  bool buffering_jxlp_is_last;
+
+  // Injects the next buffered jxlp box (if available) into codestream_copy.
+  // Returns true if a box was injected.
+  bool InjectNextBufferedJxlpBox() {
+    auto it = jxlp_ooo_buffer.find(next_jxlp_index);
+    if (it == jxlp_ooo_buffer.end()) return false;
+    auto& [data, is_last] = it->second;
+    codestream_copy.insert(codestream_copy.end(), data.begin(), data.end());
+    if (is_last) last_codestream_seen = true;
+    next_jxlp_index++;
+    jxlp_ooo_buffer.erase(it);
+    return true;
+  }
+
 #if JPEGXL_ENABLE_BOXES
   jxl::JxlBoxContentDecoder box_content_decoder;
 #endif
@@ -705,6 +735,11 @@ void JxlDecoderRewindDecodingState(JxlDecoder* dec) {
   memset(dec->box_decoded_type, 0, sizeof(dec->box_decoded_type));
   dec->box_event = false;
   dec->box_stage = BoxStage::kHeader;
+  dec->jxl_file_format_version = 0;
+  dec->next_jxlp_index = 0;
+  dec->jxlp_ooo_buffer.clear();
+  dec->buffering_jxlp_index = 0;
+  dec->buffering_jxlp_is_last = false;
   dec->box_out_buffer_set = false;
   dec->box_out_buffer_set_current_box = false;
   dec->box_out_buffer = nullptr;
@@ -1881,11 +1916,18 @@ static JxlDecoderStatus HandleBoxes(JxlDecoder* dec) {
       if (dec->box_contents_size < 12) {
         return JXL_INPUT_ERROR("file type box too small");
       }
-      if (dec->avail_in < 4) return JXL_DEC_NEED_MORE_INPUT;
+      if (dec->avail_in < 8) return JXL_DEC_NEED_MORE_INPUT;
       if (memcmp(dec->next_in, "jxl ", 4) != 0) {
         return JXL_INPUT_ERROR("file type box major brand must be \"jxl \"");
       }
-      dec->AdvanceInput(4);
+      uint32_t version = LoadBE32(dec->next_in + 4);
+      if (version > 1) {
+        return JXL_INPUT_ERROR(
+            "unknown jxl file format version %u (known versions: 0, 1)",
+            version);
+      }
+      dec->jxl_file_format_version = version;
+      dec->AdvanceInput(8);
       dec->box_stage = BoxStage::kSkip;
     } else if (dec->box_stage == BoxStage::kPartialCodestream) {
       if (dec->last_codestream_seen) {
@@ -1896,14 +1938,33 @@ static JxlDecoderStatus HandleBoxes(JxlDecoder* dec) {
       if (!dec->box_contents_unbounded && dec->box_contents_size < 4) {
         return JXL_INPUT_ERROR("jxlp box too small to contain index");
       }
-      size_t jxlp_index = LoadBE32(dec->next_in);
-      // The high bit of jxlp_index indicates whether this is the last
-      // jxlp box.
-      if (jxlp_index & 0x80000000) {
-        dec->last_codestream_seen = true;
+      uint32_t jxlp_index = LoadBE32(dec->next_in);
+      uint32_t counter = jxlp_index & 0x7FFFFFFF;
+      bool is_last = (jxlp_index & 0x80000000) != 0;
+
+      if (counter < dec->next_jxlp_index) {
+        return JXL_INPUT_ERROR(
+            "jxlp box index %u is a duplicate (already processed)", counter);
       }
-      dec->AdvanceInput(4);
-      dec->box_stage = BoxStage::kCodestream;
+      dec->AdvanceInput(4);  // consume the 4-byte jxlp counter header
+
+      if (counter == dec->next_jxlp_index) {
+        dec->next_jxlp_index++;
+        if (is_last) dec->last_codestream_seen = true;
+        dec->box_stage = BoxStage::kCodestream;
+      } else if (dec->jxl_file_format_version >= 1) {
+        // Out-of-order box (version 1+): buffer payload for later injection.
+        dec->buffering_jxlp_index = counter;
+        dec->buffering_jxlp_is_last = is_last;
+        dec->jxlp_ooo_buffer.emplace(
+            counter, std::make_pair(std::vector<uint8_t>(), is_last));
+        dec->box_stage = BoxStage::kBufferingJxlp;
+      } else {
+        return JXL_INPUT_ERROR(
+            "jxlp box index %u is out of order (expected %u); out-of-order "
+            "jxlp boxes require file format version 1 in the ftyp box",
+            counter, dec->next_jxlp_index);
+      }
     } else if (dec->box_stage == BoxStage::kCodestream) {
       JxlDecoderStatus status = jxl::JxlDecoderProcessCodestream(dec);
 #if JPEGXL_ENABLE_TRANSCODE_JPEG
@@ -1916,6 +1977,8 @@ static JxlDecoderStatus HandleBoxes(JxlDecoder* dec) {
       if (status == JXL_DEC_NEED_MORE_INPUT) {
         if (dec->file_pos == dec->box_contents_end &&
             !dec->box_contents_unbounded) {
+          // Physical box exhausted; inject the next buffered OOO box if ready.
+          if (dec->InjectNextBufferedJxlpBox()) continue;
           dec->box_stage = BoxStage::kHeader;
           continue;
         }
@@ -1939,6 +2002,24 @@ static JxlDecoderStatus HandleBoxes(JxlDecoder* dec) {
         }
       }
       return status;
+    } else if (dec->box_stage == BoxStage::kBufferingJxlp) {
+      size_t remaining =
+          dec->box_contents_unbounded
+              ? dec->avail_in
+              : std::min<size_t>(dec->avail_in,
+                                 dec->box_contents_end - dec->file_pos);
+      auto& entry = dec->jxlp_ooo_buffer[dec->buffering_jxlp_index];
+      entry.first.insert(entry.first.end(), dec->next_in,
+                         dec->next_in + remaining);
+      dec->AdvanceInput(remaining);
+
+      bool box_done = !dec->box_contents_unbounded &&
+                      dec->file_pos >= dec->box_contents_end;
+      if (!box_done) {
+        return JXL_DEC_NEED_MORE_INPUT;
+      }
+      // Box fully buffered; parse the next box header.
+      dec->box_stage = BoxStage::kHeader;
 #if JPEGXL_ENABLE_TRANSCODE_JPEG
     } else if (dec->box_stage == BoxStage::kJpegRecon) {
       if (!dec->jpeg_decoder.IsParsingBox()) {
@@ -2707,7 +2788,7 @@ JxlDecoderStatus JxlDecoderSetOutputColorProfile(
   }
   if ((!dec->passes_state->output_encoding_info.cms_set) &&
       (icc_data != nullptr ||
-      (!dec->image_metadata.xyb_encoded && !same_encoding))) {
+       (!dec->image_metadata.xyb_encoded && !same_encoding))) {
     return JXL_API_ERROR(
         "must set color management system via JxlDecoderSetCms");
   }


### PR DESCRIPTION
Fixes #4735.

Also now checks the `ftyp` minor version number and refuses to decode if the version is not 0 or 1.

If the version is 0 (as in current output of cjxl and the current edition of 18181-2), it now also checks the order of `jxlp` boxes and refuses to decode files with out-of-order `jxlp` boxes.

If the version is 1 (which will likely be defined in a future edition of 18181-2), it allows out-of-order `jxlp` boxes and decodes them in the right order.