### PR TITLE
Better QuantizeHistogram

### DIFF
--- a/lib/jxl/ac_context.h
+++ b/lib/jxl/ac_context.h
@@ -83,7 +83,7 @@ static JXL_INLINE size_t ZeroDensityContext(size_t nonzeros_left, size_t k,
 }
 
 struct BlockCtxMap {
-  std::vector<int> dc_thresholds[3];
+  std::vector<int32_t> dc_thresholds[3];
   std::vector<uint32_t> qf_thresholds;
   std::vector<uint8_t> ctx_map;
   size_t num_ctxs, num_dc_ctxs;

--- a/lib/jxl/enc_Knuth_partition.h
+++ b/lib/jxl/enc_Knuth_partition.h
@@ -7,8 +7,11 @@
 #define LIB_JXL_ENC_KNUTH_PARTITION_H_
 
 #include <algorithm>
+#include <cmath>
+#include <cstddef>
 #include <cstdint>
 #include <limits>
+#include <numeric>
 #include <vector>
 
 namespace jxl {
@@ -150,6 +153,66 @@ struct KnuthPartitionSolver {
     return thresholds;
   }
 };
+
+inline int64_t HistogramPartitionCost(uint64_t count) {
+  if (count <= 1) return 0;
+  const double dcount = static_cast<double>(count);
+  constexpr double cost_scale = 1 << 10;  // enough for current purposes
+  return static_cast<int64_t>(
+      std::llround(dcount * std::log2(dcount) * cost_scale));
+}
+
+// Generates `num_intervals` bins with the best partition for entropy coding.
+template<typename T>
+inline std::vector<int32_t> QuantizeHistogram(
+    const T& histogram, size_t num_intervals,
+    int32_t threshold_offset = 0) {
+  size_t M = histogram.size();
+  size_t target_intervals = std::min(num_intervals, M);
+  if (target_intervals <= 1) return {};
+  // Return an empty threshold list if the histogram is single-bin
+  std::vector<uint64_t> prefix(M + 1, 0);
+  size_t nonzero_bins = 0;
+  for (size_t i = 0; i < M; ++i) {
+    prefix[i + 1] = prefix[i] + histogram[i];
+    nonzero_bins += (histogram[i] != 0);
+  }
+  if (nonzero_bins < 2) return {};
+  // If the target number of intervals is greater or equal than the number of
+  // symbols, return a threshold for each symbol.
+  if (target_intervals >= M) {
+    std::vector<int32_t> thresholds;
+    thresholds.reserve(M - 1);
+    for (size_t i = 0; i + 1 < M; ++i) {
+      thresholds.push_back(static_cast<int32_t>(i) + threshold_offset);
+    }
+    return thresholds;
+  }
+
+  // Build differential cost table.
+  KnuthPartitionSolver solver(M);
+  solver.ResetCosts(M * M);
+  for (size_t n = 0; n < M; ++n) {
+    int64_t prev_base = 0;
+    for (size_t l = 0; l <= n; ++l) {
+      uint64_t total = prefix[n + 1] - prefix[l];
+      int64_t base = HistogramPartitionCost(total);
+      if (n > 0 && l < n) {
+        base -= HistogramPartitionCost(prefix[n] - prefix[l]);
+      }
+      solver.costs[n * M + l] = base - prev_base;
+      prev_base = base;
+    }
+  }
+
+  std::vector<int32_t> thresholds;
+  thresholds.reserve(target_intervals - 1);
+  for (uint32_t split_point : solver.Solve(target_intervals, M)) {
+    thresholds.push_back(static_cast<int32_t>(split_point) - 1 +
+                         threshold_offset);
+  }
+  return thresholds;
+}
 
 }  // namespace jxl
 

--- a/lib/jxl/enc_Knuth_partition.h
+++ b/lib/jxl/enc_Knuth_partition.h
@@ -1,0 +1,156 @@
+// Copyright (c) the JPEG XL Project Authors. All rights reserved.
+//
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+#ifndef LIB_JXL_ENC_KNUTH_PARTITION_H_
+#define LIB_JXL_ENC_KNUTH_PARTITION_H_
+
+#include <algorithm>
+#include <cstdint>
+#include <limits>
+#include <vector>
+
+namespace jxl {
+
+// Knuth-optimized solver for contiguous 1D partitioning on a diff-form cost
+// matrix. Callers fill `costs` in diff form and then call `Solve`.
+struct KnuthPartitionSolver {
+  // Lazily materialized `M * M` interval cost matrix.
+  // In diff form, `costs[n * M + l]` is the incremental contribution needed to
+  // recover the total cost of putting ranks `[l..n]` into one cell.
+  std::vector<int64_t> costs;
+
+  // DP tables for row-wise optimal partitioning.
+  std::vector<int64_t> DP_prev;
+  std::vector<int64_t> DP_curr;
+  std::vector<uint16_t> split_table;
+  std::vector<uint16_t> row_done;
+  std::vector<int64_t> row_cum;
+
+  explicit KnuthPartitionSolver(size_t max_m = 0)
+      : DP_prev(max_m, 0),
+        DP_curr(max_m, 0),
+        row_done(max_m, 0),
+        row_cum(max_m, 0) {}
+
+  void ResetCosts(size_t cost_size) {
+    if (costs.size() < cost_size) {
+      costs.assign(cost_size, 0);
+    } else {
+      std::fill(costs.begin(), costs.begin() + cost_size, 0);
+    }
+  }
+
+  // Lazily materialise `costs[n * M + l]` = entropy of merging ranks
+  // `[l..n]` into one cell. The matrix is stored in diff form after the cost
+  // build pass: `costs[n * M + v]` holds the diff contributed by rank `v` to
+  // row `n`.
+  //
+  // Recurrence: `cost[l..n] = cost[l..n-1] + Σ_{v=l}^{n} diff(n, v)`.
+  // That is, merging rank `n` into an interval already covering `[l..n-1]`
+  // adds the total diff accumulated at row `n` from column `l` onward.
+  // `row_cum[n]` caches the running prefix sum of diffs already scanned in
+  // row `n`; `row_done[n]` is the last column fully converted (UINT16_MAX
+  // means none yet, used as a sentinel to distinguish "not started" from
+  // "column 0 done").
+  void EnsureDiffCost(uint32_t M, uint32_t l, uint32_t n) {
+    l = std::min(l, n);
+    if (row_done[n] != UINT16_MAX && row_done[n] >= l) return;
+    // Row `nn` needs columns up to `min(l, nn)` because row `nn+1` accesses
+    // `costs[nn*M+v]` for `v` in `[0, min(l, nn)]`. Processing rows from 0
+    // to `n` guarantees that `costs[(nn-1)*M+v]` is already available when
+    // computing row `nn`.
+    for (uint32_t nn = 0; nn <= n; ++nn) {
+      uint32_t needed = std::min(l, nn);
+      if (row_done[nn] != UINT16_MAX && row_done[nn] >= needed) continue;
+      uint32_t start = (row_done[nn] == UINT16_MAX) ? 0u : (row_done[nn] + 1);
+      int64_t cum = (start == 0) ? 0 : row_cum[nn];
+      for (uint32_t v = start; v <= needed; ++v) {
+        cum += costs[nn * M + v];
+        if (nn > 0 && v < nn) {
+          costs[nn * M + v] = costs[(nn - 1) * M + v] + cum;
+        } else {
+          costs[nn * M + v] = cum;
+        }
+      }
+      row_cum[nn] = cum;
+      row_done[nn] = static_cast<uint16_t>(needed);
+    }
+  }
+
+  // Accessor for materialized interval cost.
+  int64_t GetDiffCost(uint32_t M, uint32_t l, uint32_t n) {
+    EnsureDiffCost(M, l, n);
+    return costs[n * M + l];
+  }
+
+  // Implements Knuth’s dynamic programming optimization to solve
+  // the 1D optimal partitioning problem.
+  // `O(K × M)` using both monotonicity bounds via right-to-left `n`
+  // traversal. Works on diff-form `costs` and lazily materialises
+  // `cost[l..n]` entries on demand while DP requests them.
+  std::vector<uint32_t> Solve(uint32_t K, uint32_t M_eff,
+                              int64_t* best_cost = nullptr) {
+    if (M_eff == 0) {
+      if (best_cost != nullptr) *best_cost = 0;
+      return {};
+    }
+    if (M_eff <= 1 || K <= 1) {
+      if (best_cost != nullptr) *best_cost = GetDiffCost(M_eff, 0, M_eff - 1);
+      return {};
+    }
+
+    split_table.assign(K * M_eff, 0);
+    if (row_done.size() < M_eff) row_done.resize(M_eff);
+    if (row_cum.size() < M_eff) row_cum.resize(M_eff);
+    std::fill(row_done.begin(), row_done.begin() + M_eff, UINT16_MAX);
+    std::fill(row_cum.begin(), row_cum.begin() + M_eff, 0);
+    if (DP_prev.size() < M_eff) DP_prev.resize(M_eff);
+    if (DP_curr.size() < M_eff) DP_curr.resize(M_eff);
+
+    for (uint32_t n = 0; n < M_eff; ++n) {
+      DP_prev[n] = GetDiffCost(M_eff, 0, n);
+    }
+
+    constexpr int64_t INF = std::numeric_limits<int64_t>::max();
+    for (uint32_t k = 1; k < K; ++k) {
+      std::fill(DP_curr.begin(), DP_curr.begin() + M_eff, INF);
+      uint16_t* split_curr = split_table.data() + k * M_eff;
+      const uint16_t* split_prev = split_curr - M_eff;
+      uint32_t s_max = M_eff - 1;
+      for (uint32_t n_plus_1 = M_eff; n_plus_1 > 0; --n_plus_1) {
+        uint32_t n = n_plus_1 - 1;
+        uint32_t s_min = std::max<uint32_t>(split_prev[n], k);
+        if (s_min > s_max) continue;
+        uint32_t best_s = s_min;
+        for (uint32_t s = s_min; s <= s_max; ++s) {
+          int64_t val = DP_prev[s - 1] + GetDiffCost(M_eff, s, n);
+          if (val < DP_curr[n]) {
+            DP_curr[n] = val;
+            best_s = s;
+          }
+        }
+        split_curr[n] = static_cast<uint16_t>(best_s);
+        s_max = std::min(best_s, n - 1);
+      }
+      DP_prev.swap(DP_curr);
+    }
+
+    std::vector<uint32_t> thresholds;
+    thresholds.reserve(K - 1);
+    uint32_t v = M_eff - 1;
+    for (uint32_t k = K - 1; k > 0; --k) {
+      uint32_t s = split_table[k * M_eff + v];
+      thresholds.push_back(s);
+      v = s - 1;
+    }
+    std::reverse(thresholds.begin(), thresholds.end());
+    if (best_cost != nullptr) *best_cost = DP_prev[M_eff - 1];
+    return thresholds;
+  }
+};
+
+}  // namespace jxl
+
+#endif  // LIB_JXL_ENC_KNUTH_PARTITION_H_

--- a/lib/jxl/enc_Knuth_partition.h
+++ b/lib/jxl/enc_Knuth_partition.h
@@ -11,10 +11,21 @@
 #include <cstddef>
 #include <cstdint>
 #include <limits>
-#include <numeric>
 #include <vector>
 
+#include "lib/jxl/base/status.h"
+
 namespace jxl {
+
+// Finds thresholds for merging ordered histogram bins into a fixed number of
+// contiguous buckets. The interval cost is the bucket population's `n log n`;
+// since the total population is constant, minimizing the sum of these costs is
+// equivalent to maximizing the entropy of the bucket distribution. This gives
+// better use of the available bucket budget on skewed histograms, where simple
+// percentile bucketing can collapse several requested buckets into one, while
+// the DP-based approach tries to merge only those buckets that would minimally
+// increase the total cost. The DP uses Knuth optimization, relying on monotonic
+// optimal split points for this cost.
 
 // Knuth-optimized solver for contiguous 1D partitioning on a diff-form cost
 // matrix. Callers fill `costs` in diff form and then call `Solve`.
@@ -25,6 +36,8 @@ struct KnuthPartitionSolver {
   std::vector<int64_t> costs;
 
   // DP tables for row-wise optimal partitioning.
+  // Split indices are stored as `uint16_t`: this solver is quadratic in `M`,
+  // so `M > 65535` is outside the practical range for intended callers.
   std::vector<int64_t> DP_prev;
   std::vector<int64_t> DP_curr;
   std::vector<uint16_t> split_table;
@@ -58,7 +71,7 @@ struct KnuthPartitionSolver {
   // means none yet, used as a sentinel to distinguish "not started" from
   // "column 0 done").
   void EnsureDiffCost(uint32_t M, uint32_t l, uint32_t n) {
-    l = std::min(l, n);
+    JXL_DASSERT(l < M && n < M && l <= n);
     if (row_done[n] != UINT16_MAX && row_done[n] >= l) return;
     // Row `nn` needs columns up to `min(l, nn)` because row `nn+1` accesses
     // `costs[nn*M+v]` for `v` in `[0, min(l, nn)]`. Processing rows from 0
@@ -93,42 +106,41 @@ struct KnuthPartitionSolver {
   // `O(K × M)` using both monotonicity bounds via right-to-left `n`
   // traversal. Works on diff-form `costs` and lazily materialises
   // `cost[l..n]` entries on demand while DP requests them.
-  std::vector<uint32_t> Solve(uint32_t K, uint32_t M_eff,
+  // `Solve()` may only be called once as it destroys the cost matrix.
+  std::vector<uint16_t> Solve(uint32_t K, uint32_t M,
                               int64_t* best_cost = nullptr) {
-    if (M_eff == 0) {
-      if (best_cost != nullptr) *best_cost = 0;
-      return {};
-    }
-    if (M_eff <= 1 || K <= 1) {
-      if (best_cost != nullptr) *best_cost = GetDiffCost(M_eff, 0, M_eff - 1);
+    if (M <= 1 || K <= 1) {
+      if (best_cost != nullptr) {
+        *best_cost = (M == 0) ? 0 : GetDiffCost(M, 0, M - 1);
+      }
       return {};
     }
 
-    split_table.assign(K * M_eff, 0);
-    if (row_done.size() < M_eff) row_done.resize(M_eff);
-    if (row_cum.size() < M_eff) row_cum.resize(M_eff);
-    std::fill(row_done.begin(), row_done.begin() + M_eff, UINT16_MAX);
-    std::fill(row_cum.begin(), row_cum.begin() + M_eff, 0);
-    if (DP_prev.size() < M_eff) DP_prev.resize(M_eff);
-    if (DP_curr.size() < M_eff) DP_curr.resize(M_eff);
+    split_table.assign(K * M, 0);
+    if (row_done.size() < M) row_done.resize(M);
+    if (row_cum.size() < M) row_cum.resize(M);
+    std::fill(row_done.begin(), row_done.begin() + M, UINT16_MAX);
+    std::fill(row_cum.begin(), row_cum.begin() + M, 0);
+    if (DP_prev.size() < M) DP_prev.resize(M);
+    if (DP_curr.size() < M) DP_curr.resize(M);
 
-    for (uint32_t n = 0; n < M_eff; ++n) {
-      DP_prev[n] = GetDiffCost(M_eff, 0, n);
+    for (uint32_t n = 0; n < M; ++n) {
+      DP_prev[n] = GetDiffCost(M, 0, n);
     }
 
     constexpr int64_t INF = std::numeric_limits<int64_t>::max();
     for (uint32_t k = 1; k < K; ++k) {
-      std::fill(DP_curr.begin(), DP_curr.begin() + M_eff, INF);
-      uint16_t* split_curr = split_table.data() + k * M_eff;
-      const uint16_t* split_prev = split_curr - M_eff;
-      uint32_t s_max = M_eff - 1;
-      for (uint32_t n_plus_1 = M_eff; n_plus_1 > 0; --n_plus_1) {
+      std::fill(DP_curr.begin(), DP_curr.begin() + M, INF);
+      uint16_t* split_curr = split_table.data() + k * M;
+      const uint16_t* split_prev = split_curr - M;
+      uint32_t s_max = M - 1;
+      for (uint32_t n_plus_1 = M; n_plus_1 > 0; --n_plus_1) {
         uint32_t n = n_plus_1 - 1;
         uint32_t s_min = std::max<uint32_t>(split_prev[n], k);
         if (s_min > s_max) continue;
         uint32_t best_s = s_min;
         for (uint32_t s = s_min; s <= s_max; ++s) {
-          int64_t val = DP_prev[s - 1] + GetDiffCost(M_eff, s, n);
+          int64_t val = DP_prev[s - 1] + GetDiffCost(M, s, n);
           if (val < DP_curr[n]) {
             DP_curr[n] = val;
             best_s = s;
@@ -140,16 +152,16 @@ struct KnuthPartitionSolver {
       DP_prev.swap(DP_curr);
     }
 
-    std::vector<uint32_t> thresholds;
+    std::vector<uint16_t> thresholds;
     thresholds.reserve(K - 1);
-    uint32_t v = M_eff - 1;
+    uint32_t v = M - 1;
     for (uint32_t k = K - 1; k > 0; --k) {
-      uint32_t s = split_table[k * M_eff + v];
+      uint16_t s = split_table[k * M + v];
       thresholds.push_back(s);
       v = s - 1;
     }
     std::reverse(thresholds.begin(), thresholds.end());
-    if (best_cost != nullptr) *best_cost = DP_prev[M_eff - 1];
+    if (best_cost != nullptr) *best_cost = DP_prev[M - 1];
     return thresholds;
   }
 };
@@ -168,9 +180,11 @@ inline std::vector<int32_t> QuantizeHistogram(
     const T& histogram, size_t num_intervals,
     int32_t threshold_offset = 0) {
   size_t M = histogram.size();
+  JXL_DASSERT(M <= std::numeric_limits<uint16_t>::max());
   size_t target_intervals = std::min(num_intervals, M);
+
   if (target_intervals <= 1) return {};
-  // Return an empty threshold list if the histogram is single-bin
+  // Return an empty threshold list if the histogram is single-bin.
   std::vector<uint64_t> prefix(M + 1, 0);
   size_t nonzero_bins = 0;
   for (size_t i = 0; i < M; ++i) {
@@ -187,6 +201,21 @@ inline std::vector<int32_t> QuantizeHistogram(
       thresholds.push_back(static_cast<int32_t>(i) + threshold_offset);
     }
     return thresholds;
+  }
+
+  // Fast path for 2 intervals (1 threshold).
+  if (target_intervals == 2) {
+    int64_t best = std::numeric_limits<int64_t>::max();
+    size_t best_s = 1;
+    for (size_t s = 1; s < M; ++s) {
+      int64_t cost = HistogramPartitionCost(prefix[s]) +
+                     HistogramPartitionCost(prefix[M] - prefix[s]);
+      if (cost < best) {
+        best = cost;
+        best_s = s;
+      }
+    }
+    return {static_cast<int32_t>(best_s) - 1 + threshold_offset};
   }
 
   // Build differential cost table.
@@ -207,7 +236,7 @@ inline std::vector<int32_t> QuantizeHistogram(
 
   std::vector<int32_t> thresholds;
   thresholds.reserve(target_intervals - 1);
-  for (uint32_t split_point : solver.Solve(target_intervals, M)) {
+  for (uint16_t split_point : solver.Solve(target_intervals, M)) {
     thresholds.push_back(static_cast<int32_t>(split_point) - 1 +
                          threshold_offset);
   }

--- a/lib/jxl/enc_frame.cc
+++ b/lib/jxl/enc_frame.cc
@@ -39,6 +39,7 @@
 #include "lib/jxl/dct_util.h"
 #include "lib/jxl/dec_external_image.h"
 #include "lib/jxl/dec_modular.h"
+#include "lib/jxl/enc_Knuth_partition.h"
 #include "lib/jxl/enc_ac_strategy.h"
 #include "lib/jxl/enc_adaptive_quantization.h"
 #include "lib/jxl/enc_ans.h"
@@ -957,9 +958,8 @@ Status ComputeJPEGTranscodingData(const jpeg::JPEGData& jpeg_data,
     }
   }
   // JPEG DC is from -1024 to 1023.
-  std::vector<size_t> dc_counts;
-  dc_counts.resize(2048);
-  size_t total_dc[3] = {};
+  std::vector<uint32_t> dc_counts(2048);
+  uint32_t total_dc[3] = {};
   for (size_t c : {1, 0, 2}) {
     if (jpeg_data.components.size() == 1 && c != 1) {
       for (auto& coeff : enc_state->coeffs) {
@@ -1049,25 +1049,15 @@ Status ComputeJPEGTranscodingData(const jpeg::JPEGData& jpeg_data,
   auto& dct = enc_state->shared.block_ctx_map.dc_thresholds;
   auto& num_dc_ctxs = enc_state->shared.block_ctx_map.num_dc_ctxs;
 
-  for (size_t i = 0; i < 3; i++) {
-    dct[i].clear();
-  }
+  for (auto& i : dct) i.clear();
   // use more contexts for larger and higher quality images
-  int num_thresholds = CeilLog2Nonzero(total_dc[1]) -
-                       CeilLog2Nonzero(static_cast<unsigned>(
-                           qt[1] + qt[2] + qt[3] + qt[4] + qt[5])) -
-                       7;
+  int num_intervals = CeilLog2Nonzero(total_dc[1]) -
+                      CeilLog2Nonzero(static_cast<unsigned>(
+                          qt[1] + qt[2] + qt[3] + qt[4] + qt[5])) -
+                      6;
   // up to 8 buckets, based on luma only
-  num_thresholds = jxl::Clamp1(num_thresholds, 1, 7);
-  size_t cumsum = 0;
-  size_t cut = total_dc[1] / (num_thresholds + 1);
-  for (int j = 0; j < 2048; j++) {
-    cumsum += dc_counts[j];
-    if (cumsum > cut) {
-      dct[1].push_back(j - 1025);
-      cut = total_dc[1] * (dct[1].size() + 1) / (num_thresholds + 1);
-    }
-  }
+  num_intervals = jxl::Clamp1(num_intervals, 2, 8);
+  dct[1] = QuantizeHistogram(dc_counts, num_intervals, -1024);
   num_dc_ctxs = dct[1].size() + 1;
 
   auto& ctx_map = enc_state->shared.block_ctx_map.ctx_map;

--- a/lib/jxl/enc_heuristics.cc
+++ b/lib/jxl/enc_heuristics.cc
@@ -36,6 +36,7 @@
 #include "lib/jxl/color_encoding_internal.h"
 #include "lib/jxl/common.h"
 #include "lib/jxl/dct_util.h"
+#include "lib/jxl/enc_Knuth_partition.h"
 #include "lib/jxl/dec_cache.h"
 #include "lib/jxl/dec_group.h"
 #include "lib/jxl/dec_noise.h"
@@ -110,7 +111,7 @@ void FindBestBlockEntropyModel(const CompressParams& cparams, const ImageI& rqf,
       }
     }
 
-    size_t qf_counts[256] = {};
+    std::array<size_t, 256> qf_counts = {};
     size_t qf_ord_counts[kNumOrders][256] = {};
     size_t ord_counts[kNumOrders] = {};
   };
@@ -124,33 +125,16 @@ void FindBestBlockEntropyModel(const CompressParams& cparams, const ImageI& rqf,
   std::vector<uint32_t>& qft = block_ctx_map->qf_thresholds;
   qft.clear();
   // Divide the quant field in up to num_qf_segments segments.
-  size_t cumsum = 0;
-  size_t next = 1;
-  size_t last_cut = 256;
-  size_t cut = tot * next / num_qf_segments;
-  for (uint32_t j = 0; j < 256; j++) {
-    cumsum += counters->qf_counts[j];
-    if (cumsum > cut) {
-      if (j != 0) {
-        qft.push_back(j);
-      }
-      last_cut = j;
-      while (cumsum > cut) {
-        next++;
-        cut = tot * next / num_qf_segments;
-      }
-    } else if (next > qft.size() + 1) {
-      if (j - 1 == last_cut && j != 0) {
-        qft.push_back(j);
-      }
-    }
+  for (int32_t threshold :
+       QuantizeHistogram(counters->qf_counts, num_qf_segments, 1)) {
+    qft.push_back(static_cast<uint32_t>(threshold));
   }
 
   // Count the occurrences of each segment.
   std::vector<size_t> counts(kNumOrders * (qft.size() + 1));
   size_t qft_pos = 0;
   for (size_t j = 0; j < 256; j++) {
-    if (qft_pos < qft.size() && j == qft[qft_pos]) {
+    if (qft_pos < qft.size() && j >= qft[qft_pos]) {
       qft_pos++;
     }
     for (size_t i = 0; i < kNumOrders; i++) {

--- a/lib/jxl/jxl_test.cc
+++ b/lib/jxl/jxl_test.cc
@@ -1583,7 +1583,7 @@ JXL_TRANSCODE_JPEG_TEST(JxlTest, RoundtripJpegRecompression444wh12) {
   const std::vector<uint8_t> orig =
       ReadTestData("jxl/flower/flower.png.im_q85_444_1x2.jpg");
   // JPEG size is 703,874 bytes.
-  EXPECT_NEAR(RoundtripJpeg(orig, pool.get()), 569206u, 20);
+  EXPECT_NEAR(RoundtripJpeg(orig, pool.get()), 569256u, 20);
 }
 
 JXL_TRANSCODE_JPEG_TEST(JxlTest, RoundtripJpegRecompression422) {
@@ -1609,7 +1609,7 @@ JXL_TRANSCODE_JPEG_TEST(JxlTest, RoundtripJpegRecompressionAsymmetric) {
   const std::vector<uint8_t> orig =
       ReadTestData("jxl/flower/flower.png.im_q85_asymmetric.jpg");
   // JPEG size is 604,601 bytes.
-  EXPECT_NEAR(RoundtripJpeg(orig, pool.get()), 500974u, 20u);
+  EXPECT_NEAR(RoundtripJpeg(orig, pool.get()), 501001u, 20u);
 }
 
 JXL_TRANSCODE_JPEG_TEST(JxlTest, RoundtripJpegRecompression420Progr) {

--- a/lib/jxl/jxl_test.cc
+++ b/lib/jxl/jxl_test.cc
@@ -1085,7 +1085,7 @@ JXL_SLOW_TEST(JxlTest, RoundtripLossless8) {
   PackedPixelFile ppf_out;
   size_t compressed_size =
       Roundtrip(t.ppf(), cparams, dparams, pool.get(), &ppf_out);
-  EXPECT_EQ(compressed_size, 218284u);
+  EXPECT_EQ(compressed_size, 215768u);
   EXPECT_EQ(ComputeDistance2(t.ppf(), ppf_out), 0.0);
 }
 
@@ -1165,7 +1165,7 @@ TEST(JxlTest, RoundtripLossless8Alpha) {
 
   PackedPixelFile ppf_out;
   size_t compressed_size = Roundtrip(t.ppf(), cparams, dparams, pool, &ppf_out);
-  EXPECT_EQ(compressed_size, 246071u);
+  EXPECT_EQ(compressed_size, 243527u);
   EXPECT_EQ(ComputeDistance2(t.ppf(), ppf_out), 0.0);
   EXPECT_EQ(ppf_out.info.alpha_bits, 8u);
   EXPECT_TRUE(test::SameAlpha(t.ppf(), ppf_out));
@@ -1205,7 +1205,7 @@ TEST(JxlTest, RoundtripLossless16Alpha) {
   PackedPixelFile ppf_out;
   // TODO(szabadka) Investigate big size difference on i686
   size_t compressed_size = Roundtrip(t.ppf(), cparams, dparams, pool, &ppf_out);
-  EXPECT_NEAR(compressed_size, 3334u, 100u);
+  EXPECT_NEAR(compressed_size, 2421u, 100u);
   EXPECT_EQ(ComputeDistance2(t.ppf(), ppf_out), 0.0);
   EXPECT_EQ(ppf_out.info.alpha_bits, 16u);
   EXPECT_TRUE(test::SameAlpha(t.ppf(), ppf_out));
@@ -1341,7 +1341,7 @@ TEST(JxlTest, RoundtripLossless8Gray) {
   dparams.accepted_formats.push_back(t.ppf().frames[0].color.format);
 
   PackedPixelFile ppf_out;
-  EXPECT_EQ(Roundtrip(t.ppf(), cparams, dparams, pool, &ppf_out), 92495u);
+  EXPECT_EQ(Roundtrip(t.ppf(), cparams, dparams, pool, &ppf_out), 92360u);
   EXPECT_EQ(ComputeDistance2(t.ppf(), ppf_out), 0.0);
   EXPECT_EQ(ppf_out.color_encoding.color_space, JXL_COLOR_SPACE_GRAY);
   EXPECT_EQ(ppf_out.info.bits_per_sample, 8u);

--- a/lib/jxl/modular/encoding/enc_ma.cc
+++ b/lib/jxl/modular/encoding/enc_ma.cc
@@ -763,29 +763,28 @@ std::vector<int32_t> QuantizeHistogram(const std::vector<uint32_t> &histogram,
   if (histogram.empty() || num_chunks == 0) return {};
   uint64_t sum = std::accumulate(histogram.begin(), histogram.end(), 0LU);
   if (sum == 0) return {};
-  const uint32_t M = static_cast<uint32_t>(histogram.size());
-  const uint32_t target_intervals =
-      std::min<uint32_t>(static_cast<uint32_t>(num_chunks), M);
+  size_t M = histogram.size();
+  size_t target_intervals = std::min(num_chunks, M);
   if (target_intervals <= 1) return {};
   if (target_intervals >= M) {
     std::vector<int32_t> thresholds;
     thresholds.reserve(M - 1);
-    for (uint32_t i = 0; i + 1 < M; ++i) {
+    for (size_t i = 0; i + 1 < M; ++i) {
       thresholds.push_back(static_cast<int32_t>(i));
     }
     return thresholds;
   }
 
   std::vector<uint64_t> prefix(M + 1, 0);
-  for (uint32_t i = 0; i < M; ++i) {
+  for (size_t i = 0; i < M; ++i) {
     prefix[i + 1] = prefix[i] + histogram[i];
   }
 
   KnuthPartitionSolver solver(M);
-  solver.ResetCosts(static_cast<size_t>(M) * M);
-  for (uint32_t n = 0; n < M; ++n) {
+  solver.ResetCosts(M * M);
+  for (size_t n = 0; n < M; ++n) {
     int64_t prev_base = 0;
-    for (uint32_t l = 0; l <= n; ++l) {
+    for (size_t l = 0; l <= n; ++l) {
       const uint64_t total = prefix[n + 1] - prefix[l];
       int64_t base = HistogramIntervalCost(total);
       if (n > 0 && l < n) {

--- a/lib/jxl/modular/encoding/enc_ma.cc
+++ b/lib/jxl/modular/encoding/enc_ma.cc
@@ -752,56 +752,6 @@ void TreeSamples::Swap(size_t a, size_t b) {
 }
 
 namespace {
-int64_t HistogramIntervalCost(uint64_t count) {
-  if (count <= 1) return 0;
-  const double dcount = static_cast<double>(count);
-  return static_cast<int64_t>(std::llround(dcount * std::log2(dcount) * (1 << 10)));
-}
-
-std::vector<int32_t> QuantizeHistogram(const std::vector<uint32_t> &histogram,
-                                       size_t num_chunks) {
-  if (histogram.empty() || num_chunks == 0) return {};
-  uint64_t sum = std::accumulate(histogram.begin(), histogram.end(), 0LU);
-  if (sum == 0) return {};
-  size_t M = histogram.size();
-  size_t target_intervals = std::min(num_chunks, M);
-  if (target_intervals <= 1) return {};
-  if (target_intervals >= M) {
-    std::vector<int32_t> thresholds;
-    thresholds.reserve(M - 1);
-    for (size_t i = 0; i + 1 < M; ++i) {
-      thresholds.push_back(static_cast<int32_t>(i));
-    }
-    return thresholds;
-  }
-
-  std::vector<uint64_t> prefix(M + 1, 0);
-  for (size_t i = 0; i < M; ++i) {
-    prefix[i + 1] = prefix[i] + histogram[i];
-  }
-
-  KnuthPartitionSolver solver(M);
-  solver.ResetCosts(M * M);
-  for (size_t n = 0; n < M; ++n) {
-    int64_t prev_base = 0;
-    for (size_t l = 0; l <= n; ++l) {
-      const uint64_t total = prefix[n + 1] - prefix[l];
-      int64_t base = HistogramIntervalCost(total);
-      if (n > 0 && l < n) {
-        base -= HistogramIntervalCost(prefix[n] - prefix[l]);
-      }
-      solver.costs[n * M + l] = base - prev_base;
-      prev_base = base;
-    }
-  }
-
-  std::vector<int32_t> thresholds;
-  for (uint32_t split_point : solver.Solve(target_intervals, M)) {
-    thresholds.push_back(static_cast<int32_t>(split_point - 1));
-  }
-  return thresholds;
-}
-
 std::vector<int32_t> QuantizeSamples(const std::vector<int32_t> &samples,
                                      size_t num_chunks) {
   if (samples.empty()) return {};
@@ -813,9 +763,7 @@ std::vector<int32_t> QuantizeSamples(const std::vector<int32_t> &samples,
     uint32_t sample_offset = jxl::Clamp1(s, -kRange, kRange) - min;
     counts[sample_offset]++;
   }
-  std::vector<int32_t> thresholds = QuantizeHistogram(counts, num_chunks);
-  for (auto &v : thresholds) v += min;
-  return thresholds;
+  return QuantizeHistogram(counts, num_chunks, min);
 }
 
 // `to[i]` is assigned value `v` conforming `from[v] <= i && from[v-1] > i`.

--- a/lib/jxl/modular/encoding/enc_ma.cc
+++ b/lib/jxl/modular/encoding/enc_ma.cc
@@ -31,6 +31,7 @@
 
 #include "lib/jxl/base/fast_math-inl.h"
 #include "lib/jxl/base/random.h"
+#include "lib/jxl/enc_Knuth_partition.h"
 #include "lib/jxl/enc_ans.h"
 #include "lib/jxl/modular/encoding/context_predict.h"
 #include "lib/jxl/modular/options.h"
@@ -751,26 +752,54 @@ void TreeSamples::Swap(size_t a, size_t b) {
 }
 
 namespace {
+int64_t HistogramIntervalCost(uint64_t count) {
+  if (count <= 1) return 0;
+  const double dcount = static_cast<double>(count);
+  return static_cast<int64_t>(std::llround(dcount * std::log2(dcount) * (1 << 10)));
+}
+
 std::vector<int32_t> QuantizeHistogram(const std::vector<uint32_t> &histogram,
                                        size_t num_chunks) {
   if (histogram.empty() || num_chunks == 0) return {};
   uint64_t sum = std::accumulate(histogram.begin(), histogram.end(), 0LU);
   if (sum == 0) return {};
-  // TODO(veluca): selecting distinct quantiles is likely not the best
-  // way to go about this.
-  std::vector<int32_t> thresholds;
-  uint64_t cumsum = 0;
-  uint64_t threshold = 1;
-  for (size_t i = 0; i < histogram.size(); i++) {
-    cumsum += histogram[i];
-    if (cumsum * num_chunks >= threshold * sum) {
-      thresholds.push_back(i);
-      while (cumsum * num_chunks >= threshold * sum) threshold++;
+  const uint32_t M = static_cast<uint32_t>(histogram.size());
+  const uint32_t target_intervals =
+      std::min<uint32_t>(static_cast<uint32_t>(num_chunks), M);
+  if (target_intervals <= 1) return {};
+  if (target_intervals >= M) {
+    std::vector<int32_t> thresholds;
+    thresholds.reserve(M - 1);
+    for (uint32_t i = 0; i + 1 < M; ++i) {
+      thresholds.push_back(static_cast<int32_t>(i));
+    }
+    return thresholds;
+  }
+
+  std::vector<uint64_t> prefix(M + 1, 0);
+  for (uint32_t i = 0; i < M; ++i) {
+    prefix[i + 1] = prefix[i] + histogram[i];
+  }
+
+  KnuthPartitionSolver solver(M);
+  solver.ResetCosts(static_cast<size_t>(M) * M);
+  for (uint32_t n = 0; n < M; ++n) {
+    int64_t prev_base = 0;
+    for (uint32_t l = 0; l <= n; ++l) {
+      const uint64_t total = prefix[n + 1] - prefix[l];
+      int64_t base = HistogramIntervalCost(total);
+      if (n > 0 && l < n) {
+        base -= HistogramIntervalCost(prefix[n] - prefix[l]);
+      }
+      solver.costs[n * M + l] = base - prev_base;
+      prev_base = base;
     }
   }
-  JXL_DASSERT(thresholds.size() <= num_chunks);
-  // last value collects all histogram and is not really a threshold
-  thresholds.pop_back();
+
+  std::vector<int32_t> thresholds;
+  for (uint32_t split_point : solver.Solve(target_intervals, M)) {
+    thresholds.push_back(static_cast<int32_t>(split_point - 1));
+  }
   return thresholds;
 }
 

--- a/lib/jxl/passes_test.cc
+++ b/lib/jxl/passes_test.cc
@@ -363,7 +363,7 @@ TEST(PassesTest, ProgressiveDownsample2DegradesCorrectly) {
 
   ASSERT_TRUE(
       EncodeImageJXL(cparams, ppf, /*jpeg_bytes=*/nullptr, &compressed));
-  EXPECT_LE(compressed.size(), 55750u);
+  EXPECT_LE(compressed.size(), 55826u);
 
   JXLDecompressParams dparams;
   DefaultAcceptedFormats(dparams);

--- a/lib/jxl_lists.bzl
+++ b/lib/jxl_lists.bzl
@@ -295,6 +295,7 @@ libjxl_dec_sources = [
 libjxl_enc_sources = [
     "jxl/butteraugli/butteraugli.cc",
     "jxl/butteraugli/butteraugli.h",
+    "jxl/enc_Knuth_partition.h",
     "jxl/enc_ac_strategy.cc",
     "jxl/enc_ac_strategy.h",
     "jxl/enc_adaptive_quantization.cc",

--- a/lib/jxl_lists.cmake
+++ b/lib/jxl_lists.cmake
@@ -292,6 +292,7 @@ set(JPEGXL_INTERNAL_DEC_SOURCES
 set(JPEGXL_INTERNAL_ENC_SOURCES
   jxl/butteraugli/butteraugli.cc
   jxl/butteraugli/butteraugli.h
+  jxl/enc_Knuth_partition.h
   jxl/enc_ac_strategy.cc
   jxl/enc_ac_strategy.h
   jxl/enc_adaptive_quantization.cc

--- a/lib/lib.gni
+++ b/lib/lib.gni
@@ -293,6 +293,7 @@ libjxl_dec_sources = [
 libjxl_enc_sources = [
     "jxl/butteraugli/butteraugli.cc",
     "jxl/butteraugli/butteraugli.h",
+    "jxl/enc_Knuth_partition.h",
     "jxl/enc_ac_strategy.cc",
     "jxl/enc_ac_strategy.h",
     "jxl/enc_adaptive_quantization.cc",


### PR DESCRIPTION
### Description

A part of JPEG optimizer, useful by itself: optimal Knuth DP solver to find best histogram bucketing for minimal entropy. The performance difference by `./ci.sh gbench` is just pure noise on my machine, but some of lossless images with alpha drop in size quite nice (see test changes). Supersedes #4232. 

### Pull Request Checklist

- [x] **CLA Signed**: Have you signed the [Contributor License Agreement](https://code.google.com/legal/individual-cla-v1.0.html) (individual or corporate, as appropriate)? Only contributions from signed contributors can be accepted.
- [x] **Authors**: Have you considered adding your name to the [AUTHORS](AUTHORS) file?
- [x] **Code Style**: Have you ensured your code adheres to the project's coding style guidelines? You can use `./ci.sh lint` for automatic code formatting.