### PR TITLE
encoder output mode using out-of-order jxlp

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Added
+ - decoder: support for out-of-order `jxlp` boxes (ftyp minor version 1).
+ - encoder API: `JXL_ENC_FRAME_SETTING_OUTPUT_MODE` frame setting to control
+   how the codestream is written to the output. Mode 0 (default) buffers the
+   output internally and produces a normally ordered, progressively decodable
+   codestream. Mode 1 uses seek-based streaming (reduces peak memory for large
+   images, requires a seekable output stream). Mode 2 uses out-of-order `jxlp`
+   boxes (reduces peak memory without requiring seeking, but requires a decoder
+   that supports ftyp minor version 1).
+
 ### Changed / clarified
  - decoder API: timeframes to successfully invoke `JxlDecoderSetImageOutBuffer`
    and `JxlDecoderSetPreviewOutBuffer` are non-intersecting; it is not possible

--- a/lib/include/jxl/encode.h
+++ b/lib/include/jxl/encode.h
@@ -340,18 +340,18 @@ typedef enum {
    */
   JXL_ENC_FRAME_SETTING_JPEG_COMPRESS_BOXES = 33,
 
-  /** Control what kind of buffering is used, when using chunked image frames.
+  /** Control what kind of input buffering is used, when using chunked image frames.
+   * When using streaming input the encoder minimizes memory usage, potentially at
+   * a cost in compression density (though not necessarily).
    * -1 = default (let the encoder decide)
    * 0 = buffers everything, basically the same as non-streamed code path
    (mainly for testing)
    * 1 = buffers everything for images that are 2048 x 2048 or smaller, and
    *     uses streaming input and buffered output for larger images
    * 2 = same as 1, but the threshold to use streaming input is lower
-   * 3 = same as 2, but the output is also streaming
+   * 3 = deprecated; same as 2, but also sets output mode to 1.
    *
-   * When using streaming input and output the encoder minimizes memory usage at
-   * the cost of compression density. Also note that images produced with
-   * streaming output (mode 3) might not be progressively decodable.
+   * Output buffering is controlled via @ref JXL_ENC_FRAME_SETTING_OUTPUT_MODE.
    */
   JXL_ENC_FRAME_SETTING_BUFFERING = 34,
 
@@ -391,6 +391,31 @@ typedef enum {
    * optimizations disabled.
    */
   JXL_ENC_FRAME_SETTING_DISABLE_PERCEPTUAL_HEURISTICS = 39,
+
+  /** Control how codestream bytes are written to the output. Unlike
+   * @ref JXL_ENC_FRAME_SETTING_BUFFERING (which controls input buffering),
+   * this setting controls the output ordering and memory trade-offs.
+   *
+   * Modes 1 and 2 reduce peak memory usage by avoiding buffering the output
+   * bitstream, but produce codestreams in an order not suitable for
+   * progressive decoding.
+   *
+   * -1 = default (let the encoder decide).
+   * 0 = buffer the output bitstream internally; write frames in normal order.
+   *     No seeking required. The codestream can be decoded progressively.
+   *     This is the most compatible mode.
+   * 1 = seek-based streaming: write group data first, then seek back to write
+   *     the frame header and TOC. Reduces peak memory for large images.
+   *     Requires a seekable output stream. Produces maximally compatible files.
+   * 2 = out-of-order jxlp streaming: each codestream section is a separate
+   *     jxlp box written in encoding order; jxlp counters reflect codestream
+   *     order so a decoder can reassemble a standard, progressively decodable
+   *     codestream by sorting the boxes. Reduces peak memory without requiring
+   *     output seeking. Requires ftyp version 1, which is not supported by
+   *     older decoders. If mode 2 is used for any frame, it must also be used
+   *     for the first frame (the ftyp version cannot be changed once written).
+   */
+  JXL_ENC_FRAME_SETTING_OUTPUT_MODE = 40,
 
   /** Enum value not to be used as an option. This value is added to force the
    * C compiler to have the enum to take a known size.

--- a/lib/jxl/common.h
+++ b/lib/jxl/common.h
@@ -8,7 +8,9 @@
 
 // Shared constants.
 
+#include <array>
 #include <cstddef>
+#include <cstdint>
 
 #ifndef JXL_HIGH_PRECISION
 #define JXL_HIGH_PRECISION 1
@@ -26,6 +28,10 @@
 
 namespace jxl {
 // Some enums and typedefs used by more than one header file.
+
+// The 12-byte JXL container signature box (all valid containers start with it).
+constexpr std::array<uint8_t, 12> kJxlSignatureBox = {
+    0x00, 0x00, 0x00, 0x0C, 'J', 'X', 'L', ' ', 0x0D, 0x0A, 0x87, 0x0A};
 
 // Maximum number of passes in an image.
 constexpr size_t kMaxNumPasses = 11;

--- a/lib/jxl/decode.cc
+++ b/lib/jxl/decode.cc
@@ -132,13 +132,11 @@ JxlSignature ReadSignature(const uint8_t* buf, size_t len, size_t* pos) {
 
   // JPEG XL container
   if (len >= 1 && buf[0] == 0) {
-    if (len < 12) {
+    if (len < jxl::kJxlSignatureBox.size()) {
       return JXL_SIG_NOT_ENOUGH_BYTES;
-    } else if (buf[1] == 0 && buf[2] == 0 && buf[3] == 0xC && buf[4] == 'J' &&
-               buf[5] == 'X' && buf[6] == 'L' && buf[7] == ' ' &&
-               buf[8] == 0xD && buf[9] == 0xA && buf[10] == 0x87 &&
-               buf[11] == 0xA) {
-      *pos += 12;
+    } else if (memcmp(buf, jxl::kJxlSignatureBox.data(),
+                      jxl::kJxlSignatureBox.size()) == 0) {
+      *pos += jxl::kJxlSignatureBox.size();
       return JXL_SIG_CONTAINER;
     } else {
       return JXL_SIG_INVALID;

--- a/lib/jxl/decode_test.cc
+++ b/lib/jxl/decode_test.cc
@@ -5062,8 +5062,7 @@ JXL_TRANSCODE_JPEG_TEST(DecodeTest, JPEGReconstructionTest) {
   std::vector<uint8_t> encoded_jpeg_data;
   ASSERT_TRUE(EncodeJPEGData(memory_manager, jpeg_data_copy, &encoded_jpeg_data,
                              cparams));
-  std::vector<uint8_t> container;
-  jxl::Bytes(jxl::kContainerHeader).AppendTo(container);
+  std::vector<uint8_t> container = jxl::MakeContainerHeader(0);
   jxl::AppendBoxHeader(jxl::MakeBoxType("jbrd"), encoded_jpeg_data.size(),
                        false, &container);
   jxl::Bytes(encoded_jpeg_data).AppendTo(container);

--- a/lib/jxl/enc_frame.cc
+++ b/lib/jxl/enc_frame.cc
@@ -23,6 +23,7 @@
 #include "lib/jxl/ac_context.h"
 #include "lib/jxl/ac_strategy.h"
 #include "lib/jxl/base/bits.h"
+#include "lib/jxl/base/byte_order.h"
 #include "lib/jxl/base/common.h"
 #include "lib/jxl/base/compiler_specific.h"
 #include "lib/jxl/base/data_parallel.h"
@@ -1963,19 +1964,13 @@ size_t ComputeDcGlobalPadding(const std::vector<size_t>& group_sizes,
   return group_data_offset - actual_offset;
 }
 
+// write_fn is called once per section (dc_group, then each ac_group).
 Status OutputGroups(std::vector<std::unique_ptr<BitWriter>>&& group_codes,
-                    std::vector<size_t>* group_sizes,
-                    JxlEncoderOutputProcessorWrapper* output_processor) {
+                    std::function<Status(PaddedBytes&&)> write_fn) {
   JXL_ENSURE(group_codes.size() >= 4);
-  {
-    PaddedBytes dc_group = std::move(*group_codes[1]).TakeBytes();
-    group_sizes->push_back(dc_group.size());
-    JXL_RETURN_IF_ERROR(AppendData(*output_processor, dc_group));
-  }
+  JXL_RETURN_IF_ERROR(write_fn(std::move(*group_codes[1]).TakeBytes()));
   for (size_t i = 3; i < group_codes.size(); ++i) {
-    PaddedBytes ac_group = std::move(*group_codes[i]).TakeBytes();
-    group_sizes->push_back(ac_group.size());
-    JXL_RETURN_IF_ERROR(AppendData(*output_processor, ac_group));
+    JXL_RETURN_IF_ERROR(write_fn(std::move(*group_codes[i]).TakeBytes()));
   }
   return true;
 }
@@ -2052,9 +2047,10 @@ StatusOr<std::unique_ptr<BitWriter>> OutputAcGlobal(
 JXL_NOINLINE Status EncodeFrameStreaming(
     JxlMemoryManager* memory_manager, const CompressParams& cparams,
     const FrameInfo& frame_info, const CodecMetadata* metadata,
-    JxlEncoderChunkedFrameAdapter& frame_data, bool streaming_output,
-    const JxlCmsInterface& cms, ThreadPool* pool,
-    JxlEncoderOutputProcessorWrapper* output_processor, AuxOut* aux_out) {
+    JxlEncoderChunkedFrameAdapter& frame_data, const JxlCmsInterface& cms,
+    ThreadPool* pool, JxlEncoderOutputProcessorWrapper* output_processor,
+    AuxOut* aux_out, uint32_t* jxlp_counter) {
+  const int output_mode = cparams.output_mode;
   auto enc_state = jxl::make_unique<PassesEncoderState>(memory_manager);
   SetProgressiveMode(cparams, &enc_state->progressive_splitter);
   FrameHeader frame_header(metadata);
@@ -2085,10 +2081,52 @@ JXL_NOINLINE Status EncodeFrameStreaming(
   PaddedBytes frame_header_bytes{memory_manager};
   PaddedBytes dc_global_bytes{memory_manager};
   std::vector<size_t> group_sizes;
-  size_t start_pos = output_processor->CurrentPosition();
-  std::vector<std::unique_ptr<BitWriter>> global_group_codes(
+  const bool streaming_output = (output_mode == 1);
+  const bool streaming = (output_mode >= 1);
+  const bool ooo = (output_mode == 2 && jxlp_counter != nullptr);
+  size_t start_pos =
+      (streaming_output && output_processor) ? output_processor->CurrentPosition() : 0;
+  const size_t total_sections =
       NumTocEntries(frame_header.ToFrameDimensions().num_groups,
-                    dc_group_order.size(), num_passes));
+                    dc_group_order.size(), num_passes);
+  std::vector<std::unique_ptr<BitWriter>> global_group_codes(
+      streaming ? 0 : total_sections);
+
+  // For OOO mode: inv_perm maps encoding_pos to codestream_slot so that
+  // jxlp box counters (jxlp_base + slot + 2) produce codestream order on sort.
+  size_t encoding_pos = 0;
+  std::vector<size_t> inv_perm;
+  if (ooo) {
+    inv_perm.resize(permutation.size());
+    for (size_t j = 0; j < permutation.size(); j++) {
+      inv_perm[permutation[j]] = j;
+    }
+  }
+
+  auto write_jxlp = [&](uint32_t counter, bool is_last,
+                         Span<const uint8_t> data) -> Status {
+    uint8_t hdr[kLargeBoxHeaderSize + 4];
+    const size_t hdr_size =
+        WriteBoxHeader(MakeBoxType("jxlp"), 4 + data.size(),
+                       /*unbounded=*/false, /*force_large_box=*/false, hdr);
+    StoreBE32(counter | (is_last ? 0x80000000u : 0u), hdr + hdr_size);
+    JXL_RETURN_IF_ERROR(AppendData(*output_processor,
+                                   Span<const uint8_t>(hdr, hdr_size + 4)));
+    return AppendData(*output_processor, data);
+  };
+
+  const uint32_t jxlp_base = jxlp_counter ? *jxlp_counter : 0;
+
+  auto write_group_section = [&](PaddedBytes&& bytes) -> Status {
+    group_sizes.push_back(bytes.size());
+    if (ooo) {
+      const size_t slot = inv_perm[encoding_pos++];
+      const bool is_last = (slot + 1 == total_sections) && frame_info.is_last;
+      return write_jxlp(jxlp_base + static_cast<uint32_t>(slot) + 2, is_last,
+                        Span<const uint8_t>(bytes.data(), bytes.size()));
+    }
+    return AppendData(*output_processor, bytes);
+  };
   for (size_t i = 0; i < dc_group_order.size(); ++i) {
     size_t dc_ix = dc_group_order[i];
     size_t dc_y = dc_ix / dc_group_xsize;
@@ -2145,11 +2183,18 @@ JXL_NOINLINE Status EncodeFrameStreaming(
         group_sizes.push_back(dc_global_bytes.size());
         JXL_RETURN_IF_ERROR(
             output_processor->Seek(start_pos + group_data_offset));
+      } else if (ooo) {
+        JXL_RETURN_IF_ERROR(write_jxlp(
+            jxlp_base, /*is_last=*/false,
+            Span<const uint8_t>(frame_header_bytes.data(),
+                                frame_header_bytes.size())));
+        JXL_RETURN_IF_ERROR(
+            write_group_section(std::move(*group_codes[0]).TakeBytes()));
       }
     }
-    if (streaming_output) {
+    if (streaming) {
       JXL_RETURN_IF_ERROR(
-          OutputGroups(std::move(group_codes), &group_sizes, output_processor));
+          OutputGroups(std::move(group_codes), write_group_section));
     } else {
       JXL_ENSURE(group_codes.size() >= 4);
       if (i == 0) {
@@ -2177,16 +2222,15 @@ JXL_NOINLINE Status EncodeFrameStreaming(
         std::unique_ptr<BitWriter> writer,
         OutputAcGlobal(*enc_state, frame_header.ToFrameDimensions(), aux_out));
     JXL_RETURN_IF_ERROR(writer->Shrink());
-    if (streaming_output) {
-      PaddedBytes ac_global = std::move(*writer).TakeBytes();
-      group_sizes.push_back(ac_global.size());
-      JXL_RETURN_IF_ERROR(AppendData(*output_processor, ac_global));
+    if (streaming) {
+      JXL_RETURN_IF_ERROR(
+          write_group_section(std::move(*writer).TakeBytes()));
     } else {
       global_group_codes[1 + dc_group_order.size()] = std::move(writer);
     }
   } else {
-    if (streaming_output) {
-      group_sizes.push_back(0);
+    if (streaming) {
+      JXL_RETURN_IF_ERROR(write_group_section(PaddedBytes{memory_manager}));
     } else {
       global_group_codes[1 + dc_group_order.size()] =
           jxl::make_unique<BitWriter>(memory_manager);
@@ -2213,6 +2257,22 @@ JXL_NOINLINE Status EncodeFrameStreaming(
     JXL_ENSURE(output_processor->CurrentPosition() ==
                start_pos + group_data_offset);
     JXL_RETURN_IF_ERROR(output_processor->Seek(end_pos));
+  } else if (ooo) {
+    // Write TOC (in codestream order) as jxlp[jxlp_base+1]; counter +1 means
+    // the decoder processes it before the group sections (counters >= +2).
+    JXL_ENSURE(group_sizes.size() == permutation.size());
+    std::vector<size_t> codestream_sizes(permutation.size());
+    for (size_t j = 0; j < permutation.size(); j++) {
+      codestream_sizes[j] = group_sizes[permutation[j]];
+    }
+    JXL_ASSIGN_OR_RETURN(PaddedBytes toc_bytes,
+                         EncodeTOC(memory_manager, codestream_sizes, aux_out));
+    JXL_RETURN_IF_ERROR(
+        write_jxlp(jxlp_base + 1, /*is_last=*/false,
+                   Span<const uint8_t>(toc_bytes.data(), toc_bytes.size())));
+    if (jxlp_counter != nullptr) {
+      *jxlp_counter = jxlp_base + static_cast<uint32_t>(total_sections) + 2;
+    }
   } else {
     for (auto& g : global_group_codes) {
       group_sizes.push_back(g->BitsWritten() / 8);
@@ -2223,8 +2283,8 @@ JXL_NOINLINE Status EncodeFrameStreaming(
     JXL_RETURN_IF_ERROR(AppendData(*output_processor, frame_header_bytes));
     JXL_RETURN_IF_ERROR(AppendData(*output_processor, toc_bytes));
     for (auto& g : global_group_codes) {
-      PaddedBytes bytes = std::move(*g).TakeBytes();
-      JXL_RETURN_IF_ERROR(AppendData(*output_processor, bytes));
+      JXL_RETURN_IF_ERROR(
+          AppendData(*output_processor, std::move(*g).TakeBytes()));
     }
   }
   return true;
@@ -2481,7 +2541,7 @@ Status EncodeFrame(JxlMemoryManager* memory_manager,
                    JxlEncoderChunkedFrameAdapter& frame_data,
                    const JxlCmsInterface& cms, ThreadPool* pool,
                    JxlEncoderOutputProcessorWrapper* output_processor,
-                   AuxOut* aux_out) {
+                   AuxOut* aux_out, uint32_t* jxlp_counter) {
   CompressParams cparams = cparams_orig;
   if (cparams.speed_tier == SpeedTier::kTectonicPlate &&
       !cparams.IsLossless()) {
@@ -2495,7 +2555,7 @@ Status EncodeFrame(JxlMemoryManager* memory_manager,
   if (cparams.speed_tier == SpeedTier::kTectonicPlate) {
     // Test palette performance to inform later trials.
     std::vector<CompressParams> all_params;
-    CompressParams cparams_attempt = cparams_orig;
+    CompressParams cparams_attempt = cparams;
     cparams_attempt.speed_tier = SpeedTier::kGlacier;
 
     cparams_attempt.options.max_properties = 4;
@@ -2522,7 +2582,7 @@ Status EncodeFrame(JxlMemoryManager* memory_manager,
       JxlEncoderOutputProcessorWrapper local_output(memory_manager);
       JXL_RETURN_IF_ERROR(EncodeFrame(memory_manager, all_params[task],
                                       frame_info, metadata, frame_data, cms,
-                                      nullptr, &local_output, aux_out));
+                                      nullptr, &local_output, aux_out, nullptr));
       size[task] = local_output.CurrentPosition();
       return true;
     };
@@ -2535,10 +2595,10 @@ Status EncodeFrame(JxlMemoryManager* memory_manager,
     size_t best_idx_test = 0;
 
     if (size_test[0] <= size_test[1]) {
-      all_params = TectonicPlateSettingsLessPalette(cparams_orig);
+      all_params = TectonicPlateSettingsLessPalette(cparams);
     } else {
       best_idx_test = 1;
-      all_params = TectonicPlateSettingsMorePalette(cparams_orig);
+      all_params = TectonicPlateSettingsMorePalette(cparams);
     }
 
     size.clear();
@@ -2615,9 +2675,14 @@ Status EncodeFrame(JxlMemoryManager* memory_manager,
 
   if (CanDoStreamingEncoding(cparams, frame_info, *metadata, frame_data)) {
     return EncodeFrameStreaming(memory_manager, cparams, frame_info, metadata,
-                                frame_data, cparams.buffering > 2, cms, pool,
-                                output_processor, aux_out);
+                                frame_data, cms, pool, output_processor,
+                                aux_out, jxlp_counter);
   } else {
+    if (cparams.output_mode == 2 && jxlp_counter != nullptr) {
+      // Leave a 12-byte gap for the jxlp box header; encode.cc fills it in.
+      JXL_RETURN_IF_ERROR(
+          output_processor->Seek(output_processor->CurrentPosition() + 12));
+    }
     return EncodeFrameOneShot(memory_manager, cparams, frame_info, metadata,
                               frame_data, cms, pool, output_processor, aux_out);
   }
@@ -2667,7 +2732,7 @@ Status EncodeFrame(JxlMemoryManager* memory_manager,
   JxlEncoderOutputProcessorWrapper output_processor(memory_manager);
   JXL_RETURN_IF_ERROR(EncodeFrame(memory_manager, cparams_orig, fi, metadata,
                                   frame_data, cms, pool, &output_processor,
-                                  aux_out));
+                                  aux_out, nullptr));
   JXL_RETURN_IF_ERROR(output_processor.SetFinalizedPosition());
   std::vector<uint8_t> output;
   JXL_RETURN_IF_ERROR(output_processor.CopyOutput(output));

--- a/lib/jxl/enc_frame.cc
+++ b/lib/jxl/enc_frame.cc
@@ -1775,6 +1775,7 @@ Status PermuteGroups(const CompressParams& cparams,
       permutation->push_back(pass_start + v);
     }
   }
+  if (group_codes == nullptr) return true;
   std::vector<std::unique_ptr<BitWriter>> new_group_codes(group_codes->size());
   for (size_t i = 0; i < permutation->size(); i++) {
     new_group_codes[(*permutation)[i]] = std::move((*group_codes)[i]);
@@ -1916,21 +1917,6 @@ size_t TOCSize(const std::vector<size_t>& group_sizes) {
     toc_bits += kTOCBits[TOCBucket(group_size)];
   }
   return (toc_bits + 7) / 8;
-}
-
-StatusOr<PaddedBytes> EncodeTOC(JxlMemoryManager* memory_manager,
-                                const std::vector<size_t>& group_sizes,
-                                AuxOut* aux_out) {
-  BitWriter writer{memory_manager};
-  JXL_RETURN_IF_ERROR(writer.WithMaxBits(
-      32 * group_sizes.size(), LayerType::Toc, aux_out, [&]() -> Status {
-        for (size_t group_size : group_sizes) {
-          JXL_RETURN_IF_ERROR(U32Coder::Write(kTocDist, group_size, &writer));
-        }
-        writer.ZeroPadToByte();  // before first group
-        return true;
-      }));
-  return std::move(writer).TakeBytes();
 }
 
 Status ComputeGroupDataOffset(size_t frame_header_size, size_t dc_global_size,
@@ -2092,8 +2078,11 @@ JXL_NOINLINE Status EncodeFrameStreaming(
   std::vector<std::unique_ptr<BitWriter>> global_group_codes(
       streaming ? 0 : total_sections);
 
-  // For OOO mode: inv_perm maps encoding_pos to codestream_slot so that
-  // jxlp box counters (jxlp_base + slot + 2) produce codestream order on sort.
+  // Compute group_order_perm for all modes (centerfirst, if requested).
+  // For ooo mode, also compute inv_perm (encoding_pos → canonical_idx).
+  std::vector<coeff_order_t> group_order_perm;
+  JXL_RETURN_IF_ERROR(PermuteGroups(cparams, frame_header.ToFrameDimensions(),
+                                    num_passes, &group_order_perm, nullptr));
   size_t encoding_pos = 0;
   std::vector<size_t> inv_perm;
   if (ooo) {
@@ -2120,9 +2109,12 @@ JXL_NOINLINE Status EncodeFrameStreaming(
   auto write_group_section = [&](PaddedBytes&& bytes) -> Status {
     group_sizes.push_back(bytes.size());
     if (ooo) {
-      const size_t slot = inv_perm[encoding_pos++];
-      const bool is_last = (slot + 1 == total_sections) && frame_info.is_last;
-      return write_jxlp(jxlp_base + static_cast<uint32_t>(slot) + 2, is_last,
+      const size_t canonical_idx = inv_perm[encoding_pos++];
+      const size_t cs_pos = group_order_perm.empty()
+                                ? canonical_idx
+                                : group_order_perm[canonical_idx];
+      const bool is_last = (cs_pos + 1 == total_sections) && frame_info.is_last;
+      return write_jxlp(jxlp_base + static_cast<uint32_t>(cs_pos) + 2, is_last,
                         Span<const uint8_t>(bytes.data(), bytes.size()));
     }
     return AppendData(*output_processor, bytes);
@@ -2156,19 +2148,8 @@ JXL_NOINLINE Status EncodeFrameStreaming(
     if (i == 0) {
       BitWriter writer{memory_manager};
       JXL_RETURN_IF_ERROR(WriteFrameHeader(frame_header, &writer, aux_out));
-      JXL_RETURN_IF_ERROR(
-          writer.WithMaxBits(8, LayerType::Header, aux_out, [&]() -> Status {
-            if (streaming_output) {
-              writer.Write(1, 1);  // write permutation
-              JXL_RETURN_IF_ERROR(EncodePermutation(
-                  permutation.data(), /*skip=*/0, permutation.size(), &writer,
-                  LayerType::Header, aux_out));
-            } else {
-              writer.Write(1, 0); // no permutation
-            }
-            writer.ZeroPadToByte();
-            return true;
-          }));
+      JXL_RETURN_IF_ERROR(WriteTocPermutation(
+          streaming_output ? permutation : group_order_perm, &writer, aux_out));
       frame_header_bytes = std::move(writer).TakeBytes();
       if (streaming_output) {
         dc_global_bytes = std::move(*group_codes[0]).TakeBytes();
@@ -2244,8 +2225,9 @@ JXL_NOINLINE Status EncodeFrameStreaming(
         ComputeDcGlobalPadding(group_sizes, frame_header_bytes.size(),
                                group_data_offset, min_dc_global_size);
     group_sizes[0] += padding_size;
-    JXL_ASSIGN_OR_RETURN(PaddedBytes toc_bytes,
-                         EncodeTOC(memory_manager, group_sizes, aux_out));
+    BitWriter toc_writer{memory_manager};
+    JXL_RETURN_IF_ERROR(WriteTocSizes(group_sizes, &toc_writer, aux_out));
+    PaddedBytes toc_bytes = std::move(toc_writer).TakeBytes();
     std::vector<uint8_t> padding_bytes(padding_size);
     JXL_RETURN_IF_ERROR(AppendData(*output_processor, frame_header_bytes));
     JXL_RETURN_IF_ERROR(AppendData(*output_processor, toc_bytes));
@@ -2262,11 +2244,16 @@ JXL_NOINLINE Status EncodeFrameStreaming(
     // the decoder processes it before the group sections (counters >= +2).
     JXL_ENSURE(group_sizes.size() == permutation.size());
     std::vector<size_t> codestream_sizes(permutation.size());
-    for (size_t j = 0; j < permutation.size(); j++) {
-      codestream_sizes[j] = group_sizes[permutation[j]];
+    for (size_t canonical_idx = 0; canonical_idx < permutation.size();
+         canonical_idx++) {
+      const size_t cs_pos = group_order_perm.empty()
+                                ? canonical_idx
+                                : group_order_perm[canonical_idx];
+      codestream_sizes[cs_pos] = group_sizes[permutation[canonical_idx]];
     }
-    JXL_ASSIGN_OR_RETURN(PaddedBytes toc_bytes,
-                         EncodeTOC(memory_manager, codestream_sizes, aux_out));
+    BitWriter toc_writer{memory_manager};
+    JXL_RETURN_IF_ERROR(WriteTocSizes(codestream_sizes, &toc_writer, aux_out));
+    PaddedBytes toc_bytes = std::move(toc_writer).TakeBytes();
     JXL_RETURN_IF_ERROR(
         write_jxlp(jxlp_base + 1, /*is_last=*/false,
                    Span<const uint8_t>(toc_bytes.data(), toc_bytes.size())));
@@ -2278,10 +2265,24 @@ JXL_NOINLINE Status EncodeFrameStreaming(
       group_sizes.push_back(g->BitsWritten() / 8);
     }
     JXL_ENSURE(group_sizes.size() == permutation.size());
-    JXL_ASSIGN_OR_RETURN(PaddedBytes toc_bytes,
-                         EncodeTOC(memory_manager, group_sizes, aux_out));
-    JXL_RETURN_IF_ERROR(AppendData(*output_processor, frame_header_bytes));
-    JXL_RETURN_IF_ERROR(AppendData(*output_processor, toc_bytes));
+    if (!group_order_perm.empty()) {
+      std::vector<std::unique_ptr<BitWriter>> reordered(
+          group_order_perm.size());
+      std::vector<size_t> reordered_sizes(group_sizes.size());
+      for (size_t i = 0; i < group_order_perm.size(); i++) {
+        reordered[group_order_perm[i]] = std::move(global_group_codes[i]);
+        reordered_sizes[group_order_perm[i]] = group_sizes[i];
+      }
+      global_group_codes.swap(reordered);
+      group_sizes.swap(reordered_sizes);
+    }
+    BitWriter combined{memory_manager};
+    JXL_RETURN_IF_ERROR(WriteFrameHeader(frame_header, &combined, aux_out));
+    JXL_RETURN_IF_ERROR(
+        WriteTocPermutation(group_order_perm, &combined, aux_out));
+    JXL_RETURN_IF_ERROR(WriteTocSizes(group_sizes, &combined, aux_out));
+    JXL_RETURN_IF_ERROR(
+        AppendData(*output_processor, std::move(combined).TakeBytes()));
     for (auto& g : global_group_codes) {
       JXL_RETURN_IF_ERROR(
           AppendData(*output_processor, std::move(*g).TakeBytes()));
@@ -2328,8 +2329,14 @@ Status EncodeFrameOneShot(JxlMemoryManager* memory_manager,
   JXL_RETURN_IF_ERROR(PermuteGroups(cparams, enc_state->shared.frame_dim,
                                     num_passes, &permutation, &group_codes));
 
-  JXL_RETURN_IF_ERROR(
-      WriteGroupOffsets(group_codes, permutation, &writer, aux_out));
+  std::vector<size_t> group_sizes;
+  group_sizes.reserve(group_codes.size());
+  for (const auto& bw : group_codes) {
+    JXL_ENSURE(bw->BitsWritten() % kBitsPerByte == 0);
+    group_sizes.push_back(bw->BitsWritten() / kBitsPerByte);
+  }
+  JXL_RETURN_IF_ERROR(WriteTocPermutation(permutation, &writer, aux_out));
+  JXL_RETURN_IF_ERROR(WriteTocSizes(group_sizes, &writer, aux_out));
 
   JXL_RETURN_IF_ERROR(writer.AppendByteAligned(group_codes));
   PaddedBytes frame_bytes = std::move(writer).TakeBytes();

--- a/lib/jxl/enc_frame.h
+++ b/lib/jxl/enc_frame.h
@@ -92,13 +92,14 @@ Status ParamsPostInit(CompressParams* p);
 // be processed in parallel by `pool`. metadata is the ImageMetadata encoded in
 // the codestream, and must be used for the FrameHeaders, do not use
 // ib.metadata.
+// For output_mode 2, jxlp_counter tracks written jxlp box indices (in/out).
 Status EncodeFrame(JxlMemoryManager* memory_manager,
                    const CompressParams& cparams_orig,
                    const FrameInfo& frame_info, const CodecMetadata* metadata,
                    JxlEncoderChunkedFrameAdapter& frame_data,
                    const JxlCmsInterface& cms, ThreadPool* pool,
                    JxlEncoderOutputProcessorWrapper* output_processor,
-                   AuxOut* aux_out);
+                   AuxOut* aux_out, uint32_t* jxlp_counter);
 
 Status EncodeFrame(JxlMemoryManager* memory_manager,
                    const CompressParams& cparams_orig,

--- a/lib/jxl/enc_params.h
+++ b/lib/jxl/enc_params.h
@@ -169,6 +169,8 @@ struct CompressParams {
 
   // See JXL_ENC_FRAME_SETTING_BUFFERING option value.
   int buffering = -1;
+  // Output streaming mode: 0=buffered, 1=seek-based streaming, 2=OOO jxlp.
+  int output_mode = 0;
   // See JXL_ENC_FRAME_SETTING_USE_FULL_IMAGE_HEURISTICS option value.
   bool use_full_image_heuristics = true;
 

--- a/lib/jxl/enc_toc.cc
+++ b/lib/jxl/enc_toc.cc
@@ -6,7 +6,6 @@
 #include "lib/jxl/enc_toc.h"
 
 #include <cstddef>
-#include <memory>
 #include <vector>
 
 #include "lib/jxl/base/common.h"
@@ -20,28 +19,29 @@
 #include "lib/jxl/toc.h"
 
 namespace jxl {
-Status WriteGroupOffsets(
-    const std::vector<std::unique_ptr<BitWriter>>& group_codes,
-    const std::vector<coeff_order_t>& permutation,
-    BitWriter* JXL_RESTRICT writer, AuxOut* aux_out) {
-  return writer->WithMaxBits(
-      MaxBits(group_codes.size()), LayerType::Toc, aux_out, [&]() -> Status {
-        if (!permutation.empty() && !group_codes.empty()) {
-          // Don't write a permutation at all for an empty group_codes.
-          writer->Write(1, 1);  // permutation
-          JXL_ENSURE(permutation.size() == group_codes.size());
-          JXL_RETURN_IF_ERROR(EncodePermutation(permutation.data(), /*skip=*/0,
-                                                permutation.size(), writer,
-                                                LayerType::Header, aux_out));
 
+Status WriteTocPermutation(const std::vector<coeff_order_t>& permutation,
+                           BitWriter* JXL_RESTRICT writer, AuxOut* aux_out) {
+  return writer->WithMaxBits(
+      MaxBits(0), LayerType::Toc, aux_out, [&]() -> Status {
+        if (!permutation.empty()) {
+          writer->Write(1, 1);  // permutation present
+          JXL_RETURN_IF_ERROR(EncodePermutation(
+              permutation.data(), /*skip=*/0, permutation.size(), writer,
+              LayerType::Header, aux_out));
         } else {
           writer->Write(1, 0);  // no permutation
         }
         writer->ZeroPadToByte();  // before TOC entries
+        return true;
+      });
+}
 
-        for (const auto& bw : group_codes) {
-          JXL_ENSURE(bw->BitsWritten() % kBitsPerByte == 0);
-          const size_t group_size = bw->BitsWritten() / kBitsPerByte;
+Status WriteTocSizes(const std::vector<size_t>& group_sizes,
+                     BitWriter* JXL_RESTRICT writer, AuxOut* aux_out) {
+  return writer->WithMaxBits(
+      MaxBits(group_sizes.size()), LayerType::Toc, aux_out, [&]() -> Status {
+        for (size_t group_size : group_sizes) {
           JXL_RETURN_IF_ERROR(U32Coder::Write(kTocDist, group_size, writer));
         }
         writer->ZeroPadToByte();  // before first group

--- a/lib/jxl/enc_toc.h
+++ b/lib/jxl/enc_toc.h
@@ -6,7 +6,7 @@
 #ifndef LIB_JXL_ENC_TOC_H_
 #define LIB_JXL_ENC_TOC_H_
 
-#include <memory>
+#include <cstddef>
 #include <vector>
 
 #include "lib/jxl/base/compiler_specific.h"
@@ -18,12 +18,14 @@ namespace jxl {
 
 struct AuxOut;
 
-// Writes the group offsets. If the permutation vector is empty, the identity
-// permutation will be used.
-Status WriteGroupOffsets(
-    const std::vector<std::unique_ptr<BitWriter>>& group_codes,
-    const std::vector<coeff_order_t>& permutation,
-    BitWriter* JXL_RESTRICT writer, AuxOut* aux_out);
+// Writes the TOC permutation header:
+//   permutation flag (1 bit) + optional EncodePermutation + ZeroPadToByte.
+Status WriteTocPermutation(const std::vector<coeff_order_t>& permutation,
+                           BitWriter* JXL_RESTRICT writer, AuxOut* aux_out);
+
+// Writes the TOC size entries
+Status WriteTocSizes(const std::vector<size_t>& group_sizes,
+                     BitWriter* JXL_RESTRICT writer, AuxOut* aux_out);
 
 }  // namespace jxl
 

--- a/lib/jxl/encode.cc
+++ b/lib/jxl/encode.cc
@@ -38,7 +38,6 @@
 #include "lib/jxl/base/status.h"
 #include "lib/jxl/cms/color_encoding_cms.h"
 #include "lib/jxl/color_encoding_internal.h"
-#include "lib/jxl/common.h"
 #include "lib/jxl/enc_aux_out.h"
 #include "lib/jxl/enc_bit_writer.h"
 #include "lib/jxl/enc_cache.h"
@@ -474,6 +473,9 @@ void QueueFrame(
   }
 
   jxl::JxlEncoderQueuedInput queued_input(frame_settings->enc->memory_manager);
+  int om = frame->option_values.cparams.output_mode;
+  if (om < 0) om = (frame->option_values.cparams.buffering == 3 ? 1 : 0);
+  queued_input.output_mode = om;
   queued_input.frame = std::move(frame);
   frame_settings->enc->input_queue.emplace_back(std::move(queued_input));
   frame_settings->enc->num_queued_frames++;
@@ -483,6 +485,10 @@ void QueueFastLosslessFrame(const JxlEncoderFrameSettings* frame_settings,
                             JxlFastLosslessFrameState* fast_lossless_frame) {
   jxl::JxlEncoderQueuedInput queued_input(frame_settings->enc->memory_manager);
   queued_input.fast_lossless_frame.reset(fast_lossless_frame);
+  int om = frame_settings->values.cparams.output_mode;
+  if (om < 0) om = (frame_settings->values.cparams.buffering == 3 ? 1 : 0);
+  if (om == 2) om = 1;  // OOO streaming not implemented for fast_lossless
+  queued_input.output_mode = om;
   frame_settings->enc->input_queue.emplace_back(std::move(queued_input));
   frame_settings->enc->num_queued_frames++;
 }
@@ -761,6 +767,15 @@ jxl::Status JxlEncoder::ProcessOneEnqueuedInput() {
 
   jxl::JxlEncoderQueuedInput& input = input_queue[0];
 
+  const int output_mode = input.output_mode;  // resolved at queue time
+
+  // Mode 2 requires that the container was started with ftyp version 1.
+  if (output_mode == 2 && wrote_bytes && container_ftyp_version != 1) {
+    return JXL_API_ERROR(this, JXL_ENC_ERR_API_USAGE,
+                         "output mode 2 requires ftyp version 1, but the "
+                         "container header was already written without it");
+  }
+
   // TODO(lode): split this into 3 functions: for adding the signature and other
   // initial headers (jbrd, ...), one for adding frame, and one for adding user
   // box.
@@ -820,21 +835,21 @@ jxl::Status JxlEncoder::ProcessOneEnqueuedInput() {
     // the next frame to start here for indexing purposes.
     codestream_bytes_written_end_of_frame += header_bytes.size();
 
-    if (MustUseContainer()) {
+    if (MustUseContainer(output_mode)) {
+      container_ftyp_version = (output_mode == 2) ? 1 : 0;
       // Add "JXL " and ftyp box.
-      {
-        JXL_ASSIGN_OR_RETURN(auto buffer, output_processor.GetBuffer(
-                                              jxl::kContainerHeader.size()));
-        JXL_RETURN_IF_ERROR(buffer.append(jxl::kContainerHeader));
-      }
+      JXL_RETURN_IF_ERROR(AppendData(output_processor,
+                                     jxl::MakeContainerHeader(output_mode == 2 ? 1 : 0)));
+
       if (codestream_level != 5) {
         // Add jxll box directly after the ftyp box to indicate the codestream
         // level.
-        JXL_ASSIGN_OR_RETURN(auto buffer, output_processor.GetBuffer(
-                                              jxl::kLevelBoxHeader.size() + 1));
-        JXL_RETURN_IF_ERROR(buffer.append(jxl::kLevelBoxHeader));
-        uint8_t cl = codestream_level;
-        JXL_RETURN_IF_ERROR(buffer.append(&cl, 1));
+        const uint8_t level = static_cast<uint8_t>(codestream_level);
+        std::vector<uint8_t> jxll_box;
+        jxl::AppendBoxHeader(jxl::MakeBoxType("jxll"), 1,
+                             /*unbounded=*/false, &jxll_box);
+        jxll_box.push_back(level);
+        JXL_RETURN_IF_ERROR(AppendData(output_processor, jxll_box));
       }
 
       // Whether to write the basic info and color profile header of the
@@ -944,8 +959,10 @@ jxl::Status JxlEncoder::ProcessOneEnqueuedInput() {
     size_t box_header_size =
         use_large_box ? jxl::kLargeBoxHeaderSize : jxl::kSmallBoxHeaderSize;
 
-    const size_t frame_start_pos = output_processor.CurrentPosition();
-    if (MustUseContainer()) {
+    size_t frame_start_pos = output_processor.CurrentPosition();
+    const size_t n0 = jxlp_counter;
+
+    if (MustUseContainer(output_mode) && output_mode != 2) {
       if (!last_frame || jxlp_counter > 0) {
         // If this is the last frame and no jxlp boxes were used yet, it's
         // slightly more efficient to write a jxlc box since it has 4 bytes
@@ -955,9 +972,29 @@ jxl::Status JxlEncoder::ProcessOneEnqueuedInput() {
       JXL_RETURN_IF_ERROR(
           output_processor.Seek(frame_start_pos + box_header_size));
     }
-    const size_t frame_codestream_start = output_processor.CurrentPosition();
+    const size_t content_start = output_processor.CurrentPosition();
 
-    JXL_RETURN_IF_ERROR(AppendData(output_processor, header_bytes));
+    if (!header_bytes.empty()) {
+      if (output_mode == 2) {
+        uint8_t hdr[jxl::kLargeBoxHeaderSize + 4];
+        const size_t hdr_size = jxl::WriteBoxHeader(
+            jxl::MakeBoxType("jxlp"), 4 + header_bytes.size(),
+            /*unbounded=*/false, /*force_large_box=*/false, hdr);
+        WriteJxlpBoxCounter(static_cast<uint32_t>(jxlp_counter++),
+                            /*last=*/false, hdr + hdr_size);
+        JXL_RETURN_IF_ERROR(AppendData(output_processor,
+                                       jxl::Span<const uint8_t>(hdr, hdr_size + 4)));
+      }
+      JXL_RETURN_IF_ERROR(AppendData(output_processor, header_bytes));
+    }
+
+    // For mode 2: frame_start_pos points to where EncodeFrame may leave a
+    // 12-byte gap on one-shot fallback; we detect and fill it via n1 below.
+    if (output_mode == 2) {
+      frame_start_pos = output_processor.CurrentPosition();
+      box_header_size = 12;
+    }
+    const uint32_t n1 = jxlp_counter;
 
     if (input_frame) {
       frame_index_box.AddFrame(codestream_bytes_written_end_of_frame, duration,
@@ -1011,14 +1048,18 @@ jxl::Status JxlEncoder::ProcessOneEnqueuedInput() {
       frame_info.duration = duration;
       frame_info.timecode = timecode;
       frame_info.name = input_frame->option_values.frame_name;
-
-      if (!jxl::EncodeFrame(&memory_manager, input_frame->option_values.cparams,
-                            frame_info, &metadata, input_frame->frame_data, cms,
+      jxl::CompressParams frame_cparams = input_frame->option_values.cparams;
+      frame_cparams.output_mode = output_mode;
+      uint32_t jxlp_ctr = static_cast<uint32_t>(jxlp_counter);
+      if (!jxl::EncodeFrame(&memory_manager, frame_cparams, frame_info,
+                            &metadata, input_frame->frame_data, cms,
                             thread_pool.get(), &output_processor,
-                            input_frame->option_values.aux_out)) {
+                            input_frame->option_values.aux_out, &jxlp_ctr)) {
         return JXL_API_ERROR(this, JXL_ENC_ERR_GENERIC,
                              "Failed to encode frame");
       }
+      jxlp_counter = jxlp_ctr;
+      last_used_cparams = input_frame->option_values.cparams;
     } else {
       JXL_ENSURE(fast_lossless_frame);
       RunnerTicket ticket{thread_pool.get()};
@@ -1031,18 +1072,21 @@ jxl::Status JxlEncoder::ProcessOneEnqueuedInput() {
       }
     }
 
-    const size_t frame_codestream_end = output_processor.CurrentPosition();
-    const size_t frame_codestream_size =
-        frame_codestream_end - frame_codestream_start;
+    const size_t content_size =
+        output_processor.CurrentPosition() - content_start;
 
     codestream_bytes_written_end_of_frame +=
-        frame_codestream_size - header_bytes.size();
+        content_size - header_bytes.size() - (jxlp_counter - n0) * 12;
 
-    if (MustUseContainer()) {
+    if (MustUseContainer(output_mode) && (output_mode != 2 || jxlp_counter == n1)) {
       JXL_RETURN_IF_ERROR(output_processor.Seek(frame_start_pos));
       std::vector<uint8_t> box_header(box_header_size);
+      // For mode 2 fallback the box wraps only the frame data (not header_bytes).
+      const size_t frame_content_size = output_mode == 2
+          ? content_size - (frame_start_pos - content_start) - 12
+          : content_size;
       if (!use_large_box &&
-          frame_codestream_size >= jxl::kLargeBoxContentSizeThreshold) {
+          frame_content_size >= jxl::kLargeBoxContentSizeThreshold) {
         // Assuming our upper bound estimate is correct, this should never
         // happen.
         return JXL_API_ERROR(
@@ -1052,25 +1096,23 @@ jxl::Status JxlEncoder::ProcessOneEnqueuedInput() {
       }
       if (last_frame && jxlp_counter == 0) {
         size_t n = jxl::WriteBoxHeader(
-            jxl::MakeBoxType("jxlc"), frame_codestream_size,
+            jxl::MakeBoxType("jxlc"), frame_content_size,
             /*unbounded=*/false, use_large_box, box_header.data());
         JXL_ENSURE(n == box_header_size);
       } else {
         size_t n = jxl::WriteBoxHeader(
-            jxl::MakeBoxType("jxlp"), frame_codestream_size + 4,
+            jxl::MakeBoxType("jxlp"), frame_content_size + 4,
             /*unbounded=*/false, use_large_box, box_header.data());
         JXL_ENSURE(n == box_header_size - 4);
         WriteJxlpBoxCounter(jxlp_counter++, last_frame,
                             &box_header[box_header_size - 4]);
       }
       JXL_RETURN_IF_ERROR(AppendData(output_processor, box_header));
-      JXL_ENSURE(output_processor.CurrentPosition() == frame_codestream_start);
-      JXL_RETURN_IF_ERROR(output_processor.Seek(frame_codestream_end));
+      JXL_ENSURE(output_processor.CurrentPosition() ==
+                 frame_start_pos + box_header_size);
+      JXL_RETURN_IF_ERROR(output_processor.Seek(content_start + content_size));
     }
     JXL_RETURN_IF_ERROR(output_processor.SetFinalizedPosition());
-    if (input_frame) {
-      last_used_cparams = input_frame->option_values.cparams;
-    }
     if (last_frame && frame_index_box.StoreFrameIndexBox()) {
       std::vector<uint8_t> index_box_content;
       // Enough buffer has been allocated, this function should never fail in
@@ -1861,6 +1903,13 @@ JxlEncoderStatus JxlEncoderFrameSettingsSetOption(
             "Set uses_original_profile=true for non-perceptual encoding");
       }
       break;
+    case JXL_ENC_FRAME_SETTING_OUTPUT_MODE:
+      if (value < -1 || value > 2) {
+        return JXL_API_ERROR(frame_settings->enc, JXL_ENC_ERR_NOT_SUPPORTED,
+                             "Output mode has to be in [-1..2]");
+      }
+      frame_settings->values.cparams.output_mode = value;
+      break;
 
     default:
       return JXL_API_ERROR(frame_settings->enc, JXL_ENC_ERR_NOT_SUPPORTED,
@@ -2004,6 +2053,7 @@ void JxlEncoderReset(JxlEncoder* enc) {
   enc->intensity_target_set = false;
   enc->use_container = false;
   enc->use_boxes = false;
+  enc->container_ftyp_version = -1;
   enc->store_jpeg_metadata = false;
   enc->codestream_level = -1;
   enc->output_processor =

--- a/lib/jxl/encode.cc
+++ b/lib/jxl/encode.cc
@@ -836,10 +836,18 @@ jxl::Status JxlEncoder::ProcessOneEnqueuedInput() {
     codestream_bytes_written_end_of_frame += header_bytes.size();
 
     if (MustUseContainer(output_mode)) {
-      container_ftyp_version = (output_mode == 2) ? 1 : 0;
+      // If any queued input uses output mode 2, ftyp version 1 is needed.
+      int ftyp_version = (output_mode == 2) ? 1 : 0;
+      for (const auto& qi : input_queue) {
+        if (qi.output_mode == 2) {
+          ftyp_version = 1;
+          break;
+        }
+      }
+      container_ftyp_version = ftyp_version;
       // Add "JXL " and ftyp box.
-      JXL_RETURN_IF_ERROR(AppendData(output_processor,
-                                     jxl::MakeContainerHeader(output_mode == 2 ? 1 : 0)));
+      JXL_RETURN_IF_ERROR(
+          AppendData(output_processor, jxl::MakeContainerHeader(ftyp_version)));
 
       if (codestream_level != 5) {
         // Add jxll box directly after the ftyp box to indicate the codestream
@@ -982,8 +990,8 @@ jxl::Status JxlEncoder::ProcessOneEnqueuedInput() {
             /*unbounded=*/false, /*force_large_box=*/false, hdr);
         WriteJxlpBoxCounter(static_cast<uint32_t>(jxlp_counter++),
                             /*last=*/false, hdr + hdr_size);
-        JXL_RETURN_IF_ERROR(AppendData(output_processor,
-                                       jxl::Span<const uint8_t>(hdr, hdr_size + 4)));
+        JXL_RETURN_IF_ERROR(AppendData(
+            output_processor, jxl::Span<const uint8_t>(hdr, hdr_size + 4)));
       }
       JXL_RETURN_IF_ERROR(AppendData(output_processor, header_bytes));
     }
@@ -1078,13 +1086,16 @@ jxl::Status JxlEncoder::ProcessOneEnqueuedInput() {
     codestream_bytes_written_end_of_frame +=
         content_size - header_bytes.size() - (jxlp_counter - n0) * 12;
 
-    if (MustUseContainer(output_mode) && (output_mode != 2 || jxlp_counter == n1)) {
+    if (MustUseContainer(output_mode) &&
+        (output_mode != 2 || jxlp_counter == n1)) {
       JXL_RETURN_IF_ERROR(output_processor.Seek(frame_start_pos));
       std::vector<uint8_t> box_header(box_header_size);
-      // For mode 2 fallback the box wraps only the frame data (not header_bytes).
-      const size_t frame_content_size = output_mode == 2
-          ? content_size - (frame_start_pos - content_start) - 12
-          : content_size;
+      // For mode 2 fallback the box wraps only the frame data (not
+      // header_bytes).
+      const size_t frame_content_size =
+          output_mode == 2
+              ? content_size - (frame_start_pos - content_start) - 12
+              : content_size;
       if (!use_large_box &&
           frame_content_size >= jxl::kLargeBoxContentSizeThreshold) {
         // Assuming our upper bound estimate is correct, this should never

--- a/lib/jxl/encode_internal.h
+++ b/lib/jxl/encode_internal.h
@@ -27,6 +27,7 @@
 
 #include "lib/jxl/base/c_callback_support.h"
 #include "lib/jxl/base/common.h"
+#include "lib/jxl/common.h"
 #include "lib/jxl/base/compiler_specific.h"
 #include "lib/jxl/base/data_parallel.h"
 #include "lib/jxl/base/status.h"
@@ -142,13 +143,6 @@ constexpr BoxType MakeBoxType(const char* type) {
         static_cast<uint8_t>(type[2]), static_cast<uint8_t>(type[3])}});
 }
 
-constexpr std::array<unsigned char, 32> kContainerHeader = {
-    0,   0,   0, 0xc, 'J',  'X', 'L', ' ', 0xd, 0xa, 0x87,
-    0xa, 0,   0, 0,   0x14, 'f', 't', 'y', 'p', 'j', 'x',
-    'l', ' ', 0, 0,   0,    0,   'j', 'x', 'l', ' '};
-
-constexpr std::array<unsigned char, 8> kLevelBoxHeader = {0,   0,   0,   0x9,
-                                                          'j', 'x', 'l', 'l'};
 
 static JXL_INLINE size_t BitsPerChannel(JxlDataType data_type) {
   switch (data_type) {
@@ -397,6 +391,7 @@ struct JxlEncoderQueuedInput {
   MemoryManagerUniquePtr<JxlEncoderQueuedBox> box;
   FJXLFrameUniquePtr fast_lossless_frame = {nullptr,
                                             JxlFastLosslessFreeFrameState};
+  int output_mode = -1;  // effective output mode, resolved at queue time
 };
 
 static constexpr size_t kSmallBoxHeaderSize = 8;
@@ -418,6 +413,19 @@ void AppendBoxHeader(const jxl::BoxType& type, size_t size, bool unbounded,
       WriteBoxHeader(type, size, unbounded, /*force_large_box=*/false,
                      output->data() + current_size);
   output->resize(current_size + header_size);
+}
+
+// Returns the JXL container signature box and ftyp box.
+// ftyp_version: 0 = standard delivery order, 1 = out-of-order jxlp boxes.
+inline std::vector<uint8_t> MakeContainerHeader(int ftyp_version) {
+  std::vector<uint8_t> out(kJxlSignatureBox.begin(), kJxlSignatureBox.end());
+  // ftyp box: major brand "jxl ", minor version, compatible brand "jxl ".
+  const uint8_t ftyp[] = {'j', 'x', 'l', ' ',
+                           0,   0,   0,   static_cast<uint8_t>(ftyp_version),
+                           'j', 'x', 'l', ' '};
+  AppendBoxHeader(MakeBoxType("ftyp"), sizeof(ftyp), /*unbounded=*/false, &out);
+  out.insert(out.end(), ftyp, ftyp + sizeof(ftyp));
+  return out;
 }
 
 }  // namespace jxl
@@ -623,6 +631,8 @@ struct JxlEncoder {
   bool use_container;
   // User declared they will add metadata boxes
   bool use_boxes;
+  // -1 = no container written yet; 0 = ftyp v0 written; 1 = ftyp v1 written.
+  int container_ftyp_version = -1;
 
   // TODO(lode): move level into jxl::CompressParams since some C++
   // implementation decisions should be based on it: level 10 allows more
@@ -659,9 +669,10 @@ struct JxlEncoder {
   // the bytes to the output_byte_queue.
   jxl::Status ProcessOneEnqueuedInput();
 
-  bool MustUseContainer() const {
-    return use_container || (codestream_level != 5 && codestream_level != -1) ||
-           store_jpeg_metadata || use_boxes;
+  bool MustUseContainer(int output_mode = 0) const {
+    return container_ftyp_version >= 0 || use_container ||
+           (codestream_level != 5 && codestream_level != -1) ||
+           store_jpeg_metadata || use_boxes || output_mode == 2;
   }
 
   // `write_box` must never seek before the position the output wrapper was at

--- a/lib/jxl/encode_test.cc
+++ b/lib/jxl/encode_test.cc
@@ -1728,6 +1728,7 @@ class JxlChunkedFrameInputSourceAdapter {
 
 struct StreamingTestParam {
   size_t bitmask;
+  int output_mode = 0;
   bool use_container() const { return static_cast<bool>(bitmask & 0x1); }
   bool return_large_buffers() const { return static_cast<bool>(bitmask & 0x2); }
   bool multiple_frames() const { return static_cast<bool>(bitmask & 0x4); }
@@ -1743,15 +1744,20 @@ struct StreamingTestParam {
 
   static std::vector<StreamingTestParam> All() {
     std::vector<StreamingTestParam> params;
-    params.reserve(256);
+    params.reserve(768);
     for (size_t bitmask = 0; bitmask < 256; bitmask++) {
-      params.push_back(StreamingTestParam{bitmask});
+      for (int mode : {0, 1, 2}) {
+        params.push_back(StreamingTestParam{bitmask, mode});
+      }
     }
     return params;
   }
 };
 
 std::ostream& operator<<(std::ostream& out, StreamingTestParam p) {
+  const char* mode_names[] = {"BufferOutput_", "StreamOutputSeekForTOC_",
+                              "StreamOutputOOOjxlp_"};
+  out << mode_names[p.output_mode];
   if (p.use_container()) {
     out << "WithContainer_";
   } else {
@@ -1834,7 +1840,11 @@ class EncoderStreamingTest : public testing::TestWithParam<StreamingTestParam> {
     EXPECT_EQ(JXL_ENC_SUCCESS,
               JxlEncoderFrameSettingsSetOption(frame_settings,
                                                JXL_ENC_FRAME_SETTING_BUFFERING,
-                                               streaming ? 3 : 0));
+                                               streaming ? 2 : 0));
+    EXPECT_EQ(JXL_ENC_SUCCESS,
+              JxlEncoderFrameSettingsSetOption(
+                  frame_settings, JXL_ENC_FRAME_SETTING_OUTPUT_MODE,
+                  p.output_mode));
     EXPECT_EQ(JXL_ENC_SUCCESS,
               JxlEncoderFrameSettingsSetOption(
                   frame_settings,

--- a/lib/jxl/encode_test.cc
+++ b/lib/jxl/encode_test.cc
@@ -2209,7 +2209,7 @@ TEST(EncodeTest, OutputModeComparisonTest) {
     ASSERT_TRUE(DecodeImageJXL(m0d.data(), m0d.size(), dparams, nullptr,
                                &ppf_decoded, nullptr));
     EXPECT_SLIGHTLY_BELOW(jxl::test::ButteraugliDistance(ppf_orig, ppf_decoded),
-                          2.2f);
+                          2.5f);
   }
 
   // Size observations (reference machine: m0d=284295, m0p=284335,

--- a/lib/jxl/encode_test.cc
+++ b/lib/jxl/encode_test.cc
@@ -1841,10 +1841,10 @@ class EncoderStreamingTest : public testing::TestWithParam<StreamingTestParam> {
               JxlEncoderFrameSettingsSetOption(frame_settings,
                                                JXL_ENC_FRAME_SETTING_BUFFERING,
                                                streaming ? 2 : 0));
-    EXPECT_EQ(JXL_ENC_SUCCESS,
-              JxlEncoderFrameSettingsSetOption(
-                  frame_settings, JXL_ENC_FRAME_SETTING_OUTPUT_MODE,
-                  p.output_mode));
+    EXPECT_EQ(
+        JXL_ENC_SUCCESS,
+        JxlEncoderFrameSettingsSetOption(
+            frame_settings, JXL_ENC_FRAME_SETTING_OUTPUT_MODE, p.output_mode));
     EXPECT_EQ(JXL_ENC_SUCCESS,
               JxlEncoderFrameSettingsSetOption(
                   frame_settings,
@@ -2139,4 +2139,97 @@ TEST(EncoderTest, CMYK) {
   jxl::extras::PackedPixelFile ppf;
   EXPECT_TRUE(DecodeImageJXL(compressed.data(), compressed.size(), dparams,
                              nullptr, &ppf, nullptr));
+}
+
+namespace {
+std::vector<uint8_t> EncodeWithOutputMode(
+    const jxl::extras::PackedPixelFile& ppf, int output_mode, int group_order) {
+  JxlEncoderPtr enc = JxlEncoderMake(nullptr);
+  JxlEncoderFrameSettings* fs =
+      JxlEncoderFrameSettingsCreate(enc.get(), nullptr);
+  JxlBasicInfo info;
+  JxlEncoderInitBasicInfo(&info);
+  info.xsize = ppf.info.xsize;
+  info.ysize = ppf.info.ysize;
+  info.bits_per_sample = ppf.info.bits_per_sample;
+  info.num_color_channels = ppf.info.num_color_channels;
+  EXPECT_EQ(JXL_ENC_SUCCESS, JxlEncoderSetCodestreamLevel(enc.get(), 10));
+  EXPECT_EQ(JXL_ENC_SUCCESS, JxlEncoderSetBasicInfo(enc.get(), &info));
+  EXPECT_EQ(JXL_ENC_SUCCESS,
+            JxlEncoderSetColorEncoding(enc.get(), &ppf.color_encoding));
+  EXPECT_EQ(JXL_ENC_SUCCESS, JxlEncoderSetFrameDistance(fs, 2.0f));
+  EXPECT_EQ(JXL_ENC_SUCCESS, JxlEncoderFrameSettingsSetOption(
+                                 fs, JXL_ENC_FRAME_SETTING_EFFORT, 6));
+  EXPECT_EQ(JXL_ENC_SUCCESS, JxlEncoderFrameSettingsSetOption(
+                                 fs, JXL_ENC_FRAME_SETTING_BUFFERING, 2));
+  EXPECT_EQ(JXL_ENC_SUCCESS,
+            JxlEncoderFrameSettingsSetOption(
+                fs, JXL_ENC_FRAME_SETTING_OUTPUT_MODE, output_mode));
+  EXPECT_EQ(JXL_ENC_SUCCESS,
+            JxlEncoderFrameSettingsSetOption(
+                fs, JXL_ENC_FRAME_SETTING_GROUP_ORDER, group_order));
+  const jxl::extras::PackedImage& color = ppf.frames[0].color;
+  EXPECT_EQ(JXL_ENC_SUCCESS,
+            JxlEncoderAddImageFrame(fs, &color.format, color.pixels(),
+                                    color.pixels_size));
+  JxlEncoderCloseInput(enc.get());
+  JxlStreamingAdapter adapter(enc.get(), /*return_large_buffers=*/true,
+                              /*can_seek=*/output_mode == 1);
+  EXPECT_EQ(JXL_ENC_SUCCESS, JxlEncoderFlushInput(enc.get()));
+  return std::move(adapter).output();
+}
+}  // namespace
+
+// Verifies that output modes 0/1/2 × default/centerfirst group order all
+// produce the same decoded pixels but different (small-overhead) bitstreams.
+TEST(EncodeTest, OutputModeComparisonTest) {
+  jxl::test::TestImage t;
+  ASSERT_TRUE(
+      t.DecodeFromBytes(jxl::test::ReadTestData("jxl/flower/flower.png")));
+  const jxl::extras::PackedPixelFile& ppf_orig = t.ppf();
+
+  const auto m0d = EncodeWithOutputMode(ppf_orig, 0, 0);
+  const auto m0p = EncodeWithOutputMode(ppf_orig, 0, 1);
+  const auto m1d = EncodeWithOutputMode(ppf_orig, 1, 0);
+  const auto m1p = EncodeWithOutputMode(ppf_orig, 1, 1);
+  const auto m2d = EncodeWithOutputMode(ppf_orig, 2, 0);
+  const auto m2p = EncodeWithOutputMode(ppf_orig, 2, 1);
+
+  // All 6 variants must decode to the same pixels.
+  EXPECT_TRUE(SameDecodedPixels(m0d, m0p));
+  EXPECT_TRUE(SameDecodedPixels(m0d, m1d));
+  EXPECT_TRUE(SameDecodedPixels(m0d, m1p));
+  EXPECT_TRUE(SameDecodedPixels(m0d, m2d));
+  EXPECT_TRUE(SameDecodedPixels(m0d, m2p));
+
+  // Butteraugli distance of decoded output vs original.
+  {
+    jxl::extras::JXLDecompressParams dparams;
+    dparams.accepted_formats = {ppf_orig.frames[0].color.format};
+    jxl::extras::PackedPixelFile ppf_decoded;
+    ASSERT_TRUE(DecodeImageJXL(m0d.data(), m0d.size(), dparams, nullptr,
+                               &ppf_decoded, nullptr));
+    EXPECT_SLIGHTLY_BELOW(jxl::test::ButteraugliDistance(ppf_orig, ppf_decoded),
+                          2.2f);
+  }
+
+  // Size observations (reference machine: m0d=284344, m0p=284384,
+  //   m1d=m1p=284473, m2d=285068, m2p=285108):
+  // - Mode 1 ignores the group_order setting (uses its own streaming
+  // permutation).
+  EXPECT_EQ(m1d.size(), m1p.size());
+  // - Centerfirst adds ~40 bytes (permutation encoding, 54 groups) for modes 0
+  //   and 2.
+  EXPECT_LT(m0d.size(), m0p.size());
+  EXPECT_LT(m2d.size(), m2p.size());
+  EXPECT_SLIGHTLY_BELOW(m0p.size() - m0d.size(), 50);
+  EXPECT_SLIGHTLY_BELOW(m2p.size() - m2d.size(), 50);
+  // - Mode 1 seek-streaming adds ~129 bytes over mode 0 buffered streaming
+  //   (streaming permutation in the TOC).
+  EXPECT_LT(m0d.size(), m1d.size());
+  EXPECT_SLIGHTLY_BELOW(m1d.size() - m0d.size(), 160);
+  // - Ooo mode (mode 2) is larger than mode 1 due to one jxlp box per group
+  //   section (~595 bytes on this image, ~0.21% of the ~285 kB file).
+  EXPECT_LT(m1d.size(), m2d.size());
+  EXPECT_SLIGHTLY_BELOW(m2d.size() - m1d.size(), 700);
 }

--- a/lib/jxl/encode_test.cc
+++ b/lib/jxl/encode_test.cc
@@ -2158,7 +2158,7 @@ std::vector<uint8_t> EncodeWithOutputMode(
             JxlEncoderSetColorEncoding(enc.get(), &ppf.color_encoding));
   EXPECT_EQ(JXL_ENC_SUCCESS, JxlEncoderSetFrameDistance(fs, 2.0f));
   EXPECT_EQ(JXL_ENC_SUCCESS, JxlEncoderFrameSettingsSetOption(
-                                 fs, JXL_ENC_FRAME_SETTING_EFFORT, 6));
+                                 fs, JXL_ENC_FRAME_SETTING_EFFORT, 3));
   EXPECT_EQ(JXL_ENC_SUCCESS, JxlEncoderFrameSettingsSetOption(
                                  fs, JXL_ENC_FRAME_SETTING_BUFFERING, 2));
   EXPECT_EQ(JXL_ENC_SUCCESS,

--- a/lib/jxl/encode_test.cc
+++ b/lib/jxl/encode_test.cc
@@ -2153,7 +2153,6 @@ std::vector<uint8_t> EncodeWithOutputMode(
   info.ysize = ppf.info.ysize;
   info.bits_per_sample = ppf.info.bits_per_sample;
   info.num_color_channels = ppf.info.num_color_channels;
-  EXPECT_EQ(JXL_ENC_SUCCESS, JxlEncoderSetCodestreamLevel(enc.get(), 10));
   EXPECT_EQ(JXL_ENC_SUCCESS, JxlEncoderSetBasicInfo(enc.get(), &info));
   EXPECT_EQ(JXL_ENC_SUCCESS,
             JxlEncoderSetColorEncoding(enc.get(), &ppf.color_encoding));
@@ -2213,10 +2212,12 @@ TEST(EncodeTest, OutputModeComparisonTest) {
                           2.2f);
   }
 
-  // Size observations (reference machine: m0d=284344, m0p=284384,
-  //   m1d=m1p=284473, m2d=285068, m2p=285108):
+  // Size observations (reference machine: m0d=284295, m0p=284335,
+  //   m1d=m1p=284424, m2d=285059, m2p=285099).
+  // Note: modes 0 and 1 produce naked codestreams; mode 2 always uses a
+  // container (jxlp boxes), so its overhead is measured against mode 1.
   // - Mode 1 ignores the group_order setting (uses its own streaming
-  // permutation).
+  //   permutation).
   EXPECT_EQ(m1d.size(), m1p.size());
   // - Centerfirst adds ~40 bytes (permutation encoding, 54 groups) for modes 0
   //   and 2.
@@ -2224,12 +2225,12 @@ TEST(EncodeTest, OutputModeComparisonTest) {
   EXPECT_LT(m2d.size(), m2p.size());
   EXPECT_SLIGHTLY_BELOW(m0p.size() - m0d.size(), 50);
   EXPECT_SLIGHTLY_BELOW(m2p.size() - m2d.size(), 50);
-  // - Mode 1 seek-streaming adds ~129 bytes over mode 0 buffered streaming
-  //   (streaming permutation in the TOC).
+  // - Mode 1 seek-streaming adds ~129 bytes over mode 0 (streaming permutation
+  //   in the TOC).
   EXPECT_LT(m0d.size(), m1d.size());
   EXPECT_SLIGHTLY_BELOW(m1d.size() - m0d.size(), 160);
-  // - Ooo mode (mode 2) is larger than mode 1 due to one jxlp box per group
-  //   section (~595 bytes on this image, ~0.21% of the ~285 kB file).
+  // - Mode 2 uses a container (jxlp boxes + ftyp header), adding ~635 bytes
+  //   over mode 1 (~0.22% of the ~285 kB file).
   EXPECT_LT(m1d.size(), m2d.size());
-  EXPECT_SLIGHTLY_BELOW(m2d.size() - m1d.size(), 700);
+  EXPECT_SLIGHTLY_BELOW(m2d.size() - m1d.size(), 750);
 }

--- a/lib/jxl/modular_test.cc
+++ b/lib/jxl/modular_test.cc
@@ -560,7 +560,12 @@ TEST(ModularTest, PredictorIntegerOverflow) {
       return true;
     }));
   }
-  EXPECT_TRUE(WriteGroupOffsets(group_codes, {}, &writer, nullptr));
+  std::vector<size_t> sizes_0;
+  for (const auto& bw : group_codes) {
+    sizes_0.push_back(bw->BitsWritten() / kBitsPerByte);
+  }
+  EXPECT_TRUE(WriteTocPermutation({}, &writer, nullptr));
+  EXPECT_TRUE(WriteTocSizes(sizes_0, &writer, nullptr));
   ASSERT_TRUE(writer.AppendByteAligned(group_codes));
 
   PaddedBytes compressed = std::move(writer).TakeBytes();
@@ -611,7 +616,12 @@ TEST(ModularTest, UnsqueezeIntegerOverflow) {
       return true;
     }));
   }
-  EXPECT_TRUE(WriteGroupOffsets(group_codes, {}, &writer, nullptr));
+  std::vector<size_t> sizes_1;
+  for (const auto& bw : group_codes) {
+    sizes_1.push_back(bw->BitsWritten() / kBitsPerByte);
+  }
+  EXPECT_TRUE(WriteTocPermutation({}, &writer, nullptr));
+  EXPECT_TRUE(WriteTocSizes(sizes_1, &writer, nullptr));
   ASSERT_TRUE(writer.AppendByteAligned(group_codes));
 
   PaddedBytes compressed = std::move(writer).TakeBytes();

--- a/lib/jxl/toc_test.cc
+++ b/lib/jxl/toc_test.cc
@@ -71,7 +71,12 @@ void Roundtrip(size_t num_entries, bool permute, Rng* rng) {
 
   BitWriter writer{memory_manager};
   AuxOut aux_out;
-  ASSERT_TRUE(WriteGroupOffsets(group_codes, permutation, &writer, &aux_out));
+  std::vector<size_t> sizes;
+  for (const auto& bw : group_codes) {
+    sizes.push_back(bw->BitsWritten() / kBitsPerByte);
+  }
+  ASSERT_TRUE(WriteTocPermutation(permutation, &writer, &aux_out));
+  ASSERT_TRUE(WriteTocSizes(sizes, &writer, &aux_out));
 
   BitReader reader(writer.GetSpan());
   std::vector<uint64_t> group_offsets;

--- a/tools/cjxl_main.cc
+++ b/tools/cjxl_main.cc
@@ -241,13 +241,13 @@ struct CompressArgs {
 
     cmdline->AddOptionValue(
         '\0', "buffering", "-1..3",
-        "How frames are buffered when encoding, which affects memory usage and "
-        "compression.\n    "
+        "Controls how much input buffering libjxl uses, affecting memory usage "
+        "and compression quality.\n    "
         "-1 = encoder chooses (default). "
-        "0 = buffer everything (most memory, best compression).\n    "
-        "1 = stream input for large images, buffer output. "
-        "2 = stream input, buffer output.\n    "
-        "3 = stream both input and output (least memory, worst compression)",
+        "0 = buffer entire image (most memory, best compression).\n    "
+        "1 = stream input for large images. "
+        "2 = stream input with a lower threshold.\n    "
+        "3 = deprecated; use --output_mode to control output streaming.",
         &buffering, &ParseInt64, -1);
 
     cmdline->AddOptionValue('\0', "faster_decoding", "0..4",
@@ -367,6 +367,13 @@ struct CompressArgs {
     cmdline->AddOptionFlag('\0', "streaming_output",
                            "Enable incremental writing of the output file.",
                            &streaming_output, &SetBooleanTrue, 3);
+
+    cmdline->AddOptionValue(
+        '\0', "output_mode", "-1..2",
+        "Output mode: -1=default (let encoder decide), 0=buffer output "
+        "internally, 1=streaming with seeking, 2=OOO jxlp (ftyp v1, no "
+        "seeking required).",
+        &output_mode, &ParseInt64, 3);
 
     cmdline->AddOptionFlag('\0', "disable_output",
                            "Do not write an output file.", &disable_output,
@@ -489,6 +496,7 @@ struct CompressArgs {
   jxl::Override print_profile = jxl::Override::kDefault;
   bool streaming_input = false;
   bool streaming_output = false;
+  int64_t output_mode = -1;
 
   bool verbose = false;
 
@@ -1159,10 +1167,8 @@ int main(int argc, char** argv) {
   params.runner = JxlThreadParallelRunner;
   params.runner_opaque = runner.get();
 
-  if (args.streaming_input) {
-    params.options.emplace_back(JXL_ENC_FRAME_SETTING_BUFFERING,
-                                static_cast<int64_t>(3), 0);
-  }
+  params.options.emplace_back(JXL_ENC_FRAME_SETTING_OUTPUT_MODE,
+                               args.output_mode, 0);
 
   jpegxl::tools::SpeedStats stats;
   jpegxl::tools::JxlOutputProcessor output_processor;

--- a/tools/djxl_fuzzer_corpus.cc
+++ b/tools/djxl_fuzzer_corpus.cc
@@ -270,9 +270,7 @@ bool GenerateFile(const char* output_dir, const ImageSpec& spec,
     std::vector<uint8_t> encoded_jpeg_data;
     JXL_RETURN_IF_ERROR(EncodeJPEGData(memory_manager, *io->Main().jpeg_data,
                                        &encoded_jpeg_data, params));
-    std::vector<uint8_t> header;
-    header.insert(header.end(), jxl::kContainerHeader.begin(),
-                  jxl::kContainerHeader.end());
+    std::vector<uint8_t> header = jxl::MakeContainerHeader(0);
     jxl::AppendBoxHeader(jxl::MakeBoxType("jbrd"), encoded_jpeg_data.size(),
                          false, &header);
     jxl::Bytes(encoded_jpeg_data).AppendTo(header);


### PR DESCRIPTION
(builds on https://github.com/libjxl/libjxl/pull/4741)

This adds a new encoder option `JXL_ENC_FRAME_SETTING_OUTPUT_MODE` to set the output mode:

- mode 0 (default): buffer the entire output codestream, progressive-decodable
- mode 1 (streaming output using seek): this does what used to be buffering=3: use a permuted TOC to write sections in an order convenient for chunked encode but not progressively decodable; use seeking to update the TOC and jxlp box size after encode
- mode 2 (ooo jxlp, new): uses `ftyp` version 1 which allows `jxlp` boxes to be in arbitrary order. Writes sections in the same order as in mode 1, but wraps each of them in its own `jxlp` box. The final `jxlp` box contains the TOC. No seeking is required during encode, and the 'logical' codestream does not use a permuted TOC, but it is shuffled at the file format level since it is split in `jxlp` boxes that are out of order.

It is not recommended to start using output mode 2 since current decoders do not support this yet. This is mostly just to create test bitstreams; it could be useful in some very specific use cases but generally sticking to mode 0 is recommended (to produce progressive-decodable output).