### PR TITLE
Guard AlignedArray::Create against allocation size overflow

### DIFF
--- a/lib/jxl/memory_manager_internal.h
+++ b/lib/jxl/memory_manager_internal.h
@@ -14,6 +14,7 @@
 #include <memory>
 #include <utility>
 
+#include "lib/jxl/base/common.h"
 #include "lib/jxl/base/compiler_specific.h"
 #include "lib/jxl/base/status.h"
 
@@ -145,7 +146,10 @@ class AlignedArray {
 
   static StatusOr<AlignedArray> Create(JxlMemoryManager* memory_manager,
                                        size_t size) {
-    size_t storage_size = size * sizeof(T);
+    size_t storage_size;
+    if (!SafeMul(size, sizeof(T), &storage_size)) {
+      return JXL_FAILURE("Allocation too large");
+    }
     JXL_ASSIGN_OR_RETURN(AlignedMemory storage,
                          AlignedMemory::Create(memory_manager, storage_size));
     T* items = storage.address<T>();

--- a/lib/jxl/memory_manager_internal.h
+++ b/lib/jxl/memory_manager_internal.h
@@ -147,7 +147,7 @@ class AlignedArray {
   static StatusOr<AlignedArray> Create(JxlMemoryManager* memory_manager,
                                        size_t size) {
     size_t storage_size;
-    if (!SafeMul(size, sizeof(T), &storage_size)) {
+    if (!SafeMul(size, sizeof(T), storage_size)) {
       return JXL_FAILURE("Allocation too large");
     }
     JXL_ASSIGN_OR_RETURN(AlignedMemory storage,

--- a/lib/jxl/memory_manager_internal.h
+++ b/lib/jxl/memory_manager_internal.h
@@ -147,7 +147,7 @@ class AlignedArray {
   static StatusOr<AlignedArray> Create(JxlMemoryManager* memory_manager,
                                        size_t size) {
     size_t storage_size;
-    if (!SafeMul(size, sizeof(T), storage_size)) {
+    if (!SafeMul<size_t>(size, sizeof(T), storage_size)) {
       return JXL_FAILURE("Allocation too large");
     }
     JXL_ASSIGN_OR_RETURN(AlignedMemory storage,


### PR DESCRIPTION
This patch adds an overflow check in AlignedArray::Create when computing the
allocation size for the backing storage.

Previously the code multiplied `size * sizeof(T)` directly before allocating.
On platforms where size_t can overflow, very large values could wrap and result
in a smaller-than-expected allocation.

The change uses the existing SafeMul helper to validate the multiplication
before passing the size to AlignedMemory::Create.

This does not change behavior for valid inputs and improves robustness of the
shared allocation helper.