### PR TITLE
Fix one-off for sampling scope.

### DIFF
--- a/lib/jxl/enc_fast_lossless.cc
+++ b/lib/jxl/enc_fast_lossless.cc
@@ -3890,7 +3890,8 @@ JxlFastLosslessFrameState* LLPrepare(JxlChunkedFrameInputSource input,
         std::max<ptrdiff_t>(
             0, static_cast<ptrdiff_t>(ys) - static_cast<ptrdiff_t>(num_rows)) /
         2;
-    int y_count = std::min<int>(num_rows, ys - y_begin_group);
+    int y_count =
+        std::max<int>(0, std::min<int>(num_rows, ys - y_begin_group - 1));
     int x_max = xs / kChunkSize * kChunkSize;
     CollectSamples(rgba, 0, y_begin_group, x_max, stride, y_count, raw_counts,
                    lz77_counts, onegroup, !collided, bitdepth, nb_chans,


### PR DESCRIPTION
In CollectSamples we process `1 + row_count` rows (+1 for `yskip`); thus `row_count` have to be limited: 1 + row_count + y_begin_group <= ys

NB: that might mean that 0 rows will be sampled.

Fixes #4750
