### PR TITLE
Handle cases when get_color_channel_data_at returns nullptr

### DIFF
--- a/lib/jxl/enc_fast_lossless.cc
+++ b/lib/jxl/enc_fast_lossless.cc
@@ -3801,6 +3801,7 @@ JxlFastLosslessFrameState* LLPrepare(JxlChunkedFrameInputSource input,
       // TODO(szabadka): Add RAII wrapper around this.
       const void* buffer = input.get_color_channel_data_at(input.opaque, x0, y0,
                                                            xs, ys, &stride);
+      if (buffer == nullptr) return nullptr;
       auto rgba = reinterpret_cast<const unsigned char*>(buffer);
       for (size_t y = 0; y < ys && !collided; y++) {
         const unsigned char* r = rgba + stride * y;
@@ -3885,6 +3886,9 @@ JxlFastLosslessFrameState* LLPrepare(JxlChunkedFrameInputSource input,
     size_t stride;
     const void* buffer =
         input.get_color_channel_data_at(input.opaque, x0, y0, xs, ys, &stride);
+    if (buffer == nullptr) {
+      return false;
+    }
     auto rgba = reinterpret_cast<const unsigned char*>(buffer);
     int y_begin_group =
         std::max<ptrdiff_t>(
@@ -3896,6 +3900,7 @@ JxlFastLosslessFrameState* LLPrepare(JxlChunkedFrameInputSource input,
                    lz77_counts, onegroup, !collided, bitdepth, nb_chans,
                    big_endian, lookup.data());
     input.release_buffer(input.opaque, buffer);
+    return true;
   };
 
   // TODO(veluca): that `64` is an arbitrary constant, meant to correspond to
@@ -3908,13 +3913,17 @@ JxlFastLosslessFrameState* LLPrepare(JxlChunkedFrameInputSource input,
       size_t y0 = yg * 256;
       size_t ys = std::min<size_t>(height - y0, 256);
       size_t num_rows = 2 * effort * ys / 256;
-      sample_rows(xg, yg, num_rows);
+      if (!sample_rows(xg, yg, num_rows)) {
+        return nullptr;
+      }
     }
   } else {
     // sample the middle (effort * 2 * num_groups) rows of the center group
     // (possibly all of them).
-    sample_rows((num_groups_x - 1) / 2, (num_groups_y - 1) / 2,
-                2 * effort * num_groups_x * num_groups_y);
+    if (!sample_rows((num_groups_x - 1) / 2, (num_groups_y - 1) / 2,
+                     2 * effort * num_groups_x * num_groups_y)) {
+      return nullptr;
+    }
   }
 
   // TODO(veluca): can probably improve this and make it bitdepth-dependent.
@@ -4063,6 +4072,10 @@ jxl::Status LLProcess(JxlFastLosslessFrameState* frame_state, bool is_last,
       JxlChunkedFrameInputSource input = frame_state->input;
       const void* buffer = input.get_color_channel_data_at(input.opaque, x0, y0,
                                                            xs, ys, &stride);
+      if (buffer == nullptr) {
+        has_error = 1;
+        return;
+      }
       const unsigned char* rgba =
           reinterpret_cast<const unsigned char*>(buffer);
 

--- a/lib/jxl/encode.cc
+++ b/lib/jxl/encode.cc
@@ -2386,6 +2386,10 @@ JxlEncoderStatus JxlEncoderAddImageFrameInternal(
         frame_data.GetInputSource(), xsize, ysize, num_channels,
         frame_settings->enc->metadata.m.bit_depth.bits_per_sample, big_endian,
         /*effort=*/2, oneshot);
+    if (!frame_state) {
+      return JXL_API_ERROR(frame_settings->enc, JXL_ENC_ERR_GENERIC,
+                           "Internal: JxlFastLosslessPrepareFrame failed");
+    }
     if (!streaming) {
       bool ok =
           JxlFastLosslessProcessFrame(frame_state, /*is_last=*/false, &ticket,


### PR DESCRIPTION
That was not covered in fast lossless encoder.

Fixes #4751
