### PR TITLE
Fix negative-count memcpy in EXR decoder

### DIFF
--- a/lib/extras/dec/exr.cc
+++ b/lib/extras/dec/exr.cc
@@ -347,36 +347,37 @@ Status DecodeImageEXR(Span<const uint8_t> bytes, const ColorHints& color_hints,
     input.readPixels(start_y, end_y);
 
     // Copy read data into the result image
-    for (int exr_y = start_y; exr_y <= end_y; ++exr_y) {
-      const int image_y = exr_y - displayWindow.min.y;
-      const char* const JXL_RESTRICT input_row =
-          &input_rows[(exr_y - start_y) * colorPixelBytes * row_size];
-      uint8_t* row = static_cast<uint8_t*>(frame.color.pixels()) +
-                     frame.color.stride * image_y;
+    const int exr_x1 = std::max(dataWindow.min.x, displayWindow.min.x);
+    const int exr_x2 = std::min(dataWindow.max.x, displayWindow.max.x);
+    const int exr_x_span = std::max(0, exr_x2 - exr_x1 + 1);
+    if (exr_x_span > 0) {
+      for (int exr_y = start_y; exr_y <= end_y; ++exr_y) {
+        const int image_y = exr_y - displayWindow.min.y;
+        const char* const JXL_RESTRICT input_row =
+            &input_rows[(exr_y - start_y) * colorPixelBytes * row_size];
+        uint8_t* row = static_cast<uint8_t*>(frame.color.pixels()) +
+                       frame.color.stride * image_y;
 
-      const int exr_x1 = std::max(dataWindow.min.x, displayWindow.min.x);
-      const int exr_x2 = std::min(dataWindow.max.x, displayWindow.max.x);
+        const char* exr_ptr =
+            input_row + (exr_x1 - dataWindow.min.x) * colorPixelBytes;
+        uint8_t* image_ptr =
+            row + (exr_x1 - displayWindow.min.x) * colorPixelBytes;
+        memcpy(image_ptr, exr_ptr, exr_x_span * colorPixelBytes);
 
-      const char* exr_ptr =
-          input_row + (exr_x1 - dataWindow.min.x) * colorPixelBytes;
-      uint8_t* image_ptr =
-          row + (exr_x1 - displayWindow.min.x) * colorPixelBytes;
-      memcpy(image_ptr, exr_ptr, (exr_x2 - exr_x1 + 1) * colorPixelBytes);
+        const char* JXL_RESTRICT input_ec_slice = input_extra_rows.data();
+        for (PackedImage& ec : frame.extra_channels) {
+          const char* const JXL_RESTRICT input_ec_row =
+              input_ec_slice + (exr_y - start_y) * ec.stride;
+          uint8_t* ec_row =
+              static_cast<uint8_t*>(ec.pixels()) + ec.stride * image_y;
+          input_ec_slice += ec.stride * (end_y - start_y + 1);
 
-      const char* JXL_RESTRICT input_ec_slice = input_extra_rows.data();
-      for (PackedImage& ec : frame.extra_channels) {
-        const char* const JXL_RESTRICT input_ec_row =
-            input_ec_slice + (exr_y - start_y) * ec.stride;
-        uint8_t* ec_row =
-            static_cast<uint8_t*>(ec.pixels()) + ec.stride * image_y;
-        input_ec_slice += ec.stride * (end_y - start_y + 1);
-
-        const char* exr_ec_ptr =
-            input_ec_row + (exr_x1 - dataWindow.min.x) * ec.pixel_stride();
-        uint8_t* image_ec_ptr =
-            ec_row + (exr_x1 - displayWindow.min.x) * ec.pixel_stride();
-        memcpy(image_ec_ptr, exr_ec_ptr,
-               (exr_x2 - exr_x1 + 1) * ec.pixel_stride());
+          const char* exr_ec_ptr =
+              input_ec_row + (exr_x1 - dataWindow.min.x) * ec.pixel_stride();
+          uint8_t* image_ec_ptr =
+              ec_row + (exr_x1 - displayWindow.min.x) * ec.pixel_stride();
+          memcpy(image_ec_ptr, exr_ec_ptr, exr_x_span * ec.pixel_stride());
+        }
       }
     }
   }


### PR DESCRIPTION

**Negative-count memcpy in EXR decoder** (`lib/extras/dec/exr.cc`)

In `DecodeImageEXR`, when the EXR data window and display window have no horizontal overlap, the intersection produces `exr_x2 < exr_x1` (after `std::max` / `std::min`). The expression `(exr_x2 - exr_x1 + 1)` then wraps to a huge `size_t` and is passed to `memcpy`, causing a massive out-of-bounds read and write on both the color buffer and any extra channels.

Triggered by a malformed EXR file whose `dataWindow` and `displayWindow` X ranges do not intersect.

## Fix

* Hoist `exr_x1` and `exr_x2` above the `exr_y` loop (they don't depend on `exr_y`).
* Compute `exr_x_span = std::max(0, exr_x2 - exr_x1 + 1)`.
* Skip the entire `exr_y` loop when `exr_x_span == 0` (no overlap, no work to do).
* Use `exr_x_span` directly in both `memcpy` calls (color + extra channels).

## Context

The same code path exists in `google/jpegli` (forked from libjxl). A fix with identical structure has been submitted there as [google/jpegli#216](https://github.com/google/jpegli/pull/216), where the loop-cleanup shape was suggested by @eustas in review.

## Test plan

* [ ] Maintainers run existing EXR decoder tests to confirm no regression on well-formed inputs.
* [ ] Verify on a malformed EXR with disjoint `dataWindow` / `displayWindow` X ranges that the decoder no longer trips ASan.