### PR TITLE
Check that residual does not overflow

### DIFF
--- a/lib/jxl/base/common.h
+++ b/lib/jxl/base/common.h
@@ -18,6 +18,10 @@
 #include <type_traits>
 #include <vector>
 
+#if JXL_COMPILER_MSVC
+#include <intrin.h>
+#endif
+
 #include "lib/jxl/base/compiler_specific.h"
 
 namespace jxl {
@@ -48,6 +52,21 @@ static inline bool SafeMul(const U a, const U b, U& product) {
   if (b > (std::numeric_limits<U>::max() / a)) return false;
   product = a * b;
   return true;
+}
+
+static inline bool SubOverflow(const int32_t a, const int32_t b, int32_t& c) {
+  // Clang 3.8+ / GCC 5.1+
+#if JXL_COMPILER_GCC || JXL_COMPILER_CLANG
+  return __builtin_sub_overflow(a, b, &c);
+#elif JXL_COMPILER_MSVC >= 1937
+  return _sub_overflow_i32(/*carry*/ 0, a, b, &c);
+#else
+  uint32_t ua = static_cast<uint32_t>(a);
+  uint32_t ub = static_cast<uint32_t>(b);
+  uint32_t uc = ua - ub;
+  c = static_cast<int32_t>(uc);
+  return !!(((ua ^ ub) & (ua ^ uc)) >> 31);
+#endif
 }
 
 template <typename T1, typename T2>

--- a/lib/jxl/modular/encoding/enc_encoding.cc
+++ b/lib/jxl/modular/encoding/enc_encoding.cc
@@ -286,6 +286,7 @@ Status EncodeModularChannelMAANS(const Image &image, pixel_type chan,
     const ptrdiff_t onerow = channel.plane.PixelsPerRow();
     weighted::State wp_state(wp_header, channel.w, channel.h);
     Properties properties(1);
+    bool unhealthy = false;
     for (size_t y = 0; y < channel.h; y++) {
       const pixel_type *JXL_RESTRICT r = channel.Row(y);
       for (size_t x = 0; x < channel.w; x++) {
@@ -303,10 +304,14 @@ Status EncodeModularChannelMAANS(const Image &image, pixel_type chan,
             kPropRangeFast +
             jxl::Clamp1(properties[0], -kPropRangeFast, kPropRangeFast - 1);
         uint32_t ctx_id = tree_lut->context_lookup[pos];
-        int32_t residual = r[x] - guess;
+        int32_t residual;
+        unhealthy |= SubOverflow(r[x], guess, residual);
         *tokenp++ = Token(ctx_id, PackSigned(residual));
         wp_state.UpdateErrors(r[x], x, y, channel.w);
       }
+    }
+    if (unhealthy) {
+      return JXL_FAILURE("Residual overflow");
     }
   } else if (tree.size() == 1 && tree[0].predictor == Predictor::Gradient &&
              tree[0].multiplier == 1 && tree[0].predictor_offset == 0 &&


### PR DESCRIPTION
Add `SubOverflow` - portable wrapper for builtin.

To avoid control flow disturbance we allow overflow to happen, but save the fact to stop processing later.

Hopefully clamped-gradient paths are not affected

Fixes #4733
