### PR TITLE
Enable "uninitialize field" analysis.

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -21,6 +21,7 @@
 
 Checks: >-
   bugprone-*,
+  cppcoreguidelines-pro-type-member-init,
   clang-*,
   -clang-diagnostic-unused-command-line-argument,
   google-*,

--- a/lib/jxl/box_content_decoder.h
+++ b/lib/jxl/box_content_decoder.h
@@ -32,7 +32,7 @@ class JxlBoxContentDecoder {
                            size_t* avail_out);
 
  private:
-  BrotliDecoderState* brotli_dec;
+  BrotliDecoderState* brotli_dec = nullptr;
 
   bool header_done_;
   bool brob_decode_;


### PR DESCRIPTION
Do some suppressions, some initializations. Many warnings still need to be addressed.
