### PR TITLE
Fix GIF palette OOB read and PNM size overflow checks

### DIFF
--- a/lib/extras/dec/gif.cc
+++ b/lib/extras/dec/gif.cc
@@ -375,7 +375,7 @@ Status DecodeImageGIF(Span<const uint8_t> bytes, const ColorHints& color_hints,
                          y * sub_frame_image.xsize;
         for (size_t x = 0; x < image_rect.xsize(); ++x, ++byte_index) {
           const GifByteType byte = image.RasterBits[byte_index];
-          if (byte > color_map->ColorCount) {
+          if (byte >= color_map->ColorCount) {
             return JXL_FAILURE("GIF color is out of bounds");
           }
           if (byte == gcb.TransparentColor) {

--- a/lib/extras/dec/pnm.cc
+++ b/lib/extras/dec/pnm.cc
@@ -526,9 +526,16 @@ Status DecodeImagePNM(const Span<const uint8_t> bytes,
   // EC format is same as color, but 1-channel.
   JxlPixelFormat ec_format = format;
   ec_format.num_channels = 1;
-  size_t required_pnm_size =
-      header.ysize * header.xsize *
-      (num_interleaved_channels + header.ec_types.size()) * twidth;
+  // Compute required pixel-data size with overflow checks. Without these,
+  // a crafted header (large xsize/ysize) wraps the multiplication and lets
+  // the size check below pass while the actual memcpy below reads OOB.
+  size_t total_channels = num_interleaved_channels + header.ec_types.size();
+  size_t required_pnm_size;
+  if (!SafeMul(header.xsize, total_channels, required_pnm_size) ||
+      !SafeMul(required_pnm_size, twidth, required_pnm_size) ||
+      !SafeMul(required_pnm_size, header.ysize, required_pnm_size)) {
+    return JXL_FAILURE("PNM image dimensions are too large");
+  }
   size_t pnm_remaining_size = bytes.data() + bytes.size() - pos;
   if (pnm_remaining_size < required_pnm_size) {
     return JXL_FAILURE("PNM file too small");


### PR DESCRIPTION
This patch fixes two decoder-internal memory safety issues in lib/extras/dec/.

### GIF decoder: off-by-one palette bounds check

File: lib/extras/dec/gif.cc

The GIF decoder validated palette indices using:

    if (byte > color_map->ColorCount)

This incorrectly allowed `byte == ColorCount`, even though valid palette indices are only:

    0 .. ColorCount - 1

As a result, decoding could read one element past the end of:

    color_map->Colors

The replace path already used the `correct >= check` so this patch aligns both paths and removes the off-by-one OOB read.

### PNM/PAM decoder: overflow-safe required size calculation

File: lib/extras/dec/pnm.cc

The required pixel-data size calculation previously chained multiple unchecked multiplications:

    header.ysize * header.xsize *
    (num_interleaved_channels + header.ec_types.size()) * twidth

Large crafted image dimensions could overflow `size_t` causing the computed size to wrap and incorrectly pass the subsequent bounds check. Later image-copy operations could then read past the end of the input buffer.

The fix replaces the unchecked arithmetic with chained `SafeMul()` calls, consistent with existing overflow-hardening patterns in the codebase. Decoding now fails cleanly if the computed image size exceeds representable limits.

Together these changes harden two independent decoder paths against malformed untrusted inputs and eliminate reachable out-of-bounds read conditions.