### PR TITLE
harden PackedImage allocation arithmetic

### DIFF
--- a/lib/extras/codec_test.cc
+++ b/lib/extras/codec_test.cc
@@ -14,6 +14,7 @@
 #include <cstdio>
 #include <cstdlib>
 #include <cstring>
+#include <limits>
 #include <memory>
 #include <sstream>
 #include <string>
@@ -459,6 +460,46 @@ TEST(CodecTest, FormatNegotiation) {
   EXPECT_EQ(format.num_channels, info.num_color_channels);
   // 16 is the smallest accepted format that can accommodate the 12-bit data.
   EXPECT_EQ(format.data_type, JXL_TYPE_UINT16);
+}
+
+TEST(CodecTest, PackedImageRejectsOverflowingSizes) {
+  JxlPixelFormat format = {/*num_channels=*/4,
+                           /*data_type=*/JXL_TYPE_FLOAT,
+                           /*endianness=*/JXL_NATIVE_ENDIAN,
+                           /*align=*/0};
+
+  EXPECT_FALSE(
+      PackedImage::Create(std::numeric_limits<size_t>::max() / 16 + 1, 1,
+                          format)
+          .ok());
+  EXPECT_FALSE(
+      PackedImage::Create(std::numeric_limits<size_t>::max() / 16, 2, format)
+          .ok());
+}
+
+TEST(CodecTest, PackedImageRejectsOverflowingAlignment) {
+  JxlPixelFormat format = {/*num_channels=*/1,
+                           /*data_type=*/JXL_TYPE_UINT8,
+                           /*endianness=*/JXL_NATIVE_ENDIAN,
+                           /*align=*/32};
+
+  EXPECT_FALSE(
+      PackedImage::Create(std::numeric_limits<size_t>::max() - 15, 1, format)
+          .ok());
+}
+
+TEST(CodecTest, PackedImageAllowsEmptyRows) {
+  JxlPixelFormat format = {/*num_channels=*/3,
+                           /*data_type=*/JXL_TYPE_UINT8,
+                           /*endianness=*/JXL_NATIVE_ENDIAN,
+                           /*align=*/0};
+
+  JXL_TEST_ASSIGN_OR_DIE(PackedImage image, PackedImage::Create(0, 1, format));
+  EXPECT_EQ(image.xsize, 0u);
+  EXPECT_EQ(image.ysize, 1u);
+  EXPECT_EQ(image.stride, 0u);
+  EXPECT_EQ(image.pixels_size, 0u);
+  EXPECT_NE(image.pixels(), nullptr);
 }
 
 TEST(CodecTest, FormatNegotiationGrayscalePromotion) {

--- a/lib/extras/packed_image.cc
+++ b/lib/extras/packed_image.cc
@@ -35,9 +35,10 @@ namespace extras {
 // Class representing an interleaved image with a bunch of channels.
 StatusOr<PackedImage> PackedImage::Create(size_t xsize, size_t ysize,
                                           const JxlPixelFormat& format) {
+  JXL_RETURN_IF_ERROR(ValidateDataType(format.data_type));
   JXL_ASSIGN_OR_RETURN(size_t stride, CalcStride(format, xsize));
-  size_t pixels_size = ysize * stride;
-  if ((pixels_size / stride) != ysize) {
+  size_t pixels_size;
+  if (!SafeMul(ysize, stride, pixels_size)) {
     return JXL_FAILURE("Image too big");
   }
   PackedImage image(xsize, ysize, format, stride);
@@ -117,15 +118,24 @@ PackedImage::PackedImage(size_t xsize, size_t ysize,
 
 StatusOr<size_t> PackedImage::CalcStride(const JxlPixelFormat& format,
                                          size_t xsize) {
-  size_t multiplier = (BitsPerChannel(format.data_type) * format.num_channels /
-                       jxl::kBitsPerByte);
-  size_t stride = xsize * multiplier;
-  if ((stride / multiplier) != xsize) {
+  JXL_RETURN_IF_ERROR(ValidateDataType(format.data_type));
+  size_t bits_per_pixel;
+  if (!SafeMul(BitsPerChannel(format.data_type),
+               static_cast<size_t>(format.num_channels), bits_per_pixel)) {
+    return JXL_FAILURE("Image too big");
+  }
+  size_t multiplier = bits_per_pixel / jxl::kBitsPerByte;
+  size_t stride;
+  if (!SafeMul(xsize, multiplier, stride)) {
     return JXL_FAILURE("Image too big");
   }
   if (format.align > 1) {
-    size_t aligned_stride = jxl::DivCeil(stride, format.align) * format.align;
-    if (stride > aligned_stride) {
+    size_t align_offset;
+    if (!SafeAdd(stride, format.align - 1, align_offset)) {
+      return JXL_FAILURE("Image too big");
+    }
+    size_t aligned_stride;
+    if (!SafeMul(align_offset / format.align, format.align, aligned_stride)) {
       return JXL_FAILURE("Image too big");
     }
     stride = aligned_stride;


### PR DESCRIPTION
## Summary

Harden `PackedImage` allocation and stride arithmetic by replacing fragile divide-back overflow checks with checked `SafeMul`/`SafeAdd` operations.

## Changes

- Use `SafeMul` for:
  - bits-per-pixel calculation
  - row stride calculation
  - total pixel buffer size calculation

- Use `SafeAdd` during alignment round-up to avoid overflow in aligned stride computation.

- Remove divide-based overflow checks that relied on already-computed arithmetic.

- Preserve zero-width image handling without triggering divide-by-zero behavior.