### PR TITLE
Fix jpeg recon int overflow

### DIFF
--- a/lib/jxl/jpeg/dec_jpeg_data_writer.cc
+++ b/lib/jxl/jpeg/dec_jpeg_data_writer.cc
@@ -843,7 +843,8 @@ SerializationStatus JXL_NOINLINE DoEncodeScan(const JPEGData& jpg,
           for (int ix = 0; ix < n_blocks_x; ++ix) {
             int block_y = ss.mcu_y * n_blocks_y + iy;
             int block_x = mcu_x * n_blocks_x + ix;
-            int block_idx = block_y * c.width_in_blocks + block_x;
+            size_t block_idx =
+                static_cast<size_t>(block_y) * c.width_in_blocks + block_x;
             if (ss.block_scan_index == ss.next_reset_point) {
               Flush(coding_state, bw);
               ss.next_reset_point = get_next_reset_point();

--- a/lib/jxl/jpeg/dec_jpeg_data_writer.cc
+++ b/lib/jxl/jpeg/dec_jpeg_data_writer.cc
@@ -844,7 +844,8 @@ SerializationStatus JXL_NOINLINE DoEncodeScan(const JPEGData& jpg,
             int block_y = ss.mcu_y * n_blocks_y + iy;
             int block_x = mcu_x * n_blocks_x + ix;
             size_t block_idx =
-                static_cast<size_t>(block_y) * c.width_in_blocks + block_x;
+                static_cast<size_t>(block_y) * c.width_in_blocks +
+                static_cast<size_t>(block_x);
             if (ss.block_scan_index == ss.next_reset_point) {
               Flush(coding_state, bw);
               ss.next_reset_point = get_next_reset_point();

--- a/lib/jxl/jpeg/enc_jpeg_data_reader.cc
+++ b/lib/jxl/jpeg/enc_jpeg_data_reader.cc
@@ -834,7 +834,8 @@ Status ProcessScan(const uint8_t* data, const size_t len,
             int block_y = mcu_y * nblocks_y + iy;
             int block_x = mcu_x * nblocks_x + ix;
             size_t block_idx =
-                static_cast<size_t>(block_y) * c->width_in_blocks + block_x;
+                static_cast<size_t>(block_y) * c->width_in_blocks +
+                static_cast<size_t>(block_x);
             bool reset_state = false;
             int num_zero_runs = 0;
             coeff_t* coeffs = &c->coeffs[block_idx * kDCTBlockSize];

--- a/lib/jxl/jpeg/enc_jpeg_data_reader.cc
+++ b/lib/jxl/jpeg/enc_jpeg_data_reader.cc
@@ -833,7 +833,8 @@ Status ProcessScan(const uint8_t* data, const size_t len,
           for (int ix = 0; ix < nblocks_x; ++ix) {
             int block_y = mcu_y * nblocks_y + iy;
             int block_x = mcu_x * nblocks_x + ix;
-            int block_idx = block_y * c->width_in_blocks + block_x;
+            size_t block_idx =
+                static_cast<size_t>(block_y) * c->width_in_blocks + block_x;
             bool reset_state = false;
             int num_zero_runs = 0;
             coeff_t* coeffs = &c->coeffs[block_idx * kDCTBlockSize];


### PR DESCRIPTION
Fixes #4779

### Problem
`cjxl --lossless_jpeg=1` accepts a large baseline JPEG and writes a JXL with JPEG bitstream reconstruction data, but `djxl` then cannot reconstruct it ("could not decode losslessly to JPEG, retrying with --pixels_to_jpeg"). No error is reported at encode time. Smaller images round-trip losslessly.

### Reproduction
- A baseline JPEG whose largest component exceeds ~33.5M blocks (e.g. 53717x45898), i.e. roughly >= 2 gigapixel.
- `cjxl --lossless_jpeg=1 big.jpg big.jxl` succeeds; `jxlinfo big.jxl` shows "JPEG bitstream reconstruction data available".
- `djxl big.jxl out.jpg` fails lossless reconstruction and falls back to pixels.
- ~0.87 Gpx (~13.6M blocks) round-trips; ~2.47 Gpx (~38.5M blocks) fails — threshold consistent with signed 32-bit overflow at `block_idx * 64`.

### Cause
The `coeffs` buffer is correctly 64-bit sized (`uint64_t num_blocks; coeffs.resize(num_blocks * kDCTBlockSize)`), but the per-block index is 32-bit `int` in two scan loops:
- `lib/jxl/jpeg/enc_jpeg_data_reader.cc`: `int block_idx = ...;` then `&c->coeffs[block_idx * kDCTBlockSize]`
- `lib/jxl/jpeg/dec_jpeg_data_writer.cc`: `int block_idx = ...;` then `&c.coeffs[block_idx << 6]`

Once `block_idx > INT_MAX / 64` (~33,554,431), `block_idx * kDCTBlockSize` / `block_idx << 6` overflows signed `int`, yielding an out-of-range offset and corrupt reconstruction. No bounds check triggers because the buffer itself is large enough.

### Fix
Widen `block_idx` to `size_t` at both sites; the multiply/shift then promote to 64-bit. No other behavior change. Verified: JPEGs with >2.1B coefficients/component now reconstruct bit-exact; smaller files unchanged.