### PR TITLE
Fix off-by-one heap OOB read in GIF palette index check

### DIFF
--- a/lib/extras/dec/gif.cc
+++ b/lib/extras/dec/gif.cc
@@ -375,7 +375,7 @@ Status DecodeImageGIF(Span<const uint8_t> bytes, const ColorHints& color_hints,
                          y * sub_frame_image.xsize;
         for (size_t x = 0; x < image_rect.xsize(); ++x, ++byte_index) {
           const GifByteType byte = image.RasterBits[byte_index];
-          if (byte > color_map->ColorCount) {
+          if (byte >= color_map->ColorCount) {
             return JXL_FAILURE("GIF color is out of bounds");
           }
           if (byte == gcb.TransparentColor) {


### PR DESCRIPTION
## Summary

`DecodeImageGIF` in [`lib/extras/dec/gif.cc`](https://github.com/libjxl/libjxl/blob/main/lib/extras/dec/gif.cc#L378) has an off-by-one in the non-replace branch when validating a palette index against the colormap size. The check uses `>` instead of `>=`, allowing `byte == ColorCount`, which then reads one `GifColorType` (3 bytes) past the end of the heap-allocated `Colors` array.

## Root cause

```cpp
for (size_t x = 0; x < image_rect.xsize(); ++x, ++byte_index) {
  const GifByteType byte = image.RasterBits[byte_index];
  if (byte > color_map->ColorCount) {          // off-by-one: should be `>=`
    return JXL_FAILURE("GIF color is out of bounds");
  }
  ...
  GifColorType color = color_map->Colors[byte];  // OOB when byte == ColorCount
  row[x].r = color.Red;
  row[x].g = color.Green;
  row[x].b = color.Blue;
  ...
}
```

Valid indices into `Colors` are `[0, ColorCount - 1]`. With `>`, `byte == ColorCount` passes the check and the next line reads `Colors[ColorCount]` — one struct past the allocation.

The sibling check on [line 343](https://github.com/libjxl/libjxl/blob/main/lib/extras/dec/gif.cc#L343) (the replace path) already uses the correct `>=`; this PR brings the non-replace branch in line.

## Impact

- 3-byte heap out-of-bounds READ per malicious raster byte.
- The read bytes are written into `row[x].r/g/b`, so the leaked heap contents are observable in the decoded image (info-disclosure of adjacent heap memory).
- Triggered via `cjxl <malicious.gif> out.jxl`. The malicious GIF needs a colormap with `ColorCount < 256` and a raster byte equal to `ColorCount`, decoded through the non-replace path (default for most frames).

## Fix

One character — `>` → `>=`:

```diff
-          if (byte > color_map->ColorCount) {
+          if (byte >= color_map->ColorCount) {
             return JXL_FAILURE("GIF color is out of bounds");
           }
```

## Test plan

- [x] Standalone ASAN reproducer (4-color heap-allocated palette, 1-pixel raster with `index == ColorCount`) fires `heap-buffer-overflow READ of size 3 at 0 bytes after 12-byte region` on the current code.
- [x] Same reproducer with the fix applied runs ASAN-clean (malicious byte is rejected).
- [ ] CI: existing GIF decode tests should remain green (no behavior change for valid inputs — only rejects an additional out-of-range index value).