### PR TITLE
Remove unnecessary zip layer from release assets

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -101,7 +101,7 @@ jobs:
       with:
         name: jxl-linux-x86_64-static
         path: jxl-linux-x86_64-static.tar.gz
-        compression-level: 0
+        archive: false
 
 
 
@@ -223,7 +223,7 @@ jobs:
       with:
         name: jxl-debs-amd64-${{ env.ARTIFACT_SUFFIX }}
         path: jxl-debs-amd64-${{ env.ARTIFACT_SUFFIX }}.tar.gz
-        compression-level: 0
+        archive: false
 
 
   windows_build:
@@ -371,7 +371,7 @@ jobs:
         name: jxl-${{matrix.triplet}}
         path: |
           jxl-${{matrix.triplet}}.zip
-        compression-level: 0
+        archive: false
 
     - name: Upload 7Z release 
       if: matrix.upload != 'OFF'
@@ -380,7 +380,7 @@ jobs:
         name: jxl-${{matrix.triplet}}-7z
         path: |
           jxl-${{matrix.triplet}}.7z
-        compression-level: 0
+        archive: false
 
 
   publish_release_assets:


### PR DESCRIPTION
<!-- Thank you for considering a contribution to `libjxl`! -->

### Description

<!-- Please provide a brief description of the changes in this PR and any additional context (e.g., why these changes were made, related issues, etc.). -->

Thank you for this great product.

I believe the assets currently distributed via Releases are in a “zip-in-zip” format.
Ref: [https://github.com/libjxl/libjxl/issues/4329](https://github.com/libjxl/libjxl/issues/4329)

However, this format is not handled well by some package managers.  
Ref: https://github.com/aquaproj/aqua/issues/4832

Since there does not seem to be any real benefit to using a zip-in-zip format, and the drawbacks outweigh the advantages, I tried removing one layer of zipping.

The `upload-artifact` action provides an `Unzipped` option, so I enabled that and replaced the now unnecessary `compression-level: 0`.
Ref: [https://github.com/actions/upload-artifact#upload-an-individual-file-unzipped](https://github.com/actions/upload-artifact#upload-an-individual-file-unzipped)

You can check the actual build results from the following test PR if needed:
[https://github.com/yashikota/libjxl/pull/1/checks](https://github.com/yashikota/libjxl/pull/1/checks)

This removes the unnecessary extra zipping and makes the release assets available in a more preferable distribution format.

One possible concern is that systems currently relying on the zip-in-zip format may no longer work. However, since this does not modify existing assets and only changes the format of future releases to a better one, I believe the impact should be minimal.

### Pull Request Checklist

- [x] **CLA Signed**: Have you signed the [Contributor License Agreement](https://code.google.com/legal/individual-cla-v1.0.html) (individual or corporate, as appropriate)? Only contributions from signed contributors can be accepted.
- [x] **Authors**: Have you considered adding your name to the [AUTHORS](AUTHORS) file?
- [x] **Code Style**: Have you ensured your code adheres to the project's coding style guidelines? You can use `./ci.sh lint` for automatic code formatting.


Please review the full [contributing guidelines](https://github.com/libjxl/libjxl/blob/main/CONTRIBUTING.md) for more details.
