### PR TITLE
Fix heap OOB read in DetectIccProfile for short APP2 markers

### DIFF
--- a/lib/jxl/jpeg/enc_jpeg_data.cc
+++ b/lib/jxl/jpeg/enc_jpeg_data.cc
@@ -53,8 +53,9 @@ Status DetectIccProfile(JPEGData& jpeg_data) {
     size_t tag_length = (app[pos] << 8) + app[pos + 1];
     pos += 2;
     JXL_ENSURE(app.size() == tag_length + 1);
-    // Empty payload is 2 bytes for tag length itself + signature
-    if (tag_length < 2 + sizeof kIccProfileTag) continue;
+    // Minimum is 2 bytes for tag length itself + signature + 2 bytes for
+    // chunk_id and num_chunks (read below).
+    if (tag_length < 2 + sizeof kIccProfileTag + 2) continue;
 
     if (memcmp(&app[pos], kIccProfileTag, sizeof kIccProfileTag) != 0) continue;
     pos += sizeof kIccProfileTag;


### PR DESCRIPTION
## What the bug is

`DetectIccProfile` in `lib/jxl/jpeg/enc_jpeg_data.cc` validates the APP2 marker length with

```cpp
// Empty payload is 2 bytes for tag length itself + signature
if (tag_length < 2 + sizeof kIccProfileTag) continue;   // line 57
```

i.e. it requires `tag_length >= 14` (2 length bytes + 12-byte `"ICC_PROFILE\0"` signature). The function then reads two more bytes:

```cpp
pos += sizeof kIccProfileTag;
uint8_t chunk_id = app[pos++];      // line 61
uint8_t num_chunks = app[pos++];    // line 62
```

without an additional size check.

Because `ProcessAPP` in `lib/jxl/jpeg/enc_jpeg_data_reader.cc` stores each marker as `marker_code(1) + length_bytes(2) + payload(tag_length - 2)`, `app.size()` equals `tag_length + 1`. A crafted APP2 marker carrying exactly `"ICC_PROFILE\0"` and `tag_length = 14` (or 15) gives `app.size() = 15` (or 16), so `app[15]` (and `app[16]`) are read one or two bytes past the end of the heap-allocated marker buffer.

The OOB-read bytes are not just discarded:

* `if (chunk_id != num_icc + 1) continue;` -- they steer control flow.
* `if (num_icc_jpeg == 0) num_icc_jpeg = num_chunks;` -- they're persisted in `num_icc_jpeg`, which is later used in `num_icc != num_icc_jpeg` and is otherwise propagated through the JPEGData structure that is later re-emitted by `dec_jpeg_data.cc` (`marker[16] = num_icc;` etc., guarded only by the `kICC` type that this function itself is assigning).

So this is an attacker-controllable heap out-of-bounds read in the JPEG-to-JXL transcode path (`ParseJPG` -> `EncodeJPEGData` -> `DetectIccProfile`).

## How to reproduce

A standalone reproducer mimicking the function and using AddressSanitizer:

```cpp
static const uint8_t kIccProfileTag[12] = "ICC_PROFILE";
std::vector<uint8_t> app = { 0xE2, 0x00, 0x0E,
    'I','C','C','_','P','R','O','F','I','L','E','\0' };
// app.size() == 15
// Run DetectIccProfile logic on `app`.
```

ASAN output (excerpt):

```
==ERROR: AddressSanitizer: heap-buffer-overflow on address 0x60200000015f
READ of size 1 at 0x60200000015f thread T0
    #0 Probe(...) repro.cc:32
0x60200000015f is located 15 bytes inside of 16-byte region [0x602000000150,0x602000000160)
```

The equivalent crafted JPEG is just `FF D8 FF E2 00 0E "ICC_PROFILE\0" FF D9` (SOI, APP2 with `length = 0x000E` and a bare `"ICC_PROFILE\0"` payload, EOI). Any caller that runs `EncodeJPEGData` on such a JPEG (e.g. `cjxl` transcoding a JPEG into JXL) trips the OOB read.

## What the fix does

The fix is local to the callee. The minimum `tag_length` is raised by 2 so that the size check also covers the `chunk_id` and `num_chunks` bytes that the function unconditionally reads:

```cpp
// Minimum is 2 bytes for tag length itself + signature + 2 bytes for
// chunk_id and num_chunks (read below).
if (tag_length < 2 + sizeof kIccProfileTag + 2) continue;
```

Markers that previously slipped past the check with `tag_length = 14` or `15` are now treated as non-ICC and skipped, exactly like any other unrelated APP2 marker. Legitimate ICC markers carry `chunk_id` and `num_chunks`, so they have `tag_length >= 16` and are unaffected.

## Evidence

* With the original check, the standalone reproducer triggers an ASAN heap-buffer-overflow at the `chunk_id = app[pos++]` line.
* With the patched check, the same input is rejected and ASAN is clean.
* A legitimate marker with `tag_length = 16` still detects as ICC (confirmed in the reproducer).
* `cmake --build build --target jxl` succeeds on the patched tree locally.