### PR TITLE
Guard size arithmetic in DecodeImagePNM against overflow

### DIFF
--- a/lib/extras/dec/pnm.cc
+++ b/lib/extras/dec/pnm.cc
@@ -537,9 +537,23 @@ Status DecodeImagePNM(const Span<const uint8_t> bytes,
   // EC format is same as color, but 1-channel.
   JxlPixelFormat ec_format = format;
   ec_format.num_channels = 1;
-  size_t required_pnm_size =
-      header.ysize * header.xsize *
-      (num_interleaved_channels + header.ec_types.size()) * twidth;
+  size_t total_channels;
+  if (!SafeAdd(static_cast<size_t>(num_interleaved_channels),
+               header.ec_types.size(), total_channels)) {
+    return JXL_FAILURE("PNM image dimensions are too large");
+  }
+  size_t bytes_per_pixel;
+  if (!SafeMul(total_channels, twidth, bytes_per_pixel)) {
+    return JXL_FAILURE("PNM image dimensions are too large");
+  }
+  size_t row_size;
+  if (!SafeMul(header.xsize, bytes_per_pixel, row_size)) {
+    return JXL_FAILURE("PNM image dimensions are too large");
+  }
+  size_t required_pnm_size;
+  if (!SafeMul(header.ysize, row_size, required_pnm_size)) {
+    return JXL_FAILURE("PNM image dimensions are too large");
+  }
   size_t pnm_remaining_size = bytes.data() + bytes.size() - pos;
   if (pnm_remaining_size < required_pnm_size) {
     return JXL_FAILURE("PNM file too small");


### PR DESCRIPTION
## What

In `lib/extras/dec/pnm.cc:540`, `DecodeImagePNM` computes the expected pixel
data size as a four-way multiplication of unchecked `size_t` values:

```c
size_t required_pnm_size =
    header.ysize * header.xsize *
    (num_interleaved_channels + header.ec_types.size()) * twidth;
size_t pnm_remaining_size = bytes.data() + bytes.size() - pos;
if (pnm_remaining_size < required_pnm_size) {
  return JXL_FAILURE("PNM file too small");
}
```

`VerifyDimensions` (called a few lines above) caps `xsize * ysize` at
`dec_max_pixels` (2^40 by default), but `header.ec_types.size()` has no
such cap: it grows by one each time the PAM header parser sees a
`TUPLTYPE` entry (see `ParseHeaderPAM`, `lib/extras/dec/pnm.cc:217-251`),
and the input span is not bounded a priori. With on the order of a few
million `TUPLTYPE` entries, the product
`xsize * ysize * total_channels * twidth` wraps modulo `SIZE_MAX`, after
which the `pnm_remaining_size < required_pnm_size` check can be satisfied
by an input whose body is much shorter than what the deinterleaved
per-pixel loop in the `!ec_out.empty()` branch
(`lib/extras/dec/pnm.cc:584-599`) actually reads from `pos`. That loop
walks one pixel at a time and increments `pos` accordingly, so once the
bound is bypassed it reads past `bytes.data() + bytes.size()`.

## How to observe

Reproducer (standalone, no libjxl symbols):

```c++
size_t xsize = 1ull << 10;
size_t ysize = 1ull << 30;          // xsize*ysize = 2^40 (== dec_max_pixels)
size_t total_channels = 3 + (1ull << 25);  // pathological ec_types.size()
size_t twidth = 2;
// True 128-bit product:           0x0000_0004_0000_0600_0000_0000
// size_t (SIZE_MAX):               0xffff_ffff_ffff_ffff
// Unchecked size_t product wraps to: 0x60000000000  <-- much smaller
```

The wrapped value satisfies the bounds check even though the real number
of bytes the loop will consume is `0x4_00000600000000000`.

## What this PR does

Use `SafeAdd` / `SafeMul` (already used elsewhere in this file and
introduced for `ChunkedPNMDecoder::Init` in #4774) to compute
`total_channels`, `bytes_per_pixel`, `row_size`, and `required_pnm_size`
step by step, returning the existing "image dimensions are too large"
error if any step overflows. The fix is local to the callee
(`DecodeImagePNM`); no callers change.

## Why local to the callee

The overflow happens inside `DecodeImagePNM` and the only correct fix is
to perform the size computation safely there. Callers cannot reason
about the wrapped value because the function exposes only the boolean
result.

## Build / test evidence

* `clang++ -std=c++17 ... -c lib/extras/dec/pnm.cc` succeeds cleanly with
  the patch applied (verified locally on macOS / Apple clang).
* A standalone arithmetic reproducer (described above) confirms that
  `SafeMul` detects the overflow and that the unchecked product wraps to
  a value much smaller than the actual buffer demand.

This mirrors the shape of #4774, which hardened the `ChunkedPNMDecoder`
variant; the non-chunked `DecodeImagePNM` was left with the original
unchecked multiply.