### PR TITLE
Harden PGX decoder size arithmetic checks

### DIFF
--- a/lib/extras/dec/pgx.cc
+++ b/lib/extras/dec/pgx.cc
@@ -10,11 +10,13 @@
 
 #include <cstdint>
 #include <cstring>
+#include <limits>
 #include <utility>
 
 #include "lib/extras/dec/color_hints.h"
 #include "lib/extras/packed_image.h"
 #include "lib/extras/size_constraints.h"
+#include "lib/jxl/base/common.h"
 #include "lib/jxl/base/span.h"
 #include "lib/jxl/base/status.h"
 
@@ -51,8 +53,11 @@ class Parser {
 
     *number = 0;
     while (pos_ < end_ && *pos_ >= '0' && *pos_ <= '9') {
-      *number *= 10;
-      *number += *pos_ - '0';
+      const size_t digit = static_cast<size_t>(*pos_ - '0');
+      if (*number > (std::numeric_limits<size_t>::max() - digit) / 10) {
+        return JXL_FAILURE("PGX: number too large");
+      }
+      *number = *number * 10 + digit;
       ++pos_;
     }
 
@@ -136,9 +141,14 @@ class Parser {
       return JXL_FAILURE("PGX: signed not yet supported");
     }
 
-    size_t numpixels = header->xsize * header->ysize;
-    size_t bytes_per_pixel = header->bits_per_sample <= 8 ? 1 : 2;
-    if (pos_ + numpixels * bytes_per_pixel > end_) {
+    const size_t bytes_per_pixel = header->bits_per_sample <= 8 ? 1 : 2;
+    size_t numpixels;
+    size_t bytes_needed;
+    if (!SafeMul(header->xsize, header->ysize, numpixels) ||
+        !SafeMul(numpixels, bytes_per_pixel, bytes_needed)) {
+      return JXL_FAILURE("PGX: image dimensions are too large");
+    }
+    if (static_cast<size_t>(end_ - pos_) < bytes_needed) {
       return JXL_FAILURE("PGX: data too small");
     }
 

--- a/lib/extras/dec/pgx_test.cc
+++ b/lib/extras/dec/pgx_test.cc
@@ -88,6 +88,27 @@ TEST(CodecPGXTest, Test16bits) {
   }
 }
 
+// Crafted PGX with > 19 digit dimension: without the ParseUnsigned overflow
+// guard, the size_t multiplication during ASCII parsing silently wraps. The
+// decoder must reject this before any size arithmetic runs.
+TEST(CodecPGXTest, RejectsDimensionsThatOverflowParseUnsigned) {
+  std::string pgx = "PG ML + 8 99999999999999999999999 2\np";
+  PackedPixelFile ppf;
+  EXPECT_FALSE(DecodeImagePGX(MakeSpan(pgx.c_str()), ColorHints(), &ppf));
+}
+
+// Crafted PGX whose individual dimensions fit in size_t but whose product
+// xsize*ysize wraps. Without SafeMul on the data-size check, the data-too-
+// small test can be bypassed and the decoder relies entirely on
+// VerifyDimensions to catch it. With SafeMul, the parser rejects up front.
+TEST(CodecPGXTest, RejectsDimensionProductOverflow) {
+  // 2^33 * 2^33 = 2^66, wraps to 0 in size_t (on 64-bit). On 32-bit either
+  // dimension alone already overflows ParseUnsigned and is rejected there.
+  std::string pgx = "PG ML + 8 8589934592 8589934592\n";
+  PackedPixelFile ppf;
+  EXPECT_FALSE(DecodeImagePGX(MakeSpan(pgx.c_str()), ColorHints(), &ppf));
+}
+
 }  // namespace
 }  // namespace extras
 }  // namespace jxl


### PR DESCRIPTION
Harden the PGX decoder against integer overflow during numeric parsing and image size computation.

This adds explicit overflow checks while parsing dimensions and replaces unchecked size arithmetic with `SafeMul`.

## Changes

### `lib/extras/dec/pgx.cc`

* Added overflow detection in `Parser::ParseUnsigned()`

  * Rejects dimensions that overflow `size_t`
  * Returns:

    ```
    PGX: number too large
    ```

* Replaced unchecked multiplications with `SafeMul`

  * `xsize * ysize`
  * `numpixels * bytes_per_pixel`

* Reworked:

  ```cpp
  pos_ + bytes_needed > end_
  ```

  into:

  ```cpp
  static_cast<size_t>(end_ - pos_) < bytes_needed
  ```

  to avoid pointer-arithmetic overflow concerns.

* Added required includes:

  ```cpp
  #include <limits>
  #include "lib/jxl/base/common.h"
  ```

### `lib/extras/dec/pgx_test.cc`

Added regression tests for:

* overflow during ASCII dimension parsing
* overflow in dimension product computation