### PR TITLE
Reject mismatched frame dimensions in PGX encoder

### DIFF
--- a/lib/extras/enc/pgx.cc
+++ b/lib/extras/enc/pgx.cc
@@ -57,6 +57,18 @@ Status EncodeImagePGX(const PackedFrame& frame, const JxlBasicInfo& info,
   JXL_RETURN_IF_ERROR(EncodeHeader(info, header, &header_size));
 
   const PackedImage& color = frame.color;
+  // num_samples below is derived from `info`, but pixel data is read from
+  // `color.pixels()`, which is sized for the frame's actual dimensions.
+  // VerifyImageSize (in encode.cc) only checks the frame's internal
+  // consistency and channel count; it does not enforce that the frame
+  // dimensions equal the basic-info dimensions. If `info` carries
+  // dimensions larger than the frame (e.g. a cropped sub-frame in an
+  // animated grayscale APNG, where ppf.info stores the full-canvas size
+  // while each PackedFrame stores its viewport size), the memcpy below
+  // would read past the end of the frame buffer.
+  if (color.xsize != info.xsize || color.ysize != info.ysize) {
+    return JXL_FAILURE("PGX: frame dimensions do not match basic info");
+  }
   const JxlPixelFormat format = color.format;
   const uint8_t* in = reinterpret_cast<const uint8_t*>(color.pixels());
   JXL_RETURN_IF_ERROR(PackedImage::ValidateDataType(format.data_type));


### PR DESCRIPTION
## The bug

In `lib/extras/enc/pgx.cc`, `EncodeImagePGX` derives the output buffer size from `info.xsize * info.ysize`:

```cpp
const uint8_t* in = reinterpret_cast<const uint8_t*>(color.pixels());
...
size_t num_samples = static_cast<size_t>(info.xsize) * info.ysize;   // <-- size from info
...
memcpy(pixels.data(), in, num_samples * bytes_per_sample);           // <-- reads from frame buffer
```

but the source pointer `in` is `color.pixels()`, which is sized for the frame's actual dimensions (`color.xsize * color.ysize * pixel_stride`). The base `Encoder::VerifyImageSize` (`lib/extras/enc/encode.cc:76`) only validates the frame's internal stride/size invariants and that the number of channels matches the basic info — there is an explicit, still-current comment in that function noting that frame dimensions are *not* checked against info dimensions:

```cpp
// TODO(jon): frames do not necessarily have to match image size,
// but probably this is still assumed in some encoders
if (  // image.xsize != info.xsize || image.ysize != info.ysize ||
    image.format.num_channels != info_num_channels) {
```

So if any caller hands `PGXEncoder::Encode` a `PackedPixelFile` where `ppf.info` carries larger dimensions than `frame.color` (the APNG decoder is one such producer: it sets `ppf.info.xsize/ysize` to the full canvas at `apng.cc:1007-1008`, while individual `PackedFrame::color` buffers are sized to each frame's `fcTL` viewport), the `memcpy` reads past the end of the frame's heap allocation.

## Reproducer (AddressSanitizer)

Construct a `PackedPixelFile` whose `info` claims 1024×1024 grayscale 8-bit but whose only frame is 16×16:

```cpp
PackedPixelFile ppf;
JxlEncoderInitBasicInfo(&ppf.info);
ppf.info.xsize = 1024;
ppf.info.ysize = 1024;
ppf.info.bits_per_sample = 8;
ppf.info.num_color_channels = 1;
ppf.info.alpha_bits = 0;
ppf.info.orientation = JXL_ORIENT_IDENTITY;

JxlPixelFormat fmt{1u, JXL_TYPE_UINT8, JXL_NATIVE_ENDIAN, 0};
auto frame = PackedFrame::Create(16, 16, fmt).value_();   // 256-byte buffer
ppf.frames.emplace_back(std::move(frame));

EncodedImage out;
GetPGXEncoder()->Encode(ppf, &out, /*pool=*/nullptr);
```

Built against the unpatched tree with `-fsanitize=address`:

```
==ERROR: AddressSanitizer: heap-buffer-overflow on address 0x611000000140
READ of size 1048576 at 0x611000000140 thread T0
    #0 memcpy
    #1 jxl::extras::(anonymous namespace)::PGXEncoder::Encode(...)
    #2 main
0x611000000140 is located 0 bytes after 256-byte region [0x611000000040,0x611000000140)
allocated by thread T0 here:
    #0 malloc
    #1 jxl::extras::PackedFrame::Create(unsigned long, unsigned long, JxlPixelFormat const&)
```

i.e. 1 MiB read past the end of a 256-byte heap allocation.

## The fix

The fix is local to the callee: before using `info.xsize`/`info.ysize` for any size calculation, verify that they match the frame's actual buffer dimensions and return a clear error if not. Other extras encoders (PNM/PAM/PGM/PPM/PFM) already derive their byte counts from `image.xsize`/`image.ysize`/`image.pixels_size`, so this check only tightens the encoder that genuinely assumed the equality.

## Test evidence

With the patch applied and the same reproducer rebuilt, `Encode` returns a clean error and ASan reports no issues:

```
Encode correctly rejected the mismatched frame.
```

Both runs were performed on an arm64 macOS build configured with `-DJPEGXL_ENABLE_TOOLS=ON -DJPEGXL_ENABLE_TRANSCODE_JPEG=ON` and `-fsanitize=address`. The translation unit `lib/extras/enc/pgx.cc` builds cleanly via `make jxl_extras_codec` after the change.