### PR TITLE
[v0.7.x] backport CVE-2023-0645: OOB read in FindExifTagPosition

### DIFF
--- a/lib/jxl/exif.h
+++ b/lib/jxl/exif.h
@@ -41,6 +41,7 @@ inline size_t FindExifTagPosition(const std::vector<uint8_t>& exif,
   uint32_t offset = (bigendian ? LoadBE32(t) : LoadLE32(t));
   if (exif.size() < 12 + offset + 2 || offset < 8) return 0;
   t += offset - 4;
+  if(t + 2 >= exif.data() + exif.size()) return 0; // gdb_affter_SIGSEGV: 44 uint16_t nb_tags = (bigendian ? LoadBE16(t) : LoadLE16(t));
   uint16_t nb_tags = (bigendian ? LoadBE16(t) : LoadLE16(t));
   t += 2;
   while (nb_tags > 0) {


### PR DESCRIPTION
`d95b050c1822` adds a bounds check in `FindExifTagPosition` (lib/jxl/exif.h) that's missing on v0.7.x. the existing `exif.size() < 12 + offset + 2` check can be bypassed by a 32-bit overflow in offset, after which `LoadLE16(t)` reads past the buffer. the fix adds `if (t + 2 >= exif.data() + exif.size()) return 0;`.

ran the function verbatim with a crafted exif blob whose IFD offset (0xFFFFFFF8) wraps the size check: pre-fix asan reports an OOB read/SEGV, post-fix it returns 0. clean cherry-pick to v0.7.x.

upstream: https://github.com/libjxl/libjxl/commit/d95b050c1822
CVE: https://nvd.nist.gov/vuln/detail/CVE-2023-0645

old CVE but the fix never reached v0.7.x. no full build run.