### PR TITLE
Apply SubOverflow to remaining r[x] - guess sites in modular encoder

### DIFF
--- a/lib/jxl/enc_modular.cc
+++ b/lib/jxl/enc_modular.cc
@@ -251,6 +251,7 @@ float EstimateWPCost(const Image& img, size_t i) {
     const ptrdiff_t onerow = ch.plane.PixelsPerRow();
     weighted::State wp_state(wp_header, ch.w, ch.h);
     Properties properties(1);
+    bool unhealthy = false;
     for (size_t y = 0; y < ch.h; y++) {
       const pixel_type* JXL_RESTRICT r = ch.Row(y);
       for (size_t x = 0; x < ch.w; x++) {
@@ -268,7 +269,8 @@ float EstimateWPCost(const Image& img, size_t i) {
         for (int c : cutoffs) {
           ctx += (c >= properties[0]) ? 1 : 0;
         }
-        pixel_type res = r[x] - guess;
+        pixel_type res;
+        unhealthy |= SubOverflow(r[x], guess, res);
         uint32_t token;
         uint32_t nbits;
         uint32_t bits;
@@ -277,6 +279,10 @@ float EstimateWPCost(const Image& img, size_t i) {
         extra_bits += nbits;
         wp_state.UpdateErrors(r[x], x, y, ch.w);
       }
+    }
+    if (unhealthy) {
+      // Force this predictor option to be rejected by the cost selector.
+      return std::numeric_limits<float>::max();
     }
     for (auto& h : histo) {
       histo_cost += h.ShannonEntropy();

--- a/lib/jxl/modular/encoding/enc_encoding.cc
+++ b/lib/jxl/modular/encoding/enc_encoding.cc
@@ -321,6 +321,7 @@ Status EncodeModularChannelMAANS(const Image &image, pixel_type chan,
                 &predictor_img.Plane(c));
     }
     const ptrdiff_t onerow = channel.plane.PixelsPerRow();
+    bool unhealthy = false;
     for (size_t y = 0; y < channel.h; y++) {
       const pixel_type *JXL_RESTRICT r = channel.Row(y);
       for (size_t x = 0; x < channel.w; x++) {
@@ -328,9 +329,13 @@ Status EncodeModularChannelMAANS(const Image &image, pixel_type chan,
         pixel_type_w top = (y ? *(r + x - onerow) : left);
         pixel_type_w topleft = (x && y ? *(r + x - 1 - onerow) : left);
         int32_t guess = ClampedGradient(top, left, topleft);
-        int32_t residual = r[x] - guess;
+        int32_t residual;
+        unhealthy |= SubOverflow(r[x], guess, residual);
         *tokenp++ = Token(tree[0].childID, PackSigned(residual));
       }
+    }
+    if (unhealthy) {
+      return JXL_FAILURE("Residual overflow");
     }
   } else if (is_gradient_only && !skip_encoder_fast_path) {
     for (size_t c = 0; c < 3; c++) {
@@ -338,6 +343,7 @@ Status EncodeModularChannelMAANS(const Image &image, pixel_type chan,
                 &predictor_img.Plane(c));
     }
     const ptrdiff_t onerow = channel.plane.PixelsPerRow();
+    bool unhealthy = false;
     for (size_t y = 0; y < channel.h; y++) {
       const pixel_type *JXL_RESTRICT r = channel.Row(y);
       for (size_t x = 0; x < channel.w; x++) {
@@ -351,9 +357,13 @@ Status EncodeModularChannelMAANS(const Image &image, pixel_type chan,
                 std::max<pixel_type_w>(-kPropRangeFast, top + left - topleft),
                 kPropRangeFast - 1);
         uint32_t ctx_id = tree_lut->context_lookup[pos];
-        int32_t residual = r[x] - guess;
+        int32_t residual;
+        unhealthy |= SubOverflow(r[x], guess, residual);
         *tokenp++ = Token(ctx_id, PackSigned(residual));
       }
+    }
+    if (unhealthy) {
+      return JXL_FAILURE("Residual overflow");
     }
   } else if (tree.size() == 1 && tree[0].predictor == Predictor::Zero &&
              tree[0].multiplier == 1 && tree[0].predictor_offset == 0 &&


### PR DESCRIPTION
## Description

Fixes #4767
Sibling fix to #4759 ("Check that residual does not overflow", commit 87bee19).

## Summary

`EncodeModularChannelMAANS()` in `lib/jxl/modular/encoding/enc_encoding.cc` and `EstimateWPCost()` in `lib/jxl/enc_modular.cc` compute the residual between a pixel value and its predicted value using a 32-bit signed subtraction:

```cpp
// lib/jxl/modular/encoding/enc_encoding.cc, current code at line 354:
int32_t guess = ClampedGradient(top, left, topleft);
// ... compute pos / ctx_id ...
int32_t residual = r[x] - guess;
*tokenp++ = Token(ctx_id, PackSigned(residual));
```

Both `r[x]` and `guess` are `int32_t` (`pixel_type` is `int32_t` per `lib/jxl/modular/modular_image.h:25`). When `r[x]` is near `INT32_MIN` and `guess` is positive (or vice versa), the subtraction overflows — undefined behavior under the C++ standard. Compiled with `-fsanitize=signed-integer-overflow`, kleisauke's testcase from #4767 trips the sanitizer with `signed integer overflow: -2147483648 - 931135488 cannot be represented in type 'int'`.

PR #4759 already fixed one occurrence — the `is_wp_only` weighted-predictor fast path — by routing the subtraction through a new `SubOverflow()` helper added in `lib/jxl/base/common.h` and accumulating an `unhealthy` flag that aborts encoding with `JXL_FAILURE("Residual overflow")`. Three more occurrences with the same `int32_t` operand types remain:

- `enc_encoding.cc:331` — `Predictor::Gradient` fast path
- `enc_encoding.cc:354` — gradient-only with properties (this is the site that fires kleisauke's reproducer)
- `enc_modular.cc:271` — `EstimateWPCost()` cost-estimation loop

The other `pixel_type_w residual = ...` lines in the same function (387, 419, 451) are not affected: their right-hand side is `PredictionResult::guess`, declared `pixel_type_w` (int64_t) at `context_predict.h:447`, so usual arithmetic conversions widen the subtraction to 64-bit before the operation.

## Why this is the same bug class as #4733

kleisauke explicitly notes in #4767 that "all occurrences of `r[x] - guess` need analogous fix to commit 87bee19". The three sites in this PR are byte-for-byte the same pattern as the site #4759 fixed.

Compare the now-fixed `is_wp_only` site:

```cpp
int32_t residual;
unhealthy |= SubOverflow(r[x], guess, residual);   // overflow-safe
*tokenp++ = Token(ctx_id, PackSigned(residual));
```

against the still-broken sibling at line 354:

```cpp
int32_t residual = r[x] - guess;                   // raw int32_t subtraction, UB on overflow
*tokenp++ = Token(ctx_id, PackSigned(residual));
```

Same operand types, same surrounding loop shape, same UB. This PR applies the same fix.

## Fix

Apply the `SubOverflow` + `unhealthy`-flag pattern at all three sibling sites. For `EncodeModularChannelMAANS()`:

```cpp
const ptrdiff_t onerow = channel.plane.PixelsPerRow();
bool unhealthy = false;
for (size_t y = 0; y < channel.h; y++) {
  const pixel_type *JXL_RESTRICT r = channel.Row(y);
  for (size_t x = 0; x < channel.w; x++) {
    // ... compute guess ...
    int32_t residual;
    unhealthy |= SubOverflow(r[x], guess, residual);
    *tokenp++ = Token(/*ctx*/, PackSigned(residual));
  }
}
if (unhealthy) {
  return JXL_FAILURE("Residual overflow");
}
```

`EstimateWPCost()` returns `float`, so the unhealthy path returns `std::numeric_limits<float>::infinity()` to make the cost selector reject this predictor option:

```cpp
if (unhealthy) {
  return std::numeric_limits<float>::infinity();
}
```


## Test

Built libjxl with `-fsanitize=signed-integer-overflow,undefined -fno-sanitize-recover=signed-integer-overflow` (GCC 11) and ran kleisauke's reproducer (`clusterfuzz-testcase-minimized-jxlsave_buffer_fuzzer-6532992561643520.raw.txt`, args `13 40 4`):

- **On unpatched HEAD:** UBSan reports `signed integer overflow: -2147483648 - 931135488 cannot be represented in type 'int'` at `enc_encoding.cc:354`, with the same stack frames as kleisauke's report (`EncodeModularChannelMAANS` → `ModularCompress` → `ModularFrameEncoder::ComputeTokens` → `ThreadParallelRunner::RunRange`).

- **With this PR:** the encoder returns `JXL_FAILURE("Residual overflow")`, surfaced through the C API as `JXL_ENC_ERROR`. No UBSan trip.

Smoke-tested a normal 32×32 float32 RGB image (lossy and lossless) on the patched build to confirm no regression on the happy path: both encode cleanly without UBSan.

---