### PR TITLE
Reject too-small ICC APP markers in SetJPEGDataFromICC

### DIFF
--- a/lib/jxl/jpeg/jpeg_data.cc
+++ b/lib/jxl/jpeg/jpeg_data.cc
@@ -471,6 +471,10 @@ Status SetJPEGDataFromICC(const std::vector<uint8_t>& icc,
     if (jpeg_data->app_marker_type[i] != jpeg::AppMarkerType::kICC) {
       continue;
     }
+    if (jpeg_data->app_data[i].size() < 17) {
+      return JXL_FAILURE("ICC APP marker too small: %" PRIuS,
+                         jpeg_data->app_data[i].size());
+    }
     size_t len = jpeg_data->app_data[i].size() - 17;
     if (icc_pos + len > icc.size()) {
       return JXL_FAILURE(


### PR DESCRIPTION
SetJPEGDataFromICC computes `len = jpeg_data->app_data[i].size() - 17` on
each marker tagged `kICC`, but JPEGData::VisitFields only enforces
`app.size() >= 3` and does not cross-check the type. A crafted jbrd box
with two kICC markers (one valid, one of size 0) underflows `len` to
SIZE_MAX-16, wraps `icc_pos + len` past the bounds check, and reaches
`memcpy(&app_data[i][17], ...)` with an OOB destination. The sibling
helpers `ExifBoxContentSize` and `XmlBoxContentSize` already do the
same minimum-size check.