### PR TITLE
guard ParseHeaderPGX size arithmetic against overflow

### DIFF
--- a/lib/extras/dec/pgx.cc
+++ b/lib/extras/dec/pgx.cc
@@ -15,6 +15,7 @@
 #include "lib/extras/dec/color_hints.h"
 #include "lib/extras/packed_image.h"
 #include "lib/extras/size_constraints.h"
+#include "lib/jxl/base/common.h"
 #include "lib/jxl/base/span.h"
 #include "lib/jxl/base/status.h"
 
@@ -136,9 +137,13 @@ class Parser {
       return JXL_FAILURE("PGX: signed not yet supported");
     }
 
-    size_t numpixels = header->xsize * header->ysize;
     size_t bytes_per_pixel = header->bits_per_sample <= 8 ? 1 : 2;
-    if (pos_ + numpixels * bytes_per_pixel > end_) {
+    size_t required;
+    if (!SafeMul(header->xsize, header->ysize, required) ||
+        !SafeMul(required, bytes_per_pixel, required)) {
+      return JXL_FAILURE("PGX: image dimensions are too large");
+    }
+    if (required > static_cast<size_t>(end_ - pos_)) {
       return JXL_FAILURE("PGX: data too small");
     }
 


### PR DESCRIPTION
`Parser::ParseHeaderPGX` in `lib/extras/dec/pgx.cc` reads xsize/ysize via
`ParseUnsigned`, which does not bound the parsed value, then evaluates
`pos_ + header->xsize * header->ysize * bytes_per_pixel > end_`. A
crafted header with 20+ digit dimensions wraps the multiplication in
size_t and turns the bounds check into UB pointer arithmetic on `pos_`.
`VerifyDimensions` in `DecodeImagePGX` catches the bad dimensions one
level up, but the parser-layer check should not rely on that. Mirrors
the SafeMul guards added for PNM in #4773 and #4774.