### PR TITLE
validate marker bounds before access in Exif/XMP and ICC handling

### DIFF
--- a/lib/jxl/jpeg/dec_jpeg_data.cc
+++ b/lib/jxl/jpeg/dec_jpeg_data.cc
@@ -72,6 +72,9 @@ Status DecodeJPEGData(Span<const uint8_t> encoded, JPEGData* jpeg_data) {
   size_t num_icc = 0;
   for (size_t i = 0; i < jpeg_data->app_data.size(); i++) {
     auto& marker = jpeg_data->app_data[i];
+    if (marker.size() < 3) {
+      return JXL_FAILURE("APP marker too short");
+    }
     if (jpeg_data->app_marker_type[i] != AppMarkerType::kUnknown) {
       // Set the size of the marker.
       size_t size_minus_1 = marker.size() - 1;

--- a/lib/jxl/jpeg/dec_jpeg_data.cc
+++ b/lib/jxl/jpeg/dec_jpeg_data.cc
@@ -98,17 +98,17 @@ Status DecodeJPEGData(Span<const uint8_t> encoded, JPEGData* jpeg_data) {
       marker[16] = num_icc;
     }
     if (jpeg_data->app_marker_type[i] == AppMarkerType::kExif) {
-      marker[0] = 0xE1;
       if (marker.size() < 3 + sizeof kExifTag) {
         return JXL_FAILURE("Incorrect Exif marker size");
       }
+      marker[0] = 0xE1;
       memcpy(&marker[3], kExifTag, sizeof kExifTag);
     }
     if (jpeg_data->app_marker_type[i] == AppMarkerType::kXMP) {
-      marker[0] = 0xE1;
       if (marker.size() < 3 + sizeof kXMPTag) {
         return JXL_FAILURE("Incorrect XMP marker size");
       }
+      marker[0] = 0xE1;
       memcpy(&marker[3], kXMPTag, sizeof kXMPTag);
     }
   }

--- a/lib/jxl/jpeg/enc_jpeg_data.cc
+++ b/lib/jxl/jpeg/enc_jpeg_data.cc
@@ -46,10 +46,10 @@ Status DetectIccProfile(JPEGData& jpeg_data) {
   size_t num_icc_jpeg = 0;
   for (size_t i = 0; i < jpeg_data.app_data.size(); i++) {
     const auto& app = jpeg_data.app_data[i];
-    size_t pos = 0;
-    if (app[pos++] != 0xE2) continue;
     // At least APPn + size; otherwise it should be intermarker-data.
     JXL_ENSURE(app.size() >= 3);
+    size_t pos = 0;
+    if (app[pos++] != 0xE2) continue;
     size_t tag_length = (app[pos] << 8) + app[pos + 1];
     pos += 2;
     JXL_ENSURE(app.size() == tag_length + 1);


### PR DESCRIPTION
Reorders existing validation checks in JPEG marker handling so bounds/invariant checks occur before buffer access or mutation.

## Changes

### `lib/jxl/jpeg/dec_jpeg_data.cc`

* In `DecodeJPEGData`, moved the Exif/XMP marker size checks before `marker[0] = 0xE1`.
* Prevents partial mutation of undersized markers on failure paths.
* No behavioral change for valid inputs.

### `lib/jxl/jpeg/enc_jpeg_data.cc`

* In `DetectIccProfile`, moved `JXL_ENSURE(app.size() >= 3)` before the first `app[pos++]` access.
* Makes the size invariant explicit at the point of first read.