### PR TITLE
Fix undefined behavior in patch blending foreground pointer arithmetic

### DIFF
--- a/lib/jxl/blending.cc
+++ b/lib/jxl/blending.cc
@@ -41,8 +41,9 @@ bool NeedsBlending(const FrameHeader& frame_header) {
 
 Status PerformBlending(
     JxlMemoryManager* memory_manager, const float* const* bg,
-    const float* const* fg, float* const* out, size_t x0, size_t xsize,
-    const PatchBlending& color_blending, const PatchBlending* ec_blending,
+    const float* const* fg, float* const* out, size_t x0, size_t fg_x0,
+    size_t xsize, const PatchBlending& color_blending,
+    const PatchBlending* ec_blending,
     const std::vector<ExtraChannelInfo>& extra_channel_info) {
   bool has_alpha = false;
   size_t num_ec = extra_channel_info.size();
@@ -59,55 +60,61 @@ Status PerformBlending(
     switch (ec_blending[i].mode) {
       case PatchBlendMode::kAdd:
         for (size_t x = 0; x < xsize; x++) {
-          tmp.Row(3 + i)[x] = bg[3 + i][x + x0] + fg[3 + i][x + x0];
+          tmp.Row(3 + i)[x] = bg[3 + i][x + x0] + fg[3 + i][x + fg_x0];
         }
         continue;
 
       case PatchBlendMode::kBlendAbove: {
         size_t alpha = ec_blending[i].alpha_channel;
         bool is_premultiplied = extra_channel_info[alpha].alpha_associated;
-        PerformAlphaBlending(bg[3 + i] + x0, bg[3 + alpha] + x0, fg[3 + i] + x0,
-                             fg[3 + alpha] + x0, tmp.Row(3 + i), xsize,
-                             is_premultiplied, ec_blending[i].clamp);
+        PerformAlphaBlending(bg[3 + i] + x0, bg[3 + alpha] + x0,
+                             fg[3 + i] + fg_x0, fg[3 + alpha] + fg_x0,
+                             tmp.Row(3 + i), xsize, is_premultiplied,
+                             ec_blending[i].clamp);
         continue;
       }
 
       case PatchBlendMode::kBlendBelow: {
         size_t alpha = ec_blending[i].alpha_channel;
         bool is_premultiplied = extra_channel_info[alpha].alpha_associated;
-        PerformAlphaBlending(fg[3 + i] + x0, fg[3 + alpha] + x0, bg[3 + i] + x0,
-                             bg[3 + alpha] + x0, tmp.Row(3 + i), xsize,
-                             is_premultiplied, ec_blending[i].clamp);
+        PerformAlphaBlending(fg[3 + i] + fg_x0, fg[3 + alpha] + fg_x0,
+                             bg[3 + i] + x0, bg[3 + alpha] + x0,
+                             tmp.Row(3 + i), xsize, is_premultiplied,
+                             ec_blending[i].clamp);
         continue;
       }
 
       case PatchBlendMode::kAlphaWeightedAddAbove: {
         size_t alpha = ec_blending[i].alpha_channel;
-        PerformAlphaWeightedAdd(bg[3 + i] + x0, fg[3 + i] + x0,
-                                fg[3 + alpha] + x0, tmp.Row(3 + i), xsize,
+        PerformAlphaWeightedAdd(bg[3 + i] + x0, fg[3 + i] + fg_x0,
+                                fg[3 + alpha] + fg_x0, tmp.Row(3 + i), xsize,
                                 ec_blending[i].clamp);
         continue;
       }
 
       case PatchBlendMode::kAlphaWeightedAddBelow: {
         size_t alpha = ec_blending[i].alpha_channel;
-        PerformAlphaWeightedAdd(fg[3 + i] + x0, bg[3 + i] + x0,
+        PerformAlphaWeightedAdd(fg[3 + i] + fg_x0, bg[3 + i] + x0,
                                 bg[3 + alpha] + x0, tmp.Row(3 + i), xsize,
                                 ec_blending[i].clamp);
         continue;
       }
 
       case PatchBlendMode::kMul:
-        PerformMulBlending(bg[3 + i] + x0, fg[3 + i] + x0, tmp.Row(3 + i),
+        PerformMulBlending(bg[3 + i] + x0, fg[3 + i] + fg_x0, tmp.Row(3 + i),
                            xsize, ec_blending[i].clamp);
         continue;
 
       case PatchBlendMode::kReplace:
-        if (xsize) memcpy(tmp.Row(3 + i), fg[3 + i] + x0, xsize * sizeof(**fg));
+        if (xsize) {
+          memcpy(tmp.Row(3 + i), fg[3 + i] + fg_x0, xsize * sizeof(**fg));
+        }
         continue;
 
       case PatchBlendMode::kNone:
-        if (xsize) memcpy(tmp.Row(3 + i), bg[3 + i] + x0, xsize * sizeof(**fg));
+        if (xsize) {
+          memcpy(tmp.Row(3 + i), bg[3 + i] + x0, xsize * sizeof(**fg));
+        }
         continue;
     }
   }
@@ -115,35 +122,39 @@ Status PerformBlending(
 
   const auto add = [&]() {
     for (int p = 0; p < 3; p++) {
-      float* out = tmp.Row(p);
+      float* tmp_out = tmp.Row(p);
       for (size_t x = 0; x < xsize; x++) {
-        out[x] = bg[p][x + x0] + fg[p][x + x0];
+        tmp_out[x] = bg[p][x + x0] + fg[p][x + fg_x0];
       }
     }
   };
 
-  const auto blend_weighted = [&](const float* const* bottom,
-                                  const float* const* top) {
+  // `bot` and `top` may be either `bg` (use bot_x0/top_x0 = x0) or `fg`
+  // (use bot_x0/top_x0 = fg_x0); the caller passes the matching offset.
+  const auto blend_weighted = [&](const float* const* bot, size_t bot_x0,
+                                  const float* const* top, size_t top_x0) {
     bool is_premultiplied = extra_channel_info[alpha].alpha_associated;
     PerformAlphaBlending(
-        {bottom[0] + x0, bottom[1] + x0, bottom[2] + x0,
-         bottom[3 + alpha] + x0},
-        {top[0] + x0, top[1] + x0, top[2] + x0, top[3 + alpha] + x0},
+        {bot[0] + bot_x0, bot[1] + bot_x0, bot[2] + bot_x0,
+         bot[3 + alpha] + bot_x0},
+        {top[0] + top_x0, top[1] + top_x0, top[2] + top_x0,
+         top[3 + alpha] + top_x0},
         {tmp.Row(0), tmp.Row(1), tmp.Row(2), tmp.Row(3 + alpha)}, xsize,
         is_premultiplied, color_blending.clamp);
   };
 
-  const auto add_weighted = [&](const float* const* bottom,
-                                const float* const* top) {
+  const auto add_weighted = [&](const float* const* bot, size_t bot_x0,
+                                const float* const* top, size_t top_x0) {
     for (size_t c = 0; c < 3; c++) {
-      PerformAlphaWeightedAdd(bottom[c] + x0, top[c] + x0, top[3 + alpha] + x0,
-                              tmp.Row(c), xsize, color_blending.clamp);
+      PerformAlphaWeightedAdd(bot[c] + bot_x0, top[c] + top_x0,
+                              top[3 + alpha] + top_x0, tmp.Row(c), xsize,
+                              color_blending.clamp);
     }
   };
 
-  const auto copy = [&](const float* const* src) {
+  const auto copy = [&](const float* const* src, size_t src_x0) {
     for (size_t p = 0; p < 3; p++) {
-      memcpy(tmp.Row(p), src[p] + x0, xsize * sizeof(**src));
+      memcpy(tmp.Row(p), src[p] + src_x0, xsize * sizeof(**src));
     }
   };
 
@@ -153,34 +164,34 @@ Status PerformBlending(
       break;
 
     case PatchBlendMode::kAlphaWeightedAddAbove:
-      has_alpha ? add_weighted(bg, fg) : add();
+      has_alpha ? add_weighted(bg, x0, fg, fg_x0) : add();
       break;
 
     case PatchBlendMode::kAlphaWeightedAddBelow:
-      has_alpha ? add_weighted(fg, bg) : add();
+      has_alpha ? add_weighted(fg, fg_x0, bg, x0) : add();
       break;
 
     case PatchBlendMode::kBlendAbove:
-      has_alpha ? blend_weighted(bg, fg) : copy(fg);
+      has_alpha ? blend_weighted(bg, x0, fg, fg_x0) : copy(fg, fg_x0);
       break;
 
     case PatchBlendMode::kBlendBelow:
-      has_alpha ? blend_weighted(fg, bg) : copy(fg);
+      has_alpha ? blend_weighted(fg, fg_x0, bg, x0) : copy(fg, fg_x0);
       break;
 
     case PatchBlendMode::kMul:
       for (int p = 0; p < 3; p++) {
-        PerformMulBlending(bg[p] + x0, fg[p] + x0, tmp.Row(p), xsize,
+        PerformMulBlending(bg[p] + x0, fg[p] + fg_x0, tmp.Row(p), xsize,
                            color_blending.clamp);
       }
       break;
 
     case PatchBlendMode::kReplace:
-      copy(fg);
+      copy(fg, fg_x0);
       break;
 
     case PatchBlendMode::kNone:
-      copy(bg);
+      copy(bg, x0);
   }
 
   for (size_t i = 0; i < 3 + num_ec; i++) {

--- a/lib/jxl/blending.h
+++ b/lib/jxl/blending.h
@@ -20,9 +20,13 @@ namespace jxl {
 
 bool NeedsBlending(const FrameHeader& frame_header);
 
+// Reads `bg` and writes `out` at offset `x0`; reads `fg` at offset `fg_x0`.
+// Splitting bg/out and fg offsets lets callers pre-shift `fg` to a non-negative
+// origin instead of relying on unsigned-wrap pointer arithmetic to align it.
 Status PerformBlending(JxlMemoryManager* memory_manager, const float* const* bg,
                        const float* const* fg, float* const* out, size_t x0,
-                       size_t xsize, const PatchBlending& color_blending,
+                       size_t fg_x0, size_t xsize,
+                       const PatchBlending& color_blending,
                        const PatchBlending* ec_blending,
                        const std::vector<ExtraChannelInfo>& extra_channel_info);
 

--- a/lib/jxl/dec_patch_dictionary.cc
+++ b/lib/jxl/dec_patch_dictionary.cc
@@ -336,20 +336,27 @@ Status PatchDictionary::AddOneRow(
     if (bx + patch_xsize < x0) continue;
     size_t patch_x0 = std::max(bx, x0);
     size_t patch_x1 = std::min(bx + patch_xsize, x0 + xsize);
+    // Both subtractions are non-negative by construction:
+    // patch_x0 = max(bx, x0) guarantees patch_x0 >= bx and patch_x0 >= x0.
+    // ref_pos.x0 + patch_in_ref <= ref_pos.x0 + ref_pos.xsize <= ib.xsize(),
+    // checked at PatchDictionary::Decode time, so the resulting fg pointer
+    // is always within the reference frame row.
+    const size_t patch_in_ref = patch_x0 - bx;
+    const size_t out_in_seg = patch_x0 - x0;
     for (size_t c = 0; c < 3; c++) {
       fg_ptrs[c] = reference_frames_->at(ref).frame->color()->ConstPlaneRow(
                        c, ref_pos.y0 + iy) +
-                   ref_pos.x0 + x0 - bx;
+                   ref_pos.x0 + patch_in_ref;
     }
     for (size_t i = 0; i < num_ec; i++) {
       fg_ptrs[3 + i] =
           reference_frames_->at(ref).frame->extra_channels()[i].ConstRow(
               ref_pos.y0 + iy) +
-          ref_pos.x0 + x0 - bx;
+          ref_pos.x0 + patch_in_ref;
     }
     JXL_RETURN_IF_ERROR(PerformBlending(
-        memory_manager_, inout, fg_ptrs.data(), inout, patch_x0 - x0,
-        patch_x1 - patch_x0, blendings_[blending_idx],
+        memory_manager_, inout, fg_ptrs.data(), inout, out_in_seg,
+        /*fg_x0=*/0, patch_x1 - patch_x0, blendings_[blending_idx],
         blendings_.data() + blending_idx + 1, extra_channel_info));
   }
   return true;

--- a/lib/jxl/render_pipeline/stage_blending.cc
+++ b/lib/jxl/render_pipeline/stage_blending.cc
@@ -178,9 +178,9 @@ class BlendingStage : public RenderPipelineStage {
       }
     }
     return PerformBlending(memory_manager, bg_row_ptrs_.data(),
-                           fg_row_ptrs_.data(), fg_row_ptrs_.data(), 0, xsize,
-                           blending_info_[0], blending_info_.data() + 1,
-                           *extra_channel_info_);
+                           fg_row_ptrs_.data(), fg_row_ptrs_.data(), 0,
+                           /*fg_x0=*/0, xsize, blending_info_[0],
+                           blending_info_.data() + 1, *extra_channel_info_);
   }
 
   RenderPipelineChannelMode GetChannelMode(size_t c) const final {


### PR DESCRIPTION
This PR removes undefined behavior in patch blending caused by foreground pointer arithmetic that could transiently form out-of-bounds pointers through unsigned subtraction.

Previously, foreground pointers were constructed using:

```cpp
ref_pos.x0 + x0 - bx
```

When `bx > x0`, the subtraction could underflow in `size_t` arithmetic before pointer formation, even though the eventual reads resolved to valid memory.

The fix separates foreground (`fg`) addressing from background/output (`bg`/`out`) addressing inside `PerformBlending` and restructures the patch alignment logic so all intermediate arithmetic is non-negative by construction.

No intended behavior changes on valid inputs.

### Changes

#### `lib/jxl/blending.h`

* Added a dedicated `fg_x0` parameter to `PerformBlending`
* Documented the pointer-safety rationale

#### `lib/jxl/blending.cc`

* Split foreground and background/output offset handling
* Updated all blending paths and helper lambdas to use explicit side-specific offsets
* `bg/out` continue using `x0`
* `fg` now uses `fg_x0`

#### `lib/jxl/dec_patch_dictionary.cc`

* Reworked patch alignment logic using non-negative offsets:

  ```cpp
  patch_in_ref = patch_x0 - bx;
  out_in_seg   = patch_x0 - x0;
  ```
* Pre-shifts foreground pointers directly
* Calls `PerformBlending(..., fg_x0 = 0, ...)`

#### `lib/jxl/render_pipeline/stage_blending.cc`

* Updated call site to pass `fg_x0 = 0`
* No functional behavior change

### Tests

Build/test execution was not completed locally because submodules were not initialized in the checkout.

Recommended validation before merge:

* Full project build
* `jxl_tests`
* Patch dictionary decoding coverage
* Render pipeline blending tests
* UBSan/ASan validation for patch blending paths
