### PR TITLE
Fix heap OOB read/write in extras::AlphaBlend gray+alpha path

### DIFF
--- a/lib/extras/alpha_blend.cc
+++ b/lib/extras/alpha_blend.cc
@@ -24,13 +24,14 @@ Status AlphaBlend(PackedFrame* frame, const float background[3]) {
   if (format.num_channels != 2 && format.num_channels != 4) {
     return true;
   }
+  const bool is_gray_alpha = (format.num_channels == 2);
   --format.num_channels;
   JXL_ASSIGN_OR_RETURN(PackedImage blended,
                        PackedImage::Create(im.xsize, im.ysize, format));
   // TODO(szabadka) SIMDify this and make it work for float16.
   for (size_t y = 0; y < im.ysize; ++y) {
     for (size_t x = 0; x < im.xsize; ++x) {
-      if (format.num_channels == 2) {
+      if (is_gray_alpha) {
         float g = im.GetPixelValue(y, x, 0);
         float a = im.GetPixelValue(y, x, 1);
         float out = g * a + background[0] * (1 - a);


### PR DESCRIPTION
## What the bug is

`AlphaBlend` in `lib/extras/alpha_blend.cc` picks between a gray+alpha branch and an RGBA branch by checking `format.num_channels == 2` inside the per-pixel loop. The check runs *after* `--format.num_channels` on line 27, so by the time it executes the value is `1` or `3` — never `2`. The gray+alpha branch is therefore dead code, and a grayscale+alpha input (input `num_channels == 2`) is processed by the RGBA branch instead.

```cpp
// lib/extras/alpha_blend.cc
JxlPixelFormat format = im.format;
if (format.num_channels != 2 && format.num_channels != 4) {
  return true;
}
--format.num_channels;                                      // line 27: mutates format
JXL_ASSIGN_OR_RETURN(PackedImage blended,
                     PackedImage::Create(im.xsize, im.ysize, format));
for (size_t y = 0; y < im.ysize; ++y) {
  for (size_t x = 0; x < im.xsize; ++x) {
    if (format.num_channels == 2) {                         // line 33: tests post-decrement value
      // gray+alpha branch -- never taken
      ...
    } else {
      // RGBA branch -- always taken
      float r = im.GetPixelValue(y, x, 0);
      float g = im.GetPixelValue(y, x, 1);
      float b = im.GetPixelValue(y, x, 2);                  // OOB if im has 2 channels
      float a = im.GetPixelValue(y, x, 3);                  // OOB if im has 2 channels
      ...
      blended.SetPixelValue(y, x, 0, out_r);
      blended.SetPixelValue(y, x, 1, out_g);                // OOB if blended has 1 channel
      blended.SetPixelValue(y, x, 2, out_b);                // OOB if blended has 1 channel
    }
  }
}
```

`PackedImage::pixels(y, x, c)` (`lib/extras/packed_image.h:45-48`) is an unchecked

```cpp
buf + y * stride + x * pixel_stride_ + c * bytes_per_channel_;
```

so reading `c = 2, 3` on a 2-channel image, and writing `c = 1, 2` on a 1-channel image, walks past the heap allocation at the last pixel of the last row.

## How to reproduce

For a 4×3 UINT8 grayscale+alpha input the offsets are deterministic:

- `im` (input, `num_channels = 2`): `pixels_size = ysize * xsize * num_channels * bpc = 3 * 4 * 2 * 1 = 24` bytes
- `blended` (output, created with the post-decrement format, `num_channels = 1`): `pixels_size = 3 * 4 * 1 * 1 = 12` bytes

At the last pixel `(y = 2, x = 3)` the RGBA branch executes:

| access | offset (`y*stride + x*pixel_stride + c*bpc`) | buffer size | result |
|---|---|---|---|
| `im.GetPixelValue(2, 3, 0)` | `2*8 + 3*2 + 0` = 22 | 24 | in bounds |
| `im.GetPixelValue(2, 3, 1)` | `2*8 + 3*2 + 1` = 23 | 24 | in bounds |
| `im.GetPixelValue(2, 3, 2)` | `2*8 + 3*2 + 2` = 24 | 24 | **OOB read** |
| `im.GetPixelValue(2, 3, 3)` | `2*8 + 3*2 + 3` = 25 | 24 | **OOB read** |
| `blended.SetPixelValue(2, 3, 0)` | `2*4 + 3*1 + 0` = 11 | 12 | in bounds |
| `blended.SetPixelValue(2, 3, 1)` | `2*4 + 3*1 + 1` = 12 | 12 | **OOB write** |
| `blended.SetPixelValue(2, 3, 2)` | `2*4 + 3*1 + 2` = 13 | 12 | **OOB write** |

Each access is the raw pointer arithmetic from `PackedImage::pixels()`, with no bounds check.

End-to-end trigger: any grayscale-with-alpha JXL file processed with the installed `djxl` tool:

```
djxl gray_alpha.jxl out.png --alpha_blend
```

`extras::AlphaBlend` is the function `djxl --alpha_blend` calls into, so this is reachable from the standard tool with a single file argument. Compiling `djxl` with `-fsanitize=address` and running on such a file surfaces a heap-buffer-overflow at the last pixel access in this loop.

## What the fix does

Capture the original channel count into a `const bool` *before* the decrement and branch on that. The gray+alpha and RGBA cases are dispatched on the input shape (`is_gray_alpha`) rather than on the already-mutated destination shape, so:

- a 2-channel input now takes the (previously dead) gray+alpha branch, which reads channels 0–1 from `im` and writes channel 0 to `blended` — all in bounds.
- a 4-channel input still takes the RGBA branch unchanged.

```diff
   if (format.num_channels != 2 && format.num_channels != 4) {
     return true;
   }
+  const bool is_gray_alpha = (format.num_channels == 2);
   --format.num_channels;
   JXL_ASSIGN_OR_RETURN(PackedImage blended,
                        PackedImage::Create(im.xsize, im.ysize, format));
   // TODO(szabadka) SIMDify this and make it work for float16.
   for (size_t y = 0; y < im.ysize; ++y) {
     for (size_t x = 0; x < im.xsize; ++x) {
-      if (format.num_channels == 2) {
+      if (is_gray_alpha) {
         float g = im.GetPixelValue(y, x, 0);
         float a = im.GetPixelValue(y, x, 1);
         float out = g * a + background[0] * (1 - a);
```

## Evidence

* Buggy code introduced in commit `a689a624` (Sept 2023, "Add options for alpha blending for djxl."), unchanged since.
* Bug present at current `main` (verified at `4279d483`).
* With the patch applied, the gray+alpha branch is taken for 2-channel input and the RGBA branch for 4-channel input, so the per-pixel access pattern matches the source/destination shapes in both cases — no access exceeds the allocated `pixels_size` for either buffer.
