### PR TITLE
Reject oversized gain map payloads before narrowing to uint32_t

### DIFF
--- a/lib/extras/gain_map.cc
+++ b/lib/extras/gain_map.cc
@@ -11,6 +11,7 @@
 #include <cstdint>
 #include <cstdlib>
 #include <cstring>
+#include <limits>
 
 #include "lib/jxl/base/byte_order.h"
 #include "lib/jxl/base/common.h"
@@ -215,12 +216,14 @@ JXL_BOOL JxlGainMapReadBundle(JxlGainMapBundle* map_bundle,
 
   // Calculate remaining bytes for gain map
   cursor = next_cursor;
-  // This calculation is guaranteed not to underflow because `cursor` is always
-  // updated to a position within or at the end of `input_buffer` (not beyond).
-  // Thus, subtracting `cursor` from `input_buffer_size` (the total size of the
-  // buffer) will always result in a non-negative integer representing the
-  // remaining buffer size.
-  map_bundle->gain_map_size = input_buffer_size - cursor;
+  // Compute remaining buffer size and ensure it fits into the public
+  // `uint32_t gain_map_size` field to avoid silent truncation on platforms
+  // where `size_t` is wider than 32 bits.
+  size_t remaining = input_buffer_size - cursor;
+  if (remaining > std::numeric_limits<uint32_t>::max()) {
+    return JXL_FALSE;
+  }
+  map_bundle->gain_map_size = static_cast<uint32_t>(remaining);
   SAFE_CURSOR_UPDATE(map_bundle->gain_map_size);
   map_bundle->gain_map = input_buffer + cursor;
 


### PR DESCRIPTION
## Summary

Reject remaining gain map payload sizes that cannot be represented in the public `uint32_t gain_map_size` field.

## Problem

`JxlGainMapReadBundle` computes the remaining payload length using `size_t` values and stores it directly into `gain_map_size`, which is a `uint32_t`.

On platforms where `size_t` is wider than 32 bits, oversized remaining payload lengths could be silently truncated during the narrowing conversion.

## Fix

Add an explicit bounds check before assigning the remaining payload size to `gain_map_size`.

If the remaining payload exceeds `UINT32_MAX`, return `JXL_FALSE` instead of truncating the value.

## Notes

* Preserves existing API and ABI behavior for valid inputs.
* Changes only the read path.
* No write-path or serialization logic changes.
* No behavioral impact for representable payload sizes.