### PR TITLE
Fix heap-buffer-overflow in DecodeImageAPNG: validate frameRaw.rows bounds before access

### DIFF
--- a/lib/extras/dec/apng.cc
+++ b/lib/extras/dec/apng.cc
@@ -886,6 +886,10 @@ Status DecodeImageAPNG(const Span<const uint8_t> bytes,
     size_t ysize = static_cast<size_t>(vp.ysize());
     JXL_ASSIGN_OR_RETURN(PackedImage image,
                          PackedImage::Create(xsize, ysize, format));
+    if (ctx.frameRaw.rows.size() < ysize) {
+      return JXL_FAILURE("APNG frame has fewer decoded rows (%zu) than expected height (%zu)",
+                         ctx.frameRaw.rows.size(), ysize);
+    }
     for (size_t y = 0; y < ysize; ++y) {
       // TODO(eustas): ensure multiplication is safe
       memcpy(static_cast<uint8_t*>(image.pixels()) + image.stride * y,


### PR DESCRIPTION
## Summary

Fixes a heap-buffer-overflow in `DecodeImageAPNG` (apng.cc:892) when a crafted APNG frame declares a viewport height larger than the number of decoded rows.

## Root Cause

```cpp
for (size_t y = 0; y < ysize; ++y) {
  memcpy(..., ctx.frameRaw.rows[y], bytes_per_pixel * xsize); // OOB if rows.size() < ysize
}
```

A malformed APNG can declare a `vp.ysize()` value greater than the number of rows actually decoded into `ctx.frameRaw.rows`. The loop then reads `rows[y]` past the end of the vector, resulting in a heap-buffer-overflow read of a stale pointer and subsequent use of that pointer as a memcpy source.

The TODO comment at that line even notes: `// TODO(eustas): ensure multiplication is safe`.

## Fix

Add an explicit bounds check before the loop:

```cpp
if (ctx.frameRaw.rows.size() < ysize) {
  return JXL_FAILURE("APNG frame has fewer decoded rows than expected height");
}
```

Fixes #4803.
