### PR TITLE
icc_codec: make DecodeVarInt return Status and report errors

### DIFF
--- a/lib/jxl/icc_codec.cc
+++ b/lib/jxl/icc_codec.cc
@@ -52,24 +52,41 @@ Status Shuffle(JxlMemoryManager* memory_manager, uint8_t* data, size_t size,
   return true;
 }
 
-// TODO(eustas): should be 20, or even 18, once DecodeVarInt is improved;
-//               currently DecodeVarInt does not signal the errors, and marks
-//               11 bytes as used even if only 10 are used (and 9 is enough for
-//               63-bit values).
-constexpr const size_t kPreambleSize = 22;  // enough for reading 2 VarInts
+// Two base-128 varints at up to 10 bytes each.
+constexpr size_t kPreambleSize = 20;
 
-uint64_t DecodeVarInt(const uint8_t* input, size_t inputSize, size_t* pos) {
-  size_t i;
+// Decodes a base-128 unsigned varint into *out, advancing *pos by the exact
+// number of bytes consumed. Returns an error if the input is truncated, if
+// the terminator (top-bit-clear byte) is not seen within 10 bytes, or if the
+// 10th byte encodes a value that does not fit in a uint64_t.
+Status DecodeVarInt(const uint8_t* input, size_t inputSize, size_t* pos,
+                    uint64_t* out) {
   uint64_t ret = 0;
-  for (i = 0; *pos + i < inputSize && i < 10; ++i) {
-    ret |= static_cast<uint64_t>(input[*pos + i] & 127)
-           << static_cast<uint64_t>(7 * i);
-    // If the next-byte flag is not set, stop
-    if ((input[*pos + i] & 128) == 0) break;
+  // 9 bytes cover bits 0..62; the 10th byte may only contribute bit 63.
+  for (size_t i = 0; i < 9; ++i) {
+    if (*pos >= inputSize) {
+      return JXL_FAILURE("DecodeVarInt: truncated input");
+    }
+    const uint8_t byte = input[(*pos)++];
+    ret |= static_cast<uint64_t>(byte & 0x7F) << (7 * i);
+    if ((byte & 0x80) == 0) {
+      *out = ret;
+      return true;
+    }
   }
-  // TODO(user): Return a decoding error if i == 10.
-  *pos += i + 1;
-  return ret;
+  if (*pos >= inputSize) {
+    return JXL_FAILURE("DecodeVarInt: truncated input (10th byte)");
+  }
+  const uint8_t byte = input[(*pos)++];
+  if ((byte & 0x80) != 0) {
+    return JXL_FAILURE("DecodeVarInt: varint exceeds 10 bytes");
+  }
+  if ((byte & 0x7E) != 0) {
+    return JXL_FAILURE("DecodeVarInt: value exceeds 2^64 - 1");
+  }
+  ret |= static_cast<uint64_t>(byte & 0x01) << 63;
+  *out = ret;
+  return true;
 }
 
 }  // namespace
@@ -80,10 +97,11 @@ Status CheckPreamble(const PaddedBytes& data, size_t enc_size) {
   const uint8_t* enc = data.data();
   size_t size = data.size();
   size_t pos = 0;
-  uint64_t osize = DecodeVarInt(enc, size, &pos);
+  uint64_t osize;
+  JXL_RETURN_IF_ERROR(DecodeVarInt(enc, size, &pos, &osize));
   JXL_RETURN_IF_ERROR(CheckIs32Bit(osize));
-  if (pos >= size) return JXL_FAILURE("Out of bounds");
-  uint64_t csize = DecodeVarInt(enc, size, &pos);
+  uint64_t csize;
+  JXL_RETURN_IF_ERROR(DecodeVarInt(enc, size, &pos, &csize));
   JXL_RETURN_IF_ERROR(CheckIs32Bit(csize));
   JXL_RETURN_IF_ERROR(CheckOutOfBounds(pos, csize, size));
   // We expect that UnpredictICC inflates input, not the other way round.
@@ -102,17 +120,12 @@ Status UnpredictICC(const uint8_t* enc, size_t size, PaddedBytes* result) {
   if (!result->empty()) return JXL_FAILURE("result must be empty initially");
   JxlMemoryManager* memory_manager = result->memory_manager();
   size_t pos = 0;
-  // TODO(lode): technically speaking we need to check that the entire varint
-  // decoding never goes out of bounds, not just the first byte. This requires
-  // a DecodeVarInt function that returns an error code. It is safe to use
-  // DecodeVarInt with out of bounds values, it silently returns, but the
-  // specification requires an error. Idem for all DecodeVarInt below.
-  if (pos >= size) return JXL_FAILURE("Out of bounds");
-  uint64_t osize = DecodeVarInt(enc, size, &pos);  // Output size
+  uint64_t osize;
+  JXL_RETURN_IF_ERROR(DecodeVarInt(enc, size, &pos, &osize));  // Output size
   JXL_RETURN_IF_ERROR(CheckIs32Bit(osize));
-  if (pos >= size) return JXL_FAILURE("Out of bounds");
-  uint64_t csize = DecodeVarInt(enc, size, &pos);  // Commands size
-  // Every command is translated to at least on byte.
+  uint64_t csize;
+  JXL_RETURN_IF_ERROR(DecodeVarInt(enc, size, &pos, &csize));  // Commands size
+  // Every command is translated to at least one byte.
   JXL_RETURN_IF_ERROR(CheckIs32Bit(csize));
   size_t cpos = pos;  // pos in commands stream
   JXL_RETURN_IF_ERROR(CheckOutOfBounds(pos, csize, size));
@@ -136,7 +149,8 @@ Status UnpredictICC(const uint8_t* enc, size_t size, PaddedBytes* result) {
   if (cpos >= commands_end) return JXL_FAILURE("Out of bounds");
 
   // Tag list
-  uint64_t numtags = DecodeVarInt(enc, size, &cpos);
+  uint64_t numtags;
+  JXL_RETURN_IF_ERROR(DecodeVarInt(enc, commands_end, &cpos, &numtags));
 
   if (numtags != 0) {
     numtags--;
@@ -178,8 +192,7 @@ Status UnpredictICC(const uint8_t* enc, size_t size, PaddedBytes* result) {
       }
 
       if (command & kFlagBitOffset) {
-        if (cpos >= commands_end) return JXL_FAILURE("Out of bounds");
-        tagstart = DecodeVarInt(enc, size, &cpos);
+        JXL_RETURN_IF_ERROR(DecodeVarInt(enc, commands_end, &cpos, &tagstart));
       } else {
         JXL_RETURN_IF_ERROR(CheckIs32Bit(prevtagstart));
         tagstart = prevtagstart + prevtagsize;
@@ -187,8 +200,7 @@ Status UnpredictICC(const uint8_t* enc, size_t size, PaddedBytes* result) {
       JXL_RETURN_IF_ERROR(CheckIs32Bit(tagstart));
       JXL_RETURN_IF_ERROR(AppendUint32(tagstart, result));
       if (command & kFlagBitSize) {
-        if (cpos >= commands_end) return JXL_FAILURE("Out of bounds");
-        tagsize = DecodeVarInt(enc, size, &cpos);
+        JXL_RETURN_IF_ERROR(DecodeVarInt(enc, commands_end, &cpos, &tagsize));
       }
       JXL_RETURN_IF_ERROR(CheckIs32Bit(tagsize));
       JXL_RETURN_IF_ERROR(AppendUint32(tagsize, result));
@@ -223,15 +235,15 @@ Status UnpredictICC(const uint8_t* enc, size_t size, PaddedBytes* result) {
     if (cpos == commands_end) break;  // Valid end
     uint8_t command = enc[cpos++];
     if (command == kCommandInsert) {
-      if (cpos >= commands_end) return JXL_FAILURE("Out of bounds");
-      uint64_t num = DecodeVarInt(enc, size, &cpos);
+      uint64_t num;
+      JXL_RETURN_IF_ERROR(DecodeVarInt(enc, commands_end, &cpos, &num));
       JXL_RETURN_IF_ERROR(CheckOutOfBounds(pos, num, size));
       for (size_t i = 0; i < num; i++) {
         JXL_RETURN_IF_ERROR(result->push_back(enc[pos++]));
       }
     } else if (command == kCommandShuffle2 || command == kCommandShuffle4) {
-      if (cpos >= commands_end) return JXL_FAILURE("Out of bounds");
-      uint64_t num = DecodeVarInt(enc, size, &cpos);
+      uint64_t num;
+      JXL_RETURN_IF_ERROR(DecodeVarInt(enc, commands_end, &cpos, &num));
       JXL_RETURN_IF_ERROR(CheckOutOfBounds(pos, num, size));
       PaddedBytes shuffled(memory_manager);
       JXL_ASSIGN_OR_RETURN(shuffled,
@@ -260,8 +272,7 @@ Status UnpredictICC(const uint8_t* enc, size_t size, PaddedBytes* result) {
 
       uint64_t stride = width;
       if (flags & 16) {
-        if (cpos >= commands_end) return JXL_FAILURE("Out of bounds");
-        stride = DecodeVarInt(enc, size, &cpos);
+        JXL_RETURN_IF_ERROR(DecodeVarInt(enc, commands_end, &cpos, &stride));
         if (stride < width) {
           return JXL_FAILURE("Invalid stride");
         }
@@ -275,8 +286,8 @@ Status UnpredictICC(const uint8_t* enc, size_t size, PaddedBytes* result) {
         return JXL_FAILURE("Invalid stride");
       }
 
-      if (cpos >= commands_end) return JXL_FAILURE("Out of bounds");
-      uint64_t num = DecodeVarInt(enc, size, &cpos);  // in bytes
+      uint64_t num;
+      JXL_RETURN_IF_ERROR(DecodeVarInt(enc, commands_end, &cpos, &num));  // in bytes
       JXL_RETURN_IF_ERROR(CheckOutOfBounds(pos, num, size));
 
       PaddedBytes shuffled(memory_manager);


### PR DESCRIPTION
## Summary

`DecodeVarInt()` at `lib/jxl/icc_codec.cc:61` silently mishandles three input conditions that the file's own TODOs have flagged for several releases:

- `lib/jxl/icc_codec.cc:55-58` — "DecodeVarInt does not signal the errors, and marks 11 bytes as used even if only 10 are used"
- `lib/jxl/icc_codec.cc:137-141` (pre-patch) — "we need to check that the entire varint decoding never goes out of bounds, not just the first byte. This requires a DecodeVarInt function that returns an error code"

The bugs are:

1. **Mid-varint truncation.** When the input ends before the terminator byte, the function returns a partially-decoded value with no error indication. The `if (pos >= size)` guard each caller inserts only covers the first byte of a multi-byte varint.
2. **Position over-advance.** When the loop exits via the `i < 10` condition (i.e. 10 continuation bytes were seen), `*pos += i + 1` advances 11 bytes for a 10-byte varint, desyncing every later read in the same stream.
3. **Silent overflow.** A 10th byte whose bits 1..6 are set encodes a value above 2^63 - 1; the previous code drops those bits and returns a value that does not match the encoded varint.

Each of these is exercisable from attacker-controlled bytes via the ICC profile decoding path: bug (1) lets a crafted stream make `CheckOutOfBounds(pos, csize, size)` operate on a garbage `pos`; bug (2) lets the same stream shift every subsequent varint by one byte; bug (3) lets the stream return a value that no longer matches its encoding.

## Change

`DecodeVarInt` is replaced with a `Status`-returning variant that:

- reads at most 9 bytes for the 0..62-bit range and an optional 10th byte for bit 63 only;
- returns `JXL_FAILURE` on truncation, on an unterminated 10-byte sequence, and on a 10th-byte value that would overflow `uint64_t`;
- advances `*pos` by exactly the number of bytes consumed.

All 11 call sites in `icc_codec.cc` are migrated to propagate the `Status` via `JXL_RETURN_IF_ERROR`. The per-call `if (pos >= size)` and `if (cpos >= commands_end)` guards in front of each varint read are removed because the helper now reports those conditions itself.

`kPreambleSize` drops from 22 to 20 to match the new maximum of two 10-byte varints, addressing the explicit value in the `TODO(eustas)` at line 55.

## Diff

```
 lib/jxl/icc_codec.cc | 95 +++++++++++++++++++++++++++++-----------------------
 1 file changed, 53 insertions(+), 42 deletions(-)
```

11 call sites changed:

- `CheckPreamble` (lines 115, 118 pre-patch)
- `UnpredictICC` (lines 143, 146, 171, 214, 223, 259, 266, 296, 311 pre-patch)

## Behavioural compatibility

Every legitimate varint produced by a conforming encoder fits in ≤ 10 bytes and ends with a terminator within bounds, so the helper takes the same fast-path and returns the same value for all valid input. Malformed input (truncated, oversize, or `> 2^64`-encoded varints) now returns `JXL_FAILURE` instead of silently returning garbage.

## Build

```
cmake --build build --target jxl_dec
```

succeeds locally on macOS/arm64 (Debug, `-DJPEGXL_ENABLE_BENCHMARK=OFF -DBUILD_TESTING=OFF` …). No new warnings; the pre-existing `-Wframe-larger-than` warnings in `dec_jpeg_data_writer.cc` are unrelated.

## Dedup

`gh pr list --search "DecodeVarInt OR icc_codec.cc"` shows no in-flight PR touching this code path on `main` as of the date of submission.