### PR TITLE
Fix silent LZ77 length overflow handling in ANSSymbolReader

### DIFF
--- a/lib/jxl/dec_ans.h
+++ b/lib/jxl/dec_ans.h
@@ -326,8 +326,16 @@ class ANSSymbolReader {
           size_t to_fill = std::min<size_t>(num_to_copy_, kWindowSize);
           memset(lz77_window_, 0, to_fill * sizeof(lz77_window_[0]));
         }
-        // TODO(eustas): overflow; mark BitReader as unhealthy
-        if (num_to_copy_ < lz77_min_length_) return 0;
+        if (JXL_UNLIKELY(num_to_copy_ < lz77_min_length_)) {
+          // num_to_copy_ = ReadHybridUintConfig(...) + lz77_min_length_ above
+          // wrapped (lz77_min_length_ added to a value near SIZE_MAX). Stop
+          // accepting further data so the corruption surfaces at the next
+          // AllReadsWithinBounds() / Close() check instead of letting the
+          // decoder keep producing phantom symbols from the LZ77 window.
+          num_to_copy_ = 0;
+          br->MarkUnhealthy();
+          return 0;
+        }
         // the code below is the same as doing this:
         //        return ReadHybridUintClustered<uses_lz77>(ctx, br);
         // but gcc doesn't like recursive inlining

--- a/lib/jxl/dec_bit_reader.h
+++ b/lib/jxl/dec_bit_reader.h
@@ -219,6 +219,19 @@ class BitReader {
     return static_cast<size_t>(end_minus_8_ + 8 - first_byte_);
   }
 
+  // Forces the BitReader into an out-of-bounds state. Used by higher-level
+  // decoders to short-circuit further reads when they detect a corrupt stream
+  // (e.g. an LZ77 length-code overflow): after this call, subsequent reads
+  // still return zeros, but AllReadsWithinBounds() and Close() will report
+  // failure so the corruption surfaces at the next checkpoint rather than
+  // silently producing phantom-zero symbols.
+  void MarkUnhealthy() {
+    next_byte_ = end_minus_8_ + 8;
+    // Add enough overread to make TotalBitsConsumed() exceed TotalBytes() *
+    // kBitsPerByte regardless of how many bits remain in buf_.
+    overread_bytes_ += 8;
+  }
+
   // Returns whether all the bits read so far have been within the input bounds.
   // When reading past the EOF, the Read*() and Consume() functions return zeros
   // but flag a failure when calling Close() without checking this function.


### PR DESCRIPTION
Fixes an integer overflow path in `ANSSymbolReader` where:

```cpp
num_to_copy_ = ReadHybridUintConfig(...) + lz77_min_length_;
```

could wrap around `SIZE_MAX`.

Previously, the decoder detected the wrap via:

```cpp
if (num_to_copy_ < lz77_min_length_) return 0;
```

but only returned early without invalidating the `BitReader` state. Since `BitReader` continues returning zero-filled data after corruption/out-of-bounds conditions, decoding could continue producing phantom symbols from the LZ77 window instead of surfacing a hard failure.

## Changes

- Detect wrapped `num_to_copy_` values
- Reset `num_to_copy_` to prevent stale window emission
- Add `BitReader::MarkUnhealthy()`
- Force subsequent `AllReadsWithinBounds()` / `Close()` validation failure after corruption is detected

## Result

Corrupt streams that trigger the LZ77 length overflow path now reliably transition the decoder into a failed state instead of silently continuing decode with synthesized output.
