### PR TITLE
Optimize release artifacts

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -64,6 +64,7 @@ jobs:
           libopenexr-dev \
           libpng-dev \
           libwebp-dev \
+          lzip \
           ninja-build \
           pkg-config \
           xdg-utils \

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -64,9 +64,9 @@ jobs:
           libopenexr-dev \
           libpng-dev \
           libwebp-dev \
-          tarlz \
           ninja-build \
           pkg-config \
+          tarlz \
           xdg-utils \
         #
         echo "CC=clang" >> $GITHUB_ENV
@@ -94,7 +94,7 @@ jobs:
       run: |
         ROOT=`pwd`
         cd build
-        tarlz -9cvf ${ROOT}/jxl-linux-x86_64-static.tar.lz -I \
+        tarlz -9cvf ${ROOT}/jxl-linux-x86_64-static.tar.lz \
           LICENSE* tools/{cjxl,djxl,benchmark_xl,jxlinfo,butteraugli_main,ssimulacra2}
 
     - name: Upload release tarball

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -216,13 +216,13 @@ jobs:
       run: |
         ROOT=`pwd`
         cd build/debs/
-        tar -Jcvf ${ROOT}/jxl-debs-amd64-${{ env.ARTIFACT_SUFFIX }}.tar.xz *jxl*.*
+        tar -cvf ${ROOT}/jxl-debs-amd64-${{ env.ARTIFACT_SUFFIX }}.tar *jxl*.*
 
     - name: Upload release tarball
       uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       with:
         name: jxl-debs-amd64-${{ env.ARTIFACT_SUFFIX }}
-        path: jxl-debs-amd64-${{ env.ARTIFACT_SUFFIX }}.tar.xz
+        path: jxl-debs-amd64-${{ env.ARTIFACT_SUFFIX }}.tar
         archive: false
 
 

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -64,7 +64,7 @@ jobs:
           libopenexr-dev \
           libpng-dev \
           libwebp-dev \
-          lzip \
+          tarlz \
           ninja-build \
           pkg-config \
           xdg-utils \
@@ -94,7 +94,7 @@ jobs:
       run: |
         ROOT=`pwd`
         cd build
-        tar -cvf ${ROOT}/jxl-linux-x86_64-static.tar.lz -I 'lzip -9' \
+        tarlz -9cvf ${ROOT}/jxl-linux-x86_64-static.tar.lz -I \
           LICENSE* tools/{cjxl,djxl,benchmark_xl,jxlinfo,butteraugli_main,ssimulacra2}
 
     - name: Upload release tarball

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -362,7 +362,7 @@ jobs:
       shell: 'bash'
       if: matrix.upload != 'OFF'
       run: |
-        7z -mx=9 -mfb=273 -mmt=1 a jxl-${{matrix.triplet}}.7z ${PREFIX}/bin ${PREFIX}/include ${PREFIX}/lib ${PREFIX}/licenses
+        7z -mx=9 -mfb=273 a jxl-${{matrix.triplet}}.7z ${PREFIX}/bin ${PREFIX}/include ${PREFIX}/lib ${PREFIX}/licenses
         7z -mm=Deflate64 -mfb=257 -mpass=15 -mtp=2 a jxl-${{matrix.triplet}}.zip ${PREFIX}/bin ${PREFIX}/include ${PREFIX}/lib ${PREFIX}/licenses
 
     - name: Upload ZIP release 

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -93,7 +93,7 @@ jobs:
       run: |
         ROOT=`pwd`
         cd build
-        tar -Jcvf ${ROOT}/jxl-linux-x86_64-static.tar.gz \
+        tar -Jcvf ${ROOT}/jxl-linux-x86_64-static.tar.xz \
           LICENSE* tools/{cjxl,djxl,benchmark_xl,jxlinfo,butteraugli_main,ssimulacra2}
 
     - name: Upload release tarball
@@ -216,7 +216,7 @@ jobs:
       run: |
         ROOT=`pwd`
         cd build/debs/
-        tar -Jcvf ${ROOT}/jxl-debs-amd64-${{ env.ARTIFACT_SUFFIX }}.tar.gz *jxl*.*
+        tar -Jcvf ${ROOT}/jxl-debs-amd64-${{ env.ARTIFACT_SUFFIX }}.tar.xz *jxl*.*
 
     - name: Upload release tarball
       uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -93,14 +93,14 @@ jobs:
       run: |
         ROOT=`pwd`
         cd build
-        tar -zcvf ${ROOT}/jxl-linux-x86_64-static.tar.gz \
+        tar -Jcvf ${ROOT}/jxl-linux-x86_64-static.tar.gz \
           LICENSE* tools/{cjxl,djxl,benchmark_xl,jxlinfo,butteraugli_main,ssimulacra2}
 
     - name: Upload release tarball
       uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       with:
         name: jxl-linux-x86_64-static
-        path: jxl-linux-x86_64-static.tar.gz
+        path: jxl-linux-x86_64-static.tar.xz
         archive: false
 
 
@@ -216,13 +216,13 @@ jobs:
       run: |
         ROOT=`pwd`
         cd build/debs/
-        tar -zcvf ${ROOT}/jxl-debs-amd64-${{ env.ARTIFACT_SUFFIX }}.tar.gz *jxl*.*
+        tar -Jcvf ${ROOT}/jxl-debs-amd64-${{ env.ARTIFACT_SUFFIX }}.tar.gz *jxl*.*
 
     - name: Upload release tarball
       uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       with:
         name: jxl-debs-amd64-${{ env.ARTIFACT_SUFFIX }}
-        path: jxl-debs-amd64-${{ env.ARTIFACT_SUFFIX }}.tar.gz
+        path: jxl-debs-amd64-${{ env.ARTIFACT_SUFFIX }}.tar.xz
         archive: false
 
 
@@ -362,7 +362,7 @@ jobs:
       if: matrix.upload != 'OFF'
       run: |
         7z -mx=9 -mfb=273 -mmt=1 -ms=on a jxl-${{matrix.triplet}}.7z ${PREFIX}/bin ${PREFIX}/include ${PREFIX}/lib ${PREFIX}/licenses
-        7z -mx=9 a jxl-${{matrix.triplet}}.zip ${PREFIX}/bin ${PREFIX}/include ${PREFIX}/lib ${PREFIX}/licenses
+        7z -mm=Deflate64 -mx=9 -mfb=257 -mpass=12 a jxl-${{matrix.triplet}}.zip ${PREFIX}/bin ${PREFIX}/include ${PREFIX}/lib ${PREFIX}/licenses
 
     - name: Upload ZIP release 
       if: matrix.upload != 'OFF'

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -93,14 +93,14 @@ jobs:
       run: |
         ROOT=`pwd`
         cd build
-        tar -Jcvf ${ROOT}/jxl-linux-x86_64-static.tar.xz \
+        tar -cvf ${ROOT}/jxl-linux-x86_64-static.tar.lz -I 'lzip -9' \
           LICENSE* tools/{cjxl,djxl,benchmark_xl,jxlinfo,butteraugli_main,ssimulacra2}
 
     - name: Upload release tarball
       uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       with:
         name: jxl-linux-x86_64-static
-        path: jxl-linux-x86_64-static.tar.xz
+        path: jxl-linux-x86_64-static.tar.lz
         archive: false
 
 

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -362,8 +362,8 @@ jobs:
       shell: 'bash'
       if: matrix.upload != 'OFF'
       run: |
-        7z -mx=9 -mfb=273 -mmt=1 -ms=on a jxl-${{matrix.triplet}}.7z ${PREFIX}/bin ${PREFIX}/include ${PREFIX}/lib ${PREFIX}/licenses
-        7z -mm=Deflate64 -mx=9 -mfb=257 -mpass=12 a jxl-${{matrix.triplet}}.zip ${PREFIX}/bin ${PREFIX}/include ${PREFIX}/lib ${PREFIX}/licenses
+        7z -mx=9 -mfb=273 -mmt=1 a jxl-${{matrix.triplet}}.7z ${PREFIX}/bin ${PREFIX}/include ${PREFIX}/lib ${PREFIX}/licenses
+        7z -mm=Deflate64 -mfb=257 -mpass=15 -mtp=2 a jxl-${{matrix.triplet}}.zip ${PREFIX}/bin ${PREFIX}/include ${PREFIX}/lib ${PREFIX}/licenses
 
     - name: Upload ZIP release 
       if: matrix.upload != 'OFF'


### PR DESCRIPTION
Done with the help of @goodusername123. 
 - The .deb packages themselves are already xz compressed, so using gzip is redundant and unnecessary. A simple tar works here with no significant file size increase.
 - The Linux static builds now use lzip instead of gzip which results in a major file size reduction from 13 MB to 3.84 MB.
 - The Windows builds are slightly smaller, using more aggressive zip compression and Deflate64 instead of Deflate. The Windows static zips went from 39.6 MB to 38.5 MB.
 - Removed `-ms`, 7z is already solid by default.
 - Removed `-mmt=1` so 7z is no longer constrained to 1 thread, allowing it to compress faster.
 - Added `-mtp=2` for Windows zips, we don't need 100 ns precision for file timestamps.

The rationale to use Deflate64 is that it has been supported natively since Windows Vista. Likewise, lzip has been supported in GNU tar utility since 2010.