### PR TITLE
Add custom Opsin Inverse Matrix (XYB Color Bias tuning)

### DIFF
--- a/lib/include/jxl/encode.h
+++ b/lib/include/jxl/encode.h
@@ -424,6 +424,14 @@ typedef enum {
    */
   JXL_ENC_FRAME_SETTING_YELLOW_BIAS = 42,
 
+  /** Set the red multiplier for the L-cone to tune the red bias (e.g. 0.85).
+   * Range [0, 1]. */
+  JXL_ENC_FRAME_SETTING_RED_BIAS = 42,
+
+  /** Set the green multiplier for the M-cone to tune the green bias (e.g. 0.85).
+   * Range [0, 1]. */
+  JXL_ENC_FRAME_SETTING_GREEN_BIAS = 43,
+
   /** Enum value not to be used as an option. This value is added to force the
    * C compiler to have the enum to take a known size.
    */

--- a/lib/include/jxl/encode.h
+++ b/lib/include/jxl/encode.h
@@ -416,6 +416,13 @@ typedef enum {
    *     for the first frame (the ftyp version cannot be changed once written).
    */
   JXL_ENC_FRAME_SETTING_OUTPUT_MODE = 40,
+  /** Isolate the S-cone in the XYB transform. 0 = disabled (default), 1 = enabled.
+   */
+  JXL_ENC_FRAME_SETTING_ISOLATE_S_CONE = 41,
+
+  /** Tune the blue multiplier for the S-cone. -1.0 means disable (default).
+   */
+  JXL_ENC_FRAME_SETTING_YELLOW_BIAS = 42,
 
   /** Enum value not to be used as an option. This value is added to force the
    * C compiler to have the enum to take a known size.

--- a/lib/include/jxl/encode.h
+++ b/lib/include/jxl/encode.h
@@ -419,24 +419,30 @@ typedef enum {
   /** Isolate the S-cone in the XYB transform. 0 = disabled (default), 1 = enabled.
    */
   JXL_ENC_FRAME_SETTING_ISOLATE_S_CONE = 41,
-
-  /** Tune the blue multiplier for the S-cone. -1.0 means disable (default).
+  /** Dynamically scale yellow bias based on butteraugli distance to boost color
+   * accuracy. Scales from distance 0.3 and maxes out at 3.0. 0 = disabled
+   * (default), 1 = enabled. Note: For multi-frame animations, the scaling
+   * multiplier is calculated based on the first frame's distance and applied
+   * globally to the entire sequence.
    */
-  JXL_ENC_FRAME_SETTING_YELLOW_BIAS = 42,
+  JXL_ENC_FRAME_SETTING_COLOR_BOOST = 42,
+
+  /** Tune the yellow multiplier for the S-cone. -1.0 means disable (default).
+   */
+  JXL_ENC_FRAME_SETTING_YELLOW_BIAS = 43,
 
   /** Set the red multiplier for the L-cone to tune the red bias (e.g. 0.85).
    * Range [0, 1]. */
-  JXL_ENC_FRAME_SETTING_RED_BIAS = 42,
+  JXL_ENC_FRAME_SETTING_RED_BIAS = 44,
 
-  /** Set the green multiplier for the M-cone to tune the green bias (e.g. 0.85).
-   * Range [0, 1]. */
-  JXL_ENC_FRAME_SETTING_GREEN_BIAS = 43,
+  /** Set the green multiplier for the M-cone to tune the green bias (e.g.
+   * 0.85). Range [0, 1]. */
+  JXL_ENC_FRAME_SETTING_GREEN_BIAS = 45,
 
   /** Enum value not to be used as an option. This value is added to force the
    * C compiler to have the enum to take a known size.
    */
   JXL_ENC_FRAME_SETTING_FILL_ENUM = 65535,
-
 } JxlEncoderFrameSettingId;
 
 /**

--- a/lib/include/jxl/encode.h
+++ b/lib/include/jxl/encode.h
@@ -416,28 +416,29 @@ typedef enum {
    *     for the first frame (the ftyp version cannot be changed once written).
    */
   JXL_ENC_FRAME_SETTING_OUTPUT_MODE = 40,
-  /** Isolate the S-cone in the XYB transform. 0 = disabled (default), 1 = enabled.
-   */
-  JXL_ENC_FRAME_SETTING_ISOLATE_S_CONE = 41,
+
   /** Dynamically scale yellow bias based on butteraugli distance to boost color
    * accuracy. Scales from distance 0.3 and maxes out at 3.0. 0 = disabled
    * (default), 1 = enabled. Note: For multi-frame animations, the scaling
    * multiplier is calculated based on the first frame's distance and applied
    * globally to the entire sequence.
    */
-  JXL_ENC_FRAME_SETTING_COLOR_BOOST = 42,
+  JXL_ENC_FRAME_SETTING_COLOR_BOOST = 41,
 
-  /** Tune the yellow multiplier for the S-cone. -1.0 means disable (default).
+  /** Sets the yellow multiplier for the S-cone (e.g. 0.85). Range [0, 1]. -1.0
+   * means disable (default).
    */
-  JXL_ENC_FRAME_SETTING_YELLOW_BIAS = 43,
+  JXL_ENC_FRAME_SETTING_YELLOW_BIAS = 42,
 
-  /** Set the red multiplier for the L-cone to tune the red bias (e.g. 0.85).
-   * Range [0, 1]. */
-  JXL_ENC_FRAME_SETTING_RED_BIAS = 44,
+  /** Sets the red multiplier for the L-cone (e.g. 0.85). Range [0, 1]. -1.0
+   * means disable (default).
+   */
+  JXL_ENC_FRAME_SETTING_RED_BIAS = 43,
 
-  /** Set the green multiplier for the M-cone to tune the green bias (e.g.
-   * 0.85). Range [0, 1]. */
-  JXL_ENC_FRAME_SETTING_GREEN_BIAS = 45,
+  /** Sets the green multiplier for the M-cone (e.g. 0.85). Range [0, 1]. -1.0
+   * means disable (default).
+   */
+  JXL_ENC_FRAME_SETTING_GREEN_BIAS = 44,
 
   /** Enum value not to be used as an option. This value is added to force the
    * C compiler to have the enum to take a known size.

--- a/lib/jxl/enc_frame.cc
+++ b/lib/jxl/enc_frame.cc
@@ -1606,8 +1606,28 @@ Status ComputeEncodingData(
                                              patch_rect.ysize()));
         linear = &linear_storage;
       }
+
+      const float* custom_opsin_ptr = nullptr;
+      float custom_opsin[9] = {
+        0.30f, 0.622f, 0.078f,
+        0.23f, 0.692f, 0.078f,
+        0.243f, 0.205f, 0.552f
+      };
+      if (cparams.isolate_s_cone || cparams.yellow_bias >= 0.0f) {
+        if (cparams.isolate_s_cone) {
+          custom_opsin[6] = 0.0f; custom_opsin[7] = 0.0f; custom_opsin[8] = 1.0f;
+        } else {
+          float b = cparams.yellow_bias;
+          float r_ratio = 0.243f / (0.243f + 0.205f);
+          custom_opsin[8] = b;
+          custom_opsin[6] = r_ratio * (1.0f - b);
+          custom_opsin[7] = (1.0f - r_ratio) * (1.0f - b);
+        }
+        custom_opsin_ptr = custom_opsin;
+      }
+
       JXL_RETURN_IF_ERROR(ToXYB(c_enc, metadata->m.IntensityTarget(), black,
-                                pool, &color, cms, linear));
+                                pool, &color, cms, linear, custom_opsin_ptr));
     } else {
       // Nothing to do.
       // RGB or YCbCr: forward YCbCr is not implemented, this is only used

--- a/lib/jxl/enc_frame.cc
+++ b/lib/jxl/enc_frame.cc
@@ -1614,10 +1614,24 @@ Status ComputeEncodingData(
         jxl::cms::kM10, jxl::cms::kM11, jxl::cms::kM12,
         jxl::cms::kM20, jxl::cms::kM21, jxl::cms::kM22
       };
-      if (cparams.isolate_s_cone || cparams.yellow_bias >= 0.0f) {
+      if (cparams.red_bias >= 0.0f || cparams.green_bias >= 0.0f || cparams.isolate_s_cone || cparams.yellow_bias >= 0.0f) {
+        if (cparams.red_bias >= 0.0f) {
+          float r = cparams.red_bias;
+          float g_ratio = jxl::cms::kM01 / (jxl::cms::kM01 + jxl::cms::kM02);
+          custom_opsin[0] = r;
+          custom_opsin[1] = g_ratio * (1.0f - r);
+          custom_opsin[2] = (1.0f - g_ratio) * (1.0f - r);
+        }
+        if (cparams.green_bias >= 0.0f) {
+          float g = cparams.green_bias;
+          float r_ratio = jxl::cms::kM10 / (jxl::cms::kM10 + jxl::cms::kM12);
+          custom_opsin[4] = g;
+          custom_opsin[3] = r_ratio * (1.0f - g);
+          custom_opsin[5] = (1.0f - r_ratio) * (1.0f - g);
+        }
         if (cparams.isolate_s_cone) {
           custom_opsin[6] = 0.0f; custom_opsin[7] = 0.0f; custom_opsin[8] = 1.0f;
-        } else {
+        } else if (cparams.yellow_bias >= 0.0f) {
           float b = cparams.yellow_bias;
           float r_ratio = jxl::cms::kM20 / (jxl::cms::kM20 + jxl::cms::kM21);
           custom_opsin[8] = b;

--- a/lib/jxl/enc_frame.cc
+++ b/lib/jxl/enc_frame.cc
@@ -32,8 +32,8 @@
 #include "lib/jxl/base/rect.h"
 #include "lib/jxl/base/span.h"
 #include "lib/jxl/base/status.h"
-#include "lib/jxl/cms/opsin_params.h"
 #include "lib/jxl/chroma_from_luma.h"
+#include "lib/jxl/cms/opsin_params.h"
 #include "lib/jxl/coeff_order.h"
 #include "lib/jxl/coeff_order_fwd.h"
 #include "lib/jxl/color_encoding_internal.h"
@@ -1609,34 +1609,15 @@ Status ComputeEncodingData(
       }
 
       const float* custom_opsin_ptr = nullptr;
-      float custom_opsin[9] = {
-        jxl::cms::kM00, jxl::cms::kM01, jxl::cms::kM02,
-        jxl::cms::kM10, jxl::cms::kM11, jxl::cms::kM12,
-        jxl::cms::kM20, jxl::cms::kM21, jxl::cms::kM22
-      };
-      if (cparams.red_bias >= 0.0f || cparams.green_bias >= 0.0f || cparams.isolate_s_cone || cparams.yellow_bias >= 0.0f) {
-        if (cparams.red_bias >= 0.0f) {
-          float r = cparams.red_bias;
-          float g_ratio = jxl::cms::kM01 / (jxl::cms::kM01 + jxl::cms::kM02);
-          custom_opsin[0] = r;
-          custom_opsin[1] = g_ratio * (1.0f - r);
-          custom_opsin[2] = (1.0f - g_ratio) * (1.0f - r);
-        }
-        if (cparams.green_bias >= 0.0f) {
-          float g = cparams.green_bias;
-          float r_ratio = jxl::cms::kM10 / (jxl::cms::kM10 + jxl::cms::kM12);
-          custom_opsin[4] = g;
-          custom_opsin[3] = r_ratio * (1.0f - g);
-          custom_opsin[5] = (1.0f - r_ratio) * (1.0f - g);
-        }
-        if (cparams.isolate_s_cone) {
-          custom_opsin[6] = 0.0f; custom_opsin[7] = 0.0f; custom_opsin[8] = 1.0f;
-        } else if (cparams.yellow_bias >= 0.0f) {
-          float b = cparams.yellow_bias;
-          float r_ratio = jxl::cms::kM20 / (jxl::cms::kM20 + jxl::cms::kM21);
-          custom_opsin[8] = b;
-          custom_opsin[6] = r_ratio * (1.0f - b);
-          custom_opsin[7] = (1.0f - r_ratio) * (1.0f - b);
+      float custom_opsin[9];
+      if (!metadata->transform_data.opsin_inverse_matrix.all_default) {
+        jxl::Matrix3x3 forward_matrix =
+            metadata->transform_data.opsin_inverse_matrix.inverse_matrix;
+        JXL_RETURN_IF_ERROR(jxl::Inv3x3Matrix(forward_matrix));
+        for (int i = 0; i < 3; i++) {
+          for (int j = 0; j < 3; j++) {
+            custom_opsin[i * 3 + j] = forward_matrix[i][j];
+          }
         }
         custom_opsin_ptr = custom_opsin;
       }

--- a/lib/jxl/enc_frame.cc
+++ b/lib/jxl/enc_frame.cc
@@ -32,6 +32,7 @@
 #include "lib/jxl/base/rect.h"
 #include "lib/jxl/base/span.h"
 #include "lib/jxl/base/status.h"
+#include "lib/jxl/cms/opsin_params.h"
 #include "lib/jxl/chroma_from_luma.h"
 #include "lib/jxl/coeff_order.h"
 #include "lib/jxl/coeff_order_fwd.h"
@@ -1609,16 +1610,16 @@ Status ComputeEncodingData(
 
       const float* custom_opsin_ptr = nullptr;
       float custom_opsin[9] = {
-        0.30f, 0.622f, 0.078f,
-        0.23f, 0.692f, 0.078f,
-        0.243f, 0.205f, 0.552f
+        jxl::cms::kM00, jxl::cms::kM01, jxl::cms::kM02,
+        jxl::cms::kM10, jxl::cms::kM11, jxl::cms::kM12,
+        jxl::cms::kM20, jxl::cms::kM21, jxl::cms::kM22
       };
       if (cparams.isolate_s_cone || cparams.yellow_bias >= 0.0f) {
         if (cparams.isolate_s_cone) {
           custom_opsin[6] = 0.0f; custom_opsin[7] = 0.0f; custom_opsin[8] = 1.0f;
         } else {
           float b = cparams.yellow_bias;
-          float r_ratio = 0.243f / (0.243f + 0.205f);
+          float r_ratio = jxl::cms::kM20 / (jxl::cms::kM20 + jxl::cms::kM21);
           custom_opsin[8] = b;
           custom_opsin[6] = r_ratio * (1.0f - b);
           custom_opsin[7] = (1.0f - r_ratio) * (1.0f - b);

--- a/lib/jxl/enc_params.h
+++ b/lib/jxl/enc_params.h
@@ -106,8 +106,10 @@ struct CompressParams {
   // exposure for a given ISO setting on a 35mm camera.
   float photon_noise_iso = 0;
 
-  bool isolate_s_cone = false;
   float yellow_bias = -1.0f;
+  float red_bias = -1.0f;
+  float green_bias = -1.0f;
+  bool isolate_s_cone = false;
 
   // modular mode options below
   ModularOptions options;

--- a/lib/jxl/enc_params.h
+++ b/lib/jxl/enc_params.h
@@ -109,7 +109,7 @@ struct CompressParams {
   float yellow_bias = -1.0f;
   float red_bias = -1.0f;
   float green_bias = -1.0f;
-  bool isolate_s_cone = false;
+  bool color_boost = false;
 
   // modular mode options below
   ModularOptions options;

--- a/lib/jxl/enc_params.h
+++ b/lib/jxl/enc_params.h
@@ -106,6 +106,9 @@ struct CompressParams {
   // exposure for a given ISO setting on a 35mm camera.
   float photon_noise_iso = 0;
 
+  bool isolate_s_cone = false;
+  float yellow_bias = -1.0f;
+
   // modular mode options below
   ModularOptions options;
 

--- a/lib/jxl/enc_params.h
+++ b/lib/jxl/enc_params.h
@@ -106,6 +106,7 @@ struct CompressParams {
   // exposure for a given ISO setting on a 35mm camera.
   float photon_noise_iso = 0;
 
+  // Custom opsin matrix tuning parameters.
   float yellow_bias = -1.0f;
   float red_bias = -1.0f;
   float green_bias = -1.0f;

--- a/lib/jxl/enc_xyb.cc
+++ b/lib/jxl/enc_xyb.cc
@@ -40,9 +40,12 @@ namespace HWY_NAMESPACE {
 
 // These templates are not found via ADL.
 using hwy::HWY_NAMESPACE::Add;
+using hwy::HWY_NAMESPACE::IfThenElse;
+using hwy::HWY_NAMESPACE::Lt;
 using hwy::HWY_NAMESPACE::Mul;
 using hwy::HWY_NAMESPACE::MulAdd;
 using hwy::HWY_NAMESPACE::Sub;
+using hwy::HWY_NAMESPACE::Zero;
 using hwy::HWY_NAMESPACE::ZeroIfNegative;
 
 // 4x3 matrix * 3x1 SIMD vectors
@@ -211,13 +214,15 @@ Status SRGBToXYBAndLinear(const float* JXL_RESTRICT premul_absorb,
   return true;
 }
 
-void ComputePremulAbsorb(float intensity_target, float* premul_absorb) {
+void ComputePremulAbsorb(float intensity_target, float* premul_absorb,
+                         const float* custom_opsin) {
   const HWY_FULL(float) d;
   const size_t N = Lanes(d);
   const float mul = intensity_target / 255.0f;
   for (size_t j = 0; j < 3; ++j) {
     for (size_t i = 0; i < 3; ++i) {
-      const auto absorb = Set(d, jxl::cms::kOpsinAbsorbanceMatrix[j][i] * mul);
+      const float val = custom_opsin ? custom_opsin[j * 3 + i] : jxl::cms::kOpsinAbsorbanceMatrix[j][i];
+      const auto absorb = Set(d, val * mul);
       Store(absorb, d, premul_absorb + (j * 3 + i) * N);
     }
   }
@@ -232,7 +237,8 @@ void ComputePremulAbsorb(float intensity_target, float* premul_absorb) {
 // it does not contain a sensitivity multiplier based on the blurred image.
 Status ToXYB(const ColorEncoding& c_current, float intensity_target,
              const ImageF* black, ThreadPool* pool, Image3F* JXL_RESTRICT image,
-             const JxlCmsInterface& cms, Image3F* const JXL_RESTRICT linear) {
+             const JxlCmsInterface& cms, Image3F* const JXL_RESTRICT linear,
+             const float* custom_opsin) {
   JXL_ENSURE(image);
   if (black) JXL_ENSURE(SameSize(*image, *black));
   if (linear) JXL_ENSURE(SameSize(*image, *linear));
@@ -246,7 +252,7 @@ Status ToXYB(const ColorEncoding& c_current, float intensity_target,
       AlignedMemory mem,
       AlignedMemory::Create(memory_manager, Lanes(d) * 12 * sizeof(float)));
   float* premul_absorb = mem.address<float>();
-  ComputePremulAbsorb(intensity_target, premul_absorb);
+  ComputePremulAbsorb(intensity_target, premul_absorb, custom_opsin);
 
   const bool want_linear = (linear != nullptr);
 
@@ -360,9 +366,10 @@ namespace jxl {
 HWY_EXPORT(ToXYB);
 Status ToXYB(const ColorEncoding& c_current, float intensity_target,
              const ImageF* black, ThreadPool* pool, Image3F* JXL_RESTRICT image,
-             const JxlCmsInterface& cms, Image3F* const JXL_RESTRICT linear) {
+             const JxlCmsInterface& cms, Image3F* const JXL_RESTRICT linear,
+             const float* custom_opsin) {
   return HWY_DYNAMIC_DISPATCH(ToXYB)(c_current, intensity_target, black, pool,
-                                     image, cms, linear);
+                                     image, cms, linear, custom_opsin);
 }
 
 HWY_EXPORT(LinearRGBRowToXYB);
@@ -374,14 +381,16 @@ void LinearRGBRowToXYB(float* JXL_RESTRICT row0, float* JXL_RESTRICT row1,
 }
 
 HWY_EXPORT(ComputePremulAbsorb);
-void ComputePremulAbsorb(float intensity_target, float* premul_absorb) {
-  HWY_DYNAMIC_DISPATCH(ComputePremulAbsorb)(intensity_target, premul_absorb);
+void ComputePremulAbsorb(float intensity_target, float* premul_absorb,
+                         const float* custom_opsin) {
+  HWY_DYNAMIC_DISPATCH(ComputePremulAbsorb)(intensity_target, premul_absorb, custom_opsin);
 }
 
 void ScaleXYBRow(float* JXL_RESTRICT row0, float* JXL_RESTRICT row1,
                  float* JXL_RESTRICT row2, size_t xsize) {
   for (size_t x = 0; x < xsize; x++) {
-    row2[x] = (row2[x] - row1[x] + jxl::cms::kScaledXYBOffset[2]) *
+    float s_minus_y = row2[x] - row1[x];
+    row2[x] = (s_minus_y + jxl::cms::kScaledXYBOffset[2]) *
               jxl::cms::kScaledXYBScale[2];
     row0[x] = (row0[x] + jxl::cms::kScaledXYBOffset[0]) *
               jxl::cms::kScaledXYBScale[0];

--- a/lib/jxl/enc_xyb.cc
+++ b/lib/jxl/enc_xyb.cc
@@ -40,12 +40,9 @@ namespace HWY_NAMESPACE {
 
 // These templates are not found via ADL.
 using hwy::HWY_NAMESPACE::Add;
-using hwy::HWY_NAMESPACE::IfThenElse;
-using hwy::HWY_NAMESPACE::Lt;
 using hwy::HWY_NAMESPACE::Mul;
 using hwy::HWY_NAMESPACE::MulAdd;
 using hwy::HWY_NAMESPACE::Sub;
-using hwy::HWY_NAMESPACE::Zero;
 using hwy::HWY_NAMESPACE::ZeroIfNegative;
 
 // 4x3 matrix * 3x1 SIMD vectors

--- a/lib/jxl/enc_xyb.h
+++ b/lib/jxl/enc_xyb.h
@@ -24,13 +24,16 @@ namespace jxl {
 // with a linear sRGB copy of `image`.
 Status ToXYB(const ColorEncoding& c_current, float intensity_target,
              const ImageF* black, ThreadPool* pool, Image3F* JXL_RESTRICT image,
-             const JxlCmsInterface& cms, Image3F* JXL_RESTRICT linear);
+             const JxlCmsInterface& cms,
+             Image3F* const JXL_RESTRICT linear = nullptr,
+             const float* custom_opsin = nullptr);
 
 void LinearRGBRowToXYB(float* JXL_RESTRICT row0, float* JXL_RESTRICT row1,
                        float* JXL_RESTRICT row2,
                        const float* JXL_RESTRICT premul_absorb, size_t xsize);
 
-void ComputePremulAbsorb(float intensity_target, float* premul_absorb);
+void ComputePremulAbsorb(float intensity_target, float* premul_absorb,
+                         const float* custom_opsin = nullptr);
 
 // Transforms each color component of the given XYB image into the [0.0, 1.0]
 // interval with an affine transform.

--- a/lib/jxl/encode.cc
+++ b/lib/jxl/encode.cc
@@ -36,6 +36,7 @@
 #include "lib/jxl/base/sanitizers.h"
 #include "lib/jxl/base/span.h"
 #include "lib/jxl/base/status.h"
+#include "lib/jxl/base/matrix_ops.h"
 #include "lib/jxl/cms/color_encoding_cms.h"
 #include "lib/jxl/color_encoding_internal.h"
 #include "lib/jxl/enc_aux_out.h"
@@ -808,6 +809,39 @@ jxl::Status JxlEncoder::ProcessOneEnqueuedInput() {
     }
     jxl::AuxOut* aux_out =
         input.frame ? input.frame->option_values.aux_out : nullptr;
+
+    if (input.frame) {
+      if (input.frame->option_values.cparams.isolate_s_cone || input.frame->option_values.cparams.yellow_bias >= 0.0f) {
+        metadata.transform_data.all_default = false;
+        metadata.transform_data.opsin_inverse_matrix.all_default = false;
+        
+        jxl::Matrix3x3 custom_opsin = {{
+          {{0.30f, 0.622f, 0.078f}},
+          {{0.23f, 0.692f, 0.078f}},
+          {{0.243f, 0.205f, 0.552f}} // default
+        }};
+        if (input.frame->option_values.cparams.isolate_s_cone) {
+          custom_opsin[2][0] = 0.0f;
+          custom_opsin[2][1] = 0.0f;
+          custom_opsin[2][2] = 1.0f;
+        } else {
+          float b = input.frame->option_values.cparams.yellow_bias;
+          float r_ratio = 0.243f / (0.243f + 0.205f);
+          custom_opsin[2][2] = b;
+          custom_opsin[2][0] = r_ratio * (1.0f - b);
+          custom_opsin[2][1] = (1.0f - r_ratio) * (1.0f - b);
+        }
+        
+        // matrix_ops.h Inv3x3Matrix modifies the matrix in place.
+        JXL_RETURN_IF_ERROR(jxl::Inv3x3Matrix(custom_opsin));
+        for (int i = 0; i < 3; i++) {
+          for (int j = 0; j < 3; j++) {
+            metadata.transform_data.opsin_inverse_matrix.inverse_matrix[i][j] = custom_opsin[i][j];
+          }
+        }
+      }
+    }
+
     jxl::BitWriter writer{&memory_manager};
     if (!WriteCodestreamHeaders(&metadata, &writer, aux_out)) {
       return JXL_API_ERROR(this, JXL_ENC_ERR_GENERIC,
@@ -1922,6 +1956,9 @@ JxlEncoderStatus JxlEncoderFrameSettingsSetOption(
       frame_settings->values.cparams.output_mode = value;
       break;
 
+    case JXL_ENC_FRAME_SETTING_ISOLATE_S_CONE:
+      frame_settings->values.cparams.isolate_s_cone = default_to_true(value);
+      return JxlErrorOrStatus::Success();
     default:
       return JXL_API_ERROR(frame_settings->enc, JXL_ENC_ERR_NOT_SUPPORTED,
                            "Unknown option");
@@ -1938,6 +1975,10 @@ JxlEncoderStatus JxlEncoderFrameSettingsSetFloatOption(
       // TODO(lode): add encoder setting to set the 8 floating point values of
       // the noise synthesis parameters per frame for more fine grained control.
       frame_settings->values.cparams.photon_noise_iso = value;
+      return JxlErrorOrStatus::Success();
+    case JXL_ENC_FRAME_SETTING_YELLOW_BIAS:
+      frame_settings->values.cparams.yellow_bias = value;
+      return JxlErrorOrStatus::Success();
       return JxlErrorOrStatus::Success();
     case JXL_ENC_FRAME_SETTING_MODULAR_MA_TREE_LEARNING_PERCENT:
       if (value < -1.f || value > 100.f) {

--- a/lib/jxl/encode.cc
+++ b/lib/jxl/encode.cc
@@ -31,14 +31,14 @@
 #include "lib/jxl/base/compiler_specific.h"
 #include "lib/jxl/base/data_parallel.h"
 #include "lib/jxl/base/exif.h"
+#include "lib/jxl/base/matrix_ops.h"
 #include "lib/jxl/base/override.h"
 #include "lib/jxl/base/printf_macros.h"
 #include "lib/jxl/base/sanitizers.h"
 #include "lib/jxl/base/span.h"
 #include "lib/jxl/base/status.h"
-#include "lib/jxl/base/matrix_ops.h"
-#include "lib/jxl/cms/opsin_params.h"
 #include "lib/jxl/cms/color_encoding_cms.h"
+#include "lib/jxl/cms/opsin_params.h"
 #include "lib/jxl/color_encoding_internal.h"
 #include "lib/jxl/enc_aux_out.h"
 #include "lib/jxl/enc_bit_writer.h"
@@ -762,6 +762,46 @@ void FastLosslessRunnerAdapter(void* void_ticket, void* opaque,
   }
 }
 
+void ComputeCustomOpsinMatrix(const jxl::CompressParams& cparams,
+                              jxl::Matrix3x3& custom_opsin) {
+  custom_opsin = {{
+      {{jxl::cms::kM00, jxl::cms::kM01, jxl::cms::kM02}},
+      {{jxl::cms::kM10, jxl::cms::kM11, jxl::cms::kM12}},
+      {{jxl::cms::kM20, jxl::cms::kM21, jxl::cms::kM22}},
+  }};
+  if (cparams.red_bias >= 0.0f) {
+    float r = cparams.red_bias;
+    float g_ratio = jxl::cms::kM01 / (jxl::cms::kM01 + jxl::cms::kM02);
+    custom_opsin[0][0] = r;
+    custom_opsin[0][1] = g_ratio * (1.0f - r);
+    custom_opsin[0][2] = (1.0f - g_ratio) * (1.0f - r);
+  }
+  if (cparams.green_bias >= 0.0f) {
+    float g = cparams.green_bias;
+    float r_ratio = jxl::cms::kM10 / (jxl::cms::kM10 + jxl::cms::kM12);
+    custom_opsin[1][1] = g;
+    custom_opsin[1][0] = r_ratio * (1.0f - g);
+    custom_opsin[1][2] = (1.0f - r_ratio) * (1.0f - g);
+  }
+  if (cparams.yellow_bias >= 0.0f) {
+    float b = cparams.yellow_bias;
+    float r_ratio = jxl::cms::kM20 / (jxl::cms::kM20 + jxl::cms::kM21);
+    custom_opsin[2][2] = b;
+    custom_opsin[2][0] = r_ratio * (1.0f - b);
+    custom_opsin[2][1] = (1.0f - r_ratio) * (1.0f - b);
+  } else if (cparams.color_boost && cparams.butteraugli_distance > 0.3f) {
+    // Yellow dynamic scaling
+    float dist =
+        std::max(0.3f, std::min(3.0f, cparams.butteraugli_distance));
+    float factor = (dist - 0.3f) / 2.7f;
+    float b = jxl::cms::kM22 + factor * (0.85f - jxl::cms::kM22);
+    float r_ratio_b = jxl::cms::kM20 / (jxl::cms::kM20 + jxl::cms::kM21);
+    custom_opsin[2][2] = b;
+    custom_opsin[2][0] = r_ratio_b * (1.0f - b);
+    custom_opsin[2][1] = (1.0f - r_ratio_b) * (1.0f - b);
+  }
+}
+
 }  // namespace
 
 jxl::Status JxlEncoder::ProcessOneEnqueuedInput() {
@@ -820,43 +860,18 @@ jxl::Status JxlEncoder::ProcessOneEnqueuedInput() {
     }
 
     if (first_frame_settings) {
+      bool active_color_boost =
+          first_frame_settings->cparams.color_boost &&
+          first_frame_settings->cparams.butteraugli_distance > 0.3f;
       if (first_frame_settings->cparams.red_bias >= 0.0f ||
           first_frame_settings->cparams.green_bias >= 0.0f ||
-          first_frame_settings->cparams.isolate_s_cone ||
+          active_color_boost ||
           first_frame_settings->cparams.yellow_bias >= 0.0f) {
         metadata.transform_data.all_default = false;
         metadata.transform_data.opsin_inverse_matrix.all_default = false;
 
-        jxl::Matrix3x3 custom_opsin = {{
-            {{jxl::cms::kM00, jxl::cms::kM01, jxl::cms::kM02}},
-            {{jxl::cms::kM10, jxl::cms::kM11, jxl::cms::kM12}},
-            {{jxl::cms::kM20, jxl::cms::kM21, jxl::cms::kM22}},
-        }};
-        if (first_frame_settings->cparams.red_bias >= 0.0f) {
-          float r = first_frame_settings->cparams.red_bias;
-          float g_ratio = jxl::cms::kM01 / (jxl::cms::kM01 + jxl::cms::kM02);
-          custom_opsin[0][0] = r;
-          custom_opsin[0][1] = g_ratio * (1.0f - r);
-          custom_opsin[0][2] = (1.0f - g_ratio) * (1.0f - r);
-        }
-        if (first_frame_settings->cparams.green_bias >= 0.0f) {
-          float g = first_frame_settings->cparams.green_bias;
-          float r_ratio = jxl::cms::kM10 / (jxl::cms::kM10 + jxl::cms::kM12);
-          custom_opsin[1][1] = g;
-          custom_opsin[1][0] = r_ratio * (1.0f - g);
-          custom_opsin[1][2] = (1.0f - r_ratio) * (1.0f - g);
-        }
-        if (first_frame_settings->cparams.isolate_s_cone) {
-          custom_opsin[2][0] = 0.0f;
-          custom_opsin[2][1] = 0.0f;
-          custom_opsin[2][2] = 1.0f;
-        } else if (first_frame_settings->cparams.yellow_bias >= 0.0f) {
-          float b = first_frame_settings->cparams.yellow_bias;
-          float r_ratio = jxl::cms::kM20 / (jxl::cms::kM20 + jxl::cms::kM21);
-          custom_opsin[2][2] = b;
-          custom_opsin[2][0] = r_ratio * (1.0f - b);
-          custom_opsin[2][1] = (1.0f - r_ratio) * (1.0f - b);
-        }
+        jxl::Matrix3x3 custom_opsin;
+        ComputeCustomOpsinMatrix(first_frame_settings->cparams, custom_opsin);
 
         // matrix_ops.h Inv3x3Matrix modifies the matrix in place.
         JXL_RETURN_IF_ERROR(jxl::Inv3x3Matrix(custom_opsin));
@@ -1990,8 +2005,8 @@ JxlEncoderStatus JxlEncoderFrameSettingsSetOption(
       frame_settings->values.cparams.output_mode = value;
       break;
 
-    case JXL_ENC_FRAME_SETTING_ISOLATE_S_CONE:
-      frame_settings->values.cparams.isolate_s_cone = default_to_true(value);
+    case JXL_ENC_FRAME_SETTING_COLOR_BOOST:
+      frame_settings->values.cparams.color_boost = (value > 0.5f);
       return JxlErrorOrStatus::Success();
     default:
       return JXL_API_ERROR(frame_settings->enc, JXL_ENC_ERR_NOT_SUPPORTED,

--- a/lib/jxl/encode.cc
+++ b/lib/jxl/encode.cc
@@ -37,6 +37,7 @@
 #include "lib/jxl/base/span.h"
 #include "lib/jxl/base/status.h"
 #include "lib/jxl/base/matrix_ops.h"
+#include "lib/jxl/cms/opsin_params.h"
 #include "lib/jxl/cms/color_encoding_cms.h"
 #include "lib/jxl/color_encoding_internal.h"
 #include "lib/jxl/enc_aux_out.h"
@@ -810,35 +811,52 @@ jxl::Status JxlEncoder::ProcessOneEnqueuedInput() {
     jxl::AuxOut* aux_out =
         input.frame ? input.frame->option_values.aux_out : nullptr;
 
-    if (input.frame) {
-      if (input.frame->option_values.cparams.isolate_s_cone || input.frame->option_values.cparams.yellow_bias >= 0.0f) {
+    const jxl::JxlEncoderFrameSettingsValues* first_frame_settings = nullptr;
+    for (const auto& queued_input : input_queue) {
+      if (queued_input.frame) {
+        first_frame_settings = &queued_input.frame->option_values;
+        break;
+      }
+    }
+
+    if (first_frame_settings) {
+      if (first_frame_settings->cparams.isolate_s_cone ||
+          first_frame_settings->cparams.yellow_bias >= 0.0f) {
         metadata.transform_data.all_default = false;
         metadata.transform_data.opsin_inverse_matrix.all_default = false;
-        
+
         jxl::Matrix3x3 custom_opsin = {{
-          {{0.30f, 0.622f, 0.078f}},
-          {{0.23f, 0.692f, 0.078f}},
-          {{0.243f, 0.205f, 0.552f}} // default
+            {{jxl::cms::kM00, jxl::cms::kM01, jxl::cms::kM02}},
+            {{jxl::cms::kM10, jxl::cms::kM11, jxl::cms::kM12}},
+            {{jxl::cms::kM20, jxl::cms::kM21, jxl::cms::kM22}},
         }};
-        if (input.frame->option_values.cparams.isolate_s_cone) {
+        if (first_frame_settings->cparams.isolate_s_cone) {
           custom_opsin[2][0] = 0.0f;
           custom_opsin[2][1] = 0.0f;
           custom_opsin[2][2] = 1.0f;
         } else {
-          float b = input.frame->option_values.cparams.yellow_bias;
-          float r_ratio = 0.243f / (0.243f + 0.205f);
+          float b = first_frame_settings->cparams.yellow_bias;
+          float r_ratio = jxl::cms::kM20 / (jxl::cms::kM20 + jxl::cms::kM21);
           custom_opsin[2][2] = b;
           custom_opsin[2][0] = r_ratio * (1.0f - b);
           custom_opsin[2][1] = (1.0f - r_ratio) * (1.0f - b);
         }
-        
+
         // matrix_ops.h Inv3x3Matrix modifies the matrix in place.
         JXL_RETURN_IF_ERROR(jxl::Inv3x3Matrix(custom_opsin));
         for (int i = 0; i < 3; i++) {
           for (int j = 0; j < 3; j++) {
-            metadata.transform_data.opsin_inverse_matrix.inverse_matrix[i][j] = custom_opsin[i][j];
+            metadata.transform_data.opsin_inverse_matrix.inverse_matrix[i][j] =
+                custom_opsin[i][j];
           }
         }
+        // Spec (Annex L.2.1, Table L.1): when all_default=false, the decoder
+        // reads opsin_biases and quant_biases from the bitstream. Explicitly
+        // set them to the standard defaults so the bitstream is self-consistent.
+        auto& oim = metadata.transform_data.opsin_inverse_matrix;
+        oim.opsin_biases[0] = jxl::cms::kNegOpsinAbsorbanceBiasRGB[0];
+        oim.opsin_biases[1] = jxl::cms::kNegOpsinAbsorbanceBiasRGB[1];
+        oim.opsin_biases[2] = jxl::cms::kNegOpsinAbsorbanceBiasRGB[2];
       }
     }
 
@@ -1977,8 +1995,11 @@ JxlEncoderStatus JxlEncoderFrameSettingsSetFloatOption(
       frame_settings->values.cparams.photon_noise_iso = value;
       return JxlErrorOrStatus::Success();
     case JXL_ENC_FRAME_SETTING_YELLOW_BIAS:
+      if (value < 0.0f || value > 1.0f) {
+        return JXL_API_ERROR(frame_settings->enc, JXL_ENC_ERR_API_USAGE,
+                             "Yellow bias must be in [0.0, 1.0]");
+      }
       frame_settings->values.cparams.yellow_bias = value;
-      return JxlErrorOrStatus::Success();
       return JxlErrorOrStatus::Success();
     case JXL_ENC_FRAME_SETTING_MODULAR_MA_TREE_LEARNING_PERCENT:
       if (value < -1.f || value > 100.f) {

--- a/lib/jxl/encode.cc
+++ b/lib/jxl/encode.cc
@@ -2008,6 +2008,7 @@ JxlEncoderStatus JxlEncoderFrameSettingsSetOption(
     case JXL_ENC_FRAME_SETTING_COLOR_BOOST:
       frame_settings->values.cparams.color_boost = (value > 0.5f);
       return JxlErrorOrStatus::Success();
+
     default:
       return JXL_API_ERROR(frame_settings->enc, JXL_ENC_ERR_NOT_SUPPORTED,
                            "Unknown option");
@@ -2026,23 +2027,23 @@ JxlEncoderStatus JxlEncoderFrameSettingsSetFloatOption(
       frame_settings->values.cparams.photon_noise_iso = value;
       return JxlErrorOrStatus::Success();
     case JXL_ENC_FRAME_SETTING_YELLOW_BIAS:
-      if (value < 0.0f || value > 1.0f) {
+      if (value != -1.0f && (value < 0.0f || value > 1.0f)) {
         return JXL_API_ERROR(frame_settings->enc, JXL_ENC_ERR_API_USAGE,
-                             "Yellow bias must be in [0.0, 1.0]");
+                             "Yellow bias must be in [0.0, 1.0] or -1.0 to disable");
       }
       frame_settings->values.cparams.yellow_bias = value;
       return JxlErrorOrStatus::Success();
     case JXL_ENC_FRAME_SETTING_RED_BIAS:
-      if (value < 0.0f || value > 1.0f) {
+      if (value != -1.0f && (value < 0.0f || value > 1.0f)) {
         return JXL_API_ERROR(frame_settings->enc, JXL_ENC_ERR_API_USAGE,
-                             "Red bias must be in [0.0, 1.0]");
+                             "Red bias must be in [0.0, 1.0] or -1.0 to disable");
       }
       frame_settings->values.cparams.red_bias = value;
       return JxlErrorOrStatus::Success();
     case JXL_ENC_FRAME_SETTING_GREEN_BIAS:
-      if (value < 0.0f || value > 1.0f) {
+      if (value != -1.0f && (value < 0.0f || value > 1.0f)) {
         return JXL_API_ERROR(frame_settings->enc, JXL_ENC_ERR_API_USAGE,
-                             "Green bias must be in [0.0, 1.0]");
+                             "Green bias must be in [0.0, 1.0] or -1.0 to disable");
       }
       frame_settings->values.cparams.green_bias = value;
       return JxlErrorOrStatus::Success();

--- a/lib/jxl/encode.cc
+++ b/lib/jxl/encode.cc
@@ -820,7 +820,9 @@ jxl::Status JxlEncoder::ProcessOneEnqueuedInput() {
     }
 
     if (first_frame_settings) {
-      if (first_frame_settings->cparams.isolate_s_cone ||
+      if (first_frame_settings->cparams.red_bias >= 0.0f ||
+          first_frame_settings->cparams.green_bias >= 0.0f ||
+          first_frame_settings->cparams.isolate_s_cone ||
           first_frame_settings->cparams.yellow_bias >= 0.0f) {
         metadata.transform_data.all_default = false;
         metadata.transform_data.opsin_inverse_matrix.all_default = false;
@@ -830,11 +832,25 @@ jxl::Status JxlEncoder::ProcessOneEnqueuedInput() {
             {{jxl::cms::kM10, jxl::cms::kM11, jxl::cms::kM12}},
             {{jxl::cms::kM20, jxl::cms::kM21, jxl::cms::kM22}},
         }};
+        if (first_frame_settings->cparams.red_bias >= 0.0f) {
+          float r = first_frame_settings->cparams.red_bias;
+          float g_ratio = jxl::cms::kM01 / (jxl::cms::kM01 + jxl::cms::kM02);
+          custom_opsin[0][0] = r;
+          custom_opsin[0][1] = g_ratio * (1.0f - r);
+          custom_opsin[0][2] = (1.0f - g_ratio) * (1.0f - r);
+        }
+        if (first_frame_settings->cparams.green_bias >= 0.0f) {
+          float g = first_frame_settings->cparams.green_bias;
+          float r_ratio = jxl::cms::kM10 / (jxl::cms::kM10 + jxl::cms::kM12);
+          custom_opsin[1][1] = g;
+          custom_opsin[1][0] = r_ratio * (1.0f - g);
+          custom_opsin[1][2] = (1.0f - r_ratio) * (1.0f - g);
+        }
         if (first_frame_settings->cparams.isolate_s_cone) {
           custom_opsin[2][0] = 0.0f;
           custom_opsin[2][1] = 0.0f;
           custom_opsin[2][2] = 1.0f;
-        } else {
+        } else if (first_frame_settings->cparams.yellow_bias >= 0.0f) {
           float b = first_frame_settings->cparams.yellow_bias;
           float r_ratio = jxl::cms::kM20 / (jxl::cms::kM20 + jxl::cms::kM21);
           custom_opsin[2][2] = b;
@@ -2000,6 +2016,20 @@ JxlEncoderStatus JxlEncoderFrameSettingsSetFloatOption(
                              "Yellow bias must be in [0.0, 1.0]");
       }
       frame_settings->values.cparams.yellow_bias = value;
+      return JxlErrorOrStatus::Success();
+    case JXL_ENC_FRAME_SETTING_RED_BIAS:
+      if (value < 0.0f || value > 1.0f) {
+        return JXL_API_ERROR(frame_settings->enc, JXL_ENC_ERR_API_USAGE,
+                             "Red bias must be in [0.0, 1.0]");
+      }
+      frame_settings->values.cparams.red_bias = value;
+      return JxlErrorOrStatus::Success();
+    case JXL_ENC_FRAME_SETTING_GREEN_BIAS:
+      if (value < 0.0f || value > 1.0f) {
+        return JXL_API_ERROR(frame_settings->enc, JXL_ENC_ERR_API_USAGE,
+                             "Green bias must be in [0.0, 1.0]");
+      }
+      frame_settings->values.cparams.green_bias = value;
       return JxlErrorOrStatus::Success();
     case JXL_ENC_FRAME_SETTING_MODULAR_MA_TREE_LEARNING_PERCENT:
       if (value < -1.f || value > 100.f) {

--- a/tools/cjxl_main.cc
+++ b/tools/cjxl_main.cc
@@ -412,22 +412,22 @@ struct CompressArgs {
 
     cmdline->AddOptionFlag('\0', "color_boost",
                            "Dynamically scale yellow bias based on butteraugli "
-                           "distance to boost color accuracy."
+                           "distance to boost color accuracy. "
                            "The strength scales from distance 0.3 to 3.0.",
                            &color_boost, &SetBooleanTrue, 4);
 
     cmdline->AddOptionValue('\0', "yellow_bias", "FLOAT",
-                            "Set the blue multiplier for the S-cone to tune "
-                            "the yellow bias (default 0.55).",
+                            "Set the yellow multiplier for the S-cone to tune "
+                            "the yellow bias (range [0, 1], default: disabled).",
                             &yellow_bias, &ParseFloat, 4);
 
     cmdline->AddOptionValue('\0', "red_bias", "FLOAT",
                             "Set the red multiplier for the L-cone to tune the "
-                            "red bias (default 0.3).",
+                            "red bias (range [0, 1], default: disabled).",
                             &red_bias, &ParseFloat, 4);
     cmdline->AddOptionValue('\0', "green_bias", "FLOAT",
                             "Set the green multiplier for the M-cone to tune "
-                            "the green bias (default 0.69).",
+                            "the green bias (range [0, 1], default: disabled).",
                             &green_bias, &ParseFloat, 4);
 
     cmdline->AddHelpText("\nModular mode options:", 4);

--- a/tools/cjxl_main.cc
+++ b/tools/cjxl_main.cc
@@ -411,12 +411,22 @@ struct CompressArgs {
                            4);
 
     cmdline->AddOptionFlag('\0', "isolate_s_cone",
-                           "Use a custom Opsin Inverse Matrix to isolate the S-cone from red/green cross-talk.",
+                           "Use a custom Opsin Inverse Matrix to isolate the "
+                           "S-cone from red/green cross-talk.",
                            &isolate_s_cone, &SetBooleanTrue, 4);
 
     cmdline->AddOptionValue('\0', "yellow_bias", "FLOAT",
-                            "Set the blue multiplier for the S-cone to tune the yellow bias (e.g. 0.85).",
+                            "Set the blue multiplier for the S-cone to tune "
+                            "the yellow bias (default 0.55).",
                             &yellow_bias, &ParseFloat, 4);
+
+    cmdline->AddOptionValue('\0', "red_bias", "FLOAT",
+                            "Set the red multiplier for the L-cone to tune the "
+                            "red bias (default 0.3).",
+                            &red_bias, &ParseFloat, 4);
+    cmdline->AddOptionValue('\0', "green_bias", "FLOAT",
+                            "Set the green multiplier for the M-cone to tune the green bias (default 0.69).",
+                            &green_bias, &ParseFloat, 4);
 
     cmdline->AddHelpText("\nModular mode options:", 4);
 
@@ -548,6 +558,8 @@ struct CompressArgs {
   bool disable_perceptual_optimizations = false;
   bool isolate_s_cone = false;
   float yellow_bias = -1.0f;
+  float red_bias = -1.0f;
+  float green_bias = -1.0f;
 
   size_t faster_decoding = 0;
   int64_t resampling = -1;
@@ -729,12 +741,22 @@ void ProcessFlags(const jxl::extras::Codec codec,
   if (args->disable_perceptual_optimizations) {
     params->AddOption(JXL_ENC_FRAME_SETTING_DISABLE_PERCEPTUAL_HEURISTICS, 1);
   }
-  
+
   if (args->isolate_s_cone) {
-    params->options.emplace_back(JXL_ENC_FRAME_SETTING_ISOLATE_S_CONE, static_cast<int64_t>(1), 0);
+    params->options.emplace_back(JXL_ENC_FRAME_SETTING_ISOLATE_S_CONE,
+                                 static_cast<int64_t>(1), 0);
   }
   if (args->yellow_bias >= 0.0f) {
-    params->options.emplace_back(JXL_ENC_FRAME_SETTING_YELLOW_BIAS, args->yellow_bias, 0);
+    params->options.emplace_back(JXL_ENC_FRAME_SETTING_YELLOW_BIAS,
+                                 args->yellow_bias, 0);
+  }
+  if (args->red_bias >= 0.0f) {
+    params->options.emplace_back(JXL_ENC_FRAME_SETTING_RED_BIAS, args->red_bias,
+                                 0);
+  }
+  if (args->green_bias >= 0.0f) {
+    params->options.emplace_back(JXL_ENC_FRAME_SETTING_GREEN_BIAS,
+                                 args->green_bias, 0);
   }
 
   if (!args->frame_indexing.empty()) {

--- a/tools/cjxl_main.cc
+++ b/tools/cjxl_main.cc
@@ -410,6 +410,14 @@ struct CompressArgs {
                            &disable_perceptual_optimizations, &SetBooleanTrue,
                            4);
 
+    cmdline->AddOptionFlag('\0', "isolate_s_cone",
+                           "Use a custom Opsin Inverse Matrix to isolate the S-cone from red/green cross-talk.",
+                           &isolate_s_cone, &SetBooleanTrue, 4);
+
+    cmdline->AddOptionValue('\0', "yellow_bias", "FLOAT",
+                            "Set the blue multiplier for the S-cone to tune the yellow bias (e.g. 0.85).",
+                            &yellow_bias, &ParseFloat, 4);
+
     cmdline->AddHelpText("\nModular mode options:", 4);
 
     // modular mode options
@@ -538,6 +546,8 @@ struct CompressArgs {
 
   bool allow_expert_options = false;
   bool disable_perceptual_optimizations = false;
+  bool isolate_s_cone = false;
+  float yellow_bias = -1.0f;
 
   size_t faster_decoding = 0;
   int64_t resampling = -1;
@@ -718,6 +728,13 @@ void ProcessFlags(const jxl::extras::Codec codec,
   params->allow_expert_options = args->allow_expert_options;
   if (args->disable_perceptual_optimizations) {
     params->AddOption(JXL_ENC_FRAME_SETTING_DISABLE_PERCEPTUAL_HEURISTICS, 1);
+  }
+  
+  if (args->isolate_s_cone) {
+    params->options.emplace_back(JXL_ENC_FRAME_SETTING_ISOLATE_S_CONE, static_cast<int64_t>(1), 0);
+  }
+  if (args->yellow_bias >= 0.0f) {
+    params->options.emplace_back(JXL_ENC_FRAME_SETTING_YELLOW_BIAS, args->yellow_bias, 0);
   }
 
   if (!args->frame_indexing.empty()) {

--- a/tools/cjxl_main.cc
+++ b/tools/cjxl_main.cc
@@ -410,10 +410,11 @@ struct CompressArgs {
                            &disable_perceptual_optimizations, &SetBooleanTrue,
                            4);
 
-    cmdline->AddOptionFlag('\0', "isolate_s_cone",
-                           "Use a custom Opsin Inverse Matrix to isolate the "
-                           "S-cone from red/green cross-talk.",
-                           &isolate_s_cone, &SetBooleanTrue, 4);
+    cmdline->AddOptionFlag('\0', "color_boost",
+                           "Dynamically scale yellow bias based on butteraugli "
+                           "distance to boost color accuracy."
+                           "The strength scales from distance 0.3 to 3.0.",
+                           &color_boost, &SetBooleanTrue, 4);
 
     cmdline->AddOptionValue('\0', "yellow_bias", "FLOAT",
                             "Set the blue multiplier for the S-cone to tune "
@@ -425,7 +426,8 @@ struct CompressArgs {
                             "red bias (default 0.3).",
                             &red_bias, &ParseFloat, 4);
     cmdline->AddOptionValue('\0', "green_bias", "FLOAT",
-                            "Set the green multiplier for the M-cone to tune the green bias (default 0.69).",
+                            "Set the green multiplier for the M-cone to tune "
+                            "the green bias (default 0.69).",
                             &green_bias, &ParseFloat, 4);
 
     cmdline->AddHelpText("\nModular mode options:", 4);
@@ -556,7 +558,7 @@ struct CompressArgs {
 
   bool allow_expert_options = false;
   bool disable_perceptual_optimizations = false;
-  bool isolate_s_cone = false;
+  bool color_boost = false;
   float yellow_bias = -1.0f;
   float red_bias = -1.0f;
   float green_bias = -1.0f;
@@ -742,21 +744,18 @@ void ProcessFlags(const jxl::extras::Codec codec,
     params->AddOption(JXL_ENC_FRAME_SETTING_DISABLE_PERCEPTUAL_HEURISTICS, 1);
   }
 
-  if (args->isolate_s_cone) {
-    params->options.emplace_back(JXL_ENC_FRAME_SETTING_ISOLATE_S_CONE,
-                                 static_cast<int64_t>(1), 0);
+  if (args->color_boost) {
+    params->AddOption(JXL_ENC_FRAME_SETTING_COLOR_BOOST, 1);
   }
   if (args->yellow_bias >= 0.0f) {
-    params->options.emplace_back(JXL_ENC_FRAME_SETTING_YELLOW_BIAS,
-                                 args->yellow_bias, 0);
+    params->AddFloatOption(JXL_ENC_FRAME_SETTING_YELLOW_BIAS,
+                           args->yellow_bias);
   }
   if (args->red_bias >= 0.0f) {
-    params->options.emplace_back(JXL_ENC_FRAME_SETTING_RED_BIAS, args->red_bias,
-                                 0);
+    params->AddFloatOption(JXL_ENC_FRAME_SETTING_RED_BIAS, args->red_bias);
   }
   if (args->green_bias >= 0.0f) {
-    params->options.emplace_back(JXL_ENC_FRAME_SETTING_GREEN_BIAS,
-                                 args->green_bias, 0);
+    params->AddFloatOption(JXL_ENC_FRAME_SETTING_GREEN_BIAS, args->green_bias);
   }
 
   if (!args->frame_indexing.empty()) {


### PR DESCRIPTION
New API additions allowing the user to manually tune the RGB -> LMS color pipeline.

`JXL_ENC_FRAME_SETTING_COLOR_BOOST`: A boolean toggle that applies a scaling `yellow_bias` based on quantization.
`JXL_ENC_FRAME_SETTING_RED_BIAS`: Float value to tune the L-cone multiplier.
`JXL_ENC_FRAME_SETTING_GREEN_BIAS`: Float value to tune the M-cone multiplier.
`JXL_ENC_FRAME_SETTING_YELLOW_BIAS`: Float value to tune the S-cone multiplier.

New CLI Flags has been added to cjxl to accompany these new API features:

`--color_boost`: Applies `yellow_bias` which fixes the yellow desaturation issues present. The strength increases with quantization.
`--red_bias <float>, --green_bias <float>, --yellow_bias <float>`: Manually tune individual cone responses.

**Note**: The custom forward matrix is computed, inverted, and serialized via the `OpsinInverseMatrix` bundle with `all_default=false`. Because this is a codestream-level header, for multi-frame animations, the scaling multiplier is calculated based on the first frame's distance and applied globally.

I think it's in a good spot right now, unless somebody else has a better idea for more intuitive names.

Fixes: #3616 and possibly other color related issues.
