### PR TITLE
enc_fast_lossless: size single-group DC global buffer for the actual sample bit budget

### DIFF
--- a/lib/jxl/enc_fast_lossless.cc
+++ b/lib/jxl/enc_fast_lossless.cc
@@ -2923,8 +2923,19 @@ constexpr uint8_t MoreThan14Bits::kMinRawLength[];
 constexpr uint8_t MoreThan14Bits::kMaxRawLength[];
 
 bool PrepareDCGlobalCommon(bool is_single_group, size_t width, size_t height,
+                           size_t max_encoded_bits_per_sample,
                            const PrefixCode code[4], BitWriter* output) {
-  if (!output->Allocate(100000 + (is_single_group ? width * height * 16 : 0))) {
+  // In single-group mode the pixel data of (at least) channel 0 is written
+  // into this same buffer, so it must be budgeted for the worst-case encoded
+  // size of a sample, which is `max_encoded_bits_per_sample` (up to 24 for
+  // >14-bit input), not a hardcoded 16. Using 16 here under-allocates for
+  // 15/16-bit images and leads to a heap-buffer-overflow when the data is
+  // incompressible. The non-single-group path already uses
+  // BitDepth::MaxEncodedBitsPerSample() (see WriteACSection).
+  if (!output->Allocate(100000 +
+                        (is_single_group
+                             ? width * height * max_encoded_bits_per_sample
+                             : 0))) {
     return false;
   }
   // No patches, spline or noise.
@@ -3004,9 +3015,10 @@ bool PrepareDCGlobalCommon(bool is_single_group, size_t width, size_t height,
 }
 
 bool PrepareDCGlobal(bool is_single_group, size_t width, size_t height,
-                     size_t nb_chans, const PrefixCode code[4],
-                     BitWriter* output) {
-  if (!PrepareDCGlobalCommon(is_single_group, width, height, code, output)) {
+                     size_t max_encoded_bits_per_sample, size_t nb_chans,
+                     const PrefixCode code[4], BitWriter* output) {
+  if (!PrepareDCGlobalCommon(is_single_group, width, height,
+                             max_encoded_bits_per_sample, code, output)) {
     return false;
   }
   if (nb_chans > 2) {
@@ -3669,10 +3681,12 @@ void CollectSamples(const unsigned char* rgba, size_t x0, size_t y0, size_t xs,
 }
 
 bool PrepareDCGlobalPalette(bool is_single_group, size_t width, size_t height,
-                            size_t nb_chans, const PrefixCode code[4],
+                            size_t max_encoded_bits_per_sample, size_t nb_chans,
+                            const PrefixCode code[4],
                             const std::vector<uint32_t>& palette,
                             size_t pcolors, BitWriter* output) {
-  if (!PrepareDCGlobalCommon(is_single_group, width, height, code, output)) {
+  if (!PrepareDCGlobalCommon(is_single_group, width, height,
+                             max_encoded_bits_per_sample, code, output)) {
     return false;
   }
   output->Write(2, 0b01);     // 1 transform
@@ -3993,13 +4007,15 @@ JxlFastLosslessFrameState* LLPrepare(JxlChunkedFrameInputSource input,
   frame_state->group_data = std::vector<std::array<BitWriter, 4>>(num_groups);
   frame_state->group_sizes.resize(num_groups);
   if (collided) {
-    if (!PrepareDCGlobal(onegroup, width, height, nb_chans, frame_state->hcode,
-                         &frame_state->group_data[0][0])) {
+    if (!PrepareDCGlobal(onegroup, width, height,
+                         bitdepth.MaxEncodedBitsPerSample(), nb_chans,
+                         frame_state->hcode, &frame_state->group_data[0][0])) {
       delete frame_state;
       return nullptr;
     }
   } else {
-    if (!PrepareDCGlobalPalette(onegroup, width, height, nb_chans,
+    if (!PrepareDCGlobalPalette(onegroup, width, height,
+                                bitdepth.MaxEncodedBitsPerSample(), nb_chans,
                                 frame_state->hcode, palette, pcolors,
                                 &frame_state->group_data[0][0])) {
       delete frame_state;

--- a/lib/jxl/enc_fast_lossless.cc
+++ b/lib/jxl/enc_fast_lossless.cc
@@ -2925,13 +2925,6 @@ constexpr uint8_t MoreThan14Bits::kMaxRawLength[];
 bool PrepareDCGlobalCommon(bool is_single_group, size_t width, size_t height,
                            size_t max_encoded_bits_per_sample,
                            const PrefixCode code[4], BitWriter* output) {
-  // In single-group mode the pixel data of (at least) channel 0 is written
-  // into this same buffer, so it must be budgeted for the worst-case encoded
-  // size of a sample, which is `max_encoded_bits_per_sample` (up to 24 for
-  // >14-bit input), not a hardcoded 16. Using 16 here under-allocates for
-  // 15/16-bit images and leads to a heap-buffer-overflow when the data is
-  // incompressible. The non-single-group path already uses
-  // BitDepth::MaxEncodedBitsPerSample() (see WriteACSection).
   if (!output->Allocate(100000 +
                         (is_single_group
                              ? width * height * max_encoded_bits_per_sample


### PR DESCRIPTION
## Problem

In single-group mode the fast-lossless encoder writes the channel-0 residuals into the same `BitWriter` that `PrepareDCGlobalCommon()` allocates:

```cpp
if (!output->Allocate(100000 + (is_single_group ? width * height * 16 : 0))) {
```

The `16` assumes at most 16 encoded bits per sample, but the worst case is `BitDepth::MaxEncodedBitsPerSample()`, which is up to 24 bits for `MoreThan14Bits` (and 21/22 for the 9–14-bit depths). When a 15/16-bit image's channel-0 data is incompressible, the residuals need more than the budgeted space and the encoder writes past the end of the buffer.

The non-single-group path already budgets correctly, using `bitdepth.MaxEncodedBitsPerSample()` in `WriteACSection()`:

```cpp
if (!output[i].Allocate(xs * ys * bitdepth.MaxEncodedBitsPerSample() + 4)) {
```

so only the single-group DC-global path was missing the same treatment.

## Reproduction

`cjxl input.ppm -d 0 -e 1` on a 256×256 16-bit image with incompressible content (a `P6 256 256 65535` PPM of pseudo-random samples). With an ASan build:

```
==ERROR: AddressSanitizer: heap-buffer-overflow ... WRITE of size 8
  #0 MoreThan14Bits::EncodeChunkSimd  enc_fast_lossless.cc:2917
  #1 LLProcess<MoreThan14Bits>        enc_fast_lossless.cc:4104
0x... is located 6 bytes after 143636-byte region
  allocated by ... PrepareDCGlobalCommon enc_fast_lossless.cc:2927
```

143636 = `(100000 + 256*256*16)/8 + 64`, i.e. the `:2927` allocation. Effort ≥ 2 uses the regular modular encoder and is unaffected.

## Fix

Thread `BitDepth::MaxEncodedBitsPerSample()` from `LLPrepare()` into `PrepareDCGlobalCommon()` / `PrepareDCGlobal()` / `PrepareDCGlobalPalette()` and use it instead of the hardcoded `16`.

After the change the reproducer encodes cleanly under ASan, and a lossless round-trip (`cjxl -d 0 -e 1` then `djxl`) is bit-identical to the input across 8/10/12/14/16-bit grayscale and RGB images, single- and multi-group.