### PR TITLE
Harden release asset upload workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -408,5 +408,6 @@ jobs:
     - name: Publish assets
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        RELEASE_TAG: ${{ github.event.release.tag_name }}
       run: |
-        gh release upload ${{ github.event.release.tag_name }} ./release_assets/*
+        gh release upload "$RELEASE_TAG" ./release_assets/*


### PR DESCRIPTION
This tightens the release asset upload step without changing the release process.

The release tag is now passed through a step environment variable and quoted before being used in the `gh release upload` command. This avoids direct GitHub context interpolation inside the shell command while preserving the existing release permissions and artifact upload behavior.

I verified the workflow YAML still parses, `git diff --check` passes, and `zizmor --min-severity medium --min-confidence medium .github/workflows/release.yaml` reports no findings.
