### PR TITLE
Reject overflowing PNM header numbers

### DIFF
--- a/lib/extras/codec_test.cc
+++ b/lib/extras/codec_test.cc
@@ -14,6 +14,7 @@
 #include <cstdio>
 #include <cstdlib>
 #include <cstring>
+#include <limits>
 #include <memory>
 #include <sstream>
 #include <string>
@@ -394,6 +395,9 @@ TEST(CodecTest, LosslessPNMRoundtrip) {
 TEST(CodecTest, TestPNM) {
   size_t u = 77777;  // Initialized to wrong value.
   double d = 77.77;
+  const std::string max_unsigned =
+      std::to_string(std::numeric_limits<size_t>::max());
+
 // Failing to parse invalid strings results in a crash if `JXL_CRASH_ON_ERROR`
 // is defined and hence the tests fail. Therefore we only run these tests if
 // `JXL_CRASH_ON_ERROR` is not defined.
@@ -402,6 +406,8 @@ TEST(CodecTest, TestPNM) {
   ASSERT_FALSE(PnmParseUnsigned(MakeSpan("+"), &u));
   ASSERT_FALSE(PnmParseUnsigned(MakeSpan("-"), &u));
   ASSERT_FALSE(PnmParseUnsigned(MakeSpan("A"), &u));
+  const std::string overflowing_unsigned = max_unsigned + "0";
+  ASSERT_FALSE(PnmParseUnsigned(MakeSpan(overflowing_unsigned.c_str()), &u));
 
   ASSERT_FALSE(PnmParseSigned(MakeSpan(""), &d));
   ASSERT_FALSE(PnmParseSigned(MakeSpan("+"), &d));
@@ -413,6 +419,9 @@ TEST(CodecTest, TestPNM) {
 
   ASSERT_TRUE(PnmParseUnsigned(MakeSpan("32"), &u));
   ASSERT_TRUE(u == 32);
+
+  ASSERT_TRUE(PnmParseUnsigned(MakeSpan(max_unsigned.c_str()), &u));
+  ASSERT_TRUE(u == std::numeric_limits<size_t>::max());
 
   ASSERT_TRUE(PnmParseSigned(MakeSpan("1"), &d));
   ASSERT_TRUE(d == 1.0);

--- a/lib/extras/dec/pnm.cc
+++ b/lib/extras/dec/pnm.cc
@@ -88,8 +88,11 @@ class Parser {
 
     *number = 0;
     while (pos_ < end_ && *pos_ >= '0' && *pos_ <= '9') {
-      *number *= 10;
-      *number += *pos_ - '0';
+      const size_t digit = *pos_ - '0';
+      if (!SafeMul(*number, static_cast<size_t>(10), *number) ||
+          !SafeAdd(*number, digit, *number)) {
+        return JXL_FAILURE("PNM: unsigned number too large");
+      }
       ++pos_;
     }
 

--- a/tools/fast_lossless/pam-input.h
+++ b/tools/fast_lossless/pam-input.h
@@ -62,8 +62,11 @@ class Parser {
 
     *number = 0;
     while (pos_ < end_ && *pos_ >= '0' && *pos_ <= '9') {
-      *number *= 10;
-      *number += *pos_ - '0';
+      const size_t digit = *pos_ - '0';
+      if (*number > (SIZE_MAX - digit) / 10) {
+        return error_msg("PNM: unsigned number too large");
+      }
+      *number = *number * 10 + digit;
       ++pos_;
     }
 


### PR DESCRIPTION
## Summary
- reject PNM/PAM unsigned header numbers when decimal accumulation would overflow size_t
- apply the same guard to the fast-lossless PAM parser copy
- add boundary coverage for SIZE_MAX and overflowing values in CodecTest.TestPNM

## Testing
- git diff --check
- /tmp/pnm_parse_harness
- /tmp/pam_parse_harness

Note: full CTest configuration in this container is blocked by missing system PNG development headers; the harnesses compile and exercise the patched parser paths directly.