### PR TITLE
don't segfault on non-existing files

### DIFF
--- a/tools/file_io.h
+++ b/tools/file_io.h
@@ -37,6 +37,7 @@ class FileWrapper {
       : file_(pathname == "-" ? (mode[0] == 'r' ? stdin : stdout)
                               : fopen(pathname.c_str(), mode)),
         close_on_delete_(pathname != "-") {
+    if (file_ == nullptr) return;
 #ifdef _WIN32
     struct __stat64 s = {};
     int err = _fstat64(_fileno(file_), &s);


### PR DESCRIPTION
There was some regression that caused any non-existing file or other fopen() failure to make tools segfault rather than produce an error.

In particular, for `icc_simplify` this made it impossible to make it produce profiles from a string (e.g. `icc_simplify sRGB sRGB.icc`) which would now segfault after trying to open `sRGB` as a file, instead of trying to interpret it as a colorspace string instead of a filename.