### PR TITLE
Fix GIF always being decoded as RGBA

### DIFF
--- a/lib/extras/dec/gif.cc
+++ b/lib/extras/dec/gif.cc
@@ -265,7 +265,7 @@ Status DecodeImageGIF(Span<const uint8_t> bytes, const ColorHints& color_hints,
       // If we do not have an alpha-channel and a==255 (fully opaque),
       // we can skip setting this pixel-value and rely on
       // "no alpha channel = no transparency".
-      if (a == 255 && !frame->extra_channels.empty()) return true;
+      if (a == 255 && frame->extra_channels.empty()) return true;
       JXL_RETURN_IF_ERROR(ensure_have_alpha(frame));
       static_cast<uint8_t*>(
           frame->extra_channels[0].pixels())[y * frame->color.xsize + x] = a;


### PR DESCRIPTION
Fixes #1851 