### PR TITLE
Save memory in ValidateTree

### DIFF
--- a/lib/jxl/modular/encoding/dec_ma.cc
+++ b/lib/jxl/modular/encoding/dec_ma.cc
@@ -27,53 +27,87 @@ namespace jxl {
 
 namespace {
 
-Status ValidateTree(const Tree &tree) {
+enum class NextAction { CHECK_AND_GO_LEFT, GO_RIGHT, POP };
+
+struct WorkItem {
+  size_t node_index;
+  pixel_type orig_l;
+  pixel_type orig_u;
+  NextAction action;
+};
+
+Status ValidateTree(const Tree& tree) {
+  if (tree.empty()) return true;
+  // TODO(eustas): or invalid?
+
   int num_properties = 0;
   for (auto node : tree) {
     if (node.property >= num_properties) {
       num_properties = node.property + 1;
     }
   }
-  std::vector<int> height(tree.size());
+
   std::vector<std::pair<pixel_type, pixel_type>> property_ranges(
-      num_properties * tree.size());
+      num_properties);
   for (int i = 0; i < num_properties; i++) {
     property_ranges[i].first = std::numeric_limits<pixel_type>::min();
     property_ranges[i].second = std::numeric_limits<pixel_type>::max();
   }
-  const int kHeightLimit = 2048;
-  for (size_t i = 0; i < tree.size(); i++) {
-    if (height[i] > kHeightLimit) {
-      return JXL_FAILURE("Tree too tall: %d", height[i]);
-    }
-    if (tree[i].property == -1) continue;
-    height[tree[i].lchild] = height[i] + 1;
-    height[tree[i].rchild] = height[i] + 1;
-    for (size_t p = 0; p < static_cast<size_t>(num_properties); p++) {
-      if (p == static_cast<size_t>(tree[i].property)) {
-        pixel_type l = property_ranges[i * num_properties + p].first;
-        pixel_type u = property_ranges[i * num_properties + p].second;
-        pixel_type val = tree[i].splitval;
-        if (l > val || u <= val) {
+
+  constexpr size_t kHeightLimit = 2048;
+
+  std::vector<WorkItem> stack;
+  stack.push_back({/*node_index=*/0, /*orig_l=*/0, /*orig_u=*/0,
+                   NextAction::CHECK_AND_GO_LEFT});
+
+  while (!stack.empty()) {
+    if (stack.size() >= kHeightLimit) return JXL_FAILURE("Tree too tall");
+    WorkItem& item = stack.back();
+    const auto& node = tree[item.node_index];
+    switch (item.action) {
+      case NextAction::CHECK_AND_GO_LEFT: {
+        int16_t p = node.property;
+        if (p == -1) {
+          stack.pop_back();
+          continue;
+        }
+        PropertyVal v = node.splitval;
+        pixel_type l = property_ranges[p].first;
+        pixel_type u = property_ranges[p].second;
+        if (l > v || u <= v) {
           return JXL_FAILURE("Invalid tree");
         }
-        property_ranges[tree[i].lchild * num_properties + p] =
-            std::make_pair(val + 1, u);
-        property_ranges[tree[i].rchild * num_properties + p] =
-            std::make_pair(l, val);
-      } else {
-        property_ranges[tree[i].lchild * num_properties + p] =
-            property_ranges[i * num_properties + p];
-        property_ranges[tree[i].rchild * num_properties + p] =
-            property_ranges[i * num_properties + p];
+        item.orig_l = l;
+        item.orig_u = u;
+        item.action = NextAction::GO_RIGHT;
+        property_ranges[node.property].first = node.splitval + 1;
+        stack.push_back({/*node_index=*/node.lchild,
+                         /*orig_l=*/0, /*orig_u=*/0,
+                         NextAction::CHECK_AND_GO_LEFT});
+        continue;
       }
+
+      case NextAction::GO_RIGHT:
+        item.action = NextAction::POP;
+        property_ranges[node.property].first = item.orig_l;
+        property_ranges[node.property].second = node.splitval;
+        stack.push_back({/*node_index=*/node.rchild,
+                         /*orig_l=*/0, /*orig_u=*/0,
+                         NextAction::CHECK_AND_GO_LEFT});
+        continue;
+
+      case NextAction::POP:
+        property_ranges[node.property].second = item.orig_u;
+        stack.pop_back();
+        continue;
     }
   }
+
   return true;
 }
 
-Status DecodeTree(BitReader *br, ANSSymbolReader *reader,
-                  const std::vector<uint8_t> &context_map, Tree *tree,
+Status DecodeTree(BitReader* br, ANSSymbolReader* reader,
+                  const std::vector<uint8_t>& context_map, Tree* tree,
                   size_t tree_size_limit) {
   size_t leaf_id = 0;
   size_t to_decode = 1;
@@ -125,7 +159,7 @@ Status DecodeTree(BitReader *br, ANSSymbolReader *reader,
 }
 }  // namespace
 
-Status DecodeTree(JxlMemoryManager *memory_manager, BitReader *br, Tree *tree,
+Status DecodeTree(JxlMemoryManager* memory_manager, BitReader* br, Tree* tree,
                   size_t tree_size_limit) {
   std::vector<uint8_t> tree_context_map;
   ANSCode tree_code;


### PR DESCRIPTION
In worst case old implementation would need to store/process `tree_size * num_props` items; that is `1<<22 * 256`.
With new implementation we omit the first multiplier.
