### PR TITLE
Improve spline caching:

### DIFF
--- a/lib/jxl/dec_frame.cc
+++ b/lib/jxl/dec_frame.cc
@@ -289,7 +289,7 @@ Status FrameDecoder::ProcessDCGlobal(BitReader* br) {
   shared.image_features.splines.Clear();
   if (frame_header_.flags & FrameHeader::kSplines) {
     JXL_RETURN_IF_ERROR(shared.image_features.splines.Decode(
-        memory_manager, br, frame_dim_.xsize * frame_dim_.ysize));
+        br, frame_dim_.xsize * frame_dim_.ysize));
   }
   if (frame_header_.flags & FrameHeader::kNoise) {
     JXL_RETURN_IF_ERROR(DecodeNoise(br, &shared.image_features.noise_params));

--- a/lib/jxl/enc_heuristics.cc
+++ b/lib/jxl/enc_heuristics.cc
@@ -1042,11 +1042,12 @@ Status LossyFrameHeuristics(const FrameHeader& frame_header,
   JxlMemoryManager* memory_manager = enc_state->memory_manager();
 
   // Find and subtract splines.
-  if (cparams.custom_splines.HasAny()) {
-    image_features.splines = cparams.custom_splines;
+  bool override_splines = cparams.custom_splines.HasAny();
+  if (override_splines) {
+    image_features.splines.SetData(cparams.custom_splines);
   }
   if (!streaming_mode && cparams.speed_tier <= SpeedTier::kSquirrel) {
-    if (!cparams.custom_splines.HasAny()) {
+    if (!override_splines) {
       image_features.splines = FindSplines(*opsin);
     }
     JXL_RETURN_IF_ERROR(image_features.splines.InitializeDrawCache(

--- a/lib/jxl/enc_modular.cc
+++ b/lib/jxl/enc_modular.cc
@@ -720,7 +720,7 @@ Status ModularFrameEncoder::ComputeEncodingData(
   if (cparams_.custom_splines.HasAny()) {
     PassesSharedState& shared = enc_state->shared;
     ImageFeatures& image_features = shared.image_features;
-    image_features.splines = cparams_.custom_splines;
+    image_features.splines.SetData(cparams_.custom_splines);
   }
 
   // Convert ImageBundle to modular Image object

--- a/lib/jxl/enc_params.h
+++ b/lib/jxl/enc_params.h
@@ -182,7 +182,7 @@ struct CompressParams {
   Tree custom_fixed_tree;
   // If not empty, these custom splines will be used instead of the computed
   // ones. Used in jxl_from_tee tool.
-  Splines custom_splines;
+  SplineDataView custom_splines{};
   // If not null, overrides progressive mode settings. Used in decode_test.
   const ProgressiveMode* custom_progressive_mode = nullptr;
 

--- a/lib/jxl/enc_splines.cc
+++ b/lib/jxl/enc_splines.cc
@@ -46,7 +46,7 @@ class QuantizedSplineEncoder {
 
 namespace {
 
-void EncodeAllStartingPoints(const std::vector<Spline::Point>& points,
+void EncodeAllStartingPoints(Span<const Spline::Point> points,
                              std::vector<Token>* tokens) {
   int64_t last_x = 0;
   int64_t last_y = 0;
@@ -76,8 +76,7 @@ Status EncodeSplines(const Splines& splines, BitWriter* writer,
                      const HistogramParams& histogram_params, AuxOut* aux_out) {
   JXL_ENSURE(splines.HasAny());
 
-  const std::vector<QuantizedSpline>& quantized_splines =
-      splines.QuantizedSplines();
+  Span<const QuantizedSpline> quantized_splines = splines.QuantizedSplines();
   std::vector<std::vector<Token>> tokens(1);
   tokens[0].emplace_back(static_cast<uint32_t>(kNumSplinesContext),
                          static_cast<uint32_t>(quantized_splines.size() - 1));
@@ -103,7 +102,7 @@ Status EncodeSplines(const Splines& splines, BitWriter* writer,
 
 Splines FindSplines(const Image3F& opsin) {
   // TODO(user): implement spline detection.
-  return {};
+  return Splines{opsin.memory_manager()};
 }
 
 }  // namespace jxl

--- a/lib/jxl/passes_state.h
+++ b/lib/jxl/passes_state.h
@@ -37,7 +37,7 @@ namespace jxl {
 
 struct ImageFeatures {
   explicit ImageFeatures(JxlMemoryManager* memory_manager_)
-      : patches(memory_manager_) {}
+      : patches(memory_manager_), splines(memory_manager_) {}
   NoiseParams noise_params;
   PatchDictionary patches;
   Splines splines;

--- a/lib/jxl/render_pipeline/render_pipeline_test.cc
+++ b/lib/jxl/render_pipeline/render_pipeline_test.cc
@@ -203,7 +203,7 @@ struct RenderPipelineTestInputSettings {
 
   bool add_spot_color = false;
 
-  Splines splines;
+  bool has_splines;
 
   JXL_NOINLINE void Reset() {
     input_path.clear();
@@ -213,9 +213,34 @@ struct RenderPipelineTestInputSettings {
     cparams = CompressParams();
     cparams_descr.clear();
     add_spot_color = false;
-    splines.Clear();
+    has_splines = false;
   }
 };
+
+Status CreateTestSplines(std::vector<QuantizedSpline>& quantized_splines,
+                         std::vector<Spline::Point>& starting_points) {
+  quantized_splines.clear();
+  starting_points.clear();
+  const ColorCorrelation color_correlation{};
+  std::vector<Spline::Point> control_points{{9, 54},  {118, 159}, {97, 3},
+                                            {10, 40}, {150, 25},  {120, 300}};
+  const Spline spline{control_points,
+                      /*color_dct=*/
+                      {Dct32{0.03125f, 0.00625f, 0.003125f},
+                       Dct32{1.f, 0.321875f}, Dct32{1.f, 0.24375f}},
+                      /*sigma_dct=*/{0.3125f, 0.f, 0.f, 0.0625f}};
+  std::vector<Spline> spline_data = {spline};
+  for (const Spline& ospline : spline_data) {
+    JXL_ASSIGN_OR_RETURN(
+        QuantizedSpline qspline,
+        QuantizedSpline::Create(ospline, /*quantization_adjustment=*/0,
+                                color_correlation.YtoXRatio(0),
+                                color_correlation.YtoBRatio(0)));
+    quantized_splines.emplace_back(std::move(qspline));
+    starting_points.push_back(ospline.control_points.front());
+  }
+  return true;
+}
 
 class RenderPipelineTestParam
     : public ::testing::TestWithParam<RenderPipelineTestInputSettings> {};
@@ -270,7 +295,16 @@ TEST_P(RenderPipelineTestParam, PipelineTest) {
 
   std::vector<uint8_t> compressed;
 
-  config.cparams.custom_splines = config.splines;
+  std::vector<QuantizedSpline> quantized_splines;
+  std::vector<Spline::Point> starting_points;
+  if (config.has_splines) {
+    ASSERT_TRUE(CreateTestSplines(quantized_splines, starting_points));
+    config.cparams.custom_splines = {
+        Span<const QuantizedSpline>(quantized_splines),
+        Span<const Spline::Point>(starting_points)};
+  } else {
+    config.cparams.custom_splines = {};
+  }
   ASSERT_TRUE(test::EncodeFile(config.cparams, io.get(), &compressed, &pool));
 
   auto io_default = jxl::make_unique<CodecInOut>(memory_manager);
@@ -298,31 +332,6 @@ TEST_P(RenderPipelineTestParam, PipelineTest) {
           io_default->frames[i].extra_channels()[ec], kMaxError, kMaxError, _));
     }
   }
-}
-
-StatusOr<Splines> CreateTestSplines() {
-  const ColorCorrelation color_correlation{};
-  std::vector<Spline::Point> control_points{{9, 54},  {118, 159}, {97, 3},
-                                            {10, 40}, {150, 25},  {120, 300}};
-  const Spline spline{control_points,
-                      /*color_dct=*/
-                      {Dct32{0.03125f, 0.00625f, 0.003125f},
-                       Dct32{1.f, 0.321875f}, Dct32{1.f, 0.24375f}},
-                      /*sigma_dct=*/{0.3125f, 0.f, 0.f, 0.0625f}};
-  std::vector<Spline> spline_data = {spline};
-  std::vector<QuantizedSpline> quantized_splines;
-  std::vector<Spline::Point> starting_points;
-  for (const Spline& ospline : spline_data) {
-    JXL_ASSIGN_OR_RETURN(
-        QuantizedSpline qspline,
-        QuantizedSpline::Create(ospline, /*quantization_adjustment=*/0,
-                                color_correlation.YtoXRatio(0),
-                                color_correlation.YtoBRatio(0)));
-    quantized_splines.emplace_back(std::move(qspline));
-    starting_points.push_back(ospline.control_points.front());
-  }
-  return Splines(/*quantization_adjustment=*/0, std::move(quantized_splines),
-                 std::move(starting_points));
 }
 
 std::vector<RenderPipelineTestInputSettings> GeneratePipelineTests() {
@@ -403,7 +412,7 @@ std::vector<RenderPipelineTestInputSettings> GeneratePipelineTests() {
     {
       s = stub;
       s.cparams_descr = "Splines";
-      JXL_TEST_ASSIGN_OR_DIE(s.splines, CreateTestSplines());
+      s.has_splines = true;
       all_tests.push_back(s);
     }
 

--- a/lib/jxl/splines.cc
+++ b/lib/jxl/splines.cc
@@ -29,6 +29,7 @@
 #include "lib/jxl/dec_ans.h"
 #include "lib/jxl/dec_bit_reader.h"
 #include "lib/jxl/image.h"
+#include "lib/jxl/memory_manager_internal.h"
 #include "lib/jxl/pack_signed.h"
 
 #undef HWY_TARGET_INCLUDE
@@ -125,10 +126,10 @@ void DrawSegment(const SplineSegment& segment, const bool add, const size_t y,
   }
 }
 
-void ComputeSegments(const Spline::Point& center, const float intensity,
-                     const float color[3], const float sigma,
-                     std::vector<SplineSegment>& segments,
-                     std::vector<std::pair<size_t, size_t>>& segments_by_y) {
+void ComputeSegments(size_t image_ysize, const Spline::Point& center,
+                     const float intensity, const float color[3],
+                     const float sigma, std::vector<SplineSegment>& segments,
+                     std::vector<SplineSegmentSpan>& segment_spans) {
   // Sanity check sigma, inverse sigma and intensity
   if (!(std::isfinite(sigma) && sigma != 0.0f && std::isfinite(1.0f / sigma) &&
         std::isfinite(intensity))) {
@@ -150,6 +151,13 @@ void ComputeSegments(const Spline::Point& center, const float intensity,
   const float maximum_distance =
       std::sqrt(-2.0f * sigma * sigma *
                 (std::log(0.1f) * kDistanceExp - std::log(max_color)));
+
+  ptrdiff_t y0 = std::llround(center.y - maximum_distance);
+  y0 = std::max<ptrdiff_t>(y0, 0);
+  ptrdiff_t y1 = std::llround(center.y + maximum_distance) + 1;
+  y1 = std::min<ptrdiff_t>(y1, image_ysize);
+  if (y1 <= y0) return;
+
   SplineSegment segment;
   segment.center_y = center.y;
   segment.center_x = center.x;
@@ -157,31 +165,27 @@ void ComputeSegments(const Spline::Point& center, const float intensity,
   segment.inv_sigma = 1.0f / sigma;
   segment.sigma_over_4_times_intensity = .25f * sigma * intensity;
   segment.maximum_distance = maximum_distance;
-  ptrdiff_t y0 = std::llround(center.y - maximum_distance);
-  ptrdiff_t y1 =
-      std::llround(center.y + maximum_distance) + 1;  // one-past-the-end
-  for (ptrdiff_t y = std::max<ptrdiff_t>(y0, 0); y < y1; y++) {
-    segments_by_y.emplace_back(y, segments.size());
-  }
-  segments.push_back(segment);
+  segments.emplace_back(segment);
+
+  segment_spans.emplace_back(y0, y1);
 }
 
 void DrawSegments(float* JXL_RESTRICT row_x, float* JXL_RESTRICT row_y,
                   float* JXL_RESTRICT row_b, size_t y, size_t x0, size_t x1,
                   const bool add, const SplineSegment* segments,
                   const size_t* segment_indices,
-                  const size_t* segment_y_start) {
+                  const ptrdiff_t* segment_y_start) {
   float* JXL_RESTRICT rows[3] = {row_x, row_y, row_b};
-  for (size_t i = segment_y_start[y]; i < segment_y_start[y + 1]; i++) {
+  for (ptrdiff_t i = segment_y_start[y]; i < segment_y_start[y + 1]; i++) {
     DrawSegment(segments[segment_indices[i]], add, y, x0, x1, rows);
   }
 }
 
 void SegmentsFromPoints(
-    const Spline& spline,
+    size_t image_ysize, const Spline& spline,
     const std::vector<std::pair<Spline::Point, float>>& points_to_draw,
     const float arc_length, std::vector<SplineSegment>& segments,
-    std::vector<std::pair<size_t, size_t>>& segments_by_y) {
+    std::vector<SplineSegmentSpan>& segments_spans) {
   const float inv_arc_length = 1.0f / arc_length;
   int k = 0;
   for (const auto& point_to_draw : points_to_draw) {
@@ -197,7 +201,8 @@ void SegmentsFromPoints(
     }
     const float sigma =
         ContinuousIDCT(spline.sigma_dct, (32 - 1) * progress_along_arc);
-    ComputeSegments(point, multiplier, color, sigma, segments, segments_by_y);
+    ComputeSegments(image_ysize, point, multiplier, color, sigma, segments,
+                    segments_spans);
   }
 }
 }  // namespace
@@ -577,20 +582,25 @@ Status QuantizedSpline::Decode(const std::vector<uint8_t>& context_map,
   return true;
 }
 
-void Splines::Clear() {
-  quantization_adjustment_ = 0;
-  splines_.clear();
-  starting_points_.clear();
-  segments_.clear();
-  segment_indices_.clear();
-  segment_y_start_.clear();
+void Splines::SetData(SplineDataView data) {
+  Clear();
+  data_ = data;
 }
 
-Status Splines::Decode(JxlMemoryManager* memory_manager, jxl::BitReader* br,
-                       const size_t num_pixels) {
+void Splines::Clear() {
+  quantization_adjustment_ = 0;
+  splines_storage_.clear();
+  starting_points_storage_.clear();
+  data_ = {};
+  segments_.clear();
+  segment_indices_ = AlignedMemory();
+  segment_y_start_ = AlignedMemory();
+}
+
+Status Splines::Decode(jxl::BitReader* br, const size_t num_pixels) {
   std::vector<uint8_t> context_map;
   ANSCode code;
-  JXL_RETURN_IF_ERROR(DecodeHistograms(memory_manager, br, kNumSplineContexts,
+  JXL_RETURN_IF_ERROR(DecodeHistograms(memory_manager_, br, kNumSplineContexts,
                                        &code, &context_map));
   JXL_ASSIGN_OR_RETURN(ANSSymbolReader decoder,
                        ANSSymbolReader::Create(&code, br));
@@ -603,23 +613,26 @@ Status Splines::Decode(JxlMemoryManager* memory_manager, jxl::BitReader* br,
     return JXL_FAILURE("Too many splines: %" PRIuS, num_splines);
   }
   num_splines++;
-  JXL_RETURN_IF_ERROR(DecodeAllStartingPoints(&starting_points_, br, &decoder,
-                                              context_map, num_splines));
+  JXL_RETURN_IF_ERROR(DecodeAllStartingPoints(
+      &starting_points_storage_, br, &decoder, context_map, num_splines));
 
   quantization_adjustment_ = UnpackSigned(
       decoder.ReadHybridUint(kQuantizationAdjustmentContext, br, context_map));
 
-  splines_.clear();
-  splines_.reserve(num_splines);
+  splines_storage_.clear();
+  splines_storage_.reserve(num_splines);
   size_t num_control_points = num_splines;
   for (size_t i = 0; i < num_splines; ++i) {
     QuantizedSpline spline;
     JXL_RETURN_IF_ERROR(spline.Decode(context_map, &decoder, br,
                                       max_control_points, &num_control_points));
-    splines_.push_back(std::move(spline));
+    splines_storage_.push_back(std::move(spline));
   }
 
   JXL_RETURN_IF_ERROR(decoder.CheckANSFinalState());
+
+  data_ = SplineDataView{Span<const QuantizedSpline>(splines_storage_),
+                         Span<const Spline::Point>(starting_points_storage_)};
 
   if (!HasAny()) {
     return JXL_FAILURE("Decoded splines but got none");
@@ -647,16 +660,16 @@ Status Splines::InitializeDrawCache(const size_t image_xsize,
   // TODO(veluca): avoid storing segments that are entirely outside image
   // boundaries.
   segments_.clear();
-  segment_indices_.clear();
-  segment_y_start_.clear();
-  std::vector<std::pair<size_t, size_t>> segments_by_y;
+  segment_indices_ = AlignedMemory();
+  segment_y_start_ = AlignedMemory();
+  std::vector<SplineSegmentSpan> segments_spans;
   std::vector<Spline::Point> intermediate_points;
   uint64_t total_estimated_area_reached = 0;
   std::vector<Spline> splines;
-  for (size_t i = 0; i < splines_.size(); ++i) {
+  for (size_t i = 0; i < data_.splines.size(); ++i) {
     Spline spline;
-    JXL_RETURN_IF_ERROR(splines_[i].Dequantize(
-        starting_points_[i], quantization_adjustment_,
+    JXL_RETURN_IF_ERROR(data_.splines[i].Dequantize(
+        data_.starting_points[i], quantization_adjustment_,
         color_correlation.YtoXRatio(0), color_correlation.YtoBRatio(0),
         image_xsize * image_ysize, &total_estimated_area_reached, spline));
     if (std::adjacent_find(spline.control_points.begin(),
@@ -699,23 +712,48 @@ Status Splines::InitializeDrawCache(const size_t image_xsize,
       continue;
     }
     HWY_DYNAMIC_DISPATCH(SegmentsFromPoints)
-    (spline, points_to_draw, arc_length, segments_, segments_by_y);
+    (image_ysize, spline, points_to_draw, arc_length, segments_,
+     segments_spans);
   }
 
-  // TODO(eustas): consider linear sorting here.
-  std::sort(segments_by_y.begin(), segments_by_y.end());
-  segment_indices_.resize(segments_by_y.size());
-  segment_y_start_.resize(image_ysize + 1);
-  for (size_t i = 0; i < segments_by_y.size(); i++) {
-    segment_indices_[i] = segments_by_y[i].second;
-    size_t y = segments_by_y[i].first;
-    if (y < image_ysize) {
-      segment_y_start_[y + 1]++;
+  size_t segment_y_start_num_bytes = (image_ysize + 2) * sizeof(ptrdiff_t);
+  JXL_ASSIGN_OR_RETURN(
+      segment_y_start_,
+      AlignedMemory::Create(memory_manager_, segment_y_start_num_bytes));
+  ptrdiff_t* segment_y_start = segment_y_start_.address<ptrdiff_t>();
+  memset(segment_y_start, 0, segment_y_start_num_bytes);
+  ptrdiff_t* population = segment_y_start + 1;
+  for (const auto& segment_span : segments_spans) {
+    population[segment_span.start]++;
+    population[segment_span.end]--;
+  }
+  // Turn to cumulative.
+  size_t total = 0;
+  ptrdiff_t coverage = 0;
+  for (size_t y = 0; y < image_ysize; y++) {
+    if (population[y] < 0) {
+      JXL_ENSURE(coverage >= -population[y]);
+    }
+    coverage += population[y];
+    population[y] = total;
+    total += coverage;
+  }
+  // population[0] == 0 (that is segment_y_start[1])
+  // We are going to place segments using population[y] as index for elements
+  // of y-th line (and increment them); that way final value of population[y]
+  // is the staring index for (y+1)-th line. Thus segment_y_start will contain
+  // indices without an offset.
+  JXL_ASSIGN_OR_RETURN(
+      segment_indices_,
+      AlignedMemory::Create(memory_manager_, total * sizeof(size_t)));
+  size_t* segment_indices = segment_indices_.address<size_t>();
+  for (size_t i = 0; i < segments_.size(); ++i) {
+    const auto& segment_span = segments_spans[i];
+    for (size_t y = segment_span.start; y < segment_span.end; y++) {
+      segment_indices[population[y]++] = i;
     }
   }
-  for (size_t y = 0; y < image_ysize; y++) {
-    segment_y_start_[y + 1] += segment_y_start_[y];
-  }
+
   return true;
 }
 
@@ -726,7 +764,7 @@ void Splines::ApplyToRow(float* JXL_RESTRICT row_x, float* JXL_RESTRICT row_y,
   if (segments_.empty()) return;
   HWY_DYNAMIC_DISPATCH(DrawSegments)
   (row_x, row_y, row_b, y, x0, x1, add, segments_.data(),
-   segment_indices_.data(), segment_y_start_.data());
+   segment_indices_.address<size_t>(), segment_y_start_.address<ptrdiff_t>());
 }
 
 template <bool add>

--- a/lib/jxl/splines.h
+++ b/lib/jxl/splines.h
@@ -17,9 +17,11 @@
 
 #include "lib/jxl/base/compiler_specific.h"
 #include "lib/jxl/base/rect.h"
+#include "lib/jxl/base/span.h"
 #include "lib/jxl/base/status.h"
 #include "lib/jxl/chroma_from_luma.h"
 #include "lib/jxl/image.h"
+#include "lib/jxl/memory_manager_internal.h"
 
 namespace jxl {
 
@@ -98,22 +100,41 @@ struct SplineSegment {
   float color[3];
 };
 
+struct SplineSegmentSpan {
+  SplineSegmentSpan() = default;
+  SplineSegmentSpan(size_t start, size_t end) : start(start), end(end) {}
+  size_t start;  // inclusive
+  size_t end;    // exclusive
+};
+
+struct SplineDataView {
+  Span<const QuantizedSpline> splines;
+  Span<const Spline::Point> starting_points;
+  bool HasAny() const { return !splines.empty(); }
+};
+
 class Splines {
  public:
-  Splines() = default;
-  explicit Splines(const int32_t quantization_adjustment,
-                   std::vector<QuantizedSpline> splines,
-                   std::vector<Spline::Point> starting_points)
-      : quantization_adjustment_(quantization_adjustment),
-        splines_(std::move(splines)),
-        starting_points_(std::move(starting_points)) {}
+  explicit Splines(JxlMemoryManager* memory_manager)
+      : memory_manager_(memory_manager) {
+    Clear();
+  }
 
-  bool HasAny() const { return !splines_.empty(); }
+  // Cannot copy.
+  Splines(const Splines&) = delete;
+  Splines& operator=(const Splines&) = delete;
+
+  // Move default.
+  Splines(Splines&&) noexcept = default;
+  Splines& operator=(Splines&&) noexcept = default;
+
+  void SetData(SplineDataView data);
+
+  bool HasAny() const { return data_.HasAny(); }
 
   void Clear();
 
-  Status Decode(JxlMemoryManager* memory_manager, BitReader* br,
-                size_t num_pixels);
+  Status Decode(BitReader* br, size_t num_pixels);
 
   void AddTo(Image3F* opsin, const Rect& opsin_rect) const;
   void AddToRow(float* JXL_RESTRICT row_x, float* JXL_RESTRICT row_y,
@@ -121,11 +142,9 @@ class Splines {
                 size_t x1) const;
   void SubtractFrom(Image3F* opsin) const;
 
-  const std::vector<QuantizedSpline>& QuantizedSplines() const {
-    return splines_;
-  }
-  const std::vector<Spline::Point>& StartingPoints() const {
-    return starting_points_;
+  Span<const QuantizedSpline> QuantizedSplines() const { return data_.splines; }
+  Span<const Spline::Point> StartingPoints() const {
+    return data_.starting_points;
   }
 
   int32_t GetQuantizationAdjustment() const { return quantization_adjustment_; }
@@ -144,12 +163,18 @@ class Splines {
   // If positive, quantization weights are multiplied by 1 + this/8, which
   // increases precision. If negative, they are divided by 1 - this/8. If 0,
   // they are unchanged.
+  JxlMemoryManager* memory_manager_;
   int32_t quantization_adjustment_ = 0;
-  std::vector<QuantizedSpline> splines_;
-  std::vector<Spline::Point> starting_points_;
+
+  // Spline data storage
+  // TODO(eustas): make memory-manager-tracked.
+  std::vector<QuantizedSpline> splines_storage_;
+  std::vector<Spline::Point> starting_points_storage_;
+
+  SplineDataView data_;
   std::vector<SplineSegment> segments_;
-  std::vector<size_t> segment_indices_;
-  std::vector<size_t> segment_y_start_;
+  AlignedMemory /*size_t*/ segment_indices_;
+  AlignedMemory /*ptrdiff_t*/ segment_y_start_;
 };
 
 }  // namespace jxl

--- a/lib/jxl/splines_gbench.cc
+++ b/lib/jxl/splines_gbench.cc
@@ -54,13 +54,14 @@ void BM_Splines(benchmark::State& state) {
     quantized_splines.emplace_back(std::move(qspline));
     starting_points.push_back(spline.control_points.front());
   }
-  Splines splines(kQuantizationAdjustment, std::move(quantized_splines),
-                  std::move(starting_points));
+  JxlMemoryManager* memory_manager = jpegxl::tools::NoMemoryManager();
+  Splines splines{memory_manager};
+  splines.SetData({Span<const QuantizedSpline>(quantized_splines),
+                   Span<const Spline::Point>(starting_points)});
 
-  JXL_ASSIGN_OR_QUIT(
-      Image3F drawing_area,
-      Image3F::Create(jpegxl::tools::NoMemoryManager(), 320, 320),
-      "Failed to allocate drawing plane.");
+  JXL_ASSIGN_OR_QUIT(Image3F drawing_area,
+                     Image3F::Create(memory_manager, 320, 320),
+                     "Failed to allocate drawing plane.");
   ZeroFillImage(&drawing_area);
   for (auto _ : state) {
     (void)_;

--- a/lib/jxl/splines_test.cc
+++ b/lib/jxl/splines_test.cc
@@ -154,8 +154,9 @@ TEST(SplinesTest, Serialization) {
     starting_points.push_back(spline.control_points.front());
   }
 
-  Splines splines(kQuantizationAdjustment, std::move(quantized_splines),
-                  std::move(starting_points));
+  Splines splines{memory_manager};
+  splines.SetData({Span<const QuantizedSpline>(quantized_splines),
+                   Span<const Spline::Point>(starting_points)});
   std::vector<Spline> quantized_spline_data;
   ASSERT_TRUE(DequantizeSplines(splines, quantized_spline_data));
   EXPECT_EQ(quantized_spline_data.size(), spline_data.size());
@@ -182,9 +183,8 @@ TEST(SplinesTest, Serialization) {
   printf("Wrote %" PRIuS " bits of splines.\n", bits_written);
 
   BitReader reader(writer.GetSpan());
-  Splines decoded_splines;
-  ASSERT_TRUE(
-      decoded_splines.Decode(memory_manager, &reader, /*num_pixels=*/1000));
+  Splines decoded_splines{memory_manager};
+  ASSERT_TRUE(decoded_splines.Decode(&reader, /*num_pixels=*/1000));
   ASSERT_TRUE(reader.JumpToByteBoundary());
   EXPECT_EQ(reader.TotalBitsConsumed(), bits_written);
   ASSERT_TRUE(reader.Close());
@@ -239,17 +239,17 @@ TEST(SplinesTest, TooManySplinesTest) {
     starting_points.push_back(spline.control_points.front());
   }
 
-  Splines splines(kQuantizationAdjustment, std::move(quantized_splines),
-                  std::move(starting_points));
+  Splines splines{memory_manager};
+  splines.SetData({Span<const QuantizedSpline>(quantized_splines),
+                   Span<const Spline::Point>(starting_points)});
   BitWriter writer{memory_manager};
   ASSERT_TRUE(EncodeSplines(splines, &writer, LayerType::Splines,
                             HistogramParams(SpeedTier::kFalcon, 1), nullptr));
   writer.ZeroPadToByte();
   // Re-read splines.
   BitReader reader(writer.GetSpan());
-  Splines decoded_splines;
-  EXPECT_FALSE(
-      decoded_splines.Decode(memory_manager, &reader, /*num_pixels=*/1000));
+  Splines decoded_splines{memory_manager};
+  EXPECT_FALSE(decoded_splines.Decode(&reader, /*num_pixels=*/1000));
   EXPECT_TRUE(reader.Close());
 }
 
@@ -277,8 +277,9 @@ TEST(SplinesTest, DuplicatePoints) {
     quantized_splines.emplace_back(std::move(qspline));
     starting_points.push_back(spline.control_points.front());
   }
-  Splines splines(kQuantizationAdjustment, std::move(quantized_splines),
-                  std::move(starting_points));
+  Splines splines{memory_manager};
+  splines.SetData({Span<const QuantizedSpline>(quantized_splines),
+                   Span<const Spline::Point>(starting_points)});
 
   JXL_TEST_ASSIGN_OR_DIE(Image3F image,
                          Image3F::Create(memory_manager, 320, 320));

--- a/tools/jxl_from_tree.cc
+++ b/tools/jxl_from_tree.cc
@@ -23,6 +23,7 @@
 #include "lib/extras/codec_in_out.h"
 #include "lib/jxl/base/common.h"
 #include "lib/jxl/base/override.h"
+#include "lib/jxl/base/span.h"
 #include "lib/jxl/base/status.h"
 #include "lib/jxl/cms/color_encoding_cms.h"
 #include "lib/jxl/color_encoding_internal.h"
@@ -64,9 +65,10 @@ using ::jxl::PassesEncoderState;
 using ::jxl::Predictor;
 using ::jxl::PropertyDecisionNode;
 using ::jxl::QuantizedSpline;
+using ::jxl::Span;
 using ::jxl::Spline;
 using ::jxl::Splines;
-using ::jxl::StatusOr;
+using ::jxl::Status;
 using ::jxl::Tree;
 
 namespace {
@@ -75,9 +77,11 @@ struct SplineData {
   std::vector<Spline> splines;
 };
 
-StatusOr<Splines> SplinesFromSplineData(const SplineData& spline_data) {
-  std::vector<QuantizedSpline> quantized_splines;
-  std::vector<Spline::Point> starting_points;
+Status SplinesFromSplineData(const SplineData& spline_data,
+                             std::vector<QuantizedSpline>& quantized_splines,
+                             std::vector<Spline::Point>& starting_points) {
+  quantized_splines.clear();
+  starting_points.clear();
   quantized_splines.reserve(spline_data.splines.size());
   starting_points.reserve(spline_data.splines.size());
   for (const Spline& spline : spline_data.splines) {
@@ -88,8 +92,7 @@ StatusOr<Splines> SplinesFromSplineData(const SplineData& spline_data) {
     quantized_splines.emplace_back(std::move(qspline));
     starting_points.push_back(spline.control_points.front());
   }
-  return Splines(spline_data.quantization_adjustment,
-                 std::move(quantized_splines), std::move(starting_points));
+  return true;
 }
 
 template <typename F>
@@ -536,8 +539,13 @@ bool ParseNode(F& tok, Tree& tree, SplineData& spline_data,
   cparams.patches = jxl::Override::kOff;
   cparams.already_downsampled = true;
   cparams.custom_fixed_tree = tree;
-  JXL_ASSIGN_OR_RETURN(cparams.custom_splines,
-                       SplinesFromSplineData(spline_data));
+
+  std::vector<QuantizedSpline> quantized_splines;
+  std::vector<Spline::Point> starting_points;
+  JXL_RETURN_IF_ERROR(
+      SplinesFromSplineData(spline_data, quantized_splines, starting_points));
+  cparams.custom_splines = {Span<const QuantizedSpline>(quantized_splines),
+                            Span<const Spline::Point>(starting_points)};
   PaddedBytes compressed{memory_manager};
 
   JXL_RETURN_IF_ERROR(io->CheckMetadata());


### PR DESCRIPTION
 - skip spans below image_ysize
 - linear sorting of splines

Drive-by:
 - store splines cache in managed memory
 - prepare to store spline data in managed memory (custom spline data is passed as view)
