### PR TITLE
Ignore format.align when we must (API contract)

### DIFF
--- a/lib/jxl/enc_external_image.cc
+++ b/lib/jxl/enc_external_image.cc
@@ -45,11 +45,11 @@ size_t JxlDataTypeBytes(JxlDataType data_type) {
 
 }  // namespace
 
-Status ConvertFromExternalNoSizeCheck(const uint8_t* data, size_t xsize,
-                                      size_t ysize, size_t stride,
-                                      size_t bits_per_sample,
-                                      JxlPixelFormat format, size_t c,
-                                      ThreadPool* pool, ImageF* channel) {
+Status ConvertFromExternalPlaneNoSizeCheck(const uint8_t* data, size_t xsize,
+                                           size_t ysize, size_t stride,
+                                           size_t bits_per_sample,
+                                           JxlPixelFormat format, size_t c,
+                                           ThreadPool* pool, ImageF* channel) {
   if (format.data_type == JXL_TYPE_UINT8) {
     JXL_RETURN_IF_ERROR(bits_per_sample > 0 && bits_per_sample <= 8);
   } else if (format.data_type == JXL_TYPE_UINT16) {
@@ -65,6 +65,11 @@ Status ConvertFromExternalNoSizeCheck(const uint8_t* data, size_t xsize,
 
   size_t bytes_per_channel = JxlDataTypeBytes(format.data_type);
   size_t bytes_per_pixel = format.num_channels * bytes_per_channel;
+  size_t bytes_per_row;
+  if (!SafeMul(xsize, bytes_per_pixel, bytes_per_row)) {
+    return JXL_FAILURE("Image dimensions are too large");
+  }
+  JXL_ENSURE(bytes_per_row <= stride);
   size_t pixel_offset = c * bytes_per_channel;
   // Only for uint8/16.
   float scale = 1.0f / ((1ull << bits_per_sample) - 1);
@@ -110,7 +115,7 @@ Status ConvertFromExternalNoSizeCheck(const uint8_t* data, size_t xsize,
   JXL_ASSIGN_OR_RETURN(Image3F color,
                        Image3F::Create(memory_manager, xsize, ysize));
   for (size_t c = 0; c < color_channels; ++c) {
-    JXL_RETURN_IF_ERROR(ConvertFromExternalNoSizeCheck(
+    JXL_RETURN_IF_ERROR(ConvertFromExternalPlaneNoSizeCheck(
         data, xsize, ysize, stride, bits_per_sample, format, c, pool,
         &color.Plane(c)));
   }
@@ -125,7 +130,7 @@ Status ConvertFromExternalNoSizeCheck(const uint8_t* data, size_t xsize,
   if (has_alpha && ib->HasAlpha()) {
     JXL_ASSIGN_OR_RETURN(ImageF alpha,
                          ImageF::Create(memory_manager, xsize, ysize));
-    JXL_RETURN_IF_ERROR(ConvertFromExternalNoSizeCheck(
+    JXL_RETURN_IF_ERROR(ConvertFromExternalPlaneNoSizeCheck(
         data, xsize, ysize, stride, bits_per_sample, format,
         format.num_channels - 1, pool, &alpha));
     JXL_RETURN_IF_ERROR(ib->SetAlpha(std::move(alpha)));
@@ -177,7 +182,7 @@ Status ConvertFromExternal(const uint8_t* data, size_t size, size_t xsize,
   if (size > row_size * ysize) {
     return JXL_FAILURE("Buffer size is too large");
   }
-  return ConvertFromExternalNoSizeCheck(
+  return ConvertFromExternalPlaneNoSizeCheck(
       data, xsize, ysize, row_size, bits_per_sample, format, c, pool, channel);
 }
 Status ConvertFromExternal(Span<const uint8_t> bytes, size_t xsize,

--- a/lib/jxl/enc_external_image.h
+++ b/lib/jxl/enc_external_image.h
@@ -20,11 +20,11 @@
 #include "lib/jxl/image_bundle.h"
 
 namespace jxl {
-Status ConvertFromExternalNoSizeCheck(const uint8_t* data, size_t xsize,
-                                      size_t ysize, size_t stride,
-                                      size_t bits_per_sample,
-                                      JxlPixelFormat format, size_t c,
-                                      ThreadPool* pool, ImageF* channel);
+Status ConvertFromExternalPlaneNoSizeCheck(const uint8_t* data, size_t xsize,
+                                           size_t ysize, size_t stride,
+                                           size_t bits_per_sample,
+                                           JxlPixelFormat format, size_t c,
+                                           ThreadPool* pool, ImageF* channel);
 
 Status ConvertFromExternalNoSizeCheck(const uint8_t* data, size_t xsize,
                                       size_t ysize, size_t stride,

--- a/lib/jxl/enc_fast_lossless.cc
+++ b/lib/jxl/enc_fast_lossless.cc
@@ -4296,13 +4296,15 @@ class FJxlFrameInput {
         bytes_per_pixel_(bitdepth <= 8 ? nb_chans : 2 * nb_chans) {}
 
   JxlChunkedFrameInputSource GetInputSource() {
-    return JxlChunkedFrameInputSource{this, GetDataAt,
-                                      [](void*, const void*) {}};
+    return JxlChunkedFrameInputSource{
+        this, GetColorChannelDataAt,
+        /*release_buffer=*/[](void*, const void*) {}};
   }
 
  private:
-  static const void* GetDataAt(void* opaque, size_t xpos, size_t ypos,
-                               size_t xsize, size_t ysize, size_t* row_offset) {
+  static const void* GetColorChannelDataAt(void* opaque, size_t xpos,
+                                           size_t ypos, size_t xsize,
+                                           size_t ysize, size_t* row_offset) {
     FJxlFrameInput* self = static_cast<FJxlFrameInput*>(opaque);
     *row_offset = self->row_stride_;
     return self->rgba_ + ypos * (*row_offset) + xpos * self->bytes_per_pixel_;

--- a/lib/jxl/enc_frame.cc
+++ b/lib/jxl/enc_frame.cc
@@ -120,12 +120,12 @@ Status ParamsPostInit(CompressParams* p) {
   }
   // Modular has to be squeezed to show progressive HF passes.
   if (p->progressive_mode == Override::kOn ||
-    p->qprogressive_mode == Override::kOn) {
+      p->qprogressive_mode == Override::kOn) {
     p->responsive = 1;
     if (p->IsLossless()) {
       p->qprogressive_mode = Override::kOn;
+    }
   }
-}
   return true;
 }
 
@@ -182,6 +182,7 @@ Status CopyColorChannels(JxlChunkedFrameInputSource input, Rect rect,
                          bool* has_interleaved_alpha) {
   JxlPixelFormat format = {4, JXL_TYPE_UINT8, JXL_NATIVE_ENDIAN, 0};
   input.get_color_channels_pixel_format(input.opaque, &format);
+  format.align = 0;  // align must be ignored.
   *has_interleaved_alpha = format.num_channels == 2 || format.num_channels == 4;
   size_t bits_per_sample =
       GetBitDepth(frame_info.image_bit_depth, metadata, format);
@@ -201,7 +202,7 @@ Status CopyColorChannels(JxlChunkedFrameInputSource input, Rect rect,
   }
   const uint8_t* data = reinterpret_cast<const uint8_t*>(buffer.get());
   for (size_t c = 0; c < color_channels; ++c) {
-    JXL_RETURN_IF_ERROR(ConvertFromExternalNoSizeCheck(
+    JXL_RETURN_IF_ERROR(ConvertFromExternalPlaneNoSizeCheck(
         data, rect.xsize(), rect.ysize(), row_offset, bits_per_sample, format,
         c, pool, &color->Plane(c)));
   }
@@ -211,7 +212,7 @@ Status CopyColorChannels(JxlChunkedFrameInputSource input, Rect rect,
   }
   if (alpha) {
     if (*has_interleaved_alpha) {
-      JXL_RETURN_IF_ERROR(ConvertFromExternalNoSizeCheck(
+      JXL_RETURN_IF_ERROR(ConvertFromExternalPlaneNoSizeCheck(
           data, rect.xsize(), rect.ysize(), row_offset, bits_per_sample, format,
           format.num_channels - 1, pool, alpha));
     } else {
@@ -248,7 +249,7 @@ Status CopyExtraChannels(JxlChunkedFrameInputSource input, Rect rect,
     }
     size_t bits_per_sample = GetBitDepth(
         frame_info.image_bit_depth, metadata.extra_channel_info[ec], ec_format);
-    if (!ConvertFromExternalNoSizeCheck(
+    if (!ConvertFromExternalPlaneNoSizeCheck(
             reinterpret_cast<const uint8_t*>(buffer.get()), rect.xsize(),
             rect.ysize(), row_offset, bits_per_sample, ec_format, 0, pool,
             &(*extra_channels)[ec])) {
@@ -1682,7 +1683,8 @@ Status ComputeEncodingData(
         // TODO(Jonnyawsom3): Figure out how to allow local trees for
         // extra channels on VarDCT images without failing tests.
         (!(cparams.responsive == 1 && cparams.IsLossless()) &&
-        cparams.buffering < 3) || !cparams.custom_fixed_tree.empty()) {
+         cparams.buffering < 3) ||
+        !cparams.custom_fixed_tree.empty()) {
       JXL_RETURN_IF_ERROR(enc_modular.ComputeTree(pool));
       JXL_RETURN_IF_ERROR(enc_modular.ComputeTokens(pool));
     }
@@ -2070,8 +2072,9 @@ JXL_NOINLINE Status EncodeFrameStreaming(
   const bool streaming_output = (output_mode == 1);
   const bool streaming = (output_mode >= 1);
   const bool ooo = (output_mode == 2 && jxlp_counter != nullptr);
-  size_t start_pos =
-      (streaming_output && output_processor) ? output_processor->CurrentPosition() : 0;
+  size_t start_pos = (streaming_output && output_processor)
+                         ? output_processor->CurrentPosition()
+                         : 0;
   const size_t total_sections =
       NumTocEntries(frame_header.ToFrameDimensions().num_groups,
                     dc_group_order.size(), num_passes);
@@ -2093,14 +2096,14 @@ JXL_NOINLINE Status EncodeFrameStreaming(
   }
 
   auto write_jxlp = [&](uint32_t counter, bool is_last,
-                         Span<const uint8_t> data) -> Status {
+                        Span<const uint8_t> data) -> Status {
     uint8_t hdr[kLargeBoxHeaderSize + 4];
     const size_t hdr_size =
         WriteBoxHeader(MakeBoxType("jxlp"), 4 + data.size(),
                        /*unbounded=*/false, /*force_large_box=*/false, hdr);
     StoreBE32(counter | (is_last ? 0x80000000u : 0u), hdr + hdr_size);
-    JXL_RETURN_IF_ERROR(AppendData(*output_processor,
-                                   Span<const uint8_t>(hdr, hdr_size + 4)));
+    JXL_RETURN_IF_ERROR(
+        AppendData(*output_processor, Span<const uint8_t>(hdr, hdr_size + 4)));
     return AppendData(*output_processor, data);
   };
 
@@ -2165,10 +2168,10 @@ JXL_NOINLINE Status EncodeFrameStreaming(
         JXL_RETURN_IF_ERROR(
             output_processor->Seek(start_pos + group_data_offset));
       } else if (ooo) {
-        JXL_RETURN_IF_ERROR(write_jxlp(
-            jxlp_base, /*is_last=*/false,
-            Span<const uint8_t>(frame_header_bytes.data(),
-                                frame_header_bytes.size())));
+        JXL_RETURN_IF_ERROR(
+            write_jxlp(jxlp_base, /*is_last=*/false,
+                       Span<const uint8_t>(frame_header_bytes.data(),
+                                           frame_header_bytes.size())));
         JXL_RETURN_IF_ERROR(
             write_group_section(std::move(*group_codes[0]).TakeBytes()));
       }
@@ -2204,8 +2207,7 @@ JXL_NOINLINE Status EncodeFrameStreaming(
         OutputAcGlobal(*enc_state, frame_header.ToFrameDimensions(), aux_out));
     JXL_RETURN_IF_ERROR(writer->Shrink());
     if (streaming) {
-      JXL_RETURN_IF_ERROR(
-          write_group_section(std::move(*writer).TakeBytes()));
+      JXL_RETURN_IF_ERROR(write_group_section(std::move(*writer).TakeBytes()));
     } else {
       global_group_codes[1 + dc_group_order.size()] = std::move(writer);
     }
@@ -2587,9 +2589,9 @@ Status EncodeFrame(JxlMemoryManager* memory_manager,
 
     const auto process_variant = [&](size_t task, size_t) -> Status {
       JxlEncoderOutputProcessorWrapper local_output(memory_manager);
-      JXL_RETURN_IF_ERROR(EncodeFrame(memory_manager, all_params[task],
-                                      frame_info, metadata, frame_data, cms,
-                                      nullptr, &local_output, aux_out, nullptr));
+      JXL_RETURN_IF_ERROR(EncodeFrame(
+          memory_manager, all_params[task], frame_info, metadata, frame_data,
+          cms, nullptr, &local_output, aux_out, nullptr));
       size[task] = local_output.CurrentPosition();
       return true;
     };
@@ -2644,10 +2646,11 @@ Status EncodeFrame(JxlMemoryManager* memory_manager,
   if (cparams.ec_resampling < cparams.resampling) {
     cparams.ec_resampling = cparams.resampling;
   }
-  if (cparams.resampling > 1 || frame_info.is_preview
-    // LF frame extra channels not implemented yet, for images with alpha
-    // level 1 doesn't render and level 2 corrupts the image.
-    || metadata->m.num_extra_channels > 0) {
+  if (cparams.resampling > 1 ||
+      frame_info.is_preview
+      // LF frame extra channels not implemented yet, for images with alpha
+      // level 1 doesn't render and level 2 corrupts the image.
+      || metadata->m.num_extra_channels > 0) {
     cparams.progressive_dc = 0;
   }
 

--- a/lib/jxl/encode_internal.h
+++ b/lib/jxl/encode_internal.h
@@ -240,6 +240,7 @@ class JxlEncoderChunkedFrameAdapter {
       JxlPixelFormat format{4, JXL_TYPE_UINT8, JXL_NATIVE_ENDIAN, 0};
       input_source_.get_color_channels_pixel_format(input_source_.opaque,
                                                     &format);
+      format.align = 0;  // .align must be ignored
       size_t row_offset;
       {
         auto buffer =
@@ -253,6 +254,7 @@ class JxlEncoderChunkedFrameAdapter {
       for (size_t ec = 0; ec + 1 < channels_.size(); ++ec) {
         input_source_.get_extra_channel_pixel_format(input_source_.opaque, ec,
                                                      &format);
+        format.align = 0;  // .align must be ignored
         auto buffer = GetExtraChannelBuffer(input_source_, ec, 0, 0, xsize,
                                             ysize, &row_offset);
         if (!buffer) continue;
@@ -340,6 +342,7 @@ class JxlEncoderChunkedFrameAdapter {
     bool CopyFromBuffer(const void* buffer, JxlPixelFormat format,
                         size_t x_size, size_t y_size, size_t row_offset) {
       if (!SetFormatAndDimensions(format, x_size, y_size)) return false;
+      JXL_ENSURE(stride_ <= row_offset);
       buffer_ = nullptr;
       copy_.resize(y_size * stride_);
       for (size_t y = 0; y < y_size; ++y) {


### PR DESCRIPTION
Drive-by: reformat, rename method for consistency
