### PR TITLE
Deal with mistakenly set "interleaved" alpha.

### DIFF
--- a/lib/extras/packed_image_convert.cc
+++ b/lib/extras/packed_image_convert.cc
@@ -76,9 +76,11 @@ Status ConvertPackedFrameToImageBundle(const JxlBasicInfo& info,
   JXL_ENSURE(io.metadata.m.color_encoding.IsGray() ==
              (frame.color.format.num_channels <= 2));
 
+  bool has_interleaved_alpha = (info.alpha_bits != 0);
   JXL_RETURN_IF_ERROR(ConvertFromExternal(
       span, frame.color.xsize, frame.color.ysize, io.metadata.m.color_encoding,
-      frame_bits_per_sample, frame.color.format, pool, bundle));
+      frame_bits_per_sample, frame.color.format, pool, bundle,
+      has_interleaved_alpha));
 
   bundle->extra_channels().resize(io.metadata.m.extra_channel_info.size());
   for (size_t i = 0; i < frame.extra_channels.size(); i++) {

--- a/lib/jxl/decode_test.cc
+++ b/lib/jxl/decode_test.cc
@@ -259,7 +259,8 @@ std::vector<uint8_t> CreateTestJXLCodestream(
   io->metadata.m.color_encoding = color_encoding;
   EXPECT_TRUE(ConvertFromExternal(pixels, xsize, ysize, color_encoding,
                                   /*bits_per_sample=*/16, format,
-                                  /* pool */ nullptr, &io->Main()));
+                                  /* pool */ nullptr, &io->Main(),
+                                  include_alpha));
   std::vector<uint8_t> encoded_jpeg_bytes;
   if (params.jpeg_codestream != nullptr) {
     if (jxl::extras::CanDecode(jxl::extras::Codec::kJPG)) {
@@ -1334,7 +1335,7 @@ TEST_P(DecodeTestParam, PixelTest) {
 
     EXPECT_TRUE(ConvertFromExternal(bytes, config.xsize, config.ysize,
                                     color_encoding, 16, format_orig, nullptr,
-                                    &io->Main()));
+                                    &io->Main(), config.include_alpha));
 
     for (uint8_t& pixel : pixels) pixel = 0;
     EXPECT_TRUE(ConvertToExternal(

--- a/lib/jxl/enc_external_image.cc
+++ b/lib/jxl/enc_external_image.cc
@@ -97,55 +97,6 @@ Status ConvertFromExternalPlaneNoSizeCheck(const uint8_t* data, size_t xsize,
   return true;
 }
 
-Status ConvertFromExternalNoSizeCheck(const uint8_t* data, size_t xsize,
-                                      size_t ysize, size_t stride,
-                                      const ColorEncoding& c_current,
-                                      size_t color_channels,
-                                      size_t bits_per_sample,
-                                      JxlPixelFormat format, ThreadPool* pool,
-                                      ImageBundle* ib) {
-  JxlMemoryManager* memory_manager = ib->memory_manager();
-  bool has_alpha = format.num_channels == 2 || format.num_channels == 4;
-  if (format.num_channels < color_channels) {
-    return JXL_FAILURE("Expected %" PRIuS
-                       " color channels, received only %u channels",
-                       color_channels, format.num_channels);
-  }
-
-  JXL_ASSIGN_OR_RETURN(Image3F color,
-                       Image3F::Create(memory_manager, xsize, ysize));
-  for (size_t c = 0; c < color_channels; ++c) {
-    JXL_RETURN_IF_ERROR(ConvertFromExternalPlaneNoSizeCheck(
-        data, xsize, ysize, stride, bits_per_sample, format, c, pool,
-        &color.Plane(c)));
-  }
-  if (color_channels == 1) {
-    JXL_RETURN_IF_ERROR(CopyImageTo(color.Plane(0), &color.Plane(1)));
-    JXL_RETURN_IF_ERROR(CopyImageTo(color.Plane(0), &color.Plane(2)));
-  }
-  JXL_RETURN_IF_ERROR(ib->SetFromImage(std::move(color), c_current));
-
-  // Passing an interleaved image with an alpha channel to an image that doesn't
-  // have alpha channel just discards the passed alpha channel.
-  if (has_alpha && ib->HasAlpha()) {
-    JXL_ASSIGN_OR_RETURN(ImageF alpha,
-                         ImageF::Create(memory_manager, xsize, ysize));
-    JXL_RETURN_IF_ERROR(ConvertFromExternalPlaneNoSizeCheck(
-        data, xsize, ysize, stride, bits_per_sample, format,
-        format.num_channels - 1, pool, &alpha));
-    JXL_RETURN_IF_ERROR(ib->SetAlpha(std::move(alpha)));
-  } else if (!has_alpha && ib->HasAlpha()) {
-    // if alpha is not passed, but it is expected, then assume
-    // it is all-opaque
-    JXL_ASSIGN_OR_RETURN(ImageF alpha,
-                         ImageF::Create(memory_manager, xsize, ysize));
-    FillImage(1.0f, &alpha);
-    JXL_RETURN_IF_ERROR(ib->SetAlpha(std::move(alpha)));
-  }
-
-  return true;
-}
-
 Status ConvertFromExternal(const uint8_t* data, size_t size, size_t xsize,
                            size_t ysize, size_t bits_per_sample,
                            JxlPixelFormat format, size_t c, ThreadPool* pool,
@@ -187,10 +138,10 @@ Status ConvertFromExternal(const uint8_t* data, size_t size, size_t xsize,
 }
 Status ConvertFromExternal(Span<const uint8_t> bytes, size_t xsize,
                            size_t ysize, const ColorEncoding& c_current,
-                           size_t color_channels, size_t bits_per_sample,
-                           JxlPixelFormat format, ThreadPool* pool,
-                           ImageBundle* ib) {
+                           size_t bits_per_sample, JxlPixelFormat format,
+                           ThreadPool* pool, ImageBundle* ib, bool set_alpha) {
   JxlMemoryManager* memory_manager = ib->memory_manager();
+  size_t color_channels = c_current.Channels();
   bool has_alpha = format.num_channels == 2 || format.num_channels == 4;
   if (format.num_channels < color_channels) {
     return JXL_FAILURE("Expected %" PRIuS
@@ -213,32 +164,22 @@ Status ConvertFromExternal(Span<const uint8_t> bytes, size_t xsize,
 
   // Passing an interleaved image with an alpha channel to an image that doesn't
   // have alpha channel just discards the passed alpha channel.
-  if (has_alpha && ib->HasAlpha()) {
+  if (set_alpha) {
     JXL_ASSIGN_OR_RETURN(ImageF alpha,
                          ImageF::Create(memory_manager, xsize, ysize));
-    JXL_RETURN_IF_ERROR(ConvertFromExternal(
-        bytes.data(), bytes.size(), xsize, ysize, bits_per_sample, format,
-        format.num_channels - 1, pool, &alpha));
-    JXL_RETURN_IF_ERROR(ib->SetAlpha(std::move(alpha)));
-  } else if (!has_alpha && ib->HasAlpha()) {
-    // if alpha is not passed, but it is expected, then assume
-    // it is all-opaque
-    JXL_ASSIGN_OR_RETURN(ImageF alpha,
-                         ImageF::Create(memory_manager, xsize, ysize));
-    FillImage(1.0f, &alpha);
+    if (has_alpha) {
+      JXL_RETURN_IF_ERROR(ConvertFromExternal(
+          bytes.data(), bytes.size(), xsize, ysize, bits_per_sample, format,
+          format.num_channels - 1, pool, &alpha));
+    } else {
+      // if alpha is not passed, but it is expected, then assume
+      // it is all-opaque
+      FillImage(1.0f, &alpha);
+    }
     JXL_RETURN_IF_ERROR(ib->SetAlpha(std::move(alpha)));
   }
 
   return true;
-}
-
-Status ConvertFromExternal(Span<const uint8_t> bytes, size_t xsize,
-                           size_t ysize, const ColorEncoding& c_current,
-                           size_t bits_per_sample, JxlPixelFormat format,
-                           ThreadPool* pool, ImageBundle* ib) {
-  return ConvertFromExternal(bytes, xsize, ysize, c_current,
-                             c_current.Channels(), bits_per_sample, format,
-                             pool, ib);
 }
 
 Status BufferToImageF(const JxlPixelFormat& pixel_format, size_t xsize,
@@ -254,11 +195,11 @@ Status BufferToImageBundle(const JxlPixelFormat& pixel_format, uint32_t xsize,
                            uint32_t ysize, const void* buffer, size_t size,
                            jxl::ThreadPool* pool,
                            const jxl::ColorEncoding& c_current,
-                           jxl::ImageBundle* ib) {
+                           jxl::ImageBundle* ib, bool set_alpha) {
   size_t bitdepth = JxlDataTypeBytes(pixel_format.data_type) * kBitsPerByte;
   JXL_RETURN_IF_ERROR(ConvertFromExternal(
       jxl::Bytes(static_cast<const uint8_t*>(buffer), size), xsize, ysize,
-      c_current, bitdepth, pixel_format, pool, ib));
+      c_current, bitdepth, pixel_format, pool, ib, set_alpha));
   JXL_RETURN_IF_ERROR(ib->VerifyMetadata());
 
   return true;

--- a/lib/jxl/enc_external_image.h
+++ b/lib/jxl/enc_external_image.h
@@ -26,14 +26,6 @@ Status ConvertFromExternalPlaneNoSizeCheck(const uint8_t* data, size_t xsize,
                                            JxlPixelFormat format, size_t c,
                                            ThreadPool* pool, ImageF* channel);
 
-Status ConvertFromExternalNoSizeCheck(const uint8_t* data, size_t xsize,
-                                      size_t ysize, size_t stride,
-                                      const ColorEncoding& c_current,
-                                      size_t color_channels,
-                                      size_t bits_per_sample,
-                                      JxlPixelFormat format, ThreadPool* pool,
-                                      ImageBundle* ib);
-
 Status ConvertFromExternal(const uint8_t* data, size_t size, size_t xsize,
                            size_t ysize, size_t bits_per_sample,
                            JxlPixelFormat format, size_t c, ThreadPool* pool,
@@ -43,13 +35,9 @@ Status ConvertFromExternal(const uint8_t* data, size_t size, size_t xsize,
 // representation. This is the opposite of ConvertToExternal().
 Status ConvertFromExternal(Span<const uint8_t> bytes, size_t xsize,
                            size_t ysize, const ColorEncoding& c_current,
-                           size_t color_channels, size_t bits_per_sample,
-                           JxlPixelFormat format, ThreadPool* pool,
-                           ImageBundle* ib);
-Status ConvertFromExternal(Span<const uint8_t> bytes, size_t xsize,
-                           size_t ysize, const ColorEncoding& c_current,
                            size_t bits_per_sample, JxlPixelFormat format,
-                           ThreadPool* pool, ImageBundle* ib);
+                           ThreadPool* pool, ImageBundle* ib,
+                           bool set_alpha = false);
 Status BufferToImageF(const JxlPixelFormat& pixel_format, size_t xsize,
                       size_t ysize, const void* buffer, size_t size,
                       ThreadPool* pool, ImageF* channel);
@@ -57,7 +45,7 @@ Status BufferToImageBundle(const JxlPixelFormat& pixel_format, uint32_t xsize,
                            uint32_t ysize, const void* buffer, size_t size,
                            jxl::ThreadPool* pool,
                            const jxl::ColorEncoding& c_current,
-                           jxl::ImageBundle* ib);
+                           jxl::ImageBundle* ib, bool set_alpha = false);
 
 }  // namespace jxl
 

--- a/lib/jxl/enc_external_image_gbench.cc
+++ b/lib/jxl/enc_external_image_gbench.cc
@@ -45,7 +45,7 @@ void BM_EncExternalImage_ConvertImageRGBA(benchmark::State& state) {
           Bytes(interleaved.data(), interleaved.size()), xsize, ysize,
           /*c_current=*/ColorEncoding::SRGB(),
           /*bits_per_sample=*/8, format,
-          /*pool=*/nullptr, &ib));
+          /*pool=*/nullptr, &ib, /*set_alpha=*/true));
     }
   }
 

--- a/lib/jxl/enc_external_image_test.cc
+++ b/lib/jxl/enc_external_image_test.cc
@@ -32,18 +32,18 @@ TEST(ExternalImageTest, InvalidSize) {
 
   JxlPixelFormat format = {4, JXL_TYPE_UINT16, JXL_BIG_ENDIAN, 0};
   std::vector<uint8_t> buf(10 * 100 * 8);
-  EXPECT_FALSE(
-      ConvertFromExternal(Bytes(buf.data(), 10), /*xsize=*/10, /*ysize=*/100,
-                          /*c_current=*/ColorEncoding::SRGB(),
-                          /*bits_per_sample=*/16, format, nullptr, &ib));
+  EXPECT_FALSE(ConvertFromExternal(
+      Bytes(buf.data(), 10), /*xsize=*/10, /*ysize=*/100,
+      /*c_current=*/ColorEncoding::SRGB(),
+      /*bits_per_sample=*/16, format, nullptr, &ib, /*set_alpha=*/true));
   EXPECT_FALSE(ConvertFromExternal(
       Bytes(buf.data(), buf.size() - 1), /*xsize=*/10, /*ysize=*/100,
       /*c_current=*/ColorEncoding::SRGB(),
-      /*bits_per_sample=*/16, format, nullptr, &ib));
-  EXPECT_TRUE(
-      ConvertFromExternal(Bytes(buf), /*xsize=*/10,
-                          /*ysize=*/100, /*c_current=*/ColorEncoding::SRGB(),
-                          /*bits_per_sample=*/16, format, nullptr, &ib));
+      /*bits_per_sample=*/16, format, nullptr, &ib, /*set_alpha=*/true));
+  EXPECT_TRUE(ConvertFromExternal(
+      Bytes(buf), /*xsize=*/10,
+      /*ysize=*/100, /*c_current=*/ColorEncoding::SRGB(),
+      /*bits_per_sample=*/16, format, nullptr, &ib, /*set_alpha=*/true));
 }
 
 TEST(ExternalImageTest, AlphaMissing) {
@@ -76,7 +76,8 @@ TEST(ExternalImageTest, AlphaPremultiplied) {
 
   JxlPixelFormat format = {4, JXL_TYPE_UINT16, JXL_BIG_ENDIAN, 0};
   EXPECT_TRUE(BufferToImageBundle(format, xsize, ysize, buf, size, nullptr,
-                                  ColorEncoding::SRGB(), &ib));
+                                  ColorEncoding::SRGB(), &ib,
+                                  /*set_alpha*/ true));
 }
 
 }  // namespace

--- a/lib/jxl/image_bundle.cc
+++ b/lib/jxl/image_bundle.cc
@@ -113,15 +113,11 @@ Status ImageBundle::SetAlpha(ImageF&& alpha) {
   // Must call SetAlphaBits first, otherwise we don't know which channel index
   JXL_ENSURE(eci != nullptr);
   JXL_ENSURE(alpha.xsize() != 0 && alpha.ysize() != 0);
-  if (extra_channels_.size() < metadata_->extra_channel_info.size()) {
-    // TODO(jon): get rid of this case
-    extra_channels_.insert(
-        extra_channels_.begin() + (eci - metadata_->extra_channel_info.data()),
-        std::move(alpha));
-  } else {
-    extra_channels_[eci - metadata_->extra_channel_info.data()] =
-        std::move(alpha);
+  size_t eci_idx = eci - metadata_->extra_channel_info.data();
+  if (eci_idx != extra_channels_.size()) {
+    return JXL_FAILURE("Incorrect SetAlpha call");
   }
+  extra_channels_.emplace_back(std::move(alpha));
   // num_extra_channels is automatically set in visitor
   JXL_RETURN_IF_ERROR(VerifySizes());
   return true;

--- a/lib/jxl/roundtrip_test.cc
+++ b/lib/jxl/roundtrip_test.cc
@@ -107,7 +107,7 @@ std::unique_ptr<jxl::CodecInOut> ConvertTestImage(
   }
   EXPECT_TRUE(ConvertFromExternal(jxl::Bytes(buf), xsize, ysize, color_encoding,
                                   /*bits_per_sample=*/bitdepth, pixel_format,
-                                  /*pool=*/nullptr, &io->Main()));
+                                  /*pool=*/nullptr, &io->Main(), has_alpha));
   return io;
 }
 
@@ -480,13 +480,12 @@ TEST(RoundtripTest, FloatFrameRoundtripTest) {
           uint32_t total_extra_channels = has_alpha + extra_channels.size();
           // There's no support (yet) for lossless extra float
           // channels, so we don't test it.
-          if (total_extra_channels == 0 || !lossless) {
-            JxlPixelFormat pixel_format = JxlPixelFormat{
-                num_channels, JXL_TYPE_FLOAT, JXL_NATIVE_ENDIAN, 0};
-            VerifyRoundtripCompression<float>(
-                63, 129, pixel_format, pixel_format, lossless, use_container, 1,
-                false, extra_channels);
-          }
+          if (lossless && (total_extra_channels > 0)) continue;
+          JxlPixelFormat pixel_format = JxlPixelFormat{
+              num_channels, JXL_TYPE_FLOAT, JXL_NATIVE_ENDIAN, 0};
+          VerifyRoundtripCompression<float>(63, 129, pixel_format, pixel_format,
+                                            lossless, use_container, 1, false,
+                                            extra_channels);
         }
       }
     }

--- a/lib/jxl/test_utils.cc
+++ b/lib/jxl/test_utils.cc
@@ -349,7 +349,7 @@ std::unique_ptr<jxl::CodecInOut> SomeTestImageToCodecInOut(
       jxl::ColorEncoding::SRGB(/*is_gray=*/num_channels < 3),
       /*bits_per_sample=*/16, format,
       /*pool=*/nullptr,
-      /*ib=*/&io->Main()));
+      /*ib=*/&io->Main(), /*set_alpha=*/true));
   return io;
 }
 

--- a/tools/benchmark/benchmark_codec_webp.cc
+++ b/tools/benchmark/benchmark_codec_webp.cc
@@ -53,7 +53,7 @@ Status FromSRGB(const size_t xsize, const size_t ysize, const bool is_gray,
   JxlPixelFormat format = {num_channels, data_type, endianness, 0};
   const Span<const uint8_t> span(pixels, end - pixels);
   return ConvertFromExternal(span, xsize, ysize, c, bits_per_sample, format,
-                             pool, ib);
+                             pool, ib, /*set_alpha=*/true);
 }
 
 struct WebPArgs {

--- a/tools/djxl_fuzzer_corpus.cc
+++ b/tools/djxl_fuzzer_corpus.cc
@@ -238,7 +238,8 @@ bool GenerateFile(const char* output_dir, const ImageSpec& spec,
     const jxl::Span<const uint8_t> span(img_data.data(), img_data.size());
     JXL_RETURN_IF_ERROR(ConvertFromExternal(
         span, spec.width, spec.height, io->metadata.m.color_encoding,
-        io->metadata.m.bit_depth.bits_per_sample, format, nullptr, &ib));
+        io->metadata.m.bit_depth.bits_per_sample, format, nullptr, &ib,
+        has_alpha));
     io->frames.push_back(std::move(ib));
     JXL_ASSIGN_OR_RETURN(
         jxl::extras::PackedFrame packed_frame,


### PR DESCRIPTION
"HasAlpha" is used in a case when we would want to check if "interleaved" alpha channel is present; but implementation is not selective and reports true if any EC has type "Alpha".

Thanks to Arthur Chan / Anthropic for repotring this.
