### PR TITLE
Postpone JPEG coeffs allocation until first SOS.

### DIFF
--- a/lib/jxl/jpeg/enc_jpeg_data_reader.cc
+++ b/lib/jxl/jpeg/enc_jpeg_data_reader.cc
@@ -121,11 +121,6 @@ Status ProcessSOF(const uint8_t* data, const size_t len, JpegReadMode mode,
     }
     c.width_in_blocks = MCU_cols * c.h_samp_factor;
     c.height_in_blocks = MCU_rows * c.v_samp_factor;
-    const uint64_t num_blocks =
-        static_cast<uint64_t>(c.width_in_blocks) * c.height_in_blocks;
-    if (mode == JpegReadMode::kReadAll) {
-      c.coeffs.resize(num_blocks * kDCTBlockSize);
-    }
   }
   JXL_JPEG_VERIFY_MARKER_END();
   return true;
@@ -801,6 +796,15 @@ Status ProcessScan(const uint8_t* data, const size_t len,
   if (Al > 10) {
     return JXL_FAILURE("Scan parameter Al=%d is not supported.", Al);
   }
+
+  for (auto& c : jpg->components) {
+    if (c.coeffs.empty()) {
+      const uint64_t num_blocks =
+          static_cast<uint64_t>(c.width_in_blocks) * c.height_in_blocks;
+      c.coeffs.resize(num_blocks * kDCTBlockSize);
+    }
+  }
+
   for (int mcu_y = 0; mcu_y < MCU_rows; ++mcu_y) {
     for (int mcu_x = 0; mcu_x < MCUs_per_row; ++mcu_x) {
       // Handle the restart intervals.
@@ -930,6 +934,7 @@ Status ReadJpeg(const uint8_t* data, const size_t len, JpegReadMode mode,
   std::vector<HuffmanTableEntry> dc_huff_lut(lut_size);
   std::vector<HuffmanTableEntry> ac_huff_lut(lut_size);
   bool found_sof = false;
+  bool found_sos = false;
   bool found_dri = false;
   uint16_t scan_progression[kMaxComponents][kDCTBlockSize] = {{0}};
 
@@ -978,6 +983,7 @@ Status ReadJpeg(const uint8_t* data, const size_t len, JpegReadMode mode,
                                           scan_progression, is_progressive,
                                           &pos, jpg));
         }
+        found_sos = true;
         break;
       case 0xdb:
         JXL_RETURN_IF_ERROR(ProcessDQT(data, len, &pos, jpg));
@@ -1022,6 +1028,9 @@ Status ReadJpeg(const uint8_t* data, const size_t len, JpegReadMode mode,
 
   if (!found_sof) {
     return JXL_FAILURE("Missing SOF marker.");
+  }
+  if (!found_sos) {
+    return JXL_FAILURE("Missing SOS marker.");
   }
 
   // Supplemental checks.

--- a/lib/jxl/jpeg/jpeg_data.cc
+++ b/lib/jxl/jpeg/jpeg_data.cc
@@ -97,6 +97,10 @@ Status JPEGData::VisitFields(Visitor* visitor) {
     }
   }
 
+  if (info.num_scans == 0) {
+    return JXL_FAILURE("JPEG: no scans\n");
+  }
+
   // Size of the APP and COM markers.
   if (visitor->IsReading()) {
     app_data.resize(info.num_app_markers);


### PR DESCRIPTION
Drive-by: reject streams without SOS (both encode and decode)

Thanks to Brian Lee / SSLab at Georgia Tech for reporting