### PR TITLE
Fix photon noise encoding for progressive images

### DIFF
--- a/lib/jxl/dec_cache.cc
+++ b/lib/jxl/dec_cache.cc
@@ -120,7 +120,9 @@ Status PassesDecoderState::PreparePipeline(const FrameHeader& frame_header,
                                            PipelineOptions options) {
   JxlMemoryManager* memory_manager = this->memory_manager();
   size_t num_c = 3 + frame_header.nonserialized_metadata->m.num_extra_channels;
-  size_t num_tmp_c = options.render_noise ? 3 : 0;
+  bool render_noise =
+      (options.render_noise && (frame_header.flags & FrameHeader::kNoise) != 0);
+  size_t num_tmp_c = render_noise ? 3 : 0;
 
   if (frame_header.CanBeReferenced()) {
     // Necessary so that SetInputSizes() can allocate output buffers as needed.
@@ -211,7 +213,7 @@ Status PassesDecoderState::PreparePipeline(const FrameHeader& frame_header,
   // Starting from this line all the stages considered to have zero xextra.
   // Upsampling does not have xextra as well (even if it happens before
   // splines/patches for EC).
-  if (options.render_noise) {
+  if (render_noise) {
     JXL_RETURN_IF_ERROR(builder.AddStage(GetConvolveNoiseStage(num_c)));
     JXL_RETURN_IF_ERROR(builder.AddStage(GetAddNoiseStage(
         shared->image_features.noise_params, shared->cmap.base(), num_c)));

--- a/lib/jxl/dec_frame.cc
+++ b/lib/jxl/dec_frame.cc
@@ -542,10 +542,7 @@ Status FrameDecoder::ProcessACGroup(size_t ac_group_id, PassesReaders& br,
   }
   decoded_passes_per_ac_group_[ac_group_id] += num_passes;
 
-  const bool render_noise =
-      ((frame_header_.flags & FrameHeader::kNoise) != 0) &&
-      (frame_header_.dc_level == 0);
-  if (render_noise) {
+  if ((frame_header_.flags & FrameHeader::kNoise) != 0) {
     PrepareNoiseInput(*dec_state_, frame_dim_, frame_header_, ac_group_id,
                       thread);
   }
@@ -660,15 +657,12 @@ Status FrameDecoder::ProcessSections(const SectionInfo* sections, size_t num,
                                   "DecodeDCGroup"));
   }
 
-  const bool render_noise =
-      ((frame_header_.flags & FrameHeader::kNoise) != 0) &&
-      (frame_header_.dc_level == 0);
   if (!HasDcGroupToDecode() && !finalized_dc_) {
     PassesDecoderState::PipelineOptions pipeline_options;
     pipeline_options.use_slow_render_pipeline = use_slow_rendering_pipeline_;
     pipeline_options.coalescing = coalescing_;
     pipeline_options.render_spotcolors = render_spotcolors_;
-    pipeline_options.render_noise = render_noise;
+    pipeline_options.render_noise = true;
     JXL_RETURN_IF_ERROR(dec_state_->PreparePipeline(
         frame_header_, &frame_header_.nonserialized_metadata->m, decoded_,
         pipeline_options));

--- a/lib/jxl/enc_frame.cc
+++ b/lib/jxl/enc_frame.cc
@@ -698,7 +698,8 @@ void ComputeNoiseParams(const CompressParams& cparams, bool streaming_mode,
     return;
   }
   if (cparams.photon_noise_iso > 0) {
-    *noise_params = SimulatePhotonNoise(frame_dim.xsize, frame_dim.ysize,
+    FrameDimensions full_frame_dim = frame_header->ToFrameDimensions();
+    *noise_params = SimulatePhotonNoise(full_frame_dim.xsize, full_frame_dim.ysize,
                                         cparams.photon_noise_iso);
   } else if (cparams.manual_noise.size() == NoiseParams::kNumNoisePoints) {
     for (size_t i = 0; i < NoiseParams::kNumNoisePoints; i++) {

--- a/lib/jxl/enc_frame.cc
+++ b/lib/jxl/enc_frame.cc
@@ -693,6 +693,10 @@ void ComputeNoiseParams(const CompressParams& cparams, bool streaming_mode,
                         bool color_is_jpeg, const Image3F& opsin,
                         const FrameDimensions& frame_dim,
                         FrameHeader* frame_header, NoiseParams* noise_params) {
+  if (frame_header->frame_type == FrameType::kDCFrame) {
+    frame_header->flags &= ~FrameHeader::kNoise;
+    return;
+  }
   if (cparams.photon_noise_iso > 0) {
     *noise_params = SimulatePhotonNoise(frame_dim.xsize, frame_dim.ysize,
                                         cparams.photon_noise_iso);

--- a/lib/jxl/enc_heuristics.cc
+++ b/lib/jxl/enc_heuristics.cc
@@ -816,7 +816,7 @@ StatusOr<Image3F> ReconstructImage(
   options.use_slow_render_pipeline = false;
   options.coalescing = false;
   options.render_spotcolors = false;
-  options.render_noise = ((frame_header.flags & FrameHeader::kNoise) != 0);
+  options.render_noise = true;
 
   JXL_RETURN_IF_ERROR(dec_state->PreparePipeline(
       frame_header, &shared.metadata->m, &decoded, options));
@@ -854,7 +854,6 @@ StatusOr<Image3F> ReconstructImage(
   return std::move(*decoded.color());
 }
 
-  
 float ComputeBlockL2Distance(const Image3F& a, const Image3F& b,
                              const ImageF& mask1x1, size_t by, size_t bx) {
   Rect rect(bx * kBlockDim, by * kBlockDim, kBlockDim, kBlockDim, a.xsize(),
@@ -876,8 +875,8 @@ float ComputeBlockL2Distance(const Image3F& a, const Image3F& b,
       float mask = row_mask[x];
       float mask2 = mask * mask;
       for (int i = 0; i < 3; ++i) {
-	float diff = row_a[i][x] - row_b[i][x];
-	err2[i] += mask2 * diff * diff;
+        float diff = row_a[i][x] - row_b[i][x];
+        err2[i] += mask2 * diff * diff;
       }
     }
   }
@@ -938,7 +937,7 @@ Status ComputeARHeuristics(const FrameHeader& frame_header,
       float* error_row = error_images[val].Row(by);
       for (size_t bx = 0; bx < frame_dim.xsize_blocks; bx++) {
         error_row[bx] = ComputeBlockL2Distance(
-	    orig_opsin, decoded, initial_quant_masking1x1, by, bx);
+            orig_opsin, decoded, initial_quant_masking1x1, by, bx);
       }
     }
   }
@@ -958,7 +957,7 @@ Status ComputeARHeuristics(const FrameHeader& frame_header,
       for (uint8_t val : epf_steps) {
         float error = error_images[val].Row(by)[bx];
         if (val == 0) {
-	  error *= kFavorNoSmoothing;
+          error *= kFavorNoSmoothing;
         }
         if (error < best_error) {
           best_val = val;
@@ -988,8 +987,9 @@ Status ComputeARHeuristics(const FrameHeader& frame_header,
         int context = epf_steps_lut[top_val] * 3 + epf_steps_lut[left_val];
         const auto& ctx_histo = histo[context];
         const int mulix = epf_steps_lut[val] + 3 * context;
-        mul[mulix] = 1.0 / (1.0 + c5 * std::log1p(ctx_histo[val] /
-						  totals[context]) / clamped_butteraugli);
+        mul[mulix] =
+            1.0 / (1.0 + c5 * std::log1p(ctx_histo[val] / totals[context]) /
+                             clamped_butteraugli);
         if (val == 0) {
           mul[mulix] *= c3;
         }

--- a/lib/jxl/enc_noise.cc
+++ b/lib/jxl/enc_noise.cc
@@ -370,6 +370,10 @@ Status EncodeNoise(const NoiseParams& noise_params, BitWriter* writer,
                    LayerType layer, AuxOut* aux_out) {
   JXL_ENSURE(noise_params.HasAny());
 
+  for (size_t i = 0; i < NoiseParams::kNumNoisePoints; i++) {
+    fprintf(stderr, "Noise LUT[%zu] = %f\n", i, noise_params.lut[i]);
+  }
+
   return writer->WithMaxBits(
       NoiseParams::kNumNoisePoints * 16, layer, aux_out, [&]() -> Status {
         for (float i : noise_params.lut) {

--- a/lib/jxl/enc_noise.cc
+++ b/lib/jxl/enc_noise.cc
@@ -370,10 +370,6 @@ Status EncodeNoise(const NoiseParams& noise_params, BitWriter* writer,
                    LayerType layer, AuxOut* aux_out) {
   JXL_ENSURE(noise_params.HasAny());
 
-  for (size_t i = 0; i < NoiseParams::kNumNoisePoints; i++) {
-    fprintf(stderr, "Noise LUT[%zu] = %f\n", i, noise_params.lut[i]);
-  }
-
   return writer->WithMaxBits(
       NoiseParams::kNumNoisePoints * 16, layer, aux_out, [&]() -> Status {
         for (float i : noise_params.lut) {


### PR DESCRIPTION
Reverts the incorrect fix and applies Jon's suggestion in https://github.com/libjxl/libjxl/pull/4514#issuecomment-4670435066, no longer encoding noise onto LF frames and using the correct scaling on progressive HF frames.

Fixes #4368