### PR TITLE
check chunked encoder buffer-size arithmetic before copying full-frame input

### DIFF
--- a/lib/jxl/encode_internal.h
+++ b/lib/jxl/encode_internal.h
@@ -332,10 +332,16 @@ class JxlEncoderChunkedFrameAdapter {
     bool SetFromBuffer(const uint8_t* buffer, size_t size,
                        JxlPixelFormat format, size_t x_size, size_t y_size) {
       if (!SetFormatAndDimensions(format, x_size, y_size)) return false;
+      if (ysize_ == 0) return false;
       buffer_ = buffer;
       buffer_size_ = size;
-      const size_t min_buffer_size =
-          stride_ * (ysize_ - 1) + xsize_ * bytes_per_pixel_;
+      size_t min_buffer_size;
+      size_t last_row_size;
+      if (!SafeMul(xsize_, bytes_per_pixel_, last_row_size)) return false;
+      if (!SafeMul(stride_, ysize_ - 1, min_buffer_size)) return false;
+      if (!SafeAdd(min_buffer_size, last_row_size, min_buffer_size)) {
+        return false;
+      }
       return min_buffer_size <= size;
     }
 
@@ -344,7 +350,9 @@ class JxlEncoderChunkedFrameAdapter {
       if (!SetFormatAndDimensions(format, x_size, y_size)) return false;
       JXL_ENSURE(stride_ <= row_offset);
       buffer_ = nullptr;
-      copy_.resize(y_size * stride_);
+      size_t copy_size;
+      if (!SafeMul(y_size, stride_, copy_size)) return false;
+      copy_.resize(copy_size);
       for (size_t y = 0; y < y_size; ++y) {
         memcpy(copy_.data() + y * stride_,
                reinterpret_cast<const uint8_t*>(buffer) + y * row_offset,

--- a/lib/jxl/encode_internal.h
+++ b/lib/jxl/encode_internal.h
@@ -326,6 +326,8 @@ class JxlEncoderChunkedFrameAdapter {
       size_t last_row_size;
       if (!SafeMul(xsize_, bytes_per_pixel_, last_row_size)) return false;
       if (!SafeRoundUpTo(last_row_size, format_.align, stride_)) return false;
+      size_t total_size;
+      if (!SafeMul(ysize_, stride_, total_size)) return false;
       return true;
     }
 
@@ -335,13 +337,9 @@ class JxlEncoderChunkedFrameAdapter {
       if (ysize_ == 0) return false;
       buffer_ = buffer;
       buffer_size_ = size;
-      size_t min_buffer_size;
-      size_t last_row_size;
-      if (!SafeMul(xsize_, bytes_per_pixel_, last_row_size)) return false;
-      if (!SafeMul(stride_, ysize_ - 1, min_buffer_size)) return false;
-      if (!SafeAdd(min_buffer_size, last_row_size, min_buffer_size)) {
-        return false;
-      }
+      // Safe: SetFormatAndDimensions() checked ysize_ * stride_.
+      const size_t min_buffer_size =
+          stride_ * (ysize_ - 1) + xsize_ * bytes_per_pixel_;
       return min_buffer_size <= size;
     }
 
@@ -350,9 +348,8 @@ class JxlEncoderChunkedFrameAdapter {
       if (!SetFormatAndDimensions(format, x_size, y_size)) return false;
       JXL_ENSURE(stride_ <= row_offset);
       buffer_ = nullptr;
-      size_t copy_size;
-      if (!SafeMul(y_size, stride_, copy_size)) return false;
-      copy_.resize(copy_size);
+      // Safe: SetFormatAndDimensions() checked y_size * stride_.
+      copy_.resize(y_size * stride_);
       for (size_t y = 0; y < y_size; ++y) {
         memcpy(copy_.data() + y * stride_,
                reinterpret_cast<const uint8_t*>(buffer) + y * row_offset,


### PR DESCRIPTION
# libjxl: check chunked encoder buffer-size arithmetic before copying full-frame input

`JxlEncoderAddChunkedFrame()` can force chunked input callbacks through the
non-streaming full-frame copy path. On 32-bit builds, the internal copy size
calculation can wrap and allocate a smaller buffer than the subsequent row-copy
loop writes.

## Bug

### 1. Wrapped destination allocation (`lib/jxl/encode_internal.h:347`)

```cpp
copy_.resize(y_size * stride_);
for (size_t y = 0; y < y_size; ++y) {
  memcpy(copy_.data() + y * stride_,
         reinterpret_cast<const uint8_t*>(buffer) + y * row_offset,
         stride_);
}
```

`SetFormatAndDimensions()` checks the per-row `stride_`, but `CopyFromBuffer()`
does not check `y_size * stride_` before resizing `copy_`.

On i386, valid level-10 dimensions can make this multiplication wrap. For
example, RGB8 input with `xsize=21846` and `ysize=65536` gives
`stride_=65538`, so:

```text
65536 * 65538 == 0x100020000
```

This wraps to `131072` on 32-bit `size_t`. The vector allocation succeeds with
131072 bytes, then the second row copy writes 65538 bytes starting exactly at
the end of that allocation.

### 2. Same unchecked size contract in `SetFromBuffer()` (`lib/jxl/encode_internal.h:337`)

```cpp
const size_t min_buffer_size =
    stride_ * (ysize_ - 1) + xsize_ * bytes_per_pixel_;
return min_buffer_size <= size;
```

The non-chunked buffer validation path uses the same unchecked multiplication
and addition pattern. If it wraps, an undersized caller-provided buffer can pass
validation.

## Reachability

`JxlEncoderAddChunkedFrame()` reaches this path through public API calls:

```cpp
bool streaming = frame_settings->enc->output_processor.OutputProcessorSet();
...
auto status = JxlEncoderAddImageFrameInternal(
    frame_settings, xsize, ysize, streaming, std::move(frame_data));
```

If no output processor is set, `streaming == false`. Then
`JxlEncoderAddImageFrameInternal()` copies the callback-backed frame before any
later encode stage:

```cpp
if (!streaming) {
  if (!frame_data.CopyBuffers()) {
    return JXL_API_ERROR(frame_settings->enc, JXL_ENC_ERR_API_USAGE,
                         "Invalid chunked frame input source");
  }
}
```

`CopyBuffers()` requests the full advertised frame from the callback:

```cpp
auto buffer = GetColorBuffer(input_source_, 0, 0, xsize, ysize, &row_offset);
channels_[0].CopyFromBuffer(buffer.get(), format, xsize, ysize, row_offset);
```

This is reachable without an output processor and without needing to reach the
later image-encoding pipeline.

## Repro

The reproducer uses the public C API and a chunked RGB8 input source:

```cpp
constexpr size_t kXSize = 21846;
constexpr size_t kYSize = 65536;
constexpr size_t kChannels = 3;
```

It sets codestream level 10, calls `JxlEncoderSetBasicInfo()` with the above
dimensions, creates frame settings, leaves the output processor unset, and calls
`JxlEncoderAddChunkedFrame()`.

Built current upstream `4a570058` as i386 with GCC ASan/UBSan:

```console
cmake -S libjxl-upstream-verify -B build-libjxl-i386-gcc-asan \
  -DCMAKE_BUILD_TYPE=RelWithDebInfo \
  -DCMAKE_C_COMPILER=gcc -DCMAKE_CXX_COMPILER=g++ \
  '-DCMAKE_C_FLAGS=-m32 -fsanitize=address,undefined -fno-omit-frame-pointer' \
  '-DCMAKE_CXX_FLAGS=-m32 -fsanitize=address,undefined -fno-omit-frame-pointer' \
  '-DCMAKE_EXE_LINKER_FLAGS=-m32 -fsanitize=address,undefined' \
  '-DCMAKE_SHARED_LINKER_FLAGS=-m32 -fsanitize=address,undefined' \
  -DBUILD_TESTING=OFF -DBUILD_SHARED_LIBS=OFF \
  -DJPEGXL_ENABLE_TOOLS=OFF -DJPEGXL_ENABLE_MANPAGES=OFF \
  -DJPEGXL_ENABLE_DOXYGEN=OFF -DJPEGXL_ENABLE_BENCHMARK=OFF \
  -DJPEGXL_ENABLE_EXAMPLES=OFF -DJPEGXL_ENABLE_JNI=OFF \
  -DJPEGXL_ENABLE_OPENEXR=OFF -DJPEGXL_ENABLE_PLUGINS=OFF \
  -DJPEGXL_ENABLE_VIEWERS=OFF -DJPEGXL_ENABLE_FUZZERS=OFF \
  -DJPEGXL_ENABLE_DEVTOOLS=OFF -DJPEGXL_ENABLE_TRANSCODE_JPEG=OFF \
  -DJPEGXL_ENABLE_SJPEG=OFF -DJPEGXL_ENABLE_SKCMS=ON

cmake --build build-libjxl-i386-gcc-asan --target jxl jxl_threads -- -j4
```

ASan result on the unpatched tree:

```text
requested rectangle: xpos=0 ypos=0 xsize=21846 ysize=65536 row_offset=65538 backing=196614
=================================================================
ERROR: AddressSanitizer: heap-buffer-overflow
WRITE of size 65538
    #0 __interceptor_memcpy
    #1 jxl::JxlEncoderChunkedFrameAdapter::Channel::CopyFromBuffer(...)
       lib/jxl/encode_internal.h:349
    #2 jxl::JxlEncoderChunkedFrameAdapter::CopyBuffers()
       lib/jxl/encode_internal.h:249
    #3 JxlEncoderAddImageFrameInternal
       lib/jxl/encode.cc:2471
    #4 JxlEncoderAddChunkedFrame
       lib/jxl/encode.cc:2547

0xf5654800 is located 0 bytes to the right of 131072-byte region
allocated by thread T0 here:
    #0 operator new(unsigned int)
    #1 std::vector<unsigned char>::resize(unsigned int)
    #2 jxl::JxlEncoderChunkedFrameAdapter::Channel::CopyFromBuffer(...)
       lib/jxl/encode_internal.h:347

SUMMARY: AddressSanitizer: heap-buffer-overflow in __interceptor_memcpy
```

## Verification

Built unpatched `4a570058` and patched tree, both i386 ASan/UBSan.

| Input | Pre-patch | Post-patch |
|---|---|---|
| Public API chunked RGB8 frame, `21846 x 65536`, no output processor | ASan heap-buffer-overflow in `CopyFromBuffer()` | `JxlEncoderAddChunkedFrame returned 1`; no sanitizer finding |

## Duplicate check

Public GitHub issue/PR searches returned no exact match for:

```text
CopyFromBuffer
copy_.resize
"y_size * stride_"
"row_offset" "stride_"
"encode_internal.h" "heap-buffer-overflow"
"JXL_ENC_FRAME_SETTING_BUFFERING" overflow
"Invalid chunked frame input source"
```

GitHub commit search also returned no hits for `CopyFromBuffer` or
`copy_.resize`.

Broader encoder-overflow searches find existing reports such as `#4593` and
`#4527`, but those are different root causes in `enc_modular.cc` and
`enc_patch_dictionary.cc`. This issue is in the pre-encode chunked input copy
path in `encode_internal.h`.

Related but not duplicate:

* `#4708` ("Harden external image buffer size calculations with safe
  arithmetic") was merged on 2026-04-14 as merge commit
  `bebfa2da4ac2f32494c1fb811c9ab1d1f18587a0`.
* That PR changed only:
  * `lib/jxl/dec_external_image.cc`
  * `lib/jxl/enc_external_image.cc`
* It did not change `lib/jxl/encode_internal.h`, and current upstream
  `4a570058` still contains the unchecked `copy_.resize(y_size * stride_)`
  in `JxlEncoderChunkedFrameAdapter::Channel::CopyFromBuffer()`.
