### PR TITLE
fix heap over-read for grayscale input in EncodeWithSJpeg

### DIFF
--- a/lib/extras/enc/jpg.cc
+++ b/lib/extras/enc/jpg.cc
@@ -509,11 +509,20 @@ Status EncodeWithSJpeg(const PackedImage& image, const JxlBasicInfo& info,
     hook->first_iter_slope = params.search_first_iter_slope;
     param.search_hook = hook.get();
   }
-  size_t stride = image.xsize * 3;
+  const size_t num_channels = image.format.num_channels;
+  if (num_channels != 1 && num_channels != 3) {
+    return JXL_FAILURE("sjpeg supports only grayscale and RGB input");
+  }
+  const size_t stride = image.xsize * num_channels;
   const uint8_t* pixels = reinterpret_cast<const uint8_t*>(image.pixels());
   std::string output;
-  JXL_RETURN_IF_ERROR(
-      sjpeg::Encode(pixels, image.xsize, image.ysize, stride, param, &output));
+  if (num_channels == 1) {
+    JXL_RETURN_IF_ERROR(sjpeg::EncodeGray(pixels, image.xsize, image.ysize,
+                                          stride, param, &output));
+  } else {
+    JXL_RETURN_IF_ERROR(sjpeg::Encode(pixels, image.xsize, image.ysize, stride,
+                                      param, &output));
+  }
   bytes->assign(
       reinterpret_cast<const uint8_t*>(output.data()),
       reinterpret_cast<const uint8_t*>(output.data() + output.size()));


### PR DESCRIPTION
### Description

`EncodeWithSJpeg` hardcodes the input stride to `xsize * 3` and always calls `sjpeg::Encode`, which interprets the buffer as packed RGB. The JPEG encoder also accepts 1-channel grayscale images (alpha is rejected, so a plain grayscale frame reaches this path), and their pixel buffer is only `xsize * ysize` bytes. sjpeg then reads three bytes per pixel and runs two-thirds past the end of the allocation. Backing a 64x64 grayscale buffer with a guard page makes the read fault inside `sjpeg::RGB24PackedToPlanar`.

sjpeg provides `EncodeGray` for exactly this case, so grayscale now goes there with a 1-byte stride (matching how the libjpeg path already handles grayscale), RGB stays on `Encode`, and any other channel count is rejected up front.

### Pull Request Checklist

- [x] **CLA Signed**: Have you signed the [Contributor License Agreement](https://code.google.com/legal/individual-cla-v1.0.html) (individual or corporate, as appropriate)? Only contributions from signed contributors can be accepted.
- [ ] **Authors**: Have you considered adding your name to the [AUTHORS](AUTHORS) file?
- [x] **Code Style**: Have you ensured your code adheres to the project's coding style guidelines? You can use `./ci.sh lint` for automatic code formatting.