### PR TITLE
Remove jpeg_quality from CodecIo

### DIFF
--- a/lib/extras/codec_in_out.h
+++ b/lib/extras/codec_in_out.h
@@ -104,9 +104,6 @@ class CodecInOut {
   ImageBundle preview_frame;
 
   std::vector<ImageBundle> frames;  // size=1 if !metadata.have_animation
-
-  // If the image should be written to a JPEG, use this quality for encoding.
-  size_t jpeg_quality;
 };
 
 }  // namespace jxl

--- a/lib/jxl/decode_test.cc
+++ b/lib/jxl/decode_test.cc
@@ -276,7 +276,7 @@ std::vector<uint8_t> CreateTestJXLCodestream(
       ppf.info.num_color_channels = grayscale ? 1 : 3;
       ppf.info.bits_per_sample = 16;
       auto encoder = extras::GetJPEGEncoder();
-      encoder->SetOption("quality", "70");
+      encoder->SetOption("q", "70");
       extras::EncodedImage encoded;
       EXPECT_TRUE(encoder->Encode(ppf, &encoded, nullptr));
       jpeg_bytes = encoded.bitstreams[0];

--- a/tools/djxl_fuzzer_corpus.cc
+++ b/tools/djxl_fuzzer_corpus.cc
@@ -257,9 +257,8 @@ bool GenerateFile(const char* output_dir, const ImageSpec& spec,
     // If this image is supposed to be a reconstructible JPEG, collect the JPEG
     // metadata and encode it in the beginning of the compressed bytes.
     std::vector<uint8_t> jpeg_bytes;
-    io->jpeg_quality = 70;
     auto encoder = jxl::extras::GetJPEGEncoder();
-    encoder->SetOption("quality", "70");
+    encoder->SetOption("q", "70");
     jxl::extras::EncodedImage encoded;
     JXL_RETURN_IF_ERROR(encoder->Encode(ppf, &encoded, nullptr));
     jpeg_bytes = encoded.bitstreams[0];

--- a/tools/hdr/image_utils.h
+++ b/tools/hdr/image_utils.h
@@ -81,8 +81,6 @@ static inline jxl::Status Encode(const jxl::CodecInOut& io,
       format.data_type = JXL_TYPE_UINT8;
       encoder = jxl::extras::GetJPEGEncoder();
       if (encoder) {
-        os << io.jpeg_quality;
-        encoder->SetOption("q", os.str());
         break;
       } else {
         return JXL_FAILURE("JPEG XL was built without JPEG support");


### PR DESCRIPTION
Reminder: the grand plan is get rid of CodecIo, when possible

Drive-by: in some places we set "quality" option, that is no-op; set "q" instead (parsed by "jpg" encoder)
