### PR TITLE
Fix MSVC ARM64 build, restrict _sub_overflow_i32 to x86/x64

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -65,6 +65,7 @@ Galaxy4594 <164440799+Galaxy4594@users.noreply.github.com>
 Gerhard Huber <support@pl32.com>
 gi-man
 Gilles Devillers (GilDev) <gildev@gmail.com>
+Giuseppe Francione <snesnopic@gmail.com>
 Heiko Becker <heirecka@exherbo.org>
 Ivan Kokorev
 Ivan Siutsou (Melirius) <melirius@gmail.com>

--- a/lib/jxl/base/common.h
+++ b/lib/jxl/base/common.h
@@ -56,7 +56,7 @@ static inline bool SubOverflow(const int32_t a, const int32_t b, int32_t& c) {
   // Clang 3.8+ / GCC 5.1+
 #if JXL_COMPILER_GCC || JXL_COMPILER_CLANG
   return __builtin_sub_overflow(a, b, &c);
-#elif JXL_COMPILER_MSVC >= 1937
+#elif JXL_COMPILER_MSVC >= 1937 && (defined(_M_AMD64) || defined(_M_IX86))
   return _sub_overflow_i32(/*carry*/ 0, a, b, &c);
 #else
   uint32_t ua = static_cast<uint32_t>(a);


### PR DESCRIPTION
### Description

The MSVC intrinsic `_sub_overflow_i32` is not available on ARM64, causing build failures when compiling with MSVC for Windows ARM64 targets.
This PR restricts its usage to x86/x64 architectures (`_M_AMD64` and `_M_IX86`), allowing ARM64 to fallback to the generic C implementation provided in the else branch. 
The change restores compilation on Windows ARM64 without affecting other platforms.

### Pull Request Checklist

- [x] **CLA Signed**: Have you signed the [Contributor License Agreement](https://code.google.com/legal/individual-cla-v1.0.html) (individual or corporate, as appropriate)? Only contributions from signed contributors can be accepted.
- [x] **Authors**: Have you considered adding your name to the [AUTHORS](AUTHORS) file?
- [x] **Code Style**: Have you ensured your code adheres to the project's coding style guidelines? You can use `./ci.sh lint` for automatic code formatting.
