### PR TITLE
fix reversed row-count check in DecodeImageAPNG frame copy

### DIFF
--- a/lib/extras/dec/apng.cc
+++ b/lib/extras/dec/apng.cc
@@ -883,7 +883,7 @@ Status DecodeImageAPNG(const Span<const uint8_t> bytes,
     const RectT<uint64_t>& vp = current_frame.viewport;
     size_t xsize = static_cast<size_t>(vp.xsize());
     size_t ysize = static_cast<size_t>(vp.ysize());
-    JXL_ENSURE(ctx.frameRaw.rows.size() <= ysize);
+    JXL_ENSURE(ysize <= ctx.frameRaw.rows.size());
     JXL_ASSIGN_OR_RETURN(PackedImage image,
                          PackedImage::Create(xsize, ysize, format));
     for (size_t y = 0; y < ysize; ++y) {


### PR DESCRIPTION
### Description

The per-frame copy in `DecodeImageAPNG` reads `ctx.frameRaw.rows[y]` for `y` up to the current frame's viewport height, but the guard added in #4870 asserts `ctx.frameRaw.rows.size() <= ysize`, which is the wrong direction to bound that read. `frameRaw.rows` is sized once to the full canvas height while `ysize` is the (possibly smaller) per-frame height, so any APNG whose animation frame is shorter than the canvas trips the `JXL_ENSURE` and fails to decode (it aborts in debug builds), even though those frames are valid. Comparing `ysize <= ctx.frameRaw.rows.size()` is the condition that actually keeps the row index in bounds and lets sub-canvas frames decode again.

I verified this with two APNGs that differ only in the second frame's height: a 32x32 canvas where frame 1 is 32x16 is rejected before this change and decodes after it, while an all-32x32 control decodes in both cases.

### Pull Request Checklist

- [x] **CLA Signed**: Have you signed the [Contributor License Agreement](https://code.google.com/legal/individual-cla-v1.0.html) (individual or corporate, as appropriate)? Only contributions from signed contributors can be accepted.
- [ ] **Authors**: Have you considered adding your name to the [AUTHORS](AUTHORS) file?
- [x] **Code Style**: Have you ensured your code adheres to the project's coding style guidelines? You can use `./ci.sh lint` for automatic code formatting.