### PR TITLE
replace static_assert with JXL_DASSERT for Highway Lanes

### DIFF
--- a/lib/jxl/modular/encoding/enc_ma.cc
+++ b/lib/jxl/modular/encoding/enc_ma.cc
@@ -49,7 +49,7 @@ const HWY_FULL(float) df;
 const HWY_FULL(int32_t) di;
 // Pad array size for use in EstimateBits.
 size_t Padded(size_t x) {
-  static_assert(Lanes(df) == Lanes(di));
+  JXL_DASSERT(Lanes(df) == Lanes(di));
   return RoundUpTo(x, Lanes(df));
 }
 


### PR DESCRIPTION
### Description

I forgot about this in the previous PR, as I had problems with both windows-arm64 and macos-arm64.
Commit c1f45f8c introduced a static assert on `Lanes(df)` in enc_ma.cc. 
On architectures that support scalable vectors, Highway's `Lanes()` is not an constant expression, leading to a build failure on macOS ARM, with this error on clang: `static assertion expression is not an integral constant expression`.

This change replaces the `static_assert` with a runtime `JXL_DASSERT` to maintain the check without breaking compilation.

### Pull Request Checklist

- [x] **CLA Signed**: Have you signed the Contributor License Agreement?
- [x] **Authors**: Have you considered adding your name to the AUTHORS file?
- [x] **Code Style**: Have you ensured your code adheres to the project's coding style guidelines?