### PR TITLE
Default GIF disposal method to DISPOSE_DO_NOT

### DIFF
--- a/lib/extras/dec/gif.cc
+++ b/lib/extras/dec/gif.cc
@@ -281,6 +281,14 @@ Status DecodeImageGIF(Span<const uint8_t> bytes, const ColorHints& color_hints,
     GraphicsControlBlock gcb;
     DGifSavedExtensionToGCB(gif.get(), i, &gcb);
     msan::UnpoisonMemory(&gcb, sizeof(gcb));
+
+    // Some encoders (and apparently some specs) represent
+    // DisposalMethod::RESTORE_PREVIOUS as 4, but 3 is used in the canonical
+    // spec and is more popular, so we normalize to 3.
+    if (gcb.DisposalMode == 4) {
+      gcb.DisposalMode = DISPOSE_PREVIOUS;
+    }
+
     bool is_full_size = total_rect.x0() == 0 && total_rect.y0() == 0 &&
                         total_rect.xsize() == canvas.color.xsize &&
                         total_rect.ysize() == canvas.color.ysize;
@@ -311,17 +319,15 @@ Status DecodeImageGIF(Span<const uint8_t> bytes, const ColorHints& color_hints,
             "blended frames");
       }
       switch (gcb.DisposalMode) {
-        case DISPOSE_DO_NOT:
-        case DISPOSE_BACKGROUND:
-          frame->frame_info.layer_info.save_as_reference = 1u;
-          last_base_was_none = false;
-          break;
         case DISPOSE_PREVIOUS:
           frame->frame_info.layer_info.save_as_reference = 0u;
           break;
+        case DISPOSAL_UNSPECIFIED:
+        case DISPOSE_DO_NOT:
+        case DISPOSE_BACKGROUND:
         default:
-          frame->frame_info.layer_info.save_as_reference = 0u;
-          last_base_was_none = true;
+          frame->frame_info.layer_info.save_as_reference = 1u;
+          last_base_was_none = false;
       }
     }
 
@@ -399,10 +405,6 @@ Status DecodeImageGIF(Span<const uint8_t> bytes, const ColorHints& color_hints,
     }
 
     switch (gcb.DisposalMode) {
-      case DISPOSE_DO_NOT:
-        canvas.color = std::move(new_canvas_image);
-        break;
-
       case DISPOSE_BACKGROUND:
         std::fill_n(static_cast<PackedRgba*>(canvas.color.pixels()),
                     canvas.color.xsize * canvas.color.ysize, background_rgba);
@@ -413,9 +415,9 @@ Status DecodeImageGIF(Span<const uint8_t> bytes, const ColorHints& color_hints,
         break;
 
       case DISPOSAL_UNSPECIFIED:
+      case DISPOSE_DO_NOT:
       default:
-        std::fill_n(static_cast<PackedRgba*>(canvas.color.pixels()),
-                    canvas.color.xsize * canvas.color.ysize, background_rgba);
+        canvas.color = std::move(new_canvas_image);
     }
   }
   // Finally, if any frame has an alpha-channel, every frame will need


### PR DESCRIPTION
And treat 4 as DISPOSE_PREVIOUS to match browser behavior.
See https://github.com/mozilla-firefox/firefox/blob/c681e91369f59d0efae43bdc465872b855e8b269/image/decoders/nsGIFDecoder2.cpp#L707

Fixes #4471 

I wonder if we need to make this configurable as well. In contrast to the delay case, the spec does not define what to do here.