### PR TITLE
Several hardening / correctness / security fixes

### DIFF
--- a/lib/jxl/dec_frame.cc
+++ b/lib/jxl/dec_frame.cc
@@ -270,11 +270,11 @@ Status FrameDecoder::ProcessDCGlobal(BitReader* br) {
   PassesSharedState& shared = dec_state_->shared_storage;
   JxlMemoryManager* memory_manager = shared.memory_manager;
   if (frame_header_.flags & FrameHeader::kPatches) {
-    bool uses_extra_channels = false;
+    bool uses_extra_channels;
     JXL_RETURN_IF_ERROR(shared.image_features.patches.Decode(
         memory_manager, br, frame_dim_.xsize_padded, frame_dim_.ysize_padded,
         shared.metadata->m.num_extra_channels, &uses_extra_channels));
-    if (uses_extra_channels && frame_header_.upsampling != 1) {
+    if (frame_header_.upsampling != 1) {
       for (size_t ecups : frame_header_.extra_channel_upsampling) {
         if (ecups != frame_header_.upsampling) {
           return JXL_FAILURE(

--- a/lib/jxl/decode.cc
+++ b/lib/jxl/decode.cc
@@ -1638,8 +1638,8 @@ size_t JxlDecoderReleaseJPEGBuffer(JxlDecoder* dec) {
 // at least. JXL_DEC_ERROR if the box header is invalid.
 static JxlDecoderStatus ParseBoxHeader(const uint8_t* in, size_t size,
                                        size_t pos, size_t file_pos,
-                                       JxlBoxType type, uint64_t* box_size,
-                                       uint64_t* header_size) {
+                                       JxlBoxType type, size_t* box_size,
+                                       size_t* header_size) {
   if (OutOfBounds(pos, 8, size)) {
     *header_size = 8;
     return JXL_DEC_NEED_MORE_INPUT;
@@ -1653,8 +1653,12 @@ static JxlDecoderStatus ParseBoxHeader(const uint8_t* in, size_t size,
   if (*box_size == 1) {
     *header_size = 16;
     if (OutOfBounds(pos, 8, size)) return JXL_DEC_NEED_MORE_INPUT;
-    *box_size = LoadBE64(in + pos);
+    uint64_t box_size_64 = LoadBE64(in + pos);
     pos += 8;
+    *box_size = static_cast<size_t>(box_size_64);
+    if (box_size_64 != static_cast<uint64_t>(*box_size)) {
+      return JXL_INPUT_ERROR("Box size overflow");
+    }
   }
   *header_size = pos - box_start;
   if (*box_size > 0 && *box_size < *header_size) {
@@ -1836,8 +1840,8 @@ static JxlDecoderStatus HandleBoxes(JxlDecoder* dec) {
         return JXL_DEC_SUCCESS;
       }
 
-      uint64_t box_size;
-      uint64_t header_size;
+      size_t box_size;
+      size_t header_size;
       JxlDecoderStatus status =
           ParseBoxHeader(dec->next_in, dec->avail_in, 0, dec->file_pos,
                          dec->box_type, &box_size, &header_size);

--- a/lib/jxl/enc_fast_lossless.cc
+++ b/lib/jxl/enc_fast_lossless.cc
@@ -2751,7 +2751,7 @@ struct From9To13Bits {
   static constexpr uint8_t kMaxRawLength[17] = {
       8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 10,
   };
-  static size_t MaxEncodedBitsPerSample() { return 21; }
+  static size_t MaxEncodedBitsPerSample() { return 22; }
   static constexpr size_t kInputBytes = 2;
   using pixel_t = int16_t;
   using upixel_t = uint16_t;
@@ -2817,7 +2817,7 @@ struct Exactly14Bits {
       7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 8, 8, 10,
   };
   static constexpr size_t bitdepth = 14;
-  static size_t MaxEncodedBitsPerSample() { return 22; }
+  static size_t MaxEncodedBitsPerSample() { return 23; }
   static constexpr size_t kInputBytes = 2;
   using pixel_t = int16_t;
   using upixel_t = uint16_t;
@@ -2874,7 +2874,7 @@ struct MoreThan14Bits {
   static constexpr uint8_t kMaxRawLength[20] = {
       7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 8, 8, 8, 8, 8, 8, 10,
   };
-  static size_t MaxEncodedBitsPerSample() { return 24; }
+  static size_t MaxEncodedBitsPerSample() { return 25; }
   static constexpr size_t kInputBytes = 2;
   using pixel_t = int32_t;
   using upixel_t = uint32_t;
@@ -2925,10 +2925,8 @@ constexpr uint8_t MoreThan14Bits::kMaxRawLength[];
 bool PrepareDCGlobalCommon(bool is_single_group, size_t width, size_t height,
                            size_t max_encoded_bits_per_sample,
                            const PrefixCode code[4], BitWriter* output) {
-  if (!output->Allocate(100000 +
-                        (is_single_group
-                             ? width * height * max_encoded_bits_per_sample
-                             : 0))) {
+  size_t num_samples = is_single_group ? (width * height) : 0;
+  if (!output->Allocate(100000 + num_samples * max_encoded_bits_per_sample)) {
     return false;
   }
   // No patches, spline or noise.

--- a/lib/jxl/jpeg/jpeg_data.cc
+++ b/lib/jxl/jpeg/jpeg_data.cc
@@ -339,14 +339,19 @@ Status JPEGData::VisitFields(Visitor* visitor) {
     last_block_idx = -1;
     for (auto& extra_zero_run : scan.extra_zero_runs) {
       uint32_t& block_idx = extra_zero_run.block_idx;
+      uint32_t& extra_zero_runs = extra_zero_run.num_extra_zero_runs;
       JXL_RETURN_IF_ERROR(visitor->U32(Val(1), BitsOffset(2, 2),
                                        BitsOffset(4, 5), BitsOffset(8, 20), 1,
-                                       &extra_zero_run.num_extra_zero_runs));
+                                       &extra_zero_runs));
       block_idx -= last_block_idx + 1;
       JXL_RETURN_IF_ERROR(visitor->U32(Val(0), BitsOffset(3, 1),
                                        BitsOffset(5, 9), BitsOffset(28, 41), 0,
                                        &block_idx));
       block_idx += last_block_idx + 1;
+      if (extra_zero_runs > 4) {
+        return JXL_FAILURE("Invalid number of extra zero runs: %u",
+                           extra_zero_runs);
+      }
       if (block_idx > (3u << 26)) {
         return JXL_FAILURE("Invalid block ID: %u", block_idx);
       }

--- a/lib/jxl/render_pipeline/render_pipeline_stage.h
+++ b/lib/jxl/render_pipeline/render_pipeline_stage.h
@@ -24,7 +24,7 @@ class FrameDecoder;
 // size) times 2: this is realized when using Gaborish + EPF + upsampling +
 // chroma subsampling.
 #if JXL_ARCH_ARM
-constexpr size_t kRenderPipelineXOffset = 16;
+constexpr size_t kRenderPipelineXOffset = 24;
 #else
 constexpr size_t kRenderPipelineXOffset = 32;
 #endif

--- a/lib/jxl/render_pipeline/stage_upsampling.cc
+++ b/lib/jxl/render_pipeline/stage_upsampling.cc
@@ -236,13 +236,14 @@ class UpsamplingStage : public RenderPipelineStage {
     std::array<float*, 25> input;
     for (ptrdiff_t iy = -2; iy <= 2; ++iy) {
       for (ptrdiff_t ix = -2; ix <= 2; ++ix) {
-        input[5 * (iy + 2) + (ix + 2)] = GetInputRow(input_rows, c_, iy) + ix;
+        input[5 * (iy + 2) + (ix + 2)] =
+            GetInputRow(input_rows, c_, iy) + x0 + ix;
       }
     }
 
     for (size_t x = 0; x < len; x += Lanes(df)) {
       for (size_t oy = 0; oy < N; oy++) {
-        float* dst_row = GetOutputRow(output_rows, c_, oy);
+        float* dst_row = GetOutputRow(output_rows, c_, oy) + x0 * N;
         for (size_t ox = 0; ox < N; ox++) {
           size_t k = N * oy + ox;
           auto acc0 = Mul(LoadU(df, input[0]), Set(df, Kernel(k, 0)));


### PR DESCRIPTION
 * Even if EC is not used, require consistent (late) upsampling when Patches are applied
 * Fix upsampling input/output offset
 * Deal with box_size type size mismatch on 32-bit platforms
 * Update MaxEncodedBitsPerSample with actual values
 * Limit "extra_zero_runs" in JPEG metadata
 * Update kRenderPipelineXOffset on ARM to respect actual maximum padding