### PR TITLE
check coefficient count overflow in jpeg ProcessScan

### DIFF
--- a/lib/jxl/jpeg/enc_jpeg_data_reader.cc
+++ b/lib/jxl/jpeg/enc_jpeg_data_reader.cc
@@ -799,9 +799,13 @@ Status ProcessScan(const uint8_t* data, const size_t len,
 
   for (auto& c : jpg->components) {
     if (c.coeffs.empty()) {
-      const uint64_t num_blocks =
-          static_cast<uint64_t>(c.width_in_blocks) * c.height_in_blocks;
-      c.coeffs.resize(num_blocks * kDCTBlockSize);
+      size_t num_blocks;
+      size_t num_coeffs;
+      if (!SafeMul(c.width_in_blocks, c.height_in_blocks, num_blocks) ||
+          !SafeMul(num_blocks, kDCTBlockSize, num_coeffs)) {
+        return JXL_FAILURE("JPEG image has too many DCT coefficients");
+      }
+      c.coeffs.resize(num_coeffs);
     }
   }
 


### PR DESCRIPTION
### Description

ProcessScan sizes each component's coefficient buffer with `num_blocks * kDCTBlockSize`, and although `num_blocks` is built in 64 bits the product is handed to `std::vector::resize`, whose `size_type` is 32-bit on ILP32 targets. ProcessSOF bounds width and height separately at 65535 but never the block count, so a 65535x65535 JPEG makes that product 2^32, which wraps to a tiny resize on 32-bit and the following MCU loop writes past the shrunken buffer. Use the same chained `SafeMul` the other parsers use so an oversized block count is rejected up front. Reachable from untrusted input via `JxlEncoderAddJPEGFrame` / `cjxl --lossless_jpeg`.

### Pull Request Checklist

- [x] **CLA Signed**: Have you signed the [Contributor License Agreement](https://code.google.com/legal/individual-cla-v1.0.html) (individual or corporate, as appropriate)? Only contributions from signed contributors can be accepted.
- [ ] **Authors**: Have you considered adding your name to the [AUTHORS](AUTHORS) file?
- [x] **Code Style**: Have you ensured your code adheres to the project's coding style guidelines? You can use `./ci.sh lint` for automatic code formatting.
