### PR TITLE
Introduce an iterative effort 10

### DIFF
--- a/lib/jxl/enc_frame.cc
+++ b/lib/jxl/enc_frame.cc
@@ -2577,19 +2577,26 @@ Status EncodeFrame(JxlMemoryManager* memory_manager,
     std::vector<CompressParams> all_params;
     CompressParams cparams_attempt = cparams;
     cparams_attempt.speed_tier_tested = true;
-
+    cparams_attempt.speed_tier = SpeedTier::kKitten; // Evaluate at effort 8
+    // Default effort 10 value (often too aggressive)
     int base_threshold = 75 + 10 * cparams.decoding_speed_tier;
 
-    // Effort 10's threshold
-    cparams_attempt.options.splitting_heuristics_node_threshold = base_threshold;
+    // Slightly below effort 9
+    cparams_attempt.options.splitting_heuristics_node_threshold = base_threshold + 9;
     all_params.push_back(cparams_attempt);
 
-    // In between
     cparams_attempt.options.splitting_heuristics_node_threshold = base_threshold + 12;
     all_params.push_back(cparams_attempt);
 
-    // Effort 9's threshold
+    // Effort 9 default
     cparams_attempt.options.splitting_heuristics_node_threshold = base_threshold + 14;
+    all_params.push_back(cparams_attempt);
+
+    // Slightly above effort 9
+    cparams_attempt.options.splitting_heuristics_node_threshold = base_threshold + 16;
+    all_params.push_back(cparams_attempt);
+
+    cparams_attempt.options.splitting_heuristics_node_threshold = base_threshold + 19;
     all_params.push_back(cparams_attempt);
 
     std::vector<size_t> size(all_params.size());
@@ -2611,7 +2618,10 @@ Status EncodeFrame(JxlMemoryManager* memory_manager,
         best_idx = i;
       }
     }
-    cparams = all_params[best_idx];
+    
+    // Apply only the best threshold, keeping original speed_tier (e.g. kGlacier)
+    cparams.options.splitting_heuristics_node_threshold = all_params[best_idx].options.splitting_heuristics_node_threshold;
+    cparams.speed_tier_tested = true;
   } else if (cparams.speed_tier == SpeedTier::kTectonicPlate) {
     // Test palette performance to inform later trials.
     std::vector<CompressParams> all_params;

--- a/lib/jxl/enc_frame.cc
+++ b/lib/jxl/enc_frame.cc
@@ -2564,7 +2564,7 @@ Status EncodeFrame(JxlMemoryManager* memory_manager,
                    JxlEncoderOutputProcessorWrapper* output_processor,
                    AuxOut* aux_out, uint32_t* jxlp_counter) {
   CompressParams cparams = cparams_orig;
-  if (cparams.speed_tier == SpeedTier::kTectonicPlate &&
+  if (cparams.speed_tier <= SpeedTier::kTectonicPlate &&
       !cparams.IsLossless()) {
     cparams.speed_tier = SpeedTier::kGlacier;
   }
@@ -2581,25 +2581,14 @@ Status EncodeFrame(JxlMemoryManager* memory_manager,
     // Default effort 10 value (often too aggressive)
     int base_threshold = 75 + 10 * cparams.decoding_speed_tier;
 
-    // Slightly below effort 9
-    cparams_attempt.options.splitting_heuristics_node_threshold = base_threshold + 9;
-    all_params.push_back(cparams_attempt);
+    //offset 14 is effort 9, we are searching for a local minimum around here
+    const int offsets[] = {9, 12, 14, 16, 19};
+    for (int offset : offsets) {
+      cparams_attempt.options.splitting_heuristics_node_threshold = base_threshold + offset;
+      all_params.push_back(cparams_attempt);
+    }
 
-    cparams_attempt.options.splitting_heuristics_node_threshold = base_threshold + 12;
-    all_params.push_back(cparams_attempt);
-
-    // Effort 9 default
-    cparams_attempt.options.splitting_heuristics_node_threshold = base_threshold + 14;
-    all_params.push_back(cparams_attempt);
-
-    // Slightly above effort 9
-    cparams_attempt.options.splitting_heuristics_node_threshold = base_threshold + 16;
-    all_params.push_back(cparams_attempt);
-
-    cparams_attempt.options.splitting_heuristics_node_threshold = base_threshold + 19;
-    all_params.push_back(cparams_attempt);
-
-    std::vector<size_t> size(all_params.size());
+    std::vector<size_t> size(all_params.size(), SIZE_MAX);
     std::unique_ptr<jpeg::JPEGData> original_jpeg = frame_data.TakeJPEGData();
     
     const auto process_variant = [&](size_t task, size_t) -> Status {
@@ -2609,26 +2598,29 @@ Status EncodeFrame(JxlMemoryManager* memory_manager,
       JxlEncoderOutputProcessorWrapper local_output(memory_manager);
       JXL_RETURN_IF_ERROR(EncodeFrame(
           memory_manager, all_params[task], frame_info, metadata, local_frame_data,
-          cms, nullptr, &local_output, aux_out, nullptr));
+          cms, nullptr, &local_output, nullptr, nullptr));
       size[task] = local_output.CurrentPosition();
       return true;
     };
-    JXL_RETURN_IF_ERROR(RunOnPool(pool, 0, all_params.size(),
-                                  ThreadPool::NoInit, process_variant,
-                                  "Compress JPEG Transcode options"));
+    
+    Status pool_status = RunOnPool(pool, 0, all_params.size(),
+                                   ThreadPool::NoInit, process_variant,
+                                   "Compress JPEG Transcode options");
 
     frame_data.SetJPEGData(std::move(original_jpeg));
-    size_t best_idx = 0;
-    for (size_t i = 1; i < all_params.size(); i++) {
-      if (size[best_idx] > size[i]) {
-        best_idx = i;
+    if (pool_status) {
+      size_t best_idx = 0;
+      for (size_t i = 1; i < all_params.size(); i++) {
+        if (size[best_idx] > size[i]) {
+          best_idx = i;
+        }
       }
+      
+      // Apply only the best threshold, keeping original speed_tier (e.g. kGlacier)
+      cparams.options.splitting_heuristics_node_threshold = all_params[best_idx].options.splitting_heuristics_node_threshold;
     }
-    
-    // Apply only the best threshold, keeping original speed_tier (e.g. kGlacier)
-    cparams.options.splitting_heuristics_node_threshold = all_params[best_idx].options.splitting_heuristics_node_threshold;
     cparams.speed_tier_tested = true;
-  } else if (cparams.speed_tier == SpeedTier::kTectonicPlate) {
+  } else if (cparams.speed_tier <= SpeedTier::kTectonicPlate) {
     // Test palette performance to inform later trials.
     std::vector<CompressParams> all_params;
     CompressParams cparams_attempt = cparams;

--- a/lib/jxl/enc_frame.cc
+++ b/lib/jxl/enc_frame.cc
@@ -2573,7 +2573,46 @@ Status EncodeFrame(JxlMemoryManager* memory_manager,
   if (cparams.speed_tier == SpeedTier::kLightning) {
     cparams.speed_tier = SpeedTier::kThunder;
   }
-  if (cparams.speed_tier == SpeedTier::kTectonicPlate) {
+  if (frame_data.IsJPEG() && cparams.speed_tier <= SpeedTier::kGlacier && !cparams.speed_tier_tested) {
+    std::vector<CompressParams> all_params;
+    CompressParams cparams_attempt = cparams;
+    cparams_attempt.speed_tier_tested = true;
+
+    int base_threshold = 75 + 10 * cparams.decoding_speed_tier;
+
+    // Effort 10's threshold
+    cparams_attempt.options.splitting_heuristics_node_threshold = base_threshold;
+    all_params.push_back(cparams_attempt);
+
+    // In between
+    cparams_attempt.options.splitting_heuristics_node_threshold = base_threshold + 12;
+    all_params.push_back(cparams_attempt);
+
+    // Effort 9's threshold
+    cparams_attempt.options.splitting_heuristics_node_threshold = base_threshold + 14;
+    all_params.push_back(cparams_attempt);
+
+    std::vector<size_t> size(all_params.size());
+    std::unique_ptr<jpeg::JPEGData> original_jpeg = frame_data.TakeJPEGData();
+    
+    for (size_t task = 0; task < all_params.size(); ++task) {
+      JxlEncoderOutputProcessorWrapper local_output(memory_manager);
+      frame_data.SetJPEGData(jxl::make_unique<jpeg::JPEGData>(*original_jpeg));
+      JXL_RETURN_IF_ERROR(EncodeFrame(
+          memory_manager, all_params[task], frame_info, metadata, frame_data,
+          cms, nullptr, &local_output, aux_out, nullptr));
+      size[task] = local_output.CurrentPosition();
+    }
+
+    frame_data.SetJPEGData(std::move(original_jpeg));
+    size_t best_idx = 0;
+    for (size_t i = 1; i < all_params.size(); i++) {
+      if (size[best_idx] > size[i]) {
+        best_idx = i;
+      }
+    }
+    cparams = all_params[best_idx];
+  } else if (cparams.speed_tier == SpeedTier::kTectonicPlate) {
     // Test palette performance to inform later trials.
     std::vector<CompressParams> all_params;
     CompressParams cparams_attempt = cparams;

--- a/lib/jxl/enc_frame.cc
+++ b/lib/jxl/enc_frame.cc
@@ -2602,14 +2602,20 @@ Status EncodeFrame(JxlMemoryManager* memory_manager,
     std::vector<size_t> size(all_params.size());
     std::unique_ptr<jpeg::JPEGData> original_jpeg = frame_data.TakeJPEGData();
     
-    for (size_t task = 0; task < all_params.size(); ++task) {
+    const auto process_variant = [&](size_t task, size_t) -> Status {
+      JxlEncoderChunkedFrameAdapter local_frame_data(frame_data.xsize, frame_data.ysize,
+                                                     metadata->m.num_extra_channels);
+      local_frame_data.SetJPEGData(jxl::make_unique<jpeg::JPEGData>(*original_jpeg));
       JxlEncoderOutputProcessorWrapper local_output(memory_manager);
-      frame_data.SetJPEGData(jxl::make_unique<jpeg::JPEGData>(*original_jpeg));
       JXL_RETURN_IF_ERROR(EncodeFrame(
-          memory_manager, all_params[task], frame_info, metadata, frame_data,
+          memory_manager, all_params[task], frame_info, metadata, local_frame_data,
           cms, nullptr, &local_output, aux_out, nullptr));
       size[task] = local_output.CurrentPosition();
-    }
+      return true;
+    };
+    JXL_RETURN_IF_ERROR(RunOnPool(pool, 0, all_params.size(),
+                                  ThreadPool::NoInit, process_variant,
+                                  "Compress JPEG Transcode options"));
 
     frame_data.SetJPEGData(std::move(original_jpeg));
     size_t best_idx = 0;

--- a/lib/jxl/enc_frame.cc
+++ b/lib/jxl/enc_frame.cc
@@ -2582,7 +2582,7 @@ Status EncodeFrame(JxlMemoryManager* memory_manager,
     int base_threshold = 75 + 10 * cparams.decoding_speed_tier;
 
     //offset 14 is effort 9, we are searching for a local minimum around here
-    const int offsets[] = {9, 12, 14, 16, 19};
+    const int offsets[] = {0, 9, 12, 14, 16, 19};
     for (int offset : offsets) {
       cparams_attempt.options.splitting_heuristics_node_threshold = base_threshold + offset;
       all_params.push_back(cparams_attempt);

--- a/lib/jxl/enc_modular.cc
+++ b/lib/jxl/enc_modular.cc
@@ -533,7 +533,7 @@ Status ModularFrameEncoder::Init(const FrameHeader& frame_header,
     }
   }
 
-  if (cparams_.options.splitting_heuristics_node_threshold < 0) {
+  if (cparams_.options.splitting_heuristics_node_threshold < 0.0f) {
     cparams_.options.splitting_heuristics_node_threshold =
         75 + 14 * static_cast<int>(cparams_.speed_tier) +
         10 * cparams_.decoding_speed_tier;

--- a/lib/jxl/enc_modular.cc
+++ b/lib/jxl/enc_modular.cc
@@ -533,9 +533,11 @@ Status ModularFrameEncoder::Init(const FrameHeader& frame_header,
     }
   }
 
-  cparams_.options.splitting_heuristics_node_threshold =
-      75 + 14 * static_cast<int>(cparams_.speed_tier) +
-      10 * cparams_.decoding_speed_tier;
+  if (cparams_.options.splitting_heuristics_node_threshold < 0) {
+    cparams_.options.splitting_heuristics_node_threshold =
+        75 + 14 * static_cast<int>(cparams_.speed_tier) +
+        10 * cparams_.decoding_speed_tier;
+  }
 
   {
     // Set properties.

--- a/lib/jxl/enc_params.h
+++ b/lib/jxl/enc_params.h
@@ -40,6 +40,7 @@ struct CompressParams {
   bool disable_perceptual_optimizations = false;
 
   SpeedTier speed_tier = SpeedTier::kSquirrel;
+  bool speed_tier_tested = false;
   int brotli_effort = -1;
 
   // 0 = default.

--- a/lib/jxl/modular/encoding/enc_encoding.cc
+++ b/lib/jxl/modular/encoding/enc_encoding.cc
@@ -228,8 +228,9 @@ StatusOr<Tree> LearnTree(
   float pixel_fraction = tree_samples.NumSamples() * 1.0f / total_pixels;
   float required_cost = pixel_fraction * 0.9 + 0.1;
   tree_samples.AllSamplesDone();
+  float node_threshold = options.splitting_heuristics_node_threshold < 0.0f ? 96.0f : options.splitting_heuristics_node_threshold;
   JXL_RETURN_IF_ERROR(ComputeBestTree(
-      tree_samples, options.splitting_heuristics_node_threshold * required_cost,
+      tree_samples, node_threshold * required_cost,
       multiplier_info, static_prop_range, options.fast_decode_multiplier,
       &tree));
   return tree;

--- a/lib/jxl/modular/options.h
+++ b/lib/jxl/modular/options.h
@@ -79,7 +79,7 @@ struct ModularOptions {
   // Properties default to channel, group, weighted, gradient residual, W-NW,
   // NW-N, N-NE, N-NN
   std::vector<uint32_t> splitting_heuristics_properties;
-  float splitting_heuristics_node_threshold = -1;
+  float splitting_heuristics_node_threshold = -1.0f;
   size_t max_property_values = 32;
 
   // Predictor to use for each channel.

--- a/lib/jxl/modular/options.h
+++ b/lib/jxl/modular/options.h
@@ -79,7 +79,7 @@ struct ModularOptions {
   // Properties default to channel, group, weighted, gradient residual, W-NW,
   // NW-N, N-NE, N-NN
   std::vector<uint32_t> splitting_heuristics_properties;
-  float splitting_heuristics_node_threshold = 96;
+  float splitting_heuristics_node_threshold = -1;
   size_t max_property_values = 32;
 
   // Predictor to use for each channel.


### PR DESCRIPTION
Fixes #3888

This PR only affects jpeg transcodes, it makes effort 10 a bit smarter, choosing a local minimum of thresholds. It simply does 5 rounds at effort 8 to speed things up. Effort 10 doesn't regress in file size anymore. ~Maybe it's worth multithreading but it's not that much slower than effort 9 (\~2.5x slowdown).~ With simple multithreading it's now only  ~1.4x slower than effort 9.

Numbers:
```
Main e 9 -- 1,512,527 bytes
Main e 10 - 1,512,935 bytes (+408 bytes!)
PR e 9 ---- 1,512,527 bytes
PR e 10 --- 1,512,323 bytes (-204 bytes)
```