### PR TITLE
Fix `publish_release_assets` (#4890)

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -405,6 +405,7 @@ jobs:
       uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
       with:
         path: release_assets
+        skip-decompress: true
         merge-multiple: true
 
     - name: Publish assets
@@ -413,3 +414,26 @@ jobs:
         GITHUB_EVENT_RELEASE_TAG_NAME: ${{ github.event.release.tag_name }}
       run: |
         gh release upload ${GITHUB_EVENT_RELEASE_TAG_NAME} ./release_assets/*
+
+
+  # Keep in sync with `publish_release_assets` workflow.
+  dry_publish_release_assets:
+    name: Publish release assets (dry run)
+    needs: [ubuntu_static_x86_64, release_ubuntu_pkg, windows_build]
+    if: github.event_name != 'release'
+    runs-on: [ubuntu-latest]
+
+    steps:
+    - name: Checkout the source
+      uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      with:
+        submodules: true
+        fetch-depth: 1
+        persist-credentials: false
+
+    - name: Download all artifacts
+      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+      with:
+        path: release_assets
+        skip-decompress: true
+        merge-multiple: true


### PR DESCRIPTION
(cherry picked from commit f0a1c5ff9dbba51ffa932433ffb80e5e6b6e22a7)
