### PR TITLE
Dust off some old documentation

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -75,7 +75,7 @@ sudo cmake --install .
 ```
 
 
-## Building JPEG XL for developers
+## Building JPEG XL for developers
 
 For experienced developers, we provide build instructions for several other environments:
 

--- a/BUILDING_OSX.md
+++ b/BUILDING_OSX.md
@@ -7,7 +7,7 @@ This manual outlines OSX specific setup. For general building and testing
 instructions see "[BUILDING](BUILDING.md)" and
 "[Building and Testing changes](doc/building_and_testing.md)".
 
-[Homebrew](https://brew.sh/) is a popular package manager. JPEG XL library and
+[Homebrew](https://brew.sh/) is a popular package manager. JPEG XL library and
 binaries could be installed using it:
 
 ```bash

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -522,7 +522,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Re-licensed the project under a BSD 3-Clause license. See the
   [LICENSE](LICENSE) and [PATENTS](PATENTS) files for details.
-- Full JPEG XL part 1 specification support: Implemented all the spec required
+- Full JPEG XL part 1 specification support: Implemented all the spec required
   to decode files to pixels, including cases that are not used by the encoder
   yet. Part 2 of the spec (container format) is final but not fully implemented
   here.
@@ -619,7 +619,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- JPEG XL bitstream format is frozen. Files encoded with 0.2 will be supported
+- JPEG XL bitstream format is frozen. Files encoded with 0.2 will be supported
   by future versions.
 
 ### Changed
@@ -635,7 +635,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Initial release of an encoder (`cjxl`) and decoder (`djxl`) that work
   together as well as a benchmark tool for comparison with other codecs
   (`benchmark_xl`).
-- Note: JPEG XL format is in the final stages of standardization, minor changes
+- Note: JPEG XL format is in the final stages of standardization, minor changes
   to the codestream format are still possible but we are not expecting any
   changes beyond what is required by bug fixing.
 - API: new decoder API in C, check the `examples/` directory for its example

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,15 +36,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Major overhaul for faster decoding and progressive lossless. (#4201, #4641,
-  #4811)
+- Major encoding overhaul for both progressive lossless and faster decoding
+  modes. (#4201, #4641, #4811)
   - Progressive lossless images are around 30-40% smaller and are now
     multithreaded increasing encoding performance by 2-5x.
-  - Lossless images with faster decoding are now 30-80% smaller and their
-    decoding speeds properly scale as the faster decoding level increases
+  - Lossless images encoded with faster decoding are now 30-80% smaller and
+    their decoding speeds properly scale as the faster decoding level increases
     from 1-4.
-  - Disabled global palette for progressive images, fixing glitchy progressive
-    loading for indexed/low color images and restoring transparency support
+  - Disabled global palette when encoding progressive images, fixing glitchy
+    progressive loading for indexed/low color images and restoring transparency
+	support
     (Note: this causes a density/speed penalty for very low bit-depth images).
 - Numerous speed/memory usage improvements.
   - Improved encoding speeds by SIMDifying `EstimateCost` (+5% performance) and
@@ -115,6 +116,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The `jpegli` codebase has been removed as it is now maintained as a separate
   project at [google/jpegli](https://github.com/google/jpegli). (#4657)
 - Dropped GIMP plugin (`libjxl-gimp-plugin`). (#4875)
+- `brotli` tool is no longer built or shipped. (#4501)
 
 ### Fixed
 
@@ -214,23 +216,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed / clarified
 
-- avoiding abort in release build (#3631 and #3639)
+- Avoiding abort in the release build. (#3631, #3639)
 
 ## [0.10.2] - 2024-03-08
 
 ### Fixed
 
-- bugs in (lossless) encoding (#3367, #3359 and #3386)
-- re-enable installation of MIME file. (#3375)
-- bugs in streaming mode (#3379 and #3380)
+- Fixed bugs in lossless encoding. (#3359, #3367, #3386)
+- Re-enabled installation of the MIME file. (#3375)
+- Fixed bugs in streaming mode. (#3379, #3380)
 
 ## [0.10.1] - 2024-02-28
 
 ### Fixed
 
-- reduce allocations (#3336 and #3339),
-  fixing a significant speed regression present since 0.9.0
-- bug in streaming encoding. (#3331)
+- Reduced allocations, fixing a significant speed regression present since
+  0.9.0. (#3336, #3339)
+- Fixed a bug in streaming encoding. (#3331)
 
 ## [0.10.0] - 2024-02-21
 
@@ -250,14 +252,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- bugs in the gdk-pixbuf plugin
-- some build issues
+- Fixed bugs in the gdk-pixbuf plugin.
+- Fixed some build issues.
 
 ## [0.9.1] - 2024-01-08
 
 ### Fixed
 
-- multiple build issues
+- Fixed multiple build issues.
 
 ## [0.9.0] - 2023-12-22
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,15 +36,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Major overhaul for faster decoding and progressive lossless. (#4201, #4641,
-  #4811)
+- Major encoding overhaul for both progressive lossless and faster decoding
+  modes. (#4201, #4641, #4811)
   - Progressive lossless images are around 30-40% smaller and are now
     multithreaded increasing encoding performance by 2-5x.
-  - Lossless images with faster decoding are now 30-80% smaller and their
-    decoding speeds properly scale as the faster decoding level increases
+  - Lossless images encoded with faster decoding are now 30-80% smaller and
+    their decoding speeds properly scale as the faster decoding level increases
     from 1-4.
-  - Disabled global palette for progressive images, fixing glitchy progressive
-    loading for indexed/low color images and restoring transparency support
+  - Disabled global palette when encoding progressive images, fixing glitchy
+    progressive loading for indexed/low color images and restoring transparency
+    support
     (Note: this causes a density/speed penalty for very low bit-depth images).
 - Numerous speed/memory usage improvements.
   - Improved encoding speeds by SIMDifying `EstimateCost` (+5% performance) and
@@ -115,10 +116,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The `jpegli` codebase has been removed as it is now maintained as a separate
   project at [google/jpegli](https://github.com/google/jpegli). (#4657)
 - Dropped GIMP plugin (`libjxl-gimp-plugin`). (#4875)
+- `brotli` tool is no longer built or shipped. (#4501)
 
 ### Fixed
 
-- Allows -E to be used in jpeg-transcoding again. (#4729)
+- Allow the `-E` flag to be used in jpeg-transcoding again. (#4729)
 - Fixed an issue where Lossy Delta Palette encoding failed on images larger
   than 2048x2048. (#4201)
 - Fixed Delta Palette with Weighted Predictor decoding. (#4837)
@@ -214,23 +216,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed / clarified
 
-- avoiding abort in release build (#3631 and #3639)
+- Avoiding abort in the release build. (#3631, #3639)
 
 ## [0.10.2] - 2024-03-08
 
 ### Fixed
 
-- bugs in (lossless) encoding (#3367, #3359 and #3386)
-- re-enable installation of MIME file. (#3375)
-- bugs in streaming mode (#3379 and #3380)
+- Fixed bugs in lossless encoding. (#3359, #3367, #3386)
+- Re-enabled installation of the MIME file. (#3375)
+- Fixed bugs in streaming mode. (#3379, #3380)
 
 ## [0.10.1] - 2024-02-28
 
 ### Fixed
 
-- reduce allocations (#3336 and #3339),
-  fixing a significant speed regression present since 0.9.0
-- bug in streaming encoding. (#3331)
+- Reduced allocations, fixing a significant speed regression present since
+  0.9.0. (#3336, #3339)
+- Fixed a bug in streaming encoding. (#3331)
 
 ## [0.10.0] - 2024-02-21
 
@@ -250,14 +252,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- bugs in the gdk-pixbuf plugin
-- some build issues
+- Fixed bugs in the gdk-pixbuf plugin.
+- Fixed some build issues.
 
 ## [0.9.1] - 2024-01-08
 
 ### Fixed
 
-- multiple build issues
+- Fixed multiple build issues.
 
 ## [0.9.0] - 2023-12-22
 
@@ -466,7 +468,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - API: New functions to decode extra channels:
   `JxlDecoderExtraChannelBufferSize` and `JxlDecoderSetExtraChannelBuffer`.
 - API: New function `JxlEncoderInitBasicInfo` to initialize `JxlBasicInfo`
-  (only needed when encoding). NOTE: it is now required to call this function
+  (only needed when encoding). Note: it is now required to call this function
   when using the encoder. Padding was added to the struct for forward
   compatibility.
 - API: Support for encoding oriented images.
@@ -520,7 +522,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Re-licensed the project under a BSD 3-Clause license. See the
   [LICENSE](LICENSE) and [PATENTS](PATENTS) files for details.
-- Full JPEG XL part 1 specification support: Implemented all the spec required
+- Full JPEG XL part 1 specification support: Implemented all the spec required
   to decode files to pixels, including cases that are not used by the encoder
   yet. Part 2 of the spec (container format) is final but not fully implemented
   here.
@@ -617,7 +619,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- JPEG XL bitstream format is frozen. Files encoded with 0.2 will be supported
+- JPEG XL bitstream format is frozen. Files encoded with 0.2 will be supported
   by future versions.
 
 ### Changed
@@ -633,7 +635,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Initial release of an encoder (`cjxl`) and decoder (`djxl`) that work
   together as well as a benchmark tool for comparison with other codecs
   (`benchmark_xl`).
-- Note: JPEG XL format is in the final stages of standardization, minor changes
+- Note: JPEG XL format is in the final stages of standardization, minor changes
   to the codestream format are still possible but we are not expecting any
   changes beyond what is required by bug fixing.
 - API: new decoder API in C, check the `examples/` directory for its example

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -70,7 +70,7 @@ behavior is threatening or harassing, report it. We are dedicated to providing
 an environment where participants feel welcome and safe.
 
 Reports should be directed to Jyrki Alakuijala <jyrki@google.com>, the
-Project Steward(s) for JPEG XL. It is the Project Steward’s duty to
+Project Steward(s) for JPEG XL. It is the Project Steward’s duty to
 receive and address reported violations of the code of conduct. They will then
 work with a committee consisting of representatives from the Open Source
 Programs Office and the Google Open Source Strategy team. If for any reason you

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -25,7 +25,7 @@ link:
 
 ## Contributing with patches and Pull Requests
 
-We'd love to accept your contributions to the JPEG XL Project. Please read
+We'd love to accept your contributions to the JPEG XL Project. Please read
 through this section before sending a Pull Request.
 
 ### Contributor License Agreements
@@ -35,7 +35,7 @@ and [PATENTS](PATENTS) files. Before we can accept your contributions, even for
 small changes, there are just a few small guidelines you need to follow:
 
 Please fill out either the individual or corporate Contributor License Agreement
-(CLA) with Google. JPEG XL Project is an an effort by multiple individuals and
+(CLA) with Google. JPEG XL Project is an an effort by multiple individuals and
 companies, including the initial contributors Cloudinary and Google, but Google
 is the legal entity in charge of receiving these CLA and relicensing this
 software:
@@ -62,7 +62,7 @@ file must include the following header when possible, with comment style adapted
 to the language as needed:
 
 ```
-// Copyright (c) the JPEG XL Project Authors. All rights reserved.
+// Copyright (c) the JPEG XL Project Authors. All rights reserved.
 //
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,9 +9,8 @@ we expect you to follow a couple of strict guidelines:
   understand, and actively submit changes.
 * Take full responsibility: You are considered the author of your Pull Request.
   You take full responsibility for the functionality, quality, and security of
-  all code you submit, regardless of how it was generated. Since you are
-  considered the author of the submitted code, you are expected to abide by
-  [Google's CLA](#contributor-license-agreements).
+  all code you submit, regardless of how it was generated, and you are required
+  to abide by [Google's CLA](#contributor-license-agreements).
 
 ## Contributing with bug reports
 
@@ -25,7 +24,7 @@ link:
 
 ## Contributing with patches and Pull Requests
 
-We'd love to accept your contributions to the JPEG XL Project. Please read
+We'd love to accept your contributions to the JPEG XL Project. Please read
 through this section before sending a Pull Request.
 
 ### Contributor License Agreements
@@ -35,7 +34,7 @@ and [PATENTS](PATENTS) files. Before we can accept your contributions, even for
 small changes, there are just a few small guidelines you need to follow:
 
 Please fill out either the individual or corporate Contributor License Agreement
-(CLA) with Google. JPEG XL Project is an an effort by multiple individuals and
+(CLA) with Google. JPEG XL Project is an effort by multiple individuals and
 companies, including the initial contributors Cloudinary and Google, but Google
 is the legal entity in charge of receiving these CLA and relicensing this
 software:

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# JPEG XL reference implementation
+# JPEG XL reference implementation
 
 [![Build/Test](https://github.com/libjxl/libjxl/actions/workflows/build_test.yml/badge.svg)](
 https://github.com/libjxl/libjxl/actions/workflows/build_test.yml)
@@ -24,18 +24,18 @@ https://codecov.io/gh/libjxl/libjxl)
 > [!IMPORTANT]
 > **Security Update:** It is highly recommended to update to v0.12 ASAP due to numerous security fixes.
 
-This repository contains a reference implementation of JPEG XL (encoder and
+This repository contains a reference implementation of JPEG XL (encoder and
 decoder), called `libjxl`. This software library is
-[used by many applications that support JPEG XL](doc/software_support.md).
+[used by many applications that support JPEG XL](doc/software_support.md).
 
-JPEG XL was standardized in 2022 as [ISO/IEC 18181](https://jpeg.org/jpegxl/workplan.html).
+JPEG XL was standardized in 2022 as [ISO/IEC 18181](https://jpeg.org/jpegxl/workplan.html).
 The [core codestream](doc/format_overview.md#codestream-features) is specified in 18181-1,
 the [file format](doc/format_overview.md#file-format-features) in 18181-2.
 [Decoder conformance](https://github.com/libjxl/conformance) is defined in 18181-3,
 and 18181-4 is the [reference software](https://github.com/libjxl/libjxl).
 
 The library API, command line options, and tools in this repository are subject
-to change, however files encoded with `cjxl` conform to the JPEG XL specification
+to change, however files encoded with `cjxl` conform to the JPEG XL specification
 and can be decoded with current and future `djxl` decoders or the `libjxl` decoding library.
 
 ## Installation
@@ -56,7 +56,7 @@ Of course you can also [build libjxl from sources](BUILDING.md).
 
 ## Usage
 
-To encode a source image to JPEG XL with default settings:
+To encode a source image to JPEG XL with default settings:
 
 ```bash
 cjxl input.png output.jxl
@@ -70,7 +70,7 @@ The [encode effort](doc/encode_effort.md) can be selected using the `--effort` p
 For more settings run `cjxl --help` or for a full list of options
 run `cjxl -v -v --help`.
 
-To decode a JPEG XL file run:
+To decode a JPEG XL file run:
 
 ```bash
 djxl input.jxl output.png
@@ -79,7 +79,7 @@ djxl input.jxl output.png
 When possible, `cjxl`/`djxl` are able to read/write the following image formats:
 OpenEXR (`.exr`), GIF (`.gif`), JPEG (`.jpg`/`.jpeg`), NetPBM (`.pam`/`.pgm`/`.ppm`),
 Portable FloatMap (`.pfm`), PGX Test Format (`.pgx`), Portable Network Graphics (`.png`),
-Animated PNG (`.png`/`.apng`), and JPEG XL itself (`.jxl`).
+Animated PNG (`.png`/`.apng`), and JPEG XL itself (`.jxl`).
 
 Specifically for JPEG files, the default `cjxl` behavior is to apply lossless
 recompression and the default `djxl` behavior is to reconstruct the original
@@ -110,24 +110,24 @@ the [PATENTS](PATENTS) file.
 
 Please note that the PATENTS file only mentions Google since Google is the legal
 entity receiving the Contributor License Agreements (CLA) from all contributors
-to the JPEG XL Project, including the initial main contributors to the JPEG XL
+to the JPEG XL Project, including the initial main contributors to the JPEG XL
 format: Cloudinary and Google.
 
 ## Additional documentation
 
 ### Codec description
 
-*   [JPEG XL Format Overview](doc/format_overview.md)
+*   [JPEG XL Format Overview](doc/format_overview.md)
 *   [Introductory paper](https://www.spiedigitallibrary.org/proceedings/Download?fullDOI=10.1117%2F12.2529237) (open-access)
 *   [XL Overview](doc/xl_overview.md) - a brief introduction to the source code modules
-*   [JPEG XL white paper](https://ds.jpeg.org/whitepapers/jpeg-xl-whitepaper.pdf)
-*   [JPEG XL official website](https://jpeg.org/jpegxl)
-*   [JPEG XL community website](https://jpegxl.info)
+*   [JPEG XL white paper](https://ds.jpeg.org/whitepapers/jpeg-xl-whitepaper.pdf)
+*   [JPEG XL official website](https://jpeg.org/jpegxl)
+*   [JPEG XL community website](https://jpegxl.info)
 
 ### Development process
 
 *   [More information on testing/build options](doc/building_and_testing.md)
-*   [Git guide for JPEG XL](doc/developing_in_github.md) - for developers
+*   [Git guide for JPEG XL](doc/developing_in_github.md) - for developers
 *   [Fuzzing](doc/fuzzing.md) - for developers
 *   [Building Web Assembly artifacts](doc/building_wasm.md)
 *   [Test coverage on Codecov.io](https://app.codecov.io/gh/libjxl/libjxl) - for
@@ -139,6 +139,6 @@ format: Cloudinary and Google.
 
 If you encounter a bug or other issue with the software, please open an Issue here.
 
-There is a [subreddit about JPEG XL](https://www.reddit.com/r/jpegxl/), and
+There is a [subreddit about JPEG XL](https://www.reddit.com/r/jpegxl/), and
 informal chatting with developers and early adopters of `libjxl` can be done on the
-[JPEG XL Discord server](https://discord.gg/DqkQgDRTFu).
+[JPEG XL Discord server](https://discord.gg/DqkQgDRTFu).

--- a/README.md
+++ b/README.md
@@ -67,14 +67,17 @@ The desired visual fidelity can be selected using the `--distance` parameter
 or using `--quality` (on a scale from 0 to 100, roughly matching libjpeg).
 The [encode effort](doc/encode_effort.md) can be selected using the `--effort` parameter.
 
-For more settings run `cjxl --help` or for a full list of options
-run `cjxl -v -v --help`.
+For more settings, run `cjxl --help`. The help output can be combined with `-v` to increase verbosity.
+Up to four `-v` flags (e.g., `cjxl -v -v -v -v --help`) reveal progressively more advanced options.
 
 To decode a JPEG XL file run:
 
 ```bash
 djxl input.jxl output.png
 ```
+
+Similar to encoding, you can run `djxl --help` to see decoding options, and pass up to two `-v` flags
+to see more advanced options.
 
 When possible, `cjxl`/`djxl` are able to read/write the following image formats:
 OpenEXR (`.exr`), GIF (`.gif`), JPEG (`.jpg`/`.jpeg`), NetPBM (`.pam`/`.pgm`/`.ppm`),

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# JPEG XL reference implementation
+# JPEG XL reference implementation
 
 [![Build/Test](https://github.com/libjxl/libjxl/actions/workflows/build_test.yml/badge.svg)](
 https://github.com/libjxl/libjxl/actions/workflows/build_test.yml)
@@ -24,18 +24,18 @@ https://codecov.io/gh/libjxl/libjxl)
 > [!IMPORTANT]
 > **Security Update:** It is highly recommended to update to v0.12 ASAP due to numerous security fixes.
 
-This repository contains a reference implementation of JPEG XL (encoder and
+This repository contains a reference implementation of JPEG XL (encoder and
 decoder), called `libjxl`. This software library is
-[used by many applications that support JPEG XL](doc/software_support.md).
+[used by many applications that support JPEG XL](doc/software_support.md).
 
-JPEG XL was standardized in 2022 as [ISO/IEC 18181](https://jpeg.org/jpegxl/workplan.html).
+JPEG XL was standardized in 2022 as [ISO/IEC 18181](https://jpeg.org/jpegxl/workplan.html).
 The [core codestream](doc/format_overview.md#codestream-features) is specified in 18181-1,
 the [file format](doc/format_overview.md#file-format-features) in 18181-2.
 [Decoder conformance](https://github.com/libjxl/conformance) is defined in 18181-3,
 and 18181-4 is the [reference software](https://github.com/libjxl/libjxl).
 
 The library API, command line options, and tools in this repository are subject
-to change, however files encoded with `cjxl` conform to the JPEG XL specification
+to change, however files encoded with `cjxl` conform to the JPEG XL specification
 and can be decoded with current and future `djxl` decoders or the `libjxl` decoding library.
 
 ## Installation
@@ -56,7 +56,7 @@ Of course you can also [build libjxl from sources](BUILDING.md).
 
 ## Usage
 
-To encode a source image to JPEG XL with default settings:
+To encode a source image to JPEG XL with default settings:
 
 ```bash
 cjxl input.png output.jxl
@@ -67,19 +67,22 @@ The desired visual fidelity can be selected using the `--distance` parameter
 or using `--quality` (on a scale from 0 to 100, roughly matching libjpeg).
 The [encode effort](doc/encode_effort.md) can be selected using the `--effort` parameter.
 
-For more settings run `cjxl --help` or for a full list of options
-run `cjxl -v -v --help`.
+For more settings, run `cjxl --help`. The help output can be combined with `-v` to increase verbosity.
+Up to four `-v` flags (e.g., `cjxl -v -v -v -v --help`) reveal progressively more advanced options.
 
-To decode a JPEG XL file run:
+To decode a JPEG XL file run:
 
 ```bash
 djxl input.jxl output.png
 ```
 
+Similar to encoding, you can run `djxl --help` to see decoding options, and pass up to two `-v` flags
+to see more advanced options.
+
 When possible, `cjxl`/`djxl` are able to read/write the following image formats:
 OpenEXR (`.exr`), GIF (`.gif`), JPEG (`.jpg`/`.jpeg`), NetPBM (`.pam`/`.pgm`/`.ppm`),
 Portable FloatMap (`.pfm`), PGX Test Format (`.pgx`), Portable Network Graphics (`.png`),
-Animated PNG (`.png`/`.apng`), and JPEG XL itself (`.jxl`).
+Animated PNG (`.png`/`.apng`), and JPEG XL itself (`.jxl`).
 
 Specifically for JPEG files, the default `cjxl` behavior is to apply lossless
 recompression and the default `djxl` behavior is to reconstruct the original
@@ -110,24 +113,24 @@ the [PATENTS](PATENTS) file.
 
 Please note that the PATENTS file only mentions Google since Google is the legal
 entity receiving the Contributor License Agreements (CLA) from all contributors
-to the JPEG XL Project, including the initial main contributors to the JPEG XL
+to the JPEG XL Project, including the initial main contributors to the JPEG XL
 format: Cloudinary and Google.
 
 ## Additional documentation
 
 ### Codec description
 
-*   [JPEG XL Format Overview](doc/format_overview.md)
+*   [JPEG XL Format Overview](doc/format_overview.md)
 *   [Introductory paper](https://www.spiedigitallibrary.org/proceedings/Download?fullDOI=10.1117%2F12.2529237) (open-access)
 *   [XL Overview](doc/xl_overview.md) - a brief introduction to the source code modules
-*   [JPEG XL white paper](https://ds.jpeg.org/whitepapers/jpeg-xl-whitepaper.pdf)
-*   [JPEG XL official website](https://jpeg.org/jpegxl)
-*   [JPEG XL community website](https://jpegxl.info)
+*   [JPEG XL white paper](https://ds.jpeg.org/whitepapers/jpeg-xl-whitepaper.pdf)
+*   [JPEG XL official website](https://jpeg.org/jpegxl)
+*   [JPEG XL community website](https://jpegxl.info)
 
 ### Development process
 
 *   [More information on testing/build options](doc/building_and_testing.md)
-*   [Git guide for JPEG XL](doc/developing_in_github.md) - for developers
+*   [Git guide for JPEG XL](doc/developing_in_github.md) - for developers
 *   [Fuzzing](doc/fuzzing.md) - for developers
 *   [Building Web Assembly artifacts](doc/building_wasm.md)
 *   [Test coverage on Codecov.io](https://app.codecov.io/gh/libjxl/libjxl) - for
@@ -139,6 +142,6 @@ format: Cloudinary and Google.
 
 If you encounter a bug or other issue with the software, please open an Issue here.
 
-There is a [subreddit about JPEG XL](https://www.reddit.com/r/jpegxl/), and
+There is a [subreddit about JPEG XL](https://www.reddit.com/r/jpegxl/), and
 informal chatting with developers and early adopters of `libjxl` can be done on the
-[JPEG XL Discord server](https://discord.gg/DqkQgDRTFu).
+[JPEG XL Discord server](https://discord.gg/DqkQgDRTFu).

--- a/doc/benchmarking.md
+++ b/doc/benchmarking.md
@@ -32,7 +32,7 @@ during encoding.
 
 [Encode_effort.md](https://github.com/libjxl/libjxl/blob/main/doc/encode_effort.md) describes what the various effort settings do.
 
-Mode: JPEG XL has two modes. The default is Var-DCT mode, which is suitable for
+Mode: JPEG XL has two modes. The default is Var-DCT mode, which is suitable for
 lossy compression. The other mode is Modular mode, which is suitable for lossless
 compression. Modular mode can also do lossy compression (e.g. `jxl:m:q50`).
 

--- a/doc/building_and_testing.md
+++ b/doc/building_and_testing.md
@@ -1,7 +1,6 @@
 # Building and Testing
 
-This file describes the building and testing facilities provided by the `ci.sh`
-script. It assumes you already have the build environment set up.
+This file describes the building and testing facilities provided by the `ci.sh` script. `ci.sh` is a convenient wrapper around `cmake` and `ctest` that simplifies building and testing the project with different configurations. It assumes you already have the build environment set up.
 
 ## Basic building
 
@@ -11,10 +10,23 @@ To build the JPEG XL software and run its unit tests, run:
 ./ci.sh release
 ```
 
+Once the build completes successfully, you will find the generated executables (like `cjxl` and `djxl`) in the `build/tools/` directory.
+
+### Cleaning the Build
+
+If you ever need to start fresh (for example, if you change a major dependency or your build gets into a weird state), simply delete the build directory:
+
+```bash
+rm -rf build/
+```
+
 ## Testing
 
-`./ci.sh` build commands including `release`, `opt`, etc. will also run tests.
-You can set the environment variable `SKIP_TEST=1` to skip this.
+By default, `./ci.sh` build commands like `release` and `opt` will automatically run all unit tests after compiling. If you want to skip testing (e.g., for a faster build), you can set the environment variable `SKIP_TEST=1`:
+
+```bash
+SKIP_TEST=1 ./ci.sh release
+```
 
 It is possible to manually run all the tests in parallel in all your CPUs with
 the command:
@@ -44,12 +56,15 @@ more options run `ctest --help`, for example, you can pass `-j1` if you want
 to run only one test at a time instead of our default of multiple tests in
 parallel.
 
-## Other commands
+## Build Configurations
 
-Running `./ci.sh` with no parameters shows a list of available commands. For
-example, you can run `opt` for optimized developer builds with symbols or
-`debug` for debug builds which do not have NDEBUG defined and therefore include
-more runtime debug information.
+The `./ci.sh` script provides three primary build configurations:
+
+* **`release`**: Builds an optimized binary and strips out all debugging symbols. Produces the smallest, fastest executable, and is ideal for end-users.
+* **`opt`**: Equivalent to CMake's `RelWithDebInfo`. Builds an optimized binary but keeps debugging symbols. Ideal for when you want speed (like a release build) but still need to profile performance or debug crashes.
+* **`debug`**: Disables optimizations and includes full debugging information. Best for stepping through code line-by-line during development.
+
+Running `./ci.sh` with no parameters will print out a full list of available commands.
 
 ### Cross-compiling
 

--- a/doc/building_and_testing.md
+++ b/doc/building_and_testing.md
@@ -4,7 +4,7 @@ This file describes the building and testing facilities provided by the `ci.sh` 
 
 ## Basic building
 
-To build the JPEG XL software and run its unit tests, run:
+To build the JPEG XL software and run its unit tests, run:
 
 ```bash
 ./ci.sh release

--- a/doc/building_and_testing.md
+++ b/doc/building_and_testing.md
@@ -1,20 +1,32 @@
 # Building and Testing
 
-This file describes the building and testing facilities provided by the `ci.sh`
-script. It assumes you already have the build environment set up.
+This file describes the building and testing facilities provided by the `ci.sh` script. `ci.sh` is a convenient wrapper around `cmake` and `ctest` that simplifies building and testing the project with different configurations. It assumes you already have the build environment set up.
 
 ## Basic building
 
-To build the JPEG XL software and run its unit tests, run:
+To build the JPEG XL software and run its unit tests, run:
 
 ```bash
 ./ci.sh release
 ```
 
+Once the build completes successfully, you will find the generated executables (like `cjxl` and `djxl`) in the `build/tools/` directory.
+
+### Cleaning the Build
+
+If you ever need to start fresh (for example, if you change a major dependency or your build gets into a weird state), simply delete the build directory:
+
+```bash
+rm -rf build/
+```
+
 ## Testing
 
-`./ci.sh` build commands including `release`, `opt`, etc. will also run tests.
-You can set the environment variable `SKIP_TEST=1` to skip this.
+By default, `./ci.sh` build commands like `release` and `opt` will automatically run all unit tests after compiling. If you want to skip testing (e.g., for a faster build), you can set the environment variable `SKIP_TEST=1`:
+
+```bash
+SKIP_TEST=1 ./ci.sh release
+```
 
 It is possible to manually run all the tests in parallel in all your CPUs with
 the command:
@@ -44,12 +56,15 @@ more options run `ctest --help`, for example, you can pass `-j1` if you want
 to run only one test at a time instead of our default of multiple tests in
 parallel.
 
-## Other commands
+## Build Configurations
 
-Running `./ci.sh` with no parameters shows a list of available commands. For
-example, you can run `opt` for optimized developer builds with symbols or
-`debug` for debug builds which do not have NDEBUG defined and therefore include
-more runtime debug information.
+The `./ci.sh` script provides three primary build configurations:
+
+* **`release`**: Builds an optimized binary and strips out all debugging symbols. Produces the smallest, fastest executable, and is ideal for end-users.
+* **`opt`**: Equivalent to CMake's `RelWithDebInfo`. Builds an optimized binary but keeps debugging symbols. Ideal for when you want speed (like a release build) but still need to profile performance or debug crashes.
+* **`debug`**: Disables optimizations and includes full debugging information. Best for stepping through code line-by-line during development.
+
+Running `./ci.sh` with no parameters will print out a full list of available commands.
 
 ### Cross-compiling
 

--- a/doc/building_wasm.md
+++ b/doc/building_wasm.md
@@ -1,6 +1,6 @@
 # Building WASM artifacts
 
-This file describes the building and testing of JPEG XL
+This file describes the building and testing of JPEG XL
 [Web Assembly](https://webassembly.org/) bundles and wrappers.
 
 These instructions assume an up-to-date Debian/Ubuntu system.

--- a/doc/color_management.md
+++ b/doc/color_management.md
@@ -40,11 +40,12 @@ error in tests. This requires parametric curves, which are only supported for
 the common sRGB case in ICC v4 profiles. ArgyllCMS does not support v4. The
 other popular open-source CMS is LittleCMS. It is also used by color-managed
 editors (Krita/darktable), which increases the chances of interoperability.
-However, LCMS has race conditions and overflow issues that prevent fuzzing. We
-will later switch to the newer skcms. Note that this library does not intend to
+However, LCMS has race conditions and overflow issues that prevent fuzzing.
+We have since migrated to and currently bundle the newer `skcms` library as our 
+default CMS to address these issues. Note that `skcms` does not intend to
 support multiProcessElements, so HDR transfer functions cannot be represented
-accurately. Thus in the long term, we will probably migrate away from ICC
-profiles entirely.
+accurately via ICC profiles, favoring the use of CICP-style enum values for
+such use-cases.
 
 ## Which viewer
 
@@ -64,5 +65,7 @@ ICC profile.
 
 -   Create a PGM/PPM/PFM file in a known color space.
 -   Invoke `cjxl` with `-x color_space=RGB_D65_202_Rel_Lin` (linear 2020). For
-    details/possible values, see color_encoding.cc `Description`.
+    details/possible values, see color_encoding.cc `Description`. Note that 
+    the CLI also directly supports named color spaces like `ProPhoto` and 
+    `AdobeRGB` or `Adobe98` through arguments.
 -   Invoke `djxl` as above with no special arguments.

--- a/doc/developing_in_github.md
+++ b/doc/developing_in_github.md
@@ -55,7 +55,7 @@ talking to GitHub.
 
 ### Fork your private copy
 
-The JPEG XL code is located in [this repo](https://github.com/libjxl/libjxl).
+The JPEG XL code is located in [this repo](https://github.com/libjxl/libjxl).
 
 The normal developer workflow in GitHub involves creating your own fork of a
 repository and uploading your own changes there. From your own copy you can
@@ -73,7 +73,7 @@ Once you are done you should have your repository at
 
 where {{USERNAME}} denotes your GitHub username.
 
-### Checkout the JPEG XL code from GitHub
+### Checkout the JPEG XL code from GitHub
 
 To get the source code on your computer you need to "clone" it. There are two
 repositories at play here, the upstream repository (`libjxl/lbjxl`) and your
@@ -254,12 +254,12 @@ The repository uses submodules for external library dependencies in
 third_party. Each submodule points to a particular external commit of the
 external repository by the hash code of that external commit. Just like
 regular source code files, this hash code is part of the current branch and
-jpeg xl commit you have checked out.
+JPEG XL commit you have checked out.
 
 When changing branches or when doing `git rebase`, git will unfortunately
-*not* automatically set those hashes to the ones of the branch or jpeg xl
+*not* automatically set those hashes to the ones of the branch or JPEG XL
 commit you changed to nor set the source files of the third_party submodules
-to the new state. That is, even though git will have updated the jpeg xl
+to the new state. That is, even though git will have updated the JPEG XL
 source code files on your disk to the new ones, it will leave the submodule
 hashes and the files in third_party in your workspace to the ones they were
 before you changed branches. This will show up in a git diff because this
@@ -269,7 +269,7 @@ not show changes in files inside the third_party directory.
 
 This mismatch can cause at least two problems:
 
-*) the jpeg xl codebase may not compile due to third_party library version
+*) the JPEG XL codebase may not compile due to third_party library version
 mismatch if e.g. API changed or a submodule was added/removed.
 
 *) when using `commit -a` your commit, which may be a technical change

--- a/doc/developing_in_windows_msys.md
+++ b/doc/developing_in_windows_msys.md
@@ -4,17 +4,17 @@
 
 ## Build Environments
 
-MSYS2 provides multiple development [environments](https://www.msys2.org/docs/environments/).  By convention, they are referred to in uppercase.  They target slightly different platforms, runtime libraries, and compiler toolchains.  For example, to build for 32-bit Windows, use the MINGW32 environment.  For interoperability with Visual Studio projects, use the UCRT64 environment.
+MSYS2 provides multiple development [environments](https://www.msys2.org/docs/environments/).  By convention, they are referred to in uppercase.  They target slightly different platforms, runtime libraries, and compiler toolchains.  For interoperability with Visual Studio projects, use the UCRT64 environment.
 
 Since all of the build environments are built on top of the MSYS environment, **all updates and package installation must be done from within the MSYS environment**.  After making any package changes, `exit` all MSYS2 terminals and restart the desired build-environment.  This reminder is repeated multiple times throughout this guide.
 
-* **MINGW32:**  To compile for 32-bit Windows (on 64-bit Windows), use packages from the `mingw32` group.  Package names are prefixed with `mingw-w64-i686`.  The naming scheme may be different on the 32-bit version of MSYS2.
+* **MINGW32 (Deprecated):**  To compile for 32-bit Windows (on 64-bit Windows), use packages from the `mingw32` group.  Package names are prefixed with `mingw-w64-i686`.  *Note: 32-bit MSYS2 is deprecated and some newer packages (like `clang`) are no longer available.*
 
-* **MINGW64:**  This is the primary environment to building for 64-bit Windows.  It uses the older MSVCRT runtime, which is widely available across Windows systems.  Package names are prefixed with `mingw-w64-x86_64`.
+* **MINGW64 (Phasing Out):**  This uses the older MSVCRT runtime, which is widely available across Windows systems. Package names are prefixed with `mingw-w64-x86_64`. *Note: As of March 2026, the MINGW64 environment is being phased out in favor of UCRT environments.*
 
-* **UCRT64:**  The Universal C Runtime (UCRT) is used by recent versions of Microsoft Visual Studio.  It ships by default with Windows 10.  For older versions of Windows, it must be provided with the application or installed by the user.  Package names are prefixed with `mingw-w64-ucrt-x86_64`.
+* **UCRT64 (Recommended):**  The Universal C Runtime (UCRT) is used by recent versions of Microsoft Visual Studio. It is the modern standard on Windows 10/11. Package names are prefixed with `mingw-w64-ucrt-x86_64`. MSYS2 strongly recommends using UCRT64 over MINGW64.
 
-* **CLANG64:**  Packages are prefixed with `mingw-w64-clang-x86_64`.
+* **CLANG64 (Recommended):**  Packages are prefixed with `mingw-w64-clang-x86_64`. MSYS2 recommends CLANG64 as a modern alternative alongside UCRT64.
 
 ## Install and Upgrade MSYS2
 
@@ -37,7 +37,6 @@ pacman -Su
 Packages are organized in groups, which share the build environment name, but in lower case.  Then they have name prefixes that indicate which group they belong to.  Consider this package search: `pacman -Ss cmake`
 
 ```
-mingw32/mingw-w64-i686-cmake
 mingw64/mingw-w64-x86_64-cmake
 ucrt64/mingw-w64-ucrt-x86_64-cmake
 clang64/mingw-w64-clang-x86_64-cmake
@@ -72,67 +71,89 @@ If packages management is done within a build environment other than MSYS, the e
 
 5. After successfully building a project, it is safe to delete `msys64.bak`
 
-## The MING64 Environment
+## The UCRT64 Environment
 
-Next set up the MING64 environment.  The following commands should be run within the MSYS environment.  `pacman -S` is used to install packages.  The `--needed` argument prevents packages from being reinstalled.
+Next set up the UCRT64 environment.  The following commands should be run within the MSYS environment.  `pacman -S` is used to install packages.  The `--needed` argument prevents packages from being reinstalled.
+
+> [!NOTE]
+> If you are unsure what dependencies `libjxl` requires in general, refer to [BUILDING.md](../BUILDING.md) as a starting point. The command below installs the MSYS2 equivalents for those packages.
 
 ```bash
-pacman -S --needed base-devel mingw-w64-x86_64-toolchain
-pacman -S git mingw-w64-x86_64-cmake mingw-w64-x86_64-ninja \
-    mingw-w64-x86_64-gtest mingw-w64-x86_64-giflib \
-    mingw-w64-x86_64-libpng mingw-w64-x86_64-libjpeg-turbo 
+pacman -S --needed base-devel mingw-w64-ucrt-x86_64-toolchain
+pacman -S git mingw-w64-ucrt-x86_64-cmake mingw-w64-ucrt-x86_64-ninja \
+    mingw-w64-ucrt-x86_64-gtest mingw-w64-ucrt-x86_64-giflib \
+    mingw-w64-ucrt-x86_64-libpng mingw-w64-ucrt-x86_64-libjpeg-turbo 
 ```
 
 ## Build `libjxl`
 
 Download the source from the libjxl [releases](https://github.com/libjxl/libjxl/releases) page.  Alternatively, you may obtain the latest development version with `git`.  Run `./deps.sh` to ensure additional third-party dependencies are downloaded.
 
-Start the MINGW64 environment, create a build directory within the source directory, and configure with `cmake`.
+Start the UCRT64 environment, create a build directory within the source directory, and configure with `cmake`.
 
 ```bash
 mkdir build
 cd build
-cmake -DCMAKE_BUILD_TYPE=RelWithDebInfo \
-   -DBUILD_TESTING=OFF -DBUILD_SHARED_LIBS=OFF \
+cmake -DCMAKE_BUILD_TYPE=Release \
+   -DBUILD_TESTING=OFF \
    -DJPEGXL_ENABLE_BENCHMARK=OFF -DJPEGXL_ENABLE_PLUGINS=ON \
-   -DJPEGXL_ENABLE_MANPAGES=OFF -DJPEGXL_FORCE_SYSTEM_BROTLI=ON \
-   -DJPEGXL_FORCE_SYSTEM_GTEST=ON ..
+   -DJPEGXL_ENABLE_MANPAGES=OFF -DJPEGXL_STATIC=ON ..
 ```
 
-Check the output to see if any dependencies were missed and need to be installed.  Adding `-G Ninja` may be helpful, but on my computer, Ninja was selected by default.  Remember that package changes must be done from the MSYS environment.  Then exit all MSYS2 terminals and restart the build environment.
+You could optionally add `-DCMAKE_EXE_LINKER_FLAGS=-s` to strip symbols to reduce the size of the binaries. Check the output to see if any dependencies were missed and need to be installed.  Adding `-G Ninja` may be helpful, but on my computer, Ninja was selected by default.  Remember that package changes must be done from the MSYS environment.  Then exit all MSYS2 terminals and restart the build environment.
 
-If all went well, you may now run `cmake` to build `libjxl`:
+If all went well, you may now build `libjxl` using either `cmake` or `ninja` directly:
 
 ```bash
-cmake --build .
+# Build using cmake
+cmake --build . --parallel
+
+# Or, build directly with ninja (if using the Ninja generator)
+ninja
 ```
 
-Do not be alarmed by the compiler warnings.  They are a caused by differences between gcc/g++ and clang.  The build should complete successfully.  Then `cjxl`, `djxl`, `jxlinfo`, and others can be run from within the build environment.  Moving them into the native Windows environment requires resolving `dll` issues that are beyond the scope of this document.
+Do not be alarmed by the compiler warnings.  They are a caused by differences between gcc/g++ and clang.  The build should complete successfully.  Then `cjxl`, `djxl`, `jxlinfo`, and others can be run from within the build environment.  Because we used `-DJPEGXL_STATIC=ON`, these executables are statically linked and can be easily moved to a native Windows environment without resolving `dll` issues.
+
+> [!WARNING]
+> If you enable OpenEXR support using `-DJPEGXL_ENABLE_OPENEXR=ON` alongside the OpenEXR package provided by `pacman`, the resulting binaries will **not** compile fully statically. If you require standalone static builds with EXR support, you must compile OpenEXR separately from source. Otherwise, leave it disabled.
 
 ## The `clang` Compiler
 
 To use the `clang` compiler, install the packages that correspond with the environment you wish to use.  Remember to make package changes from within the MSYS environment.
 
 ```
-mingw-w64-i686-clang
-mingw-w64-i686-clang-tools-extra
-mingw-w64-i686-clang-compiler-rt
-
 mingw-w64-x86_64-clang
 mingw-w64-x86_64-clang-tools-extra
-mingw-w64-x86_64-clang-compiler-rt
+mingw-w64-x86_64-compiler-rt
 
-mingw-w64-ucrt64-x86_64-clang
-mingw-w64-ucrt64-x86_64-clang-tools-extra
-mingw-w64-ucrt64-x86_64-clang-compiler-rt
+mingw-w64-ucrt-x86_64-clang
+mingw-w64-ucrt-x86_64-clang-tools-extra
+mingw-w64-ucrt-x86_64-compiler-rt
 ```
 
 After the `clang` compiler is installed, 'libjxl' can be built with the `./ci.sh` script.
 
+> [!IMPORTANT]
+> The `./ci.sh` script relies on GNU Parallel for some of its commands (like `tidy` and testing). Ensure you install it from your MSYS terminal by running `pacman -S parallel` before using the script.
+
 ```bash
-./ci.sh opt -DBUILD_TESTING=OFF -DBUILD_SHARED_LIBS=OFF \
+./ci.sh release -DBUILD_TESTING=OFF \
     -DJPEGXL_ENABLE_BENCHMARK=OFF -DJPEGXL_ENABLE_MANPAGES=OFF \
-    -DJPEGXL_FORCE_SYSTEM_BROTLI=ON -DJPEGXL_FORCE_SYSTEM_GTEST=ON
+    -DJPEGXL_STATIC=ON
 ```
 
-On my computer, `doxygen` packages needed to be installed to proceed with building.  Use `pacman -Ss doxygen` to find the packages to install.
+If the script doesn't work, navigate to the build directory to reconfigure and build with `cmake`.
+
+```bash
+export CC=clang && export CXX=clang++
+cmake -DCMAKE_BUILD_TYPE=Release \
+   -DBUILD_TESTING=OFF \
+   -DJPEGXL_ENABLE_BENCHMARK=OFF -DJPEGXL_ENABLE_PLUGINS=ON \
+   -DJPEGXL_ENABLE_MANPAGES=OFF -DJPEGXL_STATIC=ON ..
+```
+
+### Link Time Optimization (LTO)
+
+If you want to build `libjxl` with Link Time Optimization (LTO) using Clang, be aware that it will **fail to link** in the `MINGW64` environment. This is because LLVM currently cannot handle `emutls` during LTO code generation, which is used by GCC/libstdc++ in the MINGW64 environment.
+
+To successfully build with LTO, you **must** use an environment with native TLS support, such as `CLANG64` or `UCRT64`. Keep in mind that `-DJPEGXL_LTO=ON` enables full LTO, which can take a long time to link. Thin LTO is recommended for faster link times by passing `-DCMAKE_INTERPROCEDURAL_OPTIMIZATION=ON`.

--- a/doc/developing_in_windows_vcpkg.md
+++ b/doc/developing_in_windows_vcpkg.md
@@ -25,7 +25,7 @@ vcpkg install zlib:x64-windows
 
 ## Building
 
-From Visual Studio, open the CMakeLists.txt in the JPEG XL root directory.
+From Visual Studio, open the CMakeLists.txt in the JPEG XL root directory.
 Right-click the CMakeLists.txt entry in the Folder View of the Solution
 Explorer. In the context menu, select CMake Settings. Click on the green plus
 to add an x64-Clang configuration and the red minus to remove any non-Clang

--- a/doc/encode_effort.md
+++ b/doc/encode_effort.md
@@ -38,7 +38,9 @@ For the entropy coding (context clustering, lz77 search, hybriduint configuratio
   * Efforts 8 & 9 VarDCT at distances >0.5. (hidden check in code)
 * When using `--buffering=0` (buffer entire image).
 * When using `--buffering=1` and the image is 2048x2048 or smaller.
-* When using any buffering mode, and the image has 8 or fewer total groups (e.g. smaller than 768x768).
+* When using any buffering mode, and the image has 8 or fewer total groups. The default group size is 256x256
+  (meaning this applies to images smaller than ~768x768), but this threshold dynamically scales if the group
+  size is changed via the `-g` flag in Modular mode.
 * Lossless Jpeg transcoding.
 * VarDCT at distances ≥10.
 * Lossy Modular.

--- a/doc/encode_effort.md
+++ b/doc/encode_effort.md
@@ -18,32 +18,40 @@ The following table describes what the various effort settings do:
 
 |Effort | Modular (lossless) | VarDCT (lossy) |
 |-------|--------------------|----------------|
-| e1 | fast-lossless, fixed YCoCg RCT, fixed ClampedGradient predictor, simple palette detection, no MA tree (one context for everything), Huffman, simple rle-only lz77 | only 8x8, basically XYB jpeg with ANS |
-| e2 | global channel palette, fixed MA tree (context based on Gradient-error), ANS, otherwise same as e1 | same as e1 |
+| e1 | fast-lossless, fixed YCoCg RCT, fixed ClampedGradient predictor, simple palette detection, no MA tree (one context for everything), Huffman, simple rle-only lz77 | N/A (gets bumped to e2) |
+| e2 | global channel palette, fixed MA tree (context based on Gradient-error), ANS, otherwise same as e1 | only 8x8, basically XYB jpeg with ANS |
 | e3 | same as e2 but fixed Weighted predictor and fixed MA tree with context based on WP-error | e2 + better ANS |
 | e4 | try both ClampedGradient and Weighted predictor, learned MA tree, global palette | coefficient reordering |
 | e5 | e4 + patches, local palette / local channel palette, different local RCTs | e4 + simple variable blocks heuristics, adaptive quantization, gabor-like transform, chroma from luma |
-| e6 | e5 + more RCTs and MA tree properties | e5 + error diffusion, full variable blocks heuristics |
-| e7 | e6 + more RCTs and MA tree properties | e6 + patches (including dots) |
-| e8 | e7 + more RCTs, MA tree properties, and Weighted predictor parameters | e7 + Butteraugli iterations for adaptive quantization |
-| e9 | e8 + more RCTs, MA tree properties, and Weighted predictor parameters | e8 + more Butteraugli iterations |
-| e10 | e9 + global MA tree, try all predictors, and disables chunked encoding | e9 + more thorough adaptive quantization, disables chunked encoding and uses iterative downsampling |
-| e11 | e10 + previous-channel MA tree properties, different group dimensions, and try multiple e10 configurations | N/A |
+| e6 | e5 + more RCTs and MA tree properties | e5 + full variable blocks heuristics |
+| e7 | e6 + more RCTs and MA tree properties | e6 + error diffusion, patches (see chunked encoding) + better chroma from luma |
+| e8 | e7 + more RCTs, MA tree properties, and Weighted predictor parameters | e7 + better adaptive quantization with butteraugli iterations |
+| e9 | e8 + more RCTs, MA tree properties, and Weighted predictor parameters | e8 + more butteraugli iterations |
+| e10 | e9 + global MA tree, try all predictors, and disables chunked encoding | e9 + exhaustive block heuristics, iterative downsampling (only used when `--resampling=2`), and disables chunked encoding |
+| e11 | e10 + previous-channel MA tree properties, different group dimensions, and try multiple e10 configurations | N/A (bumped down to e10) |
 
 For the entropy coding (context clustering, lz77 search, hybriduint configuration): slower/more exhaustive search as effort goes up.
 
-<u>Chunked encoding is also disabled under these circumstances:</u>
-* When the image is smaller than 2048x2048.
+<u>Chunked encoding (streaming) is also disabled under these circumstances:</u>
+* When using default buffering (`--buffering=-1`):
+  * Effort 7 VarDCT at distances ≥3.0. (patches get enabled)
+  * Efforts 8 & 9 VarDCT at distances >0.5. (hidden check in code)
+* When using `--buffering=0` (buffer entire image).
+* When using `--buffering=1` and the image is 2048x2048 or smaller.
+* When using any buffering mode, and the image has 8 or fewer total groups (e.g. smaller than 768x768).
 * Lossless Jpeg transcoding.
 * VarDCT at distances ≥10.
-* Effort 7 VarDCT at distances ≥3.0.
-* Efforts 8 & 9 VarDCT at distances >0.5.
 * Lossy Modular.
 * When using any of these flags:
   * `--patches=1`
   * `--progressive_dc >0`
+  * `--progressive_ac`
+  * `--qprogressive_ac`
   * `-p`
   * `-d 0` and `-R 1`
   * `--noise=1`
   * `--resampling >1`
   * `--disable_perceptual_optimizations`
+
+> [!NOTE]
+> In version 0.12, the new flags `--buffering` and `--output_mode` were introduced to explicitly control streaming behavior. `--buffering` controls input buffering (`0` for full buffering, `1` to stream large images, `2` to stream with a lower threshold). `--output_mode` controls output codestream buffering and streaming order. By default, output is buffered (`--output_mode 0`) to allow basic progressive loading.

--- a/doc/encode_effort.md
+++ b/doc/encode_effort.md
@@ -18,32 +18,42 @@ The following table describes what the various effort settings do:
 
 |Effort | Modular (lossless) | VarDCT (lossy) |
 |-------|--------------------|----------------|
-| e1 | fast-lossless, fixed YCoCg RCT, fixed ClampedGradient predictor, simple palette detection, no MA tree (one context for everything), Huffman, simple rle-only lz77 | only 8x8, basically XYB jpeg with ANS |
-| e2 | global channel palette, fixed MA tree (context based on Gradient-error), ANS, otherwise same as e1 | same as e1 |
+| e1 | fast-lossless, fixed YCoCg RCT, fixed ClampedGradient predictor, simple palette detection, no MA tree (one context for everything), Huffman, simple rle-only lz77 | N/A (gets bumped to e2) |
+| e2 | global channel palette, fixed MA tree (context based on Gradient-error), ANS, otherwise same as e1 | only 8x8, basically XYB jpeg with ANS |
 | e3 | same as e2 but fixed Weighted predictor and fixed MA tree with context based on WP-error | e2 + better ANS |
 | e4 | try both ClampedGradient and Weighted predictor, learned MA tree, global palette | coefficient reordering |
 | e5 | e4 + patches, local palette / local channel palette, different local RCTs | e4 + simple variable blocks heuristics, adaptive quantization, gabor-like transform, chroma from luma |
-| e6 | e5 + more RCTs and MA tree properties | e5 + error diffusion, full variable blocks heuristics |
-| e7 | e6 + more RCTs and MA tree properties | e6 + patches (including dots) |
-| e8 | e7 + more RCTs, MA tree properties, and Weighted predictor parameters | e7 + Butteraugli iterations for adaptive quantization |
-| e9 | e8 + more RCTs, MA tree properties, and Weighted predictor parameters | e8 + more Butteraugli iterations |
-| e10 | e9 + global MA tree, try all predictors, and disables chunked encoding | e9 + more thorough adaptive quantization, disables chunked encoding and uses iterative downsampling |
-| e11 | e10 + previous-channel MA tree properties, different group dimensions, and try multiple e10 configurations | N/A |
+| e6 | e5 + more RCTs and MA tree properties | e5 + full variable blocks heuristics |
+| e7 | e6 + more RCTs and MA tree properties | e6 + error diffusion, patches (see chunked encoding) + better chroma from luma |
+| e8 | e7 + more RCTs, MA tree properties, and Weighted predictor parameters | e7 + better adaptive quantization with butteraugli iterations |
+| e9 | e8 + more RCTs, MA tree properties, and Weighted predictor parameters | e8 + more butteraugli iterations |
+| e10 | e9 + global MA tree, try all predictors, and disables chunked encoding | e9 + exhaustive block heuristics, iterative downsampling (only used when `--resampling=2`), and disables chunked encoding |
+| e11 | e10 + previous-channel MA tree properties, different group dimensions, and try multiple e10 configurations | N/A (bumped down to e10) |
 
 For the entropy coding (context clustering, lz77 search, hybriduint configuration): slower/more exhaustive search as effort goes up.
 
-<u>Chunked encoding is also disabled under these circumstances:</u>
-* When the image is smaller than 2048x2048.
+<u>Chunked encoding (streaming) is also disabled under these circumstances:</u>
+* When using default buffering (`--buffering=-1`):
+  * Effort 7 VarDCT at distances ≥3.0. (patches get enabled)
+  * Efforts 8 & 9 VarDCT at distances >0.5. (hidden check in code)
+* When using `--buffering=0` (buffer entire image).
+* When using `--buffering=1` and the image is 2048x2048 or smaller.
+* When using any buffering mode, and the image has 8 or fewer total groups. The default group size is 256x256
+  (meaning this applies to images smaller than ~768x768), but this threshold dynamically scales if the group
+  size is changed via the `-g` flag in Modular mode.
 * Lossless Jpeg transcoding.
 * VarDCT at distances ≥10.
-* Effort 7 VarDCT at distances ≥3.0.
-* Efforts 8 & 9 VarDCT at distances >0.5.
 * Lossy Modular.
 * When using any of these flags:
   * `--patches=1`
   * `--progressive_dc >0`
+  * `--progressive_ac`
+  * `--qprogressive_ac`
   * `-p`
   * `-d 0` and `-R 1`
   * `--noise=1`
   * `--resampling >1`
   * `--disable_perceptual_optimizations`
+
+> [!NOTE]
+> In version 0.12, the new flags `--buffering` and `--output_mode` were introduced to explicitly control streaming behavior. `--buffering` controls input buffering (`0` for full buffering, `1` to stream large images, `2` to stream with a lower threshold). `--output_mode` controls output codestream buffering and streaming order. By default, output is buffered (`--output_mode 0`) to allow basic progressive loading.

--- a/doc/format_overview.md
+++ b/doc/format_overview.md
@@ -229,16 +229,21 @@ the optional container format allows storing additional information.
 
 ## Metadata
 
-Three types of metadata can be included in a JPEG XL container:
+Multiple types of metadata can be included in a JPEG XL container:
 
 *   Exif (`Exif`)
 *   XMP (`xml `)
 *   JUMBF (`jumb`)
+*   Gain Map bundle (`jhgm`)
 
 This metadata can contain information about the image, such as copyright
 notices, GPS coordinates, camera settings, etc.
 If it contains rendering-impacting information (such as Exif orientation),
 the information in the codestream takes precedence.
+
+For Gain Maps both SDR-to-HDR and HDR-to-SDR forms are supported however
+only the latter (HDR-to-SDR) is recommended due to JPEG XL already
+having native support for HDR.
 
 ## Compressed Metadata
 

--- a/doc/format_overview.md
+++ b/doc/format_overview.md
@@ -1,6 +1,6 @@
-# JPEG XL Format Overview
+# JPEG XL Format Overview
 
-This document gives an overview of the JPEG XL file format and codestream,
+This document gives an overview of the JPEG XL file format and codestream,
 its features, and the underlying design rationale.
 The aim of this document is to provide general insight into the
 format capabilities and design, thus helping developers
@@ -8,7 +8,7 @@ better understand how to use the `libjxl` API.
 
 ## Codestream and File Format
 
-The JPEG XL format is defined in ISO/IEC 18181. This standard consists of
+The JPEG XL format is defined in ISO/IEC 18181. This standard consists of
 four parts:
 
 *   18181-1: Core codestream
@@ -24,13 +24,13 @@ the pixel data itself, colorspace information, orientation, upsampling, etc.
 
 ### File format
 
-The JPEG XL file format can take two forms:
+The JPEG XL file format can take two forms:
 
 *   A 'naked' codestream. In this case, only the image/animation data itself is
 stored, and no additional metadata can be included. Such a file starts with the
-bytes `0xFF0A` (the JPEG marker for "start of JPEG XL codestream").
+bytes `0xFF0A` (the JPEG marker for "start of JPEG XL codestream").
 *   An ISOBMFF-based container. This is a box-based container that includes a
-JPEG XL codestream box (`jxlc`), and can optionally include other boxes with
+JPEG XL codestream box (`jxlc`), and can optionally include other boxes with
 additional information, such as Exif metadata. In this case, the file starts with
 the bytes `0x0000000C 4A584C20 0D0A870A`.
 
@@ -41,12 +41,12 @@ decoders, to verify that they implement all coding tools correctly and accuratel
 
 ### Reference implementation
 
-The `libjxl` software is the reference implementation of JPEG XL.
+The `libjxl` software is the reference implementation of JPEG XL.
 
 
 ## Metadata versus Image Data
 
-JPEG XL makes a clear separation between metadata and image data.
+JPEG XL makes a clear separation between metadata and image data.
 Everything that is needed to correctly display an image is
 considered to be image data, and is part of the core codestream. This includes
 elements that have traditionally been considered 'metadata', such as ICC profiles
@@ -71,7 +71,7 @@ without affecting the displayed image.
 
 ### Color Management
 
-In JPEG XL, images always have a fully defined colorspace, i.e. it is always
+In JPEG XL, images always have a fully defined colorspace, i.e. it is always
 unambiguous how to interpret the pixel values. There are two options:
 
 *   Pixel data is in a specified (non-XYB) colorspace, and the decoder will produce
@@ -92,7 +92,7 @@ the original image was in, that has a sufficiently wide gamut and a
 suitable transfer curve to represent the image data with high fidelity
 using a limited bit depth representation.
 
-Colorspaces can be signaled in two ways in JPEG XL:
+Colorspaces can be signaled in two ways in JPEG XL:
 
 *    CICP-style Enum values: This is a very compact representation that
 covers most or all of the common colorspaces. The decoder can convert
@@ -105,7 +105,7 @@ conversions.
 
 ### Frames
 
-A JPEG XL codestream contains one or more frames. In the case of animation,
+A JPEG XL codestream contains one or more frames. In the case of animation,
 these frames have a duration and can be looped (infinitely or a number of times).
 Zero-duration frames are possible and represent different layers of the image.
 
@@ -198,7 +198,7 @@ decoded.
 Then the HF groups are encoded, corresponding to the remaining AC
 coefficients. The HF groups can be encoded in multiple passes for
 more progressive refinement steps; the coefficients of all passes
-are added. Unlike JPEG progressive scan scripts, JPEG XL allows
+are added. Unlike JPEG progressive scan scripts, JPEG XL allows
 signaling any amount of detail in any part of the image in any pass.
 
 In Modular mode, groups can have dimensions 128x128, 256x256, 512x512
@@ -229,7 +229,7 @@ the optional container format allows storing additional information.
 
 ## Metadata
 
-Multiple types of metadata can be included in a JPEG XL container:
+Multiple types of metadata can be included in a JPEG XL container:
 
 *   Exif (`Exif`)
 *   XMP (`xml `)
@@ -242,7 +242,7 @@ If it contains rendering-impacting information (such as Exif orientation),
 the information in the codestream takes precedence.
 
 For Gain Maps both SDR-to-HDR and HDR-to-SDR forms are supported however
-only the latter (HDR-to-SDR) is recommended due to JPEG XL already
+only the latter (HDR-to-SDR) is recommended due to JPEG XL already
 having native support for HDR.
 
 ## Compressed Metadata
@@ -255,7 +255,7 @@ the first four bytes of the box contents define the actual box type
 
 ## JPEG Bitstream Reconstruction Data
 
-JPEG XL can losslessly recompress existing JPEG files.
+JPEG XL can losslessly recompress existing JPEG files.
 The general design philosophy still applies in this case:
 all the image data is stored in the codestream box, including the DCT
 coefficients of the original JPEG image and possibly an ICC profile or
@@ -276,7 +276,7 @@ needed to reconstruct the original JPEG file.
 ## Frame Index
 
 The container can optionally store a `jxli` box, which contains an index
-of offsets to keyframes of a JPEG XL animation. It is not needed to display
+of offsets to keyframes of a JPEG XL animation. It is not needed to display
 the animation, but it does facilitate efficient seeking.
 
 ## Partial Codestream

--- a/doc/format_overview.md
+++ b/doc/format_overview.md
@@ -1,6 +1,6 @@
-# JPEG XL Format Overview
+# JPEG XL Format Overview
 
-This document gives an overview of the JPEG XL file format and codestream,
+This document gives an overview of the JPEG XL file format and codestream,
 its features, and the underlying design rationale.
 The aim of this document is to provide general insight into the
 format capabilities and design, thus helping developers
@@ -8,7 +8,7 @@ better understand how to use the `libjxl` API.
 
 ## Codestream and File Format
 
-The JPEG XL format is defined in ISO/IEC 18181. This standard consists of
+The JPEG XL format is defined in ISO/IEC 18181. This standard consists of
 four parts:
 
 *   18181-1: Core codestream
@@ -24,13 +24,13 @@ the pixel data itself, colorspace information, orientation, upsampling, etc.
 
 ### File format
 
-The JPEG XL file format can take two forms:
+The JPEG XL file format can take two forms:
 
 *   A 'naked' codestream. In this case, only the image/animation data itself is
 stored, and no additional metadata can be included. Such a file starts with the
-bytes `0xFF0A` (the JPEG marker for "start of JPEG XL codestream").
+bytes `0xFF0A` (the JPEG marker for "start of JPEG XL codestream").
 *   An ISOBMFF-based container. This is a box-based container that includes a
-JPEG XL codestream box (`jxlc`), and can optionally include other boxes with
+JPEG XL codestream box (`jxlc`), and can optionally include other boxes with
 additional information, such as Exif metadata. In this case, the file starts with
 the bytes `0x0000000C 4A584C20 0D0A870A`.
 
@@ -41,12 +41,12 @@ decoders, to verify that they implement all coding tools correctly and accuratel
 
 ### Reference implementation
 
-The `libjxl` software is the reference implementation of JPEG XL.
+The `libjxl` software is the reference implementation of JPEG XL.
 
 
 ## Metadata versus Image Data
 
-JPEG XL makes a clear separation between metadata and image data.
+JPEG XL makes a clear separation between metadata and image data.
 Everything that is needed to correctly display an image is
 considered to be image data, and is part of the core codestream. This includes
 elements that have traditionally been considered 'metadata', such as ICC profiles
@@ -71,7 +71,7 @@ without affecting the displayed image.
 
 ### Color Management
 
-In JPEG XL, images always have a fully defined colorspace, i.e. it is always
+In JPEG XL, images always have a fully defined colorspace, i.e. it is always
 unambiguous how to interpret the pixel values. There are two options:
 
 *   Pixel data is in a specified (non-XYB) colorspace, and the decoder will produce
@@ -92,7 +92,7 @@ the original image was in, that has a sufficiently wide gamut and a
 suitable transfer curve to represent the image data with high fidelity
 using a limited bit depth representation.
 
-Colorspaces can be signaled in two ways in JPEG XL:
+Colorspaces can be signaled in two ways in JPEG XL:
 
 *    CICP-style Enum values: This is a very compact representation that
 covers most or all of the common colorspaces. The decoder can convert
@@ -105,7 +105,7 @@ conversions.
 
 ### Frames
 
-A JPEG XL codestream contains one or more frames. In the case of animation,
+A JPEG XL codestream contains one or more frames. In the case of animation,
 these frames have a duration and can be looped (infinitely or a number of times).
 Zero-duration frames are possible and represent different layers of the image.
 
@@ -198,7 +198,7 @@ decoded.
 Then the HF groups are encoded, corresponding to the remaining AC
 coefficients. The HF groups can be encoded in multiple passes for
 more progressive refinement steps; the coefficients of all passes
-are added. Unlike JPEG progressive scan scripts, JPEG XL allows
+are added. Unlike JPEG progressive scan scripts, JPEG XL allows
 signaling any amount of detail in any part of the image in any pass.
 
 In Modular mode, groups can have dimensions 128x128, 256x256, 512x512
@@ -229,16 +229,21 @@ the optional container format allows storing additional information.
 
 ## Metadata
 
-Three types of metadata can be included in a JPEG XL container:
+Multiple types of metadata can be included in a JPEG XL container:
 
 *   Exif (`Exif`)
 *   XMP (`xml `)
 *   JUMBF (`jumb`)
+*   Gain Map bundle (`jhgm`)
 
 This metadata can contain information about the image, such as copyright
 notices, GPS coordinates, camera settings, etc.
 If it contains rendering-impacting information (such as Exif orientation),
 the information in the codestream takes precedence.
+
+For Gain Maps both SDR-to-HDR and HDR-to-SDR forms are supported however
+only the latter (HDR-to-SDR) is recommended due to JPEG XL already
+having native support for HDR.
 
 ## Compressed Metadata
 
@@ -250,7 +255,7 @@ the first four bytes of the box contents define the actual box type
 
 ## JPEG Bitstream Reconstruction Data
 
-JPEG XL can losslessly recompress existing JPEG files.
+JPEG XL can losslessly recompress existing JPEG files.
 The general design philosophy still applies in this case:
 all the image data is stored in the codestream box, including the DCT
 coefficients of the original JPEG image and possibly an ICC profile or
@@ -271,7 +276,7 @@ needed to reconstruct the original JPEG file.
 ## Frame Index
 
 The container can optionally store a `jxli` box, which contains an index
-of offsets to keyframes of a JPEG XL animation. It is not needed to display
+of offsets to keyframes of a JPEG XL animation. It is not needed to display
 the animation, but it does facilitate efficient seeking.
 
 ## Partial Codestream

--- a/doc/man/cjxl.txt
+++ b/doc/man/cjxl.txt
@@ -5,7 +5,7 @@
 Name
 ----
 
-cjxl - compress images to JPEG XL
+cjxl - compress images to JPEG XL
 
 Synopsis
 --------
@@ -15,7 +15,7 @@ Synopsis
 Description
 -----------
 
-`cjxl` compresses an image or animation to the JPEG XL format. It is intended to
+`cjxl` compresses an image or animation to the JPEG XL format. It is intended to
 spare users the trouble of determining a set of optimal parameters for each
 individual image. Instead, for a given target quality, it should provide
 consistent visual results across various kinds of images. The defaults have been
@@ -249,7 +249,7 @@ Examples
 --------
 
 ----
-# Compress a PNG file to a high-quality JPEG XL version.
+# Compress a PNG file to a high-quality JPEG XL version.
 $ cjxl input.png output.jxl
 
 # Compress it at a slightly lower quality, appropriate for web use.

--- a/doc/man/cjxl.txt
+++ b/doc/man/cjxl.txt
@@ -1,4 +1,4 @@
-cjxl(1)
+﻿cjxl(1)
 =======
 :doctype: manpage
 
@@ -31,53 +31,220 @@ cjxl input.gif output.jxl
 Options
 -------
 
--h::
---help::
-    Displays the options that `cjxl` supports. On its own, it will only show
-    basic options. It can be combined with `-v` or `-v -v` to show increasingly
-    advanced options as well.
+Basic options:
+~~~~~~~~~~~~~~
 
+-d DISTANCE::
+--distance=DISTANCE::
+    Target visual distance in JND units, range: 0.0 .. 25.0.
+    0.0 = mathematically lossless, default for JPEG/GIF input.
+    1.0 = visually lossless, default for other input.
+    Recommended range: 0.5 .. 3.0. Higher values allow more distortion.
+    Mutually exclusive with --quality.
+-q QUALITY::
+--quality=QUALITY::
+    Internally mapped to --distance, range: 0 .. 100.
+    100 = mathematically lossless. 90 = visually lossless.
+    Quality values roughly match libjpeg quality.
+    Recommended range: 68 .. 96. Mutually exclusive with --distance.
+-e EFFORT::
+--effort=EFFORT::
+    Encoder effort, range: 1 .. 10, default = 7.
+    Higher values allow more computation, generally achieving smaller output at same quality.
+    For lossy encoding, higher effort should achieve more accurate quality.
+-V::
+--version::
+    Print encoder library version number and exit.
+--quiet::
+    Minimal printing.
 -v::
 --verbose::
-    Increases verbosity. Can be repeated to increase it further, and also
-    applies to `--help`.
+    Verbose printing; can be repeated and also applies to help (!).
 
--d 'distance'::
---distance='distance'::
-    The preferred way to specify quality. It is specified in multiples of a
-    just-noticeable difference. That is, `-d 0` is mathematically lossless,
-    `-d 1` should be visually lossless, and higher distances yield denser and
-    denser files with lower and lower fidelity. Lossy sources such as JPEG and
-    GIF files are compressed losslessly by default, and in the case of JPEG
-    files specifically, the original JPEG can then be reconstructed bit-for-bit.
-    For lossless sources, `-d 1` is the default.
 
--q 'quality'::
---quality='quality'::
-    Alternative way to indicate the desired quality. 100 is lossless and lower
-    values yield smaller files. There is no lower bound to this quality
-    parameter, but positive values should approximately match the quality
-    setting of libjpeg.
+Advanced options:
+~~~~~~~~~~~~~~~~~
 
--e 'effort'::
---effort='effort'::
-    Controls the amount of effort that goes into producing an ``optimal'' file
-    in terms of quality/size. That is to say, all other parameters being equal,
-    a higher effort should yield a file that is at least as dense and possibly
-    denser, and with at least as high and possibly higher quality.
-+
-Recognized effort settings, from fastest to slowest, are:
-+
-- 1 or ``lightning''
-- 2 or ``thunder''
-- 3 or ``falcon''
-- 4 or ``cheetah''
-- 5 or ``hare''
-- 6 or ``wombat''
-- 7 or ``squirrel'' (default)
-- 8 or ``kitten''
-- 9 or ``tortoise''
+-a DISTANCE::
+--alpha_distance=DISTANCE::
+    Target visual distance for the alpha channel, range: 0.0 .. 25.0, default = 0.0.
+    0.0 = mathematically lossless. 1.0 = visually lossless.
+    Recommended range: 0.5 .. 3.0.
+-p::
+--progressive::
+    More progressive/responsive decoding.
+--group_order=0|1::
+    Order in which groups are stored in the codestream for progressive rendering, default = 0.
+    0 = scanline order. 1 = center-first order.
+--container=0|1::
+    0 = do not use the container format unless it is needed.
+    1 = use the container format even if it is not needed.
+--compress_boxes=0|1::
+    Disable/enable Brotli compression for metadata boxes, default = 1. 0 = disable. 1 = enable.
+--brotli_effort=EFFORT::
+    Brotli effort, range: 0 .. 11, default = 9.
+    Higher values allow more computation targeting higher density.
+-m 0|1::
+--modular=0|1::
+    0 = use VarDCT mode. 1 = use modular mode. Default = encoder chooses.
+-j 0|1::
+--lossless_jpeg=0|1::
+    0 = decode JPEG input to pixels and reencode. 1 = losslessly transcode JPEG data. Default = 1.
+--num_threads=THREADS::
+    Number of worker threads, default = -1.
+    -1 = use machine default. 0 = do not use multithreading.
+--photon_noise_iso=ISO_FILM_SPEED::
+    Add noise to the image emulating photographic film or sensor noise, default = 0.
+    Higher values add more noise, e.g. 100 gives a low amount of noise, 3200 gives a lot of noise.
+--intensity_target=NITS::
+    Upper bound on the intensity level present in the image, in nits.
+    0 = choose a sensible value based on the color encoding. Default = 0.
+-x key=value::
+--dec-hints=key=value::
+    Use with 'raw' formats like PPM which do not store colorspace information
+    and metadata, or to strip or modify metadata from formats that do.
+    The key 'color_space' indicates an enumerated ColorEncoding, for example:
+    -x color_space=RGB_D65_SRG_Per_SRG is sRGB with perceptual rendering intent
+    -x color_space=RGB_D65_202_Rel_PeQ is Rec.2100 PQ with relative rendering intent
+    Shorthands: sRGB, DisplayP3, Adobe98, ProPhoto, Rec2100PQ, Rec2100HLG
+    The key 'icc_pathname' refers to a binary file containing an ICC profile.
+    The keys 'exif', 'xmp', and 'jumbf' refer to a binary file containing metadata;
+    existing metadata of the same type will be overwritten.
+    Specific metadata can be stripped using e.g. -x strip=exif.
+    Stripping metadata with lossless JPEG recompression won't allow reconstruction,
+    hence `--allow_jpeg_reconstruction=0` must be passed in this case.
 
+
+More advanced options:
+~~~~~~~~~~~~~~~~~~~~~~
+
+--allow_jpeg_reconstruction=0|1::
+    Disable/enable storing JPEG reconstruction metadata with lossless JPEG transcoding,
+    default = 1. 0 = disable. 1 = enable.
+--codestream_level=-1|5|10::
+    The codestream level.
+--buffering=-1..3::
+    Controls how much input buffering libjxl uses, affecting memory usage and compression quality.
+    -1 = encoder chooses (default). 0 = buffer entire image (most memory, best compression).
+    1 = stream input for large images. 2 = stream input with a lower threshold.
+    3 = deprecated; use --output_mode to control output streaming.
+--faster_decoding=0..4::
+    Higher values improve decode speed at the expense of quality or density, default = 0.
+--premultiply=-1|0|1::
+    Force premultiplied (associated) alpha.
+--keep_invisible=0|1::
+    0 = allow modifying invisible pixels for better density, default for lossy output.
+    1 = preserve colors of invisible pixels, default for lossless output.
+--center_x=-1..XSIZE::
+    Set the horizontal position of center for center-first group ordering, range: [-1 .. xsize).
+    -1 = middle of the image. Default = -1.
+--center_y=-1..YSIZE::
+    Set the vertical position of center for center-first group ordering, range: [-1 .. xsize).
+    -1 = middle of the image. Default = -1.
+--progressive_ac::
+    Use the progressive mode for AC.
+--qprogressive_ac::
+    Use the progressive mode for AC with shift quantization.
+--progressive_dc=-1..2::
+    Number of progressive-DC frames, default = -1. -1 = encoder chooses.
+    0 = disable. 1 = extra 64x64 low-resolution pass. 2 = extra 512x512 and 64x64 passes.
+--resampling=-1|1|2|4|8::
+    Resampling for color channels, default = -1.
+    -1 = apply resampling only for very low quality.
+    1 = 1x1 downsampling. 2 = 2x2 downsampling. 4 = 4x4 downsampling. 8 = 8x8 downsampling.
+--ec_resampling=-1|1|2|4|8::
+    Resampling for extra channels. Same as --resampling but for extra channels like alpha.
+--already_downsampled::
+    Do not downsample before encoding, but still signal that the decoder should upsample.
+--upsampling_mode=-1|0|1::
+    Decoder upsampling mode, mostly useful in combination with --already_downsampled.
+    -1 = non-separable upsampling. 0 = nearest neighbor (useful for pixel art). Default = -1.
+--epf=-1..3::
+    Edge preserving filter strength, default = -1. -1 = encoder chooses.
+--gaborish=0|1::
+    0 = don't use the gaborish filter. 1 = use gaborish. Default = encoder chooses.
+--override_bitdepth=BITDEPTH::
+    Set the bit depth, default = 0. 0 = use the input image bit depth.
+
+
+Options for experimentation / benchmarking:
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+--noise=0|1::
+    Disable/enable adaptive noise generation, default = encoder chooses. 0 = disable. 1 = enable.
+    It is recommended to use --photon_noise_iso instead.
+--jpeg_reconstruction_cfl=0|1::
+    Disable/enable chroma-from-luma (CFL) for lossless JPEG reconstruction.
+    0 = disable. 1 = enable.
+--num_reps=REPS::
+    How many times to compress, for benchmarking.
+--streaming_input::
+    Enable streaming processing of the input file, supported for PPM and PGM input.
+--streaming_output::
+    Enable incremental writing of the output file.
+--output_mode=-1..2::
+    Output mode: -1=default (let encoder decide), 0=buffer output internally, 1=streaming with seeking, 2=OOO jxlp (ftyp v1, no seeking required).
+--disable_output::
+    Do not write an output file.
+--dots=0|1::
+    Disable/enable dots generation. 0 = disable. 1 = enable. Default = encoder chooses.
+--patches=0|1::
+    Disable/enable patches generation. 0 = disable. 1 = enable. Default = encoder chooses.
+--frame_indexing=INDICES::
+    INDICES is of the form '^(0*|1[01]*)'. The i-th position indicates whether the i-th
+    frame will be indexed in the frame index box.
+--allow_expert_options::
+    Allow setting effort to 11 for somewhat denser lossless compression at an extreme compute cost.
+--disable_perceptual_optimizations::
+    Disable perceptual optimizations.
+
+
+Modular mode options:
+~~~~~~~~~~~~~~~~~~~~~
+
+-I PERCENT::
+--iterations=PERCENT::
+    Percentage of pixels used to learn MA trees, default = -1.
+    -1 = encoder chooses. 0 = don't use MA trees.
+    Higher values use more memory and may result in better compression.
+-C -1..41::
+--modular_colorspace=-1..41::
+    Color transform, default = -1. -1 = try several per group, depending on effort. 0 = RGB (none).
+    1 .. 41 = fixed RCT. 6 = YCoCg.
+-g -1..3::
+--modular_group_size=-1..3::
+    Group size, default = -1.
+    -1 = encoder chooses. 0 = 128x128. 1 = 256x256. 2 = 512x512. 3 = 1024x1024.
+-P 0..15::
+--modular_predictor=0..15::
+    Predictor(s) to use. 0 = zero. 1 = left. 2 = top. 3 = avg0. 4 = select. 5 = gradient.
+    6 = weighted. 7 = topright. 8 = topleft. 9 = leftleft. 10 = avg1. 11 = avg2. 12 = avg3.
+    13 = toptop predictive average. 14 = mix 5 and 6. 15 = mix everything.
+    Default = 14 at effort < 10 and 15 at effort 10.
+-E -1..11::
+--modular_nb_prev_channels=-1..11::
+    Maximum number of previous-channel MA tree properties to use, default -1. -1 = encoder chooses.
+--modular_palette_colors=COLORS::
+    Use palette if number of colors is smaller than or equal to this.
+--modular_lossy_palette::
+    Use delta palette in a lossy way; it is recommended to also set --modular_palette_colors=0
+    with this option to use the default palette only.
+-X PERCENT::
+--pre-compact=PERCENT::
+    Use global channel palette if the number of sample values is smaller
+    than this percentage of the nominal range.
+-Y PERCENT::
+--post-compact=PERCENT::
+    Use local (per-group) channel palette if the number of sample values is
+    smaller than this percentage of the nominal range.
+-R 0|1::
+--responsive=0|1::
+    0 = don't apply the Squeeze transform. Default for lossless output.
+    1 = apply the Squeeze transform. Default for lossy output.
+
+-h::
+--help::
+    Prints this help message. All options are shown above.
 Examples
 --------
 
@@ -100,3 +267,4 @@ See also
 --------
 
 *djxl*(1)
+

--- a/doc/man/cjxl.txt
+++ b/doc/man/cjxl.txt
@@ -15,7 +15,7 @@ Synopsis
 Description
 -----------
 
-`cjxl` compresses an image or animation to the JPEG XL format. It is intended to
+`cjxl` compresses an image or animation to the JPEG XL format. It is intended to
 spare users the trouble of determining a set of optimal parameters for each
 individual image. Instead, for a given target quality, it should provide
 consistent visual results across various kinds of images. The defaults have been
@@ -31,58 +31,225 @@ cjxl input.gif output.jxl
 Options
 -------
 
--h::
---help::
-    Displays the options that `cjxl` supports. On its own, it will only show
-    basic options. It can be combined with `-v` or `-v -v` to show increasingly
-    advanced options as well.
+Basic options:
+~~~~~~~~~~~~~~
 
+-d DISTANCE::
+--distance=DISTANCE::
+    Target visual distance in JND units, range: 0.0 .. 25.0.
+    0.0 = mathematically lossless, default for JPEG/GIF input.
+    1.0 = visually lossless, default for other input.
+    Recommended range: 0.5 .. 3.0. Higher values allow more distortion.
+    Mutually exclusive with --quality.
+-q QUALITY::
+--quality=QUALITY::
+    Internally mapped to --distance, range: 0 .. 100.
+    100 = mathematically lossless. 90 = visually lossless.
+    Quality values roughly match libjpeg quality.
+    Recommended range: 68 .. 96. Mutually exclusive with --distance.
+-e EFFORT::
+--effort=EFFORT::
+    Encoder effort, range: 1 .. 10, default = 7.
+    Higher values allow more computation, generally achieving smaller output at same quality.
+    For lossy encoding, higher effort should achieve more accurate quality.
+-V::
+--version::
+    Print encoder library version number and exit.
+--quiet::
+    Minimal printing.
 -v::
 --verbose::
-    Increases verbosity. Can be repeated to increase it further, and also
-    applies to `--help`.
+    Verbose printing; can be repeated and also applies to help (!).
 
--d 'distance'::
---distance='distance'::
-    The preferred way to specify quality. It is specified in multiples of a
-    just-noticeable difference. That is, `-d 0` is mathematically lossless,
-    `-d 1` should be visually lossless, and higher distances yield denser and
-    denser files with lower and lower fidelity. Lossy sources such as JPEG and
-    GIF files are compressed losslessly by default, and in the case of JPEG
-    files specifically, the original JPEG can then be reconstructed bit-for-bit.
-    For lossless sources, `-d 1` is the default.
 
--q 'quality'::
---quality='quality'::
-    Alternative way to indicate the desired quality. 100 is lossless and lower
-    values yield smaller files. There is no lower bound to this quality
-    parameter, but positive values should approximately match the quality
-    setting of libjpeg.
+Advanced options:
+~~~~~~~~~~~~~~~~~
 
--e 'effort'::
---effort='effort'::
-    Controls the amount of effort that goes into producing an ``optimal'' file
-    in terms of quality/size. That is to say, all other parameters being equal,
-    a higher effort should yield a file that is at least as dense and possibly
-    denser, and with at least as high and possibly higher quality.
-+
-Recognized effort settings, from fastest to slowest, are:
-+
-- 1 or ``lightning''
-- 2 or ``thunder''
-- 3 or ``falcon''
-- 4 or ``cheetah''
-- 5 or ``hare''
-- 6 or ``wombat''
-- 7 or ``squirrel'' (default)
-- 8 or ``kitten''
-- 9 or ``tortoise''
+-a DISTANCE::
+--alpha_distance=DISTANCE::
+    Target visual distance for the alpha channel, range: 0.0 .. 25.0, default = 0.0.
+    0.0 = mathematically lossless. 1.0 = visually lossless.
+    Recommended range: 0.5 .. 3.0.
+-p::
+--progressive::
+    More progressive/responsive decoding.
+--group_order=0|1::
+    Order in which groups are stored in the codestream for progressive rendering, default = 0.
+    0 = scanline order. 1 = center-first order.
+--container=0|1::
+    0 = do not use the container format unless it is needed.
+    1 = use the container format even if it is not needed.
+--compress_boxes=0|1::
+    Disable/enable Brotli compression for metadata boxes, default = 1. 0 = disable. 1 = enable.
+--brotli_effort=EFFORT::
+    Brotli effort, range: 0 .. 11, default = 9.
+    Higher values allow more computation targeting higher density.
+-m 0|1::
+--modular=0|1::
+    0 = use VarDCT mode. 1 = use modular mode. Default = encoder chooses.
+-j 0|1::
+--lossless_jpeg=0|1::
+    0 = decode JPEG input to pixels and reencode. 1 = losslessly transcode JPEG data. Default = 1.
+--num_threads=THREADS::
+    Number of worker threads, default = -1.
+    -1 = use machine default. 0 = do not use multithreading.
+--photon_noise_iso=ISO_FILM_SPEED::
+    Add noise to the image emulating photographic film or sensor noise, default = 0.
+    Higher values add more noise, e.g. 100 gives a low amount of noise, 3200 gives a lot of noise.
+--intensity_target=NITS::
+    Upper bound on the intensity level present in the image, in nits.
+    0 = choose a sensible value based on the color encoding. Default = 0.
+-x key=value::
+--dec-hints=key=value::
+    Use with 'raw' formats like PPM which do not store colorspace information
+    and metadata, or to strip or modify metadata from formats that do.
+    The key 'color_space' indicates an enumerated ColorEncoding, for example:
+    -x color_space=RGB_D65_SRG_Per_SRG is sRGB with perceptual rendering intent
+    -x color_space=RGB_D65_202_Rel_PeQ is Rec.2100 PQ with relative rendering intent
+    Shorthands: sRGB, DisplayP3, Adobe98, ProPhoto, Rec2100PQ, Rec2100HLG
+    The key 'icc_pathname' refers to a binary file containing an ICC profile.
+    The keys 'exif', 'xmp', and 'jumbf' refer to a binary file containing metadata;
+    existing metadata of the same type will be overwritten.
+    Specific metadata can be stripped using e.g. -x strip=exif.
+    Stripping metadata with lossless JPEG recompression won't allow reconstruction,
+    hence `--allow_jpeg_reconstruction=0` must be passed in this case.
 
+
+More advanced options:
+~~~~~~~~~~~~~~~~~~~~~~
+
+--allow_jpeg_reconstruction=0|1::
+    Disable/enable storing JPEG reconstruction metadata with lossless JPEG transcoding,
+    default = 1. 0 = disable. 1 = enable.
+--codestream_level=-1|5|10::
+    The codestream level.
+--buffering=-1..3::
+    Controls how much input buffering libjxl uses, affecting memory usage and compression quality.
+    -1 = encoder chooses (default). 0 = buffer entire image (most memory, best compression).
+    1 = stream input for large images. 2 = stream input with a lower threshold.
+    3 = deprecated; use --output_mode to control output streaming.
+--faster_decoding=0..4::
+    Higher values improve decode speed at the expense of quality or density, default = 0.
+--premultiply=-1|0|1::
+    Force premultiplied (associated) alpha.
+--keep_invisible=0|1::
+    0 = allow modifying invisible pixels for better density, default for lossy output.
+    1 = preserve colors of invisible pixels, default for lossless output.
+--center_x=-1..XSIZE::
+    Set the horizontal position of center for center-first group ordering, range: [-1 .. xsize).
+    -1 = middle of the image. Default = -1.
+--center_y=-1..YSIZE::
+    Set the vertical position of center for center-first group ordering, range: [-1 .. ysize).
+    -1 = middle of the image. Default = -1.
+--progressive_ac::
+    Use the progressive mode for AC.
+--qprogressive_ac::
+    Use the progressive mode for AC with shift quantization.
+--progressive_dc=-1..2::
+    Number of progressive-DC frames, default = -1. -1 = encoder chooses.
+    0 = disable. 1 = extra 64x64 low-resolution pass. 2 = extra 512x512 and 64x64 passes.
+--resampling=-1|1|2|4|8::
+    Resampling for color channels, default = -1.
+    -1 = apply resampling only for very low quality.
+    1 = 1x1 downsampling. 2 = 2x2 downsampling. 4 = 4x4 downsampling. 8 = 8x8 downsampling.
+--ec_resampling=-1|1|2|4|8::
+    Resampling for extra channels. Same as --resampling but for extra channels like alpha.
+--already_downsampled::
+    Do not downsample before encoding, but still signal that the decoder should upsample.
+--upsampling_mode=-1|0|1::
+    Decoder upsampling mode, mostly useful in combination with --already_downsampled.
+    -1 = non-separable upsampling. 0 = nearest neighbor (useful for pixel art). Default = -1.
+--epf=-1..3::
+    Edge preserving filter strength, default = -1. -1 = encoder chooses.
+--gaborish=0|1::
+    0 = don't use the gaborish filter. 1 = use gaborish. Default = encoder chooses.
+--override_bitdepth=BITDEPTH::
+    Set the bit depth, default = 0. 0 = use the input image bit depth.
+
+
+Options for experimentation / benchmarking:
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+--noise=0|1::
+    Disable/enable adaptive noise generation, default = encoder chooses. 0 = disable. 1 = enable.
+    It is recommended to use --photon_noise_iso instead.
+--jpeg_reconstruction_cfl=0|1::
+    Disable/enable chroma-from-luma (CFL) for lossless JPEG reconstruction.
+    0 = disable. 1 = enable.
+--num_reps=REPS::
+    How many times to compress, for benchmarking.
+--streaming_input::
+    Enable streaming processing of the input file, supported for PPM and PGM input.
+--streaming_output::
+    Enable incremental writing of the output file.
+--output_mode=-1..2::
+    Output mode: -1=default (let encoder decide), 0=buffer output internally, 1=streaming with seeking, 2=OOO jxlp (ftyp v1, no seeking required).
+--disable_output::
+    Do not write an output file.
+--dots=0|1::
+    Disable/enable dots generation. 0 = disable. 1 = enable. Default = encoder chooses.
+--patches=0|1::
+    Disable/enable patches generation. 0 = disable. 1 = enable. Default = encoder chooses.
+--frame_indexing=INDICES::
+    INDICES is of the form '^(0*|1[01]*)'. The i-th position indicates whether the i-th
+    frame will be indexed in the frame index box.
+--allow_expert_options::
+    Allow setting effort to 11 for somewhat denser lossless compression at an extreme compute cost.
+--disable_perceptual_optimizations::
+    Disable perceptual optimizations.
+
+
+Modular mode options:
+~~~~~~~~~~~~~~~~~~~~~
+
+-I PERCENT::
+--iterations=PERCENT::
+    Percentage of pixels used to learn MA trees, default = -1.
+    -1 = encoder chooses. 0 = don't use MA trees.
+    Higher values use more memory and may result in better compression.
+-C -1..41::
+--modular_colorspace=-1..41::
+    Color transform, default = -1. -1 = try several per group, depending on effort. 0 = RGB (none).
+    1 .. 41 = fixed RCT. 6 = YCoCg.
+-g -1..3::
+--modular_group_size=-1..3::
+    Group size, default = -1.
+    -1 = encoder chooses. 0 = 128x128. 1 = 256x256. 2 = 512x512. 3 = 1024x1024.
+-P 0..15::
+--modular_predictor=0..15::
+    Predictor(s) to use. 0 = zero. 1 = left. 2 = top. 3 = avg0. 4 = select. 5 = gradient.
+    6 = weighted. 7 = topright. 8 = topleft. 9 = leftleft. 10 = avg1. 11 = avg2. 12 = avg3.
+    13 = toptop predictive average. 14 = mix 5 and 6. 15 = mix everything.
+    Default = 14 at effort < 10 and 15 at effort 10.
+-E -1..11::
+--modular_nb_prev_channels=-1..11::
+    Maximum number of previous-channel MA tree properties to use, default -1. -1 = encoder chooses.
+--modular_palette_colors=COLORS::
+    Use palette if number of colors is smaller than or equal to this.
+--modular_lossy_palette::
+    Use delta palette in a lossy way; it is recommended to also set --modular_palette_colors=0
+    with this option to use the default palette only.
+-X PERCENT::
+--pre-compact=PERCENT::
+    Use global channel palette if the number of sample values is smaller
+    than this percentage of the nominal range.
+-Y PERCENT::
+--post-compact=PERCENT::
+    Use local (per-group) channel palette if the number of sample values is
+    smaller than this percentage of the nominal range.
+-R 0|1::
+--responsive=0|1::
+    0 = don't apply the Squeeze transform. Default for lossless output.
+    1 = apply the Squeeze transform. Default for lossy output.
+
+-h::
+--help::
+    Prints this help message. All options are shown above.
 Examples
 --------
 
 ----
-# Compress a PNG file to a high-quality JPEG XL version.
+# Compress a PNG file to a high-quality JPEG XL version.
 $ cjxl input.png output.jxl
 
 # Compress it at a slightly lower quality, appropriate for web use.
@@ -100,3 +267,4 @@ See also
 --------
 
 *djxl*(1)
+

--- a/doc/man/djxl.txt
+++ b/doc/man/djxl.txt
@@ -1,4 +1,4 @@
-djxl(1)
+﻿djxl(1)
 =======
 :doctype: manpage
 
@@ -24,25 +24,91 @@ produced, with names of the form "'output'-*framenumber*.ext".
 Options
 -------
 
--h::
---help::
-    Displays the options that `djxl` supports.
+Basic options:
+~~~~~~~~~~~~~~
 
+--output_format=OUTPUT_FORMAT_DESC::
+    Set the output format. This overrides the output format detected from a potential file extension in the OUTPUT filename.
+    Must be one of png, apng, jpg, jpeg, npy, pgx, pam, pgm, ppm, pnm, pfm, exr, exif, xmp, xml, jumb, jumbf when converted to lower case.
+-V::
+--version::
+    Print version number and exit.
+--quiet::
+    Silence output (except for errors).
+-v::
+--verbose::
+    Verbose output; can be repeated and also applies to help (!).
+
+
+Advanced options:
+~~~~~~~~~~~~~~~~~
+
+--num_threads=N::
+    Number of worker threads (-1 == use machine default, 0 == do not use multithreading).
+--bits_per_sample=N::
+    Sets the output bit depth. The value 0 (default for PNM) means the original (input) bit depth.
+    The value -1 (default for other codecs) means it depends on the output format capabilities
+    and the input bit depth (e.g. decoding a 12-bit image to PNG will produce a 16-bit PNG).
+--display_nits=N::
+    If set to a non-zero value, tone maps the image the given peak display luminance.
+--color_space=COLORSPACE_DESC::
+    Sets the desired output color space of the image. For example:
+    --color_space=RGB_D65_SRG_Per_SRG is sRGB with perceptual rendering intent
+    --color_space=RGB_D65_202_Rel_PeQ is Rec.2100 PQ with relative rendering intent
+-s 1|2|4|8::
+--downsampling=1|2|4|8::
+    If the input JXL stream contains hints for target downsampling ratios,
+    only decode what is needed to produce an image intended for this downsampling ratio.
+--allow_partial_files::
+    Allow decoding of truncated files.
 -j::
 --pixels_to_jpeg::
-    By default, if the input JPEG XL contains a recompressed JPEG file,
-    djxl reconstructs the exact original JPEG file if the output file has the
-    `.jpg` (or `.jpeg`) filename extension.
-    This flag causes the decoder to instead decode the image to pixels and
-    encode a new (lossy) JPEG in this case.
+    By default, if the input JXL is a recompressed JPEG file, djxl reconstructs that JPEG file.
+    This flag causes the decoder to instead decode to pixels and encode a new (lossy) JPEG.
+-J::
+--reconstruct_jpeg::
+    Losslessly reconstruct a JPEG if possible, and fail otherwise.
+-q N::
+--jpeg_quality=N::
+    Sets the JPEG output quality, default is 95. Setting this option implies --pixels_to_jpeg.
 
 
--q 'quality'::
---jpeg_quality='quality'::
-    When decoding to `.jpg`, use this output quality. This option implicitly
-    enables the --pixels_to_jpeg option.
+Options for experimentation / benchmarking:
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
+--num_reps=N::
+    Sets the number of times to decompress the image. Useful for benchmarking. Default is 1.
+--disable_output::
+    No output file will be written (for benchmarking)
+--output_extra_channels::
+    If set, all extra channels will be written either as part of the main output file (e.g. alpha channel in png) or as separate output files with suffix -ecN in their names. If not set, the (first) alpha channel will only be written when the output format supports alpha channels and all other extra channels won't be decoded. Files are concatenated when outputting to stdout. Only has an effect when decoding to (A)PNG or PPM/PNM/PFM/PAM
+--output_frames::
+    If set, all frames will be written either as part of the main output file if that supports animation, or as separate output files with suffix -N in their names. Files are concatenated when outputting to stdout.
+--use_sjpeg::
+    Use sjpeg instead of libjpeg for JPEG output.
+--norender_spotcolors::
+    Disables rendering of spot colors.
+--no_coalescing::
+    Disables coalescing of layers.
+--preview_out=FILENAME::
+    If specified, writes the preview image to this file.
+--icc_out=FILENAME::
+    If specified, writes the ICC profile of the decoded image to this file.
+--orig_icc_out=FILENAME::
+    If specified, writes the ICC profile of the original image to this file
+    This can be different from the ICC profile of the decoded image if --color_space was specified.
+--metadata_out=FILENAME::
+    If specified, writes metadata info to a JSON file. Used by the conformance test script
+--background=#NNNNNN::
+    Specifies the background color for the --alpha_blend option. Recognized values are 'black', 'white' (default), or '#NNNNNN'
+--alpha_blend::
+    Blends alpha channel with the color image using background color specified by --background (default is white).
+--print_read_bytes::
+    Print total number of decoded bytes.
 
+-h::
+--help::
+    Prints this help message. All options are shown above.
 Examples
 --------
 
@@ -59,3 +125,4 @@ See also
 --------
 
 *cjxl*(1)
+

--- a/doc/man/djxl.txt
+++ b/doc/man/djxl.txt
@@ -5,7 +5,7 @@
 Name
 ----
 
-djxl - decompress JPEG XL images
+djxl - decompress JPEG XL images
 
 Synopsis
 --------
@@ -15,9 +15,9 @@ Synopsis
 Description
 -----------
 
-`djxl` decompresses a JPEG XL image or animation. The output format is determined
+`djxl` decompresses a JPEG XL image or animation. The output format is determined
 by the extension of the output file, which can be `.png`, `.jpg`, `.ppm`, `.pfm`.
-If the JPEG XL input file contains an animation, multiple output files will be
+If the JPEG XL input file contains an animation, multiple output files will be
 produced, with names of the form "'output'-*framenumber*.ext".
 
 
@@ -113,7 +113,7 @@ Examples
 --------
 
 ----
-# Decompress a JPEG XL file to PNG
+# Decompress a JPEG XL file to PNG
 $ djxl input.jxl output.png
 
 # Reconstruct a losslessly-recompressed JPEG file

--- a/doc/man/djxl.txt
+++ b/doc/man/djxl.txt
@@ -15,39 +15,105 @@ Synopsis
 Description
 -----------
 
-`djxl` decompresses a JPEG XL image or animation. The output format is determined
+`djxl` decompresses a JPEG XL image or animation. The output format is determined
 by the extension of the output file, which can be `.png`, `.jpg`, `.ppm`, `.pfm`.
-If the JPEG XL input file contains an animation, multiple output files will be
+If the JPEG XL input file contains an animation, multiple output files will be
 produced, with names of the form "'output'-*framenumber*.ext".
 
 
 Options
 -------
 
--h::
---help::
-    Displays the options that `djxl` supports.
+Basic options:
+~~~~~~~~~~~~~~
 
+--output_format=OUTPUT_FORMAT_DESC::
+    Set the output format. This overrides the output format detected from a potential file extension in the OUTPUT filename.
+    Must be one of png, apng, jpg, jpeg, npy, pgx, pam, pgm, ppm, pnm, pfm, exr, exif, xmp, xml, jumb, jumbf when converted to lower case.
+-V::
+--version::
+    Print version number and exit.
+--quiet::
+    Silence output (except for errors).
+-v::
+--verbose::
+    Verbose output; can be repeated and also applies to help (!).
+
+
+Advanced options:
+~~~~~~~~~~~~~~~~~
+
+--num_threads=N::
+    Number of worker threads (-1 == use machine default, 0 == do not use multithreading).
+--bits_per_sample=N::
+    Sets the output bit depth. The value 0 (default for PNM) means the original (input) bit depth.
+    The value -1 (default for other codecs) means it depends on the output format capabilities
+    and the input bit depth (e.g. decoding a 12-bit image to PNG will produce a 16-bit PNG).
+--display_nits=N::
+    If set to a non-zero value, tone maps the image to the given peak display luminance.
+--color_space=COLORSPACE_DESC::
+    Sets the desired output color space of the image. For example:
+    --color_space=RGB_D65_SRG_Per_SRG is sRGB with perceptual rendering intent
+    --color_space=RGB_D65_202_Rel_PeQ is Rec.2100 PQ with relative rendering intent
+-s 1|2|4|8::
+--downsampling=1|2|4|8::
+    If the input JXL stream contains hints for target downsampling ratios,
+    only decode what is needed to produce an image intended for this downsampling ratio.
+--allow_partial_files::
+    Allow decoding of truncated files.
 -j::
 --pixels_to_jpeg::
-    By default, if the input JPEG XL contains a recompressed JPEG file,
-    djxl reconstructs the exact original JPEG file if the output file has the
-    `.jpg` (or `.jpeg`) filename extension.
-    This flag causes the decoder to instead decode the image to pixels and
-    encode a new (lossy) JPEG in this case.
+    By default, if the input JXL is a recompressed JPEG file, djxl reconstructs that JPEG file.
+    This flag causes the decoder to instead decode to pixels and encode a new (lossy) JPEG.
+-J::
+--reconstruct_jpeg::
+    Losslessly reconstruct a JPEG if possible, and fail otherwise.
+-q N::
+--jpeg_quality=N::
+    Sets the JPEG output quality, default is 95. Setting this option implies --pixels_to_jpeg.
 
 
--q 'quality'::
---jpeg_quality='quality'::
-    When decoding to `.jpg`, use this output quality. This option implicitly
-    enables the --pixels_to_jpeg option.
+Options for experimentation / benchmarking:
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
+--num_reps=N::
+    Sets the number of times to decompress the image. Useful for benchmarking. Default is 1.
+--disable_output::
+    No output file will be written (for benchmarking)
+--output_extra_channels::
+    If set, all extra channels will be written either as part of the main output file (e.g. alpha channel in png) or as separate output files with suffix -ecN in their names. If not set, the (first) alpha channel will only be written when the output format supports alpha channels and all other extra channels won't be decoded. Files are concatenated when outputting to stdout. Only has an effect when decoding to (A)PNG or PPM/PNM/PFM/PAM
+--output_frames::
+    If set, all frames will be written either as part of the main output file if that supports animation, or as separate output files with suffix -N in their names. Files are concatenated when outputting to stdout.
+--use_sjpeg::
+    Use sjpeg instead of libjpeg for JPEG output.
+--norender_spotcolors::
+    Disables rendering of spot colors.
+--no_coalescing::
+    Disables coalescing of layers.
+--preview_out=FILENAME::
+    If specified, writes the preview image to this file.
+--icc_out=FILENAME::
+    If specified, writes the ICC profile of the decoded image to this file.
+--orig_icc_out=FILENAME::
+    If specified, writes the ICC profile of the original image to this file
+    This can be different from the ICC profile of the decoded image if --color_space was specified.
+--metadata_out=FILENAME::
+    If specified, writes metadata info to a JSON file. Used by the conformance test script
+--background=#NNNNNN::
+    Specifies the background color for the --alpha_blend option. Recognized values are 'black', 'white' (default), or '#NNNNNN'
+--alpha_blend::
+    Blends alpha channel with the color image using background color specified by --background (default is white).
+--print_read_bytes::
+    Print total number of decoded bytes.
 
+-h::
+--help::
+    Prints this help message. All options are shown above.
 Examples
 --------
 
 ----
-# Decompress a JPEG XL file to PNG
+# Decompress a JPEG XL file to PNG
 $ djxl input.jxl output.png
 
 # Reconstruct a losslessly-recompressed JPEG file
@@ -59,3 +125,4 @@ See also
 --------
 
 *cjxl*(1)
+

--- a/doc/release.md
+++ b/doc/release.md
@@ -334,7 +334,7 @@ cmake --install build --prefix="/usr"
 
 cd /src/ImageMagick
 ./configure --with-jxl=yes
-# check for "JPEG XL --with-jxl=yes yes"
+# check for "JPEG XL --with-jxl=yes yes"
 make -j `nproc`
 ./utilities/magick -version
 

--- a/doc/software_support.md
+++ b/doc/software_support.md
@@ -1,6 +1,6 @@
-# JPEG XL software support
+# JPEG XL software support
 
-This document attempts to keep track of software that is using libjxl to support JPEG XL.
+This document attempts to keep track of software that is using libjxl to support JPEG XL.
 This list serves several purposes:
 
 - thank/acknowledge other projects for integrating jxl support
@@ -34,7 +34,7 @@ For all browsers and to track browsers progress see [Can I Use](https://caniuse.
 - [GDAL](https://gdal.org/drivers/raster/jpegxl.html): supported since 3.4.0 as a TIFF codec, and 3.6.0 as standalone format
 - [GraphicsMagick](http://www.graphicsmagick.org/NEWS.html#march-26-2022): supported since 1.3.38
 - [SAIL](https://sail.software): supported since 0.9.0
-- [JPEG XL Coder](https://github.com/awxkee/jxl-coder): Supports version from Android 5.0 (API Level 21)
+- [JPEG XL Coder](https://github.com/awxkee/jxl-coder): Supports version from Android 5.0 (API Level 21)
 - [SDWebImageJPEGXLCoder](https://github.com/SDWebImage/SDWebImageJPEGXLCoder): supported since 0.1.0
 
 ## Metadata manipulation libraries
@@ -68,7 +68,7 @@ For all browsers and to track browsers progress see [Can I Use](https://caniuse.
 - [Photoshop](https://gitlab.com/SuperSaltyGamer/jpegxlformat); plugin for Adobe Photoshop 2020 and above on Windows, supports 8-bit and 16-bit color depth, embedded ICC color profiles, transparency.
 - [XL Converter](https://github.com/JacobDev1/xl-converter)
 - [Image Toolbox (supported since 2.6.0)](https://github.com/T8RIN/ImageToolbox)
-- [JPEG XL Toolbox by SUIKA LTD](https://apps.apple.com/app/jpeg-xl-toolbox/id6470681357)
+- [JPEG XL Toolbox by SUIKA LTD](https://apps.apple.com/app/jpeg-xl-toolbox/id6470681357)
 - [RawTherapee (since 5.11)](https://github.com/Beep6581/RawTherapee); Currently only opening of JXL files is supported. [Exporting is expected for the 6.0 release](https://github.com/Beep6581/RawTherapee/pull/7097)
 
 ## Image viewers

--- a/doc/xl_overview.md
+++ b/doc/xl_overview.md
@@ -2,7 +2,7 @@
 
 ## Requirements
 
-JPEG XL was designed for two main requirements:
+JPEG XL was designed for two main requirements:
 
 *   high quality: visually lossless at reasonable bitrates;
 *   decoding speed: multithreaded decoding should be able to reach around
@@ -15,7 +15,7 @@ support of color spaces and transfer functions.
 High performance is achieved by designing the format with careful consideration
 of memory bandwidth usage and ease of SIMD/GPU implementation.
 
-The full requirements for JPEG XL are listed in document wg1m82079.
+The full requirements for JPEG XL are listed in document wg1m82079.
 
 ## General architecture
 
@@ -99,7 +99,7 @@ appending additional images and could be too constraining for the encoder.
 
 ## Lossless
 
-JPEG XL supports tools for lossless coding designed by Alexander Rhatushnyak and
+JPEG XL supports tools for lossless coding designed by Alexander Rhatushnyak and
 Jon Sneyers. They are about 60-75% of size of PNG, and smaller than WebP
 lossless for photos.
 

--- a/tools/benchmark/benchmark_args.cc
+++ b/tools/benchmark/benchmark_args.cc
@@ -89,9 +89,9 @@ Status BenchmarkArgs::AddCommandLineOptions() {
           false);
   AddFlag(&silent_errors, "silent_errors",
           "If true, doesn't print error messages on compression or"
-          " decompression errors. Errors counts are still visible in the"
+          " decompression errors. Error counts are still visible in the"
           " 'Errors' column of the result table. Please note that depending"
-          " depending on the JXL build settings, error messages and asserts"
+          " on the JXL build settings, error messages and asserts"
           " from within the codec may be printed irrespective of this flag"
           " anyway, use release build to ensure no messages.",
           false);

--- a/tools/cjxl_main.cc
+++ b/tools/cjxl_main.cc
@@ -277,7 +277,7 @@ struct CompressArgs {
     cmdline->AddOptionValue(
         '\0', "center_y", "-1..YSIZE",
         "Set the vertical position of center for center-first group ordering, "
-        "range: [-1 .. xsize).\n"
+        "range: [-1 .. ysize).\n"
         "    -1 = middle of the image. Default = -1.",
         &center_y, &ParseInt64, 2);
 

--- a/tools/djxl_main.cc
+++ b/tools/djxl_main.cc
@@ -97,7 +97,7 @@ struct DecompressArgs {
 
     cmdline->AddOptionValue('\0', "display_nits", "N",
                             "If set to a non-zero value, tone maps the image "
-                            "the given peak display luminance.",
+                            "to the given peak display luminance.",
                             &display_nits, &ParseDouble, 1);
 
     cmdline->AddOptionValue(

--- a/tools/jxltran.cc
+++ b/tools/jxltran.cc
@@ -163,7 +163,7 @@ JxlDecoderStatus apply_file_format_options(
         }
       } else if (status == JXL_DEC_BOX_NEED_MORE_OUTPUT) {
         if (box == jxll) {
-          fprintf(stderr, "jxll box too large");
+          fprintf(stderr, "jxll box too large\n");
           JxlDecoderReleaseBoxBuffer(dec.get());
           continue;
         }
@@ -190,7 +190,7 @@ JxlDecoderStatus apply_file_format_options(
           JxlDecoderReleaseBoxBuffer(dec.get());
           if (level > 5) {
             fprintf(stderr,
-                    "Warning: extracting raw codestream that"
+                    "Warning: extracting raw codestream that "
                     "is greater than level 5\n");
           }
         }


### PR DESCRIPTION
* Correct some old info in the encode effort doc.
* Add missing information in the changelog (removed brotli tool) and made the formatting consistent.
* Updated msys2 building docs.
* Building and testing doc made more clear.
* Specify that libjxl uses `skcms` by default instead of `lcms2`.
* Modern man pages, the old ones were from 2021!
* And a tiny mention that Gainmaps (ugh) exist.
* Use a non-breaking space in JPEG XL.
* General typo and string fixes.
* Replaced "expected" with "required" for the AI policy 