### PR TITLE
Disable fast lossless for non-replace blend modes

### DIFF
--- a/lib/jxl/encode.cc
+++ b/lib/jxl/encode.cc
@@ -2327,6 +2327,10 @@ static bool CanDoFastLossless(const JxlEncoderFrameSettings* frame_settings,
   if (frame_settings->values.header.layer_info.have_crop) {
     return false;
   }
+  if (frame_settings->values.header.layer_info.blend_info.blendmode !=
+      JXL_BLEND_REPLACE) {
+    return false;
+  }
   if (frame_settings->enc->metadata.m.have_animation) {
     return false;
   }

--- a/lib/jxl/encode.cc
+++ b/lib/jxl/encode.cc
@@ -2331,6 +2331,19 @@ static bool CanDoFastLossless(const JxlEncoderFrameSettings* frame_settings,
       JXL_BLEND_REPLACE) {
     return false;
   }
+  if (frame_settings->values.header.layer_info.save_as_reference != 0 ||
+      frame_settings->values.header.layer_info.blend_info.source != 0) {
+    return false;
+  }
+  if (!frame_settings->values.extra_channel_blend_info.empty()) {
+    if (frame_settings->values.extra_channel_blend_info[0].blendmode !=
+        JXL_BLEND_REPLACE) {
+      return false;
+    }
+    if (frame_settings->values.extra_channel_blend_info[0].source != 0) {
+      return false;
+    }
+  }
   if (frame_settings->enc->metadata.m.have_animation) {
     return false;
   }


### PR DESCRIPTION
Fast lossless always writes the frame header with blend mode set to kReplace, blend source = 0, save_as_reference = 0, so don't use it for frames that have non-default blending settings.

Fixes #4900

- [x] **CLA Signed**: Have you signed the [Contributor License Agreement](https://code.google.com/legal/individual-cla-v1.0.html) (individual or corporate, as appropriate)? Only contributions from signed contributors can be accepted.
- [x] **Authors**: Have you considered adding your name to the [AUTHORS](AUTHORS) file?
- [x] **Code Style**: Have you ensured your code adheres to the project's coding style guidelines? You can use `./ci.sh lint` for automatic code formatting.
