### PR TITLE
Avoid signed overflow in modular quantization 

### DIFF
--- a/lib/jxl/enc_modular.cc
+++ b/lib/jxl/enc_modular.cc
@@ -146,14 +146,18 @@ Status QuantizeChannel(Channel& ch, const int q) {
     for (size_t x = 0; x < ch.plane.xsize(); x++) {
       const pixel_type_w sample = row[x];
       const pixel_type_w magnitude = sample < 0 ? -sample : sample;
-      const pixel_type_w quantized_magnitude =
+      const pixel_type_w rounded_magnitude =
           ((magnitude + half_q) / q) * q;
+      const pixel_type_w max_magnitude =
+          sample < 0 ? -static_cast<pixel_type_w>(
+                           std::numeric_limits<pixel_type>::min())
+                     : std::numeric_limits<pixel_type>::max();
+      const pixel_type_w max_quantized_magnitude =
+          (max_magnitude / q) * q;
+      const pixel_type_w quantized_magnitude =
+          std::min(rounded_magnitude, max_quantized_magnitude);
       const pixel_type_w quantized =
           sample < 0 ? -quantized_magnitude : quantized_magnitude;
-      if (quantized < std::numeric_limits<pixel_type>::min() ||
-          quantized > std::numeric_limits<pixel_type>::max()) {
-        return JXL_FAILURE("Quantized modular sample out of range");
-      }
       row[x] = static_cast<pixel_type>(quantized);
     }
   }

--- a/lib/jxl/enc_modular.cc
+++ b/lib/jxl/enc_modular.cc
@@ -137,18 +137,27 @@ Status MergeTrees(const std::vector<Tree>& trees,
   return true;
 }
 
-void QuantizeChannel(Channel& ch, const int q) {
-  if (q == 1) return;
+Status QuantizeChannel(Channel& ch, const int q) {
+  if (q == 1) return true;
+  if (q < 1) return JXL_FAILURE("Invalid modular quantizer");
+  const pixel_type_w half_q = q / 2;
   for (size_t y = 0; y < ch.plane.ysize(); y++) {
     pixel_type* row = ch.plane.Row(y);
     for (size_t x = 0; x < ch.plane.xsize(); x++) {
-      if (row[x] < 0) {
-        row[x] = -((-row[x] + q / 2) / q) * q;
-      } else {
-        row[x] = ((row[x] + q / 2) / q) * q;
+      const pixel_type_w sample = row[x];
+      const pixel_type_w magnitude = sample < 0 ? -sample : sample;
+      const pixel_type_w quantized_magnitude =
+          ((magnitude + half_q) / q) * q;
+      const pixel_type_w quantized =
+          sample < 0 ? -quantized_magnitude : quantized_magnitude;
+      if (quantized < std::numeric_limits<pixel_type>::min() ||
+          quantized > std::numeric_limits<pixel_type>::max()) {
+        return JXL_FAILURE("Quantized modular sample out of range");
       }
+      row[x] = static_cast<pixel_type>(quantized);
     }
   }
+  return true;
 }
 
 // convert binary32 float that corresponds to custom [bits]-bit float (with
@@ -1028,7 +1037,7 @@ Status ModularFrameEncoder::ComputeEncodingData(
         }
       }
       if (q < 1) q = 1;
-      QuantizeChannel(gi.channel[i], q);
+      JXL_RETURN_IF_ERROR(QuantizeChannel(gi.channel[i], q));
       quants_[i] = q;
     }
   }

--- a/lib/jxl/roundtrip_test.cc
+++ b/lib/jxl/roundtrip_test.cc
@@ -492,6 +492,65 @@ TEST(RoundtripTest, FloatFrameRoundtripTest) {
   }
 }
 
+TEST(RoundtripTest, ProgressiveFloatModularQuantizationAtIntegerLimit) {
+  constexpr uint32_t kXSize = 1;
+  constexpr uint32_t kYSize = 8;
+  constexpr uint32_t kNumChannels = 3;
+  const std::vector<uint32_t> pixels = {
+      0x20202020, 0x20202020, 0x20202020, 0x20202020, 0x20202020,
+      0x20202020, 0x20202020, 0x20202020, 0x20202020, 0x20202020,
+      0x20202020, 0x20202020, 0xffffffff, 0xffff2020, 0x20202020,
+      0x20202020, 0x6f202020, 0x20202020, 0x20202020, 0x20202020,
+      0x20202020, 0x202020ff, 0xffffffff, 0xff202020,
+  };
+  const JxlPixelFormat pixel_format = {kNumChannels, JXL_TYPE_FLOAT,
+                                       JXL_NATIVE_ENDIAN, 0};
+
+  JxlEncoderPtr enc = JxlEncoderMake(nullptr);
+  ASSERT_NE(nullptr, enc.get());
+
+  JxlBasicInfo basic_info;
+  JxlEncoderInitBasicInfo(&basic_info);
+  basic_info.xsize = kXSize;
+  basic_info.ysize = kYSize;
+  basic_info.bits_per_sample = 32;
+  basic_info.exponent_bits_per_sample = 8;
+  basic_info.uses_original_profile = JXL_FALSE;
+  ASSERT_EQ(JXL_ENC_SUCCESS, JxlEncoderSetBasicInfo(enc.get(), &basic_info));
+
+  JxlColorEncoding color_encoding;
+  JxlColorEncodingSetToLinearSRGB(&color_encoding, JXL_FALSE);
+  ASSERT_EQ(JXL_ENC_SUCCESS,
+            JxlEncoderSetColorEncoding(enc.get(), &color_encoding));
+
+  JxlEncoderFrameSettings* frame_settings =
+      JxlEncoderFrameSettingsCreate(enc.get(), nullptr);
+  ASSERT_NE(nullptr, frame_settings);
+  ASSERT_EQ(JXL_ENC_SUCCESS,
+            JxlEncoderSetFrameDistance(
+                frame_settings, JxlEncoderDistanceFromQuality(75.0f)));
+  ASSERT_EQ(JXL_ENC_SUCCESS,
+            JxlEncoderFrameSettingsSetOption(
+                frame_settings, JXL_ENC_FRAME_SETTING_PROGRESSIVE_DC, 1));
+  ASSERT_EQ(JXL_ENC_SUCCESS,
+            JxlEncoderFrameSettingsSetOption(
+                frame_settings, JXL_ENC_FRAME_SETTING_QPROGRESSIVE_AC, 1));
+  ASSERT_EQ(JXL_ENC_SUCCESS,
+            JxlEncoderFrameSettingsSetOption(
+                frame_settings, JXL_ENC_FRAME_SETTING_RESPONSIVE, 1));
+  ASSERT_EQ(JXL_ENC_SUCCESS,
+            JxlEncoderFrameSettingsSetOption(
+                frame_settings, JXL_ENC_FRAME_SETTING_GROUP_ORDER, 1));
+  ASSERT_EQ(JXL_ENC_SUCCESS,
+            JxlEncoderAddImageFrame(frame_settings, &pixel_format,
+                                    pixels.data(),
+                                    pixels.size() * sizeof(pixels[0])));
+  JxlEncoderCloseInput(enc.get());
+
+  std::vector<uint8_t> compressed;
+  EncodeWithEncoder(enc.get(), &compressed);
+}
+
 TEST(RoundtripTest, Uint16FrameRoundtripTest) {
   std::vector<std::vector<std::pair<JxlExtraChannelType, std::string>>>
       extra_channels_cases = {{},


### PR DESCRIPTION
# Avoid signed overflow in modular quantization

## Summary

`QuantizeChannel()` performs modular lossy quantization using `pixel_type`
(`int32_t`) arithmetic. For negative samples it negates the sample before
rounding:

```c++
row[x] = -((-row[x] + q / 2) / q) * q;
```

When `row[x]` is `INT32_MIN`, the `-row[x]` expression invokes signed integer
overflow before any wider type can be used. The positive branch also performs
`row[x] + q / 2` in `pixel_type`, which can overflow for large positive
samples.

This change computes the quantized magnitude in `pixel_type_w` (`int64_t`),
checks that the final rounded value is representable as `pixel_type`, and
propagates a `Status` failure instead of relying on undefined behavior.

Fixes #4873.


The issue reports a UBSan finding from fuzzing:

```text
runtime error: negation of -2147483648 cannot be represented in type
'pixel_type' (aka 'int')
```

The reported stack reaches:

- `jxl::(anonymous namespace)::QuantizeChannel()`
- `jxl::ModularFrameEncoder::ComputeEncodingData()`
- `jxl::EncodeFrame()`



## Reachability

The issue is reachable through the public encoder path when inputs and encoder
settings select modular lossy quantization. The reporter's reproducer encodes a
PFM input to JXL and reaches `QuantizeChannel()` from
`ModularFrameEncoder::ComputeEncodingData()`.

In the affected code path, `QuantizeChannel()` is called after modular
transforms when `ModularPartIsLossless()` is false. Channel samples are stored
as `pixel_type` (`int32_t`), so an `INT32_MIN` sample reaches the negative
branch and triggers undefined behavior during negation.

## Fix

- Change `QuantizeChannel()` from a `void` helper to a `Status`-returning
  helper.
- Compute the sample magnitude, rounded magnitude, and signed quantized result
  in `pixel_type_w`.
- Reject invalid quantizers defensively.
- Check the final quantized value against `std::numeric_limits<pixel_type>`
  before casting back to `pixel_type`.
- Propagate the failure at the existing call site with `JXL_RETURN_IF_ERROR`.

## Verification

Performed:

- Confirmed `libjxl/libjxl#4873` is open and contains a UBSan stack trace for
  `QuantizeChannel()`.
- Confirmed the local source matches the reported issue: `pixel_type` is
  `int32_t`, and the old code negates `row[x]` before widening.

