### PR TITLE
Fix signed integer overflow in modular forward transform arithmetic

### DIFF
--- a/lib/jxl/enc_modular_simd.cc
+++ b/lib/jxl/enc_modular_simd.cc
@@ -19,6 +19,7 @@
 #include "lib/jxl/enc_ans_params.h"
 #include "lib/jxl/memory_manager_internal.h"
 #include "lib/jxl/modular/modular_image.h"
+#include "lib/jxl/modular/transform/transform.h"
 
 #undef HWY_TARGET_INCLUDE
 #define HWY_TARGET_INCLUDE "lib/jxl/enc_modular_simd.cc"
@@ -84,7 +85,8 @@ StatusOr<float> EstimateCost(const Image& img) {
         for (uint32_t c : cutoffs) {
           ctx += (max_diff < c) ? 1 : 0;
         }
-        pixel_type res = r[x] - ClampedGradient(top, left, topleft);
+        pixel_type res =
+            PixelSub(r[x], ClampedGradient(top, left, topleft));
         uint32_t token;
         uint32_t nbits;
         uint32_t bits;

--- a/lib/jxl/modular/transform/enc_rct.cc
+++ b/lib/jxl/modular/transform/enc_rct.cc
@@ -43,10 +43,10 @@ bool FwdRctRow(size_t w, const pixel_type* in0, const pixel_type* in1,
       pixel_type R = in0[x];
       pixel_type G = in1[x];
       pixel_type B = in2[x];
-      pixel_type o1 = R - B;
-      pixel_type tmp = B + (o1 >> 1);
-      pixel_type o2 = G - tmp;
-      out0[x] = tmp + (o2 >> 1);
+      pixel_type o1 = PixelSub(R, B);
+      pixel_type tmp = PixelAdd(B, o1 >> 1);
+      pixel_type o2 = PixelSub(G, tmp);
+      out0[x] = PixelAdd(tmp, o2 >> 1);
       out1[x] = o1;
       out2[x] = o2;
     }
@@ -58,11 +58,11 @@ bool FwdRctRow(size_t w, const pixel_type* in0, const pixel_type* in1,
     pixel_type Second = in1[x];
     pixel_type Third = in2[x];
     if (second == 1) {
-      Second = Second - First;
+      Second = PixelSub(Second, First);
     } else if (second == 2) {
-      Second = Second - ((First + Third) >> 1);
+      Second = PixelSub(Second, PixelAdd(First, Third) >> 1);
     }
-    if (third) Third = Third - First;
+    if (third) Third = PixelSub(Third, First);
     out0[x] = First;
     out1[x] = Second;
     out2[x] = Third;

--- a/lib/jxl/modular/transform/enc_squeeze.cc
+++ b/lib/jxl/modular/transform/enc_squeeze.cc
@@ -10,6 +10,7 @@
 #include <cstddef>
 #include <cstdint>
 #include <cstdlib>
+#include <limits>
 #include <utility>
 #include <vector>
 
@@ -22,7 +23,20 @@
 
 namespace jxl {
 
-#define AVERAGE(X, Y) (((X) + (Y) + (((X) > (Y)) ? 1 : 0)) >> 1)
+namespace {
+
+pixel_type_w Average(pixel_type a, pixel_type b) {
+  const pixel_type_w sum =
+      static_cast<pixel_type_w>(a) + b + (a > b ? 1 : 0);
+  return sum / 2 - (sum < 0 && sum % 2 != 0 ? 1 : 0);
+}
+
+bool FitsInPixelType(pixel_type_w value) {
+  return value >= std::numeric_limits<pixel_type>::min() &&
+         value <= std::numeric_limits<pixel_type>::max();
+}
+
+}  // namespace
 
 Status FwdHSqueeze(Image &input, int c, int rc) {
   const Channel &chin = input.channel[c];
@@ -47,23 +61,31 @@ Status FwdHSqueeze(Image &input, int c, int rc) {
     for (size_t x = 0; x < chout_residual.w; x++) {
       pixel_type A = p_in[x * 2];
       pixel_type B = p_in[x * 2 + 1];
-      pixel_type avg = AVERAGE(A, B);
+      pixel_type avg = static_cast<pixel_type>(Average(A, B));
       p_out[x] = avg;
 
-      pixel_type diff = A - B;
+      const pixel_type_w diff = static_cast<pixel_type_w>(A) - B;
+      if (!FitsInPixelType(diff)) {
+        return JXL_FAILURE("Horizontal squeeze difference out of range");
+      }
 
       pixel_type next_avg = avg;
       if (x + 1 < chout_residual.w) {
         pixel_type C = p_in[x * 2 + 2];
         pixel_type D = p_in[x * 2 + 3];
-        next_avg = AVERAGE(C, D);  // which will be chout.value(y,x+1)
+        next_avg = static_cast<pixel_type>(
+            Average(C, D));  // which will be chout.value(y,x+1)
       } else if (chin.w & 1) {
         next_avg = p_in[x * 2 + 2];
       }
       pixel_type left = (x > 0 ? p_in[x * 2 - 1] : avg);
-      pixel_type tendency = SmoothTendency(left, avg, next_avg);
+      const pixel_type_w tendency = SmoothTendency(left, avg, next_avg);
 
-      p_res[x] = diff - tendency;
+      const pixel_type_w residual = diff - tendency;
+      if (!FitsInPixelType(residual)) {
+        return JXL_FAILURE("Horizontal squeeze residual out of range");
+      }
+      p_res[x] = static_cast<pixel_type>(residual);
     }
     if (chin.w & 1) {
       int x = chout.w - 1;
@@ -99,24 +121,32 @@ Status FwdVSqueeze(Image &input, int c, int rc) {
     for (size_t x = 0; x < chout.w; x++) {
       pixel_type A = p_in[x];
       pixel_type B = p_in[x + onerow_in];
-      pixel_type avg = AVERAGE(A, B);
+      pixel_type avg = static_cast<pixel_type>(Average(A, B));
       p_out[x] = avg;
 
-      pixel_type diff = A - B;
+      const pixel_type_w diff = static_cast<pixel_type_w>(A) - B;
+      if (!FitsInPixelType(diff)) {
+        return JXL_FAILURE("Vertical squeeze difference out of range");
+      }
 
       pixel_type next_avg = avg;
       if (y + 1 < chout_residual.h) {
         pixel_type C = p_in[x + 2 * onerow_in];
         pixel_type D = p_in[x + 3 * onerow_in];
-        next_avg = AVERAGE(C, D);  // which will be chout.value(y+1,x)
+        next_avg = static_cast<pixel_type>(
+            Average(C, D));  // which will be chout.value(y+1,x)
       } else if (chin.h & 1) {
         next_avg = p_in[x + 2 * onerow_in];
       }
       pixel_type top =
           (y > 0 ? p_in[static_cast<ptrdiff_t>(x) - onerow_in] : avg);
-      pixel_type tendency = SmoothTendency(top, avg, next_avg);
+      const pixel_type_w tendency = SmoothTendency(top, avg, next_avg);
 
-      p_res[x] = diff - tendency;
+      const pixel_type_w residual = diff - tendency;
+      if (!FitsInPixelType(residual)) {
+        return JXL_FAILURE("Vertical squeeze residual out of range");
+      }
+      p_res[x] = static_cast<pixel_type>(residual);
     }
   }
   if (chin.h & 1) {

--- a/lib/jxl/modular/transform/transform.h
+++ b/lib/jxl/modular/transform/transform.h
@@ -77,6 +77,11 @@ static inline pixel_type PixelAdd(pixel_type a, pixel_type b) {
                                  static_cast<uint32_t>(b));
 }
 
+static inline pixel_type PixelSub(pixel_type a, pixel_type b) {
+  return static_cast<pixel_type>(static_cast<uint32_t>(a) -
+                                 static_cast<uint32_t>(b));
+}
+
 }  // namespace jxl
 
 #endif  // LIB_JXL_MODULAR_TRANSFORM_TRANSFORM_H_

--- a/lib/jxl/modular_test.cc
+++ b/lib/jxl/modular_test.cc
@@ -11,6 +11,7 @@
 #include <cmath>
 #include <cstddef>
 #include <cstdint>
+#include <limits>
 #include <memory>
 #include <sstream>
 #include <string>
@@ -38,6 +39,7 @@
 #include "lib/jxl/enc_aux_out.h"
 #include "lib/jxl/enc_bit_writer.h"
 #include "lib/jxl/enc_fields.h"
+#include "lib/jxl/enc_modular_simd.h"
 #include "lib/jxl/enc_params.h"
 #include "lib/jxl/enc_toc.h"
 #include "lib/jxl/fields.h"
@@ -52,6 +54,9 @@
 #include "lib/jxl/modular/encoding/encoding.h"
 #include "lib/jxl/modular/modular_image.h"
 #include "lib/jxl/modular/options.h"
+#include "lib/jxl/modular/transform/enc_rct.h"
+#include "lib/jxl/modular/transform/enc_squeeze.h"
+#include "lib/jxl/modular/transform/rct.h"
 #include "lib/jxl/modular/transform/squeeze_params.h"
 #include "lib/jxl/modular/transform/transform.h"
 #include "lib/jxl/padded_bytes.h"
@@ -175,6 +180,86 @@ TEST(ModularTest, RoundtripLosslessCustomWpPermuteRCT) {
       Roundtrip(t.ppf(), cparams, dparams, nullptr, &ppf_out);
   EXPECT_LE(compressed_size, 10169u);
   EXPECT_EQ(0.0f, test::ComputeDistance2(t.ppf(), ppf_out));
+}
+
+TEST(ModularTest, RctExtremeSamplesRoundtrip) {
+  JxlMemoryManager* memory_manager = jxl::test::MemoryManager();
+  constexpr size_t kXSize = 4;
+  constexpr pixel_type kSamples[3][kXSize] = {
+      {std::numeric_limits<pixel_type>::min(),
+       std::numeric_limits<pixel_type>::max(), -1, 0},
+      {std::numeric_limits<pixel_type>::max(),
+       std::numeric_limits<pixel_type>::min(), 0, -1},
+      {0, -1, std::numeric_limits<pixel_type>::max(),
+       std::numeric_limits<pixel_type>::min()},
+  };
+
+  for (size_t rct_type = 1; rct_type < 42; ++rct_type) {
+    JXL_TEST_ASSIGN_OR_DIE(
+        Image image,
+        Image::Create(memory_manager, kXSize, 1, /*bitdepth=*/32, 3));
+    for (size_t c = 0; c < 3; ++c) {
+      for (size_t x = 0; x < kXSize; ++x) {
+        image.channel[c].Row(0)[x] = kSamples[c][x];
+      }
+    }
+
+    ASSERT_TRUE(FwdRct(image, /*begin_c=*/0, rct_type, /*pool=*/nullptr));
+    ASSERT_TRUE(InvRCT(image, /*begin_c=*/0, rct_type, /*pool=*/nullptr));
+    for (size_t c = 0; c < 3; ++c) {
+      for (size_t x = 0; x < kXSize; ++x) {
+        EXPECT_EQ(kSamples[c][x], image.channel[c].Row(0)[x])
+            << "rct_type = " << rct_type << ", c = " << c
+            << ", x = " << x;
+      }
+    }
+  }
+}
+
+TEST(ModularTest, EstimateCostExtremeSamples) {
+  JxlMemoryManager* memory_manager = jxl::test::MemoryManager();
+  JXL_TEST_ASSIGN_OR_DIE(
+      Image image,
+      Image::Create(memory_manager, 2, 1, /*bitdepth=*/32, 1));
+  image.channel[0].Row(0)[0] = std::numeric_limits<pixel_type>::min();
+  image.channel[0].Row(0)[1] = std::numeric_limits<pixel_type>::max();
+
+  JXL_TEST_ASSIGN_OR_DIE(const float cost, EstimateCost(image));
+  EXPECT_TRUE(std::isfinite(cost));
+}
+
+TEST(ModularTest, SqueezeRejectsUnrepresentableDifference) {
+  JxlMemoryManager* memory_manager = jxl::test::MemoryManager();
+  for (bool horizontal : {false, true}) {
+    const size_t xsize = horizontal ? 2 : 1;
+    const size_t ysize = horizontal ? 1 : 2;
+    JXL_TEST_ASSIGN_OR_DIE(
+        Image image,
+        Image::Create(memory_manager, xsize, ysize, /*bitdepth=*/32, 1));
+    image.channel[0].Row(0)[0] = std::numeric_limits<pixel_type>::max();
+    if (horizontal) {
+      image.channel[0].Row(0)[1] = std::numeric_limits<pixel_type>::min();
+    } else {
+      image.channel[0].Row(1)[0] = std::numeric_limits<pixel_type>::min();
+    }
+
+    SqueezeParams params;
+    params.horizontal = horizontal;
+    params.in_place = true;
+    params.begin_c = 0;
+    params.num_c = 1;
+    EXPECT_FALSE(FwdSqueeze(image, {params}, /*pool=*/nullptr));
+    ASSERT_EQ(1u, image.channel.size());
+    EXPECT_EQ(std::numeric_limits<pixel_type>::max(),
+              image.channel[0].Row(0)[0]);
+    if (horizontal) {
+      EXPECT_EQ(std::numeric_limits<pixel_type>::min(),
+                image.channel[0].Row(0)[1]);
+    } else {
+      EXPECT_EQ(std::numeric_limits<pixel_type>::min(),
+                image.channel[0].Row(1)[0]);
+    }
+  }
 }
 
 TEST(ModularTest, RoundtripLossyDeltaPalette) {


### PR DESCRIPTION
# modular: avoid signed overflow in forward transform arithmetic

## Summary

This change removes signed-integer undefined behavior from scalar modular
encoder paths that operate on 32-bit samples.

- Performs reversible RCT addition and subtraction with explicit modulo-2^32
  arithmetic.
- Uses the same defined subtraction in the scalar modular cost estimator.
- Computes squeeze averages and differences in the wider modular sample type.
- Rejects squeeze differences or residuals that cannot be represented by
  `pixel_type`.
- Adds focused regression coverage for extreme 32-bit samples.

## Bug

The modular encoder accepts signed 32-bit channel samples, but several scalar
forward-transform expressions performed arithmetic directly in `pixel_type`.
Extreme sample combinations could therefore overflow signed `int` before the
result was stored or widened.

The affected expressions included:

- RCT channel subtraction and YCoCg intermediate addition.
- Residual subtraction in the scalar modular cost estimator.
- Squeeze average, difference, and residual calculation.

For example, subtracting `INT32_MIN` from `INT32_MAX` in the forward squeeze
path triggers UBSan before the encoder can decide whether the transformed
sample is representable. Similar inputs trigger scalar RCT and cost-estimator
overflows.

Signed overflow is undefined behavior in C++. In sanitizer or hardened builds
it can terminate encoding, and optimized builds must not depend on the
two's-complement result produced by a particular compiler.

## UBSan reproduction before the fix

The failures below were reproduced from pristine `main` in a UBSan build with
`HWY_COMPILE_ONLY_SCALAR` and `UBSAN_OPTIONS=halt_on_error=1`.

### Forward RCT

```text
[ RUN      ] ModularTest.RctExtremeSamplesRoundtrip
lib/jxl/modular/transform/enc_rct.cc:65:22: runtime error:
signed integer overflow: 0 - -2147483648 cannot be represented in type 'int'
    #0 jxl::N_SCALAR::FwdRctRow<1ul>(...)
       lib/jxl/modular/transform/enc_rct.cc:65
    #1 jxl::N_SCALAR::FwdRctImpl(...)
    #2 jxl::FwdRct(...)
```

The test process exits with status 1 when UBSan is configured to halt on the
first undefined operation.

### Modular cost estimator

```text
[ RUN      ] ModularTest.EstimateCostExtremeSamples
lib/jxl/enc_modular_simd.cc:87:67: runtime error:
signed integer overflow: 2147483647 - -2147483648 cannot be represented in
type 'int'
    #0 jxl::N_SCALAR::EstimateCost(jxl::Image const&)
       lib/jxl/enc_modular_simd.cc:87
    #1 jxl::EstimateCost(jxl::Image const&)
```

The test process exits with status 1 before a cost can be returned.

### Forward squeeze

```text
[ RUN      ] ModularTest.SqueezeExtremeDifference
lib/jxl/modular/transform/enc_squeeze.cc:53:18: runtime error:
signed integer overflow: 2147483647 - -2147483648 cannot be represented in
type 'int'
    #0 jxl::FwdHSqueeze(jxl::Image&, int, int)
       lib/jxl/modular/transform/enc_squeeze.cc:53
    #1 jxl::FwdSqueeze(...)
```

The test process exits with status 1 while calculating the transformed
difference.

## Fix

The existing `PixelAdd()` helper defines reversible modular addition by
performing the operation as `uint32_t`. This change adds the corresponding
`PixelSub()` helper and uses it in scalar forward RCT and cost-estimation code,
matching the wrapping behavior of the SIMD operations and inverse RCT.

Squeeze arithmetic requires different handling. Its average is computed in
`pixel_type_w` while preserving the original floor-rounding behavior. The
forward transform then computes the mathematical difference and predicted
residual in `pixel_type_w`. If either value is outside the `pixel_type` range,
encoding fails cleanly instead of overflowing or narrowing an unrepresentable
value.

The squeeze output channels are staged locally, so a rejected single-channel
transform leaves the original channel unchanged.

## Behavior after the fix

The patched scalar-only UBSan build completes all three focused regressions
without an undefined-behavior report:

```text
[==========] Running 3 tests from 1 test suite.
[ RUN      ] ModularTest.RctExtremeSamplesRoundtrip
[       OK ] ModularTest.RctExtremeSamplesRoundtrip
[ RUN      ] ModularTest.EstimateCostExtremeSamples
[       OK ] ModularTest.EstimateCostExtremeSamples
[ RUN      ] ModularTest.SqueezeRejectsUnrepresentableDifference
[       OK ] ModularTest.SqueezeRejectsUnrepresentableDifference
[==========] 3 tests from 1 test suite ran.
[  PASSED  ] 3 tests.
```

The observable result depends on whether the transform is representable:

- RCT and cost-estimator subtraction now use defined modulo-2^32 arithmetic,
  so encoding continues normally and RCT remains exactly reversible.
- An extreme squeeze difference that cannot be stored losslessly no longer
  reaches signed overflow. `FwdSqueeze()` returns a failure status such as:

```text
JXL_FAILURE: Horizontal squeeze difference out of range
JXL_RETURN_IF_ERROR: FwdHSqueeze(input, c, offset + c - beginc)
```

The vertical path similarly reports `Vertical squeeze difference out of
range`. The caller receives a normal encoder failure instead of a UBSan abort,
and the tested input channel remains unchanged.


