### PR TITLE
parse color description numbers with the C locale

### DIFF
--- a/lib/extras/dec/color_description.cc
+++ b/lib/extras/dec/color_description.cc
@@ -8,10 +8,10 @@
 #include <jxl/color_encoding.h>
 
 #include <array>
-#include <cerrno>
 #include <cmath>
 #include <cstddef>
-#include <cstdlib>
+#include <locale>
+#include <sstream>
 #include <string>
 
 #include "lib/jxl/base/common.h"
@@ -100,17 +100,19 @@ class Tokenizer {
 };
 
 Status ParseDouble(const std::string& num, double* d) {
-  char* end;
-  errno = 0;
-  *d = strtod(num.c_str(), &end);
-  if (*d == 0.0 && end == num.c_str()) {
+  // strtod honors the global C locale, so under a non-C LC_NUMERIC (e.g. one
+  // that uses ',' as the decimal separator) it stops at the '.' and silently
+  // truncates values like "0.5" to 0. Parse with the classic (C) locale so a
+  // color description is decoded the same way regardless of the embedder's
+  // locale.
+  std::istringstream is(num);
+  is.imbue(std::locale::classic());
+  is >> *d;
+  if (is.fail()) {
     return JXL_FAILURE("Invalid double: %s", num.c_str());
   }
   if (std::isnan(*d)) {
     return JXL_FAILURE("Invalid double: %s", num.c_str());
-  }
-  if (errno == ERANGE) {
-    return JXL_FAILURE("Double out of range: %s", num.c_str());
   }
   return true;
 }

--- a/lib/extras/dec/color_description_test.cc
+++ b/lib/extras/dec/color_description_test.cc
@@ -7,6 +7,7 @@
 
 #include <jxl/color_encoding.h>
 
+#include <clocale>
 #include <cstdio>
 #include <string>
 
@@ -37,6 +38,41 @@ TEST(ColorDescriptionTest, NanGamma) {
   const std::string description = "Gra_2_Per_gnan";
   JxlColorEncoding c;
   EXPECT_FALSE(ParseDescription(description, &c));
+}
+
+// Fractional values in a description (gamma, custom white point / primaries)
+// must parse independently of the process LC_NUMERIC locale. Under a locale
+// whose decimal separator is ',', the old strtod-based parser truncated
+// "2.2" to 2 and "0.3127" to 0.
+TEST(ColorDescriptionTest, FractionalValuesIgnoreLocale) {
+  const char* current = std::setlocale(LC_NUMERIC, nullptr);
+  const std::string saved_locale = current ? current : "C";
+  bool have_comma_locale = false;
+  for (const char* name : {"de_DE.UTF-8", "de_DE.utf8", "de_DE", "fr_FR.UTF-8",
+                           "nl_NL.UTF-8", "de_DE.ISO8859-15"}) {
+    if (std::setlocale(LC_NUMERIC, name) != nullptr &&
+        std::string(std::localeconv()->decimal_point) == ",") {
+      have_comma_locale = true;
+      break;
+    }
+  }
+  if (!have_comma_locale) {
+    std::setlocale(LC_NUMERIC, saved_locale.c_str());
+    GTEST_SKIP() << "No locale with ',' decimal separator available.";
+  }
+
+  JxlColorEncoding gamma = {};
+  EXPECT_TRUE(ParseDescription("Gra_D65_Per_g2.2", &gamma));
+  EXPECT_EQ(gamma.transfer_function, JXL_TRANSFER_FUNCTION_GAMMA);
+  EXPECT_NEAR(gamma.gamma, 2.2, 1e-9);
+
+  JxlColorEncoding wp = {};
+  EXPECT_TRUE(ParseDescription("RGB_0.3127;0.3290_SRG_Rel_SRG", &wp));
+  EXPECT_EQ(wp.white_point, JXL_WHITE_POINT_CUSTOM);
+  EXPECT_NEAR(wp.white_point_xy[0], 0.3127, 1e-9);
+  EXPECT_NEAR(wp.white_point_xy[1], 0.3290, 1e-9);
+
+  std::setlocale(LC_NUMERIC, saved_locale.c_str());
 }
 
 }  // namespace jxl


### PR DESCRIPTION
### Description

`ParseDouble` in `lib/extras/dec/color_description.cc` parses the fractional values in a color description (custom white point / primaries `x;y` coordinates, and the gamma in forms like `g2.2`) with `strtod`, which follows the process `LC_NUMERIC` locale. When the embedding application has set a locale whose decimal separator is not `.`, `strtod` stops at the dot and silently returns a truncated value, so `0.3127` parses as `0` and `g2.2` as gamma `2`, decoding the wrong color without any error. This parses the value with the classic C locale instead, matching how the extras code already forces `std::locale::classic()` for case folding. The added test fails on the current code under a comma-decimal locale and passes with the change.

### Pull Request Checklist

- [x] **CLA Signed**: Have you signed the [Contributor License Agreement](https://code.google.com/legal/individual-cla-v1.0.html) (individual or corporate, as appropriate)? Only contributions from signed contributors can be accepted.
- [ ] **Authors**: Have you considered adding your name to the [AUTHORS](AUTHORS) file?
- [x] **Code Style**: Have you ensured your code adheres to the project's coding style guidelines? You can use `./ci.sh lint` for automatic code formatting.