### PR TITLE
validate extra channel output bit depth in the decoder API

### DIFF
--- a/lib/jxl/decode.cc
+++ b/lib/jxl/decode.cc
@@ -188,6 +188,21 @@ uint32_t GetBitDepth(JxlBitDepth bit_depth, const T& metadata,
   return 0;
 }
 
+template <typename T>
+JxlDecoderStatus VerifyOutputBitDepth(JxlBitDepth bit_depth, const T& metadata,
+                                      JxlPixelFormat format) {
+  uint32_t bits_per_sample = GetBitDepth(bit_depth, metadata, format);
+  if (bits_per_sample == 0) return JXL_API_ERROR("Invalid output bit depth");
+  if (format.data_type == JXL_TYPE_UINT8 && bits_per_sample > 8) {
+    return JXL_API_ERROR("Invalid bit depth %u for uint8 output",
+                         bits_per_sample);
+  } else if (format.data_type == JXL_TYPE_UINT16 && bits_per_sample > 16) {
+    return JXL_API_ERROR("Invalid bit depth %u for uint16 output",
+                         bits_per_sample);
+  }
+  return JXL_DEC_SUCCESS;
+}
+
 enum class DecoderStage : uint32_t {
   kInited,              // Decoder created, no JxlDecoderProcessInput called yet
   kStarted,             // Running JxlDecoderProcessInput calls
@@ -2637,6 +2652,10 @@ JxlDecoderStatus JxlDecoderSetExtraChannelBuffer(JxlDecoder* dec,
 
   if (size < min_size) return JXL_DEC_ERROR;
 
+  JXL_API_RETURN_IF_ERROR(
+      VerifyOutputBitDepth(dec->image_out_bit_depth,
+                           dec->metadata.m.extra_channel_info[index], *format));
+
   if (dec->extra_channel_output.size() <= index) {
     dec->extra_channel_output.resize(dec->metadata.m.num_extra_channels,
                                      {{}, nullptr, 0});
@@ -2976,25 +2995,6 @@ JxlDecoderStatus JxlDecoderSetProgressiveDetail(JxlDecoder* dec,
   return JXL_DEC_SUCCESS;
 }
 
-namespace {
-
-template <typename T>
-JxlDecoderStatus VerifyOutputBitDepth(JxlBitDepth bit_depth, const T& metadata,
-                                      JxlPixelFormat format) {
-  uint32_t bits_per_sample = GetBitDepth(bit_depth, metadata, format);
-  if (bits_per_sample == 0) return JXL_API_ERROR("Invalid output bit depth");
-  if (format.data_type == JXL_TYPE_UINT8 && bits_per_sample > 8) {
-    return JXL_API_ERROR("Invalid bit depth %u for uint8 output",
-                         bits_per_sample);
-  } else if (format.data_type == JXL_TYPE_UINT16 && bits_per_sample > 16) {
-    return JXL_API_ERROR("Invalid bit depth %u for uint16 output",
-                         bits_per_sample);
-  }
-  return JXL_DEC_SUCCESS;
-}
-
-}  // namespace
-
 JxlDecoderStatus JxlDecoderSetImageOutBitDepth(JxlDecoder* dec,
                                                const JxlBitDepth* bit_depth) {
   if (!dec->image_out_buffer_set) {
@@ -3002,6 +3002,13 @@ JxlDecoderStatus JxlDecoderSetImageOutBitDepth(JxlDecoder* dec,
   }
   JXL_API_RETURN_IF_ERROR(
       VerifyOutputBitDepth(*bit_depth, dec->metadata.m, dec->image_out_format));
+  // Extra channel buffers may already be set; they use the same bit depth.
+  for (size_t i = 0; i < dec->extra_channel_output.size(); ++i) {
+    const auto& extra = dec->extra_channel_output[i];
+    if (extra.buffer == nullptr) continue;
+    JXL_API_RETURN_IF_ERROR(VerifyOutputBitDepth(
+        *bit_depth, dec->metadata.m.extra_channel_info[i], extra.format));
+  }
   dec->image_out_bit_depth = *bit_depth;
   return JXL_DEC_SUCCESS;
 }

--- a/lib/jxl/decode_test.cc
+++ b/lib/jxl/decode_test.cc
@@ -5765,6 +5765,116 @@ TEST(DecodeTest, SpotColorTest) {
   }
 }
 
+TEST(DecodeTest, ExtraChannelBitDepthTest) {
+  JxlMemoryManager* memory_manager = jxl::test::MemoryManager();
+  auto io = jxl::make_unique<jxl::CodecInOut>(memory_manager);
+  size_t xsize = 8;
+  size_t ysize = 8;
+  io->metadata.m.color_encoding = jxl::ColorEncoding::LinearSRGB();
+  JXL_TEST_ASSIGN_OR_DIE(Image3F main,
+                         Image3F::Create(memory_manager, xsize, ysize));
+  JXL_TEST_ASSIGN_OR_DIE(ImageF ec_image,
+                         ImageF::Create(memory_manager, xsize, ysize));
+  jxl::ZeroFillImage(&main);
+  jxl::ZeroFillImage(&ec_image);
+  ASSERT_TRUE(
+      io->SetFromImage(std::move(main), jxl::ColorEncoding::LinearSRGB()));
+
+  // A binary32 extra channel; its bit depth does not fit uint8 output.
+  jxl::ExtraChannelInfo info;
+  info.bit_depth.floating_point_sample = true;
+  info.bit_depth.bits_per_sample = 32;
+  info.bit_depth.exponent_bits_per_sample = 8;
+  info.dim_shift = 0;
+  info.type = jxl::ExtraChannel::kOptional;
+  io->metadata.m.extra_channel_info.push_back(info);
+  std::vector<ImageF> ec;
+  ec.push_back(std::move(ec_image));
+  ASSERT_TRUE(io->frames[0].SetExtraChannels(std::move(ec)));
+
+  jxl::CompressParams cparams;
+  cparams.speed_tier = jxl::SpeedTier::kLightning;
+  cparams.modular_mode = true;
+  cparams.color_transform = jxl::ColorTransform::kNone;
+  cparams.butteraugli_distance = 0.f;
+
+  std::vector<uint8_t> compressed;
+  EXPECT_TRUE(jxl::test::EncodeFile(cparams, io.get(), &compressed));
+
+  JxlPixelFormat format = {3, JXL_TYPE_UINT8, JXL_LITTLE_ENDIAN, 0};
+  JxlPixelFormat ec_format = {1, JXL_TYPE_UINT8, JXL_LITTLE_ENDIAN, 0};
+  JxlBitDepth from_codestream;
+  from_codestream.type = JXL_BIT_DEPTH_FROM_CODESTREAM;
+  JxlBitDepth from_format;
+  from_format.type = JXL_BIT_DEPTH_FROM_PIXEL_FORMAT;
+
+  // Set up a decoder up to the point where the output buffers are requested.
+  const auto init = [&](JxlDecoderPtr* dec, std::vector<uint8_t>* image,
+                        std::vector<uint8_t>* extra) {
+    *dec = JxlDecoderMake(nullptr);
+    EXPECT_EQ(JXL_DEC_SUCCESS,
+              JxlDecoderSubscribeEvents(
+                  dec->get(), JXL_DEC_BASIC_INFO | JXL_DEC_FULL_IMAGE));
+    EXPECT_EQ(JXL_DEC_SUCCESS, JxlDecoderSetInput(dec->get(), compressed.data(),
+                                                  compressed.size()));
+    EXPECT_EQ(JXL_DEC_BASIC_INFO, JxlDecoderProcessInput(dec->get()));
+    EXPECT_EQ(JXL_DEC_NEED_IMAGE_OUT_BUFFER,
+              JxlDecoderProcessInput(dec->get()));
+    size_t buffer_size;
+    size_t extra_size;
+    EXPECT_EQ(JXL_DEC_SUCCESS,
+              JxlDecoderImageOutBufferSize(dec->get(), &format, &buffer_size));
+    EXPECT_EQ(JXL_DEC_SUCCESS, JxlDecoderExtraChannelBufferSize(
+                                   dec->get(), &ec_format, &extra_size, 0));
+    image->resize(buffer_size);
+    extra->resize(extra_size);
+    EXPECT_EQ(JXL_DEC_SUCCESS,
+              JxlDecoderSetImageOutBuffer(dec->get(), &format, image->data(),
+                                          image->size()));
+  };
+
+  {
+    // The codestream bit depth (32) does not fit the uint8 extra channel
+    // buffer, so it must be rejected instead of reaching the output stage.
+    JxlDecoderPtr dec;
+    std::vector<uint8_t> image;
+    std::vector<uint8_t> extra;
+    init(&dec, &image, &extra);
+    EXPECT_EQ(JXL_DEC_SUCCESS,
+              JxlDecoderSetImageOutBitDepth(dec.get(), &from_codestream));
+    EXPECT_EQ(JXL_DEC_ERROR,
+              JxlDecoderSetExtraChannelBuffer(dec.get(), &ec_format,
+                                              extra.data(), extra.size(), 0));
+  }
+
+  {
+    // Same, with the bit depth requested after the extra channel buffer.
+    JxlDecoderPtr dec;
+    std::vector<uint8_t> image;
+    std::vector<uint8_t> extra;
+    init(&dec, &image, &extra);
+    EXPECT_EQ(JXL_DEC_SUCCESS,
+              JxlDecoderSetExtraChannelBuffer(dec.get(), &ec_format,
+                                              extra.data(), extra.size(), 0));
+    EXPECT_EQ(JXL_DEC_ERROR,
+              JxlDecoderSetImageOutBitDepth(dec.get(), &from_codestream));
+  }
+
+  {
+    // A bit depth that does fit the buffer decodes as before.
+    JxlDecoderPtr dec;
+    std::vector<uint8_t> image;
+    std::vector<uint8_t> extra;
+    init(&dec, &image, &extra);
+    EXPECT_EQ(JXL_DEC_SUCCESS,
+              JxlDecoderSetImageOutBitDepth(dec.get(), &from_format));
+    EXPECT_EQ(JXL_DEC_SUCCESS,
+              JxlDecoderSetExtraChannelBuffer(dec.get(), &ec_format,
+                                              extra.data(), extra.size(), 0));
+    EXPECT_EQ(JXL_DEC_FULL_IMAGE, JxlDecoderProcessInput(dec.get()));
+  }
+}
+
 TEST(DecodeTest, CloseInput) {
   std::vector<uint8_t> partial_file = {0xff};
 


### PR DESCRIPTION
### Description

`JxlDecoderSetExtraChannelBuffer` never checks the requested output bit depth against the buffer's pixel type, unlike the color path, which goes through `VerifyOutputBitDepth`. Under `JXL_BIT_DEPTH_FROM_CODESTREAM` (what `djxl` selects by default) a binary32 extra channel reports 32 bits, and that value reaches `StoreUnsignedRow`, where `(1u << out.bits_per_sample_) - 1` shifts a 32-bit unsigned by 32; UBSan reports `shift exponent 32 is too large for 32-bit type 'unsigned int'` at `stage_write.cc:551` when running `djxl` on a grayscale file carrying a float extra channel, and since the multiplier lands on 0 the extra channel is also written out as a PGM with `MAXVAL 0` that our own PNM decoder then rejects. The existing `VerifyOutputBitDepth` template moves up next to `GetBitDepth` and is now called from the extra channel setter, and `JxlDecoderSetImageOutBitDepth` re-checks extra channel outputs that are already registered so that either call order is covered; extra channels whose bit depth fits the output type decode exactly as before.

### Pull Request Checklist

- [x] **CLA Signed**: Have you signed the [Contributor License Agreement](https://code.google.com/legal/individual-cla-v1.0.html) (individual or corporate, as appropriate)? Only contributions from signed contributors can be accepted.
- [ ] **Authors**: Have you considered adding your name to the [AUTHORS](AUTHORS) file?
- [x] **Code Style**: Have you ensured your code adheres to the project's coding style guidelines? You can use `./ci.sh lint` for automatic code formatting.
