### PR TITLE
Reduce stack size by allocating allowed_counts on the heap during initialization.

### DIFF
--- a/lib/jxl/enc_ans.cc
+++ b/lib/jxl/enc_ans.cc
@@ -580,7 +580,7 @@ const AEH::Lg2LUT AEH::lg2 = [] {
 
 const AEH::AllowedCounts AEH::allowed_counts = [] {
   auto result = std::make_unique<AllowedCounts>();
-  
+
   for (uint32_t shift = 0; shift < result->array.size(); ++shift) {
     auto& ac = result->array[shift];
     auto& ai = result->index[shift];

--- a/lib/jxl/enc_ans.cc
+++ b/lib/jxl/enc_ans.cc
@@ -579,11 +579,11 @@ const AEH::Lg2LUT AEH::lg2 = [] {
 }();
 
 const AEH::AllowedCounts AEH::allowed_counts = [] {
-  AllowedCounts result;
-
-  for (uint32_t shift = 0; shift < result.array.size(); ++shift) {
-    auto& ac = result.array[shift];
-    auto& ai = result.index[shift];
+  auto result = std::make_unique<AllowedCounts>();
+  
+  for (uint32_t shift = 0; shift < result->array.size(); ++shift) {
+    auto& ac = result->array[shift];
+    auto& ai = result->index[shift];
     ANSHistBin last = ~0;
     size_t slot = 0;
     // TODO(eustas): are those "default" values relevant?
@@ -611,7 +611,7 @@ const AEH::AllowedCounts AEH::allowed_counts = [] {
     }
   }
 
-  return result;
+  return *result;
 }();
 
 }  // namespace


### PR DESCRIPTION
<!-- Thank you for considering a contribution to `libjxl`! -->

### Description

During static initialization of `AEH::allowed_counts` in `enc_ans.cc`, the local variable `AllowedCounts result` was allocated on the stack. Since `AllowedCounts` contains two `std::array<std::array<...>, 12>` members with a combined size of ~480KB, this caused a stack overflow on threads with a limited stack size.

The fix allocates result on the heap using `std::make_unique<AllowedCounts>()` inside the static initializer lambda. This moves the 480KB off the stack while preserving the original contiguous memory layout and `std::array` access patterns.

### Pull Request Checklist

- [x] **CLA Signed**: Have you signed the [Contributor License Agreement](https://code.google.com/legal/individual-cla-v1.0.html) (individual or corporate, as appropriate)? Only contributions from signed contributors can be accepted.
- [x] **Authors**: Have you considered adding your name to the [AUTHORS](AUTHORS) file?
- [x] **Code Style**: Have you ensured your code adheres to the project's coding style guidelines? You can use `./ci.sh lint` for automatic code formatting.


Please review the full [contributing guidelines](https://github.com/libjxl/libjxl/blob/main/CONTRIBUTING.md) for more details.
