### PR TITLE
add a note in BUILDING.md for users who have an error launching built executable

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -74,6 +74,13 @@ The encoder/decoder tools will be available in the `build/tools` directory.
 sudo cmake --install .
 ```
 
+### <a name="update_cache"></a> Update library cache
+
+If running a executable give you "error while loading shared libraries: libjxl_threads.so.0.12", update the library cache:
+
+```bash
+sudo ldconfig
+```
 
 ## Building JPEG XL for developers
 


### PR DESCRIPTION
### Description

I followed the building instructions in BUILDING.md.

I installed the binaries

When I tested to run "djxl", I got an error :
` error while loading shared libraries: libjxl_threads.so.0.12: cannot open shared object file: No such file or directory`

<img width="1289" height="400" alt="Capture d’écran du 2026-07-05 19-46-45" src="https://github.com/user-attachments/assets/a9b82783-11f4-48a3-ae68-614f8cf4145d" />

The command `sudo ldconfig` update the library cache. And you can see in my picture that it works

This commit adds a note in BUILDING.md for people who will encounter this error

### Pull Request Checklist

- [x] **CLA Signed**: Have you signed the [Contributor License Agreement](https://code.google.com/legal/individual-cla-v1.0.html) (individual or corporate, as appropriate)? Only contributions from signed contributors can be accepted.
- [x] **Authors**: Have you considered adding your name to the [AUTHORS](AUTHORS) file?
- [x] **Code Style**: Have you ensured your code adheres to the project's coding style guidelines? You can use `./ci.sh lint` for automatic code formatting. -> not necessary, this commit only change BUILDING.md