### PR TITLE
Limit learned MA trees to decoder bounds

### DIFF
--- a/lib/jxl/dec_modular.cc
+++ b/lib/jxl/dec_modular.cc
@@ -29,6 +29,7 @@
 #include "lib/jxl/image_ops.h"
 #include "lib/jxl/loop_filter.h"
 #include "lib/jxl/modular/encoding/dec_ma.h"
+#include "lib/jxl/modular/encoding/ma_common.h"
 #include "lib/jxl/modular/options.h"
 #include "lib/jxl/quant_weights.h"
 #include "lib/jxl/quantizer.h"
@@ -223,10 +224,8 @@ Status ModularFrameDecoder::DecodeGlobalInfo(BitReader* reader,
   if (!allow_truncated_group ||
       reader->TotalBitsConsumed() < reader->TotalBytes() * kBitsPerByte) {
     if (has_tree) {
-      size_t tree_size_limit =
-          std::min(static_cast<size_t>(1 << 22),
-                   1024 + frame_dim.xsize * frame_dim.ysize *
-                              (nb_chans + nb_extra) / 16);
+      size_t tree_size_limit = MaxGlobalTreeSize(
+          frame_dim.xsize, frame_dim.ysize, nb_chans + nb_extra);
       JXL_RETURN_IF_ERROR(
           DecodeTree(memory_manager, reader, &tree, tree_size_limit));
       JXL_RETURN_IF_ERROR(DecodeHistograms(

--- a/lib/jxl/enc_modular.cc
+++ b/lib/jxl/enc_modular.cc
@@ -463,6 +463,15 @@ Status ModularFrameEncoder::Init(const FrameHeader& frame_header,
                                  bool streaming_mode) {
   frame_dim_ = frame_header.ToFrameDimensions();
   cparams_ = cparams_orig;
+  const auto& metadata = frame_header.nonserialized_metadata->m;
+  size_t num_channels = 3;
+  if (metadata.color_encoding.IsGray() &&
+      frame_header.color_transform == ColorTransform::kNone) {
+    num_channels = 1;
+  }
+  max_tree_size_ =
+      MaxGlobalTreeSize(frame_dim_.xsize, frame_dim_.ysize,
+                        num_channels + metadata.extra_channel_info.size());
 
   size_t num_streams =
       ModularStreamId::Num(frame_dim_, frame_header.passes.num_passes);
@@ -1202,7 +1211,7 @@ Status ModularFrameEncoder::ComputeTree(ThreadPool* pool) {
         JXL_ASSIGN_OR_RETURN(
             trees[chunk],
             LearnTree(stream_images_.data(), stream_options_.data(), start,
-                      stop, multiplier_info));
+                      stop, multiplier_info, max_tree_size_));
       } else {
         size_t total_pixels = 0;
         for (size_t i = start; i < stop; i++) {
@@ -1244,6 +1253,7 @@ Status ModularFrameEncoder::ComputeTree(ThreadPool* pool) {
       tree_ = {PropertyDecisionNode::Leaf(Predictor::Gradient)};
     }
   }
+  JXL_ENSURE(tree_.size() <= max_tree_size_);
   tree_tokens_.resize(1);
   tree_tokens_[0].clear();
   Tree decoded_tree;

--- a/lib/jxl/enc_modular.h
+++ b/lib/jxl/enc_modular.h
@@ -29,6 +29,7 @@
 #include "lib/jxl/image_metadata.h"
 #include "lib/jxl/modular/encoding/dec_ma.h"
 #include "lib/jxl/modular/encoding/encoding.h"
+#include "lib/jxl/modular/encoding/ma_common.h"
 #include "lib/jxl/modular/modular_image.h"
 #include "lib/jxl/modular/options.h"
 #include "lib/jxl/quant_weights.h"
@@ -116,6 +117,7 @@ class ModularFrameEncoder {
   EntropyEncodingData code_;
   std::vector<uint8_t> context_map_;
   FrameDimensions frame_dim_;
+  size_t max_tree_size_ = kMaxTreeSize;
   CompressParams cparams_;
   std::vector<size_t> tree_splits_;
   std::vector<std::vector<uint32_t>> gi_channel_;

--- a/lib/jxl/modular/encoding/enc_encoding.cc
+++ b/lib/jxl/modular/encoding/enc_encoding.cc
@@ -210,7 +210,8 @@ StatusOr<Tree> LearnTree(
     TreeSamples &&tree_samples, size_t total_pixels,
     const ModularOptions &options,
     const std::vector<ModularMultiplierInfo> &multiplier_info = {},
-    StaticPropRange static_prop_range = {}) {
+    StaticPropRange static_prop_range = {},
+    size_t max_tree_size = kMaxTreeSize) {
   Tree tree;
   for (size_t i = 0; i < kNumStaticProperties; i++) {
     if (static_prop_range[i][1] == 0) {
@@ -231,7 +232,7 @@ StatusOr<Tree> LearnTree(
   JXL_RETURN_IF_ERROR(ComputeBestTree(
       tree_samples, options.splitting_heuristics_node_threshold * required_cost,
       multiplier_info, static_prop_range, options.fast_decode_multiplier,
-      &tree));
+      max_tree_size, &tree));
   return tree;
 }
 
@@ -570,7 +571,8 @@ Tree PredefinedTree(ModularOptions::TreeKind tree_kind, size_t total_pixels,
 StatusOr<Tree> LearnTree(
     const Image *images, const ModularOptions *options, const uint32_t start,
     const uint32_t stop,
-    const std::vector<ModularMultiplierInfo> &multiplier_info = {}) {
+    const std::vector<ModularMultiplierInfo> &multiplier_info,
+    size_t max_tree_size) {
   TreeSamples tree_samples;
   JXL_RETURN_IF_ERROR(tree_samples.SetPredictor(options[start].predictor,
                                                 options[start].wp_tree_mode));
@@ -642,9 +644,10 @@ StatusOr<Tree> LearnTree(
   }
 
   // TODO(veluca): parallelize more.
-  JXL_ASSIGN_OR_RETURN(Tree tree,
-                       LearnTree(std::move(tree_samples), total_pixels,
-                                 options[start], multiplier_info, range));
+  JXL_ASSIGN_OR_RETURN(
+      Tree tree,
+      LearnTree(std::move(tree_samples), total_pixels, options[start],
+                multiplier_info, range, max_tree_size));
   return tree;
 }
 
@@ -744,7 +747,8 @@ Status ModularGenericCompress(const Image &image, const ModularOptions &opts,
   // Compute tree.
   Tree tree;
   if (options.tree_kind == ModularOptions::TreeKind::kLearn) {
-    JXL_ASSIGN_OR_RETURN(tree, LearnTree(&image, &options, 0, 1));
+    JXL_ASSIGN_OR_RETURN(tree,
+                         LearnTree(&image, &options, 0, 1, {}, kMaxTreeSize));
   } else {
     size_t total_pixels = 0;
     for (size_t i = 0; i < nb_channels; i++) {

--- a/lib/jxl/modular/encoding/enc_encoding.h
+++ b/lib/jxl/modular/encoding/enc_encoding.h
@@ -14,6 +14,7 @@
 #include "lib/jxl/enc_ans.h"
 #include "lib/jxl/enc_bit_writer.h"
 #include "lib/jxl/modular/encoding/dec_ma.h"
+#include "lib/jxl/modular/encoding/ma_common.h"
 #include "lib/jxl/modular/modular_image.h"
 #include "lib/jxl/modular/options.h"
 
@@ -29,7 +30,8 @@ Tree PredefinedTree(ModularOptions::TreeKind tree_kind, size_t total_pixels,
 StatusOr<Tree> LearnTree(
     const Image *images, const ModularOptions *opts, uint32_t start,
     uint32_t stop,
-    const std::vector<ModularMultiplierInfo> &multiplier_info = {});
+    const std::vector<ModularMultiplierInfo> &multiplier_info = {},
+    size_t max_tree_size = kMaxTreeSize);
 
 // Default single-image compress.
 Status ModularGenericCompress(const Image &image, const ModularOptions &opts,

--- a/lib/jxl/modular/encoding/enc_ma.cc
+++ b/lib/jxl/modular/encoding/enc_ma.cc
@@ -167,7 +167,8 @@ void CollectExtraBitsIncrease(TreeSamples &tree_samples,
 void FindBestSplit(TreeSamples &tree_samples, float threshold,
                    const std::vector<ModularMultiplierInfo> &mul_info,
                    StaticPropRange initial_static_prop_range,
-                   float fast_decode_multiplier, Tree *tree) {
+                   float fast_decode_multiplier, size_t max_tree_size,
+                   Tree *tree) {
   struct NodeInfo {
     size_t pos;
     size_t begin;
@@ -464,7 +465,8 @@ void FindBestSplit(TreeSamples &tree_samples, float threshold,
       }
     }
 
-    if (best->Cost() + threshold < base_bits) {
+    if (best->Cost() + threshold < base_bits &&
+        tree->size() + 2 <= max_tree_size) {
       uint32_t p = tree_samples.PropertyFromIndex(best->prop);
       pixel_type dequant =
           tree_samples.UnquantizeProperty(best->prop, best->val);
@@ -512,7 +514,9 @@ HWY_EXPORT(FindBestSplit);  // Local function.
 Status ComputeBestTree(TreeSamples &tree_samples, float threshold,
                        const std::vector<ModularMultiplierInfo> &mul_info,
                        StaticPropRange static_prop_range,
-                       float fast_decode_multiplier, Tree *tree) {
+                       float fast_decode_multiplier, size_t max_tree_size,
+                       Tree *tree) {
+  JXL_ENSURE(max_tree_size >= 1);
   // TODO(veluca): take into account that different contexts can have different
   // uint configs.
   //
@@ -528,7 +532,7 @@ Status ComputeBestTree(TreeSamples &tree_samples, float threshold,
              std::numeric_limits<uint32_t>::max());
   HWY_DYNAMIC_DISPATCH(FindBestSplit)
   (tree_samples, threshold, mul_info, static_prop_range, fast_decode_multiplier,
-   tree);
+   max_tree_size, tree);
   return true;
 }
 

--- a/lib/jxl/modular/encoding/enc_ma.h
+++ b/lib/jxl/modular/encoding/enc_ma.h
@@ -176,7 +176,8 @@ void CollectPixelSamples(const Image &image, const ModularOptions &options,
 Status ComputeBestTree(TreeSamples &tree_samples, float threshold,
                        const std::vector<ModularMultiplierInfo> &mul_info,
                        StaticPropRange static_prop_range,
-                       float fast_decode_multiplier, Tree *tree);
+                       float fast_decode_multiplier, size_t max_tree_size,
+                       Tree *tree);
 
 }  // namespace jxl
 #endif  // LIB_JXL_MODULAR_ENCODING_ENC_MA_H_

--- a/lib/jxl/modular/encoding/ma_common.h
+++ b/lib/jxl/modular/encoding/ma_common.h
@@ -23,6 +23,20 @@ enum MATreeContext : size_t {
 
 static constexpr size_t kMaxTreeSize = 1 << 22;
 
+inline constexpr size_t MaxGlobalTreeSize(size_t xsize, size_t ysize,
+                                          size_t num_channels) {
+  constexpr size_t kBaseTreeSize = 1024;
+  constexpr size_t kScaledSizeLimit = (kMaxTreeSize - kBaseTreeSize) * 16;
+  if (xsize != 0 && ysize > kScaledSizeLimit / xsize) {
+    return kMaxTreeSize;
+  }
+  const size_t num_pixels = xsize * ysize;
+  if (num_channels != 0 && num_pixels > kScaledSizeLimit / num_channels) {
+    return kMaxTreeSize;
+  }
+  return kBaseTreeSize + num_pixels * num_channels / 16;
+}
+
 }  // namespace jxl
 
 #endif  // LIB_JXL_MODULAR_ENCODING_MA_COMMON_H_

--- a/lib/jxl/modular_test.cc
+++ b/lib/jxl/modular_test.cc
@@ -338,6 +338,38 @@ TEST(ModularTest, RoundtripExtraProperties) {
   }
 }
 
+TEST(ModularTest, LearnedTreeFitsGlobalDecoderLimit) {
+  JxlMemoryManager* memory_manager = jxl::test::MemoryManager();
+  constexpr size_t kSize = 64;
+  constexpr size_t kNumChannels = 3;
+  JXL_TEST_ASSIGN_OR_DIE(
+      Image image, Image::Create(memory_manager, kSize, kSize, /*bitdepth=*/8,
+                                 kNumChannels));
+  Rng rng(0);
+  for (Channel& channel : image.channel) {
+    for (size_t y = 0; y < kSize; ++y) {
+      pixel_type* row = channel.plane.Row(y);
+      for (size_t x = 0; x < kSize; ++x) {
+        row[x] = rng.UniformU(0, 256);
+      }
+    }
+  }
+
+  ModularOptions options;
+  options.predictor = Predictor::Zero;
+  options.nb_repeats = 1.0f;
+  options.splitting_heuristics_node_threshold = 0.0f;
+  options.max_property_values = 256;
+  constexpr size_t kGlobalTreeSizeLimit =
+      MaxGlobalTreeSize(kSize, kSize, kNumChannels);
+  JXL_TEST_ASSIGN_OR_DIE(
+      Tree tree, LearnTree(&image, &options, /*start=*/0, /*stop=*/1,
+                           /*multiplier_info=*/{}, kGlobalTreeSizeLimit));
+
+  EXPECT_LE(tree.size(), kGlobalTreeSizeLimit)
+      << "encoder learned a global MA tree that its decoder rejects";
+}
+
 struct RoundtripLosslessConfig {
   int bitdepth;
   int responsive;


### PR DESCRIPTION
### Description

Global modular MA trees were only capped by the absolute `kMaxTreeSize`, while decoders also enforce a dimension-derived limit. This allowed `cjxl` to emit a bitstream that the same revision of `djxl` rejected.

This change:

- shares an overflow-safe global tree limit calculation between encoder and decoder;
- passes that limit into MA-tree learning and stops adding splits at the bound;
- verifies the final frame tree before tokenization; and
- adds a deterministic regression test that learned 17099 nodes against a 1792-node decoder limit before the fix.

Fixes #4600.

Testing:

- `build-4600/lib/tests/modular_test`: 79/79 passed
- `./ci.sh lint 18`: passed
- exact issue input and flags: `cjxl` output decodes successfully, and source/decoded frame MD5 values match

### Pull Request Checklist

- [ ] **CLA Signed**: Contributor has not accepted the CLA in this PR workflow.
- [x] **Authors**: Considered; no AUTHORS change included.
- [x] **Code Style**: `./ci.sh lint 18` passes.
