### PR TITLE
Tune LZ77 cost comparison and match evaluation

### DIFF
--- a/lib/jxl/enc_ans.cc
+++ b/lib/jxl/enc_ans.cc
@@ -1355,7 +1355,7 @@ HistogramParams HistogramParams::ForModular(
             : HistogramParams::ANSHistogramStrategy::kApproximate;
     params.lz77_method =
         cparams.modular_mode && cparams.speed_tier <= SpeedTier::kHare
-            ? HistogramParams::LZ77Method::kRLE
+            ? HistogramParams::LZ77Method::kLZ77b3w3f
             : HistogramParams::LZ77Method::kNone;
     // Near-lossless DC, as well as modular mode, require choosing hybrid uint
     // more carefully.
@@ -1368,7 +1368,7 @@ HistogramParams HistogramParams::ForModular(
   } else if (cparams.speed_tier <= SpeedTier::kTortoise) {
     params.lz77_method = HistogramParams::LZ77Method::kOptc256;
   } else {
-    params.lz77_method = HistogramParams::LZ77Method::kLZ77b3w3f;
+    params.lz77_method = HistogramParams::LZ77Method::kLZ77b7w3t;
   }
   if (cparams.decoding_speed_tier >= 2) {
     params.max_histograms = 12;

--- a/lib/jxl/enc_lz77.cc
+++ b/lib/jxl/enc_lz77.cc
@@ -607,7 +607,7 @@ std::vector<std::vector<Token>> ApplyLZ77_LZ77(
       if (kRuntimeCostComparison && lz77_cost > cost) {
         // If literal cost is very low (e.g. solid colors), skip the entire match
         // to avoid O(n^2) behavior.
-		if (cost < len) {
+		if (cost < 0.25f * len) {
           for (size_t offset = 1; offset < len; offset++) {
             out.push_back(in[pos+offset]);
             hash_map.Update(pos + offset);

--- a/lib/jxl/enc_lz77.cc
+++ b/lib/jxl/enc_lz77.cc
@@ -638,7 +638,7 @@ std::vector<std::vector<Token>> ApplyLZ77_Optimal(
     const HistogramParams& params, size_t num_contexts,
     const std::vector<std::vector<Token>>& tokens, const LZ77Params& lz77) {
   std::vector<std::vector<Token>> tokens_for_cost_estimate =
-      ApplyLZ77_LZ77(params, num_contexts, tokens, lz77);
+      ApplyLZ77_LZ77<7, 3, true>(params, num_contexts, tokens, lz77);
   // If greedy-LZ77 does not give better compression than no-lz77, no reason to
   // run the optimal matching.
   if (tokens_for_cost_estimate.empty()) return {};

--- a/lib/jxl/enc_lz77.cc
+++ b/lib/jxl/enc_lz77.cc
@@ -605,6 +605,15 @@ std::vector<std::vector<Token>> ApplyLZ77_LZ77(
 						sce.AddSymbolCost(out.back().context);
 
       if (kRuntimeCostComparison && lz77_cost > cost) {
+        // If literal cost is very low (e.g. solid colors), skip the entire match
+        // to avoid O(n^2) behavior.
+		if (cost < len) {
+          for (size_t offset = 1; offset < len; offset++) {
+            out.push_back(in[pos+offset]);
+            hash_map.Update(pos + offset);
+          }
+          pos += len - 1;
+        }
         continue;
       }
 

--- a/lib/jxl/enc_lz77.cc
+++ b/lib/jxl/enc_lz77.cc
@@ -601,19 +601,15 @@ std::vector<std::vector<Token>> ApplyLZ77_LZ77(
       // Bit cost comparison: raw tokens vs LZ77 pair
       float cost = sym_cost[pos + len] - sym_cost[pos];
       size_t lz77_len = len - lz77.min_length;
-      float lz77_cost = LenCost(lz77_len) + DistCost(dist_symbol);
+      float lz77_cost = LenCost(lz77_len) + DistCost(dist_symbol) +
+						sce.AddSymbolCost(out.back().context);
 
       if (kRuntimeCostComparison && lz77_cost > cost) {
-        for (size_t offset = 1; offset < len; offset++) {
-          out.push_back(in[pos+offset]);
-          hash_map.Update(pos + offset);
-        }
-        pos += len - 1;
         continue;
       }
 
 
-      bit_decrease += cost - lz77_cost - sce.AddSymbolCost(out.back().context);
+      bit_decrease += cost - lz77_cost;
 
       // Emit LZ77 length and distance tokens
       out.back().value = len - min_length;


### PR DESCRIPTION
In the recent LZ77 rewrite there was a mention that the `t` modes compress worse than `f` modes, in my testing I can confirm their findings. This PR fixes a couple bugs which seems to fix this issue. (I haven't tested on a wide range of images yet)

1. Context cost missing in comparison: `AddSymbolCost` was left out when checking `lz77_cost > cost`, but was subtracted from `bit_decrease` later. Because `lz77_cost` was underestimated during the decision check, it ended up accepting matches that were actually worse for compression than keeping raw literals.

2. Skipping ahead on match rejection: When `kRuntimeCostComparison` rejected a match of length `len` at position `pos`, it was emitting `len - 1` literals and jumping `pos` forward by `len - 1`. Skipping over those intermediate positions meant we missed any potential matches starting at `pos + 1`, `pos + 2`, etc. 

Fixing `lz77_cost` to include `AddSymbolCost` up front and letting the loop naturally advance to `pos + 1` on rejection resolves both regressions.

A quick benchmark:
```
-d 0 -e 7 -g 3 -P 0 -I 0
kLZ77b3w3f
Compressed to 485.4 kB (1.873 bpp).

kLZ77b3w3t Main
Compressed to 487.4 kB (1.881 bpp). +2 kB

kLZ77b3w3t Post PR
Compressed to 482.6 kB (1.862 bpp). -2.8 kB
```