### PR TITLE
Re-enable squeezed delta palette

### DIFF
--- a/lib/jxl/enc_modular.cc
+++ b/lib/jxl/enc_modular.cc
@@ -893,8 +893,10 @@ Status ModularFrameEncoder::ComputeEncodingData(
        (do_color && metadata.bit_depth.bits_per_sample > 8))) {
     channel_colors_percent = cparams_.channel_colors_pre_transform_percent;
   }
-  if (!groupwise &&
-     (!(cparams_.responsive && cparams_.ModularPartIsLossless()))) {
+    // Global palette causes bad progressive loading due to interpolation
+    // but lossy palette is still required for JXL art.
+  if (!groupwise && (cparams.lossy_palette ||
+      !(cparams_.responsive && cparams_.ModularPartIsLossless()))) {
     JXL_RETURN_IF_ERROR(try_palettes(gi, max_bitdepth, maxval, cparams_,
                                      channel_colors_percent, pool));
   }

--- a/lib/jxl/enc_modular.cc
+++ b/lib/jxl/enc_modular.cc
@@ -895,7 +895,7 @@ Status ModularFrameEncoder::ComputeEncodingData(
   }
     // Global palette causes bad progressive loading due to interpolation
     // but lossy palette is still required for JXL art.
-  if (!groupwise && (cparams.lossy_palette ||
+  if (!groupwise && (cparams_.lossy_palette ||
       !(cparams_.responsive && cparams_.ModularPartIsLossless()))) {
     JXL_RETURN_IF_ERROR(try_palettes(gi, max_bitdepth, maxval, cparams_,
                                      channel_colors_percent, pool));


### PR DESCRIPTION
Previously I disabled global palette when squeeze is enabled, to avoid buggy progressive previews.
This unintentionally caused a regression in `jxl_from_tree`, breaking JXL art that utilizes squeezed delta palette, due to skipping the palette. This PR re-enables it.