### PR TITLE
Fix JPEG reconstruction when LF smoothing is enabled

### DIFF
--- a/lib/jxl/dec_frame.cc
+++ b/lib/jxl/dec_frame.cc
@@ -347,7 +347,9 @@ Status FrameDecoder::FinalizeDC() {
   JxlMemoryManager* memory_manager = dec_state_->memory_manager();
   if (frame_header_.encoding == FrameEncoding::kVarDCT &&
       !(frame_header_.flags & FrameHeader::kSkipAdaptiveDCSmoothing) &&
-      !(frame_header_.flags & FrameHeader::kUseDcFrame)) {
+      !(frame_header_.flags & FrameHeader::kUseDcFrame) &&
+      // Skip smoothing when reconstructing to JPEG.
+      !decoded_->IsJPEG()) {
     JXL_RETURN_IF_ERROR(AdaptiveDCSmoothing(
         memory_manager, dec_state_->shared->quantizer.MulDC(),
         &dec_state_->shared_storage.dc_storage, pool_));


### PR DESCRIPTION
When LF smoothing is enabled during transcoding, reconstruction wouldn't be identical due to DC coefficients being smoothed.

Doesn't affect any existing files.