### PR TITLE
Enable LF smoothing for 444 JPEG transcoding by default and allow decoding subsampled smoothing

### DIFF
--- a/lib/include/jxl/encode.h
+++ b/lib/include/jxl/encode.h
@@ -417,6 +417,11 @@ typedef enum {
    */
   JXL_ENC_FRAME_SETTING_OUTPUT_MODE = 40,
 
+  /** Enable or disable LF Smoothing for lossless JPEG recompression.
+   * -1 = default, 0 = disable smoothing, 1 = enable smoothing.
+   */
+  JXL_ENC_FRAME_SETTING_JPEG_RECON_LFS = 41,
+
   /** Enum value not to be used as an option. This value is added to force the
    * C compiler to have the enum to take a known size.
    */

--- a/lib/jxl/dec_frame.cc
+++ b/lib/jxl/dec_frame.cc
@@ -202,14 +202,6 @@ Status FrameDecoder::InitFrame(BitReader* JXL_RESTRICT br, ImageBundle* decoded,
   if (group_codes_begin + section_sizes_sum_ < group_codes_begin) {
     return JXL_FAILURE("Invalid group codes");
   }
-
-  if (!frame_header_.chroma_subsampling.Is444() &&
-      !(frame_header_.flags & FrameHeader::kSkipAdaptiveDCSmoothing) &&
-      frame_header_.encoding == FrameEncoding::kVarDCT) {
-    return JXL_FAILURE(
-        "Non-444 chroma subsampling is not allowed when adaptive DC "
-        "smoothing is enabled");
-  }
   return true;
 }
 
@@ -347,7 +339,9 @@ Status FrameDecoder::FinalizeDC() {
   JxlMemoryManager* memory_manager = dec_state_->memory_manager();
   if (frame_header_.encoding == FrameEncoding::kVarDCT &&
       !(frame_header_.flags & FrameHeader::kSkipAdaptiveDCSmoothing) &&
-      !(frame_header_.flags & FrameHeader::kUseDcFrame)) {
+      !(frame_header_.flags & FrameHeader::kUseDcFrame) &&
+      // Skip smoothing when reconstructing to JPEG.
+      !decoded_->IsJPEG()) {
     JXL_RETURN_IF_ERROR(AdaptiveDCSmoothing(
         memory_manager, dec_state_->shared->quantizer.MulDC(),
         &dec_state_->shared_storage.dc_storage, pool_));

--- a/lib/jxl/dec_frame.cc
+++ b/lib/jxl/dec_frame.cc
@@ -339,9 +339,7 @@ Status FrameDecoder::FinalizeDC() {
   JxlMemoryManager* memory_manager = dec_state_->memory_manager();
   if (frame_header_.encoding == FrameEncoding::kVarDCT &&
       !(frame_header_.flags & FrameHeader::kSkipAdaptiveDCSmoothing) &&
-      !(frame_header_.flags & FrameHeader::kUseDcFrame) &&
-      // Skip smoothing when reconstructing to JPEG.
-      !decoded_->IsJPEG()) {
+      !(frame_header_.flags & FrameHeader::kUseDcFrame)) {
     JXL_RETURN_IF_ERROR(AdaptiveDCSmoothing(
         memory_manager, dec_state_->shared->quantizer.MulDC(),
         &dec_state_->shared_storage.dc_storage, pool_));

--- a/lib/jxl/dec_frame.cc
+++ b/lib/jxl/dec_frame.cc
@@ -339,7 +339,9 @@ Status FrameDecoder::FinalizeDC() {
   JxlMemoryManager* memory_manager = dec_state_->memory_manager();
   if (frame_header_.encoding == FrameEncoding::kVarDCT &&
       !(frame_header_.flags & FrameHeader::kSkipAdaptiveDCSmoothing) &&
-      !(frame_header_.flags & FrameHeader::kUseDcFrame)) {
+      !(frame_header_.flags & FrameHeader::kUseDcFrame) &&
+      // Skip smoothing when reconstructing to JPEG.
+      !decoded_->IsJPEG()) {
     JXL_RETURN_IF_ERROR(AdaptiveDCSmoothing(
         memory_manager, dec_state_->shared->quantizer.MulDC(),
         &dec_state_->shared_storage.dc_storage, pool_));

--- a/lib/jxl/enc_frame.cc
+++ b/lib/jxl/enc_frame.cc
@@ -510,7 +510,6 @@ Status MakeFrameHeader(size_t xsize, size_t ysize,
 
   if (jpeg_data) {
     frame_header->UpdateFlag(false, FrameHeader::kUseDcFrame);
-    frame_header->UpdateFlag(true, FrameHeader::kSkipAdaptiveDCSmoothing);
   }
 
   return true;

--- a/lib/jxl/enc_frame.cc
+++ b/lib/jxl/enc_frame.cc
@@ -510,6 +510,9 @@ Status MakeFrameHeader(size_t xsize, size_t ysize,
 
   if (jpeg_data) {
     frame_header->UpdateFlag(false, FrameHeader::kUseDcFrame);
+    if (!cparams.force_lfs_jpeg_recompression) {
+      frame_header->UpdateFlag(true, FrameHeader::kSkipAdaptiveDCSmoothing);
+    }
   }
 
   return true;

--- a/lib/jxl/enc_params.h
+++ b/lib/jxl/enc_params.h
@@ -93,6 +93,8 @@ struct CompressParams {
   // effects on the decoded pixels, while still being JPEG-compliant and
   // allowing reconstruction of the original JPEG.
   bool force_cfl_jpeg_recompression = true;
+  // Apply LF Smoothing when doing JPEG recompression. Same applies as above.
+  bool force_lfs_jpeg_recompression = false;
 
   // Use brotli compression for any boxes derived from a JPEG frame.
   bool jpeg_compress_boxes = true;

--- a/lib/jxl/encode.cc
+++ b/lib/jxl/encode.cc
@@ -1651,6 +1651,7 @@ JxlEncoderStatus JxlEncoderFrameSettingsSetOption(
     case JXL_ENC_FRAME_SETTING_QPROGRESSIVE_AC:
     case JXL_ENC_FRAME_SETTING_LOSSY_PALETTE:
     case JXL_ENC_FRAME_SETTING_JPEG_RECON_CFL:
+    case JXL_ENC_FRAME_SETTING_JPEG_RECON_LFS:
     case JXL_ENC_FRAME_SETTING_JPEG_COMPRESS_BOXES:
     case JXL_ENC_FRAME_SETTING_JPEG_KEEP_EXIF:
     case JXL_ENC_FRAME_SETTING_JPEG_KEEP_XMP:
@@ -1920,6 +1921,10 @@ JxlEncoderStatus JxlEncoderFrameSettingsSetOption(
                              "Output mode has to be in [-1..2]");
       }
       frame_settings->values.cparams.output_mode = value;
+      break;
+    case JXL_ENC_FRAME_SETTING_JPEG_RECON_LFS:
+      frame_settings->values.cparams.force_lfs_jpeg_recompression =
+          default_to_false(value);
       break;
 
     default:

--- a/tools/cjxl_main.cc
+++ b/tools/cjxl_main.cc
@@ -355,6 +355,13 @@ struct CompressArgs {
         "    0 = disable. 1 = enable.",
         &jpeg_reconstruction_cfl, &ParseOverride, 3);
 
+    cmdline->AddOptionValue(
+        '\0', "jpeg_reconstruction_lfs", "0|1",
+        "Disable/enable LF Smoothing for lossless "
+        "JPEG reconstruction.\n"
+        "    0 = disable. 1 = enable.",
+        &jpeg_reconstruction_lfs, &ParseOverride, 3);
+
     cmdline->AddOptionValue('\0', "num_reps", "REPS",
                             "How many times to compress, for benchmarking.",
                             &num_reps, &ParseUnsigned, 3);
@@ -527,6 +534,7 @@ struct CompressArgs {
   int32_t premultiply = -1;
   bool already_downsampled = false;
   jxl::Override jpeg_reconstruction_cfl = jxl::Override::kDefault;
+  jxl::Override jpeg_reconstruction_lfs = jxl::Override::kDefault;
   jxl::Override modular = jxl::Override::kDefault;
   jxl::Override keep_invisible = jxl::Override::kDefault;
   jxl::Override dots = jxl::Override::kDefault;
@@ -907,6 +915,8 @@ void ProcessFlags(const jxl::extras::Codec codec,
   if (jpeg_bytes) {
     ProcessBoolFlag(args->jpeg_reconstruction_cfl,
                     JXL_ENC_FRAME_SETTING_JPEG_RECON_CFL, params);
+    ProcessBoolFlag(args->jpeg_reconstruction_lfs,
+                    JXL_ENC_FRAME_SETTING_JPEG_RECON_LFS, params);
     ProcessBoolFlag(args->compress_boxes,
                     JXL_ENC_FRAME_SETTING_JPEG_COMPRESS_BOXES, params);
   }


### PR DESCRIPTION
Significantly improves banding for low quality JPEGs while reducing filesize by ~1 byte. Requires #4931.
While 444 smoothing is allowed, subsampled smoothing requires a clarification/change to the spec, so only 444 is smoothed by default until applications have been given time to update. jxl-rs and jxl-oxide already support it.

<img width="320" height="320" alt="image" src="https://github.com/user-attachments/assets/34c84b1a-9bb7-46ba-8a63-813c3e02b5f6" />
<img width="320" height="320" alt="image" src="https://github.com/user-attachments/assets/a528b16a-d0fe-465a-a291-b971a637e71a" />
