### PR TITLE
decode: stop decoding after mixed image-output API misuse

### DIFF
--- a/lib/jxl/decode.cc
+++ b/lib/jxl/decode.cc
@@ -2585,6 +2585,12 @@ JxlDecoderStatus JxlDecoderSetImageOutBuffer(JxlDecoder* dec,
     return JXL_API_ERROR("No image out buffer needed at this time");
   }
   if (dec->image_out_buffer_set && !!dec->image_out_run_callback) {
+    // Mixing the callback and buffer output APIs is a programming error rather
+    // than a recoverable input condition: the caller may hold an incorrect
+    // belief about which output sink is installed. Per issue #4670, latch
+    // kError so no further decoding happens and the mistake surfaces at its
+    // origin. JxlDecoderReset returns the decoder to a usable state.
+    dec->stage = DecoderStage::kError;
     return JXL_API_ERROR(
         "Cannot change from image out callback to image out buffer");
   }
@@ -2682,6 +2688,10 @@ JxlDecoderStatus JxlDecoderSetMultithreadedImageOutCallback(
     JxlImageOutInitCallback init_callback, JxlImageOutRunCallback run_callback,
     JxlImageOutDestroyCallback destroy_callback, void* init_opaque) {
   if (dec->image_out_buffer_set && !!dec->image_out_buffer) {
+    // See JxlDecoderSetImageOutBuffer: mixing the two output APIs is a
+    // programming error, so latch kError rather than continuing to decode after
+    // a call the caller may believe succeeded.
+    dec->stage = DecoderStage::kError;
     return JXL_API_ERROR(
         "Cannot change from image out buffer to image out callback");
   }

--- a/lib/jxl/decode_test.cc
+++ b/lib/jxl/decode_test.cc
@@ -5779,3 +5779,123 @@ TEST(DecodeTest, CloseInput) {
   JxlDecoderCloseInput(dec.get());
   EXPECT_EQ(JXL_DEC_ERROR, JxlDecoderProcessInput(dec.get()));
 }
+
+// Issue #4670: the decoder should switch to an unrecoverable state when the
+// caller makes an invalid API call, so that a programming error surfaces at its
+// origin instead of producing unexpected output later. The canonical example
+// from the issue is setting the image-out callback after the image-out buffer.
+namespace {
+
+// Drives a fresh decoder to JXL_DEC_NEED_IMAGE_OUT_BUFFER and installs an
+// image-out buffer, i.e. the last valid state before the misuse under test.
+void SetUpDecoderWithImageOutBuffer(JxlDecoder* dec,
+                                    const std::vector<uint8_t>& data,
+                                    const JxlPixelFormat& format,
+                                    std::vector<uint8_t>* out) {
+  ASSERT_EQ(JXL_DEC_SUCCESS, JxlDecoderSubscribeEvents(
+                                 dec, JXL_DEC_BASIC_INFO | JXL_DEC_FULL_IMAGE));
+  ASSERT_EQ(JXL_DEC_SUCCESS, JxlDecoderSetInput(dec, data.data(), data.size()));
+  ASSERT_EQ(JXL_DEC_BASIC_INFO, JxlDecoderProcessInput(dec));
+  ASSERT_EQ(JXL_DEC_NEED_IMAGE_OUT_BUFFER, JxlDecoderProcessInput(dec));
+  size_t buffer_size;
+  ASSERT_EQ(JXL_DEC_SUCCESS,
+            JxlDecoderImageOutBufferSize(dec, &format, &buffer_size));
+  out->resize(buffer_size);
+  ASSERT_EQ(JXL_DEC_SUCCESS, JxlDecoderSetImageOutBuffer(
+                                 dec, &format, out->data(), out->size()));
+}
+
+}  // namespace
+
+TEST(DecodeTest, ApiMisuseLatchesUnhealthyState) {
+  size_t xsize = 57;
+  size_t ysize = 31;
+  std::vector<uint8_t> pixels = jxl::test::GetSomeTestImage(xsize, ysize, 3, 0);
+  jxl::TestCodestreamParams params;
+  std::vector<uint8_t> data = jxl::CreateTestJXLCodestream(
+      jxl::Bytes(pixels.data(), pixels.size()), xsize, ysize, 3, params);
+  JxlPixelFormat format = {3, JXL_TYPE_UINT8, JXL_LITTLE_ENDIAN, 0};
+
+  JxlDecoderPtr dec = JxlDecoderMake(nullptr);
+  std::vector<uint8_t> out;
+  SetUpDecoderWithImageOutBuffer(dec.get(), data, format, &out);
+
+  // The misuse named in issue #4670: switching to the callback API after a
+  // buffer has already been installed.
+  EXPECT_EQ(JXL_DEC_ERROR,
+            JxlDecoderSetMultithreadedImageOutCallback(
+                dec.get(), &format,
+                [](void*, size_t, size_t) -> void* { return nullptr; },
+                [](void*, size_t, size_t, size_t, size_t, const void*) {},
+                [](void*) {}, nullptr));
+
+  // Per #4670, no further decoding may happen.
+  EXPECT_EQ(JXL_DEC_ERROR, JxlDecoderProcessInput(dec.get()));
+  EXPECT_EQ(JXL_DEC_ERROR, JxlDecoderProcessInput(dec.get()));
+}
+
+TEST(DecodeTest, ApiMisuseLatchClearedByReset) {
+  size_t xsize = 57;
+  size_t ysize = 31;
+  std::vector<uint8_t> pixels = jxl::test::GetSomeTestImage(xsize, ysize, 3, 0);
+  jxl::TestCodestreamParams params;
+  std::vector<uint8_t> data = jxl::CreateTestJXLCodestream(
+      jxl::Bytes(pixels.data(), pixels.size()), xsize, ysize, 3, params);
+  JxlPixelFormat format = {3, JXL_TYPE_UINT8, JXL_LITTLE_ENDIAN, 0};
+
+  JxlDecoderPtr dec = JxlDecoderMake(nullptr);
+  std::vector<uint8_t> out;
+  SetUpDecoderWithImageOutBuffer(dec.get(), data, format, &out);
+
+  EXPECT_EQ(JXL_DEC_ERROR,
+            JxlDecoderSetMultithreadedImageOutCallback(
+                dec.get(), &format,
+                [](void*, size_t, size_t) -> void* { return nullptr; },
+                [](void*, size_t, size_t, size_t, size_t, const void*) {},
+                [](void*) {}, nullptr));
+  EXPECT_EQ(JXL_DEC_ERROR, JxlDecoderProcessInput(dec.get()));
+
+  // Reset returns the decoder to its initial configuration, so it must clear
+  // the latch and leave the object fully reusable.
+  JxlDecoderReset(dec.get());
+  std::vector<uint8_t> out2;
+  SetUpDecoderWithImageOutBuffer(dec.get(), data, format, &out2);
+  EXPECT_EQ(JXL_DEC_FULL_IMAGE, JxlDecoderProcessInput(dec.get()));
+}
+
+TEST(DecodeTest, ApiMisuseLatchesUnhealthyStateCallbackThenBuffer) {
+  size_t xsize = 57;
+  size_t ysize = 31;
+  std::vector<uint8_t> pixels = jxl::test::GetSomeTestImage(xsize, ysize, 3, 0);
+  jxl::TestCodestreamParams params;
+  std::vector<uint8_t> data = jxl::CreateTestJXLCodestream(
+      jxl::Bytes(pixels.data(), pixels.size()), xsize, ysize, 3, params);
+  JxlPixelFormat format = {3, JXL_TYPE_UINT8, JXL_LITTLE_ENDIAN, 0};
+
+  JxlDecoderPtr dec = JxlDecoderMake(nullptr);
+  ASSERT_EQ(JXL_DEC_SUCCESS,
+            JxlDecoderSubscribeEvents(dec.get(),
+                                      JXL_DEC_BASIC_INFO | JXL_DEC_FULL_IMAGE));
+  ASSERT_EQ(JXL_DEC_SUCCESS,
+            JxlDecoderSetInput(dec.get(), data.data(), data.size()));
+  ASSERT_EQ(JXL_DEC_BASIC_INFO, JxlDecoderProcessInput(dec.get()));
+  ASSERT_EQ(JXL_DEC_NEED_IMAGE_OUT_BUFFER, JxlDecoderProcessInput(dec.get()));
+
+  // Install the callback sink first, then attempt to switch to a buffer: the
+  // mirror of ApiMisuseLatchesUnhealthyState.
+  ASSERT_EQ(JXL_DEC_SUCCESS,
+            JxlDecoderSetMultithreadedImageOutCallback(
+                dec.get(), &format,
+                [](void*, size_t, size_t) -> void* { return nullptr; },
+                [](void*, size_t, size_t, size_t, size_t, const void*) {},
+                [](void*) {}, nullptr));
+
+  size_t buffer_size;
+  ASSERT_EQ(JXL_DEC_SUCCESS,
+            JxlDecoderImageOutBufferSize(dec.get(), &format, &buffer_size));
+  std::vector<uint8_t> out(buffer_size);
+  EXPECT_EQ(JXL_DEC_ERROR, JxlDecoderSetImageOutBuffer(dec.get(), &format,
+                                                       out.data(), out.size()));
+
+  EXPECT_EQ(JXL_DEC_ERROR, JxlDecoderProcessInput(dec.get()));
+}


### PR DESCRIPTION
Addresses the output-API case in #4670.

Mixing the buffer and callback image-output APIs is already rejected with `JXL_API_ERROR`:

- `JxlDecoderSetImageOutBuffer` when a callback is installed
- `JxlDecoderSetMultithreadedImageOutCallback` when a buffer is installed

But the decoder stays usable afterwards, so a caller that does not check the return value keeps decoding while possibly wrong about which output sink is installed. #4670 asks that decoding stop in this situation so the mistake surfaces where it happens.

This latches the existing `DecoderStage::kError` at both detection points. No new state is added — `JxlDecoderProcessInput` already refuses to run in `kError`, and `JxlDecoderReset` already clears it, so the decoder stays reusable.

**Tests** (`lib/jxl/decode_test.cc`): buffer→callback, callback→buffer, and that `JxlDecoderReset` clears the state and a frame still decodes to completion.

**Testing:** `decode_test` 2894/2894 (2891 existing + 3 new) under ASan+UBSan and in a release/NDEBUG build. `./ci.sh lint` clean.

The issue says "invalid calls, e.g. ...", so I kept this narrow to the image-output case — happy to extend it to other API-misuse paths if that's what you meant.
