### PR TITLE
Use bounds-carrying types in dec_huffman.cc

### DIFF
--- a/lib/jxl.cmake
+++ b/lib/jxl.cmake
@@ -25,6 +25,18 @@ endif()
 
 set_source_files_properties(jxl/enc_fast_lossless.cc PROPERTIES COMPILE_FLAGS "${FJXL_COMPILE_FLAGS}")
 
+# Files converted to bounds-carrying types. -Wunsafe-buffer-usage is enabled
+# per file so converted code cannot regress; add files here as they are done.
+set(JPEGXL_SAFE_BUFFER_SOURCES
+  jxl/dec_huffman.cc
+)
+
+check_cxx_compiler_flag("-Wunsafe-buffer-usage" JXL_CXX_UNSAFE_BUFFER_USAGE)
+if(JXL_CXX_UNSAFE_BUFFER_USAGE)
+  set_source_files_properties(${JPEGXL_SAFE_BUFFER_SOURCES} PROPERTIES
+    COMPILE_OPTIONS "-Wunsafe-buffer-usage;-Werror=unsafe-buffer-usage")
+endif()
+
 set(JPEGXL_DEC_INTERNAL_LIBS
   hwy
   Threads::Threads

--- a/lib/jxl/dec_huffman.cc
+++ b/lib/jxl/dec_huffman.cc
@@ -3,55 +3,61 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
+// Headers are not converted yet; only this file is checked.
+#ifdef __clang__
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wunsafe-buffer-usage"
+#endif
 #include "lib/jxl/dec_huffman.h"
 
-#include <jxl/types.h>
-
+#include <array>
 #include <cstdint>
-#include <cstring> /* for memset */
 #include <vector>
 
 #include "lib/jxl/ans_params.h"
 #include "lib/jxl/base/bits.h"
 #include "lib/jxl/base/compiler_specific.h"
+#include "lib/jxl/base/span.h"
 #include "lib/jxl/dec_bit_reader.h"
 #include "lib/jxl/huffman_table.h"
+#ifdef __clang__
+#pragma clang diagnostic pop
+#endif
 
 namespace jxl {
 
 static const int kCodeLengthCodes = 18;
-static const uint8_t kCodeLengthCodeOrder[kCodeLengthCodes] = {
+static const std::array<uint8_t, kCodeLengthCodes> kCodeLengthCodeOrder = {
     1, 2, 3, 4, 0, 5, 17, 6, 16, 7, 8, 9, 10, 11, 12, 13, 14, 15,
 };
 static const uint8_t kDefaultCodeLength = 8;
 static const uint8_t kCodeLengthRepeatCode = 16;
 
-JXL_BOOL ReadHuffmanCodeLengths(const uint8_t* code_length_code_lengths,
-                                int num_symbols, uint8_t* code_lengths,
-                                BitReader* br) {
+static bool ReadHuffmanCodeLengths(
+    const std::array<uint8_t, kCodeLengthCodes>& code_length_code_lengths,
+    Span<uint8_t> code_lengths, BitReader* br) {
+  const int num_symbols = static_cast<int>(code_lengths.size());
   int symbol = 0;
   uint8_t prev_code_len = kDefaultCodeLength;
   int repeat = 0;
   uint8_t repeat_code_len = 0;
   int space = 32768;
-  HuffmanCode table[32];
+  std::array<HuffmanCode, 32> table = {};
 
-  uint16_t counts[16] = {0};
+  std::array<uint16_t, 16> counts = {};
   for (int i = 0; i < kCodeLengthCodes; ++i) {
     ++counts[code_length_code_lengths[i]];
   }
-  if (!BuildHuffmanTable(table, 5, code_length_code_lengths, kCodeLengthCodes,
-                         &counts[0])) {
-    return JXL_FALSE;
+  if (!BuildHuffmanTable(table.data(), 5, code_length_code_lengths.data(),
+                         kCodeLengthCodes, counts.data())) {
+    return false;
   }
 
   while (symbol < num_symbols && space > 0) {
-    const HuffmanCode* p = table;
-    uint8_t code_len;
     br->Refill();
-    p += br->PeekFixedBits<5>();
-    br->Consume(p->bits);
-    code_len = static_cast<uint8_t>(p->value);
+    const HuffmanCode& code = table[br->PeekFixedBits<5>()];
+    br->Consume(code.bits);
+    uint8_t code_len = static_cast<uint8_t>(code.value);
     if (code_len < kCodeLengthRepeatCode) {
       repeat = 0;
       code_lengths[symbol++] = code_len;
@@ -79,10 +85,11 @@ JXL_BOOL ReadHuffmanCodeLengths(const uint8_t* code_length_code_lengths,
       repeat += static_cast<int>(br->ReadBits(extra_bits) + 3);
       repeat_delta = repeat - old_repeat;
       if (symbol + repeat_delta > num_symbols) {
-        return 0;
+        return false;
       }
-      memset(&code_lengths[symbol], repeat_code_len,
-             static_cast<size_t>(repeat_delta));
+      for (int i = 0; i < repeat_delta; ++i) {
+        code_lengths[symbol + i] = repeat_code_len;
+      }
       symbol += repeat_delta;
       if (repeat_code_len != 0) {
         space -= repeat_delta << (15 - repeat_code_len);
@@ -90,20 +97,22 @@ JXL_BOOL ReadHuffmanCodeLengths(const uint8_t* code_length_code_lengths,
     }
   }
   if (space != 0) {
-    return JXL_FALSE;
+    return false;
   }
-  memset(&code_lengths[symbol], 0, static_cast<size_t>(num_symbols - symbol));
-  return JXL_TRUE;
+  for (int i = symbol; i < num_symbols; ++i) {
+    code_lengths[i] = 0;
+  }
+  return true;
 }
 
 static JXL_INLINE bool ReadSimpleCode(size_t alphabet_size, BitReader* br,
-                                      HuffmanCode* table) {
+                                      Span<HuffmanCode> table) {
   size_t max_bits =
       (alphabet_size > 1u) ? FloorLog2Nonzero(alphabet_size - 1u) + 1 : 0;
 
   size_t num_symbols = br->ReadFixedBits<2>() + 1;
 
-  uint16_t symbols[4] = {0};
+  std::array<uint16_t, 4> symbols = {};
   for (size_t i = 0; i < num_symbols; ++i) {
     uint16_t symbol = br->ReadBits(max_bits);
     if (symbol >= alphabet_size) {
@@ -178,10 +187,11 @@ static JXL_INLINE bool ReadSimpleCode(size_t alphabet_size, BitReader* br,
     }
   }
 
-  const uint32_t goal_size = 1u << kHuffmanTableBits;
+  const size_t goal_size = 1u << kHuffmanTableBits;
   while (table_size != goal_size) {
-    memcpy(&table[table_size], &table[0],
-           static_cast<size_t>(table_size) * sizeof(table[0]));
+    for (size_t i = 0; i < table_size; ++i) {
+      table[table_size + i] = table[i];
+    }
     table_size <<= 1;
   }
 
@@ -198,46 +208,47 @@ bool HuffmanDecodingData::ReadFromBitStream(size_t alphabet_size,
   uint32_t simple_code_or_skip = br->ReadFixedBits<2>();
   if (simple_code_or_skip == 1u) {
     table_.resize(1u << kHuffmanTableBits);
-    return ReadSimpleCode(alphabet_size, br, table_.data());
+    return ReadSimpleCode(alphabet_size, br,
+                          Span<HuffmanCode>(table_.data(), table_.size()));
   }
 
   std::vector<uint8_t> code_lengths(alphabet_size, 0);
-  uint8_t code_length_code_lengths[kCodeLengthCodes] = {0};
+  std::array<uint8_t, kCodeLengthCodes> code_length_code_lengths = {};
   int space = 32;
   int num_codes = 0;
   /* Static Huffman code for the code length code lengths */
-  static const HuffmanCode huff[16] = {
+  /* clang-format off */
+  static const std::array<HuffmanCode, 16> huff = {{
       {2, 0}, {2, 4}, {2, 3}, {3, 2}, {2, 0}, {2, 4}, {2, 3}, {4, 1},
       {2, 0}, {2, 4}, {2, 3}, {3, 2}, {2, 0}, {2, 4}, {2, 3}, {4, 5},
-  };
+  }};
+  /* clang-format on */
   for (size_t i = simple_code_or_skip; i < kCodeLengthCodes && space > 0; ++i) {
     const int code_len_idx = kCodeLengthCodeOrder[i];
-    const HuffmanCode* p = huff;
-    uint8_t v;
     br->Refill();
-    p += br->PeekFixedBits<4>();
-    br->Consume(p->bits);
-    v = static_cast<uint8_t>(p->value);
+    const HuffmanCode& code = huff[br->PeekFixedBits<4>()];
+    br->Consume(code.bits);
+    uint8_t v = static_cast<uint8_t>(code.value);
     code_length_code_lengths[code_len_idx] = v;
     if (v != 0) {
       space -= (32u >> v);
       ++num_codes;
     }
   }
-  bool ok =
-      (num_codes == 1 || space == 0) &&
-      FROM_JXL_BOOL(ReadHuffmanCodeLengths(
-          code_length_code_lengths, alphabet_size, code_lengths.data(), br));
+  bool ok = (num_codes == 1 || space == 0) &&
+            ReadHuffmanCodeLengths(
+                code_length_code_lengths,
+                Span<uint8_t>(code_lengths.data(), code_lengths.size()), br);
 
   if (!ok) return false;
-  uint16_t counts[16] = {0};
+  std::array<uint16_t, 16> counts = {};
   for (size_t i = 0; i < alphabet_size; ++i) {
     ++counts[code_lengths[i]];
   }
   table_.resize(alphabet_size + 376);
   uint32_t table_size =
       BuildHuffmanTable(table_.data(), kHuffmanTableBits, code_lengths.data(),
-                        alphabet_size, &counts[0]);
+                        alphabet_size, counts.data());
   table_.resize(table_size);
   return (table_size > 0);
 }


### PR DESCRIPTION
Converts `lib/jxl/dec_huffman.cc` from raw pointer arithmetic and plain C arrays
to `jxl::Span` and `std::array`, and enables `-Wunsafe-buffer-usage` for that one
file.

## What this does and does not do

Being precise up front, because the phrase "safe buffers" oversells it:

`jxl::Span::operator[]` is `*(data() + i)`, with no bounds check. `std::array`'s
`operator[]` is also unchecked unless the standard library is built with
assertions, which this project does not enable. **So this adds no runtime bounds
checking and does not change behaviour at all.** The differential below is
byte-identical for exactly that reason.

What it does change:

- the length travels with the pointer, so it can no longer be dropped at a call
  boundary or fall out of sync with it
- the build fails if someone reintroduces raw pointer arithmetic in this file

It is groundwork for hardening, not hardening. If you wanted actual runtime
checking the next step would be a bounds check inside `jxl::Span::operator[]`, or
building the decoder with `_GLIBCXX_ASSERTIONS`. I have not done either here, and
both deserve their own discussion since they cost something.

No bug is being fixed. #4816 did the same thing locally for scanline writes.

## What changed

- `ReadHuffmanCodeLengths` takes `Span<uint8_t>` instead of a pointer plus a
  separate length. It was file-local, so no API change.
- `ReadSimpleCode` takes `Span<HuffmanCode>`.
- Fixed-size C arrays become `std::array`.
- `const HuffmanCode* p = table; p += br->PeekFixedBits<5>()` becomes
  `table[br->PeekFixedBits<5>()]`.
- `memset`/`memcpy` become indexed loops. Both run over at most 256 elements
  here, and come out slightly faster at that size.

`-Wunsafe-buffer-usage` sites in this file: 37 to 0.

## Verification

| | |
|---|---|
| `ctest` | 6857/6857 passing |
| Behaviour | byte-identical to main across 6000 generated inputs, comparing return value, table size and a hash of the decoded table |
| ASan + UBSan | clean over the same corpus |
| Throughput | 491 to 442 ns/decode (best-of-40, `-O2`) |

## The build gate

`lib/jxl.cmake` gains a list of converted files that get
`-Wunsafe-buffer-usage -Werror=unsafe-buffer-usage`, guarded by
`check_cxx_compiler_flag`. Injecting raw pointer arithmetic back into the file
fails the build.

Note the flag applies to the whole translation unit, so `byte_order.h`,
`status.h` and `dec_bit_reader.h` would otherwise fail it. I've scoped the
diagnostic around the include block. The cleaner fix is
`#pragma clang unsafe_buffer_usage begin/end` in those headers to mark them as
audited, but that touches shared headers and felt out of scope here.

**If you'd rather not carry the flag, say so and I'll drop the `lib/jxl.cmake`
hunk** — the conversion stands on its own.

## Questions

1. Is per-file `-Wunsafe-buffer-usage` something you want in the tree?
2. `jxl::Span`, or `std::span` behind a C++20 guard?
3. Would you want `jxl::Span::operator[]` to carry a bounds check? That is where
   the actual safety benefit would come from, and I'd be happy to measure it.
