### PR TITLE
Bounds-check the PGX and PNM signature reads

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -38,6 +38,7 @@ Alexander Sago <cagelight@gmail.com>
 Alifian Caesar Khalid <alifiancaesar@gmail.com>
 Alistair Barrow
 Amiralgaby
+Anantha Narayanan R <evertrustai@gmail.com>
 Andrew Kaster <andrew@ladybird.org>
 Andrius Lukas Narbutas <andrius4669@gmail.com>
 Aous Naman <aous@unsw.edu.au>

--- a/lib/extras/dec/pgx.cc
+++ b/lib/extras/dec/pgx.cc
@@ -40,7 +40,7 @@ class Parser {
 
   // Sets "pos" to the first non-header byte/pixel on success.
   Status ParseHeader(HeaderPGX* header, const uint8_t** pos) {
-    // codec.cc ensures we have at least two bytes => no range check here.
+    if (static_cast<size_t>(end_ - pos_) < 2) return false;
     if (pos_[0] != 'P' || pos_[1] != 'G') return false;
     pos_ += 2;
     return ParseHeaderPGX(header, pos);

--- a/lib/extras/dec/pgx_test.cc
+++ b/lib/extras/dec/pgx_test.cc
@@ -8,9 +8,11 @@
 #include <jxl/memory_manager.h>
 
 #include <array>
+#include <cstddef>
 #include <cstdint>
 #include <cstring>
 #include <string>
+#include <vector>
 
 #include "lib/extras/packed_image.h"
 #include "lib/extras/packed_image_convert.h"
@@ -110,6 +112,26 @@ TEST(CodecPGXTest, RejectsDimensionProductOverflow) {
   std::string pgx = "PG ML + 8 8589934592 8589934592\n";
   PackedPixelFile ppf;
   EXPECT_FALSE(DecodeImagePGX(MakeSpan(pgx.c_str()), ColorHints(), &ppf));
+}
+
+// The two-byte "PG" signature was read before any range check, relying on a
+// minimum input size enforced in a different translation unit
+// (extras/dec/decode.cc). DecodeImagePGX does not enforce that itself, so a
+// caller reaching it directly - as these tests do - read past the end of the
+// buffer. ParseHeader must enforce its own precondition.
+//
+// The buffers are heap-allocated at exactly the tested length so sanitizer
+// builds observe any overread; a string literal would hide it inside the
+// terminating NUL. Length 1 is checked first because it is the case a
+// sanitizer reports precisely - for length 0 an empty vector may yield a null
+// data() pointer, whose behaviour is not guaranteed across standard libraries.
+TEST(CodecPGXTest, RejectsInputShorterThanSignature) {
+  PackedPixelFile ppf;
+  for (const size_t len : {static_cast<size_t>(1), static_cast<size_t>(0)}) {
+    const std::vector<uint8_t> bytes(len, static_cast<uint8_t>('P'));
+    EXPECT_FALSE(
+        DecodeImagePGX(Bytes(bytes.data(), bytes.size()), ColorHints(), &ppf));
+  }
 }
 
 }  // namespace

--- a/lib/extras/dec/pnm.cc
+++ b/lib/extras/dec/pnm.cc
@@ -39,7 +39,7 @@ class Parser {
 
   // Sets "pos" to the first non-header byte/pixel on success.
   Status ParseHeader(HeaderPNM* header, const uint8_t** pos) {
-    // codec.cc ensures we have at least two bytes => no range check here.
+    if (static_cast<size_t>(end_ - pos_) < 2) return false;
     if (pos_[0] != 'P') return false;
     const uint8_t type = pos_[1];
     pos_ += 2;

--- a/lib/extras/dec/pnm_test.cc
+++ b/lib/extras/dec/pnm_test.cc
@@ -1,0 +1,58 @@
+// Copyright (c) the JPEG XL Project Authors. All rights reserved.
+//
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+#include "lib/extras/dec/pnm.h"
+
+#include <cstddef>
+#include <cstdint>
+#include <cstring>
+#include <string>
+#include <vector>
+
+#include "lib/extras/dec/color_hints.h"
+#include "lib/extras/packed_image.h"
+#include "lib/jxl/base/span.h"
+#include "lib/jxl/testing.h"
+
+namespace jxl {
+namespace extras {
+namespace {
+
+Span<const uint8_t> MakeSpan(const char* str) {
+  return Bytes(reinterpret_cast<const uint8_t*>(str), strlen(str));
+}
+
+// The two-byte "P<type>" signature was read before any range check, relying on
+// a minimum input size enforced in a different translation unit
+// (extras/dec/decode.cc). DecodeImagePNM does not enforce that itself, so a
+// caller reaching it directly - as these tests do - read past the end of the
+// buffer. The out-of-bounds byte then selected the header variant in the switch
+// that follows. ParseHeader must enforce its own precondition.
+//
+// The buffers are heap-allocated at exactly the tested length so sanitizer
+// builds observe any overread; a string literal would hide it inside the
+// terminating NUL. Length 1 is checked first because it is the case a
+// sanitizer reports precisely - for length 0 an empty vector may yield a null
+// data() pointer, whose behaviour is not guaranteed across standard libraries.
+TEST(CodecPNMTest, RejectsInputShorterThanSignature) {
+  PackedPixelFile ppf;
+  for (const size_t len : {static_cast<size_t>(1), static_cast<size_t>(0)}) {
+    const std::vector<uint8_t> bytes(len, static_cast<uint8_t>('P'));
+    EXPECT_FALSE(
+        DecodeImagePNM(Bytes(bytes.data(), bytes.size()), ColorHints(), &ppf));
+  }
+}
+
+// A complete signature with nothing after it must still be rejected, and must
+// not read beyond the two bytes it consumed.
+TEST(CodecPNMTest, RejectsSignatureOnly) {
+  PackedPixelFile ppf;
+  const std::string pnm = "P6";
+  EXPECT_FALSE(DecodeImagePNM(MakeSpan(pnm.c_str()), ColorHints(), &ppf));
+}
+
+}  // namespace
+}  // namespace extras
+}  // namespace jxl

--- a/lib/jxl_lists.bzl
+++ b/lib/jxl_lists.bzl
@@ -500,6 +500,7 @@ libjxl_tests = [
     "extras/compressed_icc_test.cc",
     "extras/dec/color_description_test.cc",
     "extras/dec/pgx_test.cc",
+    "extras/dec/pnm_test.cc",
     "extras/gain_map_test.cc",
     "jxl/ac_strategy_test.cc",
     "jxl/alpha_test.cc",

--- a/lib/jxl_lists.cmake
+++ b/lib/jxl_lists.cmake
@@ -491,6 +491,7 @@ set(JPEGXL_INTERNAL_TESTS
   extras/compressed_icc_test.cc
   extras/dec/color_description_test.cc
   extras/dec/pgx_test.cc
+  extras/dec/pnm_test.cc
   extras/gain_map_test.cc
   jxl/ac_strategy_test.cc
   jxl/alpha_test.cc

--- a/lib/lib.gni
+++ b/lib/lib.gni
@@ -498,6 +498,7 @@ libjxl_tests = [
     "extras/compressed_icc_test.cc",
     "extras/dec/color_description_test.cc",
     "extras/dec/pgx_test.cc",
+    "extras/dec/pnm_test.cc",
     "extras/gain_map_test.cc",
     "jxl/ac_strategy_test.cc",
     "jxl/alpha_test.cc",


### PR DESCRIPTION
`Parser::ParseHeader` in the PGX and PNM decoders read the two signature bytes before performing any range check:

```cpp
// lib/extras/dec/pgx.cc
// codec.cc ensures we have at least two bytes => no range check here.
if (pos_[0] != 'P' || pos_[1] != 'G') return false;

// lib/extras/dec/pnm.cc
// codec.cc ensures we have at least two bytes => no range check here.
if (pos_[0] != 'P') return false;
const uint8_t type = pos_[1];
```

Every other method in both parsers (`ParseUnsigned`, `SkipSpace`, `SkipLineBreak`, `SkipSingleWhitespace`, `SkipWhitespace`, `MatchString`) checks `pos_ == end_` before dereferencing. Only the entry points relied on an external guarantee instead.

### Why the guarantee is fragile

It is not part of either function's contract. `DecodeBytes` in `extras/dec/decode.cc` rejects inputs below `kMinBytes`, but that constant exists to bound codec *signature* length:

```cpp
static_assert(L <= kMinBytes, "Signature too long");
if (bytes.size() < L) return false;   // CheckSignatures re-checks anyway
```

So the coupling is incidental rather than designed:

- `kMinBytes` is defined twice — `extras/codec.cc` and `extras/dec/decode.cc`. Adding a format with a shorter signature and lowering it in one place would silently invalidate the parsers' precondition.
- `CheckSignatures`, which actually owns the constant, still bounds-checks defensively.
- The comment named `codec.cc`, while the guard on the path that reaches these decoders is in `decode.cc`.

`DecodeImagePGX` and `DecodeImagePNM` are declared in `dec/pgx.h` and `dec/pnm.h`, so a caller not routing through `DecodeBytes` reads past the end of the buffer.

### Reproduced under AddressSanitizer

Calling either decoder directly with a heap buffer of one byte:

```
ERROR: AddressSanitizer: heap-buffer-overflow
READ of size 1
  #0 Parser::ParseHeader(HeaderPGX*, unsigned char const**)   lib/extras/dec/pgx.cc:44:27
  #1 jxl::extras::DecodeImagePGX(...)                         lib/extras/dec/pgx.cc:171:15

ERROR: AddressSanitizer: heap-buffer-overflow
READ of size 1
  #0 Parser::ParseHeader(HeaderPNM*, unsigned char const**)   lib/extras/dec/pnm.cc:44:26
  #1 jxl::extras::DecodeImagePNM(...)                         lib/extras/dec/pnm.cc:478:15
```

In PNM the out-of-bounds byte then selects the header variant in the `switch` that follows.

### Scope

To be clear about severity: I could not reach this from untrusted input through a supported entry point. Every in-tree caller goes through `DecodeBytes`, and the `dec/*.h` headers are not installed. This is a latent issue and a pattern worth removing, not a reachable vulnerability.

### Change

Each entry point now enforces its own precondition, and the stale comment is gone. Regression tests cover zero- and one-byte inputs for both decoders.

The test buffers are heap-allocated at exactly the tested length so sanitizer builds observe any overread — a string literal would hide it inside the terminating NUL. Length 1 is checked first, since length 0 may yield a null `data()` whose behaviour is not guaranteed across standard libraries.

`pnm_test.cc` is new. The build lists were regenerated with `tools/scripts/build_cleaner.py --update`, which registers it in `jxl_lists.cmake`, `jxl_lists.bzl` and `lib.gni`. I have also added myself to `AUTHORS`.

### Testing

- Full suite: 6862/6863 passing, unchanged from the pre-patch baseline of 6859/6860 apart from the three added tests. The single failure is a local environment artifact (git symlinks under `tools/benchmark/metrics/` checked out as text files on a Windows filesystem), present before and after.
- Verified the new tests **fail** with the source change reverted, reporting the ASAN traces above — a regression test that passes against the unfixed code would be worthless.
- Clean under ASAN, and under ASAN + the full UBSAN flag set from `ci.sh cmd_asan()` with `halt_on_error=1`. Checked specifically because the zero-length case makes the parser evaluate `nullptr + 0` and `nullptr - nullptr`.
- `clang-format --style=file` clean on all changed files.

No benchmarks: this adds one integer comparison once per file during header parsing, with no per-pixel path involved.
