### PR TITLE
Bound LZ77 matches to the decoder window

### DIFF
--- a/lib/jxl/ans_test.cc
+++ b/lib/jxl/ans_test.cc
@@ -211,8 +211,9 @@ void TestCheckpointing(bool ans, bool lz77) {
   for (size_t i = 0; i < 1024; i++) {
     input_values[0].emplace_back(0, i % 4);
   }
-  // up to lz77 window size.
-  for (size_t i = 0; i < (1 << 20) - 1022; i++) {
+  // Advance beyond the LZ77 window using values that cannot match the
+  // surrounding 0..3 sequences.
+  for (size_t i = 0; i < kWindowSize; i++) {
     input_values[0].emplace_back(0, (i % 5) + 4);
   }
   // Ensure that when the window wraps around, new values are different.

--- a/lib/jxl/enc_lz77.cc
+++ b/lib/jxl/enc_lz77.cc
@@ -478,6 +478,7 @@ public:
         for (uint16_t i = 0; i < hash_table_[h].size; i++) {
             const uint32_t candidate = hash_table_[h].data[i];
             size_t dist = pos - candidate;
+            if (dist > kWindowSize) continue;
             size_t cur_length = MatchLength(candidate, pos);
 
             // Skip matches shorter than current best or min_length


### PR DESCRIPTION
## Summary

- Ignore LZ77 hash candidates that are farther back than the decoder window.
- Extend the checkpointing roundtrip test across the exact window boundary for
  both ANS and prefix-code LZ77 modes.

## Why

The hash map introduced in #4928 retains candidate positions indefinitely.
The encoder could therefore select a match more than `kWindowSize` symbols in
the past, while the decoder clamps such a distance to `kWindowSize`. Encoding
and decoding would both succeed, but the decoded symbol stream could differ
from the input.

## Testing

- Built the Release `ans_test` target on arm64 macOS.
- Ran all 39 `ans_test` cases successfully, including
  `TestCheckpointingANSLZ77` and `TestCheckpointingPrefixLZ77`.
- `git diff --check` passes.
