### PR TITLE
Add bounds-checked Span::subspan and use it in the APNG chunk loop

### DIFF
--- a/lib/extras/dec/apng.cc
+++ b/lib/extras/dec/apng.cc
@@ -904,10 +904,10 @@ Status DecodeImageAPNG(const Span<const uint8_t> bytes,
     if (chunk.empty()) {
       return JXL_FAILURE("Malformed chunk");
     }
-    Bytes type(chunk.data() + 4, 4);
+    JXL_ASSIGN_OR_RETURN(Bytes type, chunk.subspan(4, 4));
     id = LoadLE32(type.data());
     // Cut 'size' and 'type' at front and 'CRC' at the end.
-    Bytes payload(chunk.data() + 8, chunk.size() - 12);
+    JXL_ASSIGN_OR_RETURN(Bytes payload, chunk.subspan(8, chunk.size() - 12));
 
     if (!isAbc(type[0]) || !isAbc(type[1]) || !isAbc(type[2]) ||
         !isAbc(type[3])) {
@@ -1063,7 +1063,7 @@ Status DecodeImageAPNG(const Span<const uint8_t> bytes,
         png_save_uint_32(preamble.data(), payload.size() - 4);
         memcpy(preamble.data() + 4, "IDAT", 4);
         // Cut-off 'size', 'type' and 'sequence_number'
-        Bytes chunk_tail(chunk.data() + 12, chunk.size() - 12);
+        JXL_ASSIGN_OR_RETURN(Bytes chunk_tail, chunk.subspan(12));
         if (!ctx.FeedChunks(Bytes(preamble), chunk_tail)) {
           return JXL_FAILURE("Decoding fdAT failed");
         }

--- a/lib/jxl/base/span.h
+++ b/lib/jxl/base/span.h
@@ -55,6 +55,7 @@ class Span {
   constexpr T* end() const noexcept { return data() + size(); }
 
   constexpr T& operator[](size_t i) const noexcept {
+    JXL_DASSERT(i < len_);
     // MSVC 2015 accepts this as constexpr, but not ptr_[i]
     return *(data() + i);
   }
@@ -64,6 +65,29 @@ class Span {
     ptr_ += n;
     len_ -= n;
     return true;
+  }
+
+  // Bounds-checked replacement for `Span<T>(span.data() + offset, count)`.
+  //
+  // Returns an error rather than aborting: callers derive `offset` and `count`
+  // from untrusted input, so an out-of-range request is ordinary rejection of a
+  // malformed file, not a programmer error. (JXL_ENSURE would be wrong here --
+  // it aborts in debug and fuzzer builds.)
+  //
+  // `len_ - offset` is only evaluated once `offset <= len_` is known to hold,
+  // so a caller passing an underflowed `count` is rejected rather than
+  // wrapping.
+  StatusOr<Span<T>> subspan(size_t offset, size_t count) const {
+    if (offset > len_ || count > len_ - offset) {
+      return JXL_FAILURE("Span::subspan out of range");
+    }
+    return Span<T>(ptr_ + offset, count);
+  }
+
+  // Bounds-checked suffix starting at `offset`.
+  StatusOr<Span<T>> subspan(size_t offset) const {
+    if (offset > len_) return JXL_FAILURE("Span::subspan out of range");
+    return Span<T>(ptr_ + offset, len_ - offset);
   }
 
   void AppendTo(std::vector<NCT>& dst) const {

--- a/lib/jxl/base/span_test.cc
+++ b/lib/jxl/base/span_test.cc
@@ -1,0 +1,112 @@
+// Copyright (c) the JPEG XL Project Authors. All rights reserved.
+//
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+#include "lib/jxl/base/span.h"
+
+#include <cstddef>
+#include <cstdint>
+#include <utility>
+#include <vector>
+
+#include "lib/jxl/test_utils.h"
+#include "lib/jxl/testing.h"
+
+namespace jxl {
+namespace {
+
+std::vector<uint8_t> Iota(size_t n) {
+  std::vector<uint8_t> v(n);
+  for (size_t i = 0; i < n; ++i) v[i] = static_cast<uint8_t>(i);
+  return v;
+}
+
+TEST(SpanTest, SubspanReturnsRequestedRange) {
+  const std::vector<uint8_t> data = Iota(10);
+  const Bytes all(data.data(), data.size());
+
+  JXL_TEST_ASSIGN_OR_DIE(Bytes middle, all.subspan(2, 3));
+  EXPECT_EQ(3u, middle.size());
+  EXPECT_EQ(2u, middle[0]);
+  EXPECT_EQ(4u, middle[2]);
+
+  JXL_TEST_ASSIGN_OR_DIE(Bytes whole, all.subspan(0, 10));
+  EXPECT_EQ(10u, whole.size());
+  EXPECT_EQ(all.data(), whole.data());
+}
+
+TEST(SpanTest, SubspanSuffixRunsToEnd) {
+  const std::vector<uint8_t> data = Iota(10);
+  const Bytes all(data.data(), data.size());
+
+  JXL_TEST_ASSIGN_OR_DIE(Bytes tail, all.subspan(7));
+  EXPECT_EQ(3u, tail.size());
+  EXPECT_EQ(7u, tail[0]);
+
+  // A suffix starting exactly at the end is empty, not an error.
+  JXL_TEST_ASSIGN_OR_DIE(Bytes end, all.subspan(10));
+  EXPECT_TRUE(end.empty());
+}
+
+// An empty range at the one-past-the-end offset is well defined and must be
+// accepted; only offsets *beyond* that are rejected.
+TEST(SpanTest, SubspanAcceptsEmptyRangeAtEnd) {
+  const std::vector<uint8_t> data = Iota(4);
+  const Bytes all(data.data(), data.size());
+
+  JXL_TEST_ASSIGN_OR_DIE(Bytes empty, all.subspan(4, 0));
+  EXPECT_TRUE(empty.empty());
+}
+
+TEST(SpanTest, SubspanRejectsOutOfRange) {
+  const std::vector<uint8_t> data = Iota(10);
+  const Bytes all(data.data(), data.size());
+
+  EXPECT_FALSE(all.subspan(11, 0).ok());  // offset past the end
+  EXPECT_FALSE(all.subspan(11).ok());     // suffix past the end
+  EXPECT_FALSE(all.subspan(0, 11).ok());  // count longer than the span
+  EXPECT_FALSE(all.subspan(5, 6).ok());   // offset + count overruns
+  EXPECT_FALSE(all.subspan(10, 1).ok());  // one byte past the end
+}
+
+// Callers commonly compute a count by subtracting a fixed header/trailer size,
+// e.g. `chunk.subspan(8, chunk.size() - 12)`. When the span is shorter than
+// that constant the subtraction wraps to a huge size_t. subspan must reject
+// the wrapped value rather than construct a span over unrelated memory, so the
+// bound is checked as `count <= len_ - offset` only after `offset <= len_`.
+TEST(SpanTest, SubspanRejectsUnderflowedCount) {
+  const std::vector<uint8_t> data = Iota(8);
+  const Bytes chunk(data.data(), data.size());
+
+  const size_t wrapped = chunk.size() - 12;  // wraps: 8 - 12
+  EXPECT_GT(wrapped, chunk.size());
+  EXPECT_FALSE(chunk.subspan(8, wrapped).ok());
+}
+
+TEST(SpanTest, SubspanOfEmptySpan) {
+  const Bytes empty;
+  EXPECT_EQ(0u, empty.size());
+
+  JXL_TEST_ASSIGN_OR_DIE(Bytes same, empty.subspan(0, 0));
+  EXPECT_TRUE(same.empty());
+
+  EXPECT_FALSE(empty.subspan(1, 0).ok());
+  EXPECT_FALSE(empty.subspan(0, 1).ok());
+}
+
+TEST(SpanTest, SubspanComposes) {
+  const std::vector<uint8_t> data = Iota(16);
+  const Bytes all(data.data(), data.size());
+
+  JXL_TEST_ASSIGN_OR_DIE(Bytes body, all.subspan(4, 8));
+  JXL_TEST_ASSIGN_OR_DIE(Bytes inner, body.subspan(2, 4));
+  EXPECT_EQ(4u, inner.size());
+  EXPECT_EQ(6u, inner[0]);
+
+  // The narrowed span carries its own bound.
+  EXPECT_FALSE(body.subspan(0, 9).ok());
+}
+
+}  // namespace
+}  // namespace jxl

--- a/lib/jxl_lists.bzl
+++ b/lib/jxl_lists.bzl
@@ -505,6 +505,7 @@ libjxl_tests = [
     "jxl/alpha_test.cc",
     "jxl/ans_common_test.cc",
     "jxl/ans_test.cc",
+    "jxl/base/span_test.cc",
     "jxl/bit_reader_test.cc",
     "jxl/bits_test.cc",
     "jxl/blending_test.cc",

--- a/lib/jxl_lists.cmake
+++ b/lib/jxl_lists.cmake
@@ -496,6 +496,7 @@ set(JPEGXL_INTERNAL_TESTS
   jxl/alpha_test.cc
   jxl/ans_common_test.cc
   jxl/ans_test.cc
+  jxl/base/span_test.cc
   jxl/bit_reader_test.cc
   jxl/bits_test.cc
   jxl/blending_test.cc

--- a/lib/lib.gni
+++ b/lib/lib.gni
@@ -503,6 +503,7 @@ libjxl_tests = [
     "jxl/alpha_test.cc",
     "jxl/ans_common_test.cc",
     "jxl/ans_test.cc",
+    "jxl/base/span_test.cc",
     "jxl/bit_reader_test.cc",
     "jxl/bits_test.cc",
     "jxl/blending_test.cc",


### PR DESCRIPTION
`Span` carries `len_`, but nothing used it to guard access:

```cpp
constexpr T& operator[](size_t i) const noexcept {
  return *(data() + i);          // len_ unused
}
```

There was also no way to take a sub-range, so callers reached for `Span<T>(s.data() + offset, count)` — which rebuilds a span from a raw pointer and drops the bound entirely. `remove_prefix` was the only checked operation on the type.

### What this adds

**`JXL_DASSERT(i < len_)` in `operator[]`.** Compiled out in release, so it costs nothing where that would matter. It is live in `DebugOpt` and in the OSS-Fuzz build, which sets `-DJXL_IS_DEBUG_BUILD=1` specifically to keep `JXL_DASSERT` enabled:

```bash
# projects/libjxl/build.sh
# Build the fuzzers in release mode but force the inclusion of JXL_DASSERT()
export CXXFLAGS="${CXXFLAGS} -DJXL_IS_DEBUG_BUILD=1"
```

**`subspan(offset, count)` and `subspan(offset)`**, returning `StatusOr<Span<T>>`.

`subspan` returns an error rather than aborting. Callers derive `offset` and `count` from untrusted input, so an out-of-range request is ordinary rejection of a malformed file, not a programmer error — `JXL_ENSURE` would abort in debug and fuzzer builds. The bound is checked as `count <= len_ - offset` only after `offset <= len_` holds, so a caller that computes an underflowed count is rejected rather than wrapping.

### Why that matters here

That underflow shape is what the APNG chunk loop writes today:

```cpp
Bytes payload(chunk.data() + 8, chunk.size() - 12);
```

`chunk.size() - 12` wraps if the chunk is shorter than 12 bytes.

**To be clear, this is not a bug fix.** `Reader::ReadChunk` only returns a chunk when it read exactly `size + 12` bytes, so the subtraction cannot underflow as things stand. What changes is that the guarantee stops being load-bearing from another function — `subspan` rejects the wrapped count on its own, and there is a test covering precisely that case.

Three sites in the chunk loop are migrated as the first users. Semantics are unchanged: `subspan(12)` yields the same range as `Bytes(chunk.data() + 12, chunk.size() - 12)`.

### Relationship to `-Wunsafe-buffer-usage`

Moving a call site off raw pointer arithmetic makes it clean under the warning, leaving the remaining unsafe operations encapsulated inside `Span`. Compiling both styles side by side:

```
warning: unsafe pointer arithmetic   Bytes payload(chunk.data() + 8, ...);
(no warning)                         chunk.subspan(8, chunk.size() - 12)
```

Enabling the warning for a whole translation unit is deliberately left for a follow-up — `apng.cc` still has 42 such sites, plus more in `packed_image.h` and `byte_order.h`, which are shared.

### Tests

Adds `lib/jxl/base/span_test.cc` — the first test for `lib/jxl/base/`. Covers valid ranges, suffixes, the empty range at one-past-the-end, out-of-range rejection, underflowed counts, and composition of narrowed spans.

### Testing

- Full suite **6866/6867** in both `RelWithDebInfo` and `DebugOpt`, against a pre-change baseline of 6859/6860; the seven added tests account for the difference. The single failure in all runs is a local environment artifact (git symlinks under `tools/benchmark/metrics/` checked out as text files on a Windows filesystem), present before and after.
- **Zero `JXL_DASSERT` firings** across the whole suite in `DebugOpt`, i.e. nothing in the tree indexes a `Span` out of range today.
- Clean under ASAN.
- Confirmed the migrated code is actually exercised: the chunk loop runs 200 times during `CodecTest.TestRoundTrip` alone.
- `clang-format --style=file` clean; build lists regenerated with `tools/scripts/build_cleaner.py --update`.
