### PR TITLE
Make test dicsovery sequential.

### DIFF
--- a/ci.sh
+++ b/ci.sh
@@ -439,7 +439,9 @@ cmake_build_and_test() {
   fi
   # gtest_discover_tests() runs the test binaries to discover the list of tests
   # at build time, which fails under qemu.
-  ASAN_OPTIONS=detect_leaks=0 cmake --build "${BUILD_DIR}" -- $TARGETS
+  export ASAN_OPTIONS=detect_leaks=0
+  cmake --build "${BUILD_DIR}" -- $TARGETS
+  ctest -N -Q --test-dir "${BUILD_DIR}"
   # Pack test binaries if requested.
   if [[ "${PACK_TEST:-}" == "1" ]]; then
     (cd "${BUILD_DIR}"

--- a/lib/jxl_tests.cmake
+++ b/lib/jxl_tests.cmake
@@ -94,5 +94,5 @@ foreach (TESTFILE IN LISTS JPEGXL_INTERNAL_TESTS)
     set_target_properties(${TESTNAME} PROPERTIES COMPILE_FLAGS "-Wno-error")
   endif ()
   # 240 seconds because some build types (e.g. coverage) can be quite slow.
-  gtest_discover_tests(${TESTNAME} DISCOVERY_TIMEOUT 240)
+  gtest_discover_tests(${TESTNAME} DISCOVERY_TIMEOUT 240 DISCOVERY_MODE PRE_TEST)
 endforeach ()


### PR DESCRIPTION
Expectation: fixed osx pipelines
Hope: also deals with mysterious build races
Known downsides: a bit slower on many-core machines
