### PR TITLE
fix: null-ptr passed to memcpy through performblending

### DIFF
--- a/lib/jxl/blending.cc
+++ b/lib/jxl/blending.cc
@@ -142,7 +142,7 @@ Status PerformBlending(
   };
 
   const auto copy = [&](const float* const* src) {
-    //if (xsize == 0) return;
+    if (xsize == 0) return;
     for (size_t p = 0; p < 3; p++) {
       memcpy(tmp.Row(p), src[p] + x0, xsize * sizeof(**src));
     }

--- a/lib/jxl/blending.cc
+++ b/lib/jxl/blending.cc
@@ -142,6 +142,7 @@ Status PerformBlending(
   };
 
   const auto copy = [&](const float* const* src) {
+    //if (xsize == 0) return;
     for (size_t p = 0; p < 3; p++) {
       memcpy(tmp.Row(p), src[p] + x0, xsize * sizeof(**src));
     }


### PR DESCRIPTION
<!-- Thank you for considering a contribution to `libjxl`! -->

### Description

This PR attempts to fix issue: [#4944](https://github.com/libjxl/libjxl/issues/4944#issue-5152603108)

### Problem

When libjxl decodes a JPEG XL image whose frame geometry forces a zero-width blending region, `jxl::PerformBlending` (`lib/jxl/blending.cc`) unconditionally calls `memcpy` through its `copy` lambda with a destination pointer obtained from a 0-width `ImageF` allocation. That allocation has null row pointers (`PlaneBase::Allocate` returns early without allocating when `xsize_ == 0`), so `memcpy` receives a null first argument — undefined behavior that a UBSan-instrumented build aborts on. The `copy` lambda lacks the `if (xsize)` guard that every other blend mode in the same function already applies:

```
/root/FuzzAgent/src/libjxl/lib/jxl/blending.cc:146:14: runtime error: null pointer passed as argument 1, which is declared to never be null
/usr/include/string.h:44:28: note: nonnull attribute specified here
SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior blending.cc:146:14
```

The sibling extra-channel blend modes (`kReplace`/`kNone`) and the final write-back loop in the *same function* all guard against `xsize == 0` — only the color-channel `copy` lambda is missing the guard. This is an inconsistency in the function's overflow/null protection. It is a genuine library bug, not API misuse: the trigger is a syntactically valid JXL codestream (a 1×1 canvas with a crop frame wider than one modular group, blending REPLACE onto the zeroed canvas), and the decoder harness uses the public C API in its documented order.

## Fix

Add an `if (xsize == 0) return;` guard at the top of the `copy` lambda, mirroring the `if (xsize)` / `if (xsize != 0)` guards already used by the extra-channel paths and the final write-back loop in the same function:

```diff
--- a/lib/jxl/blending.cc
+++ b/lib/jxl/blending.cc
@@ -142,6 +142,7 @@ Status PerformBlending(
   };

   const auto copy = [&](const float* const* src) {
+    if (xsize == 0) return;
     for (size_t p = 0; p < 3; p++) {
       memcpy(tmp.Row(p), src[p] + x0, xsize * sizeof(**src));
     }
   };
```

This makes the lambda self-consistent with the other guarded `memcpy` calls in `PerformBlending` and removes the latent UB at its source. `PerformBlending` has a second caller (`PatchDictionary::AddPatch` in `lib/jxl/dec_patch_dictionary.cc`), so guarding at the `memcpy` site rather than only in the render-pipeline caller protects both code paths.

## Verification

### Sanitizer rebuild

Rebuilt libjxl with AddressSanitizer and UndefinedBehaviorSanitizer to confirm the null-pointer UB is gone and no memory/UB issues remain:

```
export CC=clang CXX=clang++
export CFLAGS="-fsanitize=address,undefined -fno-sanitize=function -g -O0 \
  -fstandalone-debug -fPIC -fno-inline -fno-omit-frame-pointer \
  -DFUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION"
export CXXFLAGS="$CFLAGS"
cmake -G Ninja -S . -B build-san \
  -DBUILD_TESTING=ON -DBUILD_SHARED_LIBS=OFF \
  -DJPEGXL_ENABLE_FUZZERS=OFF -DJPEGXL_ENABLE_TOOLS=ON \
  -DJPEGXL_ENABLE_OPENEXR=OFF -DJPEGXL_ENABLE_SJPEG=OFF \
  -DCMAKE_BUILD_TYPE=Release \
  -DCMAKE_C_COMPILER="$CC" -DCMAKE_CXX_COMPILER="$CXX" \
  -DCMAKE_C_FLAGS="$CFLAGS" -DCMAKE_CXX_FLAGS="$CXXFLAGS"
cmake --build build-san -j$(nproc) --target \
  jxl jxl_dec jxl_threads jxl_cms jxl-internal jxl_dec-internal \
  libbrotlicommon.a libbrotlidec.a libbrotlienc.a libhwy.a
```

### Before fix:
```
blending.cc:146:14: runtime error: null pointer passed as argument 1,
which is declared to never be null
/usr/include/string.h:44:28: note: nonnull attribute specified here
SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior blending.cc:146:14
```

### After fix:

(clean exit, code 0 — no sanitizer errors)

### Test-suite results

Ran the libjxl blending test, which decodes a multi-frame cropped image and checks per-frame output against PNG references:

```
./lib/tests/blending_test

[ RUN      ] BlendingTest.Crops
[       OK ] BlendingTest.Crops (26 ms)
[  PASSED  ] 1 test.
```
The `BlendingTest.Crops` case passes, confirming no regression in normal (nonzero `xsize`) blending behavior from the guard.


### Pull Request Checklist

- [x] **CLA Signed**: Have you signed the [Contributor License Agreement](https://code.google.com/legal/individual-cla-v1.0.html) (individual or corporate, as appropriate)? Only contributions from signed contributors can be accepted.
- [ ] **Authors**: Have you considered adding your name to the [AUTHORS](AUTHORS) file?
- [x] **Code Style**: Have you ensured your code adheres to the project's coding style guidelines? You can use `./ci.sh lint` for automatic code formatting.


Please review the full [contributing guidelines](https://github.com/libjxl/libjxl/blob/main/CONTRIBUTING.md) for more details.
