### PR TITLE
Fix low-memory render pipeline row reuse

### DIFF
--- a/lib/jxl/render_pipeline/low_memory_render_pipeline.cc
+++ b/lib/jxl/render_pipeline/low_memory_render_pipeline.cc
@@ -413,8 +413,10 @@ Status LowMemoryRenderPipeline::PrepareForThreadsInternal(size_t num,
       for (size_t i = stages_.size(); i-- > 0;) {
         if (stages_[i]->GetChannelMode(c) ==
             RenderPipelineChannelMode::kInOut) {
-          size_t stage_buffer_ysize =
-              2 * next_y_border + (1 << stages_[i]->settings_.shift_y);
+          // Prevent a newly produced bundle from exactly wrapping onto the
+          // oldest row that the next stage still needs for its border.
+          size_t stage_buffer_ysize = 2 * next_y_border + (next_y_border != 0) +
+                                      (1 << stages_[i]->settings_.shift_y);
           stage_buffer_ysize = 1 << CeilLog2Nonzero(stage_buffer_ysize);
           next_y_border = stages_[i]->settings_.border_y;
           JXL_ASSIGN_OR_RETURN(

--- a/lib/jxl/render_pipeline/render_pipeline_test.cc
+++ b/lib/jxl/render_pipeline/render_pipeline_test.cc
@@ -43,6 +43,10 @@
 #include "lib/jxl/image_test_utils.h"
 #include "lib/jxl/jpeg/enc_jpeg_data.h"
 #include "lib/jxl/jpeg/jpeg_data.h"
+#include "lib/jxl/render_pipeline/stage_chroma_upsampling.h"
+#include "lib/jxl/render_pipeline/stage_gaborish.h"
+#include "lib/jxl/render_pipeline/stage_upsampling.h"
+#include "lib/jxl/render_pipeline/stage_write.h"
 #include "lib/jxl/render_pipeline/test_render_pipeline_stages.h"
 #include "lib/jxl/splines.h"
 #include "lib/jxl/test_memory_manager.h"
@@ -189,6 +193,67 @@ TEST(RenderPipelineTest, CallAllGroupsFast) {
   }
 
   EXPECT_EQ(pipeline->PassesWithAllInput(), 1u);
+}
+
+StatusOr<Image3F> RunVirtualPaddingPipeline(JxlMemoryManager* memory_manager,
+                                            bool use_simple_pipeline) {
+  constexpr size_t kXSize = 17;
+  // Match the geometry that exposed the virtual-padding scheduling lead.
+  constexpr size_t kYSize = 229;
+  JXL_ASSIGN_OR_RETURN(Image3F output,
+                       Image3F::Create(memory_manager, kXSize, kYSize));
+
+  RenderPipeline::Builder builder(memory_manager, /*num_c=*/3);
+  JXL_RETURN_IF_ERROR(builder.AddStage(
+      GetChromaUpsamplingStage(/*channel=*/0, /*horizontal=*/false)));
+  JXL_RETURN_IF_ERROR(builder.AddStage(
+      GetChromaUpsamplingStage(/*channel=*/1, /*horizontal=*/true)));
+  JXL_RETURN_IF_ERROR(builder.AddStage(
+      GetChromaUpsamplingStage(/*channel=*/2, /*horizontal=*/true)));
+  LoopFilter loop_filter;
+  loop_filter.gab = true;
+  JXL_RETURN_IF_ERROR(builder.AddStage(GetGaborishStage(loop_filter)));
+  CustomTransformData transform_data;
+  for (size_t c = 0; c < 3; ++c) {
+    JXL_RETURN_IF_ERROR(builder.AddStage(
+        GetUpsamplingStage(memory_manager, transform_data, c, /*shift=*/3)));
+  }
+  JXL_RETURN_IF_ERROR(
+      builder.AddStage(GetWriteToImage3FStage(memory_manager, &output)));
+  if (use_simple_pipeline) builder.UseSimpleImplementation();
+
+  FrameDimensions dimensions;
+  dimensions.Set(kXSize, kYSize, /*group_size_shift=*/0,
+                 /*max_hshift=*/0, /*max_vshift=*/0,
+                 /*modular_mode=*/false, /*upsampling=*/8);
+  JXL_ASSIGN_OR_RETURN(auto pipeline, std::move(builder).Finalize(dimensions));
+  JXL_RETURN_IF_ERROR(pipeline->PrepareForThreads(1, /*use_group_ids=*/false));
+  for (size_t group = 0; group < dimensions.num_groups; ++group) {
+    auto input_buffers = pipeline->GetInputBuffers(group, 0);
+    for (size_t c = 0; c < 3; ++c) {
+      const auto& buffer = input_buffers.GetBuffer(c);
+      for (size_t y = 0; y < buffer.second.ysize(); ++y) {
+        float* row = buffer.second.Row(buffer.first, y);
+        for (size_t x = 0; x < buffer.second.xsize(); ++x) {
+          row[x] = static_cast<float>(100 * c + 10 * y + x);
+        }
+      }
+    }
+    JXL_RETURN_IF_ERROR(input_buffers.Done());
+  }
+  JXL_ENSURE(pipeline->PassesWithAllInput() == 1);
+  return output;
+}
+
+TEST(RenderPipelineTest, RetainsRowsAcrossVirtualPadding) {
+  JxlMemoryManager* memory_manager = jxl::test::MemoryManager();
+  JXL_TEST_ASSIGN_OR_DIE(
+      Image3F low_memory,
+      RunVirtualPaddingPipeline(memory_manager, /*use_simple_pipeline=*/false));
+  JXL_TEST_ASSIGN_OR_DIE(
+      Image3F simple,
+      RunVirtualPaddingPipeline(memory_manager, /*use_simple_pipeline=*/true));
+  JXL_TEST_ASSERT_OK(VerifyRelativeError(simple, low_memory, 1e-6, 1e-6, _));
 }
 
 struct RenderPipelineTestInputSettings {

--- a/lib/jxl/render_pipeline/stage_write.cc
+++ b/lib/jxl/render_pipeline/stage_write.cc
@@ -637,6 +637,10 @@ class WriteToOutputStage : public RenderPipelineStage {
   static void StoreFloatRow(const Output& out, const float* input[4],
                             size_t len, float* output) {
     const HWY_FULL(float) d;
+    const size_t padding = RoundUpTo(len, Lanes(d)) - len;
+    for (size_t c = 0; c < out.num_channels_; ++c) {
+      msan::UnpoisonMemory(input[c] + len, sizeof(input[c][0]) * padding);
+    }
     if (out.num_channels_ == 1) {
       memcpy(output, input[0], len * sizeof(output[0]));
     } else if (out.num_channels_ == 2) {
@@ -656,6 +660,8 @@ class WriteToOutputStage : public RenderPipelineStage {
                           &output[4 * i]);
       }
     }
+    msan::PoisonMemory(output + out.num_channels_ * len,
+                       sizeof(output[0]) * out.num_channels_ * padding);
   }
 
   template <typename T>


### PR DESCRIPTION
## Summary

- Prevent a low-memory stage's circular row buffer from exactly wrapping onto
  rows that a bordered consumer still needs.
- Align float output's MemorySanitizer tail handling with the existing integer
  and float16 output paths.
- Add a production-stage regression that compares the low-memory pipeline with
  the simple pipeline.

## Context

This addresses the row-reuse class exposed by public OSS-Fuzz issues
[501356662](https://issues.oss-fuzz.com/issues/501356662) (OSV-2026-564) and
[511400706](https://issues.oss-fuzz.com/issues/511400706) (OSV-2026-711).

The allocation change is deliberately narrower than the scheduling approach in
closed draft #4781: it adds one spare row only when the next stage has a
vertical border, before the existing power-of-two rounding. Draft #4785 adds
useful diagnostics and synthetic coverage, but does not change production
allocation. Neither draft is merged, and current `main` still reproduces the
uninitialized read.

## Testing

- Exact 30-byte OSS-Fuzz testcase `4959197585539072` under native ARM64 MSan:
  clean after the patch (use-of-uninitialized-value before the patch).
- `render_pipeline_test`: 175/175 passed.
- `djxl_fuzzer_test`: 44/44 passed.
- Changed-line clang-format and `git diff --check`: clean.

Assisted-by: OpenAI Codex
