### PR TITLE
Avoid integer overflow in absolute sample quantization

### DIFF
--- a/lib/jxl/modular/encoding/enc_ma.cc
+++ b/lib/jxl/modular/encoding/enc_ma.cc
@@ -799,6 +799,12 @@ std::vector<int32_t> QuantizeSamples(const std::vector<int32_t> &samples,
   return thresholds;
 }
 
+pixel_type SaturatingAbs(pixel_type value) {
+  return value == std::numeric_limits<pixel_type>::min()
+             ? std::numeric_limits<pixel_type>::max()
+             : std::abs(value);
+}
+
 // `to[i]` is assigned value `v` conforming `from[v] <= i && from[v-1] > i`.
 // This is because the decision node in the tree splits on (property) > i,
 // hence everything that is not > of a threshold should be clustered
@@ -888,7 +894,7 @@ void TreeSamples::PreQuantizeProperties(
   auto quantize_abs_pixel_property = [&]() {
     if (abs_pixel_thresholds.empty()) {
       quantize_pixel_property();  // Compute the non-abs thresholds.
-      for (auto &v : pixel_samples) v = std::abs(v);
+      for (auto &v : pixel_samples) v = SaturatingAbs(v);
       abs_pixel_thresholds =
           QuantizeSamples(pixel_samples, max_property_values);
     }
@@ -905,7 +911,7 @@ void TreeSamples::PreQuantizeProperties(
   auto quantize_abs_diff_property = [&]() {
     if (abs_diff_thresholds.empty()) {
       quantize_diff_property();  // Compute the non-abs thresholds.
-      for (auto &v : diff_samples) v = std::abs(v);
+      for (auto &v : diff_samples) v = SaturatingAbs(v);
       abs_diff_thresholds = QuantizeSamples(diff_samples, max_property_values);
     }
     return abs_diff_thresholds;

--- a/lib/jxl/modular_test.cc
+++ b/lib/jxl/modular_test.cc
@@ -11,6 +11,7 @@
 #include <cmath>
 #include <cstddef>
 #include <cstdint>
+#include <limits>
 #include <memory>
 #include <sstream>
 #include <string>
@@ -49,6 +50,7 @@
 #include "lib/jxl/image_ops.h"
 #include "lib/jxl/image_test_utils.h"
 #include "lib/jxl/modular/encoding/enc_encoding.h"
+#include "lib/jxl/modular/encoding/enc_ma.h"
 #include "lib/jxl/modular/encoding/encoding.h"
 #include "lib/jxl/modular/modular_image.h"
 #include "lib/jxl/modular/options.h"
@@ -484,6 +486,22 @@ TEST(ModularTest, RoundtripLosslessCustomFloat) {
       Roundtrip(io.get(), cparams, dparams, io2.get(), _, &compressed_size));
   EXPECT_LE(compressed_size, 23000u);
   JXL_EXPECT_OK(SamePixels(*io->Main().color(), *io2->Main().color(), _));
+}
+
+TEST(ModularTest, PreQuantizeAbsolutePropertiesAtIntegerMinimum) {
+  TreeSamples tree_samples;
+  ASSERT_TRUE(tree_samples.SetProperties(
+      {4, kNumNonrefProperties + 2}, ModularOptions::TreeMode::kDefault));
+
+  std::vector<pixel_type> pixel_samples = {
+      std::numeric_limits<pixel_type>::min()};
+  std::vector<pixel_type> diff_samples = {
+      std::numeric_limits<pixel_type>::min()};
+  tree_samples.PreQuantizeProperties(
+      {}, {}, {}, {}, pixel_samples, diff_samples, /*max_property_values=*/32);
+
+  EXPECT_EQ(std::numeric_limits<pixel_type>::max(), pixel_samples[0]);
+  EXPECT_EQ(std::numeric_limits<pixel_type>::max(), diff_samples[0]);
 }
 
 void WriteHeaders(BitWriter* writer, size_t xsize, size_t ysize) {


### PR DESCRIPTION
## Summary

- Saturate the one signed 32-bit value whose absolute value is not representable.
- Apply the safe absolute conversion to both pixel and difference samples.
- Add a direct regression for both `INT32_MIN` paths.

## Why

`TreeSamples::PreQuantizeProperties` called `std::abs` on signed 32-bit
samples. For `INT32_MIN`, the negated value cannot be represented, which
invokes undefined behavior during modular tree learning. Mapping that single
value to `INT32_MAX` preserves the intended magnitude ordering and avoids the
overflow.

Fixes #4947.

## Testing

- Reproduced the original failure with the new focused test under UBSAN.
- Focused regression passes after the patch with UBSAN halt-on-error enabled.
- Full `modular_test`: 79/79 passed under UBSAN.
- `git diff --check` passes.

Assisted-by: OpenAI Codex
