### PR TITLE
Copy ANS lookup data from the containing entry

### DIFF
--- a/lib/jxl/ans_common.h
+++ b/lib/jxl/ans_common.h
@@ -107,7 +107,7 @@ struct AliasTable {
 
 #if JXL_BYTE_ORDER_LITTLE
     uint64_t entry;
-    memcpy(&entry, &table[i].cutoff, sizeof(entry));
+    memcpy(&entry, &table[i], sizeof(entry));
     const size_t cutoff = entry & 0xFF;              // = MOVZX
     const size_t right_value = (entry >> 8) & 0xFF;  // = MOVZX
     const size_t freq0 = (entry >> 16) & 0xFFFF;


### PR DESCRIPTION
## Summary

- Copy the little-endian ANS lookup word from the containing packed entry.
- Avoid extending an eight-byte `memcpy` source range beyond the one-byte
  `cutoff` member subobject.

## Why

`AliasTable::Lookup` currently passes `&table[i].cutoff` to an eight-byte
`memcpy`. Although `cutoff` is the first member of the packed eight-byte
`Entry`, that pointer names only the one-byte member subobject, which is
flagged by intra-object bounds instrumentation. Pointing at `&table[i]`
describes the actual eight-byte source object and preserves the same layout
and fast-path behavior.

Fixes #4951.

## Testing

- Built `ans_common_test` with AppleClang 21.
- `ANSCommonTest.AliasDistributionSmoke` passes.
- `git diff --check` passes.

Assisted-by: OpenAI Codex
