### PR TITLE
modular: palettize 32-bit input again, clamping the implicit palette

### DIFF
--- a/lib/jxl/modular/transform/enc_palette.cc
+++ b/lib/jxl/modular/transform/enc_palette.cc
@@ -186,7 +186,6 @@ Status FwdPaletteIteration(Image &input, uint32_t begin_c, uint32_t end_c,
 
   size_t w = input.channel[begin_c].w;
   size_t h = input.channel[begin_c].h;
-  if (input.bitdepth >= 32) return false;
   if (!lossy && nb_colors < 2) return false;
 
   if (!lossy && nb == 1) {
@@ -339,13 +338,18 @@ Status FwdPaletteIteration(Image &input, uint32_t begin_c, uint32_t end_c,
     }
   }
 
+  // Must match the decoder, which clamps to 24 bits (see palette.cc).  Passing
+  // input.bitdepth unclamped disagrees with the decoder and overflows
+  // pixel_type inside GetPaletteValue() once the bit depth reaches 32.
+  const int bit_depth = std::min(input.bitdepth, 24);
+
   std::map<std::vector<pixel_type>, bool> implicit_color;
   std::vector<std::vector<pixel_type>> implicit_colors;
   implicit_colors.reserve(palette_internal::kImplicitPaletteSize);
   for (size_t k = 0; k < palette_internal::kImplicitPaletteSize; k++) {
     for (size_t i = 0; i < nb; i++) {
-      color[i] = palette_internal::GetPaletteValue(nullptr, k, i, 0, 0,
-                                                   input.bitdepth);
+      color[i] =
+          palette_internal::GetPaletteValue(nullptr, k, i, 0, 0, bit_depth);
     }
     implicit_color[color] = true;
     implicit_colors.push_back(color);
@@ -407,7 +411,6 @@ Status FwdPaletteIteration(Image &input, uint32_t begin_c, uint32_t end_c,
   pixel_type *JXL_RESTRICT p_palette = pch.Row(0);
   ptrdiff_t onerow = pch.plane.PixelsPerRow();
   ptrdiff_t onerow_image = input.channel[begin_c].plane.PixelsPerRow();
-  const int bit_depth = std::min(input.bitdepth, 24);
 
   if (lossy) {
     for (uint32_t i = 0; i < nb_deltas; i++) {
@@ -494,8 +497,8 @@ Status FwdPaletteIteration(Image &input, uint32_t begin_c, uint32_t end_c,
             color_with_error[c] =
                 p_in[c][x] + (palette_iteration_data.final_run ? 1 : 0) *
                                  diffusion_multiplier * error_row[0][c][x + 2];
-            color[c] = Clamp1(lround(color_with_error[c]), 0l,
-                              (1l << input.bitdepth) - 1);
+            color[c] = Clamp1(lround(color_with_error[c]), int64_t{0},
+                              (int64_t{1} << input.bitdepth) - 1);
           }
 
           for (size_t c = 0; c < nb; ++c) {

--- a/lib/jxl/modular_test.cc
+++ b/lib/jxl/modular_test.cc
@@ -11,6 +11,7 @@
 #include <cmath>
 #include <cstddef>
 #include <cstdint>
+#include <cstring>
 #include <memory>
 #include <sstream>
 #include <string>
@@ -52,6 +53,7 @@
 #include "lib/jxl/modular/encoding/encoding.h"
 #include "lib/jxl/modular/modular_image.h"
 #include "lib/jxl/modular/options.h"
+#include "lib/jxl/modular/transform/enc_palette.h"
 #include "lib/jxl/modular/transform/squeeze_params.h"
 #include "lib/jxl/modular/transform/transform.h"
 #include "lib/jxl/padded_bytes.h"
@@ -175,6 +177,73 @@ TEST(ModularTest, RoundtripLosslessCustomWpPermuteRCT) {
       Roundtrip(t.ppf(), cparams, dparams, nullptr, &ppf_out);
   EXPECT_LE(compressed_size, 10169u);
   EXPECT_EQ(0.0f, test::ComputeDistance2(t.ppf(), ppf_out));
+}
+
+// Regression test for #3511: 32-bit (float) input used to skip the palette
+// transform entirely, which made lossless HDR/float images much larger.
+//
+// The underlying problem was not the bit depth as such, but that
+// FwdPaletteIteration() built its implicit palette with input.bitdepth while
+// the decoder builds it with std::min(input.bitdepth, 24) (see palette.cc).
+// At 32 bits the encoder-side computation overflows pixel_type inside
+// GetPaletteValue(); commit 27afa5e4 worked around that by refusing to
+// palettize such images at all.
+TEST(ModularTest, Float32MultiChannelPaletteRegression) {
+  JxlMemoryManager* memory_manager = jxl::test::MemoryManager();
+  JXL_TEST_ASSIGN_OR_DIE(Image image,
+                         Image::Create(memory_manager, 256, 256,
+                                       /*bitdepth=*/32, /*nb_chans=*/3));
+
+  auto float_bits = [](float value) -> pixel_type {
+    uint32_t bits = 0;
+    memcpy(&bits, &value, sizeof(bits));
+    return static_cast<pixel_type>(bits);
+  };
+
+  // A handful of distinct HDR colours, stored as the raw IEEE-754 bit patterns
+  // that modular carries for float samples.
+  constexpr size_t kNumColors = 8;
+  const float kColors[kNumColors][3] = {
+      {1.0f, 0.5f, 0.25f},     {123.5f, 0.001f, 64.0f}, {-2.5f, 3.5f, 1e-6f},
+      {0.0f, 0.0f, 0.0f},      {480.0f, 12.0f, 0.75f},  {1e-8f, 1e8f, 1.0f},
+      {-0.125f, -64.0f, 7.0f}, {33.0f, 33.0f, 33.0f}};
+
+  uint32_t state = 0x9e3779b9u;
+  for (size_t y = 0; y < image.h; ++y) {
+    pixel_type* rows[3] = {image.channel[0].Row(y), image.channel[1].Row(y),
+                           image.channel[2].Row(y)};
+    for (size_t x = 0; x < image.w; ++x) {
+      state = state * 1664525u + 1013904223u;
+      const size_t idx = (state >> 28) % kNumColors;
+      for (size_t c = 0; c < 3; ++c) {
+        rows[c][x] = float_bits(kColors[idx][c]);
+      }
+    }
+  }
+
+  uint32_t nb_colors = 1024;
+  uint32_t nb_deltas = 0;
+  Predictor predictor = Predictor::Variable;
+  weighted::Header wp_header;
+  // Before the fix this returned without transforming anything.
+  JXL_EXPECT_OK(FwdPalette(image, /*begin_c=*/0, /*end_c=*/2, nb_colors,
+                           nb_deltas, /*ordered=*/true, /*lossy=*/false,
+                           predictor, wp_header));
+
+  // The palette is prepended as a meta channel and the three colour channels
+  // collapse into a single index channel.
+  EXPECT_EQ(1u, image.nb_meta_channels);
+  EXPECT_EQ(2u, image.channel.size());
+  EXPECT_EQ(kNumColors, nb_colors);
+
+  // Every index must address a real palette entry.
+  for (size_t y = 0; y < image.h; ++y) {
+    const pixel_type* row = image.channel[1].Row(y);
+    for (size_t x = 0; x < image.w; ++x) {
+      ASSERT_GE(row[x], 0);
+      ASSERT_LT(static_cast<uint32_t>(row[x]), nb_colors);
+    }
+  }
 }
 
 TEST(ModularTest, RoundtripLossyDeltaPalette) {


### PR DESCRIPTION
Fixes #3511.

## What regressed

`cjxl -d 0` on float32 input got much worse after 27afa5e4c2e66d917746f407674369f19b6fca47 ("Prevent integer overflow", #3450), which added:

```c++
if (input.bitdepth >= 32) return false;
```

to `FwdPaletteIteration()`. That refuses the palette transform for *any* 32-bit input, so lossless HDR/float images lose palette entirely.

## Why the overflow was there

The bail-out treated the symptom. The actual problem is that the encoder and the decoder disagreed about the bit depth used to build the **implicit** palette.

`palette.cc` (decoder) has always clamped:

```c++
const int bit_depth = std::min(input.bitdepth, 24);
```

`enc_palette.cc` declared the same clamped `bit_depth`, but *below* the implicit-palette construction, which called `GetPaletteValue()` with the raw `input.bitdepth`:

```c++
color[i] = palette_internal::GetPaletteValue(nullptr, k, i, 0, 0,
                                             input.bitdepth);
```

At 32 bits that overflows `pixel_type` inside `GetPaletteValue()`. `Scale<kSmallCube>(2, 32)` is `(2 * (2^32 - 1)) >> 2` = `2147483647`, and `palette.h:102` then adds `1 << (32 - 3)`:

```
lib/jxl/modular/transform/palette.h:102:46: runtime error: signed integer overflow:
    536870912 + 2147483647 cannot be represented in type 'int'
    #0 GetPaletteValue palette.h:102
    #1 jxl::FwdPaletteIteration(...) enc_palette.cc:351
```

(gcc `-fsanitize=signed-integer-overflow -fno-sanitize-recover=all`, reproduced by removing only the bail-out.)

## The change

* Hoist `const int bit_depth = std::min(input.bitdepth, 24);` above the implicit-palette loop and use it there, so the encoder computes the same implicit palette the decoder does and the arithmetic stays in range.
* Drop the `input.bitdepth >= 32` bail-out.
* Widen the lossy clamp from `1l << input.bitdepth` to `int64_t{1} << input.bitdepth` — `long` is 32-bit on Windows, so that shift is UB at 32 bits once this path becomes reachable again.

## Density

`cjxl -d 0`, float32 PFM input, all four **bit-exact lossless** on `djxl` round-trip (compared sample-by-sample after normalising PFM endianness):

| input | before | after |
| --- | ---: | ---: |
| RGBE-derived HDR, 512x256 | 43.143 bpp | **8.592 bpp** |
| 16 distinct RGB colors, 256x256 | 13.008 bpp | **0.542 bpp** |
| 64 distinct RGB colors, 256x256 | 40.243 bpp | **2.652 bpp** |
| 256 distinct RGB colors, 256x256 | 69.245 bpp | **7.923 bpp** |

The first case mirrors the reporter's `metro_noord_2k.hdr.pfm`: `.hdr` is Radiance RGBE, so converting to `.pfm` yields float32 samples drawn from a small discrete set, which is exactly what palette exploits.

## Tests

New `ModularTest.Float32MultiChannelPaletteRegression` drives `FwdPalette()` on a 3-channel 32-bit image built from 8 distinct HDR colors and asserts the transform happens and every emitted index addresses a real palette entry. Without the fix it fails on the untransformed data:

```
Expected: (static_cast<uint32_t>(row[x])) < (nb_colors), actual: 1094713344 vs 1024
```

Suites run locally on this branch, all green: `modular_test` **79/79**, `codec_test` **8/8**, `decode_test` **2891/2891**, `encode_test` **2330/2330**, `jxl_test` **150/150** — 5458 tests, 0 failures. `cjxl` on all four images above is UBSan-clean with the fix, and trips the overflow above without it.

## AI disclosure

Prepared with AI assistance, then reviewed and verified locally; every number above is reproducible from the commands in this description.
