### PR TITLE
cjxl: default to --faster_decoding=1 for lossless encoding

### DIFF
--- a/lib/include/jxl/encode.h
+++ b/lib/include/jxl/encode.h
@@ -133,7 +133,9 @@ typedef enum {
 
   /** Sets the decoding speed tier for the provided options. Minimum is 0
    * (slowest to decode, best quality/density), and maximum is 4 (fastest to
-   * decode, at the cost of some quality/density). Default is 0.
+   * decode, at the cost of some quality/density). When not set, the encoder
+   * chooses: 1 for images with lossless modular data (including lossless
+   * extra channels such as alpha) below effort 10, and 0 otherwise.
    */
   JXL_ENC_FRAME_SETTING_DECODING_SPEED = 1,
 
@@ -340,8 +342,10 @@ typedef enum {
    */
   JXL_ENC_FRAME_SETTING_JPEG_COMPRESS_BOXES = 33,
 
-  /** Control what kind of input buffering is used, when using chunked image frames.
-   * When using streaming input the encoder minimizes memory usage, potentially at
+  /** Control what kind of input buffering is used, when using chunked image
+   frames.
+   * When using streaming input the encoder minimizes memory usage, potentially
+   at
    * a cost in compression density (though not necessarily).
    * -1 = default (let the encoder decide)
    * 0 = buffers everything, basically the same as non-streamed code path

--- a/lib/jxl/enc_frame.cc
+++ b/lib/jxl/enc_frame.cc
@@ -118,6 +118,21 @@ Status ParamsPostInit(CompressParams* p) {
   if (p->ec_resampling <= 0) {
     p->ec_resampling = p->resampling;
   }
+  if (p->decoding_speed_tier < 0) {
+    // Lossless modular data (fully lossless images, but also e.g. lossless
+    // alpha in an otherwise lossy image) is much slower to decode than
+    // VarDCT, so by default trade a small amount of density for decode
+    // speed, except at the highest efforts where density is the priority.
+    // Note that ModularPartIsLossless() is vacuously true when there is no
+    // modular data at all, so also require a lossless image or the presence
+    // of extra channels.
+    const bool has_lossless_modular_part =
+        p->IsLossless() ||
+        (!p->ec_distance.empty() && p->ModularPartIsLossless());
+    const bool density_focused_effort = p->speed_tier <= SpeedTier::kGlacier;
+    p->decoding_speed_tier =
+        (has_lossless_modular_part && !density_focused_effort) ? 1 : 0;
+  }
   // Modular has to be squeezed to show progressive HF passes.
   if (p->progressive_mode == Override::kOn ||
       p->qprogressive_mode == Override::kOn) {
@@ -701,8 +716,8 @@ void ComputeNoiseParams(const CompressParams& cparams, bool streaming_mode,
   }
   if (cparams.photon_noise_iso > 0) {
     FrameDimensions full_frame_dim = frame_header->ToFrameDimensions();
-    *noise_params = SimulatePhotonNoise(full_frame_dim.xsize, full_frame_dim.ysize,
-                                        cparams.photon_noise_iso);
+    *noise_params = SimulatePhotonNoise(
+        full_frame_dim.xsize, full_frame_dim.ysize, cparams.photon_noise_iso);
   } else if (cparams.manual_noise.size() == NoiseParams::kNumNoisePoints) {
     for (size_t i = 0; i < NoiseParams::kNumNoisePoints; i++) {
       noise_params->lut[i] = cparams.manual_noise[i];

--- a/lib/jxl/enc_params.h
+++ b/lib/jxl/enc_params.h
@@ -42,10 +42,12 @@ struct CompressParams {
   SpeedTier speed_tier = SpeedTier::kSquirrel;
   int brotli_effort = -1;
 
-  // 0 = default.
+  // -1 = encoder chooses: 1 for images with lossless modular data below
+  //      effort 10, 0 otherwise. Resolved in ParamsPostInit.
+  // 0 = best quality/density.
   // 1 = slightly worse quality.
   // 4 = fastest speed, lowest quality
-  size_t decoding_speed_tier = 0;
+  int decoding_speed_tier = -1;
 
   ColorTransform color_transform = ColorTransform::kXYB;
 

--- a/tools/cjxl_main.cc
+++ b/tools/cjxl_main.cc
@@ -250,11 +250,13 @@ struct CompressArgs {
         "3 = deprecated; use --output_mode to control output streaming.",
         &buffering, &ParseInt64, -1);
 
-    cmdline->AddOptionValue('\0', "faster_decoding", "0..4",
-                            "Higher values improve decode speed "
-                            "at the expense of quality or density, "
-                            "default = 0.",
-                            &faster_decoding, &ParseUnsigned, 2);
+    opt_faster_decoding_id =
+        cmdline->AddOptionValue('\0', "faster_decoding", "0..4",
+                                "Higher values improve decode speed "
+                                "at the expense of quality or density; "
+                                "default = encoder chooses (1 for lossless "
+                                "encoding below effort 10, otherwise 0).",
+                                &faster_decoding, &ParseUnsigned, 2);
 
     cmdline->AddOptionValue('\0', "premultiply", "-1|0|1",
                             "Force premultiplied (associated) alpha.",
@@ -570,6 +572,7 @@ struct CompressArgs {
   CommandLineParser::OptionId opt_alpha_distance_id = -1;
   CommandLineParser::OptionId opt_quality_id = -1;
   CommandLineParser::OptionId opt_modular_group_size_id = -1;
+  CommandLineParser::OptionId opt_faster_decoding_id = -1;
 };
 
 const char* ModeFromArgs(const CompressArgs& args) {
@@ -760,11 +763,15 @@ void ProcessFlags(const jxl::extras::Codec codec,
       "epf", args->epf, JXL_ENC_FRAME_SETTING_EPF, params,
       [](int64_t x) { return (-1 <= x && x <= 3); },
       "Valid range is {-1, 0, 1, 2, 3}.");
-  ProcessFlag<int64_t>(
-      "faster_decoding", args->faster_decoding,
-      JXL_ENC_FRAME_SETTING_DECODING_SPEED, params,
-      [](int64_t x) { return (0 <= x && x <= 4); },
-      "Valid range is {0, 1, 2, 3, 4}.");
+  // Only forward --faster_decoding when given on the command line, so that
+  // the encoder can pick a default based on the other settings.
+  if (cmdline->GetOption(args->opt_faster_decoding_id)->matched()) {
+    ProcessFlag<int64_t>(
+        "faster_decoding", args->faster_decoding,
+        JXL_ENC_FRAME_SETTING_DECODING_SPEED, params,
+        [](int64_t x) { return (0 <= x && x <= 4); },
+        "Valid range is {0, 1, 2, 3, 4}.");
+  }
   ProcessFlag<int64_t>(
       "resampling", args->resampling, JXL_ENC_FRAME_SETTING_RESAMPLING, params,
       [](int64_t x) {


### PR DESCRIPTION
Lossless bitstreams produced with the current defaults are much slower to decode than lossy ones, which keeps coming up in adoption discussions (most recently in the Chrome/Mozilla intent-to-ship threads). `--faster_decoding=1` avoids the slowest-to-decode coding tool choices at a very small density cost, so make it the default for lossless pixel encoding.

Measured single-threaded (`taskset`-pinned), decoding with jxl-rs:

**[55_Cancri_e_Final_1_30.png](https://commons.wikimedia.org/wiki/File:55_Cancri_e_Final_1_30.png)** (96 MP photographic, the image used for the decode-speed complaint on blink-dev):

| encode | size | decode |
|---|---|---|
| default | 24.19 MB | 6.2 MP/s |
| `--faster_decoding=1` | 24.84 MB (+2.7%) | 11.8 MP/s (**+92%**) |
| lossless WebP (cwebp v1.6) | 29.06 MB | - |

**896x1080 digital artwork:**

| encode | size | decode |
|---|---|---|
| default | 1.287 MB | 4.1 MP/s |
| `--faster_decoding=1` | 1.301 MB (+1.0%) | 6.1 MP/s (**+51%**) |
| lossless WebP | 1.364 MB | - |

Both cases stay well below the lossless WebP size while roughly halving decode cost.

Behavior:
- `cjxl -d 0` now produces the same bitstream as `cjxl -d 0 --faster_decoding=1` did before.
- Explicitly passing `--faster_decoding=0` restores the previous default bit-exactly.
- Lossy encoding and lossless JPEG transcoding are unaffected.
