### PR TITLE
ans: read AliasTable Entry from its base, not a member pointer

### DIFF
--- a/lib/jxl/ans_common.h
+++ b/lib/jxl/ans_common.h
@@ -107,7 +107,12 @@ struct AliasTable {
 
 #if JXL_BYTE_ORDER_LITTLE
     uint64_t entry;
-    memcpy(&entry, &table[i].cutoff, sizeof(entry));
+    // Read the whole Entry, not a pointer into its first member: copying
+    // sizeof(entry) bytes from &table[i].cutoff (a 1-byte subobject) is an
+    // intra-object out-of-bounds access. table[i] is exactly this size.
+    static_assert(sizeof(Entry) == sizeof(entry),
+                  "Lookup reads an Entry as a single uint64_t load");
+    memcpy(&entry, &table[i], sizeof(entry));
     const size_t cutoff = entry & 0xFF;              // = MOVZX
     const size_t right_value = (entry >> 8) & 0xFF;  // = MOVZX
     const size_t freq0 = (entry >> 16) & 0xFFFF;


### PR DESCRIPTION
Fixes #4951.

`AliasTable::Lookup()` (`lib/jxl/ans_common.h`) reads a whole packed `Entry` as a single `uint64_t`:

```cpp
uint64_t entry;
memcpy(&entry, &table[i].cutoff, sizeof(entry));
```

`&table[i].cutoff` points at the 1-byte first member, so copying `sizeof(entry)` (8) bytes from it is an intra-object out-of-bounds access. It is undefined behavior and is flagged by sanitizers (the referent object is the `cutoff` subobject, not the whole `Entry`).

The intent is to load the entire `Entry`. `cutoff` is at offset 0 and `sizeof(Entry) == 8 == sizeof(uint64_t)`, so copying from `&table[i]` reads exactly the same bytes while giving the copy correct provenance over the whole object. The single-load optimization is preserved.

I confirmed the copy is byte-identical (same start address, same length) and added a `static_assert(sizeof(Entry) == sizeof(entry))` to document the layout the load relies on, so any future change to `Entry` that breaks the assumption fails at compile time.