### PR TITLE
enc_modular: quantize in a wider type to avoid signed overflow

### DIFF
--- a/lib/jxl/enc_modular.cc
+++ b/lib/jxl/enc_modular.cc
@@ -142,10 +142,15 @@ void QuantizeChannel(Channel& ch, const int q) {
   for (size_t y = 0; y < ch.plane.ysize(); y++) {
     pixel_type* row = ch.plane.Row(y);
     for (size_t x = 0; x < ch.plane.xsize(); x++) {
-      if (row[x] < 0) {
-        row[x] = -((-row[x] + q / 2) / q) * q;
+      // Round to the nearest multiple of q in a wider type. pixel_type is
+      // int32 and fuzzer inputs reach its extremes, where -row[x], row[x] +
+      // q/2 and the final * q all overflow (UBSan signed-integer-overflow);
+      // pixel_type_w (int64) holds every intermediate.
+      const pixel_type_w v = row[x];
+      if (v < 0) {
+        row[x] = static_cast<pixel_type>(-((-v + q / 2) / q) * q);
       } else {
-        row[x] = ((row[x] + q / 2) / q) * q;
+        row[x] = static_cast<pixel_type>(((v + q / 2) / q) * q);
       }
     }
   }


### PR DESCRIPTION
Fixes #4873.

`QuantizeChannel` (`lib/jxl/enc_modular.cc`) rounds each `pixel_type` (int32) sample to the nearest multiple of `q`:

```cpp
if (row[x] < 0) row[x] = -((-row[x] + q / 2) / q) * q;
else            row[x] =  ((row[x] + q / 2) / q) * q;
```

On the OSS-Fuzz input (a PFM whose extreme floats convert to int32 extremes), three intermediates overflow, all reported by UBSan `signed-integer-overflow`:

- `-row[x]` when `row[x] == INT32_MIN` (negation not representable),
- `row[x] + q / 2` / `-row[x] + q / 2` near the int32 bounds,
- the final `... * q`.

The rounding is done in `pixel_type_w` (int64, libjxl's own wide pixel type), which holds every intermediate, and the multiple-of-`q` result is narrowed back to `pixel_type`. I verified with a standalone UBSan harness that the widened form raises no `signed-integer-overflow` on the int32 extremes, and produces byte-identical results to the current code across the whole non-overflowing range (no behavior change for real inputs).