### PR TITLE
enc_ma: saturate std::abs to avoid INT_MIN negation overflow

### DIFF
--- a/lib/jxl/modular/encoding/enc_ma.cc
+++ b/lib/jxl/modular/encoding/enc_ma.cc
@@ -888,7 +888,13 @@ void TreeSamples::PreQuantizeProperties(
   auto quantize_abs_pixel_property = [&]() {
     if (abs_pixel_thresholds.empty()) {
       quantize_pixel_property();  // Compute the non-abs thresholds.
-      for (auto &v : pixel_samples) v = std::abs(v);
+      // std::abs(INT32_MIN) is undefined behavior (negation not representable);
+      // saturate so the absolute value stays representable and non-negative.
+      for (auto &v : pixel_samples) {
+        v = v == std::numeric_limits<pixel_type>::min()
+                ? std::numeric_limits<pixel_type>::max()
+                : std::abs(v);
+      }
       abs_pixel_thresholds =
           QuantizeSamples(pixel_samples, max_property_values);
     }


### PR DESCRIPTION
Fixes #4947.

`TreeSamples::PreQuantizeProperties` (`lib/jxl/modular/encoding/enc_ma.cc`) computes absolute-value thresholds with:

```cpp
for (auto &v : pixel_samples) v = std::abs(v);
```

`pixel_samples` holds `pixel_type` (int32). On the OSS-Fuzz input a sample reaches `INT32_MIN`, and `std::abs(INT32_MIN)` negates a value that is not representable in `int32`: undefined behavior, reported by UBSan `signed-integer-overflow` at `enc_ma.cc:891` (stack: `PreQuantizeProperties` -> `LearnTree` -> `ComputeTree`).

Saturate the single pathological value (`INT32_MIN` -> `INT32_MAX`) so the absolute value stays representable and non-negative; every other sample is unchanged. I verified under a standalone `-fsanitize=signed-integer-overflow` harness that this raises no overflow on the int32 extremes and is identical to `std::abs` for all non-`INT32_MIN` inputs.