### PR TITLE
Harden Span indexing in release builds

### DIFF
--- a/lib/jxl/base/span.h
+++ b/lib/jxl/base/span.h
@@ -56,7 +56,7 @@ class Span {
 
   constexpr T& operator[](size_t i) const noexcept {
     // MSVC 2015 accepts this as constexpr, but not ptr_[i]
-    return *(data() + i);
+    return JXL_SECURITY_CHECK(i < len_), *(data() + i);
   }
 
   Status remove_prefix(size_t n) noexcept {

--- a/lib/jxl/base/status.h
+++ b/lib/jxl/base/status.h
@@ -139,6 +139,18 @@ JXL_NORETURN inline JXL_NOINLINE bool Abort() {
 #define JXL_DASSERT(condition)
 #endif
 
+// Security checks that remain active in optimized/release builds.
+#ifndef JXL_HARDENED
+#define JXL_HARDENED 1
+#endif
+
+#if JXL_HARDENED
+#define JXL_SECURITY_CHECK(condition) \
+  (JXL_UNLIKELY(!(condition)) ? (JXL_CRASH(), false) : true)
+#else
+#define JXL_SECURITY_CHECK(condition) (true)
+#endif
+
 // A jxl::Status value from a StatusCode or Status which prints a debug message
 // when enabled.
 #define JXL_STATUS(status, format, ...)                                        \


### PR DESCRIPTION
## Summary

Harden `jxl::Span::operator[]` so its logical bound is enforced in optimized/release builds.

This implements the release-surviving bounds-checking approach proposed in #4921, narrowly scoped to `Span::operator[]`:

* add `JXL_SECURITY_CHECK`,
* enable it by default through `JXL_HARDENED=1`,
* check `i < len_` in `Span::operator[]`, and
* preserve `JXL_HARDENED=0` as an explicit opt-out.

This intentionally does not modify `subspan()` or bundle broader Safe Buffers migrations.

Addresses #4921.

cc @anonsurf004 — I independently reproduced and validated the release-build behavior described in #4921 and posted a coordination comment before opening this PR. I kept this change limited to the indexing primitive to avoid overlapping the separate `subspan()` work.

## Verification

### Functional and sanitizer testing

* Release build/tests: **6858/6858 runnable tests passed**
* ASan + UBSan build/tests: **6858/6858 runnable tests passed**
* `GaussBlurTest.SlowTestDirac1D` remained disabled
* `conformance_tooling_test` remained skipped

### Optimized hardening check

A small optimized harness verified that:

* valid `Span::operator[]` access continues to work,
* a logical out-of-bounds access traps with hardening enabled,
* the release binary retains the trap instruction, and
* `JXL_HARDENED=0` preserves the previous unchecked behavior.

### Performance

Compared the parent commit and this change using `benchmark_xl` on `testdata/jxl/flower/flower.png` with `jxl:wombat:d1`, 10 encode/decode repetitions and three alternating measured runs per build.

| Metric | Baseline mean | Hardened mean | Mean delta | Median delta |
| ------ | ------------: | ------------: | ---------: | -----------: |
| Encode |   2.3807 MP/s |   2.3600 MP/s |    -0.868% |      +1.414% |
| Decode |  32.5740 MP/s |  32.3553 MP/s |    -0.671% |      +1.494% |

All benchmark runs reported `Bugs=0`.

The mean and median move in opposite directions and the changes are within the observed run-to-run spread, so I did not observe a measurable performance regression.

## Scope

Only these files are changed:

* `lib/jxl/base/span.h`
* `lib/jxl/base/status.h`

`./ci.sh lint` passes locally.
