### PR TITLE
Fall back to other color chunks when cICP is not supported

### DIFF
--- a/lib/extras/codec_test.cc
+++ b/lib/extras/codec_test.cc
@@ -570,6 +570,86 @@ TEST(CodecTest, EncodeToPNG) {
                   decoded_ppf.info.bits_per_sample);
 }
 
+// A cICP chunk carrying a code point that libjxl does not implement must not
+// fail the whole PNG: per PNG 3rd Edition 11.3.2.6 cICP is the
+// highest-precedence color chunk only "if understood by the decoder", so an
+// unsupported one has to fall through to iCCP / sRGB / gAMA+cHRM.
+TEST(CodecTest, DecodePNGWithUnsupportedCicp) {
+  if (!CanDecode(Codec::kPNG)) {
+    fprintf(stderr, "Skipping test because of missing codec support.\n");
+    return;
+  }
+  const std::vector<uint8_t> png = jxl::test::ReadTestData(
+      "external/wesaturate/500px/tmshre_riaphotographs_srgb8.png");
+  // 8 byte signature plus a 13 byte IHDR chunk; cICP goes after IHDR and
+  // before PLTE / IDAT. The test image carries an iCCP chunk to fall back to.
+  constexpr size_t kAfterIhdr = 8 + 12 + 13;
+  ASSERT_GT(png.size(), kAfterIhdr);
+
+  const auto crc32 = [](const uint8_t* data, size_t size) {
+    uint32_t crc = 0xFFFFFFFFu;
+    for (size_t i = 0; i < size; ++i) {
+      crc ^= data[i];
+      for (int k = 0; k < 8; ++k) {
+        crc = (crc & 1) ? ((crc >> 1) ^ 0xEDB88320u) : (crc >> 1);
+      }
+    }
+    return crc ^ 0xFFFFFFFFu;
+  };
+  const auto with_cicp = [&](const std::vector<uint8_t>& payload) {
+    std::vector<uint8_t> chunk(8);
+    StoreBE32(static_cast<uint32_t>(payload.size()), chunk.data());
+    memcpy(chunk.data() + 4, "cICP", 4);
+    chunk.insert(chunk.end(), payload.begin(), payload.end());
+    uint8_t crc[4];
+    StoreBE32(crc32(chunk.data() + 4, chunk.size() - 4), crc);
+    chunk.insert(chunk.end(), crc, crc + 4);
+    std::vector<uint8_t> out(png.begin(), png.begin() + kAfterIhdr);
+    out.insert(out.end(), chunk.begin(), chunk.end());
+    out.insert(out.end(), png.begin() + kAfterIhdr, png.end());
+    return out;
+  };
+
+  // Positive control: a code point that libjxl does implement still wins over
+  // the iCCP chunk. BT.2100 primaries, PQ transfer function, identity matrix
+  // coefficients, full range.
+  {
+    PackedPixelFile ppf;
+    ASSERT_TRUE(extras::DecodeBytes(Bytes(with_cicp({9, 16, 0, 1})),
+                                    ColorHints(), &ppf));
+    EXPECT_EQ(ppf.primary_color_representation,
+              PackedPixelFile::kColorEncodingIsPrimary);
+    EXPECT_EQ(ppf.color_encoding.primaries, JXL_PRIMARIES_2100);
+    EXPECT_EQ(ppf.color_encoding.transfer_function, JXL_TRANSFER_FUNCTION_PQ);
+    EXPECT_TRUE(ppf.icc.empty());
+  }
+
+  // Syntactically valid code points that libjxl does not implement.
+  const std::vector<std::vector<uint8_t>> unsupported = {
+      {9, 16, 0, 0},  // video full range flag 0, i.e. a narrow-range image
+      {1, 7, 0, 1},   // transfer function 7, SMPTE ST 240M
+      {2, 13, 0, 1},  // colour primaries 2, "unspecified"
+  };
+  for (const std::vector<uint8_t>& payload : unsupported) {
+    PackedPixelFile ppf;
+    ASSERT_TRUE(
+        extras::DecodeBytes(Bytes(with_cicp(payload)), ColorHints(), &ppf))
+        << "cICP " << static_cast<int>(payload[0]) << " "
+        << static_cast<int>(payload[1]) << " " << static_cast<int>(payload[2])
+        << " " << static_cast<int>(payload[3]);
+    // The iCCP chunk of the test image has to remain in charge.
+    EXPECT_EQ(ppf.primary_color_representation, PackedPixelFile::kIccIsPrimary);
+    EXPECT_FALSE(ppf.icc.empty());
+  }
+
+  // Negative control: a malformed cICP chunk stays a hard error.
+  {
+    PackedPixelFile ppf;
+    EXPECT_FALSE(
+        extras::DecodeBytes(Bytes(with_cicp({9, 16, 0})), ColorHints(), &ppf));
+  }
+}
+
 }  // namespace
 }  // namespace extras
 }  // namespace jxl

--- a/lib/extras/dec/apng.cc
+++ b/lib/extras/dec/apng.cc
@@ -1075,7 +1075,18 @@ Status DecodeImageAPNG(const Span<const uint8_t> bytes,
         if (color_info_type == ColorInfoType::CICP) {
           return JXL_FAILURE("Repeated cICP chunk");
         }
-        JXL_RETURN_IF_ERROR(DecodeCicpChunk(payload, &ppf->color_encoding));
+        if (payload.size() != 4) {
+          return JXL_FAILURE("Wrong cICP size");
+        }
+        if (!DecodeCicpChunk(payload, &ppf->color_encoding)) {
+          // A code point we do not implement is not a malformed file: per PNG
+          // 3rd Edition 11.3.2.6 the cICP chunk is the highest-precedence
+          // color chunk only "if understood by the decoder". Leave
+          // color_info_type alone so that the lower-precedence chunks (iCCP,
+          // sRGB, gAMA / cHRM) still get their turn.
+          JXL_DEBUG_V(2, "Unsupported cICP chunk ignored");
+          continue;
+        }
         ppf->icc.clear();
         ppf->primary_color_representation =
             PackedPixelFile::kColorEncodingIsPrimary;


### PR DESCRIPTION
`DecodeCicpChunk()` documents that it returns false and leaves the color encoding
untouched when it meets a code point it does not implement:

```
 * If the cICP profile is not fully supported, return `false` and leave
 * `color_encoding` unmodified.
```

It keeps that promise. Every unmapped value leaves through `JXL_WARNING` plus
`return false`, before the single write at the end of the function.

The chunk loop in `apng.cc` wraps the call in `JXL_RETURN_IF_ERROR`, so "I do not
implement this" becomes "this file is broken" and the whole decode fails. Per PNG
3rd Edition 11.3.2.6 cICP takes precedence only "if understood by the decoder",
so an unsupported chunk should fall through to iCCP, sRGB or gAMA+cHRM.

The call site had that fallback before it was refactored into the chunk switch:
it used to be guarded by `if (DecodeCICP(...))`.

Which code points are affected: the primaries switch maps 1, 4, 5, 6, 7, 8, 9,
10, 11, 12 and 22, the transfer switch maps 1, 4, 5, 6, 8, 13, 14, 15, 16, 17 and
18, and the last two bytes have to be 0 and 1. Everything else fails the file
today, including value 2 on either axis, which H.273 defines as "unspecified" and
which an encoder writes when it does not know the colorimetry.

The size check moves to the call site because without it the two cases are
indistinguishable: a malformed chunk and an unimplemented code point both only
return false, and a malformed one has to stay a hard error.

Tests cover a supported code point (which must still win over the iCCP chunk),
three unsupported ones, and a truncated chunk which must still fail.

What I measured, in the container the CI describes (ubuntu 24.04 plus
`tools/scripts/install_deps.sh`), building and testing the way
`.github/workflows/build_test.yml` does:

- Without the fix the new test fails at `codec_test.cc:636` with
  `Actual: false, Expected: true` on `cICP 9 16 0 0`; with it, it passes.
- Full suite with the change: 6859 tests, 0 failed. On master without the new
  test file: 6858 tests, 0 failed. So nothing else moves.
- `./ci.sh lint` is clean with clang-format 18.1.3.

What I did not measure, so please do not read it as covered: only the release
build with clang on x86-64. Not gcc, not 32-bit, not asan or msan, not Windows
or macOS. `buildifier`, `typos-cli` and `zizmor` were not installed, so `ci.sh
lint` reported them as skipped; this change touches no Bazel, workflow or
documentation files.
