### PR TITLE
Guard zero-width blend region against null memcpy

### DIFF
--- a/lib/jxl/blending.cc
+++ b/lib/jxl/blending.cc
@@ -142,6 +142,7 @@ Status PerformBlending(
   };
 
   const auto copy = [&](const float* const* src) {
+    if (xsize == 0) return;
     for (size_t p = 0; p < 3; p++) {
       memcpy(tmp.Row(p), src[p] + x0, xsize * sizeof(**src));
     }

--- a/lib/jxl/blending_test.cc
+++ b/lib/jxl/blending_test.cc
@@ -54,5 +54,25 @@ TEST(BlendingTest, Crops) {
   }
 }
 
+TEST(BlendingTest, ZeroWidthBlendRegion) {
+  // Regression test for https://github.com/libjxl/libjxl/issues/4944.
+  // This 28-byte codestream decodes a frame whose blend region has zero width.
+  // PerformBlending() then took its kReplace/kNone color path and called
+  // memcpy() with a null destination row (obtained from the zero-width scratch
+  // image), which UndefinedBehaviorSanitizer aborts on. Decoding must not
+  // invoke undefined behavior regardless of whether it ultimately succeeds.
+  static const uint8_t kInput[] = {0xff, 0x0a, 0x00, 0x10, 0x10, 0x09, 0x08,
+                                   0x20, 0x00, 0x00, 0x10, 0x48, 0x00, 0x01,
+                                   0x00, 0x0c, 0x00, 0x00, 0x00, 0x40, 0x00,
+                                   0x04, 0x00, 0x4b, 0x20, 0x18, 0x03, 0x03};
+  extras::JXLDecompressParams dparams;
+  dparams.accepted_formats = {{3, JXL_TYPE_UINT8, JXL_LITTLE_ENDIAN, 0}};
+  extras::PackedPixelFile decoded;
+  // The return value is intentionally ignored: the point is that the decode
+  // runs to completion without tripping a sanitizer.
+  (void)DecodeImageJXL(kInput, sizeof(kInput), dparams,
+                       /*decoded_bytes=*/nullptr, &decoded);
+}
+
 }  // namespace
 }  // namespace jxl


### PR DESCRIPTION
### Problem

`PerformBlending()` in `lib/jxl/blending.cc` allocates a scratch image sized to the blend width:

```cpp
JXL_ASSIGN_OR_RETURN(ImageF tmp, ImageF::Create(memory_manager, xsize, 3 + num_ec));
```

When the blend region has zero width, `ImageF::Create(mm, 0, ...)` leaves every row pointer null. The `copy` lambda used by the `kReplace` / `kNone` **color** blend modes then calls `memcpy()` with that null destination:

```cpp
const auto copy = [&](const float* const* src) {
  for (size_t p = 0; p < 3; p++) {
    memcpy(tmp.Row(p), src[p] + x0, xsize * sizeof(**src));   // dst == nullptr
  }
};
```

The byte count is also `0`, so it is a no-op in practice, but `memcpy`'s first argument is declared `nonnull`, so passing null is undefined behavior and UBSan aborts on it (`blending.cc:146`). Reported in #4944 with a 28-byte reproducer.

### Fix

The `kReplace` / `kNone` paths for **extra channels**, a few lines up in the same function, already guard this with `if (xsize)`. This applies the same guard to the color path. The other color paths (`add`, `blend_weighted`, `add_weighted`) already loop `for (x = 0; x < xsize; ...)` and are no-ops when `xsize == 0`, so nothing else changes.

### Test

Adds `BlendingTest.ZeroWidthBlendRegion`, which decodes the 28-byte codestream from the issue via `DecodeImageJXL`. It embeds the bytes inline (no testdata change) and only asserts that the decode runs to completion — the regression is observable under a sanitizer, which CI covers.

### Verification

Built with clang 22 (RelWithDebInfo): compiles, `blending_test` links and `BlendingTest.ZeroWidthBlendRegion` passes, `clang-format` clean. A local UBSan build was not available (MSYS2 mingw clang ships no sanitizer runtime), so the UB abort itself is left to the CI sanitizer jobs.

Fixes #4944
