### PR TITLE
Handle legacy Display P3 ICC profiles

### DIFF
--- a/lib/jxl/cms/jxl_cms.cc
+++ b/lib/jxl/cms/jxl_cms.cc
@@ -444,6 +444,105 @@ void MatrixProduct(const skcms_Matrix3x3& matrix, const Color& vector_in,
   }
 }
 
+bool IsAcceptableCHAD(const skcms_Matrix3x3& chad) {
+  Matrix3x3d chad_double;
+  for (int i = 0; i < 3; ++i) {
+    for (int j = 0; j < 3; ++j) {
+      chad_double[i][j] = chad.vals[i][j];
+    }
+  }
+  return Inv3x3Matrix(chad_double);
+}
+
+bool HasICCVersion4DisplayClass(const skcms_ICCProfile& profile) {
+  return profile.buffer != nullptr && profile.size >= 128 &&
+         profile.buffer[8] == 4 && profile.buffer[12] == 'm' &&
+         profile.buffer[13] == 'n' && profile.buffer[14] == 't' &&
+         profile.buffer[15] == 'r' && profile.buffer[36] == 'a' &&
+         profile.buffer[37] == 'c' && profile.buffer[38] == 's' &&
+         profile.buffer[39] == 'p';
+}
+
+bool HasTag(const skcms_ICCProfile& profile, const char* signature) {
+  constexpr size_t kTagCountOffset = 128;
+  constexpr size_t kTagTableOffset = 132;
+  constexpr size_t kTagRecordSize = 12;
+  if (profile.buffer == nullptr || profile.size < kTagCountOffset + 4) {
+    return false;
+  }
+  const uint32_t tag_count =
+      (static_cast<uint32_t>(profile.buffer[kTagCountOffset]) << 24) |
+      (static_cast<uint32_t>(profile.buffer[kTagCountOffset + 1]) << 16) |
+      (static_cast<uint32_t>(profile.buffer[kTagCountOffset + 2]) << 8) |
+      static_cast<uint32_t>(profile.buffer[kTagCountOffset + 3]);
+  if (tag_count > (profile.size - kTagTableOffset) / kTagRecordSize) {
+    return false;
+  }
+  for (uint32_t i = 0; i < tag_count; ++i) {
+    const size_t offset = kTagTableOffset + kTagRecordSize * i;
+    if (std::memcmp(profile.buffer + offset, signature, 4) == 0) {
+      return true;
+    }
+  }
+  return false;
+}
+
+bool HasLUTTags(const skcms_ICCProfile& profile) {
+  for (const char* signature :
+       {"A2B0", "A2B1", "A2B2", "B2A0", "B2A1", "B2A2", "D2B0", "D2B1", "D2B2",
+        "D2B3", "B2D0", "B2D1", "B2D2", "B2D3"}) {
+    if (HasTag(profile, signature)) return true;
+  }
+  return false;
+}
+
+bool HasParametricTRCs(const skcms_ICCProfile& profile) {
+  return profile.trc[0].table_entries == 0 &&
+         profile.trc[1].table_entries == 0 && profile.trc[2].table_entries == 0;
+}
+
+bool IsApproximatelyD50(const Color& XYZ) {
+  static constexpr Color kD50XYZ{0.96420288f, 1.0f, 0.82490540f};
+  constexpr float kTolerance = 1e-3f;
+  return std::abs(XYZ[0] - kD50XYZ[0]) < kTolerance &&
+         std::abs(XYZ[1] - kD50XYZ[1]) < kTolerance &&
+         std::abs(XYZ[2] - kD50XYZ[2]) < kTolerance;
+}
+
+bool GetNonconformingMatrixProfileWhitePoint(const skcms_ICCProfile& profile,
+                                             const Color& media_white_point_XYZ,
+                                             Color& adapted_white_point_XYZ) {
+  // Some v4 display profiles contain a CHAD but retain the pre-v4 media
+  // white point. For a matrix/TRC profile, the colorant column sum is the
+  // adapted neutral and is a more reliable source for undoing that CHAD.
+  if (!HasICCVersion4DisplayClass(profile) ||
+      profile.data_color_space != skcms_Signature_RGB ||
+      profile.pcs != skcms_Signature_XYZ || !profile.has_trc ||
+      !profile.has_toXYZD50 || !HasTag(profile, "chad") ||
+      HasLUTTags(profile) || IsApproximatelyD50(media_white_point_XYZ)) {
+    return false;
+  }
+  Color matrix_white_point_XYZ;
+  for (int i = 0; i < 3; ++i) {
+    matrix_white_point_XYZ[i] = profile.toXYZD50.vals[i][0] +
+                                profile.toXYZD50.vals[i][1] +
+                                profile.toXYZD50.vals[i][2];
+  }
+  if (!IsApproximatelyD50(matrix_white_point_XYZ)) return false;
+  adapted_white_point_XYZ = matrix_white_point_XYZ;
+  return true;
+}
+
+bool RecoverMatrixProfileWhitePoint(const skcms_ICCProfile& profile,
+                                    const Color& media_white_point_XYZ,
+                                    Color& adapted_white_point_XYZ) {
+  skcms_Matrix3x3 CHAD;
+  return HasParametricTRCs(profile) &&
+         GetNonconformingMatrixProfileWhitePoint(profile, media_white_point_XYZ,
+                                                 adapted_white_point_XYZ) &&
+         skcms_GetCHAD(&profile, &CHAD) && IsAcceptableCHAD(CHAD);
+}
+
 // Returns white point that was specified when creating the profile.
 JXL_MUST_USE_RESULT Status UnadaptedWhitePoint(const skcms_ICCProfile& profile,
                                                CIExy* out) {
@@ -458,8 +557,15 @@ JXL_MUST_USE_RESULT Status UnadaptedWhitePoint(const skcms_ICCProfile& profile,
     *out = CIExyFromXYZ(media_white_point_XYZ);
     return true;
   }
-  // Otherwise, it has been adapted to the PCS white point using said matrix,
-  // and the adaptation needs to be undone.
+  Color adapted_white_point_XYZ;
+  if (RecoverMatrixProfileWhitePoint(profile, media_white_point_XYZ,
+                                     adapted_white_point_XYZ)) {
+    media_white_point_XYZ = adapted_white_point_XYZ;
+  }
+  // The media white point is expressed in the PCS after the chromatic
+  // adaptation in the profile. Undo that adaptation to recover the source
+  // white point. The compatibility path above replaces the inconsistent media
+  // white point with the adapted neutral before applying the same operation.
   skcms_Matrix3x3 inverse_CHAD;
   if (!skcms_Matrix3x3_invert(&CHAD, &inverse_CHAD)) {
     return JXL_FAILURE("Non-invertible ChromaticAdaptation matrix");
@@ -541,6 +647,16 @@ Status DetectTransferFunction(const skcms_ICCProfile& profile,
                               ColorEncoding* JXL_RESTRICT c) {
   JXL_ENSURE(c->color_space != ColorSpace::kXYB);
 
+  Color media_white_point_XYZ;
+  Color adapted_white_point_XYZ;
+  if (!HasParametricTRCs(profile) &&
+      skcms_GetWTPT(&profile, media_white_point_XYZ.data()) &&
+      GetNonconformingMatrixProfileWhitePoint(profile, media_white_point_XYZ,
+                                              adapted_white_point_XYZ)) {
+    c->tf.SetTransferFunction(TransferFunction::kUnknown);
+    return true;
+  }
+
   float gamma[3] = {};
   if (profile.has_trc) {
     const auto IsGamma = [](const skcms_TransferFunction& tf) {
@@ -608,8 +724,12 @@ ColorSpace ColorSpaceFromProfile(const Profile& profile) {
 }
 
 // "profile1" is pre-decoded to save time in DetectTransferFunction.
+constexpr double kIccEquivalenceTolerance = 2E-4;
+constexpr double kLegacyMatrixProfileEquivalenceTolerance = 3E-4;
+
 Status ProfileEquivalentToICC(const cmsContext context, const Profile& profile1,
-                              const IccBytes& icc, const ColorEncoding& c) {
+                              const IccBytes& icc, const ColorEncoding& c,
+                              const double tolerance) {
   const uint32_t type_src = Type64(c);
 
   Profile profile2;
@@ -644,7 +764,7 @@ Status ProfileEquivalentToICC(const cmsContext context, const Profile& profile1,
     for (in[0] = init; in[0] < 1.0; in[0] += step / 8) {
       cmsDoTransform(xform1.get(), in, out1, 1);
       cmsDoTransform(xform2.get(), in, out2, 1);
-      if (!cms::ApproxEq(out1[0], out2[0], 2E-4)) {
+      if (!cms::ApproxEq(out1[0], out2[0], tolerance)) {
         return false;
       }
     }
@@ -655,7 +775,7 @@ Status ProfileEquivalentToICC(const cmsContext context, const Profile& profile1,
           cmsDoTransform(xform1.get(), in, out1, 1);
           cmsDoTransform(xform2.get(), in, out2, 1);
           for (size_t i = 0; i < 3; ++i) {
-            if (!cms::ApproxEq(out1[i], out2[i], 2E-4)) {
+            if (!cms::ApproxEq(out1[i], out2[i], tolerance)) {
               return false;
             }
           }
@@ -667,6 +787,116 @@ Status ProfileEquivalentToICC(const cmsContext context, const Profile& profile1,
   return true;
 }
 
+bool HasLUTTags(const Profile& profile) {
+  for (const auto tag :
+       {cmsSigAToB0Tag, cmsSigAToB1Tag, cmsSigAToB2Tag, cmsSigBToA0Tag,
+        cmsSigBToA1Tag, cmsSigBToA2Tag, cmsSigDToB0Tag, cmsSigDToB1Tag,
+        cmsSigDToB2Tag, cmsSigDToB3Tag, cmsSigBToD0Tag, cmsSigBToD1Tag,
+        cmsSigBToD2Tag, cmsSigBToD3Tag}) {
+    if (cmsIsTag(profile.get(), tag)) return true;
+  }
+  return false;
+}
+
+bool HasParametricTRCs(const Profile& profile) {
+  for (const auto tag :
+       {cmsSigRedTRCTag, cmsSigGreenTRCTag, cmsSigBlueTRCTag}) {
+    const auto* trc =
+        static_cast<const cmsToneCurve*>(cmsReadTag(profile.get(), tag));
+    if (trc == nullptr || cmsGetToneCurveParametricType(trc) <= 0) return false;
+  }
+  return true;
+}
+
+bool IsApproximatelyD50(const cmsCIEXYZ& XYZ) {
+  const cmsCIEXYZ d50 = D50_XYZ();
+  constexpr cmsFloat64Number kTolerance = 1e-3;
+  return std::abs(XYZ.X - d50.X) < kTolerance &&
+         std::abs(XYZ.Y - d50.Y) < kTolerance &&
+         std::abs(XYZ.Z - d50.Z) < kTolerance;
+}
+
+bool GetInverseCHAD(const Profile& profile, Matrix3x3d* inverse_chad) {
+  const cmsMAT3* chad = static_cast<const cmsMAT3*>(
+      cmsReadTag(profile.get(), cmsSigChromaticAdaptationTag));
+  if (chad == nullptr) return false;
+  for (int i = 0; i < 3; ++i) {
+    for (int j = 0; j < 3; ++j) {
+      (*inverse_chad)[i][j] = chad->v[i].n[j];
+    }
+  }
+  return Inv3x3Matrix(*inverse_chad);
+}
+
+bool GetNonconformingMatrixProfileWhitePoint(const Profile& profile,
+                                             const cmsCIEXYZ& media_white_point,
+                                             cmsCIEXYZ* matrix_white_point) {
+  const double version = cmsGetProfileVersion(profile.get());
+  if (version < 4.0 || version >= 5.0 ||
+      cmsGetDeviceClass(profile.get()) != cmsSigDisplayClass ||
+      cmsGetColorSpace(profile.get()) != cmsSigRgbData ||
+      cmsGetPCS(profile.get()) != cmsSigXYZData ||
+      cmsReadTag(profile.get(), cmsSigRedColorantTag) == nullptr ||
+      cmsReadTag(profile.get(), cmsSigGreenColorantTag) == nullptr ||
+      cmsReadTag(profile.get(), cmsSigBlueColorantTag) == nullptr ||
+      cmsReadTag(profile.get(), cmsSigRedTRCTag) == nullptr ||
+      cmsReadTag(profile.get(), cmsSigGreenTRCTag) == nullptr ||
+      cmsReadTag(profile.get(), cmsSigBlueTRCTag) == nullptr ||
+      HasLUTTags(profile) || IsApproximatelyD50(media_white_point)) {
+    return false;
+  }
+
+  const cmsCIEXYZ* adapted_r = static_cast<const cmsCIEXYZ*>(
+      cmsReadTag(profile.get(), cmsSigRedColorantTag));
+  const cmsCIEXYZ* adapted_g = static_cast<const cmsCIEXYZ*>(
+      cmsReadTag(profile.get(), cmsSigGreenColorantTag));
+  const cmsCIEXYZ* adapted_b = static_cast<const cmsCIEXYZ*>(
+      cmsReadTag(profile.get(), cmsSigBlueColorantTag));
+  *matrix_white_point = {adapted_r->X + adapted_g->X + adapted_b->X,
+                         adapted_r->Y + adapted_g->Y + adapted_b->Y,
+                         adapted_r->Z + adapted_g->Z + adapted_b->Z};
+  return IsApproximatelyD50(*matrix_white_point);
+}
+
+bool RecoverMatrixProfileWhitePoint(const Profile& profile,
+                                    const cmsCIEXYZ& media_white_point,
+                                    cmsCIEXYZ* unadapted_white_point) {
+  cmsCIEXYZ matrix_white_point;
+  if (!HasParametricTRCs(profile) ||
+      !GetNonconformingMatrixProfileWhitePoint(profile, media_white_point,
+                                               &matrix_white_point)) {
+    return false;
+  }
+
+  Matrix3x3d inverse_chad = {};
+  if (!GetInverseCHAD(profile, &inverse_chad)) return false;
+  const Vector3d adapted = {matrix_white_point.X, matrix_white_point.Y,
+                            matrix_white_point.Z};
+  Vector3d unadapted = {};
+  Mul3x3Vector(inverse_chad, adapted, unadapted);
+  unadapted_white_point->X = unadapted[0];
+  unadapted_white_point->Y = unadapted[1];
+  unadapted_white_point->Z = unadapted[2];
+  return true;
+}
+
+bool HasNonconformingMatrixProfileShape(const Profile& profile) {
+  const cmsCIEXYZ* white_point = static_cast<const cmsCIEXYZ*>(
+      cmsReadTag(profile.get(), cmsSigMediaWhitePointTag));
+  const cmsMAT3* chad = static_cast<const cmsMAT3*>(
+      cmsReadTag(profile.get(), cmsSigChromaticAdaptationTag));
+  cmsCIEXYZ matrix_white_point;
+  return white_point != nullptr && chad != nullptr &&
+         GetNonconformingMatrixProfileWhitePoint(profile, *white_point,
+                                                 &matrix_white_point);
+}
+
+bool IsMatrixProfileWithNonconformingWhitePoint(const Profile& profile) {
+  Matrix3x3d inverse_chad = {};
+  return HasNonconformingMatrixProfileShape(profile) &&
+         GetInverseCHAD(profile, &inverse_chad);
+}
+
 // Returns white point that was specified when creating the profile.
 // NOTE: we can't just use cmsSigMediaWhitePointTag because its interpretation
 // differs between ICC versions.
@@ -675,10 +905,18 @@ JXL_MUST_USE_RESULT cmsCIEXYZ UnadaptedWhitePoint(const cmsContext context,
                                                   const ColorEncoding& c) {
   const cmsCIEXYZ* white_point = static_cast<const cmsCIEXYZ*>(
       cmsReadTag(profile.get(), cmsSigMediaWhitePointTag));
-  if (white_point != nullptr &&
-      cmsReadTag(profile.get(), cmsSigChromaticAdaptationTag) == nullptr) {
+  const cmsMAT3* chad = static_cast<const cmsMAT3*>(
+      cmsReadTag(profile.get(), cmsSigChromaticAdaptationTag));
+  if (white_point != nullptr && chad == nullptr) {
     // No chromatic adaptation matrix: the white point is already unadapted.
     return *white_point;
+  }
+  if (white_point != nullptr && chad != nullptr) {
+    cmsCIEXYZ unadapted_white_point;
+    if (RecoverMatrixProfileWhitePoint(profile, *white_point,
+                                       &unadapted_white_point)) {
+      return unadapted_white_point;
+    }
   }
 
   cmsCIEXYZ XYZ = {1.0, 1.0, 1.0};
@@ -746,14 +984,26 @@ Status IdentifyPrimaries(const cmsContext context, const Profile& profile,
     adapted_b = &converted_rgb[2];
   }
 
-  // TODO(janwas): no longer assume Bradford and D50.
-  // Undo the chromatic adaptation.
-  const cmsCIEXYZ d50 = D50_XYZ();
-
   cmsCIEXYZ r, g, b;
-  cmsAdaptToIlluminant(&r, &d50, &wp_unadapted, adapted_r);
-  cmsAdaptToIlluminant(&g, &d50, &wp_unadapted, adapted_g);
-  cmsAdaptToIlluminant(&b, &d50, &wp_unadapted, adapted_b);
+  Matrix3x3d inverse_chad = {};
+  if (HasParametricTRCs(profile) &&
+      IsMatrixProfileWithNonconformingWhitePoint(profile) &&
+      GetInverseCHAD(profile, &inverse_chad)) {
+    const cmsCIEXYZ* adapted[] = {adapted_r, adapted_g, adapted_b};
+    cmsCIEXYZ* unadapted[] = {&r, &g, &b};
+    for (size_t i = 0; i < 3; ++i) {
+      const Vector3d in = {adapted[i]->X, adapted[i]->Y, adapted[i]->Z};
+      Vector3d out = {};
+      Mul3x3Vector(inverse_chad, in, out);
+      *unadapted[i] = {out[0], out[1], out[2]};
+    }
+  } else {
+    // TODO(janwas): no longer assume Bradford and D50 for other profiles.
+    const cmsCIEXYZ d50 = D50_XYZ();
+    cmsAdaptToIlluminant(&r, &d50, &wp_unadapted, adapted_r);
+    cmsAdaptToIlluminant(&g, &d50, &wp_unadapted, adapted_g);
+    cmsAdaptToIlluminant(&b, &d50, &wp_unadapted, adapted_b);
+  }
 
   const PrimariesCIExy rgb = {CIExyFromXYZ(r), CIExyFromXYZ(g),
                               CIExyFromXYZ(b)};
@@ -763,6 +1013,22 @@ Status IdentifyPrimaries(const cmsContext context, const Profile& profile,
 Status DetectTransferFunction(const cmsContext context, const Profile& profile,
                               ColorEncoding* JXL_RESTRICT c) {
   JXL_ENSURE(c->color_space != ColorSpace::kXYB);
+
+  const bool nonconforming_matrix_profile =
+      HasNonconformingMatrixProfileShape(profile);
+  const bool compatibility_profile =
+      IsMatrixProfileWithNonconformingWhitePoint(profile);
+  if (nonconforming_matrix_profile &&
+      (!compatibility_profile || !HasParametricTRCs(profile))) {
+    c->tf.SetTransferFunction(TransferFunction::kUnknown);
+    return true;
+  }
+  // Matrix/TRC coefficients and the canonical D50 white point are quantized
+  // independently in ICC. Allow that small difference for this compatibility
+  // case while retaining the functional equivalence check.
+  const double equivalence_tolerance =
+      compatibility_profile ? kLegacyMatrixProfileEquivalenceTolerance
+                            : kIccEquivalenceTolerance;
 
   float gamma = 0;
   if (const auto* gray_trc = reinterpret_cast<const cmsToneCurve*>(
@@ -796,7 +1062,8 @@ Status DetectTransferFunction(const cmsContext context, const Profile& profile,
   if (gamma != 0 && c->tf.SetGamma(gamma)) {
     IccBytes icc_test;
     if (MaybeCreateProfile(c->ToExternal(), &icc_test) &&
-        ProfileEquivalentToICC(context, profile, icc_test, *c)) {
+        ProfileEquivalentToICC(context, profile, icc_test, *c,
+                               equivalence_tolerance)) {
       return true;
     }
   }
@@ -809,7 +1076,8 @@ Status DetectTransferFunction(const cmsContext context, const Profile& profile,
 
     IccBytes icc_test;
     if (MaybeCreateProfile(c->ToExternal(), &icc_test) &&
-        ProfileEquivalentToICC(context, profile, icc_test, *c)) {
+        ProfileEquivalentToICC(context, profile, icc_test, *c,
+                               equivalence_tolerance)) {
       return true;
     }
   }
@@ -829,7 +1097,8 @@ cmsContext GetContext() {
     context_.reset(cmsCreateContext(nullptr, nullptr));
     JXL_DASSERT(context_ != nullptr);
 
-    cmsSetLogErrorHandlerTHR(static_cast<cmsContext>(context_.get()), &ErrorHandler);
+    cmsSetLogErrorHandlerTHR(static_cast<cmsContext>(context_.get()),
+                             &ErrorHandler);
   }
   return static_cast<cmsContext>(context_.get());
 }

--- a/lib/jxl/color_management_test.cc
+++ b/lib/jxl/color_management_test.cc
@@ -8,12 +8,15 @@
 #include <jxl/memory_manager.h>
 
 #include <algorithm>
+#include <array>
 #include <cmath>
 #include <cstddef>
 #include <cstdint>
 #include <cstdio>
 #include <cstdlib>
+#include <cstring>
 #include <ostream>
+#include <set>
 #include <string>
 #include <utility>
 #include <vector>
@@ -28,6 +31,7 @@
 #include "lib/jxl/image.h"
 #include "lib/jxl/image_ops.h"
 #include "lib/jxl/image_test_utils.h"
+#include "lib/jxl/test_image.h"
 #include "lib/jxl/test_memory_manager.h"
 #include "lib/jxl/test_utils.h"
 #include "lib/jxl/testing.h"
@@ -49,6 +53,247 @@ namespace {
 constexpr size_t kWidth = 16;
 
 constexpr size_t kNumThreads = 1;  // only have a single row.
+
+size_t CountDistinctColors(const extras::PackedImage& image, size_t limit) {
+  std::set<std::array<uint16_t, 3>> colors;
+  for (size_t y = 0; y < image.ysize; ++y) {
+    for (size_t x = 0; x < image.xsize; ++x) {
+      std::array<uint16_t, 3> color;
+      for (size_t c = 0; c < color.size(); ++c) {
+        color[c] = static_cast<uint16_t>(std::lround(
+            Clamp1(image.GetPixelValue(y, x, c), 0.0f, 1.0f) * 65535.0f));
+      }
+      colors.insert(color);
+      if (colors.size() > limit) return colors.size();
+    }
+  }
+  return colors.size();
+}
+
+uint32_t ReadBE32(const uint8_t* bytes) {
+  return (static_cast<uint32_t>(bytes[0]) << 24) |
+         (static_cast<uint32_t>(bytes[1]) << 16) |
+         (static_cast<uint32_t>(bytes[2]) << 8) |
+         static_cast<uint32_t>(bytes[3]);
+}
+
+void WriteBE32(uint8_t* bytes, uint32_t value) {
+  bytes[0] = static_cast<uint8_t>(value >> 24);
+  bytes[1] = static_cast<uint8_t>(value >> 16);
+  bytes[2] = static_cast<uint8_t>(value >> 8);
+  bytes[3] = static_cast<uint8_t>(value);
+}
+
+void WriteBE16(uint8_t* bytes, uint16_t value) {
+  bytes[0] = static_cast<uint8_t>(value >> 8);
+  bytes[1] = static_cast<uint8_t>(value);
+}
+
+size_t FindIccTagRecord(const IccBytes& icc, const char* signature) {
+  if (icc.size() < 132U) return 0;
+  const uint32_t tag_count = ReadBE32(icc.data() + 128);
+  if (tag_count > (icc.size() - 132U) / 12U) return 0;
+  for (uint32_t i = 0; i < tag_count; ++i) {
+    const size_t record = 132U + 12U * i;
+    if (std::memcmp(icc.data() + record, signature, 4) == 0) return record;
+  }
+  return 0;
+}
+
+bool HasIccTag(const IccBytes& icc, const char* signature) {
+  return FindIccTagRecord(icc, signature) != 0;
+}
+
+StatusOr<IccBytes> CreateDisplayP3MatrixProfile() {
+  ColorEncoding encoding;
+  encoding.SetColorSpace(ColorSpace::kRGB);
+  JXL_RETURN_IF_ERROR(encoding.SetWhitePointType(WhitePoint::kD65));
+  JXL_RETURN_IF_ERROR(encoding.SetPrimariesType(Primaries::kP3));
+  encoding.Tf().SetTransferFunction(TransferFunction::kSRGB);
+  encoding.SetRenderingIntent(RenderingIntent::kRelative);
+  JXL_RETURN_IF_ERROR(encoding.CreateICC());
+
+  IccBytes icc = encoding.ICC();
+  const size_t cicp_record = FindIccTagRecord(icc, "cicp");
+  JXL_ENSURE(cicp_record != 0);
+  std::memcpy(icc.data() + cicp_record, "tst0", 4);
+  // A zero profile ID is valid and avoids retaining the checksum after the
+  // intentional test mutation.
+  std::fill(icc.begin() + 84, icc.begin() + 100, 0);
+  return icc;
+}
+
+StatusOr<IccBytes> CreateNonconformingDisplayP3Profile() {
+  JXL_ASSIGN_OR_RETURN(IccBytes icc, CreateDisplayP3MatrixProfile());
+
+  const size_t wtpt_record = FindIccTagRecord(icc, "wtpt");
+  JXL_ENSURE(wtpt_record != 0);
+  const size_t wtpt_offset = ReadBE32(icc.data() + wtpt_record + 4);
+  const size_t wtpt_size = ReadBE32(icc.data() + wtpt_record + 8);
+  JXL_ENSURE(wtpt_offset <= icc.size());
+  JXL_ENSURE(wtpt_size >= 20U && wtpt_size <= icc.size() - wtpt_offset);
+  JXL_ENSURE(std::memcmp(icc.data() + wtpt_offset, "XYZ ", 4) == 0);
+
+  // ICC v4 display profiles normally store D50 here. This deliberately stores
+  // D65 while retaining CHAD and D50-adapted matrix columns, matching the
+  // malformed profile shape that triggered issue #4911.
+  constexpr std::array<double, 3> kD65XYZ = {0.3127 / 0.3290, 1.0,
+                                             (1.0 - 0.3127 - 0.3290) / 0.3290};
+  for (size_t i = 0; i < kD65XYZ.size(); ++i) {
+    WriteBE32(icc.data() + wtpt_offset + 8U + 4U * i,
+              static_cast<uint32_t>(
+                  static_cast<int32_t>(std::lround(kD65XYZ[i] * 65536.0))));
+  }
+  return icc;
+}
+
+StatusOr<test::TestImage> CreateNonconformingDisplayP3TestImage(
+    const IccBytes& icc, size_t size, size_t bits_per_sample,
+    size_t alpha_pattern) {
+  test::TestImage image;
+  JXL_RETURN_IF_ERROR(image.SetDimensions(size, size));
+  JXL_RETURN_IF_ERROR(image.SetChannels(4));
+  image.SetAllBitDepths(bits_per_sample);
+  JXL_RETURN_IF_ERROR(image.SetColorEncoding("DisplayP3"));
+  JXL_ASSIGN_OR_RETURN(auto frame, image.AddFrame());
+  for (size_t y = 0; y < size; ++y) {
+    for (size_t x = 0; x < size; ++x) {
+      const double ramp = static_cast<double>(x + y * size) /
+                          static_cast<double>(size * size - 1);
+      JXL_RETURN_IF_ERROR(frame.SetValue(y, x, 0, 0.945 + 0.055 * ramp));
+      JXL_RETURN_IF_ERROR(frame.SetValue(y, x, 1, 2.0 * ramp / 65535.0));
+      JXL_RETURN_IF_ERROR(frame.SetValue(y, x, 2, 8.0 * ramp / 65535.0));
+      const double alpha = alpha_pattern == 0   ? 1.0
+                           : alpha_pattern == 1 ? (x + y) % 2
+                                                : 0.25 + 0.75 * ramp;
+      JXL_RETURN_IF_ERROR(frame.SetValue(y, x, 3, alpha));
+    }
+  }
+  image.ppf().icc.assign(icc.begin(), icc.end());
+  image.ppf().orig_icc.assign(icc.begin(), icc.end());
+  image.ppf().primary_color_representation =
+      extras::PackedPixelFile::kIccIsPrimary;
+  return image;
+}
+
+bool ReplaceIccTag(IccBytes* target, const char* target_signature,
+                   const char* new_signature, const IccBytes& source,
+                   const char* source_signature) {
+  const size_t target_record = FindIccTagRecord(*target, target_signature);
+  const size_t source_record = FindIccTagRecord(source, source_signature);
+  if (target_record == 0 || source_record == 0) return false;
+  const size_t source_offset = ReadBE32(source.data() + source_record + 4);
+  const size_t source_size = ReadBE32(source.data() + source_record + 8);
+  if (source_offset > source.size() ||
+      source_size > source.size() - source_offset) {
+    return false;
+  }
+  const size_t target_offset = (target->size() + 3U) & ~size_t{3};
+  target->resize(target_offset + source_size);
+  std::copy(source.begin() + source_offset,
+            source.begin() + source_offset + source_size,
+            target->begin() + target_offset);
+  std::memcpy(target->data() + target_record, new_signature, 4);
+  WriteBE32(target->data() + target_record + 4,
+            static_cast<uint32_t>(target_offset));
+  WriteBE32(target->data() + target_record + 8,
+            static_cast<uint32_t>(source_size));
+  WriteBE32(target->data(), static_cast<uint32_t>(target->size()));
+  return true;
+}
+
+bool ReplaceTrcsWithSampledCurve(IccBytes* icc,
+                                 bool make_non_equivalent = true) {
+  constexpr size_t kEntries = 256;
+  IccBytes curve(12U + 2U * kEntries);
+  std::memcpy(curve.data(), "curv", 4);
+  WriteBE32(curve.data() + 8, kEntries);
+  for (size_t i = 0; i < kEntries; ++i) {
+    const double x = static_cast<double>(i) / (kEntries - 1);
+    double y = x <= 0.04045 ? x / 12.92 : std::pow((x + 0.055) / 1.055, 2.4);
+    if (make_non_equivalent && i == 25) y += 0.25;
+    WriteBE16(
+        curve.data() + 12U + 2U * i,
+        static_cast<uint16_t>(std::lround(Clamp1(y, 0.0, 1.0) * 65535.0)));
+  }
+
+  const size_t offset = (icc->size() + 3U) & ~size_t{3};
+  icc->resize(offset + curve.size());
+  std::copy(curve.begin(), curve.end(), icc->begin() + offset);
+  for (const char* signature : {"rTRC", "gTRC", "bTRC"}) {
+    const size_t record = FindIccTagRecord(*icc, signature);
+    if (record == 0) return false;
+    WriteBE32(icc->data() + record + 4, static_cast<uint32_t>(offset));
+    WriteBE32(icc->data() + record + 8, static_cast<uint32_t>(curve.size()));
+  }
+  WriteBE32(icc->data(), static_cast<uint32_t>(icc->size()));
+  return true;
+}
+
+bool ModifiedTrcRemainsICC(const IccBytes& icc, size_t trc_offset,
+                           uint32_t delta) {
+  IccBytes modified_icc = icc;
+  WriteBE32(modified_icc.data() + trc_offset + 16,
+            ReadBE32(modified_icc.data() + trc_offset + 16) + delta);
+  ColorEncoding modified;
+  if (!modified.SetICC(std::move(modified_icc), JxlGetDefaultCms())) {
+    return false;
+  }
+  modified.DecideIfWantICC(*JxlGetDefaultCms());
+  return modified.WantICC();
+}
+
+void CheckNonconformingDisplayP3FullSizeLossy(
+    const extras::PackedPixelFile& input, size_t distinct_color_limit) {
+  extras::JXLCompressParams params;
+  params.distance = 1.0f;
+  extras::JXLDecompressParams decode_params;
+  decode_params.accepted_formats.push_back(
+      {4, input.frames[0].color.format.data_type,
+       input.frames[0].color.format.endianness, /*align=*/0});
+  extras::PackedPixelFile output;
+  ASSERT_GT(test::Roundtrip(input, params, decode_params, nullptr, &output),
+            0U);
+  const uint32_t output_bits =
+      input.frames[0].color.format.data_type == JXL_TYPE_UINT8 ? 8U : 16U;
+  EXPECT_EQ(output.info.bits_per_sample, output_bits);
+  EXPECT_EQ(output.primary_color_representation,
+            extras::PackedPixelFile::kColorEncodingIsPrimary);
+  EXPECT_GT(CountDistinctColors(output.frames[0].color, distinct_color_limit),
+            distinct_color_limit);
+  // Butteraugli converts both inputs through their declared color encodings,
+  // so this also checks color fidelity in a common viewing space.
+  EXPECT_LE(test::ButteraugliDistance(input, output), 1.5f);
+}
+
+void CheckNonconformingDisplayP3Tolerance(
+    const extras::PackedPixelFile& input) {
+  ASSERT_GE(input.icc.size(), 132U);
+  const uint32_t tag_count = ReadBE32(input.icc.data() + 128);
+  ASSERT_LE(tag_count, (input.icc.size() - 132U) / 12U);
+  size_t trc_offset = 0;
+  size_t trc_size = 0;
+  for (uint32_t i = 0; i < tag_count; ++i) {
+    const size_t record = 132U + 12U * i;
+    if (std::memcmp(input.icc.data() + record, "rTRC", 4) == 0) {
+      trc_offset = ReadBE32(input.icc.data() + record + 4);
+      trc_size = ReadBE32(input.icc.data() + record + 8);
+      break;
+    }
+  }
+  ASSERT_GT(trc_offset, 0U);
+  ASSERT_LE(trc_offset + trc_size, input.icc.size());
+  ASSERT_GE(trc_size, 20U);
+  ASSERT_EQ(std::memcmp(input.icc.data() + trc_offset, "para", 4), 0);
+  // Keep the v4 matrix/CHAD/white-point shape but make the shared TRC clearly
+  // non-equivalent. Both CMS implementations must retain the ICC profile.
+  EXPECT_TRUE(ModifiedTrcRemainsICC(input.icc, trc_offset, 4096));
+#if !JPEGXL_ENABLE_SKCMS
+  // In the lcms path, adding 16 fixed-point LSBs is a small mutation rejected
+  // by the relaxed 3E-4 functional-equivalence comparison.
+  EXPECT_TRUE(ModifiedTrcRemainsICC(input.icc, trc_offset, 16));
+#endif
+}
 
 struct Globals {
   // TODO(deymo): Make this a const.
@@ -268,6 +513,270 @@ TEST_F(ColorManagementTest, D2700ToSRGB) {
       transform.Run(0, sRGB_D2700_values.data(), sRGB_values.data(), 1));
   Color sRGB_expected{0.914, 0.745, 0.601};
   EXPECT_ARRAY_NEAR(sRGB_values, sRGB_expected, 1e-3);
+}
+
+TEST_F(ColorManagementTest, NonconformingDisplayP3DoesNotCollapseWithLossyXYB) {
+  JXL_TEST_ASSIGN_OR_DIE(const IccBytes expected_icc,
+                         CreateNonconformingDisplayP3Profile());
+  JXL_TEST_ASSIGN_OR_DIE(test::TestImage test_image,
+                         CreateNonconformingDisplayP3TestImage(
+                             expected_icc, 256, 16, /*alpha_pattern=*/0));
+  extras::PackedPixelFile& input = test_image.ppf();
+  ASSERT_EQ(input.primary_color_representation,
+            extras::PackedPixelFile::kIccIsPrimary);
+  EXPECT_EQ(input.icc, expected_icc);
+  EXPECT_EQ(input.info.bits_per_sample, 16U);
+  EXPECT_EQ(input.info.alpha_bits, 16U);
+
+  {
+    ColorEncoding parsed;
+    ASSERT_TRUE(parsed.SetICC(IccBytes(input.icc), JxlGetDefaultCms()));
+    ASSERT_TRUE(parsed.HasPrimaries());
+    EXPECT_EQ(parsed.GetWhitePointType(), WhitePoint::kD65);
+    EXPECT_EQ(parsed.GetPrimariesType(), Primaries::kP3);
+    EXPECT_TRUE(parsed.Tf().IsSRGB());
+  }
+
+  ASSERT_NO_FATAL_FAILURE(CheckNonconformingDisplayP3FullSizeLossy(input, 100));
+  ASSERT_NO_FATAL_FAILURE(CheckNonconformingDisplayP3Tolerance(input));
+}
+
+TEST_F(ColorManagementTest, NonconformingDisplayP3InputVariants) {
+  JXL_TEST_ASSIGN_OR_DIE(const IccBytes icc,
+                         CreateNonconformingDisplayP3Profile());
+  struct Variant {
+    size_t bits_per_sample;
+    size_t alpha_pattern;
+  };
+  for (const Variant& variant :
+       {Variant{8, 0}, Variant{10, 1}, Variant{12, 2}}) {
+    SCOPED_TRACE(testing::Message()
+                 << "bits=" << variant.bits_per_sample
+                 << " alpha_pattern=" << variant.alpha_pattern);
+    JXL_TEST_ASSIGN_OR_DIE(
+        test::TestImage test_image,
+        CreateNonconformingDisplayP3TestImage(icc, 64, variant.bits_per_sample,
+                                              variant.alpha_pattern));
+    ASSERT_NO_FATAL_FAILURE(
+        CheckNonconformingDisplayP3FullSizeLossy(test_image.ppf(), 4));
+  }
+
+  JXL_TEST_ASSIGN_OR_DIE(
+      test::TestImage lossless_image,
+      CreateNonconformingDisplayP3TestImage(icc, 64, 16, /*alpha_pattern=*/2));
+  extras::JXLCompressParams params;
+  params.distance = 0.0f;
+  extras::JXLDecompressParams decode_params;
+  decode_params.accepted_formats.push_back(
+      {4, lossless_image.ppf().frames[0].color.format.data_type,
+       lossless_image.ppf().frames[0].color.format.endianness, /*align=*/0});
+  extras::PackedPixelFile output;
+  ASSERT_GT(test::Roundtrip(lossless_image.ppf(), params, decode_params,
+                            nullptr, &output),
+            0U);
+  ASSERT_EQ(output.frames.size(), 1U);
+  EXPECT_TRUE(test::SamePixels(lossless_image.ppf().frames[0].color,
+                               output.frames[0].color));
+  EXPECT_EQ(output.primary_color_representation,
+            extras::PackedPixelFile::kIccIsPrimary);
+}
+
+TEST_F(ColorManagementTest, ConformingDisplayP3ProfileUsesStructuredFields) {
+  JXL_TEST_ASSIGN_OR_DIE(IccBytes conforming_icc,
+                         CreateDisplayP3MatrixProfile());
+  ASSERT_GE(conforming_icc.size(), 128U);
+  EXPECT_EQ(conforming_icc[8], 4U);
+  EXPECT_EQ(std::memcmp(conforming_icc.data() + 12, "mntr", 4), 0);
+  EXPECT_EQ(std::memcmp(conforming_icc.data() + 16, "RGB ", 4), 0);
+  EXPECT_EQ(std::memcmp(conforming_icc.data() + 20, "XYZ ", 4), 0);
+  for (const char* tag :
+       {"wtpt", "chad", "rXYZ", "gXYZ", "bXYZ", "rTRC", "gTRC", "bTRC"}) {
+    EXPECT_TRUE(HasIccTag(conforming_icc, tag));
+  }
+  EXPECT_FALSE(HasIccTag(conforming_icc, "A2B0"));
+  ColorEncoding actual;
+  ASSERT_TRUE(actual.SetICC(std::move(conforming_icc), JxlGetDefaultCms()));
+  actual.DecideIfWantICC(*JxlGetDefaultCms());
+  EXPECT_FALSE(actual.WantICC());
+  EXPECT_EQ(actual.GetWhitePointType(), WhitePoint::kD65);
+  EXPECT_EQ(actual.GetPrimariesType(), Primaries::kP3);
+  EXPECT_TRUE(actual.Tf().IsSRGB());
+}
+
+TEST_F(ColorManagementTest, CustomChadMatrixProfileRemainsICC) {
+  JXL_TEST_ASSIGN_OR_DIE(IccBytes icc, CreateNonconformingDisplayP3Profile());
+  const size_t chad_record = FindIccTagRecord(icc, "chad");
+  ASSERT_GT(chad_record, 0U);
+  const size_t chad_offset = ReadBE32(icc.data() + chad_record + 4);
+  const size_t chad_size = ReadBE32(icc.data() + chad_record + 8);
+  ASSERT_GE(chad_size, 44U);
+  ASSERT_LE(chad_offset + chad_size, icc.size());
+  ASSERT_EQ(std::memcmp(icc.data() + chad_offset, "sf32", 4), 0);
+
+  // Structured color fields can only regenerate Bradford adaptation. A valid
+  // profile with a different CHAD must therefore retain its ICC profile.
+  WriteBE32(icc.data() + chad_offset + 8,
+            ReadBE32(icc.data() + chad_offset + 8) + 4096);
+
+  ColorEncoding actual;
+  ASSERT_TRUE(actual.SetICC(std::move(icc), JxlGetDefaultCms()));
+  actual.DecideIfWantICC(*JxlGetDefaultCms());
+  EXPECT_TRUE(actual.WantICC());
+}
+
+TEST_F(ColorManagementTest, SingularChadIsNotSimplified) {
+  JXL_TEST_ASSIGN_OR_DIE(IccBytes icc, CreateNonconformingDisplayP3Profile());
+  const size_t chad_record = FindIccTagRecord(icc, "chad");
+  ASSERT_GT(chad_record, 0U);
+  const size_t chad_offset = ReadBE32(icc.data() + chad_record + 4);
+  const size_t chad_size = ReadBE32(icc.data() + chad_record + 8);
+  ASSERT_GE(chad_size, 44U);
+  ASSERT_LE(chad_offset + chad_size, icc.size());
+  for (size_t i = 0; i < 9; ++i) {
+    WriteBE32(icc.data() + chad_offset + 8U + 4U * i, 0);
+  }
+
+  ColorEncoding actual;
+  // Rejecting a singular CHAD is also safe. If the CMS accepts the malformed
+  // profile, it must retain the ICC rather than enter the compatibility path.
+  if (actual.SetICC(std::move(icc), JxlGetDefaultCms())) {
+    actual.DecideIfWantICC(*JxlGetDefaultCms());
+    EXPECT_TRUE(actual.WantICC());
+  }
+}
+
+TEST_F(ColorManagementTest, NearSingularChadIsNotSimplified) {
+  JXL_TEST_ASSIGN_OR_DIE(IccBytes icc, CreateNonconformingDisplayP3Profile());
+  const size_t chad_record = FindIccTagRecord(icc, "chad");
+  ASSERT_GT(chad_record, 0U);
+  const size_t chad_offset = ReadBE32(icc.data() + chad_record + 4);
+  const size_t chad_size = ReadBE32(icc.data() + chad_record + 8);
+  ASSERT_GE(chad_size, 44U);
+  ASSERT_LE(chad_offset + chad_size, icc.size());
+  ASSERT_EQ(std::memcmp(icc.data() + chad_offset, "sf32", 4), 0);
+
+  // Each diagonal value is 1/65536 in ICC s15Fixed16 notation. This is a
+  // nonzero, ICC-representable determinant below Inv3x3Matrix's threshold.
+  constexpr uint32_t kOneFixedPointLsb = 1;
+  constexpr double kDeterminant = 1.0 / (65536.0 * 65536.0 * 65536.0);
+  EXPECT_GT(kDeterminant, 0.0);
+  EXPECT_LT(kDeterminant, 1e-10);
+  for (size_t i = 0; i < 9; ++i) {
+    WriteBE32(icc.data() + chad_offset + 8U + 4U * i,
+              i % 4 == 0 ? kOneFixedPointLsb : 0);
+  }
+
+  ColorEncoding actual;
+  // Rejecting an unsafe CHAD is also safe. If the CMS accepts the malformed
+  // profile, it must retain the ICC rather than enter the compatibility path.
+  if (actual.SetICC(std::move(icc), JxlGetDefaultCms())) {
+    actual.DecideIfWantICC(*JxlGetDefaultCms());
+    EXPECT_TRUE(actual.WantICC());
+  }
+}
+
+TEST_F(ColorManagementTest, Version2DisplayP3ProfileUsesStructuredFields) {
+  JXL_TEST_ASSIGN_OR_DIE(IccBytes icc, CreateDisplayP3MatrixProfile());
+  ASSERT_GE(icc.size(), 12U);
+
+  // Change the header version to ICC v2.1. The malformed-profile compatibility
+  // rule is v4-only, and valid v2 interpretation must remain unchanged.
+  icc[8] = 2;
+  icc[9] = 0x10;
+  icc[10] = 0;
+  icc[11] = 0;
+
+  ColorEncoding actual;
+  ASSERT_TRUE(actual.SetICC(std::move(icc), JxlGetDefaultCms()));
+  actual.DecideIfWantICC(*JxlGetDefaultCms());
+  EXPECT_FALSE(actual.WantICC());
+  EXPECT_EQ(actual.GetWhitePointType(), WhitePoint::kD65);
+  EXPECT_EQ(actual.GetPrimariesType(), Primaries::kP3);
+  EXPECT_TRUE(actual.Tf().IsSRGB());
+}
+
+TEST_F(ColorManagementTest, LUTProfileRemainsICC) {
+  ColorEncoding lut_source;
+  lut_source.SetColorSpace(ColorSpace::kXYB);
+  lut_source.SetRenderingIntent(RenderingIntent::kPerceptual);
+  ASSERT_TRUE(lut_source.CreateICC());
+  ASSERT_TRUE(HasIccTag(lut_source.ICC(), "A2B0"));
+
+  JXL_TEST_ASSIGN_OR_DIE(IccBytes hybrid,
+                         CreateNonconformingDisplayP3Profile());
+  ASSERT_TRUE(ReplaceIccTag(&hybrid, "desc", "A2B0", lut_source.ICC(), "A2B0"));
+  ASSERT_TRUE(HasIccTag(hybrid, "rXYZ"));
+  ASSERT_TRUE(HasIccTag(hybrid, "rTRC"));
+  ASSERT_TRUE(HasIccTag(hybrid, "A2B0"));
+
+  ColorEncoding actual;
+  ASSERT_TRUE(actual.SetICC(std::move(hybrid), JxlGetDefaultCms()));
+  actual.DecideIfWantICC(*JxlGetDefaultCms());
+  EXPECT_TRUE(actual.WantICC());
+  EXPECT_NE(actual.GetWhitePointType(), WhitePoint::kD65);
+}
+
+TEST_F(ColorManagementTest, SampledTrcProfileSkipsWhitePointRecovery) {
+  JXL_TEST_ASSIGN_OR_DIE(IccBytes icc, CreateNonconformingDisplayP3Profile());
+  ASSERT_TRUE(ReplaceTrcsWithSampledCurve(&icc));
+
+  ColorEncoding actual;
+  ASSERT_TRUE(actual.SetICC(std::move(icc), JxlGetDefaultCms()));
+  actual.DecideIfWantICC(*JxlGetDefaultCms());
+  EXPECT_TRUE(actual.WantICC());
+  EXPECT_NE(actual.GetWhitePointType(), WhitePoint::kD65);
+}
+
+TEST_F(ColorManagementTest, NoChadProfileSkipsCompatibilityPath) {
+  JXL_TEST_ASSIGN_OR_DIE(IccBytes icc, CreateNonconformingDisplayP3Profile());
+  const size_t chad_record = FindIccTagRecord(icc, "chad");
+  ASSERT_GT(chad_record, 0U);
+  std::memcpy(icc.data() + chad_record, "tst1", 4);
+  ASSERT_TRUE(ReplaceTrcsWithSampledCurve(&icc, /*make_non_equivalent=*/false));
+
+  ColorEncoding actual;
+  ASSERT_TRUE(actual.SetICC(std::move(icc), JxlGetDefaultCms()));
+  actual.DecideIfWantICC(*JxlGetDefaultCms());
+  EXPECT_FALSE(actual.WantICC());
+  EXPECT_EQ(actual.GetWhitePointType(), WhitePoint::kD65);
+  EXPECT_EQ(actual.GetPrimariesType(), Primaries::kP3);
+  EXPECT_TRUE(actual.Tf().IsSRGB());
+}
+
+TEST_F(ColorManagementTest, UnequalTrcMatrixProfileRemainsICC) {
+  JXL_TEST_ASSIGN_OR_DIE(IccBytes icc, CreateNonconformingDisplayP3Profile());
+  ASSERT_GE(icc.size(), 132U);
+  const uint32_t tag_count = ReadBE32(icc.data() + 128);
+  ASSERT_LE(tag_count, (icc.size() - 132U) / 12U);
+  size_t green_trc_record = 0;
+  for (uint32_t i = 0; i < tag_count; ++i) {
+    const size_t record = 132U + 12U * i;
+    if (std::memcmp(icc.data() + record, "gTRC", 4) == 0) {
+      green_trc_record = record;
+      break;
+    }
+  }
+  ASSERT_GT(green_trc_record, 0U);
+  const size_t trc_offset = ReadBE32(icc.data() + green_trc_record + 4);
+  const size_t trc_size = ReadBE32(icc.data() + green_trc_record + 8);
+  ASSERT_GE(trc_size, 20U);
+  ASSERT_LE(trc_offset + trc_size, icc.size());
+
+  const IccBytes green_trc(icc.begin() + trc_offset,
+                           icc.begin() + trc_offset + trc_size);
+  const size_t new_trc_offset = (icc.size() + 3U) & ~size_t{3};
+  icc.resize(new_trc_offset + trc_size);
+  std::copy(green_trc.begin(), green_trc.end(), icc.begin() + new_trc_offset);
+  WriteBE32(icc.data(), static_cast<uint32_t>(icc.size()));
+  WriteBE32(icc.data() + green_trc_record + 4,
+            static_cast<uint32_t>(new_trc_offset));
+  WriteBE32(icc.data() + new_trc_offset + 16,
+            ReadBE32(icc.data() + new_trc_offset + 16) + 4096);
+
+  ColorEncoding actual;
+  ASSERT_TRUE(actual.SetICC(std::move(icc), JxlGetDefaultCms()));
+  actual.DecideIfWantICC(*JxlGetDefaultCms());
+  EXPECT_TRUE(actual.WantICC());
 }
 
 TEST_F(ColorManagementTest, P3HlgTo2020Hlg) {


### PR DESCRIPTION
### Description

Lossy XYB encoding can collapse the WebKit logo from #4911 to a single red color when it carries Apple's legacy 548-byte Display P3 ICC profile. The profile is a v4 RGB matrix/TRC display profile with a CHAD tag, but it stores a non-D50 media white point. This prevents libjxl from recognizing the otherwise equivalent D65/P3/sRGB encoding.

For this narrow nonconforming profile shape, recover the adapted neutral from the RGB-to-XYZD50 matrix columns before undoing the CHAD. The same compatibility rule is implemented for skcms and lcms.

The rule applies only to v4 RGB display profiles with an XYZ PCS, matrix colorants, parametric TRCs, a valid CHAD, a non-D50 media white point, a D50 matrix-column sum, and no LUT tags. It does not depend on the profile description, manufacturer, or hash.

The existing functional-equivalence check remains the final gate before replacing an ICC profile with structured color fields. In the lcms path, its tolerance is relaxed from `2e-4` to `3e-4` only for this compatibility case to account for independent ICC fixed-point quantization. A negative test verifies that a modified TRC is still retained as ICC.

The regression tests construct the relevant profiles in memory, so no third-party image or ICC assets are added.

Fixes #4911.

### Testing

- `color_management_test` with `JPEGXL_ENABLE_SKCMS=ON`: 234/234 passed
- `color_management_test` with `JPEGXL_ENABLE_SKCMS=OFF`: 234/234 passed
- Exact #4911 PNG encoded at distance 1 and decoded with both CMS builds; the red gradient is preserved instead of collapsing to one color
- Coverage includes conforming Display P3, ICC v2, lossless and lossy XYB, 8/10/12/16-bit inputs, alpha variants, LUT profiles, sampled and unequal TRCs, and invalid or unrelated CHAD matrices
- `./ci.sh lint`

### Pull Request Checklist

- [X] **CLA Signed**: Confirm that the submitting GitHub account is covered by the Google individual or corporate CLA.
- [x] **Authors**: Considered; no AUTHORS change is included to keep this fix focused.
- [x] **Code Style**: `./ci.sh lint` passes.