### PR TITLE
Add bounds-checked Span and migrate core decode paths

### DIFF
--- a/lib/jxl/base/compiler_specific.h
+++ b/lib/jxl/base/compiler_specific.h
@@ -215,4 +215,16 @@
 #define JXL_CRASH() (void)__builtin_trap()
 #endif
 
+// Release-surviving bounds check for memory safety invariants. Unlike
+// JXL_DASSERT (debug-only) or JXL_ENSURE (returns error in release), this
+// traps unconditionally — appropriate where continuing with an out-of-bounds
+// access would be worse than aborting.
+// Disable with -DJXL_HARDENED=0 for benchmarking.
+#if !defined(JXL_HARDENED) || JXL_HARDENED
+#define JXL_SECURITY_CHECK(condition) \
+  (JXL_UNLIKELY(!(condition)) ? JXL_CRASH() : (void)0)
+#else
+#define JXL_SECURITY_CHECK(condition) ((void)0)
+#endif
+
 #endif  // LIB_JXL_BASE_COMPILER_SPECIFIC_H_

--- a/lib/jxl/base/span.h
+++ b/lib/jxl/base/span.h
@@ -54,9 +54,19 @@ class Span {
 
   constexpr T* end() const noexcept { return data() + size(); }
 
-  constexpr T& operator[](size_t i) const noexcept {
-    // MSVC 2015 accepts this as constexpr, but not ptr_[i]
+  T& operator[](size_t i) const noexcept {
+    JXL_SECURITY_CHECK(i < len_);
     return *(data() + i);
+  }
+
+  Span<T> subspan(size_t offset, size_t count) const noexcept {
+    JXL_SECURITY_CHECK(offset <= len_ && count <= len_ - offset);
+    return Span<T>(ptr_ + offset, count);
+  }
+
+  Span<T> subspan(size_t offset) const noexcept {
+    JXL_SECURITY_CHECK(offset <= len_);
+    return Span<T>(ptr_ + offset, len_ - offset);
   }
 
   Status remove_prefix(size_t n) noexcept {

--- a/lib/jxl/dec_group.cc
+++ b/lib/jxl/dec_group.cc
@@ -19,6 +19,7 @@
 #include <vector>
 
 #include "lib/jxl/base/compiler_specific.h"
+#include "lib/jxl/base/span.h"
 #include "lib/jxl/chroma_from_luma.h"
 #include "lib/jxl/coeff_order_fwd.h"
 #include "lib/jxl/dct_util.h"
@@ -488,6 +489,8 @@ Status DecodeACVarBlock(size_t ctx_offset, size_t log2_covered_blocks,
   size_t ord = kStrategyOrder[acs.RawStrategy()];
   const coeff_order_t* JXL_RESTRICT order =
       &coeff_order[CoeffOrderOffset(ord, c)];
+  // Bounds-checked view of the coefficient order for this block.
+  const Span<const coeff_order_t> order_span(order, size);
 
   size_t block_ctx = block_ctx_map.Context(qdc_row[lbx], qf_row[bx], ord, c);
   const int32_t nzero_ctx =
@@ -523,10 +526,14 @@ Status DecodeACVarBlock(size_t ctx_offset, size_t log2_covered_blocks,
     const size_t neg_sign = (~u_coeff) & 1;
     const ptrdiff_t coeff =
         static_cast<ptrdiff_t>((magnitude ^ (neg_sign - 1)) << shift);
+    // Bounds-checked access: order_span[k] validates k < size, and
+    // coeff_idx < size is verified before indexing into the block.
+    const size_t coeff_idx = order_span[k];
+    JXL_SECURITY_CHECK(coeff_idx < size);
     if (ac_type == ACType::k16) {
-      block.ptr16[order[k]] += coeff;
+      block.ptr16[coeff_idx] += coeff;
     } else {
-      block.ptr32[order[k]] += coeff;
+      block.ptr32[coeff_idx] += coeff;
     }
     prev = static_cast<size_t>(u_coeff != 0);
     nzeros -= prev;

--- a/lib/jxl/modular/encoding/context_predict.h
+++ b/lib/jxl/modular/encoding/context_predict.h
@@ -15,6 +15,7 @@
 
 #include "lib/jxl/base/bits.h"
 #include "lib/jxl/base/compiler_specific.h"
+#include "lib/jxl/base/span.h"
 #include "lib/jxl/base/status.h"
 #include "lib/jxl/field_encodings.h"
 #include "lib/jxl/fields.h"
@@ -71,6 +72,7 @@ struct State {
   pixel_type_w pred = 0;  // *before* removing the added bits.
   std::vector<uint32_t> pred_errors[kNumPredictors];
   std::vector<int32_t> error;
+  size_t buf_size_ = 0;  // = (xsize + 2) * 2, for bounds-checked Span views
   const Header &header;
 
   // Allows to approximate division by a number from 1 to 64.
@@ -90,13 +92,14 @@ struct State {
     return static_cast<uint64_t>(x) << kPredExtraBits;
   }
 
-  State(const Header &header, size_t xsize, size_t ysize) : header(header) {
+  State(const Header &header, size_t xsize, size_t ysize)
+      : buf_size_((xsize + 2) * 2), header(header) {
     // Extra margin to avoid out-of-bounds writes.
     // All have space for two rows of data.
     for (auto &pred_error : pred_errors) {
-      pred_error.resize((xsize + 2) * 2);
+      pred_error.resize(buf_size_);
     }
-    error.resize((xsize + 2) * 2);
+    error.resize(buf_size_);
   }
 
   // Approximates 4+(maxweight<<24)/(x+1), avoiding division
@@ -145,8 +148,8 @@ struct State {
     for (size_t i = 0; i < kNumPredictors; i++) {
       // pred_errors[pos_N] also contains the error of pixel W.
       // pred_errors[pos_NW] also contains the error of pixel WW.
-      weights[i] = pred_errors[i][pos_N] + pred_errors[i][pos_NE] +
-                   pred_errors[i][pos_NW];
+      const Span<const uint32_t> pe(pred_errors[i].data(), buf_size_);
+      weights[i] = pe[pos_N] + pe[pos_NE] + pe[pos_NW];
       weights[i] = ErrorWeight(weights[i], header.w[i]);
     }
 
@@ -156,11 +159,12 @@ struct State {
     NW = AddBits(NW);
     NN = AddBits(NN);
 
-    pixel_type_w teW = x == 0 ? 0 : error[cur_row + x - 1];
-    pixel_type_w teN = error[pos_N];
-    pixel_type_w teNW = error[pos_NW];
+    const Span<const int32_t> err(error.data(), buf_size_);
+    pixel_type_w teW = x == 0 ? 0 : err[cur_row + x - 1];
+    pixel_type_w teN = err[pos_N];
+    pixel_type_w teNW = err[pos_NW];
     pixel_type_w sumWN = teN + teW;
-    pixel_type_w teNE = error[pos_NE];
+    pixel_type_w teNE = err[pos_NE];
 
     if (compute_properties) {
       pixel_type_w p = teW;
@@ -197,15 +201,17 @@ struct State {
     size_t cur_row = y & 1 ? 0 : (xsize + 2);
     size_t prev_row = y & 1 ? (xsize + 2) : 0;
     val = AddBits(val);
-    error[cur_row + x] = pred - val;
+    Span<int32_t> err_span(error.data(), buf_size_);
+    err_span[cur_row + x] = pred - val;
     for (size_t i = 0; i < kNumPredictors; i++) {
       pixel_type_w err =
           (std::abs(prediction[i] - val) + kPredictionRound) >> kPredExtraBits;
+      Span<uint32_t> pe(pred_errors[i].data(), buf_size_);
       // For predicting in the next row.
-      pred_errors[i][cur_row + x] = err;
+      pe[cur_row + x] = err;
       // Add the error on this pixel to the error on the NE pixel. This has the
       // effect of adding the error on this pixel to the E and EE pixels.
-      pred_errors[i][prev_row + x + 1] += err;
+      pe[prev_row + x + 1] += err;
     }
   }
 };
@@ -424,8 +430,9 @@ inline void PrecomputeReferences(const Channel &ch, size_t y,
     if (image.channel[j].hshift != image.channel[i].hshift) continue;
     if (image.channel[j].vshift != image.channel[i].vshift) continue;
     pixel_type *JXL_RESTRICT rp = references->Row(0) + offset;
-    const pixel_type *JXL_RESTRICT rpp = image.channel[j].Row(y);
-    const pixel_type *JXL_RESTRICT rpprev = image.channel[j].Row(y ? y - 1 : 0);
+    const Span<const pixel_type> rpp(image.channel[j].Row(y), ch.w);
+    const Span<const pixel_type> rpprev(
+        image.channel[j].Row(y ? y - 1 : 0), ch.w);
     for (size_t x = 0; x < ch.w; x++, rp += onerow) {
       pixel_type_w v = rpp[x];
       rp[0] = std::abs(v);
@@ -561,8 +568,8 @@ JXL_INLINE PredictionResult Predict(
   }
   if (!nec && compute_properties) {
     offset += weighted::kNumProperties;
-    // Extra properties.
-    const pixel_type *JXL_RESTRICT rp = references->Row(x);
+    // Extra properties from reference channels.
+    const Span<const pixel_type> rp(references->Row(x), references->w);
     for (size_t i = 0; i < references->w; i++) {
       (*p)[offset++] = rp[i];
     }

--- a/lib/jxl/modular/encoding/encoding.cc
+++ b/lib/jxl/modular/encoding/encoding.cc
@@ -20,6 +20,7 @@
 #include "lib/jxl/base/compiler_specific.h"
 #include "lib/jxl/base/printf_macros.h"
 #include "lib/jxl/base/scope_guard.h"
+#include "lib/jxl/base/span.h"
 #include "lib/jxl/base/status.h"
 #include "lib/jxl/dec_ans.h"
 #include "lib/jxl/dec_bit_reader.h"
@@ -257,10 +258,9 @@ Status DecodeModularChannelMAANS(BitReader *br, ANSSymbolReader *reader,
       JXL_DEBUG_V(8, "Gradient RLE (fjxl) very fast track.");
       pixel_type_w sv = UnpackSigned(fl_v);
       for (size_t y = 0; y < channel.h; y++) {
-        pixel_type *JXL_RESTRICT r = channel.Row(y);
-        const pixel_type *JXL_RESTRICT rtop = (y ? channel.Row(y - 1) : r - 1);
-        const pixel_type *JXL_RESTRICT rtopleft =
-            (y ? channel.Row(y - 1) - 1 : r - 1);
+        const Span<pixel_type> row(channel.Row(y), channel.w);
+        const Span<const pixel_type> rtop(y ? channel.Row(y - 1) : nullptr,
+                                          y ? channel.w : 0);
         pixel_type_w guess_0 = (y ? rtop[0] : 0);
         if (fl_run == 0) {
           reader->ReadHybridUintClusteredHuffRleOnly(ctx_id, br, &fl_v,
@@ -269,11 +269,11 @@ Status DecodeModularChannelMAANS(BitReader *br, ANSSymbolReader *reader,
         } else {
           fl_run--;
         }
-        r[0] = sv + guess_0;
+        row[0] = sv + guess_0;
         for (size_t x = 1; x < channel.w; x++) {
-          pixel_type left = r[x - 1];
-          pixel_type top = rtop[x];
-          pixel_type topleft = rtopleft[x];
+          pixel_type left = row[x - 1];
+          pixel_type top = (y ? rtop[x] : left);
+          pixel_type topleft = (y ? rtop[x - 1] : left);
           pixel_type_w guess = ClampedGradient(top, left, topleft);
           if (!fl_run) {
             reader->ReadHybridUintClusteredHuffRleOnly(ctx_id, br, &fl_v,
@@ -282,24 +282,25 @@ Status DecodeModularChannelMAANS(BitReader *br, ANSSymbolReader *reader,
           } else {
             fl_run--;
           }
-          r[x] = sv + guess;
+          row[x] = sv + guess;
         }
       }
       return true;
     } else if (predictor == Predictor::Gradient && offset == 0 &&
                multiplier == 1) {
       JXL_DEBUG_V(8, "Gradient very fast track.");
-      const ptrdiff_t onerow = channel.plane.PixelsPerRow();
       for (size_t y = 0; y < channel.h; y++) {
-        pixel_type *JXL_RESTRICT r = channel.Row(y);
+        const Span<pixel_type> row(channel.Row(y), channel.w);
+        const Span<const pixel_type> rtop(y ? channel.Row(y - 1) : nullptr,
+                                          y ? channel.w : 0);
         for (size_t x = 0; x < channel.w; x++) {
-          pixel_type left = (x ? r[x - 1] : y ? *(r + x - onerow) : 0);
-          pixel_type top = (y ? *(r + x - onerow) : left);
-          pixel_type topleft = (x && y ? *(r + x - 1 - onerow) : left);
+          pixel_type left = (x ? row[x - 1] : y ? rtop[x] : 0);
+          pixel_type top = (y ? rtop[x] : left);
+          pixel_type topleft = (x && y ? rtop[x - 1] : left);
           pixel_type guess = ClampedGradient(top, left, topleft);
           uint64_t v = reader->ReadHybridUintClusteredMaybeInlined<uses_lz77>(
               ctx_id, br);
-          r[x] = make_pixel(v, 1, guess);
+          row[x] = make_pixel(v, 1, guess);
         }
       }
       return true;
@@ -317,13 +318,14 @@ Status DecodeModularChannelMAANS(BitReader *br, ANSSymbolReader *reader,
 
   if (is_gradient_only) {
     JXL_DEBUG_V(8, "Gradient fast track.");
-    const ptrdiff_t onerow = channel.plane.PixelsPerRow();
     for (size_t y = 0; y < channel.h; y++) {
-      pixel_type *JXL_RESTRICT r = channel.Row(y);
+      const Span<pixel_type> row(channel.Row(y), channel.w);
+      const Span<const pixel_type> rtop(y ? channel.Row(y - 1) : nullptr,
+                                        y ? channel.w : 0);
       for (size_t x = 0; x < channel.w; x++) {
-        pixel_type_w left = (x ? r[x - 1] : y ? *(r + x - onerow) : 0);
-        pixel_type_w top = (y ? *(r + x - onerow) : left);
-        pixel_type_w topleft = (x && y ? *(r + x - 1 - onerow) : left);
+        pixel_type_w left = (x ? row[x - 1] : y ? rtop[x] : 0);
+        pixel_type_w top = (y ? rtop[x] : left);
+        pixel_type_w topleft = (x && y ? rtop[x - 1] : left);
         int32_t guess = ClampedGradient(top, left, topleft);
         uint32_t pos =
             kPropRangeFast +
@@ -333,7 +335,7 @@ Status DecodeModularChannelMAANS(BitReader *br, ANSSymbolReader *reader,
         uint32_t ctx_id = tree_lut.context_lookup[pos];
         uint64_t v =
             reader->ReadHybridUintClusteredMaybeInlined<uses_lz77>(ctx_id, br);
-        r[x] = make_pixel(v, 1, guess);
+        row[x] = make_pixel(v, 1, guess);
       }
     }
   } else if (!uses_lz77 && is_wp_only && channel.w > 8) {
@@ -341,19 +343,17 @@ Status DecodeModularChannelMAANS(BitReader *br, ANSSymbolReader *reader,
     weighted::State wp_state(wp_header, channel.w, channel.h);
     Properties properties(1);
     for (size_t y = 0; y < channel.h; y++) {
-      pixel_type *JXL_RESTRICT r = channel.Row(y);
-      const pixel_type *JXL_RESTRICT rtop = (y ? channel.Row(y - 1) : r - 1);
-      const pixel_type *JXL_RESTRICT rtoptop =
-          (y > 1 ? channel.Row(y - 2) : rtop);
-      const pixel_type *JXL_RESTRICT rtopleft =
-          (y ? channel.Row(y - 1) - 1 : r - 1);
-      const pixel_type *JXL_RESTRICT rtopright =
-          (y ? channel.Row(y - 1) + 1 : r - 1);
+      const Span<pixel_type> row(channel.Row(y), channel.w);
+      const Span<const pixel_type> rtop(y ? channel.Row(y - 1) : nullptr,
+                                        y ? channel.w : 0);
+      const Span<const pixel_type> rtoptop(
+          y > 1 ? channel.Row(y - 2) : nullptr, y > 1 ? channel.w : 0);
       size_t x = 0;
       {
         size_t offset = 0;
         pixel_type_w left = y ? rtop[x] : 0;
-        pixel_type_w toptop = y ? rtoptop[x] : 0;
+        pixel_type_w toptop =
+            y > 1 ? rtoptop[x] : (y ? rtop[x] : 0);
         pixel_type_w topright = (x + 1 < channel.w && y ? rtop[x + 1] : left);
         int32_t guess = wp_state.Predict</*compute_properties=*/true>(
             x, y, channel.w, left, left, topright, left, toptop, &properties,
@@ -364,36 +364,43 @@ Status DecodeModularChannelMAANS(BitReader *br, ANSSymbolReader *reader,
         uint32_t ctx_id = tree_lut.context_lookup[pos];
         uint64_t v =
             reader->ReadHybridUintClusteredInlined<uses_lz77>(ctx_id, br);
-        r[x] = make_pixel(v, 1, guess);
-        wp_state.UpdateErrors(r[x], x, y, channel.w);
+        row[x] = make_pixel(v, 1, guess);
+        wp_state.UpdateErrors(row[x], x, y, channel.w);
       }
       for (x = 1; x + 1 < channel.w; x++) {
         size_t offset = 0;
+        pixel_type_w N = y ? rtop[x] : row[x - 1];
+        pixel_type_w W = row[x - 1];
+        pixel_type_w NE = y ? rtop[x + 1] : W;
+        pixel_type_w NW = y ? rtop[x - 1] : W;
+        pixel_type_w NN = y > 1 ? rtoptop[x] : N;
         int32_t guess = wp_state.Predict</*compute_properties=*/true>(
-            x, y, channel.w, rtop[x], r[x - 1], rtopright[x], rtopleft[x],
-            rtoptop[x], &properties, offset);
+            x, y, channel.w, N, W, NE, NW, NN, &properties, offset);
         uint32_t pos =
             kPropRangeFast +
             jxl::Clamp1(properties[0], -kPropRangeFast, kPropRangeFast - 1);
         uint32_t ctx_id = tree_lut.context_lookup[pos];
         uint64_t v =
             reader->ReadHybridUintClusteredInlined<uses_lz77>(ctx_id, br);
-        r[x] = make_pixel(v, 1, guess);
-        wp_state.UpdateErrors(r[x], x, y, channel.w);
+        row[x] = make_pixel(v, 1, guess);
+        wp_state.UpdateErrors(row[x], x, y, channel.w);
       }
       {
         size_t offset = 0;
+        pixel_type_w N = y ? rtop[x] : row[x - 1];
+        pixel_type_w W = row[x - 1];
+        pixel_type_w NW = y ? rtop[x - 1] : W;
+        pixel_type_w NN = y > 1 ? rtoptop[x] : N;
         int32_t guess = wp_state.Predict</*compute_properties=*/true>(
-            x, y, channel.w, rtop[x], r[x - 1], rtop[x], rtopleft[x],
-            rtoptop[x], &properties, offset);
+            x, y, channel.w, N, W, N, NW, NN, &properties, offset);
         uint32_t pos =
             kPropRangeFast +
             jxl::Clamp1(properties[0], -kPropRangeFast, kPropRangeFast - 1);
         uint32_t ctx_id = tree_lut.context_lookup[pos];
         uint64_t v =
             reader->ReadHybridUintClusteredInlined<uses_lz77>(ctx_id, br);
-        r[x] = make_pixel(v, 1, guess);
-        wp_state.UpdateErrors(r[x], x, y, channel.w);
+        row[x] = make_pixel(v, 1, guess);
+        wp_state.UpdateErrors(row[x], x, y, channel.w);
       }
     }
   } else if (!tree_has_wp_prop_or_pred) {
@@ -409,6 +416,7 @@ Status DecodeModularChannelMAANS(BitReader *br, ANSSymbolReader *reader,
                         properties.size() - kNumNonrefProperties, channel.w));
     for (size_t y = 0; y < channel.h; y++) {
       pixel_type *JXL_RESTRICT p = channel.Row(y);
+      const Span<pixel_type> row(p, channel.w);
       PrecomputeReferences(channel, y, *image, chan, &references);
       InitPropsRow(&properties, static_props, y);
       if (y > 1 && channel.w > 8 && references.w == 0) {
@@ -418,7 +426,7 @@ Status DecodeModularChannelMAANS(BitReader *br, ANSSymbolReader *reader,
                               tree_lookup, references);
           uint64_t v =
               reader->ReadHybridUintClustered<uses_lz77>(res.context, br);
-          p[x] = make_pixel(v, res.multiplier, res.guess);
+          row[x] = make_pixel(v, res.multiplier, res.guess);
         }
         for (size_t x = 2; x < channel.w - 2; x++) {
           PredictionResult res =
@@ -426,7 +434,7 @@ Status DecodeModularChannelMAANS(BitReader *br, ANSSymbolReader *reader,
                                  tree_lookup, references);
           uint64_t v = reader->ReadHybridUintClusteredInlined<uses_lz77>(
               res.context, br);
-          p[x] = make_pixel(v, res.multiplier, res.guess);
+          row[x] = make_pixel(v, res.multiplier, res.guess);
         }
         for (size_t x = channel.w - 2; x < channel.w; x++) {
           PredictionResult res =
@@ -434,7 +442,7 @@ Status DecodeModularChannelMAANS(BitReader *br, ANSSymbolReader *reader,
                               tree_lookup, references);
           uint64_t v =
               reader->ReadHybridUintClustered<uses_lz77>(res.context, br);
-          p[x] = make_pixel(v, res.multiplier, res.guess);
+          row[x] = make_pixel(v, res.multiplier, res.guess);
         }
       } else {
         for (size_t x = 0; x < channel.w; x++) {
@@ -443,7 +451,7 @@ Status DecodeModularChannelMAANS(BitReader *br, ANSSymbolReader *reader,
                               tree_lookup, references);
           uint64_t v = reader->ReadHybridUintClusteredMaybeInlined<uses_lz77>(
               res.context, br);
-          p[x] = make_pixel(v, res.multiplier, res.guess);
+          row[x] = make_pixel(v, res.multiplier, res.guess);
         }
       }
     }
@@ -459,6 +467,7 @@ Status DecodeModularChannelMAANS(BitReader *br, ANSSymbolReader *reader,
     weighted::State wp_state(wp_header, channel.w, channel.h);
     for (size_t y = 0; y < channel.h; y++) {
       pixel_type *JXL_RESTRICT p = channel.Row(y);
+      const Span<pixel_type> row(p, channel.w);
       InitPropsRow(&properties, static_props, y);
       PrecomputeReferences(channel, y, *image, chan, &references);
       if (!uses_lz77 && y > 1 && channel.w > 8 && references.w == 0) {
@@ -468,8 +477,8 @@ Status DecodeModularChannelMAANS(BitReader *br, ANSSymbolReader *reader,
                             tree_lookup, references, &wp_state);
           uint64_t v =
               reader->ReadHybridUintClustered<uses_lz77>(res.context, br);
-          p[x] = make_pixel(v, res.multiplier, res.guess);
-          wp_state.UpdateErrors(p[x], x, y, channel.w);
+          row[x] = make_pixel(v, res.multiplier, res.guess);
+          wp_state.UpdateErrors(row[x], x, y, channel.w);
         }
         for (size_t x = 2; x < channel.w - 2; x++) {
           PredictionResult res =
@@ -477,8 +486,8 @@ Status DecodeModularChannelMAANS(BitReader *br, ANSSymbolReader *reader,
                                tree_lookup, references, &wp_state);
           uint64_t v = reader->ReadHybridUintClusteredInlined<uses_lz77>(
               res.context, br);
-          p[x] = make_pixel(v, res.multiplier, res.guess);
-          wp_state.UpdateErrors(p[x], x, y, channel.w);
+          row[x] = make_pixel(v, res.multiplier, res.guess);
+          wp_state.UpdateErrors(row[x], x, y, channel.w);
         }
         for (size_t x = channel.w - 2; x < channel.w; x++) {
           PredictionResult res =
@@ -486,8 +495,8 @@ Status DecodeModularChannelMAANS(BitReader *br, ANSSymbolReader *reader,
                             tree_lookup, references, &wp_state);
           uint64_t v =
               reader->ReadHybridUintClustered<uses_lz77>(res.context, br);
-          p[x] = make_pixel(v, res.multiplier, res.guess);
-          wp_state.UpdateErrors(p[x], x, y, channel.w);
+          row[x] = make_pixel(v, res.multiplier, res.guess);
+          wp_state.UpdateErrors(row[x], x, y, channel.w);
         }
       } else {
         for (size_t x = 0; x < channel.w; x++) {
@@ -496,8 +505,8 @@ Status DecodeModularChannelMAANS(BitReader *br, ANSSymbolReader *reader,
                             tree_lookup, references, &wp_state);
           uint64_t v =
               reader->ReadHybridUintClustered<uses_lz77>(res.context, br);
-          p[x] = make_pixel(v, res.multiplier, res.guess);
-          wp_state.UpdateErrors(p[x], x, y, channel.w);
+          row[x] = make_pixel(v, res.multiplier, res.guess);
+          wp_state.UpdateErrors(row[x], x, y, channel.w);
         }
       }
     }


### PR DESCRIPTION
## Summary

- Add `JXL_SECURITY_CHECK` macro: release-surviving bounds check that traps unconditionally on violation (opt-out via `-DJXL_HARDENED=0` for benchmarking)
- Harden `Span::operator[]` with bounds checking, add `subspan()` methods
- Migrate all 6 modular decode tracks in `encoding.cc` from raw pointer arithmetic to bounds-checked Span (gradient RLE, gradient very fast, gradient fast, WP fast, slow, slowest)
- Migrate `dec_group.cc` coefficient order indexing in `DecodeACVarBlock`
- Migrate `context_predict.h` weighted prediction/error buffers, `PrecomputeReferences`, and reference property reads

The `encoding.cc` migrations also eliminate undefined behavior where pointers were formed before allocated buffers (`r - 1` pattern used to alias left-neighbor access when no top row exists).

## Motivation

Addresses the question raised in #4820 about making Safe Buffers project-wide. This PR targets the core decode pipeline — the highest-impact attack surface for malicious input — which none of the existing Safe Buffers PRs cover.

`JXL_SECURITY_CHECK` fills the gap between `JXL_DASSERT` (compiled out in release) and `JXL_ENSURE` (returns `Status`, incompatible with `operator[]` return type). It uses `__builtin_trap()` via `JXL_CRASH()`, which is appropriate for memory safety invariants where continuing with an out-of-bounds access would be worse than aborting.

## Performance

Benchmarked with 4096x4096 images, single-threaded, interleaved A/B (8 iterations each):

| Path | Baseline | Safe-buf | Diff |
|---|---|---|---|
| VarDCT (dec_group.cc) | 24.34 MP/s | 24.28 MP/s | -0.25% |
| Modular lossless (encoding.cc) | 3.85 MP/s | 3.83 MP/s | -0.57% |
| Modular smooth/WP (context_predict.h) | 5.40 MP/s | 5.38 MP/s | -0.46% |

All within measurement noise (stdev 1-3%).

## Test plan

- [x] `cmake --build build && ctest --test-dir build` — 6858/6858 tests pass
- [x] No clang-format violations in changed lines
- [x] No whitespace errors (`git diff --check`)
- [x] Performance benchmarked — no regression