### PR TITLE
Drop bullseye CI

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -119,7 +119,6 @@ jobs:
         - ubuntu:24.04
         - ubuntu:22.04
         - ubuntu:20.04
-        - debian:bullseye
         - debian:bookworm
         - debian:trixie
         - debian:sid


### PR DESCRIPTION
LTS support ended last week and repo access already seems flaky.
