### PR TITLE
Scale centre-first coordinates for LF frames

### DIFF
--- a/lib/jxl/enc_frame.cc
+++ b/lib/jxl/enc_frame.cc
@@ -1718,7 +1718,8 @@ Status ComputeEncodingData(
 }
 
 Status PermuteGroups(const CompressParams& cparams,
-                     const FrameDimensions& frame_dim, size_t num_passes,
+                     const FrameDimensions& frame_dim,
+                     size_t num_passes, FrameType frame_type,
                      std::vector<coeff_order_t>* permutation,
                      std::vector<std::unique_ptr<BitWriter>>* group_codes) {
   const size_t num_groups = frame_dim.num_groups;
@@ -1737,7 +1738,8 @@ Status PermuteGroups(const CompressParams& cparams,
   // are not provided.
 
   int64_t imag_cx;
-  if (cparams.center_x != static_cast<size_t>(-1)) {
+  if (cparams.center_x != static_cast<size_t>(-1) &&
+      frame_type != FrameType::kDCFrame) {
     JXL_RETURN_IF_ERROR(cparams.center_x < frame_dim.xsize);
     imag_cx = cparams.center_x;
   } else {
@@ -1745,7 +1747,8 @@ Status PermuteGroups(const CompressParams& cparams,
   }
 
   int64_t imag_cy;
-  if (cparams.center_y != static_cast<size_t>(-1)) {
+  if (cparams.center_y != static_cast<size_t>(-1) &&
+      frame_type != FrameType::kDCFrame) {
     JXL_RETURN_IF_ERROR(cparams.center_y < frame_dim.ysize);
     imag_cy = cparams.center_y;
   } else {
@@ -2097,7 +2100,8 @@ JXL_NOINLINE Status EncodeFrameStreaming(
   // For ooo mode, also compute inv_perm (encoding_pos → canonical_idx).
   std::vector<coeff_order_t> group_order_perm;
   JXL_RETURN_IF_ERROR(PermuteGroups(cparams, frame_header.ToFrameDimensions(),
-                                    num_passes, &group_order_perm, nullptr));
+                                    num_passes, frame_header.frame_type,
+                                    &group_order_perm, nullptr));
   size_t encoding_pos = 0;
   std::vector<size_t> inv_perm;
   if (ooo) {
@@ -2341,7 +2345,8 @@ Status EncodeFrameOneShot(JxlMemoryManager* memory_manager,
 
   std::vector<coeff_order_t> permutation;
   JXL_RETURN_IF_ERROR(PermuteGroups(cparams, enc_state->shared.frame_dim,
-                                    num_passes, &permutation, &group_codes));
+                                    num_passes, frame_header.frame_type,
+                                    &permutation, &group_codes));
 
   std::vector<size_t> group_sizes;
   group_sizes.reserve(group_codes.size());

--- a/lib/jxl/enc_frame.cc
+++ b/lib/jxl/enc_frame.cc
@@ -1719,7 +1719,7 @@ Status ComputeEncodingData(
 
 Status PermuteGroups(const CompressParams& cparams,
                      const FrameDimensions& frame_dim,
-                     size_t num_passes, FrameType frame_type,
+                     size_t num_passes, size_t dc_level,
                      std::vector<coeff_order_t>* permutation,
                      std::vector<std::unique_ptr<BitWriter>>* group_codes) {
   const size_t num_groups = frame_dim.num_groups;
@@ -1731,26 +1731,28 @@ Status PermuteGroups(const CompressParams& cparams,
   std::iota(permutation->begin(), permutation->end(), 0);
   std::vector<coeff_order_t> ac_group_order(num_groups);
   std::iota(ac_group_order.begin(), ac_group_order.end(), 0);
-  size_t group_dim = frame_dim.group_dim;
+  const size_t group_dim = frame_dim.group_dim;
 
   // The center of the image is either given by parameters or chosen
   // to be the middle of the image by default if center_x, center_y resp.
   // are not provided.
 
+  // Calculate the coordinate scaling for LF frames.
+  // libjxl only implements 2 LF frames, so won't overflow.
+  const size_t dc_scale = size_t{1} << (3 * dc_level);
+  
   int64_t imag_cx;
-  if (cparams.center_x != static_cast<size_t>(-1) &&
-      frame_type != FrameType::kDCFrame) {
-    JXL_RETURN_IF_ERROR(cparams.center_x < frame_dim.xsize);
-    imag_cx = cparams.center_x;
+  if (cparams.center_x != static_cast<size_t>(-1)) {
+    imag_cx = cparams.center_x / dc_scale;
+    JXL_RETURN_IF_ERROR(imag_cx < static_cast<int64_t>(frame_dim.xsize));
   } else {
     imag_cx = frame_dim.xsize / 2;
   }
 
   int64_t imag_cy;
-  if (cparams.center_y != static_cast<size_t>(-1) &&
-      frame_type != FrameType::kDCFrame) {
-    JXL_RETURN_IF_ERROR(cparams.center_y < frame_dim.ysize);
-    imag_cy = cparams.center_y;
+  if (cparams.center_y != static_cast<size_t>(-1)) {
+    imag_cy = cparams.center_y / dc_scale;
+    JXL_RETURN_IF_ERROR(imag_cy < static_cast<int64_t>(frame_dim.ysize));
   } else {
     imag_cy = frame_dim.ysize / 2;
   }
@@ -2100,7 +2102,7 @@ JXL_NOINLINE Status EncodeFrameStreaming(
   // For ooo mode, also compute inv_perm (encoding_pos → canonical_idx).
   std::vector<coeff_order_t> group_order_perm;
   JXL_RETURN_IF_ERROR(PermuteGroups(cparams, frame_header.ToFrameDimensions(),
-                                    num_passes, frame_header.frame_type,
+                                    num_passes, frame_info.dc_level,
                                     &group_order_perm, nullptr));
   size_t encoding_pos = 0;
   std::vector<size_t> inv_perm;
@@ -2345,7 +2347,7 @@ Status EncodeFrameOneShot(JxlMemoryManager* memory_manager,
 
   std::vector<coeff_order_t> permutation;
   JXL_RETURN_IF_ERROR(PermuteGroups(cparams, enc_state->shared.frame_dim,
-                                    num_passes, frame_header.frame_type,
+                                    num_passes, frame_info.dc_level,
                                     &permutation, &group_codes));
 
   std::vector<size_t> group_sizes;


### PR DESCRIPTION
Fixes `--center_x` and `--center_y` in combination with `--progressive_dc` (Including `-p`).