### PR TITLE
Respect user palette and channel color flags

### DIFF
--- a/lib/jxl/enc_modular.cc
+++ b/lib/jxl/enc_modular.cc
@@ -333,6 +333,7 @@ StatusOr<bool> maybe_do_transform(Image& image, const Transform& tr,
 Status try_palettes(Image& gi, int& max_bitdepth, int& maxval,
                     const CompressParams& cparams_,
                     float channel_colors_percent,
+                    bool custom_channel_colors = false,
                     jxl::ThreadPool* pool = nullptr) {
   float cost_before = 0.f;
   size_t did_palette = 0;
@@ -360,14 +361,18 @@ Status try_palettes(Image& gi, int& max_bitdepth, int& maxval,
       // Rationale: small image with large palette is not effective;
       // also if the entropy (estimated bpp) is low (e.g. mostly solid/gradient
       // areas), palette is less useful and may even be counterproductive.
-      maybe_palette.nb_colors = std::min(
-          static_cast<int>(cost_before * 0.0005f + nb_pixels / 128 + 128),
-          std::abs(cparams_.palette_colors));
+      if (cparams_.custom_palette_colors) {
+        maybe_palette.nb_colors = std::abs(cparams_.palette_colors);
+      } else {
+        maybe_palette.nb_colors = std::min(
+            static_cast<int>(cost_before * 0.0005f + nb_pixels / 128 + 128),
+            std::abs(cparams_.palette_colors));
+      }
       maybe_palette.ordered_palette = cparams_.palette_colors >= 0;
       maybe_palette.lossy_palette =
           (cparams_.lossy_palette && maybe_palette.num_c == 3);
       if (maybe_palette.lossy_palette) {
-        maybe_palette.predictor = Predictor::Average4;
+        maybe_palette.predictor = cparams_.lossy_palette_predictor;
       }
       // TODO(veluca): use a custom weighted header if using the weighted
       // predictor.
@@ -382,13 +387,17 @@ Status try_palettes(Image& gi, int& max_bitdepth, int& maxval,
       Transform maybe_palette_3(TransformId::kPalette);
       maybe_palette_3.begin_c = gi.nb_meta_channels;
       maybe_palette_3.num_c = nb_chans - 1;
-      maybe_palette_3.nb_colors = std::min(
-          static_cast<int>(cost_before * 0.0005f + nb_pixels / 128 + 128),
-          std::abs(cparams_.palette_colors));
+      if (cparams_.custom_palette_colors) {
+        maybe_palette_3.nb_colors = std::abs(cparams_.palette_colors);
+      } else {
+        maybe_palette_3.nb_colors = std::min(
+            static_cast<int>(cost_before * 0.0005f + nb_pixels / 128 + 128),
+            std::abs(cparams_.palette_colors));
+      }
       maybe_palette_3.ordered_palette = cparams_.palette_colors >= 0;
       maybe_palette_3.lossy_palette = cparams_.lossy_palette;
       if (maybe_palette_3.lossy_palette) {
-        maybe_palette_3.predictor = Predictor::Average4;
+        maybe_palette_3.predictor = cparams_.lossy_palette_predictor;
       }
       JXL_ASSIGN_OR_RETURN(
           did_palette,
@@ -422,9 +431,14 @@ Status try_palettes(Image& gi, int& max_bitdepth, int& maxval,
       // actually occur, it is probably worth it to do a compaction
       // (but only if the channel palette is less than 6% the size of the
       // image itself)
-      maybe_palette_1.nb_colors =
-          std::min(static_cast<int>(nb_pixels / 16),
-                   static_cast<int>(channel_colors_percent / 100. * colors));
+      if (custom_channel_colors) {
+        maybe_palette_1.nb_colors =
+            static_cast<int>(channel_colors_percent / 100. * colors);
+      } else {
+        maybe_palette_1.nb_colors =
+            std::min(static_cast<int>(nb_pixels / 16),
+                     static_cast<int>(channel_colors_percent / 100. * colors));
+      }
       JXL_ASSIGN_OR_RETURN(
           bool did_ch_palette,
           maybe_do_transform(gi, maybe_palette_1, cparams_, weighted::Header(),
@@ -650,7 +664,14 @@ Status ModularFrameEncoder::Init(const FrameHeader& frame_header,
       cparams_.options.predictor = Predictor::Gradient;
     }
   } else {
-    if (cparams_.lossy_palette) cparams_.options.predictor = Predictor::Zero;
+    if (cparams_.lossy_palette) {
+      // Preserve requested predictor for lossy delta palette.
+      if (cparams_.options.predictor != kUndefinedPredictor &&
+          cparams_.options.predictor < Predictor::Best) {
+        cparams_.lossy_palette_predictor = cparams_.options.predictor;
+      }
+      cparams_.options.predictor = Predictor::Zero;
+    }
   }
   if (!cparams_.ModularPartIsLossless()) {
     if (cparams_.options.predictor == Predictor::Weighted ||
@@ -888,17 +909,21 @@ Status ModularFrameEncoder::ComputeEncodingData(
 
   // Global palette transforms
   float channel_colors_percent = 0;
+  bool custom_channel_colors = false;
   if (!cparams_.lossy_palette &&
       (cparams_.speed_tier <= SpeedTier::kThunder ||
        (do_color && metadata.bit_depth.bits_per_sample > 8))) {
     channel_colors_percent = cparams_.channel_colors_pre_transform_percent;
+    custom_channel_colors =
+        cparams_.custom_channel_colors_pre_transform_percent;
   }
     // Global palette causes bad progressive loading due to interpolation
     // but lossy palette is still required for JXL art.
   if (!groupwise && (cparams_.lossy_palette ||
       !(cparams_.responsive && cparams_.ModularPartIsLossless()))) {
     JXL_RETURN_IF_ERROR(try_palettes(gi, max_bitdepth, maxval, cparams_,
-                                     channel_colors_percent, pool));
+                                     channel_colors_percent,
+                                     custom_channel_colors, pool));
   }
 
   // don't do an RCT if we're short on bits
@@ -1430,9 +1455,11 @@ Status ModularFrameEncoder::PrepareStreamParams(const Rect& rect,
         !cparams.lossy_palette && cparams.speed_tier < SpeedTier::kCheetah) {
       int max_bitdepth = 0, maxval = 0;  // don't care about that here
       float channel_color_percent = 0;
-        channel_color_percent = cparams.channel_colors_percent;
+      channel_color_percent = cparams.channel_colors_percent;
+      bool custom_channel_colors = cparams.custom_channel_colors_percent;
       JXL_RETURN_IF_ERROR(try_palettes(gi, max_bitdepth, maxval, cparams,
-                                       channel_color_percent));
+                                       channel_color_percent,
+                                       custom_channel_colors));
     }
   }
 

--- a/lib/jxl/enc_params.h
+++ b/lib/jxl/enc_params.h
@@ -116,10 +116,17 @@ struct CompressParams {
 
   // Use Global channel palette if #colors < this percentage of range
   float channel_colors_pre_transform_percent = 95.f;
+  // Bypasses size clamping for global channel compact.
+  bool custom_channel_colors_pre_transform_percent = false;
   // Use Local channel palette if #colors < this percentage of range
   float channel_colors_percent = 80.f;
+  // Bypasses size clamping for local channel compact.
+  bool custom_channel_colors_percent = false;
   int palette_colors = 1 << 10;  // up to 10-bit palette is probably worthwhile
+  // Bypasses heuristic clamping for palette size.
+  bool custom_palette_colors = false;
   bool lossy_palette = false;
+  Predictor lossy_palette_predictor = Predictor::Average4;
 
   // Returns whether these params are lossless as defined by SetLossless();
   bool IsLossless() const { return modular_mode && ModularPartIsLossless(); }

--- a/lib/jxl/encode.cc
+++ b/lib/jxl/encode.cc
@@ -1794,8 +1794,10 @@ JxlEncoderStatus JxlEncoderFrameSettingsSetOption(
       }
       if (value == -1) {
         frame_settings->values.cparams.palette_colors = 1 << 10;
+        frame_settings->values.cparams.custom_palette_colors = false;
       } else {
         frame_settings->values.cparams.palette_colors = value;
+        frame_settings->values.cparams.custom_palette_colors = true;
       }
       break;
     case JXL_ENC_FRAME_SETTING_LOSSY_PALETTE:
@@ -1965,9 +1967,13 @@ JxlEncoderStatus JxlEncoderFrameSettingsSetFloatOption(
       if (value < -.5f) {
         frame_settings->values.cparams.channel_colors_pre_transform_percent =
             95.0f;
+        frame_settings->values.cparams
+            .custom_channel_colors_pre_transform_percent = false;
       } else {
         frame_settings->values.cparams.channel_colors_pre_transform_percent =
             value;
+        frame_settings->values.cparams
+            .custom_channel_colors_pre_transform_percent = true;
       }
       return JxlErrorOrStatus::Success();
     case JXL_ENC_FRAME_SETTING_CHANNEL_COLORS_GROUP_PERCENT:
@@ -1977,8 +1983,10 @@ JxlEncoderStatus JxlEncoderFrameSettingsSetFloatOption(
       }
       if (value < -.5f) {
         frame_settings->values.cparams.channel_colors_percent = 80.0f;
+        frame_settings->values.cparams.custom_channel_colors_percent = false;
       } else {
         frame_settings->values.cparams.channel_colors_percent = value;
+        frame_settings->values.cparams.custom_channel_colors_percent = true;
       }
       return JxlErrorOrStatus::Success();
     case JXL_ENC_FRAME_SETTING_EFFORT:

--- a/lib/jxl/modular_test.cc
+++ b/lib/jxl/modular_test.cc
@@ -212,7 +212,6 @@ TEST(ModularTest, RoundtripLossyDeltaPaletteWP) {
   cparams.SetLossless();
   cparams.lossy_palette = true;
   cparams.palette_colors = 0;
-  // TODO(jon): this is currently ignored, and Avg4 is always used instead
   cparams.options.predictor = jxl::Predictor::Weighted;
   extras::JXLDecompressParams dparams;
 
@@ -225,7 +224,8 @@ TEST(ModularTest, RoundtripLossyDeltaPaletteWP) {
   size_t compressed_size;
   JXL_EXPECT_OK(
       Roundtrip(io.get(), cparams, dparams, io_out.get(), _, &compressed_size));
-  EXPECT_LE(compressed_size, 6500u);
+  // Restored Weighted predictor produces ~6.7k bytes (Avg4 produced ~6.3k).
+  EXPECT_LE(compressed_size, 7000u);
   EXPECT_SLIGHTLY_BELOW(
       ButteraugliDistance(io->frames, io_out->frames, ButteraugliParams(),
                           *JxlGetDefaultCms(),


### PR DESCRIPTION
### Description

Fixes regressions introduced in #3420, preserving option overrides for paletted images:

Previously, user-specified options for palette colors and channel color percentages (`--modular_palette_colors`, `-X` / `--pre-compact`, and `-Y` / `--post-compact`) were not consistently respected:

- Heuristic Clamping in `try_palettes`: In `lib/jxl/enc_modular.cc`, `palette_colors` was unconditionally clamped by an entropy/dimension heuristic (`std::min(cost_before * 0.0005f + nb_pixels / 128 + 128, ...)`). This prevented users and benchmark scripts from forcing or experimenting with larger palette sizes on smaller or lower-entropy images.

- Hardcoded Predictor in Lossy Delta Palette:
   PR #627 originally introduced the ability to select the predictor used for lossy delta palettes. When PR #3420 refactored palette code into `try_palettes()`, it hardcoded `Predictor::Average4`, ignoring any requested predictor. The requested predictor in `lossy_palette_predictor` is preserved before setting the palette index tree to predictor zero.

~~- Override in `kTectonicPlate` (Efforts 10/11): In `lib/jxl/enc_frame.cc`, the candidate presets generated by `TectonicPlateSettingsLessPalette` and `TectonicPlateSettingsMorePalette` (as well as the initial test trial) hardcoded `palette_colors` (to `0`, `1024`, or `70000`) and channel color percentages, completely discarding any flags set.~~

Default encoder behavior is preserved when options are not set by the CLI or API.

### Test Case
Image from: https://github.com/libjxl/libjxl/issues/3720#issuecomment-4761391791
| CLI Settings | Main | PR | Δ (%) |
| --- | --- | --- | --- |
| `-d 0 -e 9` | 182.9 kB | 182.9 kB | = |
| `-d 0 -e 9 --modular_palette_colors=60000` | 182.9 kB | 159.5 kB | **-12.794%** |