### PR TITLE
decode: add optional -fbounds-safety annotation for next_in

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -190,6 +190,16 @@ set(JPEGXL_ENABLE_WASM_THREADS true CACHE BOOL
 set(JPEGXL_ENABLE_LTO false CACHE BOOL
     "Set flags to enable LTO.")
 
+# Optional Clang -fbounds-safety. Default OFF: JXL_*COUNTED_BY* macros in
+# lib/jxl/base/bounds_safety.h are inert and the ABI/build is unchanged. When
+# ON, requires a Clang that provides -fbounds-safety / <ptrcheck.h>.
+option(JPEGXL_ENABLE_FBOUNDS_SAFETY
+       "Enable Clang -fbounds-safety annotations (experimental toolchain)" OFF)
+if(JPEGXL_ENABLE_FBOUNDS_SAFETY)
+  add_definitions(-DJPEGXL_SUPPORT_FBOUNDS_SAFETY)
+  add_compile_options(-fbounds-safety)
+endif()
+
 # HWY codegen levers
 foreach(tgt IN LISTS JPEGXL_HWY_TARGETS)
   set(JPEGXL_ENABLE_HWY_${tgt}_DEFAULT true)

--- a/lib/jxl/base/bounds_safety.h
+++ b/lib/jxl/base/bounds_safety.h
@@ -1,0 +1,35 @@
+// Copyright (c) the JPEG XL Project Authors. All rights reserved.
+//
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+#ifndef LIB_JXL_BASE_BOUNDS_SAFETY_H_
+#define LIB_JXL_BASE_BOUNDS_SAFETY_H_
+
+// Portability macros for optional Clang -fbounds-safety annotations.
+//
+// When JPEGXL_SUPPORT_FBOUNDS_SAFETY is defined (typically via
+// -DJPEGXL_SUPPORT_FBOUNDS_SAFETY and a Clang toolchain that implements
+// -fbounds-safety), these macros expand to Clang bounds annotations.
+// Otherwise they expand to nothing so default builds are unchanged.
+//
+// Pattern matches libwebp / libpng inert-macro adoption: annotations are
+// inert unless explicitly enabled.
+
+#ifdef JPEGXL_SUPPORT_FBOUNDS_SAFETY
+
+#include <ptrcheck.h>
+/* Prefer __counted_by_or_null for pointers that may be NULL while the
+ * companion size field is zero (JxlDecoder next_in / avail_in pattern).
+ */
+#define JXL_COUNTED_BY(n) __counted_by(n)
+#define JXL_COUNTED_BY_OR_NULL(n) __counted_by_or_null(n)
+
+#else /* !JPEGXL_SUPPORT_FBOUNDS_SAFETY */
+
+#define JXL_COUNTED_BY(n)
+#define JXL_COUNTED_BY_OR_NULL(n)
+
+#endif /* JPEGXL_SUPPORT_FBOUNDS_SAFETY */
+
+#endif  // LIB_JXL_BASE_BOUNDS_SAFETY_H_

--- a/lib/jxl/decode.cc
+++ b/lib/jxl/decode.cc
@@ -24,6 +24,7 @@
 #include <utility>
 #include <vector>
 
+#include "lib/jxl/base/bounds_safety.h"
 #include "lib/jxl/base/byte_order.h"
 #include "lib/jxl/base/common.h"
 #include "lib/jxl/base/compiler_specific.h"
@@ -616,14 +617,18 @@ struct JxlDecoder {
   }
 #endif
 
-  const uint8_t* next_in;
+  /* avail_in is declared before next_in so JXL_COUNTED_BY_OR_NULL can name
+   * it. Capacity is assigned before the pointer at update sites.
+   */
   size_t avail_in;
+  const uint8_t* JXL_COUNTED_BY_OR_NULL(avail_in) next_in;
   bool input_closed;
 
   void AdvanceInput(size_t size) {
     JXL_DASSERT(avail_in >= size);
-    next_in += size;
+    /* counted_by: shrink capacity before advancing pointer */
     avail_in -= size;
+    next_in += size;
     file_pos += size;
   }
 
@@ -1580,13 +1585,15 @@ JxlDecoderStatus JxlDecoderSetInput(JxlDecoder* dec, const uint8_t* data,
     return JXL_API_ERROR("input already closed");
   }
 
-  dec->next_in = data;
+  /* counted_by: set capacity before pointer */
   dec->avail_in = size;
+  dec->next_in = data;
   return JXL_DEC_SUCCESS;
 }
 
 size_t JxlDecoderReleaseInput(JxlDecoder* dec) {
   size_t result = dec->avail_in;
+  /* counted_by clear: drop pointer then size */
   dec->next_in = nullptr;
   dec->avail_in = 0;
   return result;

--- a/lib/jxl_lists.bzl
+++ b/lib/jxl_lists.bzl
@@ -11,6 +11,7 @@ Run `tools/scripts/build_cleaner.py --update` to regenerate it.
 libjxl_base_sources = [
     "jxl/base/arch_macros.h",
     "jxl/base/bits.h",
+    "jxl/base/bounds_safety.h",
     "jxl/base/byte_order.h",
     "jxl/base/c_callback_support.h",
     "jxl/base/common.h",

--- a/lib/jxl_lists.cmake
+++ b/lib/jxl_lists.cmake
@@ -8,6 +8,7 @@
 set(JPEGXL_INTERNAL_BASE_SOURCES
   jxl/base/arch_macros.h
   jxl/base/bits.h
+  jxl/base/bounds_safety.h
   jxl/base/byte_order.h
   jxl/base/c_callback_support.h
   jxl/base/common.h


### PR DESCRIPTION
## Summary
Secure-by-design memory-safety hardening. Annotates `JxlDecoder` untrusted input `next_in` with optional Clang `-fbounds-safety` / counted-by-style macros and keeps capacity-then-pointer assignment.

Contributor: Jeff Bindel (`jeff@incrediblybased.co`) via GitHub `LaptopsPlural` (commit uses GitHub noreply due to email-privacy push protection). Human-authored responsibility per [CONTRIBUTING.md](https://github.com/libjxl/libjxl/blob/main/CONTRIBUTING.md) AI guidelines.

- New `lib/jxl/base/bounds_safety.h` with inert `JXL_COUNTED_BY*` macros unless enabled
- Annotate `next_in` with `JXL_COUNTED_BY_OR_NULL(avail_in)`
- Capacity-first updates in `decode.cc`
- CMake option default **OFF**

**Default builds are unchanged.** Not a vulnerability PoC.

## Test plan
- [ ] Default build (flag off)
- [ ] Decode smoke
- [ ] Experimental bounds-safety ON with supporting Clang (maintainers)