### PR TITLE
Cocoa replacement for `compare_images` on macOS

### DIFF
--- a/tools/comparison_viewer/CMakeLists.txt
+++ b/tools/comparison_viewer/CMakeLists.txt
@@ -3,9 +3,17 @@
 # Use of this source code is governed by a BSD-style
 # license that can be found in the LICENSE file.
 
+if (APPLE)
+  add_subdirectory(mac)
+endif ()
+
 find_package(Qt6 QUIET COMPONENTS Concurrent Widgets)
 if (NOT Qt6_FOUND)
-  message(WARNING "Qt6 was not found. The comparison tool will not be built.")
+  if (APPLE)
+    message(WARNING "Qt6 was not found. The codec comparison tool will not be built. (The image comparison tool will be.)")
+  else ()
+    message(WARNING "Qt6 was not found. The comparison tool will not be built.")
+  endif ()
   return()
 endif ()
 
@@ -58,19 +66,21 @@ target_link_libraries(compare_codecs
   icc_detect
 )
 
-add_executable(compare_images WIN32
-  compare_images.cc
-  settings.cc
-  settings.h
-  settings.ui
-  split_image_renderer.cc
-  split_image_renderer.h
-  split_image_view.cc
-  split_image_view.h
-  split_image_view.ui
-)
-target_link_libraries(compare_images
-  image_loading
-  Qt6::Widgets
-  icc_detect
-)
+if (NOT APPLE)
+  add_executable(compare_images WIN32
+    compare_images.cc
+    settings.cc
+    settings.h
+    settings.ui
+    split_image_renderer.cc
+    split_image_renderer.h
+    split_image_view.cc
+    split_image_view.h
+    split_image_view.ui
+  )
+  target_link_libraries(compare_images
+    image_loading
+    Qt6::Widgets
+    icc_detect
+  )
+endif ()

--- a/tools/comparison_viewer/mac/CMakeLists.txt
+++ b/tools/comparison_viewer/mac/CMakeLists.txt
@@ -1,0 +1,19 @@
+# Copyright (c) the JPEG XL Project Authors. All rights reserved.
+#
+# Use of this source code is governed by a BSD-style
+# license that can be found in the LICENSE file.
+
+enable_language(OBJC)
+
+add_executable(compare_images
+  main.m
+  CenteredClipView.h
+  CenteredClipView.m
+  ImageComparisonWindow.h
+  ImageComparisonWindow.m
+  SplitImageView.h
+  SplitImageView.m
+)
+target_compile_options(compare_images PRIVATE -fobjc-arc)
+target_link_libraries(compare_images PRIVATE "-framework Cocoa -framework QuartzCore")
+set_target_properties(compare_images PROPERTIES RUNTIME_OUTPUT_DIRECTORY ..)

--- a/tools/comparison_viewer/mac/CenteredClipView.h
+++ b/tools/comparison_viewer/mac/CenteredClipView.h
@@ -1,0 +1,9 @@
+// Copyright (c) the JPEG XL Project Authors. All rights reserved.
+//
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+#import <Cocoa/Cocoa.h>
+
+@interface CenteredClipView : NSClipView
+@end

--- a/tools/comparison_viewer/mac/CenteredClipView.m
+++ b/tools/comparison_viewer/mac/CenteredClipView.m
@@ -1,0 +1,29 @@
+// Copyright (c) the JPEG XL Project Authors. All rights reserved.
+//
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+#import "CenteredClipView.h"
+
+@implementation CenteredClipView
+
+- (NSRect)constrainBoundsRect:(NSRect)proposedBounds {
+  NSRect bounds = [super constrainBoundsRect:proposedBounds];
+
+  NSView *documentView = self.documentView;
+  if (!documentView) return bounds;
+
+  if (documentView.frame.size.width < bounds.size.width) {
+    bounds.origin.x =
+        documentView.frame.origin.x + (documentView.frame.size.width - bounds.size.width) / 2;
+  }
+
+  if (documentView.frame.size.height < bounds.size.height) {
+    bounds.origin.y =
+        documentView.frame.origin.y + (documentView.frame.size.height - bounds.size.height) / 2;
+  }
+
+  return bounds;
+}
+
+@end

--- a/tools/comparison_viewer/mac/ImageComparisonWindow.h
+++ b/tools/comparison_viewer/mac/ImageComparisonWindow.h
@@ -1,0 +1,14 @@
+// Copyright (c) the JPEG XL Project Authors. All rights reserved.
+//
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+#import <Cocoa/Cocoa.h>
+
+@interface ImageComparisonWindow : NSWindow
+
+- (instancetype)initComparisonBetween:(NSImage *)firstImage
+                                  and:(NSImage *)secondImage
+                        withReference:(NSImage *)referenceImage;
+
+@end

--- a/tools/comparison_viewer/mac/ImageComparisonWindow.m
+++ b/tools/comparison_viewer/mac/ImageComparisonWindow.m
@@ -1,0 +1,61 @@
+// Copyright (c) the JPEG XL Project Authors. All rights reserved.
+//
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+#import "ImageComparisonWindow.h"
+
+#import "CenteredClipView.h"
+#import "SplitImageView.h"
+
+@implementation ImageComparisonWindow
+
+- (instancetype)initComparisonBetween:(NSImage *)firstImage
+                                  and:(NSImage *)secondImage
+                        withReference:(NSImage *)referenceImage {
+  NSRect contentRect = NSMakeRect(0, 0, 600, 450);
+  self = [super initWithContentRect:contentRect
+                          styleMask:NSWindowStyleMaskTitled | NSWindowStyleMaskClosable |
+                                    NSWindowStyleMaskMiniaturizable | NSWindowStyleMaskResizable
+                            backing:NSBackingStoreBuffered
+                              defer:NO];
+  if (self) {
+    self.releasedWhenClosed = NO;
+    self.title = @"libjxl image comparison tool";
+
+    NSScrollView *scrollView = [[NSScrollView alloc] initWithFrame:contentRect];
+    scrollView.autoresizingMask = NSViewWidthSizable | NSViewHeightSizable;
+    scrollView.hasHorizontalScroller = YES;
+    scrollView.hasVerticalScroller = YES;
+    scrollView.autohidesScrollers = YES;
+
+    NSView *images = [[SplitImageView alloc] initComparisonBetween:firstImage
+                                                               and:secondImage
+                                                     withReference:referenceImage];
+    NSClipView *clipView = [[CenteredClipView alloc] initWithFrame:scrollView.contentView.frame];
+    clipView.autoresizingMask = NSViewWidthSizable | NSViewHeightSizable;
+    scrollView.contentView = clipView;
+    scrollView.documentView = images;
+    scrollView.allowsMagnification = YES;
+    self.contentView = scrollView;
+
+    NSSize frameSize = [NSScrollView frameSizeForContentSize:images.frame.size
+                                     horizontalScrollerClass:scrollView.horizontalScroller.class
+                                       verticalScrollerClass:scrollView.verticalScroller.class
+                                                  borderType:scrollView.borderType
+                                                 controlSize:NSControlSizeRegular
+                                               scrollerStyle:scrollView.scrollerStyle];
+
+    [self setFrame:NSIntersectionRect(self.screen.visibleFrame,
+                                      NSMakeRect(0, 0, frameSize.width, frameSize.height))
+           display:YES];
+    [self center];
+  }
+  return self;
+}
+
+- (void)cancelOperation:(id)sender {
+  [self close];
+}
+
+@end

--- a/tools/comparison_viewer/mac/SplitImageView.h
+++ b/tools/comparison_viewer/mac/SplitImageView.h
@@ -1,0 +1,14 @@
+// Copyright (c) the JPEG XL Project Authors. All rights reserved.
+//
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+#import <Cocoa/Cocoa.h>
+
+@interface SplitImageView : NSView
+
+- (instancetype)initComparisonBetween:(NSImage *)firstImage
+                                  and:(NSImage *)secondImage
+                        withReference:(NSImage *)referenceImage;
+
+@end

--- a/tools/comparison_viewer/mac/SplitImageView.m
+++ b/tools/comparison_viewer/mac/SplitImageView.m
@@ -1,0 +1,181 @@
+// Copyright (c) the JPEG XL Project Authors. All rights reserved.
+//
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+#import "SplitImageView.h"
+
+#import <AvailabilityMacros.h>
+#import <QuartzCore/QuartzCore.h>
+
+@implementation SplitImageView
+
+NSSize leftImageSize;
+NSSize rightImageSize;
+NSSize referenceImageSize;
+CALayer *leftImageLayer;
+CALayer *rightImageLayer;
+CALayer *referenceImageLayer;
+CAShapeLayer *firstSeparator;
+CAShapeLayer *secondSeparator;
+
+- (instancetype)initComparisonBetween:(NSImage *)firstImage
+                                  and:(NSImage *)secondImage
+                        withReference:(NSImage *)referenceImage {
+  leftImageSize = firstImage.size;
+  rightImageSize = secondImage.size;
+  CGFloat width = MAX(leftImageSize.width, rightImageSize.width);
+  CGFloat height = MAX(leftImageSize.height, rightImageSize.height);
+  if (referenceImage) {
+    referenceImageSize = referenceImage.size;
+    width = MAX(width, referenceImageSize.width);
+    height = MAX(height, referenceImageSize.height);
+  }
+
+  self = [super initWithFrame:NSMakeRect(0, 0, width, height)];
+  if (self) {
+    self.layer = [CALayer layer];
+    self.wantsLayer = YES;
+
+    leftImageLayer = [CALayer layer];
+    leftImageLayer.anchorPoint = NSMakePoint(0, 0);
+    leftImageLayer.bounds = NSMakeRect(0, 0, leftImageSize.width, leftImageSize.height);
+    leftImageLayer.contentsGravity = kCAGravityLeft;
+    leftImageLayer.contents = firstImage;
+    rightImageLayer = [CALayer layer];
+    rightImageLayer.anchorPoint = NSMakePoint(0, 0);
+    rightImageLayer.bounds = NSMakeRect(0, 0, rightImageSize.width, rightImageSize.height);
+    rightImageLayer.contentsGravity = kCAGravityRight;
+    rightImageLayer.contents = secondImage;
+    if (referenceImage) {
+      referenceImageLayer = [CALayer layer];
+      referenceImageLayer.anchorPoint = NSMakePoint(0, 0);
+      referenceImageLayer.bounds =
+          NSMakeRect(0, 0, referenceImageSize.width, referenceImageSize.height);
+      referenceImageLayer.contents = referenceImage;
+    }
+
+#if MAC_OS_X_VERSION_MAX_ALLOWED >= 260000
+    if (@available(macOS 26.0, *)) {
+      leftImageLayer.preferredDynamicRange = CADynamicRangeHigh;
+      rightImageLayer.preferredDynamicRange = CADynamicRangeHigh;
+      referenceImageLayer.preferredDynamicRange = CADynamicRangeHigh;
+    } else
+#endif
+#if MAC_OS_X_VERSION_MAX_ALLOWED >= 140000
+        if (@available(macOS 14.0, *)) {
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
+      leftImageLayer.wantsExtendedDynamicRangeContent = YES;
+      rightImageLayer.wantsExtendedDynamicRangeContent = YES;
+      referenceImageLayer.wantsExtendedDynamicRangeContent = YES;
+#pragma clang diagnostic pop
+    }
+#endif
+
+    if (referenceImageLayer) {
+      [self.layer addSublayer:referenceImageLayer];
+    }
+    [self.layer addSublayer:leftImageLayer];
+    [self.layer addSublayer:rightImageLayer];
+
+    NSArray *dashPattern = @[ @3, @1 ];
+    CGMutablePathRef path = CGPathCreateMutable();
+    CGPathMoveToPoint(path, nil, 0, 0);
+    CGPathAddLineToPoint(path, nil, 0, height);
+    firstSeparator = [CAShapeLayer layer];
+    firstSeparator.strokeColor = NSColor.grayColor.CGColor;
+    firstSeparator.lineWidth = 1;
+    firstSeparator.lineDashPattern = dashPattern;
+    firstSeparator.path = path;
+    [self.layer addSublayer:firstSeparator];
+    if (referenceImage) {
+      secondSeparator = [CAShapeLayer layer];
+      secondSeparator.strokeColor = NSColor.grayColor.CGColor;
+      secondSeparator.lineWidth = 1;
+      secondSeparator.lineDashPattern = dashPattern;
+      secondSeparator.path = path;
+      [self.layer addSublayer:secondSeparator];
+    }
+    CGPathRelease(path);
+
+    firstSeparator.position = NSMakePoint(200, 0);
+
+    NSTrackingArea *trackingArea = [[NSTrackingArea alloc]
+        initWithRect:NSMakeRect(self.frame.origin.x - 1000, self.frame.origin.y - 1000,
+                                self.frame.size.width + 2000, self.frame.size.height + 2000)
+             options:NSTrackingMouseMoved | NSTrackingActiveAlways
+               owner:self
+            userInfo:nil];
+    [self addTrackingArea:trackingArea];
+  }
+  return self;
+}
+
+- (void)mouseMoved:(NSEvent *)event {
+  NSPoint where = [self convertPoint:[event locationInWindow] fromView:nil];
+  [CATransaction begin];
+  [CATransaction setDisableActions:YES];
+#define CLAMP(x) (MAX(0, MIN(1, (x))))
+  firstSeparator.hidden = NO;
+  if (referenceImageLayer) {
+    leftImageLayer.contentsRect = NSMakeRect(0, 0, CLAMP((where.x - 50) / leftImageSize.width), 1);
+    rightImageLayer.contentsRect = NSMakeRect(CLAMP((where.x + 50) / rightImageSize.width), 0,
+                                              CLAMP(1 - (where.x + 50) / rightImageSize.width), 1);
+    firstSeparator.position = NSMakePoint(where.x - 50, 0);
+    secondSeparator.position = NSMakePoint(where.x + 50, 0);
+    secondSeparator.hidden = NO;
+  } else {
+    leftImageLayer.contentsRect = NSMakeRect(0, 0, CLAMP(where.x / leftImageSize.width), 1);
+    rightImageLayer.contentsRect = NSMakeRect(CLAMP(where.x / rightImageSize.width), 0,
+                                              CLAMP(1 - where.x / rightImageSize.width), 1);
+    firstSeparator.position = NSMakePoint(where.x, 0);
+  }
+#undef CLAMP
+  [CATransaction commit];
+}
+
+- (BOOL)acceptsFirstResponder {
+  return YES;
+}
+
+- (void)keyDown:(NSEvent *)event {
+  if (!(event.modifierFlags & NSEventModifierFlagNumericPad)) {
+    [super keyDown:event];
+    return;
+  }
+  NSString *characters = event.charactersIgnoringModifiers;
+  NSUInteger length = characters.length;
+  if (length != 1) {
+    [super keyDown:event];
+    return;
+  }
+  unichar key = [characters characterAtIndex:0];
+  if (!(key == NSLeftArrowFunctionKey || key == NSRightArrowFunctionKey ||
+        (referenceImageLayer && (key == NSUpArrowFunctionKey || key == NSDownArrowFunctionKey)))) {
+    [super keyDown:event];
+    return;
+  }
+  [CATransaction begin];
+  [CATransaction setDisableActions:YES];
+  firstSeparator.hidden = YES;
+  secondSeparator.hidden = YES;
+  switch (key) {
+    case NSLeftArrowFunctionKey:
+      leftImageLayer.contentsRect = NSMakeRect(0, 0, 1, 1);
+      rightImageLayer.contentsRect = NSMakeRect(0, 0, 0, 0);
+      break;
+    case NSRightArrowFunctionKey:
+      leftImageLayer.contentsRect = NSMakeRect(0, 0, 0, 0);
+      rightImageLayer.contentsRect = NSMakeRect(0, 0, 1, 1);
+      break;
+    case NSUpArrowFunctionKey:
+    case NSDownArrowFunctionKey:
+      leftImageLayer.contentsRect = NSMakeRect(0, 0, 0, 0);
+      rightImageLayer.contentsRect = NSMakeRect(0, 0, 0, 0);
+      break;
+  }
+  [CATransaction commit];
+}
+
+@end

--- a/tools/comparison_viewer/mac/main.m
+++ b/tools/comparison_viewer/mac/main.m
@@ -1,0 +1,47 @@
+// Copyright (c) the JPEG XL Project Authors. All rights reserved.
+//
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+#import <Cocoa/Cocoa.h>
+#import <stdio.h>
+
+#import "ImageComparisonWindow.h"
+
+@interface AppDelegate : NSObject <NSApplicationDelegate>
+@end
+
+@implementation AppDelegate
+
+- (BOOL)applicationShouldTerminateAfterLastWindowClosed:(NSApplication *)sender {
+  return YES;
+}
+
+@end
+
+static NSImage *loadImage(const char *const arg) {
+  return [[NSImage alloc] initByReferencingFile:[[NSString alloc] initWithUTF8String:arg]];
+}
+
+int main(int argc, const char **argv) {
+  if (argc != 3 && argc != 4) {
+    fprintf(stderr, "Usage: %s <first image> <second image> [<reference image>]\n", argv[0]);
+    return 1;
+  }
+
+  @autoreleasepool {
+    [[NSApplication sharedApplication] setActivationPolicy:NSApplicationActivationPolicyAccessory];
+    ImageComparisonWindow *window;
+    NSImage *firstImage = loadImage(argv[1]);
+    NSImage *secondImage = loadImage(argv[2]);
+    NSImage *referenceImage = argc > 3 ? loadImage(argv[3]) : nil;
+    window = [[ImageComparisonWindow alloc] initComparisonBetween:firstImage
+                                                              and:secondImage
+                                                    withReference:referenceImage];
+    [window makeKeyAndOrderFront:nil];
+    [NSApp setDelegate:[[AppDelegate alloc] init]];
+    [NSApp activateIgnoringOtherApps:YES];
+    [NSApp run];
+  }
+  return 0;
+}


### PR DESCRIPTION
This is a bit less featureful than the Qt version but supports wide-gamut / HDR images and builds quickly with no non-system dependencies.